### PR TITLE
fix(ui) Fix incorrect first seen value.

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
@@ -112,7 +112,7 @@ class MiniBarChart extends React.Component<Props> {
         show: true,
         trigger: 'item',
         formatter: ({data}) => {
-          const time = getFormattedDate(data.value, 'MMM D, YYYY LT', {
+          const time = getFormattedDate(data.coord[0], 'MMM D, YYYY LT', {
             local: !this.props.utc,
           });
           const name = truncationFormatter(data.name, props?.xAxis?.truncate);


### PR DESCRIPTION
The first seen timestamp was incorrect.  The markLine component had a value property, but the `markPoint` component does not.