### PR TITLE
feat(perf-view): Make key transactions column clickable

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/performance.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/performance.tsx
@@ -2,8 +2,9 @@ import {Client} from 'app/api';
 import {t} from 'app/locale';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 
-export function saveKeyTransaction(
+export function toggleKeyTransaction(
   api: Client,
+  isKeyTransaction: boolean,
   orgId: string,
   projects: number[],
   transactionName: string
@@ -11,41 +12,7 @@ export function saveKeyTransaction(
   const promise: Promise<undefined> = api.requestPromise(
     `/organizations/${orgId}/key-transactions/`,
     {
-      method: 'POST',
-      query: {
-        project: projects.map(id => String(id)),
-      },
-      data: {transaction: transactionName},
-    }
-  );
-
-  promise.catch(response => {
-    const non_field_errors = response?.responseJSON?.non_field_errors;
-
-    if (
-      Array.isArray(non_field_errors) &&
-      non_field_errors.length &&
-      non_field_errors[0]
-    ) {
-      addErrorMessage(response.responseJSON.non_field_errors[0]);
-    } else {
-      addErrorMessage(t('Unable to update key transaction'));
-    }
-  });
-
-  return promise;
-}
-
-export function deleteKeyTransaction(
-  api: Client,
-  orgId: string,
-  projects: number[],
-  transactionName: string
-): Promise<undefined> {
-  const promise: Promise<undefined> = api.requestPromise(
-    `/organizations/${orgId}/key-transactions/`,
-    {
-      method: 'DELETE',
+      method: isKeyTransaction ? 'DELETE' : 'POST',
       query: {
         project: projects.map(id => String(id)),
       },

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -3,7 +3,6 @@ import {Location} from 'history';
 import partial from 'lodash/partial';
 import styled from '@emotion/styled';
 
-import {IconStar} from 'app/icons';
 import {Organization} from 'app/types';
 import {t} from 'app/locale';
 import Count from 'app/components/count';
@@ -19,6 +18,7 @@ import {getAggregateAlias, AGGREGATIONS} from 'app/utils/discover/fields';
 import Projects from 'app/utils/projects';
 import {getShortEventId} from 'app/utils/events';
 
+import KeyTransactionField from './keyTransactionField';
 import {
   BarContainer,
   Container,
@@ -310,18 +310,16 @@ const SPECIAL_FIELDS: SpecialFields = {
   },
   key_transaction: {
     sortField: 'key_transaction',
-    renderFunc: data => {
-      const isKeyTransaction = (data.key_transaction ?? 0) !== 0;
-      return (
-        <Container>
-          <IconStar
-            color={isKeyTransaction ? 'yellow500' : 'gray500'}
-            isSolid={isKeyTransaction}
-            data-test-id="key-transaction-column"
-          />
-        </Container>
-      );
-    },
+    renderFunc: (data, {organization}) => (
+      <Container>
+        <KeyTransactionField
+          isKeyTransaction={(data.key_transaction ?? 0) !== 0}
+          organization={organization}
+          projectSlug={data.project}
+          transactionName={data.transaction}
+        />
+      </Container>
+    ),
   },
 };
 

--- a/src/sentry/static/sentry/app/utils/discover/keyTransactionField.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/keyTransactionField.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+
+import {toggleKeyTransaction} from 'app/actionCreators/performance';
+import {Client} from 'app/api';
+import Button from 'app/components/button';
+import {IconStar} from 'app/icons';
+import {Project, Organization} from 'app/types';
+import withApi from 'app/utils/withApi';
+import withProjects from 'app/utils/withProjects';
+
+type Props = {
+  api: Client;
+  projects: Project[];
+  /**
+   * This prop is only used to seed the initial rendering state of this component.
+   * After seeding the state, this value should not be used anymore.
+   */
+  isKeyTransaction: boolean;
+  organization: Organization | undefined;
+  projectSlug: string | undefined;
+  transactionName: string | undefined;
+};
+
+type State = {
+  isKeyTransaction: boolean;
+};
+
+class KeyTransactionField extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      isKeyTransaction: !!props.isKeyTransaction,
+    };
+  }
+
+  getProjectId(): number | null {
+    const {projects, projectSlug} = this.props;
+    const project = projects.find(proj => proj.slug === projectSlug);
+    if (!project) {
+      return null;
+    }
+    return parseInt(project.id, 10);
+  }
+
+  toggleKeyTransactionHandler = () => {
+    const {api, organization, transactionName} = this.props;
+    const {isKeyTransaction} = this.state;
+    const projectId = this.getProjectId();
+
+    // All the props are guaranteed to be not undefined at this point
+    // as they have all been validated in the render method.
+    toggleKeyTransaction(
+      api,
+      isKeyTransaction,
+      organization!.slug,
+      [projectId!],
+      transactionName!
+    ).then(() => {
+      this.setState({
+        isKeyTransaction: !isKeyTransaction,
+      });
+    });
+  };
+
+  render() {
+    const {organization, projectSlug, transactionName} = this.props;
+    const {isKeyTransaction} = this.state;
+
+    const star = (
+      <IconStar
+        size="xs"
+        color={isKeyTransaction ? 'yellow500' : 'gray500'}
+        isSolid={isKeyTransaction}
+        data-test-id="key-transaction-column"
+      />
+    );
+
+    // All these fields need to be defined in order to toggle a key transaction
+    // Since they're not defined, we just render a plain star icon with no action
+    // associated with it
+    if (
+      organization === undefined ||
+      projectSlug === undefined ||
+      transactionName === undefined ||
+      this.getProjectId() === null
+    ) {
+      return star;
+    }
+
+    return (
+      <Button
+        size="zero"
+        borderless
+        icon={star}
+        onClick={this.toggleKeyTransactionHandler}
+      />
+    );
+  }
+}
+
+export default withApi(withProjects(KeyTransactionField));

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
@@ -8,7 +8,7 @@ import {t} from 'app/locale';
 import EventView from 'app/utils/discover/eventView';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import {saveKeyTransaction, deleteKeyTransaction} from 'app/actionCreators/performance';
+import {toggleKeyTransaction} from 'app/actionCreators/performance';
 
 type Props = {
   api: Client;
@@ -96,39 +96,27 @@ class KeyTransactionButton extends React.Component<Props, State> {
       });
   };
 
-  toggleKeyTransaction = () => {
+  toggleKeyTransactionHandler = () => {
     const {eventView, api, organization, transactionName} = this.props;
+    const {isKeyTransaction} = this.state;
     const projects = eventView.project as number[];
 
     trackAnalyticsEvent({
       eventName: 'Performance Views: Key Transaction toggle',
       eventKey: 'performance_views.key_transaction.toggle',
       orgId: parseInt(organization.id, 10),
-      action: this.state.isKeyTransaction ? 'remove' : 'add',
+      action: isKeyTransaction ? 'remove' : 'add',
     });
 
-    if (!this.state.isKeyTransaction) {
-      this.setState({
-        isKeyTransaction: true,
-      });
-      saveKeyTransaction(api, organization.slug, projects, transactionName).catch(() => {
-        this.setState({
-          isKeyTransaction: false,
-        });
-      });
-    } else {
-      this.setState({
-        isKeyTransaction: false,
-      });
-
-      deleteKeyTransaction(api, organization.slug, projects, transactionName).catch(
-        () => {
-          this.setState({
-            isKeyTransaction: true,
-          });
-        }
-      );
-    }
+    toggleKeyTransaction(
+      api,
+      isKeyTransaction,
+      organization.slug,
+      projects,
+      transactionName
+    ).then(() => {
+      this.setState({isKeyTransaction: !isKeyTransaction});
+    });
   };
 
   render() {
@@ -147,7 +135,7 @@ class KeyTransactionButton extends React.Component<Props, State> {
             isSolid={!!isKeyTransaction}
           />
         }
-        onClick={this.toggleKeyTransaction}
+        onClick={this.toggleKeyTransactionHandler}
       >
         {t('Key Transaction')}
       </Button>

--- a/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
+++ b/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
@@ -1,6 +1,7 @@
 import {mount, mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
+import ProjectsStore from 'app/stores/projectsStore';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 
 describe('getFieldRenderer', function () {
@@ -11,6 +12,7 @@ describe('getFieldRenderer', function () {
     });
     organization = context.organization;
     project = context.project;
+    ProjectsStore.loadInitialData([project]);
     user = 'email:text@example.com';
 
     location = {
@@ -18,6 +20,7 @@ describe('getFieldRenderer', function () {
       query: {},
     };
     data = {
+      key_transaction: 1,
       title: 'ValueError: something bad',
       transaction: 'api.do_things',
       boolValue: 1,
@@ -33,6 +36,16 @@ describe('getFieldRenderer', function () {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/projects/${project.slug}/`,
       body: project,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/key-transactions/`,
+      method: 'POST',
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/key-transactions/`,
+      method: 'DELETE',
     });
   });
 
@@ -127,5 +140,55 @@ describe('getFieldRenderer', function () {
     const value = wrapper.find('ProjectBadge');
     expect(value).toHaveLength(1);
     expect(value.text()).toEqual(project.slug);
+  });
+
+  it('can render key transaction as a star', async function () {
+    const renderer = getFieldRenderer('key_transaction', {key_transaction: 'boolean'});
+    delete data.project;
+
+    const wrapper = mountWithTheme(
+      renderer(data, {location, organization}),
+      context.routerContext
+    );
+
+    const value = wrapper.find('IconStar');
+    expect(value).toHaveLength(1);
+    expect(value.props().isSolid).toBeTruthy();
+
+    // Since there is not project column, it's not clickable
+    expect(wrapper.find('Button')).toHaveLength(0);
+  });
+
+  it('can render key transaction as a clickable star', async function () {
+    const renderer = getFieldRenderer('key_transaction', {key_transaction: 'boolean'});
+
+    const wrapper = mountWithTheme(
+      renderer(data, {location, organization}),
+      context.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    let value;
+
+    value = wrapper.find('IconStar');
+    expect(value).toHaveLength(1);
+    expect(value.props().isSolid).toBeTruthy();
+
+    wrapper.find('Button').simulate('click');
+    await tick();
+    wrapper.update();
+
+    value = wrapper.find('IconStar');
+    expect(value).toHaveLength(1);
+    expect(value.props().isSolid).toBeFalsy();
+
+    wrapper.find('Button').simulate('click');
+    await tick();
+    wrapper.update();
+
+    value = wrapper.find('IconStar');
+    expect(value).toHaveLength(1);
+    expect(value.props().isSolid).toBeTruthy();
   });
 });


### PR DESCRIPTION
The star in key transactions column should be clickable to allow users to
mark/unmark a transaction as a key transaction.