### PR TITLE
ref(ts): Remove axis helper in miniBarChart

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
@@ -7,7 +7,6 @@ import {getFormattedDate} from 'app/utils/dates';
 import BarChart, {BarChartSeries} from './barChart';
 import BaseChart from './baseChart';
 import {truncationFormatter} from './utils';
-import XAxis from './components/xAxis';
 import Tooltip from './components/tooltip';
 
 type Marker = {
@@ -180,7 +179,7 @@ class MiniBarChart extends React.Component<Props> {
         left: markers ? 4 : 0,
         right: markers ? 4 : 0,
       },
-      xAxis: XAxis({
+      xAxis: {
         axisLine: {
           show: false,
         },
@@ -192,7 +191,7 @@ class MiniBarChart extends React.Component<Props> {
           show: false,
         },
         axisPointer: {
-          type: 'line',
+          type: 'line' as const,
           label: {
             show: false,
           },
@@ -200,7 +199,7 @@ class MiniBarChart extends React.Component<Props> {
             width: 0,
           },
         },
-      }),
+      },
       options: {
         animation: false,
       },


### PR DESCRIPTION
As part of a previous PR, accidently modified the axis and adds a pixel or two of visual diff to the barchart. This should fix it to bring it back to it's original look. This is a roll forward fix instead of reverting and putting up the PR again.