### PR TITLE
feat(discover) Improve rendering of array fields

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/arrayValue.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/arrayValue.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import overflowEllipsis from 'app/styles/overflowEllipsis';
+import space from 'app/styles/space';
+import {t} from 'app/locale';
+
+type Props = {
+  value: string[];
+};
+type State = {
+  expanded: boolean;
+};
+
+class ArrayValue extends React.Component<Props, State> {
+  state: State = {
+    expanded: false,
+  };
+  handleToggle = () => {
+    this.setState(prevState => ({
+      expanded: !prevState.expanded,
+    }));
+  };
+
+  render() {
+    const {expanded} = this.state;
+    const {value} = this.props;
+    return (
+      <ArrayContainer>
+        {expanded &&
+          value
+            .slice(0, value.length - 1)
+            .map(item => <ArrayItem key={item}>{item}</ArrayItem>)}
+        <span>
+          {value.slice(-1)[0]}
+          <button onClick={this.handleToggle}>
+            {expanded ? t('[collapse]') : t('[+%s more]', value.length - 1)}
+          </button>
+        </span>
+      </ArrayContainer>
+    );
+  }
+}
+const ArrayContainer = styled('div')`
+  ${overflowEllipsis};
+
+  & button {
+    background: none;
+    border: 0;
+    outline: none;
+    padding: 0;
+    cursor: pointer;
+    color: ${p => p.theme.blue400};
+    margin-left: ${space(0.5)};
+  }
+`;
+
+const ArrayItem = styled('span')`
+  display: block;
+  ${overflowEllipsis};
+`;
+
+export default ArrayValue;

--- a/src/sentry/static/sentry/app/utils/discover/arrayValue.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/arrayValue.tsx
@@ -30,12 +30,14 @@ class ArrayValue extends React.Component<Props, State> {
         {expanded &&
           value
             .slice(0, value.length - 1)
-            .map(item => <ArrayItem key={item}>{item}</ArrayItem>)}
+            .map((item, i) => <ArrayItem key={`${i}:${item}`}>{item}</ArrayItem>)}
         <span>
           {value.slice(-1)[0]}
-          <button onClick={this.handleToggle}>
-            {expanded ? t('[collapse]') : t('[+%s more]', value.length - 1)}
-          </button>
+          {value.length > 1 ? (
+            <button onClick={this.handleToggle}>
+              {expanded ? t('[collapse]') : t('[+%s more]', value.length - 1)}
+            </button>
+          ) : null}
         </span>
       </ArrayContainer>
     );

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -19,6 +19,7 @@ import Projects from 'app/utils/projects';
 import {getShortEventId} from 'app/utils/events';
 
 import KeyTransactionField from './keyTransactionField';
+import ArrayValue from './arrayValue';
 import {
   BarContainer,
   Container,
@@ -62,6 +63,7 @@ type FieldFormatters = {
   number: FieldFormatter;
   percentage: FieldFormatter;
   string: FieldFormatter;
+  array: FieldFormatter;
 };
 
 export type FieldTypes = keyof FieldFormatters;
@@ -145,6 +147,13 @@ const FIELD_FORMATTERS: FieldFormatters = {
         ? data[field]
         : emptyValue;
       return <Container>{value}</Container>;
+    },
+  },
+  array: {
+    isSortable: true,
+    renderFunc: (field, data) => {
+      const value = Array.isArray(data[field]) ? data[field] : [data[field]];
+      return <ArrayValue value={value} />;
     },
   },
 };

--- a/tests/js/spec/utils/discover/arrayValue.spec.jsx
+++ b/tests/js/spec/utils/discover/arrayValue.spec.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import ArrayValue from 'app/utils/discover/arrayValue';
+
+describe('Discover > ArrayValue', function () {
+  it('renders an expand link', function () {
+    const wrapper = mountWithTheme(<ArrayValue value={['one', 'two', 'three']} />);
+
+    // Should have a button
+    const button = wrapper.find('button');
+    expect(button).toHaveLength(1);
+    expect(button.text()).toEqual('[+2 more]');
+
+    // Should show last value.
+    expect(wrapper.text()).toContain('three');
+  });
+
+  it('renders all elements when expanded', function () {
+    const wrapper = mountWithTheme(<ArrayValue value={['one', 'two', 'three']} />);
+
+    // Should have a button
+    let button = wrapper.find('button');
+    button.simulate('click');
+
+    wrapper.update();
+
+    // Button text should update.
+    button = wrapper.find('button');
+    expect(button.text()).toEqual('[collapse]');
+
+    // Should show all values.
+    const text = wrapper.text();
+    expect(text).toContain('three');
+    expect(text).toContain('two');
+    expect(text).toContain('one');
+  });
+
+  it('hides toggle on 1 element', function () {
+    const wrapper = mountWithTheme(<ArrayValue value={['one']} />);
+
+    expect(wrapper.find('button')).toHaveLength(0);
+    const text = wrapper.text();
+    expect(text).toContain('one');
+  });
+
+  it('hides toggle on 0 elements', function () {
+    const wrapper = mountWithTheme(<ArrayValue value={[]} />);
+
+    expect(wrapper.find('button')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Add a toggle that lets users expand array fields and see all the values. The toggle follows the 'last' item which is the item we show when the field is collapsed. This will be applied to the various `stack.*` fields and fields like `error.type` and `error.value`.

![Screen Shot 2020-11-04 at 1 56 06 PM](https://user-images.githubusercontent.com/24086/98157131-dd3b7d80-1ea6-11eb-920b-57fae6a453ae.png)
