### PR TITLE
feat(ui): Simplify red colors

### DIFF
--- a/src/sentry/static/sentry/app/components/activity/note/input.tsx
+++ b/src/sentry/static/sentry/app/components/activity/note/input.tsx
@@ -315,7 +315,7 @@ const getNoteInputErrorStyles = p => {
       height: 0;
       border-top: 7px solid transparent;
       border-bottom: 7px solid transparent;
-      border-right: 7px solid ${p.theme.red400};
+      border-right: 7px solid ${p.theme.red300};
       position: absolute;
       left: -7px;
       top: 12px;

--- a/src/sentry/static/sentry/app/components/alerts/toastIndicator.tsx
+++ b/src/sentry/static/sentry/app/components/alerts/toastIndicator.tsx
@@ -50,7 +50,7 @@ const Icon = styled('div', {shouldForwardProp: p => p !== 'type'})<{type: string
     display: block;
   }
 
-  color: ${p => (p.type === 'success' ? p.theme.green300 : p.theme.red400)};
+  color: ${p => (p.type === 'success' ? p.theme.green300 : p.theme.red300)};
 `;
 
 const Message = styled('div')`

--- a/src/sentry/static/sentry/app/components/badge.tsx
+++ b/src/sentry/static/sentry/app/components/badge.tsx
@@ -6,7 +6,7 @@ import space from 'app/styles/space';
 import theme from 'app/utils/theme';
 
 const priorityColors = {
-  new: theme.red400,
+  new: theme.red300,
   strong: theme.blue400,
   highlight: theme.green300,
 } as const;

--- a/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
@@ -43,7 +43,7 @@ const StyledDelta = styled('div')`
     p.direction > 0
       ? p.theme.green300
       : p.direction < 0
-      ? p.theme.red400
+      ? p.theme.red300
       : p.theme.gray500};
 `;
 

--- a/src/sentry/static/sentry/app/components/debugFileFeature.tsx
+++ b/src/sentry/static/sentry/app/components/debugFileFeature.tsx
@@ -39,7 +39,7 @@ const DebugFileFeature = ({available, feature}: Props) => {
   } else if (available === false) {
     icon = (
       <IconWrapper>
-        <IconClose size="sm" color="red400" />
+        <IconClose size="sm" color="red300" />
       </IconWrapper>
     );
   }

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.tsx
@@ -52,7 +52,7 @@ class EventOrGroupHeader extends React.Component<Props> {
         )}
         {!hideIcons && status === 'ignored' && (
           <IconWrapper>
-            <IconMute color="red400" />
+            <IconMute color="red300" />
           </IconWrapper>
         )}
         {!hideIcons && isBookmarked && (
@@ -205,7 +205,7 @@ const GroupLevel = styled('div')<{level: Level}>`
       case 'error':
         return p.theme.orange400;
       case 'fatal':
-        return p.theme.red400;
+        return p.theme.red300;
       default:
         return p.theme.gray500;
     }

--- a/src/sentry/static/sentry/app/components/events/errorLevel.tsx
+++ b/src/sentry/static/sentry/app/components/events/errorLevel.tsx
@@ -9,7 +9,7 @@ function getLevelColor({level = '', theme}) {
     error: theme.orange400,
     info: theme.blue400,
     warning: theme.orange300,
-    fatal: theme.red400,
+    fatal: theme.red300,
     sample: theme.purple300,
   };
 

--- a/src/sentry/static/sentry/app/components/events/errors.tsx
+++ b/src/sentry/static/sentry/app/components/events/errors.tsx
@@ -107,7 +107,7 @@ const StyledBanner = styled(BannerContainer)`
 `;
 
 const StyledIconWarning = styled(IconWarning)`
-  color: ${p => p.theme.red400};
+  color: ${p => p.theme.red300};
 `;
 
 // TODO(theme) don't use a custom pink

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/getCrumbDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/getCrumbDetails.tsx
@@ -49,7 +49,7 @@ function getCrumbDetails(type: BreadcrumbType) {
 
     case BreadcrumbType.ERROR:
       return {
-        color: 'red400',
+        color: 'red300',
         icon: IconFire,
         description: t('Error'),
       };

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/level.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/level.tsx
@@ -17,13 +17,13 @@ const Level = React.memo(({level, searchTerm = ''}: Props) => {
   switch (level) {
     case BreadcrumbLevelType.FATAL:
       return (
-        <StyledTag color="red500">
+        <StyledTag color="red300">
           <Highlight text={searchTerm}>{t('fatal')}</Highlight>
         </StyledTag>
       );
     case BreadcrumbLevelType.ERROR:
       return (
-        <StyledTag color="red400">
+        <StyledTag color="red300">
           <Highlight text={searchTerm}>{t('error')}</Highlight>
         </StyledTag>
       );

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/styles.tsx
@@ -47,7 +47,7 @@ const GridCell = styled('div')<{
     p.hasError &&
     `
       background: #fffcfb;
-      border-bottom: 1px solid ${p.theme.red400};
+      border-bottom: 1px solid ${p.theme.red300};
       :after {
         content: '';
         position: absolute;
@@ -55,7 +55,7 @@ const GridCell = styled('div')<{
         left: 0;
         height: 1px;
         width: 100%;
-        background: ${p.theme.red400};
+        background: ${p.theme.red300};
       }
     `}
   ${p => p.isLastItem && `border-bottom: none`};
@@ -72,7 +72,7 @@ const GridCellLeft = styled(GridCell)`
     top: 0;
     bottom: 0;
     left: 21px;
-    background: ${p => (p.hasError ? p.theme.red400 : p.theme.gray300)};
+    background: ${p => (p.hasError ? p.theme.red300 : p.theme.gray300)};
     position: absolute;
     @media (min-width: ${p => p.theme.breakpoints[0]}) {
       left: 29px;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugImage.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugImage.tsx
@@ -136,7 +136,7 @@ const DebugImage = React.memo(({image, orgId, projectId, showDetails, style}: Pr
       default:
         return (
           <IconWrapper>
-            <IconFlag color="red400" />
+            <IconFlag color="red300" />
           </IconWrapper>
         );
     }

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/utils.tsx
@@ -23,7 +23,7 @@ export function getFrameHint(frame: Frame) {
   const func = frame.function || '<unknown>';
   // Custom color used to match adjacent text.
   const warningIcon = <IconQuestion size="xs" color={'#2c45a8' as any} />;
-  const errorIcon = <IconWarning size="xs" color="red400" />;
+  const errorIcon = <IconWarning size="xs" color="red300" />;
 
   if (func.match(/^@objc\s/)) {
     return [t('Objective-C -> Swift shim frame'), warningIcon];

--- a/src/sentry/static/sentry/app/components/events/interfaces/packageStatus.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/packageStatus.tsx
@@ -19,7 +19,7 @@ const PackageStatus = ({status, tooltip}: Props) => {
         return <IconCircle size="xs" />;
       case 'error':
       default:
-        return <IconFlag color="red400" size="xs" />;
+        return <IconFlag color="red300" size="xs" />;
     }
   };
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -646,7 +646,7 @@ const CursorGuide = styled('div')`
   position: absolute;
   top: 0;
   width: 1px;
-  background-color: ${p => p.theme.red400};
+  background-color: ${p => p.theme.red300};
   transform: translateX(-50%);
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -940,7 +940,7 @@ const CursorGuide = styled('div')`
   position: absolute;
   top: 0;
   width: 1px;
-  background-color: ${p => p.theme.red400};
+  background-color: ${p => p.theme.red300};
   transform: translateX(-50%);
   height: 100%;
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/option.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/option.tsx
@@ -68,10 +68,10 @@ const Option = ({id, details, name, crashed, crashedInfo}: Props) => {
                 })}
                 position="top"
               >
-                <IconFire color="red400" />
+                <IconFire color="red300" />
               </Tooltip>
             ) : (
-              <IconFire color="red400" />
+              <IconFire color="red300" />
             )}
           </InnerCell>
         )}

--- a/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
@@ -103,7 +103,7 @@ const getAddresstextBorderBottom = (
   p: Pick<Partial<Props>, 'isFoundByStackScanning' | 'isInlineFrame'> & {theme: Theme}
 ) => {
   if (p.isFoundByStackScanning) {
-    return `1px dashed ${p.theme.red400}`;
+    return `1px dashed ${p.theme.red300}`;
   }
 
   if (p.isInlineFrame) {

--- a/src/sentry/static/sentry/app/components/events/meta/annotatedText/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/meta/annotatedText/index.tsx
@@ -72,7 +72,7 @@ const AnnotatedText = ({value, meta, ...props}: Props) => {
 
     return (
       <StyledTooltipError title={getTooltipTitle(errors)}>
-        <StyledIconWarning color="red500" />
+        <StyledIconWarning color="red300" />
       </StyledTooltipError>
     );
   };

--- a/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
+++ b/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
@@ -119,7 +119,7 @@ const StyledPanel = styled(Panel)<{failedThreshold: boolean}>`
     }
 
     return `
-      border: 1px solid ${p.theme.red400};
+      border: 1px solid ${p.theme.red300};
     `;
   }};
 `;
@@ -136,7 +136,7 @@ const WarningIconContainer = styled('span')<{size: IconSize | string}>`
   height: ${p => p.theme.iconSizes[p.size] ?? p.size};
   line-height: ${p => p.theme.iconSizes[p.size] ?? p.size};
   margin-right: ${space(0.5)};
-  color: ${p => p.theme.red400};
+  color: ${p => p.theme.red300};
 `;
 
 const Value = styled('span')<{failedThreshold: boolean}>`
@@ -147,7 +147,7 @@ const Value = styled('span')<{failedThreshold: boolean}>`
     }
 
     return `
-      color: ${p.theme.red400};
+      color: ${p.theme.red300};
     `;
   }};
 `;

--- a/src/sentry/static/sentry/app/components/forms/formField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/formField.tsx
@@ -198,5 +198,5 @@ export default class FormField<
 
 const ErrorMessage = styled('p')`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.red400};
+  color: ${p => p.theme.red300};
 `;

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
@@ -501,7 +501,7 @@ const StatusMessage = styled('div')<{status?: 'success' | 'error'}>`
   grid-gap: ${space(1)};
   align-items: center;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => (p.status === 'error' ? p.theme.red400 : p.theme.gray600)};
+  color: ${p => (p.status === 'error' ? p.theme.red300 : p.theme.gray600)};
 
   > :first-child {
     ${p => p.status === 'success' && `color: ${p.theme.green300}`};

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/renderEmailValue.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/renderEmailValue.tsx
@@ -43,8 +43,8 @@ const EmailValue = styled('div')<{status: InviteStatus[string]}>`
       p.status &&
       p.status.error &&
       css`
-        color: ${p.theme.red400};
-        border-color: ${p.theme.red400};
+        color: ${p.theme.red300};
+        border-color: ${p.theme.red300};
         background-color: ${p.theme.red100};
       `};
   }

--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
@@ -243,7 +243,7 @@ const Author = styled('div')`
 
 const DisabledNotice = styled(({reason, ...p}: {reason: React.ReactNode}) => (
   <div {...p}>
-    <IconFlag color="red400" size="1.5em" />
+    <IconFlag color="red300" size="1.5em" />
     {reason}
   </div>
 ))`
@@ -251,7 +251,7 @@ const DisabledNotice = styled(({reason, ...p}: {reason: React.ReactNode}) => (
   align-items: center;
   flex: 1;
   grid-template-columns: max-content 1fr;
-  color: ${p => p.theme.red400};
+  color: ${p => p.theme.red300};
   font-size: 0.9em;
 `;
 

--- a/src/sentry/static/sentry/app/components/mutedBox.tsx
+++ b/src/sentry/static/sentry/app/components/mutedBox.tsx
@@ -62,7 +62,7 @@ class MutedBox extends React.PureComponent<Props> {
   render = () => (
     <BannerContainer priority="default">
       <BannerSummary>
-        <IconMute color="red400" size="sm" />
+        <IconMute color="red300" size="sm" />
         <span>
           {this.renderReason()}&nbsp;&mdash;&nbsp;
           {t(

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -111,7 +111,7 @@ function Task({router, task, onSkip, onMarkComplete, forwardedRef, organization}
         requisite: task.requisiteTasks[0].title,
       })}
     >
-      <IconLock size="xs" color="red400" />
+      <IconLock size="xs" color="red300" />
     </Tooltip>
   );
 

--- a/src/sentry/static/sentry/app/components/passwordStrength.tsx
+++ b/src/sentry/static/sentry/app/components/passwordStrength.tsx
@@ -37,7 +37,7 @@ type Props = {
 const PasswordStrength = ({
   value,
   labels = ['Very Weak', 'Very Weak', 'Weak', 'Strong', 'Very Strong'],
-  colors = [theme.red400, theme.red400, theme.yellow300, theme.green300, theme.green300],
+  colors = [theme.red300, theme.red300, theme.yellow300, theme.green300, theme.green300],
 }: Props) => {
   if (value === '') {
     return null;

--- a/src/sentry/static/sentry/app/components/pill.tsx
+++ b/src/sentry/static/sentry/app/components/pill.tsx
@@ -63,7 +63,7 @@ const getPillStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
       return `
         background: ${theme.red100};
         background: ${theme.red100};
-        border: 1px solid ${theme.red400};
+        border: 1px solid ${theme.red300};
       `;
     default:
       return `
@@ -84,16 +84,16 @@ const getPillValueStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
       `;
     case 'error':
       return `
-        border-left-color: ${theme.red400};
+        border-left-color: ${theme.red300};
         background: ${theme.red100};
-        border: 1px solid ${theme.red400};
+        border: 1px solid ${theme.red300};
         margin: -1px;
       `;
     case 'negative':
       return `
-        border-left-color: ${theme.red400};
+        border-left-color: ${theme.red300};
         background: ${theme.red100};
-        border: 1px solid ${theme.red400};
+        border: 1px solid ${theme.red300};
         font-family: ${theme.text.familyMono};
         margin: -1px;
       `;

--- a/src/sentry/static/sentry/app/components/placeholder.tsx
+++ b/src/sentry/static/sentry/app/components/placeholder.tsx
@@ -33,7 +33,7 @@ const Placeholder = styled((props: Props) => {
   justify-content: center;
 
   background-color: ${p => (p.error ? p.theme.red100 : p.theme.gray200)};
-  ${p => p.error && `color: ${p.theme.red300};`}
+  ${p => p.error && `color: ${p.theme.red200};`}
   width: ${p => p.width};
   height: ${p => p.height};
   ${p => (p.shape === 'circle' ? 'border-radius: 100%;' : '')}

--- a/src/sentry/static/sentry/app/components/sidebar/onboardingStatus.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/onboardingStatus.tsx
@@ -120,7 +120,7 @@ const Remaining = styled('div')`
 `;
 
 const PendingSeenIndicator = styled('div')`
-  background: ${p => p.theme.red400};
+  background: ${p => p.theme.red300};
   border-radius: 50%;
   height: 7px;
   width: 7px;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
@@ -253,7 +253,7 @@ const getCollapsedBadgeStyle = ({collapsed, theme}) => {
     position: absolute;
     right: 0;
     top: 1px;
-    background: ${theme.red400};
+    background: ${theme.red300};
     width: ${theme.sidebar.smallBadgeSize};
     height: ${theme.sidebar.smallBadgeSize};
     border-radius: ${theme.sidebar.smallBadgeSize};
@@ -267,7 +267,7 @@ const SidebarItemBadge = styled(({collapsed: _, ...props}) => <span {...props} /
   text-align: center;
   color: ${p => p.theme.white};
   font-size: 12px;
-  background: ${p => p.theme.red400};
+  background: ${p => p.theme.red300};
   width: ${p => p.theme.sidebar.badgeSize};
   height: ${p => p.theme.sidebar.badgeSize};
   border-radius: ${p => p.theme.sidebar.badgeSize};

--- a/src/sentry/static/sentry/app/components/stream/processingIssueHint.tsx
+++ b/src/sentry/static/sentry/app/components/stream/processingIssueHint.tsx
@@ -34,7 +34,7 @@ function ProcessingIssueHint({orgId, projectId, issue, showProject}: Props) {
   }
 
   if (issue.numIssues > 0) {
-    icon = <IconWarning size="sm" color="red400" />;
+    icon = <IconWarning size="sm" color="red300" />;
     text = tn(
       'There is %s issue blocking event processing',
       'There are %s issues blocking event processing',

--- a/src/sentry/static/sentry/app/styles/pulsingIndicator.tsx
+++ b/src/sentry/static/sentry/app/styles/pulsingIndicator.tsx
@@ -18,7 +18,7 @@ const pulsingIndicatorStyles = (p: {theme: Theme}) => css`
   height: 10px;
   width: 10px;
   border-radius: 50%;
-  background: ${p.theme.red400};
+  background: ${p.theme.red300};
   position: relative;
 
   &:before {
@@ -30,7 +30,7 @@ const pulsingIndicatorStyles = (p: {theme: Theme}) => css`
     border-radius: 50%;
     top: -45px;
     left: -45px;
-    border: 4px solid ${p.theme.red400};
+    border: 4px solid ${p.theme.red300};
     transform-origin: center;
     animation: ${pulse} 3s ease-out infinite;
   }

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -181,13 +181,13 @@ const alert = {
   warn: warning,
   success: {
     background: colors.green300,
-    backgroundLight: colors.green100,
+    backgroundLight: color(colors.green100).alpha(0.3).string(),
     border: colors.green200,
     iconColor: colors.green300,
   },
   error: {
     background: colors.red300,
-    backgroundLight: colors.red100,
+    backgroundLight: color(colors.red100).alpha(0.3).string(),
     border: colors.red200,
     iconColor: colors.red300,
     textLight: colors.red200,

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -35,11 +35,9 @@ const colors = {
   orange400: '#FF7738',
   orange500: '#BA4A23',
 
-  red100: '#FFECF0',
-  red200: '#F4B1BB',
-  red300: '#EA7282',
-  red400: '#FA4747',
-  red500: '#AC1025',
+  red100: '#FCC6C8',
+  red200: '#FD918F',
+  red300: '#F55459',
 
   green100: '#B6ECDF',
   green200: '#7DD6BE',
@@ -99,9 +97,9 @@ const aliases = {
   /**
    * A color that denotes an error, or something that is wrong
    */
-  error: colors.red400, // TODO(dark): colors.red300,
+  error: colors.red300, // TODO(dark): colors.red300,
 
-  /**
+  /**red200
    * A color that indicates something is disabled where user can not interact or use
    * it in the usual manner (implies that there is an "enabled" state)
    */
@@ -188,10 +186,10 @@ const alert = {
     iconColor: colors.green300,
   },
   error: {
-    background: colors.red400,
+    background: colors.red300,
     backgroundLight: colors.red100,
     border: colors.red200,
-    iconColor: colors.red400,
+    iconColor: colors.red300,
     textLight: colors.red200,
   },
 } as const;
@@ -234,7 +232,7 @@ const tag = {
   },
   error: {
     background: colors.red100,
-    iconColor: colors.red400,
+    iconColor: colors.red300,
   },
   info: {
     background: colors.blue100,
@@ -279,11 +277,11 @@ const generateButtonTheme = alias => ({
   danger: {
     color: colors.white,
     colorActive: colors.white,
-    background: colors.red400,
+    background: colors.red300,
     backgroundActive: '#bf2a1d',
     border: '#bf2a1d',
     borderActive: '#7d1c13',
-    focusShadow: color(colors.red400).alpha(0.5).string(),
+    focusShadow: color(colors.red300).alpha(0.5).string(),
   },
   link: {
     color: colors.blue400,

--- a/src/sentry/static/sentry/app/views/admin/adminOverview/apiChart.jsx
+++ b/src/sentry/static/sentry/app/views/admin/adminOverview/apiChart.jsx
@@ -107,7 +107,7 @@ class ApiChart extends React.Component {
       {
         seriesName: '5xx',
         data: this.processRawSeries(rawData['client-api.all-versions.responses.5xx']),
-        color: theme.red300,
+        color: theme.red200,
       },
     ];
   }

--- a/src/sentry/static/sentry/app/views/admin/adminOverview/eventChart.jsx
+++ b/src/sentry/static/sentry/app/views/admin/adminOverview/eventChart.jsx
@@ -127,7 +127,7 @@ class EventChart extends React.Component {
       {
         seriesName: t('Dropped'),
         data: stats.rejected,
-        color: theme.red300,
+        color: theme.red200,
       },
     ];
   }

--- a/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
@@ -166,7 +166,7 @@ const Chart = (props: Props) => {
             type: 'line',
             markLine: MarkLine({
               silent: true,
-              lineStyle: {color: theme.red300},
+              lineStyle: {color: theme.red200},
               data: [
                 {
                   yAxis: criticalTriggerAlertThreshold,
@@ -177,7 +177,7 @@ const Chart = (props: Props) => {
                 show: true,
                 position: 'insideEndTop',
                 formatter: 'CRITICAL',
-                color: theme.red400,
+                color: theme.red300,
                 fontSize: 10,
               } as any, // TODO(ts): Color is not an exposed option for label,
             }),

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -82,7 +82,7 @@ class AlertListRow extends AsyncComponent<Props, State> {
     const isResolved = status === IncidentStatus.CLOSED;
     const isWarning = status === IncidentStatus.WARNING;
 
-    const color = isResolved ? theme.gray400 : isWarning ? theme.orange300 : theme.red300;
+    const color = isResolved ? theme.gray400 : isWarning ? theme.orange300 : theme.red200;
     const text = isResolved ? t('Resolved') : isWarning ? t('Warning') : t('Critical');
 
     return (

--- a/src/sentry/static/sentry/app/views/alerts/status.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/status.tsx
@@ -26,7 +26,7 @@ const Status = ({className, incident, disableIconColor}: Props) => {
   ) : isWarning ? (
     <IconWarning color={disableIconColor ? undefined : 'orange400'} />
   ) : (
-    <IconFire color={disableIconColor ? undefined : 'red400'} />
+    <IconFire color={disableIconColor ? undefined : 'red300'} />
   );
 
   const text = isResolved ? t('Resolved') : isWarning ? t('Warning') : t('Critical');

--- a/src/sentry/static/sentry/app/views/monitors/monitorStats.jsx
+++ b/src/sentry/static/sentry/app/views/monitors/monitorStats.jsx
@@ -59,7 +59,7 @@ export default class MonitorStats extends AsyncComponent {
       success.data.push({name: timestamp, value: p.ok});
       failed.data.push({name: timestamp, value: p.error});
     });
-    const colors = [theme.green300, theme.red500];
+    const colors = [theme.green300, theme.red300];
 
     return (
       <Panel>

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
@@ -24,7 +24,7 @@ const UnhandledTag = styled((props: React.ComponentProps<typeof Tag>) => (
       <Tooltip title={t('An unhandled error was detected in this Issue.')}>
         <Tag
           priority="error"
-          icon={<IconSubtract size="xs" color="red300" isCircled />}
+          icon={<IconSubtract size="xs" color="red200" isCircled />}
           {...props}
         >
           {t('Unhandled')}

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -413,7 +413,7 @@ const Name = styled('div')`
 `;
 
 const IconCloseCircle = styled(IconClose)`
-  color: ${p => p.theme.red400};
+  color: ${p => p.theme.red300};
   margin-right: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationStats/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/index.tsx
@@ -230,7 +230,7 @@ class OrganizationStatsContainer extends React.Component<Props, State> {
     };
     const orgRejected: Series = {
       seriesName: t('Rate limited'),
-      color: theme.red400,
+      color: theme.red300,
       data: [],
     };
     const orgFiltered: Series = {

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -165,7 +165,7 @@ class VitalCard extends React.Component<Props, State> {
           {summary === null ? null : summary < failureThreshold ? (
             <StyledTag color={theme.purple300}>{t('pass')}</StyledTag>
           ) : (
-            <StyledTag color={theme.red400}>{t('fail')}</StyledTag>
+            <StyledTag color={theme.red300}>{t('fail')}</StyledTag>
           )}
         </CardSectionHeading>
         <StatNumber>{this.getFormattedStatNumber()}</StatNumber>
@@ -476,13 +476,13 @@ class VitalCard extends React.Component<Props, State> {
         show: false,
       },
       lineStyle: {
-        color: theme.red400,
+        color: theme.red300,
         type: 'dashed',
         width: 1.5,
         // prevent each individual line from looking emphasized
         // by styling it the same as the unemphasized line
         emphasis: {
-          color: theme.red400,
+          color: theme.red300,
           type: 'dashed',
           width: 1.5,
         },
@@ -511,7 +511,7 @@ class VitalCard extends React.Component<Props, State> {
     const markPoint = MarkPoint({
       animationDuration: 200,
       data: [{x: topRightPixel.x - 16, y: topRightPixel.y + 16}] as any,
-      itemStyle: {color: theme.red400},
+      itemStyle: {color: theme.red300},
       silent: true,
       symbol: `path://${FIRE_SVG_PATH}`,
       symbolKeepAspect: true,

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -89,8 +89,8 @@ export const trendToColor = {
     default: theme.green300,
   },
   [TrendChangeType.REGRESSION]: {
-    lighter: theme.red300,
-    default: theme.red400,
+    lighter: theme.red200,
+    default: theme.red300,
   },
 };
 

--- a/src/sentry/static/sentry/app/views/releases/list/crashFree.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/crashFree.tsx
@@ -12,7 +12,7 @@ const CRASH_FREE_WARNING_THRESHOLD = 99.5;
 
 const getIcon = (percent: number) => {
   if (percent < CRASH_FREE_DANGER_THRESHOLD) {
-    return <IconFire color="red400" />;
+    return <IconFire color="red300" />;
   }
 
   if (percent < CRASH_FREE_WARNING_THRESHOLD) {

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/controlState.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/controlState.tsx
@@ -66,7 +66,7 @@ const FormSpinner = styled(Spinner)`
 `;
 
 const FieldError = styled('div')`
-  color: ${p => p.theme.red500};
+  color: ${p => p.theme.red300};
   animation: ${() => pulse(1.15)} 1s ease infinite;
 `;
 export default ControlState;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldErrorReason.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldErrorReason.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {slideInUp} from 'app/styles/animations';
 
 const FieldErrorReason = styled('div')`
-  color: ${p => p.theme.red500};
+  color: ${p => p.theme.red300};
   position: absolute;
   right: 2px;
   margin-top: 6px;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldRequiredBadge.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldRequiredBadge.tsx
@@ -4,7 +4,7 @@ import space from 'app/styles/space';
 
 const FieldRequiredBadge = styled('div')`
   display: inline-block;
-  background: ${p => p.theme.red400};
+  background: ${p => p.theme.red300};
   opacity: 0.6;
   width: 5px;
   height: 5px;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -170,11 +170,7 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
 
     const isCritical = trigger.label === 'critical';
     const LINE_STYLE = {
-<<<<<<< HEAD
-      stroke: isResolution ? theme.green300 : isCritical ? theme.red500 : theme.yellow300,
-=======
-      stroke: isResolution ? theme.green300 : isCritical ? theme.red300 : theme.yellow500,
->>>>>>> a9e607789e... feat(ui): Simplify red colors
+      stroke: isResolution ? theme.green300 : isCritical ? theme.red300 : theme.yellow300,
       lineDash: [2],
     };
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -40,7 +40,7 @@ const CHART_GRID = {
 // Colors to use for trigger thresholds
 const COLOR = {
   RESOLUTION_FILL: color(theme.green200).alpha(0.1).rgb().string(),
-  CRITICAL_FILL: color(theme.red400).alpha(0.25).rgb().string(),
+  CRITICAL_FILL: color(theme.red300).alpha(0.25).rgb().string(),
   WARNING_FILL: color(theme.yellow200).alpha(0.1).rgb().string(),
 };
 
@@ -170,7 +170,11 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
 
     const isCritical = trigger.label === 'critical';
     const LINE_STYLE = {
+<<<<<<< HEAD
       stroke: isResolution ? theme.green300 : isCritical ? theme.red500 : theme.yellow300,
+=======
+      stroke: isResolution ? theme.green300 : isCritical ? theme.red300 : theme.yellow500,
+>>>>>>> a9e607789e... feat(ui): Simplify red colors
       lineDash: [2],
     };
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/form.tsx
@@ -221,7 +221,7 @@ class TriggerFormContainer extends React.Component<TriggerFormContainerProps> {
 }
 
 const CriticalIndicator = styled(CircleIndicator)`
-  background: ${p => p.theme.red400};
+  background: ${p => p.theme.red300};
   margin-right: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -34,11 +34,11 @@ const STAT_OPS = {
   'error-message': {title: t('Error Message'), color: theme.purple300},
   'discarded-hash': {title: t('Discarded Issue'), color: theme.gray300},
   'invalid-csp': {title: t('Invalid CSP'), color: theme.blue300},
-  'ip-address': {title: t('IP Address'), color: theme.red300},
+  'ip-address': {title: t('IP Address'), color: theme.red200},
   'legacy-browsers': {title: t('Legacy Browser'), color: theme.gray300},
   localhost: {title: t('Localhost'), color: theme.blue400},
   'release-version': {title: t('Release'), color: theme.purple200},
-  'web-crawlers': {title: t('Web Crawler'), color: theme.red400},
+  'web-crawlers': {title: t('Web Crawler'), color: theme.red300},
 };
 
 class ProjectFiltersChart extends React.Component<Props, State> {

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyStats.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyStats.tsx
@@ -111,7 +111,7 @@ class KeyStats extends React.Component<Props, State> {
               isGroupedByDate
               series={this.state.series}
               height={150}
-              colors={[theme.gray400, theme.red400]}
+              colors={[theme.gray400, theme.red300]}
               stacked
               labelYAxisExtents
             />

--- a/tests/js/spec/components/events/interfaces/breadcrumbs/filter.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/breadcrumbs/filter.spec.tsx
@@ -52,7 +52,7 @@ const options: React.ComponentProps<typeof Filter>['options'] = [
       type: BreadcrumbType.ERROR,
       description: 'Error',
       levels: [BreadcrumbLevelType.ERROR],
-      symbol: <Icon color="red400" icon={IconFire} size="xs" />,
+      symbol: <Icon color="red300" icon={IconFire} size="xs" />,
       isChecked: true,
     },
   ],


### PR DESCRIPTION
Continuation of the simplication of theme colors for dark mode. This changes all uses of red4/500 to red300, and 300->200.