### PR TITLE
build(gha): Fix size-limit action not running on pushes to master

### DIFF
--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   typescript-and-lint:
     name: typescript and lint
-    if: ${{ github.ref != 'refs/heads/master' }}
+    if: github.ref != 'refs/heads/master'
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
@@ -79,17 +79,17 @@ jobs:
           filters: .github/file-filters.yml
 
       - uses: volta-cli/action@v1
-        if: steps.changes.outputs.frontend == 'true'
+        if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
 
       # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        if: steps.changes.outputs.frontend == 'true'
+        if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        if: steps.changes.outputs.frontend == 'true'
+        if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -97,11 +97,11 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install dependencies
-        if: steps.changes.outputs.frontend == 'true'
+        if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
         run: yarn install --frozen-lockfile
 
       - uses: getsentry/size-limit-action@v1-dev
-        if: steps.changes.outputs.frontend == 'true'
+        if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
         with:
           main_branch: master
           skip_step: install


### PR DESCRIPTION
Previously, this workflow would only run when js files changed, so on PRs, when it would download artifacts for the workflow, it would always be guaranteed to exist. Now, we run these workflows on *all* file changes, but the steps get skipped if no frontend changes were detected, so artifacts may or may not exist for the workflow.

Ideally, we could tell the action what workflow to fetch artifacts from and the workflow would 1) only run on frontend changes and 2) always have an artifact. But for now we will always run webpack in master.