### PR TITLE
feat(ui): Remove "is:muted" recommendation from tag store

### DIFF
--- a/src/sentry/static/sentry/app/stores/tagStore.tsx
+++ b/src/sentry/static/sentry/app/stores/tagStore.tsx
@@ -78,15 +78,7 @@ const tagStoreConfig: Reflux.StoreDefinition & TagStoreInterface = {
       is: {
         key: 'is',
         name: 'Status',
-        values: [
-          'resolved',
-          'unresolved',
-          'ignored',
-          // TODO(dcramer): remove muted once data is migrated and 9.0+
-          'muted',
-          'assigned',
-          'unassigned',
-        ],
+        values: ['resolved', 'unresolved', 'ignored', 'assigned', 'unassigned'],
         predefined: true,
       },
       has: {


### PR DESCRIPTION
Trying to clean up the number of options. Will no longer autocomplete "is:muted" query which should be the same as "is:ignored"