### PR TITLE
fix(vitals): Hovering over outliers should show the count

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -469,11 +469,8 @@ class VitalCard extends React.Component<Props, State> {
           {x: topRightPixel.x, y: topRightPixel.y},
           {x: topRightPixel.x, y: failurePixel.y},
         ] as any,
-        // bottom
-        [
-          {x: topRightPixel.x, y: failurePixel.y},
-          {x: failurePixel.x, y: failurePixel.y},
-        ] as any,
+        // We do not draw the bottom line of the the box because it
+        // partially obscures possible outliers.
       ],
       label: {
         show: false,


### PR DESCRIPTION
When hovering over a bar in the failure region, the mark are component takes
focus and we see a tooltip for the failure region rather than the count in the
series. This makes it impossible to see any outliers as they are infrequent
making the bar very short and difficult to hover. This change replaces the mark
area component with four mark lines in order to show the tooltip for the series
instead of the failure region and only show the tooltip for the failure region
around the border.