### PR TITLE
fix(async-csv): Disallow data exports for bad queries

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
@@ -18,6 +18,7 @@ import {downloadAsCsv} from '../utils';
 
 type Props = {
   isLoading: boolean;
+  errored: boolean;
   title: string;
   organization: OrganizationSummary;
   eventView: EventView;
@@ -71,8 +72,8 @@ renderBrowserExportButton.propTypes = {
 };
 
 function renderAsyncExportButton(canEdit: boolean, props: Props) {
-  const {isLoading, location} = props;
-  const disabled = isLoading || canEdit === false;
+  const {isLoading, errored, location} = props;
+  const disabled = isLoading || errored || canEdit === false;
   return (
     <DataExport
       payload={{
@@ -89,6 +90,7 @@ function renderAsyncExportButton(canEdit: boolean, props: Props) {
 // Placate eslint proptype checking
 renderAsyncExportButton.propTypes = {
   isLoading: PropTypes.bool,
+  errored: PropTypes.bool,
 };
 
 function renderEditButton(canEdit: boolean, props: Props) {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -370,6 +370,7 @@ class TableView extends React.Component<TableViewProps> {
       title,
       eventView,
       isLoading,
+      error,
       tableData,
       location,
       onChangeShowTags,
@@ -380,6 +381,7 @@ class TableView extends React.Component<TableViewProps> {
       <TableActions
         title={title}
         isLoading={isLoading}
+        errored={error !== null}
         organization={organization}
         eventView={eventView}
         onEdit={this.handleEditColumns}


### PR DESCRIPTION
Data exports will always error when the discover query itself is invalid. In
these cases, the export all button should not be enabled to prevent bad exports.