### PR TITLE
fix(plugins): adds asset loading back for plugins

### DIFF
--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -44,7 +44,6 @@ class PluginSerializer(Serializer):
             "metadata": obj.get_metadata(),
             "contexts": contexts,
             "status": obj.get_status(),
-            # TODO: remove assets since they are unused
             "assets": [
                 {"url": absolute_uri(get_asset_url(obj.asset_key or obj.slug, asset))}
                 for asset in obj.get_assets()

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -523,7 +523,7 @@ export type PluginNoProject = {
   metadata: any; // TODO(ts)
   contexts: any[]; // TODO(ts)
   status: string;
-  assets: any[]; // TODO(ts)
+  assets: Array<{url: string}>;
   doc: string;
   features: string[];
   featureDescriptions: IntegrationFeature[];


### PR DESCRIPTION
I took out Plugin asset loading a few weeks ago (https://github.com/getsentry/sentry/pull/21361) because I didn't think it was used. Well, it turns out that some on-prem folks use it. This adds it back.

This is for you @nikhilkalige 😁