### PR TITLE
feat(integration-platform): adds the api_token_is_sentry_app tag for discover

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -163,6 +163,7 @@ class TokenAuthentication(StandardAuthentication):
         with configure_scope() as scope:
             scope.set_tag("api_token_type", self.token_name)
             scope.set_tag("api_token", token.id)
+            scope.set_tag("api_token_is_sentry_app", getattr(token.user, "is_sentry_app", False))
 
         return (token.user, token)
 


### PR DESCRIPTION
This PR sets the `api_token_is_sentry_app` tag where we use the `TokenAuthentication` class so we can track how many requests come from integration tokens.