### PR TITLE
fix(discover): Autocomplete for transaction.status should not error

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -295,6 +295,7 @@ class TransactionTagKeyValues(OrganizationTagKeyTestCase):
             "transaction.status", qs_params={"query": "o"}, expected=[("unknown", 1), ("ok", 1)],
         )
         self.run_test("transaction.status", qs_params={"query": "ow"}, expected=[("unknown", 1)])
+        self.run_test("transaction.status", qs_params={"query": "does-not-exist"}, expected=[])
 
     def test_op(self):
         self.run_test("transaction.op", expected=[("bar.server", 1), ("http.server", 1)])


### PR DESCRIPTION
When autocompleting transaction.status and there is no match, the query errors
in clickhouse with an empty tuple. This change skips the query entirely when
there are no matches.

Fixes SENTRY-H9A