### PR TITLE
feat(slack): case insensitive name check

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -435,7 +435,8 @@ def get_channel_id_with_timeout(integration, name, timeout):
             for c in items[result_name]:
                 # The "name" field is unique (this is the username for users)
                 # so we return immediately if we find a match.
-                if c["name"] == name:
+                # convert to lower case since all names in Slack are lowercase
+                if c["name"].lower() == name.lower():
                     return (prefix, c["id"], False)
                 # If we don't get a match on a unique identifier, we look through
                 # the users' display names, and error if there is a repeat.

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -45,7 +45,7 @@ class GetChannelIdWorkspaceTest(TestCase):
         self.add_list_response(
             "users",
             [
-                {"name": "morty", "id": "m", "profile": {"display_name": "Morty"}},
+                {"name": "first-morty", "id": "m", "profile": {"display_name": "Morty"}},
                 {"name": "other-user", "id": "o-u", "profile": {"display_name": "Jimbob"}},
                 {"name": "better_morty", "id": "bm", "profile": {"display_name": "Morty"}},
             ],
@@ -70,13 +70,13 @@ class GetChannelIdWorkspaceTest(TestCase):
         )
 
     def test_valid_channel_selected(self):
-        self.run_valid_test("#my-channel", CHANNEL_PREFIX, "m-c", False)
+        self.run_valid_test("#My-Channel", CHANNEL_PREFIX, "m-c", False)
 
     def test_valid_private_channel_selected(self):
         self.run_valid_test("#my-private-channel", CHANNEL_PREFIX, "m-p-c", False)
 
     def test_valid_member_selected(self):
-        self.run_valid_test("@morty", MEMBER_PREFIX, "m", False)
+        self.run_valid_test("@first-morty", MEMBER_PREFIX, "m", False)
 
     def test_valid_member_selected_display_name(self):
         self.run_valid_test("@Jimbob", MEMBER_PREFIX, "o-u", False)
@@ -117,7 +117,7 @@ class GetChannelIdBotTest(GetChannelIdWorkspaceTest):
         self.add_list_response(
             "users",
             [
-                {"name": "morty", "id": "m", "profile": {"display_name": "Morty"}},
+                {"name": "first-morty", "id": "m", "profile": {"display_name": "Morty"}},
                 {"name": "other-user", "id": "o-u", "profile": {"display_name": "Jimbob"}},
                 {"name": "better_morty", "id": "bm", "profile": {"display_name": "Morty"}},
             ],


### PR DESCRIPTION
This PR makes the Slack channel lookup case insensitive. This is necessary because users have a bad habit of putting in upper case letters when the Slack channel is lowercase. Right now, it's impossible to create a Slack channel with anything other than lower case letters. However, Slack's docs don't make this explicit so it's possible that some older channels have upper case letters. The impact is that if by chance an organization has two channels that are case insensitive matches to each other, we might pick the wrong one. However, that seems very unlikely and would probably cause other issues (not the least that users would get confused). Note that Microsoft Teams already has case insensitive matching.