### PR TITLE
fix(discover) Improve rendering of error.handled

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -313,6 +313,10 @@ const SPECIAL_FIELDS: SpecialFields = {
     sortField: 'error.handled',
     renderFunc: data => {
       const values = data['error.handled'];
+      // Transactions will have null, and default events have no handled attributes.
+      if (values === null || values?.length === 0) {
+        return <Container>{emptyValue}</Container>;
+      }
       const value = Array.isArray(values) ? values.slice(-1)[0] : values;
       return <Container>{[1, null].includes(value) ? 'true' : 'false'}</Container>;
     },

--- a/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
+++ b/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
@@ -91,6 +91,29 @@ describe('getFieldRenderer', function () {
     expect(wrapper.text()).toEqual('n/a');
   });
 
+  it('can render error.handled values', function () {
+    const renderer = getFieldRenderer('error.handled', {'error.handled': 'boolean'});
+
+    // Should render the last value.
+    let wrapper = mount(renderer({'error.handled': [0, 1]}, {location, organization}));
+    expect(wrapper.text()).toEqual('true');
+
+    wrapper = mount(renderer({'error.handled': [0, 0]}, {location, organization}));
+    expect(wrapper.text()).toEqual('false');
+
+    // null = true for error.handled data.
+    wrapper = mount(renderer({'error.handled': [null]}, {location, organization}));
+    expect(wrapper.text()).toEqual('true');
+
+    // Default events won't have error.handled and will return an empty list.
+    wrapper = mount(renderer({'error.handled': []}, {location, organization}));
+    expect(wrapper.text()).toEqual('n/a');
+
+    // Transactions will have null for error.handled as the 'tag' won't be set.
+    wrapper = mount(renderer({'error.handled': null}, {location, organization}));
+    expect(wrapper.text()).toEqual('n/a');
+  });
+
   it('can render user fields with aliased user', function () {
     const renderer = getFieldRenderer('user', {user: 'string'});
 


### PR DESCRIPTION
On events that don't have a handled value (default, csp, transaction) the empty list and null values should be treated as n/a. These event types cannot be handled. The `error.unhandled` field will still show `false` for these events as an event can only be unhandled if its handled state is known.