### PR TITLE
feat(workflow): Add inbox to sate tag values

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -695,6 +695,11 @@ class IssueListOverview extends React.Component<Props, State> {
     const page = isNaN(queryPageInt) ? 0 : queryPageInt;
     const pageCount = page * MAX_ITEMS + groupIds?.length;
 
+    // TODO(workflow): When organization:inbox flag is removed add 'inbox' to tagStore
+    if (organization.features.includes('inbox') && !tags?.is?.values?.includes('inbox')) {
+      tags?.is?.values?.push('inbox');
+    }
+
     return (
       <Feature organization={organization} features={['organizations:inbox']}>
         {({hasFeature}) => (


### PR DESCRIPTION
Needed to happen at the overview level so that it exists in both the search bar and the sidebar. TagStore itself couldn't quite do it because it doesn't have the organization info