### PR TITLE
feat(ui): make openMenuOnFocus default to true for selectControl

### DIFF
--- a/src/sentry/static/sentry/app/components/contextPickerModal.tsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.tsx
@@ -261,7 +261,6 @@ class ContextPickerModal extends React.Component<Props> {
         }}
         placeholder={t('Select a Project')}
         name="project"
-        openMenuOnFocus
         options={projects.map(({slug}) => ({label: slug, value: slug}))}
         onChange={this.handleSelectProject}
         onMenuOpen={this.onProjectMenuOpen}
@@ -310,7 +309,6 @@ class ContextPickerModal extends React.Component<Props> {
               placeholder={t('Select an Organization')}
               name="organization"
               options={orgChoices}
-              openMenuOnFocus
               value={organization}
               onChange={this.handleSelectOrganization}
             />

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -240,6 +240,7 @@ const SelectControl = props => {
       isMulti={props.multiple || props.multi}
       isDisabled={props.isDisabled || props.disabled}
       options={choicesOrOptions}
+      openMenuOnFocus={props.openMenuOnFocus === undefined ? true : props.openMenuOnFocus}
       {...rest}
     />
   );

--- a/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/issueAlertOptions.tsx
@@ -160,7 +160,6 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
             data-test-id="range-input"
           />
           <InlineSelectControl
-            openMenuOnFocus
             value={this.state.metric}
             choices={this.getAvailableMetricChoices()}
             onChange={metric => this.setStateAndUpdateParents({metric: metric.value})}
@@ -169,7 +168,6 @@ class IssueAlertOptions extends AsyncComponent<Props, State> {
           {t('a unique error in')}
           <InlineSelectControl
             value={this.state.interval}
-            openMenuOnFocus
             choices={this.state.intervalChoices}
             onChange={interval =>
               this.setStateAndUpdateParents({interval: interval.value})

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -235,7 +235,6 @@ export class RenderField extends React.Component<RenderProps, State> {
           <SelectControl
             placeholder={t('Sentry project\u2026')}
             name="project"
-            openMenuOnFocus
             options={projectOptions}
             components={{
               Option: customOptionProject,
@@ -247,7 +246,6 @@ export class RenderField extends React.Component<RenderProps, State> {
           <SelectControl
             placeholder={mappedValuePlaceholder}
             name="mappedDropdown"
-            openMenuOnFocus
             options={mappedItemsToShow}
             components={{
               Option: customOptionMappedValue,


### PR DESCRIPTION
The default value for `openMenuOnFocus` in React Select is false which sometimes causes problems with tests. Moreover, opening the menu on focus is generally the behavior we want anyways.