### PR TITLE
fix(ui): Format timestamp in stats chart tooltip

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
@@ -7,7 +7,6 @@ import {getFormattedDate} from 'app/utils/dates';
 import BarChart, {BarChartSeries} from './barChart';
 import BaseChart from './baseChart';
 import {truncationFormatter} from './utils';
-import Tooltip from './components/tooltip';
 
 type Marker = {
   name: string;
@@ -157,9 +156,9 @@ class MiniBarChart extends React.Component<Props> {
         };
 
     const chartOptions = {
-      tooltip: Tooltip({
-        trigger: 'axis',
-      }),
+      tooltip: {
+        trigger: 'axis' as const,
+      },
       yAxis: {
         max(value) {
           // This keeps small datasets from looking 'scary'


### PR DESCRIPTION
A recent refactor (https://github.com/getsentry/sentry/pull/21526) caused a regression.

## Before
![image](https://user-images.githubusercontent.com/9060071/98230944-11bd4100-1f5c-11eb-9a5a-e475b76a1cca.png)

## After
![image](https://user-images.githubusercontent.com/9060071/98230895-feaa7100-1f5b-11eb-9fe2-b0658e041669.png)
