### PR TITLE
fix(ui): SmartSearch onChange on autocomplete click (WOR-398)

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -1034,7 +1034,7 @@ class SmartSearchBar extends React.Component<Props, State> {
 
       // then update the autocomplete box with new contextTypes
       this.updateAutoCompleteItems();
-      this.props.onChange?.(newQuery, {} as any);
+      this.props.onChange?.(newQuery, new MouseEvent('click') as any);
     });
   };
 

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -1034,6 +1034,7 @@ class SmartSearchBar extends React.Component<Props, State> {
 
       // then update the autocomplete box with new contextTypes
       this.updateAutoCompleteItems();
+      this.props.onChange?.(newQuery, {} as any);
     });
   };
 

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -658,6 +658,25 @@ describe('SmartSearchBar', function () {
       expect(searchBar.state.query).toEqual('event.type:error id:12345 ');
     });
 
+    it('triggers onChange', function () {
+      const onChange = jest.fn();
+      const props = {
+        query: 'event.type:error id:',
+        organization,
+        supportedTags,
+      };
+      const searchBar = mountWithTheme(
+        <SmartSearchBar {...props} onChange={onChange} />,
+        options
+      ).instance();
+      searchBar.getCursorPosition = jest.fn().mockReturnValueOnce(20);
+      searchBar.onAutoComplete('12345', {type: 'tag-value'});
+      expect(onChange).toHaveBeenCalledWith(
+        'event.type:error id:12345 ',
+        expect.anything()
+      );
+    });
+
     it('keeps the negation operator is present', function () {
       const props = {
         query: '',


### PR DESCRIPTION
After clicking on an autocomplete dropdown option the query changes in the input field and should notify listeners

WOR-398 #done