### PR TITLE
feat(ui): Simplify blue colors

### DIFF
--- a/src/sentry/static/sentry/app/components/badge.tsx
+++ b/src/sentry/static/sentry/app/components/badge.tsx
@@ -7,7 +7,7 @@ import theme from 'app/utils/theme';
 
 const priorityColors = {
   new: theme.red300,
-  strong: theme.blue400,
+  strong: theme.blue300,
   highlight: theme.green300,
 } as const;
 

--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -273,7 +273,7 @@ const ToggleIcon = styled('a')`
 
   background: ${p => (p.isOpen ? p.theme.gray500 : p.theme.blue300)};
   &:hover {
-    background: ${p => (p.isOpen ? p.theme.gray600 : p.theme.blue300)};
+    background: ${p => (p.isOpen ? p.theme.gray600 : p.theme.blue200)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -271,9 +271,9 @@ const ToggleIcon = styled('a')`
   margin-left: 1px;
   border-radius: 2px;
 
-  background: ${p => (p.isOpen ? p.theme.gray500 : p.theme.blue400)};
+  background: ${p => (p.isOpen ? p.theme.gray500 : p.theme.blue300)};
   &:hover {
-    background: ${p => (p.isOpen ? p.theme.gray600 : p.theme.blue500)};
+    background: ${p => (p.isOpen ? p.theme.gray600 : p.theme.blue300)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.tsx
@@ -199,7 +199,7 @@ const GroupLevel = styled('div')<{level: Level}>`
       case 'sample':
         return p.theme.purple300;
       case 'info':
-        return p.theme.blue400;
+        return p.theme.blue300;
       case 'warning':
         return p.theme.yellow300;
       case 'error':

--- a/src/sentry/static/sentry/app/components/events/errorLevel.tsx
+++ b/src/sentry/static/sentry/app/components/events/errorLevel.tsx
@@ -7,7 +7,7 @@ const DEFAULT_SIZE = '13px';
 function getLevelColor({level = '', theme}) {
   const COLORS = {
     error: theme.orange400,
-    info: theme.blue400,
+    info: theme.blue300,
     warning: theme.orange300,
     fatal: theme.red300,
     sample: theme.purple300,

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/filter/optionsGroup.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/filter/optionsGroup.tsx
@@ -80,7 +80,7 @@ const ListItem = styled('li')<{isChecked?: boolean}>`
   }
 
   &:hover span {
-    color: ${p => p.theme.blue400};
+    color: ${p => p.theme.blue300};
     text-decoration: underline;
   }
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/getCrumbDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/getCrumbDetails.tsx
@@ -42,7 +42,7 @@ function getCrumbDetails(type: BreadcrumbType) {
 
     case BreadcrumbType.INFO:
       return {
-        color: 'blue400',
+        color: 'blue300',
         icon: IconInfo,
         description: t('Info'),
       };
@@ -69,7 +69,7 @@ function getCrumbDetails(type: BreadcrumbType) {
       };
     case BreadcrumbType.QUERY:
       return {
-        color: 'blue500',
+        color: 'blue300',
         icon: IconStack,
         description: t('Query'),
       };

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/level.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/level.tsx
@@ -29,7 +29,7 @@ const Level = React.memo(({level, searchTerm = ''}: Props) => {
       );
     case BreadcrumbLevelType.INFO:
       return (
-        <StyledTag color="blue400">
+        <StyledTag color="blue300">
           <Highlight text={searchTerm}>{t('info')}</Highlight>
         </StyledTag>
       );

--- a/src/sentry/static/sentry/app/components/events/interfaces/imageForBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/imageForBar.tsx
@@ -44,12 +44,12 @@ const Wrapper = styled('div')`
   border-bottom: 1px solid ${p => p.theme.border};
   font-weight: 700;
   code {
-    color: ${p => p.theme.blue500};
+    color: ${p => p.theme.blue300};
     font-size: ${p => p.theme.fontSizeSmall};
     background: ${p => p.theme.gray100};
   }
   a {
-    color: ${p => p.theme.blue500};
+    color: ${p => p.theme.blue300};
     &:hover {
       text-decoration: underline;
     }

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -257,7 +257,7 @@ const ListItem = styled('li')<{isChecked?: boolean}>`
   }
 
   &:hover span {
-    color: ${p => p.theme.blue400};
+    color: ${p => p.theme.blue300};
     text-decoration: underline;
   }
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/option.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/option.tsx
@@ -44,7 +44,7 @@ const Option = ({id, details, name, crashed, crashedInfo}: Props) => {
         </InnerCell>
       </GridCell>
       <GridCell>
-        <InnerCell color="blue400">
+        <InnerCell color="blue300">
           <Tooltip title={label} position="top">
             <TextOverflow>{label}</TextOverflow>
           </Tooltip>

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/selectedOption.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/selectedOption.tsx
@@ -36,5 +36,5 @@ const ThreadId = styled(TextOverflow)`
 `;
 
 const Label = styled(ThreadId)`
-  color: ${p => p.theme.blue400};
+  color: ${p => p.theme.blue300};
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
@@ -107,7 +107,7 @@ const getAddresstextBorderBottom = (
   }
 
   if (p.isInlineFrame) {
-    return `1px dashed ${p.theme.blue400}`;
+    return `1px dashed ${p.theme.blue300}`;
   }
 
   return 'none';

--- a/src/sentry/static/sentry/app/components/footer.tsx
+++ b/src/sentry/static/sentry/app/components/footer.tsx
@@ -53,7 +53,7 @@ function Footer() {
 const FooterLink = styled(ExternalLink)`
   &.focus-visible {
     outline: none;
-    box-shadow: ${p => p.theme.blue400} 0 2px 0;
+    box-shadow: ${p => p.theme.blue300} 0 2px 0;
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.tsx
+++ b/src/sentry/static/sentry/app/components/globalSelectionHeaderRow.tsx
@@ -71,7 +71,7 @@ const Content = styled('div')<{multi: boolean}>`
 
   &:hover {
     text-decoration: ${p => (p.multi ? 'underline' : null)};
-    color: ${p => (p.multi ? p.theme.blue400 : null)};
+    color: ${p => (p.multi ? p.theme.blue300 : null)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
@@ -152,7 +152,7 @@ export const IntegrationLink = styled('a')`
 
   &,
   &:hover {
-    border-bottom: 1px solid ${p => p.theme.blue400};
+    border-bottom: 1px solid ${p => p.theme.blue300};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -212,7 +212,7 @@ const InProgressIndicator = styled(({user, ...props}: InProgressIndicatorProps) 
 `;
 
 const CTA = styled('div')`
-  color: ${p => p.theme.blue400};
+  color: ${p => p.theme.blue300};
   font-size: ${p => p.theme.fontSizeMedium};
   font-weight: bold;
 `;

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -100,7 +100,7 @@ const getDropdownElementStyles = (p: {showBelowMediaQuery: number; last?: boolea
   }
 
   &:hover {
-    color: ${theme.blue500};
+    color: ${theme.blue300};
   }
   & > svg {
     margin-right: ${space(1)};

--- a/src/sentry/static/sentry/app/components/stream/processingIssueHint.tsx
+++ b/src/sentry/static/sentry/app/components/stream/processingIssueHint.tsx
@@ -52,7 +52,7 @@ function ProcessingIssueHint({orgId, projectId, issue, showProject}: Props) {
     alertType = 'error';
     showButton = true;
   } else if (issue.issuesProcessing > 0) {
-    icon = <IconSettings size="sm" color="blue400" />;
+    icon = <IconSettings size="sm" color="blue300" />;
     alertType = 'info';
     text = tn(
       'Reprocessing %s event …',

--- a/src/sentry/static/sentry/app/components/subscribeButton.tsx
+++ b/src/sentry/static/sentry/app/components/subscribeButton.tsx
@@ -23,7 +23,7 @@ export default class SubscribeButton extends React.Component<Props> {
 
   render() {
     const {size, isSubscribed, onClick, disabled} = this.props;
-    const icon = <IconBell color={isSubscribed ? 'blue400' : undefined} />;
+    const icon = <IconBell color={isSubscribed ? 'blue300' : undefined} />;
 
     return (
       <Button size={size} icon={icon} onClick={onClick} disabled={disabled}>

--- a/src/sentry/static/sentry/app/utils/discover/arrayValue.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/arrayValue.tsx
@@ -52,7 +52,7 @@ const ArrayContainer = styled('div')`
     outline: none;
     padding: 0;
     cursor: pointer;
-    color: ${p => p.theme.blue400};
+    color: ${p => p.theme.blue300};
     margin-left: ${space(0.5)};
   }
 `;

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -23,11 +23,9 @@ const colors = {
   purple200: '#A396DA',
   purple300: '#6C5FC7',
 
-  blue100: '#E9F2FF',
-  blue200: '#AFC7EE',
-  blue300: '#7199DD',
-  blue400: '#3D74DB',
-  blue500: '#194591',
+  blue100: '#D2DFF7',
+  blue200: '#92A8EA',
+  blue300: '#3D74DB',
 
   orange100: '#FFF1ED',
   orange200: '#F9C7B9',
@@ -172,10 +170,10 @@ const alert = {
     iconColor: 'inherit',
   },
   info: {
-    background: colors.blue400,
+    background: colors.blue300,
     backgroundLight: colors.blue100,
     border: colors.blue200,
-    iconColor: colors.blue400,
+    iconColor: colors.blue300,
   },
   warning,
   warn: warning,
@@ -236,7 +234,7 @@ const tag = {
   },
   info: {
     background: colors.blue100,
-    iconColor: colors.blue400,
+    iconColor: colors.blue300,
   },
   white: {
     background: colors.white,
@@ -284,8 +282,8 @@ const generateButtonTheme = alias => ({
     focusShadow: color(colors.red300).alpha(0.5).string(),
   },
   link: {
-    color: colors.blue400,
-    colorActive: colors.blue400,
+    color: colors.blue300,
+    colorActive: colors.blue300,
     background: 'transparent',
     border: false,
     borderActive: false,

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -171,7 +171,7 @@ const alert = {
   },
   info: {
     background: colors.blue300,
-    backgroundLight: colors.blue100,
+    backgroundLight: color(colors.blue100).alpha(0.3).string(),
     border: colors.blue200,
     iconColor: colors.blue300,
   },

--- a/src/sentry/static/sentry/app/views/discover/styles.tsx
+++ b/src/sentry/static/sentry/app/views/discover/styles.tsx
@@ -95,7 +95,7 @@ export const DocsSeparator = styled('div')`
 export const DocsLink = styled(ExternalLink)`
   color: ${p => p.theme.gray700};
   &:hover {
-    color: ${p => p.theme.blue400};
+    color: ${p => p.theme.blue300};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -355,7 +355,7 @@ class CellAction extends React.Component<Props, State> {
           <Reference>
             {({ref}) => (
               <MenuButton ref={ref} onClick={this.handleMenuToggle}>
-                <IconEllipsis size="sm" data-test-id="cell-action" color="blue400" />
+                <IconEllipsis size="sm" data-test-id="cell-action" color="blue300" />
               </MenuButton>
             )}
           </Reference>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -141,7 +141,7 @@ const Container = styled('div')`
 
 const IntegrationName = styled(Link)`
   font-weight: bold;
-  color: ${p => p.theme.blue400};
+  color: ${p => p.theme.blue300};
 `;
 
 const IntegrationDetails = styled('div')`

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/otherProjects.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/otherProjects.tsx
@@ -89,7 +89,7 @@ class OtherProjects extends React.Component<Props, State> {
 const Row = styled('div')`
   margin-bottom: ${space(0.25)};
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.blue400};
+  color: ${p => p.theme.blue300};
   ${overflowEllipsis}
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.jsx
@@ -99,7 +99,7 @@ const CrumbLink = styled(Link)`
 
   &.focus-visible {
     outline: none;
-    box-shadow: ${p => p.theme.blue400} 0 2px 0;
+    box-shadow: ${p => p.theme.blue300} 0 2px 0;
   }
 
   color: ${p => p.theme.gray600};

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -36,7 +36,7 @@ const STAT_OPS = {
   'invalid-csp': {title: t('Invalid CSP'), color: theme.blue300},
   'ip-address': {title: t('IP Address'), color: theme.red200},
   'legacy-browsers': {title: t('Legacy Browser'), color: theme.gray300},
-  localhost: {title: t('Localhost'), color: theme.blue400},
+  localhost: {title: t('Localhost'), color: theme.blue300},
   'release-version': {title: t('Release'), color: theme.purple200},
   'web-crawlers': {title: t('Web Crawler'), color: theme.red300},
 };


### PR DESCRIPTION
Continuation of the simplification of theme colors for dark mode. This changes all uses of blue4/500 to blue300. 100/200 were not in use previously.