### PR TITLE
build(ci): Remove travis builds and add local action to handle test artifacts

### DIFF
--- a/.github/actions/artifacts/action.yml
+++ b/.github/actions/artifacts/action.yml
@@ -1,0 +1,13 @@
+name: 'Sentry Artifacts'
+description: 'Handles uploading coverage/test artifacts to codecov and zeus'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Upload to codecov
+      shell: bash
+      run: |
+        coverage_files=$(ls .artifacts/*coverage.xml || true)
+        if [[ -n "$coverage_files" || -f .artifacts/coverage/cobertura-coverage.xml ]]; then
+          bash <(curl -s https://codecov.io/bash) -v
+        fi

--- a/.github/actions/artifacts/action.yml
+++ b/.github/actions/artifacts/action.yml
@@ -1,5 +1,5 @@
 name: 'Sentry Artifacts'
-description: 'Handles uploading coverage/test artifacts to codecov and zeus'
+description: 'Handles uploading coverage/test artifacts to codecov'
 
 runs:
   using: "composite"

--- a/.github/workflows/acceptance-py3.6.yml
+++ b/.github/workflows/acceptance-py3.6.yml
@@ -105,4 +105,7 @@ jobs:
           PYTEST_SNAPSHOTS_DIR: ${{ steps.setup.outputs.acceptance-dir }}
           USE_SNUBA: 1
 
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts
+
       # TODO(joshuarli): snapshots, visual-diff needs py3-acceptance.

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -82,6 +82,9 @@ jobs:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
 
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts
+
   acceptance:
     # TODO(joshuarli): Convert to py3 with snapshots. See other TODO as well.
     name: python2.7 acceptance

--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -87,3 +87,6 @@ jobs:
           # XXX: there is a very small chance that it'll expand to exceed Linux's limits
           #      `getconf ARG_MAX` - max # bytes of args + environ for exec()
           pre-commit run --files ${{ steps.files.outputs.all_files }}
+
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts

--- a/.github/workflows/backend-test-py3.6.yml
+++ b/.github/workflows/backend-test-py3.6.yml
@@ -76,3 +76,6 @@ jobs:
           # Note: `USE_SNUBA` is not used for backend tests because there are a few failing tests with Snuba enabled.
           unset USE_SNUBA
           make travis-test-postgres
+
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts

--- a/.github/workflows/command-line-test.yml
+++ b/.github/workflows/command-line-test.yml
@@ -52,3 +52,6 @@ jobs:
         if: steps.changes.outputs.backend == 'true'
         run: |
           make test-cli
+
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts

--- a/.github/workflows/relay-integration-test.yml
+++ b/.github/workflows/relay-integration-test.yml
@@ -61,3 +61,6 @@ jobs:
         if: steps.changes.outputs.backend == 'true'
         run: |
           make test-relay-integration
+
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts

--- a/.github/workflows/snuba-integration-test-py3.6.yml
+++ b/.github/workflows/snuba-integration-test-py3.6.yml
@@ -76,3 +76,6 @@ jobs:
         if: steps.changes.outputs.backend == 'true'
         run: |
           make travis-test-snuba
+
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts

--- a/.github/workflows/symbolicator-integration-test.yml
+++ b/.github/workflows/symbolicator-integration-test.yml
@@ -67,3 +67,6 @@ jobs:
         if: steps.changes.outputs.backend == 'true'
         run: |
           make test-symbolicator
+
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,12 +100,6 @@ after_failure:
   - dmesg | tail -n 100
 
 after_script:
-  - |
-    coverage_files=$(ls .artifacts/*coverage.xml || true)
-    if [[ -n "$coverage_files" || -f .artifacts/coverage/cobertura-coverage.xml ]]; then
-      pip install -U codecov
-      codecov -e TEST_SUITE
-    fi
   - *install_volta
 
 base_postgres: &postgres_default

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,14 +107,6 @@ after_script:
       codecov -e TEST_SUITE
     fi
   - *install_volta
-  - volta install @zeus-ci/cli
-  - zeus upload -t "text/xml+xunit" .artifacts/*junit.xml
-  - zeus upload -t "text/xml+coverage" .artifacts/*coverage.xml
-  - zeus upload -t "text/xml+coverage" .artifacts/coverage/cobertura-coverage.xml
-  - zeus upload -t "text/html+pytest" .artifacts/*pytest.html
-  - zeus upload -t "text/plain+pycodestyle" .artifacts/*pycodestyle.log
-  - zeus upload -t "text/xml+checkstyle" .artifacts/*checkstyle.xml
-  - zeus upload -t "application/webpack-stats+json" .artifacts/*webpack-stats.json
 
 base_postgres: &postgres_default
   python: 2.7
@@ -281,8 +273,6 @@ matrix:
 notifications:
   webhooks:
     urls:
-      - https://zeus.ci/hooks/fa079cf6-8e6b-11e7-9155-0a580a28081c/public/provider/travis/webhook
-
       # This is to capture travis metrics
       # Repo for this webhook is https://github.com/getsentry/sentry-development-metrics
       # Hosted on GCP

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,9 +99,6 @@ script:
 after_failure:
   - dmesg | tail -n 100
 
-after_script:
-  - *install_volta
-
 base_postgres: &postgres_default
   python: 2.7
   services:
@@ -171,98 +168,6 @@ matrix:
         # XXX: there is a very small chance that it'll expand to exceed Linux's limits
         #      `getconf ARG_MAX` - max # bytes of args + environ for exec()
         - pre-commit run --files $(git diff --diff-filter=d --name-only master)
-
-    - <<: *postgres_default
-      name: 'Backend with migrations [Postgres] (1/2)'
-      env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=0 MIGRATIONS_TEST_MIGRATE=1
-    - <<: *postgres_default
-      name: 'Backend with migrations [Postgres] (2/2)'
-      env: TEST_SUITE=postgres DB=postgres TOTAL_TEST_GROUPS=2 TEST_GROUP=1 MIGRATIONS_TEST_MIGRATE=1
-
-    - <<: *acceptance_default
-      name: 'Acceptance (1/3)'
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=3 TEST_GROUP=0
-    - <<: *acceptance_default
-      name: 'Acceptance (2/3)'
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=3 TEST_GROUP=1
-    - <<: *acceptance_default
-      name: 'Acceptance (3/3)'
-      env: TEST_SUITE=acceptance USE_SNUBA=1 TOTAL_TEST_GROUPS=3 TEST_GROUP=2
-
-    - <<: *acceptance_default
-      name: 'Plugins'
-      env: TEST_SUITE=plugins DB=postgres
-
-    - python: 2.7
-      name: 'Frontend [test]'
-      env: TEST_SUITE=js
-      before_install:
-        - *install_volta
-      install:
-        - *install_node_dependencies
-
-    - python: 2.7
-      name: 'Frontend [build]'
-      env: TEST_SUITE=js-build
-      before_install:
-        - *install_volta
-      install:
-        - *install_node_dependencies
-
-    - python: 2.7
-      name: 'Command Line'
-      env: TEST_SUITE=cli
-      services:
-        - postgresql
-        - redis-server
-      install:
-        - python setup.py install_egg_info
-        - pip install -U -e ".[dev]"
-        - sentry init
-      before_script:
-        - psql -c 'create database sentry;' -U postgres
-
-    - <<: *postgres_default
-      name: 'Symbolicator Integration'
-      env: TEST_SUITE=symbolicator
-      before_install:
-        - *base_install
-        - *start_snuba
-        - docker run -d -v $PWD/config/symbolicator/:/etc/symbolicator --network host --name symbolicator us.gcr.io/sentryio/symbolicator:nightly run -c /etc/symbolicator/config.yml
-        - docker ps -a
-
-    - <<: *postgres_default
-      name: 'Sentry-Relay integration tests'
-      env: TEST_SUITE=relay-integration DB=postgres
-      services:
-        - docker
-        - memcached
-        - redis-server
-        - postgresql
-      before_install:
-        - *base_install
-        - *start_snuba
-        - docker pull us.gcr.io/sentryio/relay:nightly # pull relay we'll run and kill it for each test
-        - docker ps -a
-
-    - python: 2.7
-      name: 'Snuba Integration with migrations'
-      env: TEST_SUITE=snuba USE_SNUBA=1 MIGRATIONS_TEST_MIGRATE=1
-      services:
-        - docker
-        - memcached
-        - redis-server
-        - postgresql
-      before_install:
-        - *base_install
-        - *start_snuba
-        - docker ps -a
-      install:
-        - python setup.py install_egg_info
-        - pip install -U -e ".[dev]"
-        - sentry init
-      before_script:
-        - psql -c 'create database sentry;' -U postgres
 
 notifications:
   webhooks:

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,8 +7,8 @@ module.exports = {
     'tests/js/spec/**/*.{js,jsx,tsx}',
     'src/sentry/static/sentry/app/**/*.{js,jsx,ts,tsx}',
   ],
-  coverageReporters: ['html', 'lcov', 'cobertura'],
-  coverageDirectory: '.artifacts/coverage/',
+  coverageReporters: ['html', 'cobertura'],
+  coverageDirectory: '.artifacts/coverage',
   snapshotSerializers: ['enzyme-to-json/serializer'],
   moduleNameMapper: {
     '^sentry-test/(.*)': '<rootDir>/tests/js/sentry-test/$1',


### PR DESCRIPTION
GHA builds have been pretty stable so far, so let's remove travis builds (except lint as there is a bug).
Adds codecov coverage artifact uploads to GHA builds.