### PR TITLE
build(gha): Refactor "check migration" workflow to use `setup-sentry` action

### DIFF
--- a/.github/workflows/check-if-migration-is-required.yml
+++ b/.github/workflows/check-if-migration-is-required.yml
@@ -8,54 +8,16 @@ on:
 
 jobs:
   main:
+    name: is migration required
     runs-on: ubuntu-16.04
 
-    env:
-      PIP_DISABLE_PIP_VERSION_CHECK: on
-      SENTRY_LIGHT_BUILD: 1
-      SENTRY_SKIP_BACKEND_VALIDATION: 1
-      MIGRATIONS_TEST_MIGRATE: 0
-
-      # The hostname used to communicate with the PostgreSQL from sentry
-      DATABASE_URL: postgresql://postgres:postgres@localhost/sentry
-
-    services:
-      postgres:
-        image: postgres:9.6
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-        ports:
-          # Maps tcp port 5432 on service container to the host
-          - 5432:5432
-        # needed because the postgres container does not provide a healthcheck
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
-      - name: Install System Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libxmlsec1-dev \
-            libmaxminddb-dev
-
       - uses: actions/checkout@v2
 
-      - name: Set up outputs
-        id: config
-        env:
-          MATRIX_INSTANCE: ${{ matrix.instance }}
-        run: |
-          echo "::set-output name=python-version::2.7.17"
-
-      - name: Set up Python ${{ steps.config.outputs.python-version }}
-        uses: actions/setup-python@v2
+      # Until GH composite actions can use `uses`, we need to setup python here
+      - uses: actions/setup-python@v2
         with:
-          python-version: ${{ steps.config.outputs.python-version}}
+          python-version: 2.7.17
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip
@@ -69,15 +31,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Install Python Dependencies
-        env:
-          PGPASSWORD: postgres
-        run: |
-          python setup.py install_egg_info
-          pip install wheel # GitHub Actions does not have this installed by default (unlike Travis)
-          pip install -U -e ".[dev]"
-          psql -c 'create database sentry;' -h localhost -U postgres
-          sentry init
+      - name: Setup sentry env
+        uses: ./.github/actions/setup-sentry
+        id: setup
+        with:
+          python: 2
 
       - name: Check if a migration is required
         env:


### PR DESCRIPTION
This refactors the "check migration" workflow to use the `setup-sentry` action.