### PR TITLE
fix(bitbucket): Fix repo lookup when workspace name has changed

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -91,8 +91,9 @@ class BitbucketIntegration(IntegrationInstallation, BitbucketIssueBasicMixin, Re
         return data.get("error", {}).get("message", "unknown error")
 
     def get_repositories(self, query=None):
+        username = self.model.metadata.get("uuid", self.username)
         if not query:
-            resp = self.get_client().get_repos(self.model.metadata.get("uuid", self.username))
+            resp = self.get_client().get_repos(username)
             return [
                 {"identifier": repo["full_name"], "name": repo["full_name"]}
                 for repo in resp.get("values", [])
@@ -100,12 +101,8 @@ class BitbucketIntegration(IntegrationInstallation, BitbucketIssueBasicMixin, Re
 
         exact_query = (u'name="%s"' % (query)).encode("utf-8")
         fuzzy_query = (u'name~"%s"' % (query)).encode("utf-8")
-        exact_search_resp = self.get_client().search_repositories(
-            self.model.metadata.get("uuid", self.username), exact_query
-        )
-        fuzzy_search_resp = self.get_client().search_repositories(
-            self.model.metadata.get("uuid", self.username), fuzzy_query
-        )
+        exact_search_resp = self.get_client().search_repositories(username, exact_query)
+        fuzzy_search_resp = self.get_client().search_repositories(username, fuzzy_query)
 
         result = OrderedSet()
 

--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -92,7 +92,7 @@ class BitbucketIntegration(IntegrationInstallation, BitbucketIssueBasicMixin, Re
 
     def get_repositories(self, query=None):
         if not query:
-            resp = self.get_client().get_repos(self.username)
+            resp = self.get_client().get_repos(self.model.metadata.get("uuid", self.username))
             return [
                 {"identifier": repo["full_name"], "name": repo["full_name"]}
                 for repo in resp.get("values", [])
@@ -100,9 +100,12 @@ class BitbucketIntegration(IntegrationInstallation, BitbucketIssueBasicMixin, Re
 
         exact_query = (u'name="%s"' % (query)).encode("utf-8")
         fuzzy_query = (u'name~"%s"' % (query)).encode("utf-8")
-
-        exact_search_resp = self.get_client().search_repositories(self.username, exact_query)
-        fuzzy_search_resp = self.get_client().search_repositories(self.username, fuzzy_query)
+        exact_search_resp = self.get_client().search_repositories(
+            self.model.metadata.get("uuid", self.username), exact_query
+        )
+        fuzzy_search_resp = self.get_client().search_repositories(
+            self.model.metadata.get("uuid", self.username), fuzzy_query
+        )
 
         result = OrderedSet()
 

--- a/tests/sentry/integrations/bitbucket/test_integration.py
+++ b/tests/sentry/integrations/bitbucket/test_integration.py
@@ -7,6 +7,8 @@ from django.core.urlresolvers import reverse
 from sentry.models import Integration
 from sentry.testutils import APITestCase
 
+from six.moves.urllib.parse import quote
+
 
 class BitbucketIntegrationTest(APITestCase):
     def setUp(self):
@@ -28,6 +30,18 @@ class BitbucketIntegrationTest(APITestCase):
         self.path = reverse(
             "sentry-extensions-bitbucket-search", args=[self.organization.slug, self.integration.id]
         )
+
+    @responses.activate
+    def test_get_repositories_with_uuid(self):
+        uuid = "{a21bd75c-0ce2-402d-b70b-e57de6fba4b3}"
+        self.integration.metadata["uuid"] = uuid
+        url = "https://api.bitbucket.org/2.0/repositories/{}".format(quote(uuid))
+        responses.add(
+            responses.GET, url, json={"values": [{"full_name": "sentryuser/stuf"}]},
+        )
+        installation = self.integration.get_installation(self.organization)
+        result = installation.get_repositories()
+        assert result == [{"identifier": u"sentryuser/stuf", "name": u"sentryuser/stuf"}]
 
     @responses.activate
     def test_get_repositories_exact_match(self):


### PR DESCRIPTION
We store the `name` of a Bitbucket integration as either the Bitbucket username or the uuid and then use this value to look up repositories. If the username has changed this lookup will fail, but if we use the uuid it's more reliable since that value doesn't change. Now we'll use the uuid if available and fall back to the username if it's not.

Fixes [SENTRY-GDY](https://sentry.io/organizations/sentry/issues/1664039854/events/latest/?project=1). 