### PR TITLE
feat(integrations): Django Forms for Jira Ticket Actions

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -406,7 +406,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         """
         return reverse("sentry-extensions-jira-search", args=[org_slug, self.model.id])
 
-    def build_dynamic_field(self, group, field_meta):
+    def build_dynamic_field(self, field_meta, group=None):
         """
         Builds a field based on Jira's meta field information
         """
@@ -426,7 +426,12 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             schema.get("items") == "user" or schema["type"] == "user"
         ):
             fieldtype = "select"
-            fkwargs["url"] = self.search_url(group.organization.slug)
+            organization = (
+                group.organization
+                if group
+                else Organization.objects.get_from_cache(id=self.organization_id)
+            )
+            fkwargs["url"] = self.search_url(organization.slug)
             fkwargs["choices"] = []
         elif schema["type"] in ["timetracking"]:
             # TODO: Implement timetracking (currently unsupported altogether)
@@ -536,12 +541,18 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             )
         return meta
 
+    def get_create_issue_config_no_params(self):
+        return self.get_create_issue_config(None, None, params={})
+
     def get_create_issue_config(self, group, user, **kwargs):
         kwargs["link_referrer"] = "jira_integration"
-        fields = super(JiraIntegration, self).get_create_issue_config(group, user, **kwargs)
         params = kwargs.get("params", {})
+        fields = []
+        defaults = {}
+        if group:
+            fields = super(JiraIntegration, self).get_create_issue_config(group, user, **kwargs)
+            defaults = self.get_defaults(group.project, user)
 
-        defaults = self.get_defaults(group.project, user)
         project_id = params.get("project", defaults.get("project"))
         client = self.get_client()
         try:
@@ -625,7 +636,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             if field in standard_fields or field in [x.strip() for x in ignored_fields]:
                 # don't overwrite the fixed fields for the form.
                 continue
-            mb_field = self.build_dynamic_field(group, issue_type_meta["fields"][field])
+
+            mb_field = self.build_dynamic_field(issue_type_meta["fields"][field], group)
             if mb_field:
                 mb_field["name"] = field
                 fields.append(mb_field)

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -70,8 +70,8 @@ class JiraCreateTicketAction(TicketEventAction):
 
         labels = ["Create a Jira ticket in the {jira_integration} account"]
 
-        if data.get("jira_project"):
-            labels.append("and {jira_project} project")
+        if data.get("project"):
+            labels.append("and {project} project")
         if data.get("issuetype"):
             labels.append("of type {issuetype}")
         if data.get("components"):

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import logging
 
 from django import forms
+from django.utils.translation import ugettext_lazy as _
 
 from sentry.integrations.jira.utils import transform_jira_fields_to_form_fields
 from sentry.models import ExternalIssue
@@ -114,6 +115,17 @@ class JiraCreateTicketAction(TicketEventAction):
                 else:
                     return transform_jira_fields_to_form_fields(fields)
         return None
+
+    def clean(self):
+        cleaned_data = super(JiraCreateTicketAction, self).clean()
+
+        jira_integration = cleaned_data.get("jira_integration")
+        try:
+            Integration.objects.get(id=jira_integration)
+        except Integration.DoesNotExist:
+            raise forms.ValidationError(
+                _("Jira integration is a required field.",), code="invalid",
+            )
 
     def generate_footer(self, rule_url):
         return u"This ticket was automatically created by Sentry via [{}|{}]".format(

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -4,37 +4,101 @@ import logging
 
 from django import forms
 
-from sentry.rules.actions.base import TicketEventAction
 from sentry.models import ExternalIssue
+from sentry.models.integration import Integration
+from sentry.rules.actions.base import TicketEventAction
+from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger("sentry.rules")
 
 
 class JiraNotifyServiceForm(forms.Form):
-    # TODO 1.0 Add form fields.
+    jira_integration = forms.ChoiceField(choices=(), widget=forms.Select())
 
     def __init__(self, *args, **kwargs):
+        integrations = [(i.id, i.name) for i in kwargs.pop("integrations")]
         super(JiraNotifyServiceForm, self).__init__(*args, **kwargs)
 
-    def clean(self):
-        return super(JiraNotifyServiceForm, self).clean()
+        if integrations:
+            self.fields["jira_integration"].initial = integrations[0][0]
+
+        self.fields["jira_integration"].choices = integrations
+        self.fields["jira_integration"].widget.choices = self.fields["jira_integration"].choices
 
 
 class JiraCreateTicketAction(TicketEventAction):
     form_cls = JiraNotifyServiceForm
-    label = u"TODO Create a {name} Jira ticket"
+    label = u"""Create a Jira ticket in the {jira_integration} account
+    and {project} project
+    of type {issuetype}
+    with components {components}
+    and due date {duedate}
+    with fixVersions {fixVersions}
+    assigned to {assignee}
+    reported by {reporter}
+    label {labels}
+    priority {priority}"""
     prompt = "Create a Jira ticket"
     provider = "jira"
     integration_key = "jira_integration"
 
     def __init__(self, *args, **kwargs):
         super(JiraCreateTicketAction, self).__init__(*args, **kwargs)
-        # TODO 1.1 Add form_fields
-        self.form_fields = {}
+        integration_choices = [(i.id, i.name) for i in self.get_integrations()]
+
+        if not self.get_integration_id() and integration_choices:
+            self.data[self.integration_key] = integration_choices[0][0]
+
+        self.form_fields = {
+            "jira_integration": {
+                "choices": integration_choices,
+                "default": self.get_integration_id(),
+                "type": "choice",
+                "updatesForm": True,
+            }
+        }
+
+        try:
+            integration = self.get_integration()
+        except Integration.DoesNotExist:
+            return
+
+        installation = integration.get_installation(self.project.organization.id)
+        if installation:
+            try:
+                fields = installation.get_create_issue_config_no_params()
+            except IntegrationError as e:
+                # TODO log when the API call fails.
+                logger.info(e)
+                return
+
+            self.update_form_fields_from_jira_fields(fields)
 
     def render_label(self):
         return self.label.format(name=self.get_integration_name())
+
+    def update_form_fields_from_jira_fields(self, fields_list):
+        """
+        The fields array from Jira doesn't exactly match the Alert Rules front
+        end's expected format. Massage the field names and types and put them in a dict.
+
+        :param fields_list: Create ticket fields from Jira as an array.
+        :return: The "create ticket" fields from Jira a dict.
+        """
+        self.form_fields.update(
+            {
+                field["name"]: {
+                    key: ({"select": "choice", "text": "string"}.get(value, value))
+                    if key == "type"
+                    else value
+                    for key, value in field.items()
+                    if key != "updatesForm"
+                }
+                for field in fields_list
+                if field["name"]
+            }
+        )
 
     def generate_footer(self, rule_url):
         return u"This ticket was automatically created by Sentry via [{}|{}]".format(

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -76,7 +76,35 @@ class JiraCreateTicketAction(TicketEventAction):
             self.update_form_fields_from_jira_fields(fields)
 
     def render_label(self):
-        return self.label.format(name=self.get_integration_name())
+        """
+        Get the rule as a string. Use human-readable values when available and
+        construct the the label by parts because there are so many optional
+        fields.
+
+        :return: String
+        """
+        labels = ["Create a Jira ticket in the {} account".format(self.get_integration_name())]
+
+        if self.data.get("jira_project"):
+            labels.append("and {jira_project} project")
+        if self.data.get("issue_type"):
+            labels.append("of type {issue_type}")
+        if self.data.get("components"):
+            labels.append("with components {components}")
+        if self.data.get("duedate"):
+            labels.append("and due date {duedate}")
+        if self.data.get("fixVersions"):
+            labels.append("with fixVersions {fixVersions}")
+        if self.data.get("assignee"):
+            labels.append("assigned to {assignee}")
+        if self.data.get("reporter"):
+            labels.append("reported by {reporter}")
+        if self.data.get("labels"):
+            labels.append("with the labels {labels}")
+        if self.data.get("priority"):
+            labels.append("priority {priority}")
+
+        return " ".join(labels).format(**self.data)
 
     def update_form_fields_from_jira_fields(self, fields_list):
         """

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import logging
+import six
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _
@@ -46,7 +47,7 @@ class JiraCreateTicketAction(TicketEventAction):
         self.form_fields = {
             "jira_integration": {
                 "choices": integration_choices,
-                "default": self.get_integration_id(),
+                "initial": six.text_type(self.get_integration_id()),
                 "type": "choice",
                 "updatesForm": True,
             }

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -20,3 +20,24 @@ def build_user_choice(user_response, user_id_field):
         "(%s)" % name if name else "",
     )
     return user_response[user_id_field], display.strip()
+
+
+def transform_jira_fields_to_form_fields(fields_list):
+    """
+    The fields array from Jira doesn't exactly match the Alert Rules front
+    end's expected format. Massage the field names and types and put them in a dict.
+
+    :param fields_list: Create ticket fields from Jira as an array.
+    :return: The "create ticket" fields from Jira as a dict.
+    """
+    return {
+        field["name"]: {
+            key: ({"select": "choice", "text": "string"}.get(value, value))
+            if key == "type"
+            else value
+            for key, value in field.items()
+            if key != "updatesForm"
+        }
+        for field in fields_list
+        if field["name"]
+    }

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -41,3 +41,12 @@ def transform_jira_fields_to_form_fields(fields_list):
         for field in fields_list
         if field["name"]
     }
+
+
+def transform_jira_choices_to_strings(fields, data):
+    return {
+        key: ({k: v for k, v in fields[key]["choices"]}.get(value, value))
+        if key in fields and fields[key]["type"] == "choice"
+        else value
+        for key, value in data.items()
+    }

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -57,6 +57,9 @@ class IntegrationEventAction(EventAction):
             status=ObjectStatus.VISIBLE,
         )
 
+    def get_integration_id(self):
+        return self.get_option(self.integration_key)
+
     def get_integration(self):
         """
         Uses the required class variables `provider` and `integration_key` with
@@ -66,11 +69,14 @@ class IntegrationEventAction(EventAction):
         :return: Integration
         """
         return Integration.objects.get(
-            id=self.get_option(self.integration_key),
+            id=self.get_integration_id(),
             provider=self.provider,
             organizations=self.project.organization,
             status=ObjectStatus.VISIBLE,
         )
+
+    def get_installation(self):
+        return self.get_integration().get_installation(self.project.organization.id)
 
     def get_form_instance(self):
         return self.form_cls(self.data, integrations=self.get_integrations())

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -85,10 +85,12 @@ class JiraCreateTicketActionTest(RuleTestCase):
         rule = self.get_rule(
             data={
                 "jira_integration": self.integration.id,
-                "issuetype": "1",
-                "issue_type": "Bug",
-                "jira_project": "Example",
-                "project": "10000",
+                "issuetype": 1,
+                "project": 10000,
+                "dynamic_form_fields": {
+                    "issuetype": {"type": "choice", "choices": [(1, "Bug")]},
+                    "project": {"type": "choice", "choices": [(10000, "Example")]},
+                },
             }
         )
 


### PR DESCRIPTION
This is a simple, temporary front end for Jira ticket rules which will be replaced with the final design which is based on a modal.

<img width="690" alt="Screen Shot 2020-11-13 at 10 43 34 AM" src="https://user-images.githubusercontent.com/31750075/99109108-28d3e280-259d-11eb-9d81-c6660de40f4f.png">

The stuff we want to keep is how the form fields are validated and saved.
