### PR TITLE
fix(vitals): Opening vitals in discover should have graph

### DIFF
--- a/tests/js/spec/views/performance/transactionVitals.spec.jsx
+++ b/tests/js/spec/views/performance/transactionVitals.spec.jsx
@@ -236,7 +236,7 @@ describe('Performance > Web Vitals', function () {
   });
 
   describe('Open in Discover button', function () {
-    it('renders open in discover buttons with required props', function () {
+    it('renders open in discover buttons with required props', async function () {
       const {project, organization, router, routerContext} = initialize();
 
       const wrapper = mountWithTheme(
@@ -248,6 +248,9 @@ describe('Performance > Web Vitals', function () {
         routerContext
       );
 
+      await tick();
+      wrapper.update();
+
       const buttons = wrapper.find('DiscoverButton');
       expect(buttons).toHaveLength(5);
 
@@ -256,8 +259,10 @@ describe('Performance > Web Vitals', function () {
           expect.objectContaining({
             pathname: '/organizations/org-slug/discover/results/',
             query: expect.objectContaining({
-              field: expect.arrayContaining([`measurements.${vitals[i].slug}`]),
-              sort: [`-measurements.${vitals[i].slug}`],
+              field: expect.arrayContaining([
+                `percentile(measurements.${vitals[i].slug},0.75)`,
+              ]),
+              sort: [`-percentile_measurements_${vitals[i].slug}_0_75`],
               query: expect.stringContaining('transaction:/'),
               project: [parseInt(project.id, 10)],
             }),
@@ -266,7 +271,7 @@ describe('Performance > Web Vitals', function () {
       });
     });
 
-    it('renders open in discover buttons with greater than condition', function () {
+    it('renders open in discover buttons with greater than condition', async function () {
       const query = {
         fpStart: '10',
         fcpStart: '10',
@@ -284,6 +289,9 @@ describe('Performance > Web Vitals', function () {
         />,
         routerContext
       );
+
+      await tick();
+      wrapper.update();
 
       const buttons = wrapper.find('DiscoverButton');
       expect(buttons).toHaveLength(5);
@@ -302,7 +310,7 @@ describe('Performance > Web Vitals', function () {
       });
     });
 
-    it('renders open in discover buttons with less than condition', function () {
+    it('renders open in discover buttons with less than condition', async function () {
       const query = {
         fpEnd: '20',
         fcpEnd: '20',
@@ -321,6 +329,9 @@ describe('Performance > Web Vitals', function () {
         routerContext
       );
 
+      await tick();
+      wrapper.update();
+
       const buttons = wrapper.find('DiscoverButton');
       expect(buttons).toHaveLength(5);
 
@@ -338,7 +349,7 @@ describe('Performance > Web Vitals', function () {
       });
     });
 
-    it('renders open in discover buttons with both condition', function () {
+    it('renders open in discover buttons with both condition', async function () {
       const query = {
         fpStart: '10',
         fpEnd: '20',
@@ -361,6 +372,9 @@ describe('Performance > Web Vitals', function () {
         />,
         routerContext
       );
+
+      await tick();
+      wrapper.update();
 
       const buttons = wrapper.find('DiscoverButton');
       expect(buttons).toHaveLength(5);
@@ -389,7 +403,7 @@ describe('Performance > Web Vitals', function () {
   });
 
   describe('reset view', function () {
-    it('disables button on default view', function () {
+    it('disables button on default view', async function () {
       const {organization, router, routerContext} = initialize();
 
       const wrapper = mountWithTheme(
@@ -401,12 +415,15 @@ describe('Performance > Web Vitals', function () {
         routerContext
       );
 
+      await tick();
+      wrapper.update();
+
       expect(
         wrapper.find('Button[data-test-id="reset-view"]').prop('disabled')
       ).toBeTruthy();
     });
 
-    it('enables button on left zoom', function () {
+    it('enables button on left zoom', async function () {
       const {organization, router, routerContext} = initialize({
         query: {
           lcpStart: '20',
@@ -422,12 +439,15 @@ describe('Performance > Web Vitals', function () {
         routerContext
       );
 
+      await tick();
+      wrapper.update();
+
       expect(
         wrapper.find('Button[data-test-id="reset-view"]').prop('disabled')
       ).toBeFalsy();
     });
 
-    it('enables button on right zoom', function () {
+    it('enables button on right zoom', async function () {
       const {organization, router, routerContext} = initialize({
         query: {
           fpEnd: '20',
@@ -443,12 +463,15 @@ describe('Performance > Web Vitals', function () {
         routerContext
       );
 
+      await tick();
+      wrapper.update();
+
       expect(
         wrapper.find('Button[data-test-id="reset-view"]').prop('disabled')
       ).toBeFalsy();
     });
 
-    it('enables button on left and right zoom', function () {
+    it('enables button on left and right zoom', async function () {
       const {organization, router, routerContext} = initialize({
         query: {
           fcpStart: '20',
@@ -465,12 +488,15 @@ describe('Performance > Web Vitals', function () {
         routerContext
       );
 
+      await tick();
+      wrapper.update();
+
       expect(
         wrapper.find('Button[data-test-id="reset-view"]').prop('disabled')
       ).toBeFalsy();
     });
 
-    it('resets view properly', function () {
+    it('resets view properly', async function () {
       const {organization, router, routerContext} = initialize({
         query: {
           fidStart: '20',
@@ -486,6 +512,9 @@ describe('Performance > Web Vitals', function () {
         />,
         routerContext
       );
+
+      await tick();
+      wrapper.update();
 
       wrapper.find('Button[data-test-id="reset-view"]').simulate('click');
       expect(browserHistory.push).toHaveBeenCalledWith({


### PR DESCRIPTION
Opening a web vital in discover currently just shows the raw values. This also
means that for users without the ability to access to edit discover queries,
there isn't much they can do. This change updates the discover query it brings
them to to include a timeseries graph of the 75th percentile for the vital.f