### PR TITLE
fix(discover): pXX functions should use first argument as return type

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -19,6 +19,7 @@ import {
   ColumnType,
   AGGREGATIONS,
   FIELDS,
+  aggregateFunctionOutputType,
   explodeFieldString,
   getAggregateAlias,
   TRACING_FIELDS,
@@ -64,14 +65,11 @@ export function decodeColumnOrder(
     if (col.kind === 'function') {
       // Aggregations can have a strict outputType or they can inherit from their field.
       // Otherwise use the FIELDS data to infer types.
-      const aggregate = AGGREGATIONS[col.function[0]];
-      if (aggregate && aggregate.outputType) {
-        column.type = aggregate.outputType;
-      } else if (FIELDS.hasOwnProperty(col.function[1])) {
-        column.type = FIELDS[col.function[1]];
-      } else if (isMeasurement(col.function[1])) {
-        column.type = measurementType(col.function[1]);
+      const outputType = aggregateFunctionOutputType(col.function[0], col.function[1]);
+      if (outputType !== null) {
+        column.type = outputType;
       }
+      const aggregate = AGGREGATIONS[col.function[0]];
       column.isSortable = aggregate && aggregate.isSortable;
     } else if (col.kind === 'field') {
       if (FIELDS.hasOwnProperty(col.field)) {

--- a/tests/js/spec/utils/discover/fields.spec.jsx
+++ b/tests/js/spec/utils/discover/fields.spec.jsx
@@ -129,6 +129,11 @@ describe('aggregateOutputType', function () {
     expect(aggregateOutputType('p95()')).toEqual('duration');
     expect(aggregateOutputType('p99()')).toEqual('duration');
     expect(aggregateOutputType('p100()')).toEqual('duration');
+    expect(aggregateOutputType('p50(transaction.duration)')).toEqual('duration');
+    expect(aggregateOutputType('p75(transaction.duration)')).toEqual('duration');
+    expect(aggregateOutputType('p95(transaction.duration)')).toEqual('duration');
+    expect(aggregateOutputType('p99(transaction.duration)')).toEqual('duration');
+    expect(aggregateOutputType('p100(transaction.duration)')).toEqual('duration');
     expect(aggregateOutputType('percentile(transaction.duration, 0.51)')).toEqual(
       'duration'
     );
@@ -171,6 +176,11 @@ describe('aggregateOutputType', function () {
     expect(aggregateOutputType('max(measurements.bar)')).toEqual('number');
     expect(aggregateOutputType('avg(measurements.bar)')).toEqual('number');
     expect(aggregateOutputType('percentile(measurements.bar, 0.5)')).toEqual('number');
+    expect(aggregateOutputType('p50(measurements.bar)')).toEqual('number');
+    expect(aggregateOutputType('p75(measurements.bar)')).toEqual('number');
+    expect(aggregateOutputType('p95(measurements.bar)')).toEqual('number');
+    expect(aggregateOutputType('p99(measurements.bar)')).toEqual('number');
+    expect(aggregateOutputType('p100(measurements.bar)')).toEqual('number');
   });
 });
 


### PR DESCRIPTION
The pXX functions currently still have a hard coded output type on the
frontend. Because they now support measurements in addition to the original
transaction duration, they need to be able to resolve the result type by
looking at its argument.