### PR TITLE
fix: Marking dangerous migration as dangerous

### DIFF
--- a/src/sentry/migrations/0121_groupinboxprojectandorg.py
+++ b/src/sentry/migrations/0121_groupinboxprojectandorg.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
     #   they can be monitored. Since data migrations will now hold a transaction open
     #   this is even more important.
     # - Adding columns to highly active tables, even ones that are NULL.
-    is_dangerous = False
+    is_dangerous = True
 
     # This flag is used to decide whether to run this migration in a transaction or not.
     # By default we prefer to run in a transaction, but for migrations where you want


### PR DESCRIPTION
This migration is dangerous, and should be marked as so.