### PR TITLE
fix share link

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
@@ -20,7 +20,7 @@ import space from 'app/styles/space';
 type Props = {
   frame: Frame;
   event: Event;
-  organization?: Organization;
+  organization: Organization; //TODO mark as not optional since it's undefined in the share issue view
   registers: {[key: string]: string};
   components: Array<SentryAppComponent>;
   isExpanded?: boolean;

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
@@ -20,7 +20,7 @@ import space from 'app/styles/space';
 type Props = {
   frame: Frame;
   event: Event;
-  organization: Organization;
+  organization?: Organization;
   registers: {[key: string]: string};
   components: Array<SentryAppComponent>;
   isExpanded?: boolean;
@@ -90,7 +90,7 @@ const Context = ({
                   />
                 </ErrorBoundary>
               )}
-              {organization.features.includes('integrations-stacktrace-link') &&
+              {organization?.features.includes('integrations-stacktrace-link') &&
                 isActive &&
                 isExpanded && (
                   <ErrorBoundary mini>


### PR DESCRIPTION
Org is undefined in the share issue view:

![Screen Shot 2020-11-05 at 8 38 46 PM](https://user-images.githubusercontent.com/8533851/98326803-eb70c300-1fa6-11eb-80f4-89344d870f20.png)

I wanted to make the `organization` prop optional but the compiler was yelling at me and I just want to get this fixed ASAP. I probably need to do a deeper dive _why_ the org is undefined tomorrow as well.

Fixes JAVASCRIPT-233F and JAVASCRIPT-233D