### PR TITLE
feat(ui): Simplify yellow colors

### DIFF
--- a/src/sentry/static/sentry/app/components/commitRow.tsx
+++ b/src/sentry/static/sentry/app/components/commitRow.tsx
@@ -135,7 +135,7 @@ const EmailWarningIcon = styled('span')`
   line-height: 12px;
   border-radius: 50%;
   border: 1px solid ${p => p.theme.white};
-  background: ${p => p.theme.yellow300};
+  background: ${p => p.theme.yellow200};
   padding: 1px 2px 3px 2px;
 `;
 

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -70,7 +70,7 @@ function IncompatibleQueryAlert({
   const pathname = `/organizations/${orgId}/discover/results/`;
 
   return (
-    <StyledAlert type="warning" icon={<IconInfo color="yellow400" size="sm" />}>
+    <StyledAlert type="warning" icon={<IconInfo color="yellow300" size="sm" />}>
       {totalErrors === 1 && (
         <React.Fragment>
           {hasProjectError &&
@@ -157,7 +157,7 @@ function IncompatibleQueryAlert({
         </React.Fragment>
       )}
       <StyledCloseButton
-        icon={<IconClose color="yellow400" size="sm" isCircled />}
+        icon={<IconClose color="yellow300" size="sm" isCircled />}
         aria-label={t('Close')}
         size="zero"
         onClick={onClose}

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.tsx
@@ -201,7 +201,7 @@ const GroupLevel = styled('div')<{level: Level}>`
       case 'info':
         return p.theme.blue400;
       case 'warning':
-        return p.theme.yellow400;
+        return p.theme.yellow300;
       case 'error':
         return p.theme.orange400;
       case 'fatal':

--- a/src/sentry/static/sentry/app/components/highlight.tsx
+++ b/src/sentry/static/sentry/app/components/highlight.tsx
@@ -43,7 +43,7 @@ const HighlightComponent = ({className, children, disabled, text}: Props) => {
 
 const Highlight = styled(HighlightComponent)`
   font-weight: normal;
-  background-color: ${p => p.theme.yellow300};
+  background-color: ${p => p.theme.yellow200};
   color: ${p => p.theme.gray700};
 `;
 

--- a/src/sentry/static/sentry/app/components/list/utils.tsx
+++ b/src/sentry/static/sentry/app/components/list/utils.tsx
@@ -40,7 +40,7 @@ const numericStyle = (theme: Theme, isSolid = false) => css`
           height: 24px;
           font-weight: 500;
           font-size: ${theme.fontSizeSmall};
-          background-color: ${theme.yellow400};
+          background-color: ${theme.yellow300};
         `
       : css`
           top: 3px;

--- a/src/sentry/static/sentry/app/components/passwordStrength.tsx
+++ b/src/sentry/static/sentry/app/components/passwordStrength.tsx
@@ -37,7 +37,7 @@ type Props = {
 const PasswordStrength = ({
   value,
   labels = ['Very Weak', 'Very Weak', 'Weak', 'Strong', 'Very Strong'],
-  colors = [theme.red400, theme.red400, theme.yellow400, theme.green300, theme.green300],
+  colors = [theme.red400, theme.red400, theme.yellow300, theme.green300, theme.green300],
 }: Props) => {
   if (value === '') {
     return null;

--- a/src/sentry/static/sentry/app/components/stream/processingIssueHint.tsx
+++ b/src/sentry/static/sentry/app/components/stream/processingIssueHint.tsx
@@ -60,7 +60,7 @@ function ProcessingIssueHint({orgId, projectId, issue, showProject}: Props) {
       issue.issuesProcessing
     );
   } else if (issue.resolveableIssues > 0) {
-    icon = <IconSettings size="sm" color="yellow400" />;
+    icon = <IconSettings size="sm" color="yellow300" />;
     alertType = 'warning';
     text = tn(
       'There is %s event pending reprocessing.',

--- a/src/sentry/static/sentry/app/utils/discover/keyTransactionField.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/keyTransactionField.tsx
@@ -69,7 +69,7 @@ class KeyTransactionField extends React.Component<Props, State> {
 
     const star = (
       <StyledKey
-        color={isKeyTransaction ? 'yellow400' : 'gray400'}
+        color={isKeyTransaction ? 'yellow300' : 'gray400'}
         isSolid={isKeyTransaction}
         data-test-id="key-transaction-column"
       />

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -162,10 +162,10 @@ const aliases = {
 } as const;
 
 const warning = {
-  background: colors.yellow500,
+  background: colors.yellow100,
   backgroundLight: colors.yellow100,
-  border: colors.yellow400,
-  iconColor: colors.yellow500,
+  border: colors.yellow300,
+  iconColor: colors.yellow300,
 } as const;
 
 const alert = {

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -228,7 +228,7 @@ const tag = {
   },
   warning: {
     background: colors.yellow100,
-    iconColor: colors.yellow400,
+    iconColor: colors.yellow300,
   },
   success: {
     background: colors.green100,

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -163,7 +163,7 @@ const aliases = {
 
 const warning = {
   background: colors.yellow100,
-  backgroundLight: colors.yellow100,
+  backgroundLight: color(colors.yellow100).alpha(0.3).string(),
   border: colors.yellow300,
   iconColor: colors.yellow300,
 } as const;

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -15,11 +15,9 @@ const colors = {
   gray700: '#4A3E56',
   gray800: '#302839',
 
-  yellow100: '#FFF9DF',
-  yellow200: '#FFF8C4',
-  yellow300: '#FFF492',
-  yellow400: '#FFC227',
-  yellow500: '#E2A301',
+  yellow100: '#FDE8b4',
+  yellow200: '#FFD577',
+  yellow300: '#FFC227',
 
   purple100: '#F5E9FF',
   purple200: '#E7D3FF',

--- a/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
@@ -143,7 +143,7 @@ const Chart = (props: Props) => {
             type: 'line',
             markLine: MarkLine({
               silent: true,
-              lineStyle: {color: theme.yellow400},
+              lineStyle: {color: theme.yellow300},
               data: [
                 {
                   yAxis: warningTriggerAlertThreshold,
@@ -154,7 +154,7 @@ const Chart = (props: Props) => {
                 show: true,
                 position: 'insideEndTop',
                 formatter: 'WARNING',
-                color: theme.yellow400,
+                color: theme.yellow300,
                 fontSize: 10,
               } as any, // TODO(ts): Color is not an exposed option for label,
             }),

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -394,7 +394,7 @@ const IconUpdate = styled('div')`
 
   margin-right: ${space(0.75)};
   border-radius: 5px;
-  background-color: ${p => p.theme.yellow400};
+  background-color: ${p => p.theme.yellow300};
 `;
 
 export default withProjects(withApi(SavedQueryButtonGroup));

--- a/src/sentry/static/sentry/app/views/issueList/actions.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.tsx
@@ -752,8 +752,8 @@ const IconPad = styled('span')`
 
 const SelectAllNotice = styled('div')`
   background-color: ${p => p.theme.yellow100};
-  border-top: 1px solid ${p => p.theme.yellow400};
-  border-bottom: 1px solid ${p => p.theme.yellow400};
+  border-top: 1px solid ${p => p.theme.yellow300};
+  border-bottom: 1px solid ${p => p.theme.yellow300};
   font-size: ${p => p.theme.fontSizeMedium};
   text-align: center;
   padding: ${space(0.5)} ${space(1.5)};

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.jsx
@@ -126,7 +126,7 @@ class GroupEventToolbar extends React.Component {
               date={getDynamicText({value: evt.dateCreated, fixed: 'Dummy timestamp'})}
               style={style}
             />
-            {isOverLatencyThreshold && <StyledIconWarning color="yellow500" />}
+            {isOverLatencyThreshold && <StyledIconWarning color="yellow300" />}
           </Tooltip>
           <ExternalLink href={jsonUrl} className="json-link">
             {'JSON'} (<FileSize bytes={evt.size} />)

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -222,7 +222,7 @@ class Table extends React.Component<Props, State> {
         const star = (
           <IconStar
             key="keyTransaction"
-            color="yellow400"
+            color="yellow300"
             isSolid
             data-test-id="key-transaction-header"
           />

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
@@ -131,7 +131,7 @@ class KeyTransactionButton extends React.Component<Props, State> {
         icon={
           <IconStar
             size="xs"
-            color={isKeyTransaction ? 'yellow400' : 'gray400'}
+            color={isKeyTransaction ? 'yellow300' : 'gray400'}
             isSolid={!!isKeyTransaction}
           />
         }

--- a/src/sentry/static/sentry/app/views/releases/list/crashFree.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/crashFree.tsx
@@ -16,7 +16,7 @@ const getIcon = (percent: number) => {
   }
 
   if (percent < CRASH_FREE_WARNING_THRESHOLD) {
-    return <IconWarning color="yellow400" />;
+    return <IconWarning color="yellow300" />;
   }
 
   return <IconCheckmark isCircled color="green300" />;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -41,7 +41,7 @@ const CHART_GRID = {
 const COLOR = {
   RESOLUTION_FILL: color(theme.green200).alpha(0.1).rgb().string(),
   CRITICAL_FILL: color(theme.red400).alpha(0.25).rgb().string(),
-  WARNING_FILL: color(theme.yellow300).alpha(0.1).rgb().string(),
+  WARNING_FILL: color(theme.yellow200).alpha(0.1).rgb().string(),
 };
 
 /**
@@ -170,7 +170,7 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
 
     const isCritical = trigger.label === 'critical';
     const LINE_STYLE = {
-      stroke: isResolution ? theme.green300 : isCritical ? theme.red500 : theme.yellow500,
+      stroke: isResolution ? theme.green300 : isCritical ? theme.red500 : theme.yellow300,
       lineDash: [2],
     };
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
@@ -226,7 +226,7 @@ const CriticalIndicator = styled(CircleIndicator)`
 `;
 
 const WarningIndicator = styled(CircleIndicator)`
-  background: ${p => p.theme.yellow400};
+  background: ${p => p.theme.yellow300};
   margin-right: ${space(1)};
 `;
 


### PR DESCRIPTION
Continuation of the simplication of theme colors for dark mode. This changes all uses of yellow4/500 to yellow300, and 300->200.