### PR TITLE
ref(ui) Update charts in manage

### DIFF
--- a/src/sentry/static/sentry/app/components/internalStatChart.jsx
+++ b/src/sentry/static/sentry/app/components/internalStatChart.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import BarChart from 'app/components/barChart';
+import MiniBarChart from 'app/components/charts/miniBarChart';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import withApi from 'app/utils/withApi';
@@ -63,23 +63,29 @@ class InternalStatChart extends React.Component {
     });
   }
 
-  getChartPoints() {
-    return this.state.data.map(([x, y]) => ({x, y}));
-  }
-
   render() {
-    if (this.state.loading) {
+    const {loading, error, data} = this.state;
+    const {label, height} = this.props;
+    if (loading) {
       return <LoadingIndicator />;
-    } else if (this.state.error) {
+    } else if (error) {
       return <LoadingError onRetry={this.fetchData} />;
     }
 
+    const series = {
+      seriesName: label,
+      data: data.map(([timestamp, value]) => ({
+        name: timestamp * 1000,
+        value,
+      })),
+    };
     return (
-      <BarChart
-        points={this.getChartPoints()}
-        className="standard-barchart"
-        label={this.props.label}
-        height={this.props.height}
+      <MiniBarChart
+        height={height}
+        series={[series]}
+        isGroupedByDate
+        showTimeInTooltip
+        labelYAxisExtents
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/admin/adminOverview/eventChart.jsx
+++ b/src/sentry/static/sentry/app/views/admin/adminOverview/eventChart.jsx
@@ -1,20 +1,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
+import MiniBarChart from 'app/components/charts/miniBarChart';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import StackedBarChart from 'app/components/stackedBarChart';
+import {t} from 'app/locale';
 import withApi from 'app/utils/withApi';
+import theme from 'app/utils/theme';
 
-const EventChart = createReactClass({
-  displayName: 'eventChart',
-
-  propTypes: {
+class EventChart extends React.Component {
+  static propTypes = {
     api: PropTypes.object.isRequired,
     since: PropTypes.number.isRequired,
     resolution: PropTypes.string.isRequired,
-  },
+  };
+
+  state = this.getInitialState();
 
   getInitialState() {
     return {
@@ -25,21 +26,20 @@ const EventChart = createReactClass({
         'events.dropped': null,
       },
       stats: {received: [], rejected: []},
-      systemTotal: {received: 0, rejected: 0, accepted: 0},
     };
-  },
+  }
 
   componentWillMount() {
     this.fetchData();
-  },
+  }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.since !== nextProps.since) {
       this.setState(this.getInitialState(), this.fetchData);
     }
-  },
+  }
 
-  fetchData() {
+  fetchData = () => {
     const statNameList = ['events.total', 'events.dropped'];
 
     statNameList.forEach(statName => {
@@ -68,22 +68,21 @@ const EventChart = createReactClass({
         },
       });
     });
-  },
+  };
 
   requestFinished() {
     const {rawData} = this.state;
     if (rawData['events.total'] && rawData['events.dropped']) {
       this.processOrgData();
     }
-  },
+  }
 
   processOrgData() {
     const {rawData} = this.state;
-    let oReceived = 0;
-    let oRejected = 0;
     const sReceived = {};
     const sRejected = {};
     const aReceived = [0, 0]; // received, points
+
     rawData['events.total'].forEach((point, idx) => {
       const dReceived = point[1];
       const dRejected = rawData['events.dropped'][idx][1];
@@ -95,62 +94,65 @@ const EventChart = createReactClass({
         sReceived[ts] += dReceived;
         sRejected[ts] += dRejected;
       }
-      oReceived += dReceived;
-      oRejected += dRejected;
       if (dReceived > 0) {
         aReceived[0] += dReceived;
         aReceived[1] += 1;
       }
     });
+
     this.setState({
-      systemTotal: {
-        received: oReceived,
-        rejected: oRejected,
-        accepted: oReceived - oRejected,
-        avgRate: parseInt(aReceived[0] / aReceived[1] / 60, 10),
-      },
       stats: {
-        rejected: Object.keys(sRejected).map(ts => ({x: ts, y: sRejected[ts] || null})),
+        rejected: Object.keys(sRejected).map(ts => ({
+          name: ts * 1000,
+          value: sRejected[ts] || 0,
+        })),
         accepted: Object.keys(sReceived).map(ts =>
           // total number of events accepted (received - rejected)
-          ({x: ts, y: sReceived[ts] - sRejected[ts]})
+          ({name: ts * 1000, value: sReceived[ts] - sRejected[ts]})
         ),
       },
       loading: false,
     });
-  },
+  }
 
   getChartSeries() {
     const {stats} = this.state;
 
     return [
       {
+        seriesName: t('Accepted'),
         data: stats.accepted,
-        label: 'Accepted',
-        color: 'rgba(86, 175, 232, 1)',
+        color: theme.blue300,
       },
       {
+        seriesName: t('Dropped'),
         data: stats.rejected,
-        color: 'rgba(244, 63, 32, 1)',
-        label: 'Dropped',
+        color: theme.red300,
       },
     ];
-  },
+  }
 
   render() {
-    if (this.state.loading) {
+    const {loading, error} = this.state;
+    if (loading) {
       return <LoadingIndicator />;
-    } else if (this.state.error) {
+    } else if (error) {
       return <LoadingError onRetry={this.fetchData} />;
     }
+    const series = this.getChartSeries();
+    const colors = series.map(({color}) => color);
     return (
-      <StackedBarChart
-        series={this.getChartSeries()}
-        height={150}
-        className="standard-barchart"
+      <MiniBarChart
+        series={series}
+        colors={colors}
+        height={110}
+        stacked
+        isGroupedByDate
+        showTimeInTooltip
+        labelYAxisExtents
       />
     );
-  },
-});
+  }
+}
 
 export default withApi(EventChart);

--- a/src/sentry/static/sentry/app/views/admin/adminOverview/index.jsx
+++ b/src/sentry/static/sentry/app/views/admin/adminOverview/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import {Panel, PanelHeader, PanelBody} from 'app/components/panels';
 import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 
@@ -19,26 +20,23 @@ export default class AdminOverview extends AsyncView {
     const resolution = '1h';
     const since = new Date().getTime() / 1000 - 3600 * 24 * 7;
     return (
-      <div>
+      <React.Fragment>
         <h3>{t('System Overview')}</h3>
 
-        <div className="box">
-          <div className="box-header">
-            <h4>
-              {t('Event Throughput')}
-              <span id="rate" className="pull-right" />
-            </h4>
-          </div>
-          <EventChart since={since} resolution={resolution} />
-        </div>
+        <Panel key="events">
+          <PanelHeader>{t('Event Throughput')}</PanelHeader>
+          <PanelBody withPadding>
+            <EventChart since={since} resolution={resolution} />
+          </PanelBody>
+        </Panel>
 
-        <div className="box">
-          <div className="box-header">
-            <h4>{t('API Responses')}</h4>
-          </div>
-          <ApiChart since={since} resolution={resolution} />
-        </div>
-      </div>
+        <Panel key="api">
+          <PanelHeader>{t('API Responses')}</PanelHeader>
+          <PanelBody withPadding>
+            <ApiChart since={since} resolution={resolution} />
+          </PanelBody>
+        </Panel>
+      </React.Fragment>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/admin/adminQueue.jsx
+++ b/src/sentry/static/sentry/app/views/admin/adminQueue.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import AsyncView from 'app/views/asyncView';
+import {Panel, PanelHeader, PanelBody} from 'app/components/panels';
 import InternalStatChart from 'app/components/internalStatChart';
 import {SelectField} from 'app/components/forms';
 
@@ -61,22 +62,22 @@ export default class AdminQueue extends AsyncView {
 
         <h3 className="no-border">Queue Overview</h3>
 
-        <div className="box">
-          <div className="box-header">
-            <h3>Global Throughput</h3>
-          </div>
-          <InternalStatChart
-            since={this.state.since}
-            resolution={this.state.resolution}
-            stat="jobs.all.started"
-            label="jobs started"
-          />
-        </div>
+        <Panel>
+          <PanelHeader>Global Throughput</PanelHeader>
+          <PanelBody withPadding>
+            <InternalStatChart
+              since={this.state.since}
+              resolution={this.state.resolution}
+              stat="jobs.all.started"
+              label="jobs started"
+            />
+          </PanelBody>
+        </Panel>
 
         <h3 className="no-border">Task Details</h3>
 
         <div>
-          <div>
+          <div className="m-b-1">
             <label>Show details for task:</label>
             <SelectField
               deprecatedSelectControl
@@ -89,30 +90,34 @@ export default class AdminQueue extends AsyncView {
           </div>
           {activeTask ? (
             <div>
-              <div className="box box-mini" key="jobs.started">
-                <div className="box-header">
+              <Panel key={`jobs.started.${activeTask}`}>
+                <PanelHeader>
                   Jobs Started <small>{activeTask}</small>
-                </div>
-                <InternalStatChart
-                  since={this.state.since}
-                  resolution={this.state.resolution}
-                  stat={`jobs.started.${this.state.activeTask}`}
-                  label="jobs"
-                  height={100}
-                />
-              </div>
-              <div className="box box-mini" key="jobs.finished">
-                <div className="box-header">
+                </PanelHeader>
+                <PanelBody withPadding>
+                  <InternalStatChart
+                    since={this.state.since}
+                    resolution={this.state.resolution}
+                    stat={`jobs.started.${activeTask}`}
+                    label="jobs"
+                    height={100}
+                  />
+                </PanelBody>
+              </Panel>
+              <Panel key={`jobs.finished.${activeTask}`}>
+                <PanelHeader>
                   Jobs Finished <small>{activeTask}</small>
-                </div>
-                <InternalStatChart
-                  since={this.state.since}
-                  resolution={this.state.resolution}
-                  stat={`jobs.finished.${this.state.activeTask}`}
-                  label="jobs"
-                  height={100}
-                />
-              </div>
+                </PanelHeader>
+                <PanelBody withPadding>
+                  <InternalStatChart
+                    since={this.state.since}
+                    resolution={this.state.resolution}
+                    stat={`jobs.finished.${activeTask}`}
+                    label="jobs"
+                    height={100}
+                  />
+                </PanelBody>
+              </Panel>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
* Remove createReactClass() usage.
* Replace some CSS classnames with Panel components.
* Replace the charts with echarts based versions.


#### Queue charts

![Screen Shot 2020-10-29 at 10 28 30 AM](https://user-images.githubusercontent.com/24086/97587671-05703b80-19d2-11eb-8e44-759dcc373360.png)

I wasn't able to get the overview charts working locally, but they also don't display data for sentry.io, so they might not be working at all 🤷 

cc @BYK 