### PR TITLE
fix(trends): Reset error when requerying api

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
@@ -152,9 +152,7 @@ class GenericDiscoverQuery<T, P> extends React.Component<Props<T, P>, State<T>> 
 
     this.setState({isLoading: true, tableFetchID});
 
-    if (setError) {
-      setError(undefined);
-    }
+    setError?.(undefined);
 
     if (limit) {
       apiPayload.per_page = limit;

--- a/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
@@ -152,6 +152,10 @@ class GenericDiscoverQuery<T, P> extends React.Component<Props<T, P>, State<T>> 
 
     this.setState({isLoading: true, tableFetchID});
 
+    if (setError) {
+      setError(undefined);
+    }
+
     if (limit) {
       apiPayload.per_page = limit;
     }


### PR DESCRIPTION
### Summary

Currently the error isn't disappearing when you change your api call and it succeeds. This will wipe the error state if you make another request.

Refs VIS-322