### PR TITLE
fix(discover): Support numeric fields with decimals

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -437,10 +437,7 @@ class SearchVisitor(NodeVisitor):
 
         if self.is_numeric_key(search_key.name):
             try:
-                if is_measurement(search_key.name):
-                    search_value = SearchValue(float(search_value.text))
-                else:
-                    search_value = SearchValue(int(search_value.text))
+                search_value = SearchValue(float(search_value.text))
             except ValueError:
                 raise InvalidSearchQuery(u"Invalid numeric query: {}".format(search_key))
             return SearchFilter(search_key, operator, search_value)

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -638,6 +638,15 @@ class ParseSearchQueryTest(unittest.TestCase):
             )
         ]
 
+    def test_numeric_filter_with_decimals(self):
+        assert parse_search_query("transaction.duration:>3.1415") == [
+            SearchFilter(
+                key=SearchKey(name="transaction.duration"),
+                operator=">",
+                value=SearchValue(raw_value=3.1415),
+            )
+        ]
+
     def test_invalid_numeric_fields(self):
         invalid_queries = ["project.id:one", "issue.id:two", "transaction.duration:>hotdog"]
         for invalid_query in invalid_queries:


### PR DESCRIPTION
- Numeric fields can support decimals, so in general we should just use
  `float` instead of `int`