### PR TITLE
build(gha): Add storybook build step to js workflow

### DIFF
--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -66,6 +66,13 @@ jobs:
         run: |
           yarn tsc -p config/tsconfig.build.json
 
+      - name: storybook
+        if: steps.changes.outputs.frontend == 'true'
+        env:
+          STORYBOOK_BUILD: 1
+        run: |
+          yarn storybook-build
+
   webpack:
     runs-on: ubuntu-16.04
     steps:


### PR DESCRIPTION
This adds a step to make sure storybook builds in the ts/lint job