### PR TITLE
fix(discover): Exploding pXX functions should result in its argument

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -199,7 +199,7 @@ function drilldownAggregate(
     } else if (!column && parameter.required === false) {
       // The parameter was not given for a non-required parameter,
       // so we fall back to the default.
-      column = aggregation.parameters[0].defaultValue;
+      column = parameter.defaultValue;
     }
   } else {
     // The aggregation does not exist or does not have any parameters,
@@ -225,28 +225,23 @@ export function getExpandedResults(
   // Mark any column as null to remove it.
   const expandedColumns: (Column | null)[] = eventView.fields.map((field: Field) => {
     const exploded = explodeFieldString(field.field);
-    switch (exploded.kind) {
-      case 'function':
-        const column = drilldownAggregate(field, exploded);
+    const column =
+      exploded.kind === 'function' ? drilldownAggregate(field, exploded) : exploded;
 
-        if (
-          // if expanding the function failed
-          column === null ||
-          // id is implicitly a part of all non-aggregate results
-          column.field === 'id' ||
-          // the new column is already present
-          fieldSet.has(column.field)
-        ) {
-          return null;
-        }
-
-        fieldSet.add(column.field);
-
-        return column;
-      default:
-        // we do not dedupe columns
-        return exploded;
+    if (
+      // if expanding the function failed
+      column === null ||
+      // id is implicitly a part of all non-aggregate results
+      column.field === 'id' ||
+      // the new column is already present
+      fieldSet.has(column.field)
+    ) {
+      return null;
     }
+
+    fieldSet.add(column.field);
+
+    return column;
   });
 
   // update the columns according the the expansion above

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -170,30 +170,43 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
   return encodedDataUrl;
 }
 
-// A map between aggregate function names and its un-aggregated form
-const TRANSFORM_AGGREGATES = {
-  last_seen: 'timestamp',
-  latest_event: '',
-  apdex: '',
-  user_misery: '',
-  failure_rate: '',
-} as const;
+const ALIASED_AGGREGATES_COLUMN = {
+  'last_seen()': 'timestamp',
+};
 
-function transformAggregate(fieldName: string, argument?: string): string {
-  // test if a field name is a percentile field name. for example: p50
-  if (/^p\d+$/.test(fieldName)) {
-    // These fields can have an optional argument. If they do contain the
-    // optional argument, then there is nothing to transform to. But if it
-    // does not contain the optional argument, then we want to transform
-    // it to `transaction.duration`.
-    return argument ? '' : 'transaction.duration';
+/**
+ * Convert an aggregate into the resulting column from a drilldown action.
+ * The result is null if the drilldown results in the aggregate being removed.
+ */
+function drilldownAggregate(
+  field: Field,
+  func: Extract<Column, {kind: 'function'}>
+): Extract<Column, {kind: 'field'}> | null {
+  const key = func.function[0];
+  const aggregation = AGGREGATIONS[key];
+  let column = func.function[1];
+
+  if (ALIASED_AGGREGATES_COLUMN.hasOwnProperty(field.field)) {
+    // Some aggregates are just shortcuts to other aggregates with
+    // predefined arguments so we can directly map them to the result.
+    column = ALIASED_AGGREGATES_COLUMN[field.field];
+  } else if (aggregation?.parameters?.[0]) {
+    const parameter = aggregation.parameters[0];
+    if (parameter.kind !== 'column') {
+      // The aggregation does not accept a column as a parameter,
+      // so we clear the column.
+      column = '';
+    } else if (!column && parameter.required === false) {
+      // The parameter was not given for a non-required parameter,
+      // so we fall back to the default.
+      column = aggregation.parameters[0].defaultValue;
+    }
+  } else {
+    // The aggregation does not exist or does not have any parameters,
+    // so we clear the column.
+    column = '';
   }
-
-  return TRANSFORM_AGGREGATES[fieldName] || '';
-}
-
-function isTransformAggregate(fieldName: string, argument?: string): boolean {
-  return transformAggregate(fieldName, argument) !== '';
+  return column ? {kind: 'field', field: column} : null;
 }
 
 /**
@@ -207,102 +220,44 @@ export function getExpandedResults(
   additionalConditions: Record<string, string>,
   dataRow?: TableDataRow | Event
 ): EventView {
-  // Find aggregate fields and flag them for updates.
-  const fieldsToUpdate: number[] = [];
-  eventView.fields.forEach((field: Field, index: number) => {
-    const column = explodeFieldString(field.field);
-    if (column.kind === 'function') {
-      fieldsToUpdate.push(index);
+  const fieldSet = new Set();
+  // Expand any functions in the resulting column, and dedupe the result.
+  // Mark any column as null to remove it.
+  const expandedColumns: (Column | null)[] = eventView.fields.map((field: Field) => {
+    const exploded = explodeFieldString(field.field);
+    switch (exploded.kind) {
+      case 'function':
+        const column = drilldownAggregate(field, exploded);
+
+        if (
+          // if expanding the function failed
+          column === null ||
+          // id is implicitly a part of all non-aggregate results
+          column.field === 'id' ||
+          // the new column is already present
+          fieldSet.has(column.field)
+        ) {
+          return null;
+        }
+
+        fieldSet.add(column.field);
+
+        return column;
+      default:
+        // we do not dedupe columns
+        return exploded;
     }
   });
 
-  let nextView = eventView.clone();
-  const transformedFields = new Set();
-  const fieldsToDelete: number[] = [];
-
-  // make a best effort to replace aggregated columns with their non-aggregated form
-  fieldsToUpdate.forEach((indexToUpdate: number) => {
-    const currentField: Field = nextView.fields[indexToUpdate];
-    const exploded = explodeFieldString(currentField.field);
-
-    let fieldNameAlias: string = '';
-    if (
-      exploded.kind === 'function' &&
-      isTransformAggregate(exploded.function[0], exploded.function[1])
-    ) {
-      fieldNameAlias = exploded.function[0];
-    } else if (exploded.kind === 'field' && exploded.field !== 'id') {
-      // Skip id fields as they are implicitly part of all non-aggregate results.
-      fieldNameAlias = exploded.field;
-    }
-
-    if (fieldNameAlias !== undefined && isTransformAggregate(fieldNameAlias)) {
-      const nextFieldName = transformAggregate(fieldNameAlias);
-      if (!nextFieldName || transformedFields.has(nextFieldName)) {
-        // this field is either duplicated in another column, or nextFieldName is undefined.
-        // in either case, we remove this column
-        fieldsToDelete.push(indexToUpdate);
-        return;
-      }
-      transformedFields.add(nextFieldName);
-
-      const updatedColumn: Column = {
-        kind: 'field',
-        field: nextFieldName,
-      };
-      nextView = nextView.withUpdatedColumn(indexToUpdate, updatedColumn, undefined);
-
-      return;
-    }
-
-    if (
-      (exploded.kind === 'field' && transformedFields.has(exploded.field)) ||
-      (exploded.kind === 'function' && transformedFields.has(exploded.function[1]))
-    ) {
-      // If we already have this field we can delete the new instance.
-      fieldsToDelete.push(indexToUpdate);
-      return;
-    }
-
-    if (exploded.kind === 'function') {
-      const field = exploded.function[1];
-
-      // Remove count an aggregates on id, as results have an implicit id in them.
-      if (exploded.function[0] === 'count' || field === 'id') {
-        fieldsToDelete.push(indexToUpdate);
-        return;
-      }
-
-      // if at least one of the parameters to the function is an available column,
-      // then we should proceed to replace it with the column, however, for functions
-      // like apdex that takes a number as its parameter we should delete it
-      const {parameters = []} = AGGREGATIONS[exploded.function[0]] ?? {};
-      if (
-        !field ||
-        (parameters.length > 0 &&
-          parameters.every(parameter => parameter.kind !== 'column'))
-      ) {
-        // This is a function with no field alias. We delete this column as it'll add a blank column in the drilldown.
-        fieldsToDelete.push(indexToUpdate);
-        return;
-      }
-      transformedFields.add(field);
-
-      const updatedColumn: Column = {
-        kind: 'field',
-        field,
-      };
-      nextView = nextView.withUpdatedColumn(indexToUpdate, updatedColumn, undefined);
-    }
-  });
-
-  // delete any columns marked for deletion
-  fieldsToDelete.reverse().forEach((index: number) => {
-    nextView = nextView.withDeletedColumn(index, undefined);
-  });
-
+  // update the columns according the the expansion above
+  const nextView = expandedColumns.reduceRight(
+    (newView, column, index) =>
+      column === null
+        ? newView.withDeletedColumn(index, undefined)
+        : newView.withUpdatedColumn(index, column, undefined),
+    eventView.clone()
+  );
   nextView.query = generateExpandedConditions(nextView, additionalConditions, dataRow);
-
   return nextView;
 }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -171,7 +171,7 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
 }
 
 const ALIASED_AGGREGATES_COLUMN = {
-  'last_seen()': 'timestamp',
+  last_seen: 'timestamp',
 };
 
 /**
@@ -179,17 +179,16 @@ const ALIASED_AGGREGATES_COLUMN = {
  * The result is null if the drilldown results in the aggregate being removed.
  */
 function drilldownAggregate(
-  field: Field,
   func: Extract<Column, {kind: 'function'}>
 ): Extract<Column, {kind: 'field'}> | null {
   const key = func.function[0];
   const aggregation = AGGREGATIONS[key];
   let column = func.function[1];
 
-  if (ALIASED_AGGREGATES_COLUMN.hasOwnProperty(field.field)) {
+  if (ALIASED_AGGREGATES_COLUMN.hasOwnProperty(key)) {
     // Some aggregates are just shortcuts to other aggregates with
     // predefined arguments so we can directly map them to the result.
-    column = ALIASED_AGGREGATES_COLUMN[field.field];
+    column = ALIASED_AGGREGATES_COLUMN[key];
   } else if (aggregation?.parameters?.[0]) {
     const parameter = aggregation.parameters[0];
     if (parameter.kind !== 'column') {
@@ -225,8 +224,7 @@ export function getExpandedResults(
   // Mark any column as null to remove it.
   const expandedColumns: (Column | null)[] = eventView.fields.map((field: Field) => {
     const exploded = explodeFieldString(field.field);
-    const column =
-      exploded.kind === 'function' ? drilldownAggregate(field, exploded) : exploded;
+    const column = exploded.kind === 'function' ? drilldownAggregate(exploded) : exploded;
 
     if (
       // if expanding the function failed

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -293,7 +293,8 @@ describe('getExpandedResults()', function () {
         {field: 'p9001()'}, // it's over 9000
         {field: 'foobar()'}, // unknown function with no parameter
         {field: 'custom_tag'},
-        {field: 'title'}, // not expected to be dropped
+        {field: 'transaction.duration'}, // should be dropped
+        {field: 'title'}, // should be dropped
         {field: 'unique_count(id)'},
         {field: 'apdex(300)'}, // should be dropped
         {field: 'user_misery(300)'}, // should be dropped
@@ -306,7 +307,6 @@ describe('getExpandedResults()', function () {
       {field: 'title'},
       {field: 'transaction.duration', width: -1},
       {field: 'custom_tag'},
-      {field: 'title'},
     ]);
 
     // transforms pXX functions with optional arguments properly

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -308,6 +308,27 @@ describe('getExpandedResults()', function () {
       {field: 'custom_tag'},
       {field: 'title'},
     ]);
+
+    // transforms pXX functions with optional arguments properly
+    view = new EventView({
+      ...state,
+      fields: [
+        {field: 'p50(transaction.duration)'},
+        {field: 'p75(measurements.foo)'},
+        {field: 'p95(measurements.bar)'},
+        {field: 'p99(measurements.fcp)'},
+        {field: 'p100(measurements.lcp)'},
+      ],
+    });
+
+    result = getExpandedResults(view, {}, {});
+    expect(result.fields).toEqual([
+      {field: 'transaction.duration', width: -1},
+      {field: 'measurements.foo', width: -1},
+      {field: 'measurements.bar', width: -1},
+      {field: 'measurements.fcp', width: -1},
+      {field: 'measurements.lcp', width: -1},
+    ]);
   });
 
   it('applies provided additional conditions', () => {


### PR DESCRIPTION
The pXX functions like p50, p75 are now able to take an optional argument in
order to support measurements. This means that expanding these functions cannot
just result in `transaction.duration` like before. This change ensures that when
an argument is passed to these functions, they will be the result of the explode
operation.