### PR TITLE
chore(dev): avoid ellipsizing descriptions of sentry cli commands

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -2,7 +2,7 @@ beautifulsoup4>=4.7.1,<4.8
 boto3>=1.4.1,<1.4.6
 botocore<1.5.71
 celery==4.4.7
-click>=5.0,<7.0
+click>=7.0,<8.0
 confluent-kafka==1.5.0
 croniter>=0.3.34,<0.4.0
 datadog>=0.15.0,<0.31.0

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -19,7 +19,7 @@ else:
     version_string = "%s (%s)" % (sentry.VERSION, sentry.__build__[:12])
 
 
-@click.group()
+@click.group(context_settings={"max_content_width": 150})
 @click.option(
     "--config",
     default="",

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -63,8 +63,7 @@ def devservices(ctx):
 @click.pass_context
 def attach(ctx, project, fast, service):
     """
-    Run a single devservice in foreground, as opposed to `up` which runs all of
-    them in the background.
+    Run a single devservice in the foreground.
 
     Accepts a single argument, the name of the service to spawn. The service
     will run with output printed to your terminal, and the ability to kill it
@@ -109,7 +108,7 @@ def attach(ctx, project, fast, service):
 @click.pass_context
 def up(ctx, services, project, exclude, fast):
     """
-    Run/update dependent services.
+    Run/update all devservices in the background.
 
     The default is everything, however you may pass positional arguments to specify
     an explicit list of services to bring up.


### PR DESCRIPTION
`src/sentry/runner/` docstrings often exceed 80 characters, which results in
ellipsized messages when navigating the help text via the `sentry` cli. To
avoid this, we bump the max_width to 150 characters, and upgrade to click>=7.0
for bug fixes that cause this to be respected.

## Example output
```
$ sentry
Usage: sentry [OPTIONS] COMMAND [ARGS]...

  Sentry is cross-platform crash reporting built with love.

  The configuration file is looked up in the `~/.sentry` config directory but this can be
  overridden with the `SENTRY_CONF` environment variable or be explicitly provided through the
  `--config` parameter.

Options:
  --config PATH  Path to configuration files.
  --version      Show the version and exit.
  --help         Show this message and exit.

Commands:
  cleanup      Delete a portion of trailing data based on creation date.
  config       Manage runtime config options.
  createuser   Create a new user.
  devserver    Starts a lightweight web server for development.
  devservices  Manage dependent development services required for Sentry.
  django       Execute Django subcommands.
  exec         Execute a script.
  export       Exports core metadata for the Sentry installation.
  files        Manage files from filestore.
  help         Show this message and exit.
  import       Imports data from a Sentry export.
  init         Initialize new configuration directory.
  migrations   Manage migrations.
  permissions  Manage Permissions for Users.
  plugins      Manage Sentry plugins.
  queues       Manage Sentry queues.
  repair       Attempt to repair any invalid data.
  run          Run a service.
  shell        Run a Python interactive interpreter.
  start        DEPRECATED see `sentry run` instead.
  tsdb         Tools for interacting with the time series database.
  upgrade      Perform any pending database migrations and upgrades.
```

```
$ sentry devservices
Usage: sentry devservices [OPTIONS] COMMAND [ARGS]...

  Manage dependent development services required for Sentry.

  Do not use in production!

Options:
  --help  Show this message and exit.

Commands:
  attach  Run a single devservice in the foreground.
  down    Shut down services without deleting their underlying containers and data.
  rm      Shut down and delete all services and associated data.
  up      Run/update all devservices in the background.
```