### PR TITLE
feat(select): Add support for using react-select with grouped options

### DIFF
--- a/docs-ui/components/form-fields.stories.js
+++ b/docs-ui/components/form-fields.stories.js
@@ -236,6 +236,38 @@ SelectFieldMultiple.story = {
   name: 'SelectField multiple',
 };
 
+export const SelectFieldGrouped = withInfo({
+  text: 'Select Control w/ Groups',
+  propTablesExclude: [Form],
+})(() => (
+  <Form>
+    <SelectField
+      name="select"
+      label="Grouped Select"
+      options={[
+        {
+          label: 'Group 1',
+          options: [
+            {value: 'choice_one', label: 'Choice One'},
+            {value: 'choice_two', label: 'Choice Two'},
+          ],
+        },
+        {
+          label: 'Group 2',
+          options: [
+            {value: 'choice_three', label: 'Choice Three'},
+            {value: 'choice_four', label: 'Choice Four'},
+          ],
+        },
+      ]}
+    />
+  </Form>
+));
+
+SelectFieldGrouped.story = {
+  name: 'SelectField grouped',
+};
+
 export const NonInlineField = withInfo({
   text: 'Radio Group used w/ FormField',
   propTablesExclude: [Form],

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -4,6 +4,7 @@ import Async from 'react-select/async';
 import Creatable from 'react-select/creatable';
 import AsyncCreatable from 'react-select/async-creatable';
 
+import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 import {IconChevron, IconClose} from 'app/icons';
 import convertFromSelect2Choices from 'app/utils/convertFromSelect2Choices';
@@ -148,6 +149,19 @@ const defaultStyles = {
   clearIndicator: indicatorStyles,
   dropdownIndicator: indicatorStyles,
   loadingIndicator: indicatorStyles,
+  groupHeading: provided => ({
+    ...provided,
+    lineHeight: '1.5',
+    fontWeight: '600',
+    backgroundColor: theme.gray200,
+    color: theme.gray700,
+    marginBottom: 0,
+    padding: `${space(1)} ${space(1.5)}`,
+  }),
+  group: provided => ({
+    ...provided,
+    padding: 0,
+  }),
 };
 
 const SelectControl = props => {
@@ -186,10 +200,11 @@ const SelectControl = props => {
      * because the select component fetches the options finding the mappedValue will fail
      * and the component won't work
      */
+    const flatOptions = choicesOrOptions.flatMap(option => option.options || option);
     mappedValue =
       props.multiple && Array.isArray(value)
-        ? value.map(val => choicesOrOptions.find(option => option.value === val))
-        : choicesOrOptions.find(opt => opt.value === value) || value;
+        ? value.map(val => flatOptions.find(option => option.value === val))
+        : flatOptions.find(opt => opt.value === value) || value;
   }
 
   // Allow the provided `styles` prop to override default styles using the same

--- a/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
@@ -18,6 +18,7 @@ export default class SelectField extends React.Component {
   static propTypes = {
     ...InputField.propTypes,
     choices: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
+    options: PropTypes.arrayOf(PropTypes.object),
     allowClear: PropTypes.bool,
     allowEmpty: PropTypes.bool,
     multiple: PropTypes.bool,


### PR DESCRIPTION
In the new metric alert builder UI we plan to use a react-select component that utilizes GroupHeadings, for example: Errors, Transactions
<img src="https://user-images.githubusercontent.com/9372512/97923480-0e437300-1d2c-11eb-955e-aad6359bc341.png" width="300"/>

This PR adds functionality to use a new nested options format, and adds a grouped react-select story to storybook 'Selectfield grouped'

WOR-405 #done completed