### PR TITLE
ref(projects) Improve the project dashboard charts

### DIFF
--- a/src/sentry/static/sentry/app/views/projectsDashboard/noEvents.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/noEvents.tsx
@@ -3,9 +3,13 @@ import styled from '@emotion/styled';
 
 import {t} from 'app/locale';
 
-const NoEvents = () => (
+type Props = {
+  seriesCount: number;
+};
+
+const NoEvents = ({seriesCount}: Props) => (
   <Container>
-    <EmptyText>{t('No activity yet.')}</EmptyText>
+    <EmptyText seriesCount={seriesCount}>{t('No activity yet.')}</EmptyText>
   </Container>
 );
 
@@ -15,15 +19,16 @@ const Container = styled('div')`
   position: absolute;
   top: 0;
   left: 0;
+  bottom: 0;
   right: 0;
 `;
 
-const EmptyText = styled('div')`
+const EmptyText = styled('div')<Props>`
   display: flex;
   align-items: center;
   justify-content: center;
   margin-left: 4px;
   margin-right: 4px;
-  height: 120px;
+  height: ${p => (p.seriesCount > 1 ? '90px' : '150px')};
   color: ${p => p.theme.gray500};
 `;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
@@ -21,7 +21,6 @@ import QuestionTooltip from 'app/components/questionTooltip';
 
 import Chart from './chart';
 import Deploys from './deploys';
-import NoEvents from './noEvents';
 
 type Props = {
   api: Client;
@@ -56,7 +55,7 @@ class ProjectCard extends React.Component<Props> {
 
   render() {
     const {organization, project, hasProjectAccess} = this.props;
-    const {id, firstEvent, stats, slug, transactionStats} = project;
+    const {id, stats, slug, transactionStats} = project;
     const totalErrors =
       stats !== undefined
         ? formatAbbreviatedNumber(stats.reduce((sum, [_, value]) => sum + value, 0))
@@ -69,6 +68,7 @@ class ProjectCard extends React.Component<Props> {
           )
         : '\u2014';
     const zeroTransactions = totalTransactions === '0';
+    const hasFirstEvent = project.firstEvent || project.firstTransactionEvent;
 
     return (
       <div data-test-id={slug}>
@@ -124,8 +124,11 @@ class ProjectCard extends React.Component<Props> {
               </SummaryLinks>
             </CardHeader>
             <ChartContainer>
-              <Chart stats={stats} transactionStats={transactionStats} />
-              {!firstEvent && <NoEvents />}
+              <Chart
+                firstEvent={hasFirstEvent}
+                stats={stats}
+                transactionStats={transactionStats}
+              />
             </ChartContainer>
             <Deploys project={project} />
           </StyledProjectCard>
@@ -193,7 +196,6 @@ const ProjectCardContainer = createReactClass<ContainerProps, ContainerState>({
 const ChartContainer = styled('div')`
   position: relative;
   background: ${p => p.theme.gray100};
-  padding-top: ${space(1)};
 `;
 
 const CardHeader = styled('div')`
@@ -216,7 +218,7 @@ const StyledProjectCard = styled('div')`
 const LoadingCard = styled('div')`
   border: 1px solid transparent;
   background-color: ${p => p.theme.gray100};
-  height: 265px;
+  height: 334px;
 `;
 
 const StyledIdBadge = styled(IdBadge)`

--- a/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
@@ -68,7 +68,7 @@ class ProjectCard extends React.Component<Props> {
           )
         : '\u2014';
     const zeroTransactions = totalTransactions === '0';
-    const hasFirstEvent = project.firstEvent || project.firstTransactionEvent;
+    const hasFirstEvent = Boolean(project.firstEvent || project.firstTransactionEvent);
 
     return (
       <div data-test-id={slug}>


### PR DESCRIPTION
Split the axes for transactions and errors. Having the data overlapping leads to users drawing false conclusions. Split charts are simpler to parse and correlate data. To further help understanding the data at a glance high water mark values are indicated in the chart y-axis. Hopefully this lets people more quickly see if something terrible has happened.

I moved the NoEvents component around so that the empty text could be positioned in a way that wouldn't overlap one of the chart axes.

#### Empty state with transactions and errors
![Screen Shot 2020-11-02 at 4 13 47 PM](https://user-images.githubusercontent.com/24086/97920880-21544400-1d28-11eb-9b99-8586d164d75c.png)

#### Empty state with only errors.
![Screen Shot 2020-11-02 at 4 27 21 PM](https://user-images.githubusercontent.com/24086/97921018-52347900-1d28-11eb-867f-8fc918156ab8.png)

#### Transactions & Errors with Data
![Screen Shot 2020-11-02 at 3 32 28 PM](https://user-images.githubusercontent.com/24086/97921206-9aec3200-1d28-11eb-822b-aedc525e36ef.png)

