### PR TITLE
fix(transactions): transaction names org releases

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -131,7 +131,7 @@ def debounce_update_release_health_data(organization, project_ids):
 
 
 class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
-    @transaction_start("ReleaseSerializerWithProjects.get")
+    @transaction_start("OrganizationReleasesEndpoint.get")
     def get(self, request, organization):
         """
         List an Organization's Releases
@@ -248,7 +248,7 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
             **paginator_kwargs
         )
 
-    @transaction_start("ReleaseSerializerWithProjects.post")
+    @transaction_start("OrganizationReleasesEndpoint.post")
     def post(self, request, organization):
         """
         Create a New Release for an Organization

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -435,7 +435,8 @@ def get_channel_id_with_timeout(integration, name, timeout):
             for c in items[result_name]:
                 # The "name" field is unique (this is the username for users)
                 # so we return immediately if we find a match.
-                if c["name"] == name:
+                # convert to lower case since all names in Slack are lowercase
+                if c["name"].lower() == name.lower():
                     return (prefix, c["id"], False)
                 # If we don't get a match on a unique identifier, we look through
                 # the users' display names, and error if there is a repeat.

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -45,7 +45,7 @@ class GetChannelIdWorkspaceTest(TestCase):
         self.add_list_response(
             "users",
             [
-                {"name": "morty", "id": "m", "profile": {"display_name": "Morty"}},
+                {"name": "first-morty", "id": "m", "profile": {"display_name": "Morty"}},
                 {"name": "other-user", "id": "o-u", "profile": {"display_name": "Jimbob"}},
                 {"name": "better_morty", "id": "bm", "profile": {"display_name": "Morty"}},
             ],
@@ -70,13 +70,13 @@ class GetChannelIdWorkspaceTest(TestCase):
         )
 
     def test_valid_channel_selected(self):
-        self.run_valid_test("#my-channel", CHANNEL_PREFIX, "m-c", False)
+        self.run_valid_test("#My-Channel", CHANNEL_PREFIX, "m-c", False)
 
     def test_valid_private_channel_selected(self):
         self.run_valid_test("#my-private-channel", CHANNEL_PREFIX, "m-p-c", False)
 
     def test_valid_member_selected(self):
-        self.run_valid_test("@morty", MEMBER_PREFIX, "m", False)
+        self.run_valid_test("@first-morty", MEMBER_PREFIX, "m", False)
 
     def test_valid_member_selected_display_name(self):
         self.run_valid_test("@Jimbob", MEMBER_PREFIX, "o-u", False)
@@ -117,7 +117,7 @@ class GetChannelIdBotTest(GetChannelIdWorkspaceTest):
         self.add_list_response(
             "users",
             [
-                {"name": "morty", "id": "m", "profile": {"display_name": "Morty"}},
+                {"name": "first-morty", "id": "m", "profile": {"display_name": "Morty"}},
                 {"name": "other-user", "id": "o-u", "profile": {"display_name": "Jimbob"}},
                 {"name": "better_morty", "id": "bm", "profile": {"display_name": "Morty"}},
             ],


### PR DESCRIPTION
I had a typo and put the transactions as `ReleaseSerializerWithProjects ` instead of `OrganizationReleasesEndpoint`.