### PR TITLE
fix: Reserve "trust" and "legal" as org slug, not project slugs

### DIFF
--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -153,6 +153,8 @@ RESERVED_ORGANIZATION_SLUGS = frozenset(
         "sentry-apps",
         "resources",
         "integration-platform",
+        "trust",
+        "legal",
     )
 )
 
@@ -175,8 +177,6 @@ RESERVED_PROJECT_SLUGS = frozenset(
         "integrations",
         "developer-settings",
         "usage",
-        "trust",
-        "legal",
     )
 )
 


### PR DESCRIPTION
In #21603 I mistakenly added my org slug reservation to the project slug array. Lol all those approvals.