### PR TITLE
feat(search): Surface all `is:` predefined values instead of only first five

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -629,11 +629,11 @@ class SmartSearchBar extends React.Component<Props, State> {
   getPredefinedTagValues = (tag: Tag, query: string): SearchItem[] =>
     (tag.values ?? [])
       .filter(value => value.indexOf(query) > -1)
-      .map(value => ({
+      .map((value, i) => ({
         value,
         desc: value,
         type: 'tag-value',
-        predefined: true,
+        ignoreMaxSearchItems: tag.maxSuggestedValues ? i < tag.maxSuggestedValues : false,
       }));
 
   /**

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -633,6 +633,7 @@ class SmartSearchBar extends React.Component<Props, State> {
         value,
         desc: value,
         type: 'tag-value',
+        predefined: true,
       }));
 
   /**

--- a/src/sentry/static/sentry/app/components/smartSearchBar/types.ts
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/types.ts
@@ -22,6 +22,7 @@ export type SearchItem = {
   desc: string;
   active?: boolean;
   children?: React.ReactNode[];
+  predefined?: boolean;
 };
 
 export type Tag = {

--- a/src/sentry/static/sentry/app/components/smartSearchBar/types.ts
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/types.ts
@@ -22,7 +22,7 @@ export type SearchItem = {
   desc: string;
   active?: boolean;
   children?: React.ReactNode[];
-  predefined?: boolean;
+  ignoreMaxSearchItems?: boolean;
 };
 
 export type Tag = {

--- a/src/sentry/static/sentry/app/components/smartSearchBar/utils.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/utils.tsx
@@ -72,7 +72,9 @@ export function createSearchGroups(
   const activeSearchItem = 0;
 
   if (maxSearchItems && maxSearchItems > 0) {
-    searchItems = searchItems.slice(0, maxSearchItems);
+    searchItems = searchItems.filter(
+      (value: SearchItem, index: number) => index < maxSearchItems || value.predefined
+    );
   }
 
   const searchGroup: SearchGroup = {

--- a/src/sentry/static/sentry/app/components/smartSearchBar/utils.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/utils.tsx
@@ -73,7 +73,8 @@ export function createSearchGroups(
 
   if (maxSearchItems && maxSearchItems > 0) {
     searchItems = searchItems.filter(
-      (value: SearchItem, index: number) => index < maxSearchItems || value.predefined
+      (value: SearchItem, index: number) =>
+        index < maxSearchItems || value.ignoreMaxSearchItems
     );
   }
 

--- a/src/sentry/static/sentry/app/stores/tagStore.tsx
+++ b/src/sentry/static/sentry/app/stores/tagStore.tsx
@@ -73,19 +73,21 @@ const tagStoreConfig: Reflux.StoreDefinition & TagStoreInterface = {
 
   getIssueAttributes() {
     // TODO(mitsuhiko): what do we do with translations here?
+    const isSuggestions = [
+      'resolved',
+      'unresolved',
+      'ignored',
+      'assigned',
+      'unassigned',
+      'linked',
+      'unlinked',
+    ];
     return {
       is: {
         key: 'is',
         name: 'Status',
-        values: [
-          'resolved',
-          'unresolved',
-          'ignored',
-          'assigned',
-          'unassigned',
-          'linked',
-          'unlinked',
-        ],
+        values: isSuggestions,
+        maxSuggestedValues: isSuggestions.length,
         predefined: true,
       },
       has: {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1755,6 +1755,11 @@ export type Tag = {
   totalValues?: number;
   predefined?: boolean;
   isInput?: boolean;
+  /**
+   * How many values should be suggested in autocomplete.
+   * Overrides SmartSearchBar's `maxSearchItems` prop.
+   */
+  maxSuggestedValues?: number;
 };
 
 export type TagCollection = {[key: string]: Tag};


### PR DESCRIPTION
Once #21593 lands, users won't actually realize that this feature is available
due to the fact that `<IssueListSearchBar />` renders
`<SmartSearchBar maxSearchItems={5} />`. To make them more discoverable, we
use `maxSearchItems` as a suggestion and allow exceeding it if the SearchItems
are from a "predefined" tags.

## Before
![image](https://user-images.githubusercontent.com/549473/97192702-62b38500-1765-11eb-961e-257e5987319d.png)

## After
![image](https://user-images.githubusercontent.com/549473/97826332-2fe22300-1c76-11eb-91a8-e043ea00e4f7.png)
