### PR TITLE
fix(trends): Disable release series animation

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -157,6 +157,7 @@ class ReleaseSeries extends React.Component {
       seriesName: 'Releases',
       data: [],
       markLine: MarkLine({
+        animation: false,
         lineStyle: {
           normal: {
             color: theme.purple400,


### PR DESCRIPTION
### Summary
This does not occur on Area charts as animation is disabled, but on line charts (trends) release series are animated in. This is inconsistent with other views.

Refs VIS-312