### PR TITLE
feat(Jira): Create Jira ticket based on alert rule

### DIFF
--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -11,74 +11,29 @@ logger = logging.getLogger("sentry.rules")
 
 
 class JiraNotifyServiceForm(forms.Form):
-    jira_project = forms.ChoiceField(choices=(), widget=forms.Select())
-    issue_type = forms.ChoiceField(choices=(), widget=forms.Select())
+    # TODO 1.0 Add form fields.
 
     def __init__(self, *args, **kwargs):
-        projects_list = [(i.id, i.name) for i in kwargs.pop("integrations")]
         super(JiraNotifyServiceForm, self).__init__(*args, **kwargs)
-
-        if projects_list:
-            self.fields["jira_project"].initial = projects_list[0][0]
-
-        self.fields["jira_project"].choices = projects_list
-        self.fields["jira_project"].widget.choices = self.fields["jira_project"].choices
-
-        self.fields["issuetype"].choices = HARDCODED_ISSUE_TYPES
-        self.fields["issuetype"].widget.choices = self.fields["issuetype"].choices
 
     def clean(self):
         return super(JiraNotifyServiceForm, self).clean()
 
 
-# TODO instead of hard-coding things, lets automatically select the first integration.
-HARDCODED_ISSUE_TYPES = [
-    ("Bug", "Bug"),
-    ("Issue", "Issue"),
-    ("Task", "Task"),
-]
-
-
 class JiraCreateTicketAction(IntegrationEventAction):
     form_cls = JiraNotifyServiceForm
-    label = u"TODO Create a {jira_integration} {jira_project} Jira ticket, name: {name} type: {issuetype}!"
+    label = u"TODO Create a {name} Jira ticket"
     prompt = "Create a Jira ticket"
     provider = "jira"
     integration_key = "jira_integration"
 
     def __init__(self, *args, **kwargs):
         super(JiraCreateTicketAction, self).__init__(*args, **kwargs)
-        all_integrations = self.get_integrations()
-        integration_choices = [(i.id, i.name) for i in all_integrations]
-
-        self.form_fields = {
-            "jira_integration": {
-                "type": "choice",
-                "choices": integration_choices,
-                "default": integration_choices[0][0],
-                "updatesForm": True,
-            },
-            "jira_project": {
-                "type": "choice",
-                "choices": integration_choices,
-                "default": integration_choices[0][0],
-                "updatesForm": True,
-            },
-            "issuetype": {
-                "type": "choice",
-                "choices": HARDCODED_ISSUE_TYPES,
-                "default": HARDCODED_ISSUE_TYPES[0][0],
-            },
-            "name": {"type": "string"},
-        }
+        # TODO 1.1 Add form_fields
+        self.form_fields = {}
 
     def render_label(self):
-        return self.label.format(
-            name=self.get_integration_name(),
-            jira_integration="JIRA",
-            jira_project="JIRA",
-            issue_type="Bug",
-        )
+        return self.label.format(name=self.get_integration_name())
 
     def after(self, event, state):
         integration = self.get_integration()

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -6,6 +6,8 @@ from django import forms
 
 from sentry.rules.actions.base import IntegrationEventAction
 
+from sentry.models.integration import Integration
+
 logger = logging.getLogger("sentry.rules")
 
 
@@ -35,4 +37,30 @@ class JiraCreateTicketAction(IntegrationEventAction):
         return self.label.format(name=self.get_integration_name())
 
     def after(self, event, state):
-        pass
+        """Create the Jira ticket for a given event"""
+
+        MOCK_DATA = {
+            "priority": "1",
+            "labels": "fuzzy",
+            "description": "Sentry Issue: [GOODGIRLHB-1|https://meowlificent.ngrok.io/organizations/sentry/issues/506/?referrer=jira_integration]\n\n{code}\nTypeError: Object [object Object] has no method 'updateFrom'\n  at poll (../../sentry/scripts/views.js:389:46)\n  at merge (../../sentry/scripts/views.js:268:16)\n  at member (../../sentry/scripts/views.js:283:50)\n\nThis is an example JavaScript exception\n{code}",
+            u"title": u"TypeError: Object [object Object] has no method 'updateFrom'",
+            "reporter": "5ab0069933719f2a50168cab",
+            "fixVersions": "",
+            "project": "10000",
+            "assignee": "5ab0069933719f2a50168cab",
+            "components": "",
+            "issuetype": "10002",
+        }
+        # TODO replace mock data with data we get from the form
+
+        # integration = self.get_integration()
+        integration = Integration.objects.get(
+            provider="jira"
+        )  # this is obviously brittle but get_integration wasn't finding it TODO make this less stupid
+        installation = integration.get_installation(self.project.organization.id)
+        # call integration.py's create_issue given the form field data
+        # this fn takes the form data and cleans it up into the format Jira wants
+        # then hits the API to create an issue
+
+        # TODO check if a Jira ticket already exists for the given event's issue. if it does, skip creating it
+        return installation.create_issue(MOCK_DATA)

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -6,6 +6,7 @@ from django import forms
 
 from sentry.rules.actions.base import IntegrationEventAction
 from sentry.models import ExternalIssue
+from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger("sentry.rules")
 
@@ -35,12 +36,22 @@ class JiraCreateTicketAction(IntegrationEventAction):
     def render_label(self):
         return self.label.format(name=self.get_integration_name())
 
+    def build_description(self, event, installation):
+        rule_url = u"/organizations/{}/alerts/rules/{}/{}/".format(
+            self.project.organization.slug, self.project.slug, self.rule.id
+        )
+        footer = u"This ticket was automatically created by Sentry via [{}|{}]".format(
+            self.rule.label, absolute_uri(rule_url),
+        )
+        return installation.get_group_description(event.group, event) + footer
+
     def after(self, event, state):
+        organization = self.project.organization
         integration = self.get_integration()
-        installation = integration.get_installation(self.project.organization.id)
+        installation = integration.get_installation(organization.id)
 
         self.data["title"] = event.title
-        self.data["description"] = installation.get_group_description(event.group, event)
+        self.data["description"] = self.build_description(event, installation)
 
         def create_issue(event, futures):
             """Create the Jira ticket for a given event"""
@@ -48,9 +59,11 @@ class JiraCreateTicketAction(IntegrationEventAction):
             # TODO check if a Jira ticket already exists for the given event's issue. if it does, skip creating it
             resp = installation.create_issue(self.data)
             ExternalIssue.objects.create(
-                organization_id=self.project.organization.id,
+                organization_id=organization.id,
                 integration_id=integration.id,
                 key=resp["key"],
+                title=event.title,
+                description=installation.get_group_description(event.group, event),
             )
             return
 

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -12,29 +12,74 @@ logger = logging.getLogger("sentry.rules")
 
 
 class JiraNotifyServiceForm(forms.Form):
-    # TODO 1.0 Add form fields.
+    jira_project = forms.ChoiceField(choices=(), widget=forms.Select())
+    issue_type = forms.ChoiceField(choices=(), widget=forms.Select())
 
     def __init__(self, *args, **kwargs):
+        projects_list = [(i.id, i.name) for i in kwargs.pop("integrations")]
         super(JiraNotifyServiceForm, self).__init__(*args, **kwargs)
+
+        if projects_list:
+            self.fields["jira_project"].initial = projects_list[0][0]
+
+        self.fields["jira_project"].choices = projects_list
+        self.fields["jira_project"].widget.choices = self.fields["jira_project"].choices
+
+        self.fields["issue_type"].choices = HARDCODED_ISSUE_TYPES
+        self.fields["issue_type"].widget.choices = self.fields["issue_type"].choices
 
     def clean(self):
         return super(JiraNotifyServiceForm, self).clean()
 
 
+# TODO instead of hard-coding things, lets automatically select the first integration.
+HARDCODED_ISSUE_TYPES = [
+    ("Bug", "Bug"),
+    ("Issue", "Issue"),
+    ("Task", "Task"),
+]
+
+
 class JiraCreateTicketAction(IntegrationEventAction):
     form_cls = JiraNotifyServiceForm
-    label = u"TODO Create a {name} Jira ticket"
+    label = u"TODO Create a {jira_integration} {jira_project} Jira ticket, name: {name} type: {issue_type}!"
     prompt = "Create a Jira ticket"
     provider = "jira"
     integration_key = "jira_project"
 
     def __init__(self, *args, **kwargs):
         super(JiraCreateTicketAction, self).__init__(*args, **kwargs)
-        # TODO 1.1 Add form_fields
-        self.form_fields = {}
+        all_integrations = self.get_integrations()
+        integration_choices = [(i.id, i.name) for i in all_integrations]
+
+        self.form_fields = {
+            "jira_integration": {
+                "type": "choice",
+                "choices": integration_choices,
+                "default": integration_choices[0][0],
+                "updatesForm": True,
+            },
+            "jira_project": {
+                "type": "choice",
+                "choices": integration_choices,
+                "default": integration_choices[0][0],
+                "updatesForm": True,
+            },
+            "issue_type": {
+                "type": "choice",
+                "choices": HARDCODED_ISSUE_TYPES,
+                "default": HARDCODED_ISSUE_TYPES[0][0],
+            },
+            "name": {"type": "string"},
+        }
 
     def render_label(self):
-        return self.label.format(name=self.get_integration_name())
+        return self.label.format(
+            name=self.get_integration_name(),
+            jira_integration="JIRA",
+            jira_project="JIRA",
+            issue_type="Bug",
+        )
 
     def after(self, event, state):
         """Create the Jira ticket for a given event"""

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -84,6 +84,9 @@ class JiraCreateTicketAction(IntegrationEventAction):
         integration = self.get_integration()
         installation = integration.get_installation(self.project.organization.id)
 
+        self.data["title"] = event.title
+        self.data["description"] = installation.get_group_description(event.group, event)
+
         def create_issue(event, futures):
             """Create the Jira ticket for a given event"""
 

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -81,23 +81,6 @@ class JiraCreateTicketAction(IntegrationEventAction):
         )
 
     def after(self, event, state):
-        # MOCK_DATA = {
-        #     "priority": "1",
-        #     "labels": "fuzzy",
-        #     "description": "here is some stuff",
-        #     u"title": u"make a different issue",
-        #     "reporter": "5ab0069933719f2a50168cab",
-        #     "fixVersions": "",
-        #     "project": "10000",
-        #     "assignee": "5ab0069933719f2a50168cab",
-        #     "components": "",
-        #     "issuetype": "10002",
-        # }
-        # print("event:", dir(event.group))
-        # form data in event actions?
-        # state is just the state of the event's issue like 'has_reappeared', 'is_new', 'is_new_group_environment', 'is_regression'
-        # TODO replace mock data with data we get from the form
-        # print("data: ", self.data)
         integration = self.get_integration()
         installation = integration.get_installation(self.project.organization.id)
 
@@ -105,7 +88,7 @@ class JiraCreateTicketAction(IntegrationEventAction):
             """Create the Jira ticket for a given event"""
 
             # TODO check if a Jira ticket already exists for the given event's issue. if it does, skip creating it
-            resp = installation.create_issue(self.data)  # MOCK_DATA
+            resp = installation.create_issue(self.data)
             ExternalIssue.objects.create(
                 organization_id=self.project.organization.id,
                 integration_id=integration.id,

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -65,7 +65,7 @@ class IntegrationEventAction(EventAction):
         :raises: Integration.DoesNotExist
         :return: Integration
         """
-        return Integration.objects.filter(
+        return Integration.objects.get(
             id=self.get_option(self.integration_key),
             provider=self.provider,
             organizations=self.project.organization,

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -13,7 +13,6 @@ class JiraCreateTicketActionTest(RuleTestCase):
     rule_cls = JiraCreateTicketAction
 
     def setUp(self):
-
         self.integration = Integration.objects.create(
             provider="jira",
             name="Jira Cloud",
@@ -26,11 +25,28 @@ class JiraCreateTicketActionTest(RuleTestCase):
         )
         self.integration.add_organization(self.organization, self.user)
         self.installation = self.integration.get_installation(self.organization.id)
+        print("integration id: ", self.integration.id)
 
     @responses.activate
     def test_creates_issue(self):
         event = self.get_event()
-        rule = self.get_rule(data={"account": self.integration.id})
+        rule = self.get_rule(
+            data={
+                "priority": "1",
+                "labels": "fuzzy",
+                "description": "here is some stuff",
+                "title": "make a different issue",
+                "reporter": "5ab0069933719f2a50168cab",
+                "fixVersions": "",
+                "project": "10000",
+                "assignee": "5ab0069933719f2a50168cab",
+                "components": "",
+                "issuetype": "10002",
+                "jira_integration": 1,
+                "jira_project": "10000",
+                "issue_type": "Bug",
+            }
+        )
         responses.add(
             responses.GET,
             "https://example.atlassian.net/rest/api/2/issue/createmeta",
@@ -46,20 +62,35 @@ class JiraCreateTicketActionTest(RuleTestCase):
             match_querystring=False,
         )
 
-        def responder(request):
-            body = json.loads(request.body)
-            assert body["fields"]["labels"] == [
-                "fuzzy"
-            ]  # this is based on MOCK_DATA and will likely change
+        # def responder(request):
+        #     body = json.loads(request.body)
+        #     return (200, {"content-type": "application/json"}, '{"key":"APP-123"}')
 
-            return (200, {"content-type": "application/json"}, '{"key":"APP-123"}')
-
-        responses.add_callback(
-            responses.POST,
-            "https://example.atlassian.net/rest/api/2/issue",
-            callback=responder,
-            match_querystring=False,
+        # responses.add_callback(
+        #     responses.POST,
+        #     "https://example.atlassian.net/rest/api/2/issue",
+        #     callback=responder,
+        #     match_querystring=False,
+        # )
+        responses.add(
+            method=responses.POST,
+            url="https://example.atlassian.net/rest/api/2/issue",
+            json={"key": "APP-123"},
+            status=202,
+            content_type="application/json",
         )
-        results = rule.after(event=event, state=self.get_state())
+        results = list(rule.after(event=event, state=self.get_state()))
+        assert len(results) == 1
+        print("results:", results)
 
-        assert results["key"]  # existence of a key means the issue was created
+        # Trigger rule callback
+        results[0].callback(event, futures=[])
+        data = json.loads(responses.calls[1].request.body)
+
+        assert data["fields"]["issuetype"]["id"] == "10002"
+        assert data["fields"]["labels"] == ["fuzzy"]
+        # should there be more fields? this is all that comes back despite all that I put in
+        # though I'm not positive those were correct
+        assert False
+
+        # assert that external issue entry was created

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -1,0 +1,65 @@
+from __future__ import absolute_import
+
+import responses
+
+from sentry.utils import json
+from sentry.models import Integration
+from sentry.testutils.cases import RuleTestCase
+from sentry.integrations.jira.notify_action import JiraCreateTicketAction
+from test_integration import SAMPLE_CREATE_META_RESPONSE, SAMPLE_GET_ISSUE_RESPONSE
+
+
+class JiraCreateTicketActionTest(RuleTestCase):
+    rule_cls = JiraCreateTicketAction
+
+    def setUp(self):
+
+        self.integration = Integration.objects.create(
+            provider="jira",
+            name="Jira Cloud",
+            metadata={
+                "oauth_client_id": "oauth-client-id",
+                "shared_secret": "a-super-secret-key-from-atlassian",
+                "base_url": "https://example.atlassian.net",
+                "domain_name": "example.atlassian.net",
+            },
+        )
+        self.integration.add_organization(self.organization, self.user)
+        self.installation = self.integration.get_installation(self.organization.id)
+
+    @responses.activate
+    def test_creates_issue(self):
+        event = self.get_event()
+        rule = self.get_rule(data={"account": self.integration.id})
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/issue/createmeta",
+            body=SAMPLE_CREATE_META_RESPONSE,
+            content_type="json",
+            match_querystring=False,
+        )
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/issue/APP-123",
+            body=SAMPLE_GET_ISSUE_RESPONSE,
+            content_type="json",
+            match_querystring=False,
+        )
+
+        def responder(request):
+            body = json.loads(request.body)
+            assert body["fields"]["labels"] == [
+                "fuzzy"
+            ]  # this is based on MOCK_DATA and will likely change
+
+            return (200, {"content-type": "application/json"}, '{"key":"APP-123"}')
+
+        responses.add_callback(
+            responses.POST,
+            "https://example.atlassian.net/rest/api/2/issue",
+            callback=responder,
+            match_querystring=False,
+        )
+        results = rule.after(event=event, state=self.get_state())
+
+        assert results["key"]  # existence of a key means the issue was created


### PR DESCRIPTION
**Context**
The ecosystem team is working on a feature that will let users set up rules similar to alert rules that will create Jira and Azure DevOps tickets if the criteria in the rule is met. This is an oft requested feature that somewhat exists on the old Jira plugin (except that creates a ticket on every new issue).

**This PR**
When a Jira alert rule has been triggered, create a Jira ticket using the form fields the user has provided when creating the rule. This also creates an instance of an `ExternalIssue` using the key of the created Jira ticket. There's also a note in the description of the Jira ticket that says "This ticket was automatically created by Sentry via {name of rule}." which links back to the rule.

![Screen Shot 2020-11-06 at 2 11 09 PM](https://user-images.githubusercontent.com/29959063/98419465-f4f73b00-2039-11eb-9f80-b874fd737a99.png)
