### PR TITLE
fix(devservices): always pull postgres to guarantee new 

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1490,6 +1490,7 @@ SENTRY_DEVSERVICES = {
     },
     "postgres": {
         "image": "postgres:9.6-alpine",
+        "pull": True,
         "ports": {"5432/tcp": 5432},
         "environment": {"POSTGRES_DB": "sentry", "POSTGRES_HOST_AUTH_METHOD": "trust"},
         "volumes": {"postgres": {"bind": "/var/lib/postgresql/data"}},


### PR DESCRIPTION
```
    health_status = resp["State"]["Health"]["Status"]
KeyError: 'Health'
```

Was observed by at least @untitaker and @Zylphrex after https://github.com/getsentry/sentry/pull/21741. This is because the healthcheck stuff is written at container creation time, and we have an optimization to reuse existing containers for postgres and some others. So you'd have to `rm postgres` then `up postgres`.

I'm just going to disable this for now, so `devservices up` just works. This will be better in the future.