### PR TITLE
fix(jira): make issue type required if we have any options for it

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -565,6 +565,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                     "type": "select",
                     "choices": issue_type_choices,
                     "updatesForm": True,
+                    "required": bool(issue_type_choices),  # required if we have any choices
                 }
             ]
         )

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -565,7 +565,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                     "type": "select",
                     "choices": issue_type_choices,
                     "updatesForm": True,
-                    "required": bool(issue_type_choices),  # required if we have any choices
+                    "required": bool(issue_type_choices),  # required if we have any type choices
                 }
             ]
         )

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -516,6 +516,7 @@ class JiraIntegrationTest(APITestCase):
                     "name": "issuetype",
                     "label": "Issue Type",
                     "updatesForm": True,
+                    "required": True,
                 },
                 {
                     "required": False,


### PR DESCRIPTION
This PR fixes a bug where pressing "create issue" on a next-gen Jira project fails after switching from another project. See error:

![Screen Shot 2020-11-02 at 4 34 52 PM](https://user-images.githubusercontent.com/8533851/97934045-5b721580-1d29-11eb-93cb-801a76164927.png)

This is happening because the selected `issuetype` doesn't exist in the new project that's being selected. The form ends up submitting a request with a bad `issuetype` and we get validation errors that don't make sense. The easiest solution is to just make the `issuetype` required to force the user to pick a drop-down option that already exists. But to make sure we don't introduce a bug, I am making it required only if we have options for `issuetype` available. But it seems unlikely for there to be no options for this field.

Note that if the `issuetype` exists for the project we are switching to, the user does not need to update the dropdown.