### PR TITLE
ref(buffer): Add process_model method

### DIFF
--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -55,6 +55,11 @@ class Buffer(Service):
     def process_pending(self, partition=None):
         return []
 
+    def process_model(self, model, columns, filters, extra=None, signal_only=None):
+        return self.process(
+            model=model, columns=columns, filters=filters, extra=extra, signal_only=signal_only
+        )
+
     def process(self, model, columns, filters, extra=None, signal_only=None):
         from sentry.models import Group
         from sentry.event_manager import ScoreClause

--- a/src/sentry/buffer/redis.py
+++ b/src/sentry/buffer/redis.py
@@ -309,6 +309,17 @@ class RedisBuffer(Buffer):
                 elif k == "s":
                     signal_only = bool(int(v))  # Should be 1 if set
 
-            super(RedisBuffer, self).process(model, incr_values, filters, extra_values, signal_only)
+            self.process_model(
+                model=model,
+                columns=incr_values,
+                filters=filters,
+                extra=extra_values,
+                signal_only=signal_only,
+            )
         finally:
             client.delete(lock_key)
+
+    def process_model(self, model, columns, filters, extra=None, signal_only=None):
+        return super(RedisBuffer, self).process(
+            model=model, columns=columns, filters=filters, extra=extra, signal_only=signal_only
+        )


### PR DESCRIPTION
To allow buffer service's processing implementation to be called directly e.g.
in case of RedisBuffer which expose only processing functionality that requires
Redis ops.