### PR TITLE
feat(ui): Add absolute tooltip to relative dates

### DIFF
--- a/src/sentry/static/sentry/app/components/group/seenInfo.tsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.tsx
@@ -71,12 +71,12 @@ class SeenInfo extends React.Component<Props> {
           <React.Fragment>
             {toTitleCase(environment)}
             {': '}
-            <TimeSince date={date} />
+            <TimeSince date={date} disabledAbsoluteTooltip />
             <br />
           </React.Fragment>
         )}
         {t('Globally: ')}
-        <TimeSince date={dateGlobal} />
+        <TimeSince date={dateGlobal} disabledAbsoluteTooltip />
       </div>
     );
   }
@@ -97,13 +97,13 @@ class SeenInfo extends React.Component<Props> {
           <TooltipWrapper>
             <Tooltip title={this.getTooltipTitle()} disableForVisualTest>
               <IconInfo size="xs" color="gray500" />
-              <TimeSince date={date} />
+              <TimeSince date={date} disabledAbsoluteTooltip />
             </Tooltip>
           </TooltipWrapper>
         ) : dateGlobal && environment === '' ? (
           <React.Fragment>
             <Tooltip title={this.getTooltipTitle()} disableForVisualTest>
-              <TimeSince date={dateGlobal} />
+              <TimeSince date={dateGlobal} disabledAbsoluteTooltip />
             </Tooltip>
           </React.Fragment>
         ) : (

--- a/src/sentry/static/sentry/app/components/timeSince.tsx
+++ b/src/sentry/static/sentry/app/components/timeSince.tsx
@@ -29,6 +29,11 @@ type Props = DefaultProps & {
    */
   date: RelaxedDateType;
 
+  /**
+   * By default we show tooltip with absolute date on hover, this prop disables that
+   */
+  disabledAbsoluteTooltip?: boolean;
+
   className?: string;
 } & TimeProps;
 
@@ -81,14 +86,23 @@ class TimeSince extends React.PureComponent<Props, State> {
   };
 
   render() {
-    const {date, suffix: _suffix, className, ...props} = this.props;
+    const {
+      date,
+      suffix: _suffix,
+      disabledAbsoluteTooltip,
+      className,
+      ...props
+    } = this.props;
     const dateObj = getDateObj(date);
     const user = ConfigStore.get('user');
     const options = user ? user.options : null;
     const format = options?.clock24Hours ? 'MMMM D YYYY HH:mm:ss z' : 'LLL z';
 
     return (
-      <Tooltip title={moment.tz(dateObj, options?.timezone ?? '').format(format)}>
+      <Tooltip
+        title={moment.tz(dateObj, options?.timezone ?? '').format(format)}
+        disabled={disabledAbsoluteTooltip}
+      >
         <time dateTime={dateObj.toISOString()} className={className} {...props}>
           {this.state.relative}
         </time>

--- a/src/sentry/static/sentry/app/components/timeSince.tsx
+++ b/src/sentry/static/sentry/app/components/timeSince.tsx
@@ -7,6 +7,8 @@ import moment from 'moment-timezone';
 import ConfigStore from 'app/stores/configStore';
 import {t} from 'app/locale';
 
+import Tooltip from './tooltip';
+
 const ONE_MINUTE_IN_MS = 60000;
 
 type RelaxedDateType = string | number | Date;
@@ -86,14 +88,11 @@ class TimeSince extends React.PureComponent<Props, State> {
     const format = options?.clock24Hours ? 'MMMM D YYYY HH:mm:ss z' : 'LLL z';
 
     return (
-      <time
-        dateTime={dateObj.toISOString()}
-        title={moment.tz(dateObj, options?.timezone ?? '').format(format)}
-        className={className}
-        {...props}
-      >
-        {this.state.relative}
-      </time>
+      <Tooltip title={moment.tz(dateObj, options?.timezone ?? '').format(format)}>
+        <time dateTime={dateObj.toISOString()} className={className} {...props}>
+          {this.state.relative}
+        </time>
+      </Tooltip>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -8,7 +8,6 @@ import {PanelItem} from 'app/components/panels';
 import {Project} from 'app/types';
 import {t, tct} from 'app/locale';
 import AsyncComponent from 'app/components/asyncComponent';
-import DateTime from 'app/components/dateTime';
 import Duration from 'app/components/duration';
 import ErrorBoundary from 'app/components/errorBoundary';
 import IdBadge from 'app/components/idBadge';
@@ -73,9 +72,7 @@ class AlertListRow extends AsyncComponent<Props, State> {
   renderTimeSince(date: string) {
     return (
       <CreatedResolvedTime>
-        <Tooltip title={<DateTime date={date} utc={false} />} position="top">
-          <TimeSince title="" date={date} />
-        </Tooltip>
+        <TimeSince date={date} />
       </CreatedResolvedTime>
     );
   }


### PR DESCRIPTION
Multiple users didn't know that we show absolute date on hover, because it takes some time till the HTML title shows up.
We changed it to use the `Tooltip` component instead. This change has been made to `TimeSince` component so the change should be app-wide.

## Before
![image](https://user-images.githubusercontent.com/9060071/97580442-9acff780-19f3-11eb-8836-b8d28df7dc82.png)

## After
![image](https://user-images.githubusercontent.com/9060071/97580166-42005f00-19f3-11eb-8fcf-68322d775c49.png)
