### PR TITLE
ref(discover): 500 on errors, instead of 400ing

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -173,6 +173,12 @@ class QueryIllegalTypeOfArgument(QueryExecutionError):
     """
 
 
+class QueryMissingColumn(QueryExecutionError):
+    """
+    Exception raised when a column is missing.
+    """
+
+
 class QueryTooManySimultaneous(QueryExecutionError):
     """
     Exception raised when a query is rejected due to too many simultaneous
@@ -208,7 +214,9 @@ class QueryConnectionFailed(QueryExecutionError):
 
 
 clickhouse_error_codes_map = {
+    10: QueryMissingColumn,
     43: QueryIllegalTypeOfArgument,
+    47: QueryMissingColumn,
     62: QuerySizeExceeded,
     160: QueryExecutionTimeMaximum,
     202: QueryTooManySimultaneous,

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -115,7 +115,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
         query = {"field": ["id", "timestamp"], "orderby": ["-timestamp", "-id"]}
         response = self.do_request(query)
-        assert response.status_code == 400, response.content
+        assert response.status_code == 500, response.content
         assert response.data["detail"] == "Internal error. Your query failed to run."
 
         mock_query.side_effect = QueryIllegalTypeOfArgument("test")


### PR DESCRIPTION
- Some of these errors were being returned as client errors, but aren't.
  This changes these to API Exceptions so that our reporting is more
  accurate.
- This also adds two new snuba errors that we've been seeing a bit more
  often, this should help us track them better so that they're not under
  the general umbrella of `QueryExecutionError`