### PR TITLE
ref(api-docs): Remove ampersand from 'cursor' param query

### DIFF
--- a/api-docs/components/parameters/pagination-cursor.json
+++ b/api-docs/components/parameters/pagination-cursor.json
@@ -1,6 +1,6 @@
 {
   "PaginationCursor": {
-    "name": "&cursor",
+    "name": "cursor",
     "in": "query",
     "required": false,
     "description": "A pointer to the last object fetched and its' sort order; used to retrieve the next or previous results.",


### PR DESCRIPTION
## Objective
Docs out-of-date with wrong param query `&cursor`. It should just be `cursor`.