### PR TITLE
ref(ts): Convert area charts to typescript

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/areaChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/areaChart.tsx
@@ -1,10 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import {EChartOption} from 'echarts';
+
+import {Series} from 'app/types/echarts';
 
 import AreaSeries from './series/areaSeries';
 import BaseChart from './baseChart';
 
-class AreaChart extends React.Component {
+type ChartProps = React.ComponentProps<typeof BaseChart>;
+
+export type AreaChartSeries = Series & Omit<EChartOption.SeriesLine, 'data' | 'name'>;
+
+type Props = Omit<ChartProps, 'series'> & {
+  stacked?: boolean;
+  series: AreaChartSeries[];
+};
+
+class AreaChart extends React.Component<Props> {
   static propTypes = {
     ...BaseChart.propTypes,
     stacked: PropTypes.bool,
@@ -18,7 +30,7 @@ class AreaChart extends React.Component {
         {...props}
         series={series.map(({seriesName, data, ...otherSeriesProps}, i) =>
           AreaSeries({
-            stack: stacked ? 'area' : false,
+            stack: stacked ? 'area' : undefined,
             name: seriesName,
             data: data.map(({name, value}) => [name, value]),
             color: colors && colors[i],

--- a/src/sentry/static/sentry/app/components/charts/stackedAreaChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/stackedAreaChart.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 
 import AreaChart from 'app/components/charts/areaChart';
 
-class StackedAreaChart extends React.Component {
+type AreaChartProps = React.ComponentProps<typeof AreaChart>;
+
+type Props = Omit<AreaChartProps, 'stacked' | 'tooltip' | 'ref'>;
+
+class StackedAreaChart extends React.Component<Props> {
   render() {
     return <AreaChart tooltip={{filter: val => val > 0}} {...this.props} stacked />;
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -157,9 +157,6 @@ class MiniGraph extends React.Component<Props> {
                 bottom: 0,
                 containLabel: false,
               }}
-              options={{
-                hoverAnimation: false,
-              }}
             />
           );
         }}

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -87,11 +87,11 @@ class Chart extends React.Component<Props> {
       xAxes: [
         {
           gridIndex: 0,
-          type: 'time',
+          type: 'time' as const,
         },
         {
           gridIndex: 1,
-          type: 'time',
+          type: 'time' as const,
         },
       ],
       yAxes: [
@@ -121,9 +121,11 @@ class Chart extends React.Component<Props> {
       utc,
       isGroupedByDate: true,
       showTimeInTooltip: true,
-      colors: [colors[0], colors[1]],
+      colors: [colors[0], colors[1]] as string[],
       tooltip: {
-        valueFormatter: tooltipFormatter,
+        valueFormatter: (value, seriesName) => {
+          return tooltipFormatter(value, seriesName);
+        },
         nameFormatter(value: string) {
           return value === 'epm()' ? 'tpm()' : value;
         },

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
@@ -127,7 +127,7 @@ class DurationPercentileChart extends AsyncComponent<Props, State> {
       return null;
     }
     const xAxis = {
-      type: 'category',
+      type: 'category' as const,
       truncate: true,
       axisLabel: {
         showMinLabel: true,
@@ -139,7 +139,7 @@ class DurationPercentileChart extends AsyncComponent<Props, State> {
       },
     };
     const yAxis = {
-      type: 'value',
+      type: 'value' as const,
       axisLabel: {
         color: theme.gray400,
         // Use p50() to force time formatting.
@@ -160,7 +160,7 @@ class DurationPercentileChart extends AsyncComponent<Props, State> {
         yAxis={yAxis}
         series={transformData(chartData.data)}
         tooltip={tooltip}
-        colors={colors}
+        colors={[...colors]}
       />
     );
   }


### PR DESCRIPTION
### Summary
This converts area charts to typescript. Also removed barCategoryGap option as it only applies to bar charts.