### PR TITLE
feat(ui): Simplify gray colors

### DIFF
--- a/docs-ui/components/colors.stories.js
+++ b/docs-ui/components/colors.stories.js
@@ -79,7 +79,8 @@ const Swatch = styled('div')`
   align-items: center;
   justify-content: center;
   background-color: ${p => p.color};
-  color: ${p => (p.color[1].match(/[0-8]{1}/) ? p.theme.gray100 : p.theme.gray500)};
+  color: ${p =>
+    p.color[1].match(/[0-8]{1}/) ? p.theme.backgroundSecondary : p.theme.gray500};
   font-size: ${p => p.theme.fontSizeSmall};
   height: 80px;
   text-align: center;

--- a/docs-ui/components/colors.stories.js
+++ b/docs-ui/components/colors.stories.js
@@ -79,7 +79,7 @@ const Swatch = styled('div')`
   align-items: center;
   justify-content: center;
   background-color: ${p => p.color};
-  color: ${p => (p.color[1].match(/[0-8]{1}/) ? p.theme.gray100 : p.theme.gray800)};
+  color: ${p => (p.color[1].match(/[0-8]{1}/) ? p.theme.gray100 : p.theme.gray500)};
   font-size: ${p => p.theme.fontSizeSmall};
   height: 80px;
   text-align: center;

--- a/docs-ui/components/layout-thirds.stories.js
+++ b/docs-ui/components/layout-thirds.stories.js
@@ -197,7 +197,7 @@ _6633WithTabNavigation.story = {
 };
 
 const Container = styled('div')`
-  background: ${p => p.theme.gray200};
+  background: ${p => p.theme.gray100};
   margin: ${space(2)};
   border: 1px solid ${p => p.theme.border};
 `;

--- a/docs-ui/components/layout-thirds.stories.js
+++ b/docs-ui/components/layout-thirds.stories.js
@@ -197,7 +197,7 @@ _6633WithTabNavigation.story = {
 };
 
 const Container = styled('div')`
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   margin: ${space(2)};
   border: 1px solid ${p => p.theme.border};
 `;

--- a/src/sentry/static/sentry/app/components/activity/item/avatar.tsx
+++ b/src/sentry/static/sentry/app/components/activity/item/avatar.tsx
@@ -57,7 +57,7 @@ const SystemAvatar = styled('span')<SystemAvatarProps>`
   align-items: center;
   width: ${p => p.size}px;
   height: ${p => p.size}px;
-  background-color: ${p => p.theme.gray800};
+  background-color: ${p => p.theme.gray500};
   color: ${p => p.theme.white};
   border-radius: 50%;
 `;

--- a/src/sentry/static/sentry/app/components/activity/item/index.tsx
+++ b/src/sentry/static/sentry/app/components/activity/item/index.tsx
@@ -189,15 +189,15 @@ const StyledActivityAvatar = styled(ActivityAvatar)`
 `;
 
 const StyledTimeSince = styled(TimeSince)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const StyledDateTime = styled(DateTime)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const StyledDateTimeWindow = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const StyledActivityBubble = styled(ActivityBubble)`

--- a/src/sentry/static/sentry/app/components/activity/note/header.tsx
+++ b/src/sentry/static/sentry/app/components/activity/note/header.tsx
@@ -53,7 +53,7 @@ const NoteHeader = ({authorName, user, onEdit, onDelete}: Props) => {
 
 const getActionStyle = (p: {theme: Theme}) => `
   padding: 0 7px;
-  color: ${p.theme.gray400};
+  color: ${p.theme.gray200};
   font-weight: normal;
 `;
 
@@ -62,7 +62,7 @@ const Edit = styled('a')`
   margin-left: 7px;
 
   &:hover {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/activity/note/index.tsx
+++ b/src/sentry/static/sentry/app/components/activity/note/index.tsx
@@ -190,7 +190,7 @@ const StyledActivityItem = styled(ActivityItem)`
 
   blockquote {
     font-size: 15px;
-    background: ${p => p.theme.gray300};
+    background: ${p => p.theme.gray200};
 
     p:last-child {
       margin-bottom: 0;

--- a/src/sentry/static/sentry/app/components/activity/note/input.tsx
+++ b/src/sentry/static/sentry/app/components/activity/note/input.tsx
@@ -404,7 +404,7 @@ const MarkdownTab = styled(NoteInputNavTab)`
     display: flex;
     align-items: center;
     margin-right: 0;
-    color: ${p => p.theme.gray600};
+    color: ${p => p.theme.gray400};
 
     float: right;
   }

--- a/src/sentry/static/sentry/app/components/alert.tsx
+++ b/src/sentry/static/sentry/app/components/alert.tsx
@@ -56,7 +56,7 @@ const alertStyles = ({theme, type = DEFAULT_TYPE, system}: Props & {theme: any})
   font-size: 15px;
   box-shadow: ${theme.dropShadowLight};
   border-radius: ${theme.borderRadius};
-  background: ${theme.gray100};
+  background: ${theme.backgroundSecondary};
   border: 1px solid ${theme.border};
 
   a:not([role='button']) {

--- a/src/sentry/static/sentry/app/components/alertLink.tsx
+++ b/src/sentry/static/sentry/app/components/alertLink.tsx
@@ -87,7 +87,7 @@ const StyledLink = styled(({openInNewTab, to, href, ...props}: StyledLinkProps) 
 })`
   display: flex;
   background-color: ${p => p.theme.alert[p.priority].backgroundLight};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   border: 1px dashed ${p => p.theme.alert[p.priority].border};
   padding: ${p => (p.size === 'small' ? `${space(1)} ${space(1.5)}` : space(2))};
   margin-bottom: ${p => (p.withoutMarginBottom ? 0 : space(3))};

--- a/src/sentry/static/sentry/app/components/alerts/toastIndicator.tsx
+++ b/src/sentry/static/sentry/app/components/alerts/toastIndicator.tsx
@@ -17,7 +17,7 @@ const Toast = styled(motion.div)`
   height: 40px;
   padding: 0 15px 0 10px;
   margin-top: 15px;
-  background: ${p => p.theme.gray800};
+  background: ${p => p.theme.gray500};
   color: #fff;
   border-radius: 44px 7px 7px 44px;
   box-shadow: 0 4px 12px 0 rgba(47, 40, 55, 0.16);
@@ -59,20 +59,20 @@ const Message = styled('div')`
 
 const Undo = styled('div')`
   display: inline-block;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   padding-left: ${space(2)};
   margin-left: ${space(2)};
-  border-left: 1px solid ${p => p.theme.gray300};
+  border-left: 1px solid ${p => p.theme.gray200};
   cursor: pointer;
 
   &:hover {
-    color: ${p => p.theme.gray400};
+    color: ${p => p.theme.gray200};
   }
 `;
 
 const StyledLoadingIndicator = styled(LoadingIndicator)`
   .loading-indicator {
-    border-color: ${p => p.theme.gray700};
+    border-color: ${p => p.theme.gray500};
     border-left-color: ${p => p.theme.purple300};
   }
 `;

--- a/src/sentry/static/sentry/app/components/assigneeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.tsx
@@ -302,7 +302,7 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
                 {assignedTo ? (
                   <ActorAvatar actor={assignedTo} className="avatar" size={24} />
                 ) : (
-                  <StyledIconUser size="20px" color="gray600" />
+                  <StyledIconUser size="20px" color="gray400" />
                 )}
                 <StyledChevron direction="down" size="xs" />
               </DropdownButton>

--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
@@ -204,7 +204,7 @@ const GuideContainer = styled('div')`
   line-height: 1.5;
   background-color: ${p => p.theme.purple300};
   border-color: ${p => p.theme.purple300};
-  color: ${p => p.theme.gray100};
+  color: ${p => p.theme.backgroundSecondary};
 `;
 
 const GuideContent = styled('div')`
@@ -213,7 +213,7 @@ const GuideContent = styled('div')`
   grid-gap: ${space(1)};
 
   a {
-    color: ${p => p.theme.gray100};
+    color: ${p => p.theme.backgroundSecondary};
     text-decoration: underline;
   }
 `;

--- a/src/sentry/static/sentry/app/components/avatar/avatarList.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/avatarList.tsx
@@ -109,8 +109,8 @@ const CollapsedUsers = styled('div')<{size: number}>`
   position: relative;
   text-align: center;
   font-weight: 600;
-  background-color: ${p => p.theme.gray300};
-  color: ${p => p.theme.gray500};
+  background-color: ${p => p.theme.gray200};
+  color: ${p => p.theme.gray300};
   font-size: ${p => Math.floor(p.size / 2.3)}px;
   width: ${p => p.size}px;
   height: ${p => p.size}px;

--- a/src/sentry/static/sentry/app/components/avatarCropper.tsx
+++ b/src/sentry/static/sentry/app/components/avatarCropper.tsx
@@ -443,7 +443,7 @@ const CropContainer = styled('div')`
 
 const Cropper = styled('div')`
   position: absolute;
-  border: 2px dashed ${p => p.theme.gray500};
+  border: 2px dashed ${p => p.theme.gray300};
 `;
 
 const Resizer = styled('div')<{position: Position}>`
@@ -451,7 +451,7 @@ const Resizer = styled('div')<{position: Position}>`
   width: 10px;
   height: 10px;
   position: absolute;
-  background-color: ${p => p.theme.gray500};
+  background-color: ${p => p.theme.gray300};
   cursor: ${p => `${p.position}-resize`};
   ${p => resizerPositions[p.position].map(pos => `${pos}: -5px;`)}
 `;

--- a/src/sentry/static/sentry/app/components/badge.tsx
+++ b/src/sentry/static/sentry/app/components/badge.tsx
@@ -31,7 +31,7 @@ const Badge = styled(({priority: _priority, text, ...props}: Props) => (
   font-weight: 600;
   text-align: center;
   color: #fff;
-  background: ${p => (p.priority ? priorityColors[p.priority] : theme.gray400)};
+  background: ${p => (p.priority ? priorityColors[p.priority] : theme.gray200)};
   transition: background 100ms linear;
 
   position: relative;

--- a/src/sentry/static/sentry/app/components/banner.tsx
+++ b/src/sentry/static/sentry/app/components/banner.tsx
@@ -66,7 +66,7 @@ const BannerWrapper = styled('div')<BannerWrapperProps>`
           background-position: center center;
         `
       : css`
-          background: ${p.theme.gray700};
+          background: ${p.theme.gray500};
         `}
 
   ${p =>

--- a/src/sentry/static/sentry/app/components/breadcrumbs.tsx
+++ b/src/sentry/static/sentry/app/components/breadcrumbs.tsx
@@ -87,12 +87,12 @@ const Breadcrumbs = ({crumbs, linkLastItem = false, ...props}: Props) => {
 };
 
 const getBreadcrumbListItemStyles = (p: {theme: Theme}) => `
-  color: ${p.theme.gray500};
+  color: ${p.theme.gray300};
   ${overflowEllipsis};
   width: auto;
 
   &:last-child {
-    color: ${p.theme.gray700};
+    color: ${p.theme.gray500};
   }
 `;
 
@@ -109,7 +109,7 @@ const BreadcrumbLink = styled(({preserveGlobalSelection, ...props}) =>
 
   &:hover,
   &:active {
-    color: ${p => p.theme.gray600};
+    color: ${p => p.theme.gray400};
   }
 `;
 
@@ -118,7 +118,7 @@ const BreadcrumbItem = styled('span')`
 `;
 
 const BreadcrumbDividerIcon = styled(IconChevron)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   margin: 0 ${space(1)};
   flex-shrink: 0;
 `;

--- a/src/sentry/static/sentry/app/components/charts/baseChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.tsx
@@ -292,11 +292,11 @@ class BaseChart extends React.Component<Props> {
           name: previous.seriesName,
           data: previous.data.map(({name, value}) => [name, value]),
           lineStyle: {
-            color: theme.gray400,
+            color: theme.gray200,
             type: 'dotted',
           },
           itemStyle: {
-            color: theme.gray400,
+            color: theme.gray200,
           },
         })
       ) ?? [];
@@ -435,9 +435,9 @@ const ChartContainer = styled('div')`
   /* Tooltip styling */
   .tooltip-series,
   .tooltip-date {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
     font-family: ${p => p.theme.text.family};
-    background: ${p => p.theme.gray800};
+    background: ${p => p.theme.gray500};
     padding: ${space(1)} ${space(2)};
     border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
   }
@@ -457,7 +457,7 @@ const ChartContainer = styled('div')`
     align-items: baseline;
   }
   .tooltip-date {
-    border-top: 1px solid ${p => p.theme.gray600};
+    border-top: 1px solid ${p => p.theme.gray400};
     text-align: center;
     position: relative;
     width: auto;
@@ -472,7 +472,7 @@ const ChartContainer = styled('div')`
     width: 0;
     position: absolute;
     pointer-events: none;
-    border-top-color: ${p => p.theme.gray800};
+    border-top-color: ${p => p.theme.gray500};
     border-width: 8px;
     margin-left: -8px;
   }

--- a/src/sentry/static/sentry/app/components/charts/breakdownBars.tsx
+++ b/src/sentry/static/sentry/app/components/charts/breakdownBars.tsx
@@ -56,14 +56,14 @@ const BarContainer = styled('div')`
 
 const Label = styled('span')`
   position: relative;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   z-index: 2;
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
 const Bar = styled('div')`
   border-radius: 2px;
-  background-color: ${p => p.theme.gray300};
+  background-color: ${p => p.theme.gray200};
   position: absolute;
   top: 0;
   left: 0;

--- a/src/sentry/static/sentry/app/components/charts/components/xAxis.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/xAxis.tsx
@@ -50,13 +50,13 @@ export default function XAxis({
     boundaryGap: false,
     axisLine: {
       lineStyle: {
-        color: theme.gray400,
+        color: theme.gray200,
       },
       ...(axisLine || {}),
     },
     axisTick: {
       lineStyle: {
-        color: theme.gray400,
+        color: theme.gray200,
       },
       ...(axisTick || {}),
     },

--- a/src/sentry/static/sentry/app/components/charts/components/yAxis.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/yAxis.tsx
@@ -11,11 +11,11 @@ export default function YAxis(props: EChartOption.YAxis = {}): EChartOption.YAxi
       show: false,
     },
     axisLabel: {
-      color: theme.gray200, // TODO(dark): gray200 --> chartLabel
+      color: theme.chartLabel,
     },
     splitLine: {
       lineStyle: {
-        color: theme.gray100, // TODO(dark): border --> gray100 --> chartLineColor
+        color: theme.chartLineColor,
       },
     },
     ...props,

--- a/src/sentry/static/sentry/app/components/charts/components/yAxis.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/yAxis.tsx
@@ -11,7 +11,7 @@ export default function YAxis(props: EChartOption.YAxis = {}): EChartOption.YAxi
       show: false,
     },
     axisLabel: {
-      color: theme.gray400, // TODO(dark): gray400 --> chartLabel
+      color: theme.gray200, // TODO(dark): gray200 --> chartLabel
     },
     splitLine: {
       lineStyle: {

--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -178,7 +178,7 @@ class Chart extends React.Component<ChartProps, State> {
       },
       yAxis: {
         axisLabel: {
-          color: theme.gray400,
+          color: theme.gray200,
           formatter: (value: number) => axisLabelFormatter(value, yAxis),
         },
       },
@@ -354,7 +354,7 @@ class EventsChart extends React.Component<Props> {
       if (errored) {
         return (
           <ErrorPanel>
-            <IconWarning color="gray500" size="lg" />
+            <IconWarning color="gray300" size="lg" />
           </ErrorPanel>
         );
       }

--- a/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
@@ -21,7 +21,7 @@ const defaultProps = {
   /**
    * Colors to use on the chart.
    */
-  colors: [theme.gray400, theme.purple300, theme.purple300] as string[],
+  colors: [theme.gray200, theme.purple300, theme.purple300] as string[],
   /**
    * Show max/min values on yAxis
    */

--- a/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
+++ b/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
@@ -71,13 +71,13 @@ const MenuContainer = styled('div')`
 const StyledDropdownButton = styled(DropdownButton)`
   padding: ${space(1)} ${space(2)};
   font-weight: normal;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   z-index: ${p => (p.isOpen ? p.theme.zIndex.dropdownAutocomplete.actor : 'auto')};
 
   &:hover,
   &:focus,
   &:active {
-    color: ${p => p.theme.gray700};
+    color: ${p => p.theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
@@ -44,7 +44,7 @@ const StyledDelta = styled('div')`
       ? p.theme.green300
       : p.direction < 0
       ? p.theme.red300
-      : p.theme.gray500};
+      : p.theme.gray300};
 `;
 
 class PercentageTableChart extends React.Component {
@@ -228,7 +228,7 @@ const Percentage = styled('div')`
 const Bar = styled('div', {shouldForwardProp: isPropValid})`
   flex: 1;
   width: ${p => p.width}%;
-  background-color: ${p => p.theme.gray400};
+  background-color: ${p => p.theme.gray200};
   height: 12px;
   border-radius: 2px;
 `;
@@ -244,7 +244,7 @@ const CountColumn = styled(Name)`
 `;
 
 const TableHeader = styled(PanelItem)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   padding: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/percentageTableChart.jsx
@@ -216,7 +216,7 @@ const PercentageLabel = styled('div')`
 const BarWrapper = styled('div')`
   flex: 1;
   margin-right: ${space(1)};
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
 `;
 
 const Percentage = styled('div')`

--- a/src/sentry/static/sentry/app/components/charts/styles.tsx
+++ b/src/sentry/static/sentry/app/components/charts/styles.tsx
@@ -12,7 +12,7 @@ export const ChartControls = styled('div')`
 export const SubHeading = styled('h3')`
   font-size: ${p => p.theme.fontSizeLarge};
   font-weight: normal;
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   margin: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -24,14 +24,14 @@ export const SectionHeading = styled('h4')`
   grid-auto-flow: column;
   grid-gap: ${space(1)};
   align-items: center;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
   margin: ${space(1)} 0;
   line-height: 1.3;
 `;
 
 export const SectionValue = styled('span')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
   margin-right: ${space(1)};
 `;

--- a/src/sentry/static/sentry/app/components/charts/tableChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/tableChart.jsx
@@ -390,7 +390,7 @@ export const TableChartRowBar = styled(({width: _width, ...props}) => <div {...p
   bottom: 0;
   left: 0;
   right: ${p => 100 - p.width}%;
-  background-color: ${p => p.theme.gray300};
+  background-color: ${p => p.theme.gray200};
   z-index: 1;
 `;
 

--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
@@ -59,7 +59,7 @@ export default class WorldMapChart extends React.Component {
         center: [10.97, 9.71],
         itemStyle: {
           normal: {
-            areaColor: theme.gray400,
+            areaColor: theme.gray200,
             borderColor: theme.gray100,
           },
           emphasis: {

--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.jsx
@@ -60,7 +60,7 @@ export default class WorldMapChart extends React.Component {
         itemStyle: {
           normal: {
             areaColor: theme.gray200,
-            borderColor: theme.gray100,
+            borderColor: theme.backgroundSecondary,
           },
           emphasis: {
             areaColor: theme.orange300,
@@ -83,7 +83,7 @@ export default class WorldMapChart extends React.Component {
     return (
       <BaseChart
         options={{
-          backgroundColor: theme.gray100,
+          backgroundColor: theme.backgroundSecondary,
           visualMap: VisualMap({
             left: 'right',
             min: 0,

--- a/src/sentry/static/sentry/app/components/checkboxFancy/checkboxFancy.tsx
+++ b/src/sentry/static/sentry/app/components/checkboxFancy/checkboxFancy.tsx
@@ -16,7 +16,9 @@ type Props = {
 const disabledStyles = (p: Props & {theme: Theme}) =>
   p.isDisabled &&
   css`
-    background: ${p.isChecked || p.isIndeterminate ? p.theme.gray200 : p.theme.gray100};
+    background: ${p.isChecked || p.isIndeterminate
+      ? p.theme.gray200
+      : p.theme.backgroundSecondary};
     border-color: ${p.theme.border};
   `;
 

--- a/src/sentry/static/sentry/app/components/checkboxFancy/checkboxFancy.tsx
+++ b/src/sentry/static/sentry/app/components/checkboxFancy/checkboxFancy.tsx
@@ -16,7 +16,7 @@ type Props = {
 const disabledStyles = (p: Props & {theme: Theme}) =>
   p.isDisabled &&
   css`
-    background: ${p.isChecked || p.isIndeterminate ? p.theme.gray400 : p.theme.gray100};
+    background: ${p.isChecked || p.isIndeterminate ? p.theme.gray200 : p.theme.gray100};
     border-color: ${p.theme.border};
   `;
 
@@ -24,7 +24,7 @@ const hoverStyles = (p: Props & {theme: Theme}) =>
   !p.isDisabled &&
   css`
     border: 2px solid
-      ${p.isChecked || p.isIndeterminate ? p.theme.purple300 : p.theme.gray700};
+      ${p.isChecked || p.isIndeterminate ? p.theme.purple300 : p.theme.gray500};
   `;
 
 const CheckboxFancy = styled(
@@ -51,7 +51,7 @@ const CheckboxFancy = styled(
   background: ${p =>
     p.isChecked || p.isIndeterminate ? p.theme.purple300 : 'transparent'};
   border: 2px solid
-    ${p => (p.isChecked || p.isIndeterminate ? p.theme.purple300 : p.theme.gray500)};
+    ${p => (p.isChecked || p.isIndeterminate ? p.theme.purple300 : p.theme.gray300)};
   cursor: ${p => (p.isDisabled ? 'not-allowed' : 'pointer')};
   ${p => (!p.isChecked || !p.isIndeterminate) && 'transition: 500ms border ease-out'};
 

--- a/src/sentry/static/sentry/app/components/clippedBox.tsx
+++ b/src/sentry/static/sentry/app/components/clippedBox.tsx
@@ -142,7 +142,7 @@ const ClipWrapper = styled('div', {
   margin-left: -${space(3)};
   margin-right: -${space(3)};
   padding: ${space(2)} ${space(3)} 0;
-  border-top: 1px solid ${p => p.theme.gray100};
+  border-top: 1px solid ${p => p.theme.backgroundSecondary};
   transition: all 5s ease-in-out;
 
   /* For "Show More" animation */

--- a/src/sentry/static/sentry/app/components/commitRow.tsx
+++ b/src/sentry/static/sentry/app/components/commitRow.tsx
@@ -156,7 +156,7 @@ const Meta = styled(TextOverflow)`
   font-size: 13px;
   line-height: 1.5;
   margin: 0;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 export default styled(CommitRow)`

--- a/src/sentry/static/sentry/app/components/contextData.jsx
+++ b/src/sentry/static/sentry/app/components/contextData.jsx
@@ -271,9 +271,9 @@ const ToggleIcon = styled('a')`
   margin-left: 1px;
   border-radius: 2px;
 
-  background: ${p => (p.isOpen ? p.theme.gray500 : p.theme.blue300)};
+  background: ${p => (p.isOpen ? p.theme.gray300 : p.theme.blue300)};
   &:hover {
-    background: ${p => (p.isOpen ? p.theme.gray600 : p.theme.blue200)};
+    background: ${p => (p.isOpen ? p.theme.gray400 : p.theme.blue200)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -315,7 +315,7 @@ function CreateAlertButton({
 export default CreateAlertButton;
 
 const StyledAlert = styled(Alert)`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   margin-bottom: 0;
 `;
 

--- a/src/sentry/static/sentry/app/components/deployBadge.tsx
+++ b/src/sentry/static/sentry/app/components/deployBadge.tsx
@@ -50,7 +50,7 @@ const DeployBadge = ({deploy, orgSlug, projectId, version, className}: Props) =>
 };
 
 const Badge = styled(Tag)`
-  background-color: ${p => p.theme.gray700};
+  background-color: ${p => p.theme.gray500};
   color: ${p => p.theme.white};
   font-size: ${p => p.theme.fontSizeSmall};
   align-items: center;

--- a/src/sentry/static/sentry/app/components/dropdownAutoComplete/menu.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoComplete/menu.tsx
@@ -381,7 +381,7 @@ const StyledInput = styled(Input)`
     font-size: 13px;
     padding: ${space(1)};
     font-weight: normal;
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 `;
 
@@ -398,7 +398,7 @@ const InputLoadingWrapper = styled('div')`
 `;
 
 const EmptyMessage = styled('div')`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   padding: ${space(2)};
   text-align: center;
   text-transform: none;
@@ -426,7 +426,7 @@ const LabelWithPadding = styled('div')`
   background-color: ${p => p.theme.gray100};
   border-bottom: 1px solid ${p => p.theme.innerBorder};
   border-width: 1px 0;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
   &:first-child {
     border-top: none;

--- a/src/sentry/static/sentry/app/components/dropdownAutoComplete/menu.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoComplete/menu.tsx
@@ -423,7 +423,7 @@ const InputWrapper = styled('div')`
 `;
 
 const LabelWithPadding = styled('div')`
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   border-bottom: 1px solid ${p => p.theme.innerBorder};
   border-width: 1px 0;
   color: ${p => p.theme.gray400};

--- a/src/sentry/static/sentry/app/components/dropdownAutoComplete/row.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoComplete/row.tsx
@@ -54,7 +54,7 @@ const Row = ({
 export default Row;
 
 const LabelWithBorder = styled('div')`
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   border-bottom: 1px solid ${p => p.theme.innerBorder};
   border-width: 1px 0;
   color: ${p => p.theme.gray400};
@@ -92,7 +92,8 @@ const AutoCompleteItem = styled('div')<{hasGrayBackground: boolean; itemSize?: I
   justify-content: center;
 
   font-size: 0.9em;
-  background-color: ${p => (p.hasGrayBackground ? p.theme.gray100 : 'transparent')};
+  background-color: ${p =>
+    p.hasGrayBackground ? p.theme.backgroundSecondary : 'transparent'};
   padding: ${p => getItemPaddingForSize(p.itemSize)};
   cursor: pointer;
   border-bottom: 1px solid ${p => p.theme.innerBorder};
@@ -102,6 +103,6 @@ const AutoCompleteItem = styled('div')<{hasGrayBackground: boolean; itemSize?: I
   }
 
   :hover {
-    background-color: ${p => p.theme.gray100};
+    background-color: ${p => p.theme.backgroundSecondary};
   }
 `;

--- a/src/sentry/static/sentry/app/components/dropdownAutoComplete/row.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoComplete/row.tsx
@@ -57,7 +57,7 @@ const LabelWithBorder = styled('div')`
   background-color: ${p => p.theme.gray100};
   border-bottom: 1px solid ${p => p.theme.innerBorder};
   border-width: 1px 0;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
 
   :first-child {

--- a/src/sentry/static/sentry/app/components/dropdownButton.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownButton.tsx
@@ -76,7 +76,7 @@ const StyledButton = styled(Button)<
 
 const LabelText = styled('em')`
   font-style: normal;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   padding-right: ${space(0.75)};
 `;
 

--- a/src/sentry/static/sentry/app/components/dropdownControl.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownControl.tsx
@@ -124,7 +124,7 @@ const Content = styled(DropdownBubble)<{isOpen: boolean}>`
 
 const DropdownItem = styled(MenuItem)`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 export default DropdownControl;

--- a/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
+++ b/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
@@ -22,7 +22,7 @@ const EmptyStateWarning = ({
   small ? (
     <EmptyMessage className={className}>
       <SmallMessage>
-        {withIcon && <StyledIconSearch color="gray500" size="lg" />}
+        {withIcon && <StyledIconSearch color="gray300" size="lg" />}
         {children}
       </SmallMessage>
     </EmptyMessage>
@@ -51,7 +51,7 @@ const EmptyStreamWrapper = styled('div')`
   }
 
   svg {
-    fill: ${p => p.theme.gray400};
+    fill: ${p => p.theme.gray200};
     margin-bottom: ${space(2)};
   }
 `;
@@ -59,7 +59,7 @@ const EmptyStreamWrapper = styled('div')`
 const SmallMessage = styled('div')`
   display: flex;
   align-items: center;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeExtraLarge};
   line-height: 1em;
 `;

--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -127,7 +127,7 @@ Anyway, we apologize for the inconvenience.`
 }
 
 const Wrapper = styled('div')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   padding: ${p => p.theme.grid * 3}px;
   max-width: 1000px;
   margin: auto;

--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
@@ -95,7 +95,7 @@ const GroupExtra = styled('div')`
   grid-gap: ${space(2)};
   justify-content: start;
   align-items: center;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeSmall};
   position: relative;
   min-width: 500px;
@@ -115,13 +115,13 @@ const CommentsLink = styled(Link)`
   grid-gap: ${space(0.5)};
   align-items: center;
   grid-auto-flow: column;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;
 
 const GroupShortId = styled(ShortId)`
   flex-shrink: 0;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 const AnnotationNoMargin = styled(EventAnnotation)`
@@ -130,7 +130,7 @@ const AnnotationNoMargin = styled(EventAnnotation)`
 `;
 
 const LoggerAnnotation = styled(AnnotationNoMargin)`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;
 
 export default withRouter(EventOrGroupExtraDetails);

--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.tsx
@@ -144,7 +144,7 @@ const Title = styled('div')`
     font-size: ${p => p.theme.fontSizeMedium};
     font-style: normal;
     font-weight: 300;
-    color: ${p => p.theme.gray600};
+    color: ${p => p.theme.gray400};
   }
 `;
 
@@ -154,7 +154,7 @@ const LocationWrapper = styled('div')`
   direction: rtl;
   text-align: left;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   span {
     direction: ltr;
   }
@@ -207,7 +207,7 @@ const GroupLevel = styled('div')<{level: Level}>`
       case 'fatal':
         return p.theme.red300;
       default:
-        return p.theme.gray500;
+        return p.theme.gray300;
     }
   }};
 

--- a/src/sentry/static/sentry/app/components/events/contextSummary/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/contextSummary.jsx
@@ -91,7 +91,7 @@ class ContextSummary extends React.Component {
 export default ContextSummary;
 
 const Wrapper = styled('div')`
-  border-top: 1px solid ${p => p.theme.gray200};
+  border-top: 1px solid ${p => p.theme.innerBorder};
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     display: grid;

--- a/src/sentry/static/sentry/app/components/events/contextSummary/contextSummary.jsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/contextSummary.jsx
@@ -91,7 +91,7 @@ class ContextSummary extends React.Component {
 export default ContextSummary;
 
 const Wrapper = styled('div')`
-  border-top: 1px solid ${p => p.theme.gray300};
+  border-top: 1px solid ${p => p.theme.gray200};
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     display: grid;

--- a/src/sentry/static/sentry/app/components/events/contextSummary/item.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/item.tsx
@@ -25,7 +25,7 @@ const Details = styled('div')`
 `;
 
 const Wrapper = styled('div')`
-  border-top: 1px solid ${p => p.theme.gray200};
+  border-top: 1px solid ${p => p.theme.innerBorder};
   padding: ${space(2)} 0 ${space(2)} 64px;
   display: flex;
   align-items: center;

--- a/src/sentry/static/sentry/app/components/events/contextSummary/item.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/item.tsx
@@ -25,7 +25,7 @@ const Details = styled('div')`
 `;
 
 const Wrapper = styled('div')`
-  border-top: 1px solid ${p => p.theme.gray300};
+  border-top: 1px solid ${p => p.theme.gray200};
   padding: ${space(2)} 0 ${space(2)} 64px;
   display: flex;
   align-items: center;

--- a/src/sentry/static/sentry/app/components/events/errors.tsx
+++ b/src/sentry/static/sentry/app/components/events/errors.tsx
@@ -89,9 +89,9 @@ class EventErrors extends React.Component<Props, State> {
 
 const linkStyle = ({theme}: {theme: Theme}) => css`
   font-weight: bold;
-  color: ${theme.gray600};
+  color: ${theme.gray400};
   :hover {
-    color: ${theme.gray700};
+    color: ${theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/eventAnnotation.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventAnnotation.tsx
@@ -6,13 +6,13 @@ const EventAnnotation = styled('span')`
   font-size: ${p => p.theme.fontSizeSmall};
   border-left: 1px solid ${p => p.theme.innerBorder};
   padding-left: ${space(1)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 
   a {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
 
     &:hover {
-      color: ${p => p.theme.gray600};
+      color: ${p => p.theme.gray400};
     }
   }
 `;

--- a/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
+++ b/src/sentry/static/sentry/app/components/events/eventCauseEmpty.jsx
@@ -194,13 +194,13 @@ const Description = styled('div')`
     font-size: 14px;
     text-transform: uppercase;
     margin-bottom: ${space(0.25)};
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 
   p {
     font-size: 13px;
     font-weight: bold;
-    color: ${p => p.theme.gray700};
+    color: ${p => p.theme.gray500};
     margin-bottom: ${space(1.5)};
   }
 `;

--- a/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
@@ -131,7 +131,7 @@ const StyledIconAnchor = styled(IconAnchor)`
 const Permalink = styled('a')`
   :hover ${StyledIconAnchor} {
     display: block;
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 `;
 
@@ -150,7 +150,7 @@ const SectionHeader = styled('div')<{isCentered?: boolean}>`
     font-size: 14px;
     font-weight: 600;
     line-height: 1.2;
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 
   & h3 {
@@ -163,7 +163,7 @@ const SectionHeader = styled('div')<{isCentered?: boolean}>`
   }
 
   & small {
-    color: ${p => p.theme.gray700};
+    color: ${p => p.theme.gray500};
     font-size: ${p => p.theme.fontSizeMedium};
     margin-right: ${space(0.5)};
     margin-left: ${space(0.5)};
@@ -171,7 +171,7 @@ const SectionHeader = styled('div')<{isCentered?: boolean}>`
     text-transform: none;
   }
   & small > span {
-    color: ${p => p.theme.gray700};
+    color: ${p => p.theme.gray500};
     border-bottom: 1px dotted ${p => p.theme.border};
     font-weight: normal;
   }

--- a/src/sentry/static/sentry/app/components/events/eventMetadata.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventMetadata.tsx
@@ -62,7 +62,7 @@ const MetaDataID = styled('div')`
 const MetadataContainer = styled('div')`
   display: flex;
   justify-content: space-between;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingComponent.tsx
@@ -78,7 +78,7 @@ export const GroupingValue = styled('code')<{valueType: string}>`
 `;
 
 const GroupingComponentWrapper = styled('div')<{isContributing: boolean}>`
-  color: ${p => (p.isContributing ? null : p.theme.gray400)};
+  color: ${p => (p.isContributing ? null : p.theme.gray200)};
 
   ${GroupingValue}, button {
     opacity: ${p => (p.isContributing ? 1 : 0.6)};

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/index.tsx
@@ -163,10 +163,10 @@ const SummaryGroupedBy = styled('small')`
 
 const ToggleButton = styled(Button)`
   font-weight: 700;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   &:hover,
   &:focus {
-    color: ${p => p.theme.gray700};
+    color: ${p => p.theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
@@ -58,7 +58,7 @@ const AssemblyWrapper = styled('div')`
   font-size: 80%;
   display: flex;
   flex-wrap: wrap;
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   text-align: center;
   position: relative;
   padding: 0 ${space(3)} 0 50px;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/category.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/category.tsx
@@ -28,7 +28,7 @@ const Category = React.memo(({category, searchTerm}: Props) => {
 export default Category;
 
 const Wrapper = styled('div')`
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 700;
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/filter/optionsGroup.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/filter/optionsGroup.tsx
@@ -47,7 +47,7 @@ const Header = styled('div')`
   display: flex;
   align-items: center;
   margin: 0;
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   color: ${p => p.theme.gray300};
   font-weight: normal;
   font-size: ${p => p.theme.fontSizeMedium};
@@ -69,7 +69,7 @@ const ListItem = styled('li')<{isChecked?: boolean}>`
   padding: ${space(1)} ${space(2)};
   border-bottom: 1px solid ${p => p.theme.border};
   :hover {
-    background-color: ${p => p.theme.gray100};
+    background-color: ${p => p.theme.backgroundSecondary};
   }
   ${CheckboxFancy} {
     opacity: ${p => (p.isChecked ? 1 : 0.3)};

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/filter/optionsGroup.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/filter/optionsGroup.tsx
@@ -48,7 +48,7 @@ const Header = styled('div')`
   align-items: center;
   margin: 0;
   background-color: ${p => p.theme.gray100};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-weight: normal;
   font-size: ${p => p.theme.fontSizeMedium};
   padding: ${space(1)} ${space(2)};

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/listHeader.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/listHeader.tsx
@@ -42,7 +42,7 @@ const StyledGridCell = styled(GridCell)`
   z-index: ${p => p.theme.zIndex.breadcrumbs.header};
   top: 0;
   border-bottom: 1px solid ${p => p.theme.border};
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   color: ${p => p.theme.gray400};
   font-weight: 600;
   text-transform: uppercase;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/listHeader.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/listHeader.tsx
@@ -43,7 +43,7 @@ const StyledGridCell = styled(GridCell)`
   top: 0;
   border-bottom: 1px solid ${p => p.theme.border};
   background: ${p => p.theme.gray100};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-weight: 600;
   text-transform: uppercase;
   line-height: 1;
@@ -71,6 +71,6 @@ const Time = styled(StyledGridCell)`
 const StyledIconSwitch = styled(IconSwitch)`
   transition: 0.15s color;
   &:hover {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/styles.tsx
@@ -21,7 +21,7 @@ const IconWrapper = styled('div', {
   z-index: ${p => p.theme.zIndex.breadcrumbs.iconWrapper};
   position: relative;
   border: 1px solid ${p => p.theme.border};
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   ${p =>
     p.color &&
     `
@@ -72,7 +72,7 @@ const GridCellLeft = styled(GridCell)`
     top: 0;
     bottom: 0;
     left: 21px;
-    background: ${p => (p.hasError ? p.theme.red300 : p.theme.gray300)};
+    background: ${p => (p.hasError ? p.theme.red300 : p.theme.gray200)};
     position: absolute;
     @media (min-width: ${p => p.theme.breakpoints[0]}) {
       left: 29px;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/styles.tsx
@@ -72,7 +72,7 @@ const GridCellLeft = styled(GridCell)`
     top: 0;
     bottom: 0;
     left: 21px;
-    background: ${p => (p.hasError ? p.theme.red300 : p.theme.gray200)};
+    background: ${p => (p.hasError ? p.theme.red300 : p.theme.innerBorder)};
     position: absolute;
     @media (min-width: ${p => p.theme.breakpoints[0]}) {
       left: 29px;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/time/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/time/index.tsx
@@ -56,5 +56,5 @@ export default Time;
 
 const Wrapper = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugImage.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugImage.tsx
@@ -305,11 +305,11 @@ const CodeFile = styled('span')`
 `;
 
 const DebugFile = styled('span')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const ImageSubtext = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const ImageProp = styled('span')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionMechanism.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionMechanism.jsx
@@ -117,9 +117,9 @@ const Wrapper = styled('div')`
 
 const iconStyle = p => css`
   transition: 0.1s linear color;
-  color: ${p.theme.gray500};
+  color: ${p.theme.gray300};
   :hover {
-    color: ${p.theme.gray700};
+    color: ${p.theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
@@ -365,7 +365,7 @@ const RepeatedFrames = styled('div')`
   border-style: solid;
   border-color: ${p => p.theme.orange500};
   color: ${p => p.theme.orange500};
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   white-space: nowrap;
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/symbol.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/symbol.tsx
@@ -89,7 +89,7 @@ const Wrapper = styled('div')`
 
   code {
     background: transparent;
-    color: ${p => p.theme.gray800};
+    color: ${p => p.theme.gray500};
     padding-right: ${space(0.5)};
   }
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/imageForBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/imageForBar.tsx
@@ -40,13 +40,13 @@ const Wrapper = styled('div')`
   align-items: baseline;
   justify-content: space-between;
   padding: ${space(0.5)} ${space(2)};
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   border-bottom: 1px solid ${p => p.theme.border};
   font-weight: 700;
   code {
     color: ${p => p.theme.blue300};
     font-size: ${p => p.theme.fontSizeSmall};
-    background: ${p => p.theme.gray100};
+    background: ${p => p.theme.backgroundSecondary};
   }
   a {
     color: ${p => p.theme.blue300};

--- a/src/sentry/static/sentry/app/components/events/interfaces/imageForBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/imageForBar.tsx
@@ -64,7 +64,7 @@ const MatchedFunctionWrapper = styled('div')`
 const MatchedFunctionCaption = styled('span')`
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 400;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   flex-shrink: 0;
 `;
 
@@ -74,9 +74,9 @@ const ResetAddressFilterCaption = styled('a')`
   padding-left: ${space(0.5)};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 400;
-  color: ${p => p.theme.gray500} !important;
+  color: ${p => p.theme.gray300} !important;
   &:hover {
-    color: ${p => p.theme.gray500} !important;
+    color: ${p => p.theme.gray300} !important;
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/openInContextLine.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/openInContextLine.tsx
@@ -61,7 +61,7 @@ export const OpenInContainer = styled('div')<{columnQuantity: number}>`
   display: grid;
   grid-template-columns: repeat(${p => p.columnQuantity}, max-content);
   grid-gap: ${space(1)};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   background-color: ${p => p.theme.white};
   font-family: ${p => p.theme.text.family};
   border-bottom: 1px solid ${p => p.theme.border};
@@ -77,10 +77,10 @@ export const OpenInLink = styled(ExternalLink)`
   align-items: center;
   grid-template-columns: max-content auto;
   grid-gap: ${space(0.75)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 export const OpenInName = styled('strong')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-weight: 700;
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/packageLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/packageLink.tsx
@@ -63,9 +63,9 @@ const Package = styled('a')<Partial<Props>>`
   font-size: 13px;
   font-weight: bold;
   padding: 0 0 0 ${space(0.5)};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   :hover {
-    color: ${p => p.theme.gray700};
+    color: ${p => p.theme.gray500};
   }
   cursor: ${p => (p.isClickable ? 'pointer' : 'default')};
   display: flex;

--- a/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/request.jsx
@@ -127,7 +127,7 @@ const MonoButton = styled(Button)`
 `;
 
 const Path = styled('span')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   text-transform: none;
   font-weight: normal;
 
@@ -146,12 +146,12 @@ const Header = styled('h3')`
 const StyledIconOpen = styled(IconOpen)`
   transition: 0.1s linear color;
   margin: 0 ${space(0.5)};
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   position: relative;
   top: 1px;
 
   &:hover {
-    color: ${p => p.theme.gray600};
+    color: ${p => p.theme.gray400};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -214,7 +214,7 @@ const StyledDropdownButton = styled(DropdownButton)<{hasDarkBorderBottomColor?: 
 const MenuContent = styled('div')`
   max-height: 250px;
   overflow-y: auto;
-  border-top: 1px solid ${p => p.theme.gray400};
+  border-top: 1px solid ${p => p.theme.gray200};
 `;
 
 const Header = styled('div')`
@@ -225,7 +225,7 @@ const Header = styled('div')`
 
   margin: 0;
   background-color: ${p => p.theme.gray100};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-weight: normal;
   font-size: ${p => p.theme.fontSizeMedium};
   padding: ${space(1)} ${space(2)};

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/filter.tsx
@@ -224,7 +224,7 @@ const Header = styled('div')`
   align-items: center;
 
   margin: 0;
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   color: ${p => p.theme.gray300};
   font-weight: normal;
   font-size: ${p => p.theme.fontSizeMedium};
@@ -246,7 +246,7 @@ const ListItem = styled('li')<{isChecked?: boolean}>`
   padding: ${space(1)} ${space(2)};
   border-bottom: 1px solid ${p => p.theme.border};
   :hover {
-    background-color: ${p => p.theme.gray100};
+    background-color: ${p => p.theme.backgroundSecondary};
   }
   ${CheckboxFancy} {
     opacity: ${p => (p.isChecked ? 1 : 0.3)};

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -488,7 +488,7 @@ const TimeAxis = styled('div')`
   border-top: 1px solid ${p => p.theme.border};
   height: ${TIME_AXIS_HEIGHT}px;
   background-color: ${p => p.theme.white};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: 10px;
   font-weight: 500;
 `;
@@ -530,7 +530,7 @@ const TickText = styled('span')<{align: TickAlignment}>`
 const TickMarker = styled('div')`
   width: 1px;
   height: 4px;
-  background-color: ${p => p.theme.gray400};
+  background-color: ${p => p.theme.gray200};
   position: absolute;
   top: 0;
   left: 0;
@@ -609,12 +609,12 @@ const ViewHandleContainer = styled('div')`
 const ViewHandleLine = styled('div')`
   height: ${MINIMAP_HEIGHT - VIEW_HANDLE_HEIGHT}px;
   width: 2px;
-  background-color: ${p => p.theme.gray800};
+  background-color: ${p => p.theme.gray500};
 `;
 
 const ViewHandle = styled('div')<{isDragging: boolean}>`
   position: absolute;
-  background-color: ${p => p.theme.gray800};
+  background-color: ${p => p.theme.gray500};
   cursor: col-resize;
   width: 8px;
   height: ${VIEW_HANDLE_HEIGHT}px;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -196,7 +196,7 @@ export const getBackgroundColor = ({
   }
 
   if (showDetail) {
-    return theme.gray800;
+    return theme.gray500;
   }
   return showStriping ? theme.gray100 : theme.white;
 };
@@ -932,7 +932,7 @@ export const SpanRowCellContainer = styled('div')<SpanRowCellProps>`
   user-select: none;
 
   &:hover > div[data-type='span-row-cell'] {
-    background-color: ${p => (p.showDetail ? p.theme.gray800 : p.theme.gray200)};
+    background-color: ${p => (p.showDetail ? p.theme.gray500 : p.theme.gray100)};
   }
 `;
 
@@ -946,7 +946,7 @@ const CursorGuide = styled('div')`
 `;
 
 export const DividerLine = styled('div')`
-  background-color: ${p => p.theme.gray400};
+  background-color: ${p => p.theme.gray200};
   position: absolute;
   height: 100%;
   width: 1px;
@@ -965,7 +965,7 @@ export const DividerLine = styled('div')`
   }
 
   &.hovering {
-    background-color: ${p => p.theme.gray800};
+    background-color: ${p => p.theme.gray500};
     width: 3px;
     transform: translateX(-1px);
     margin-right: -2px;
@@ -1043,7 +1043,7 @@ export const SpanTreeConnector = styled('div')<TogglerTypes & {orphanBranch: boo
 
   &:after {
     content: '';
-    background-color: ${p => p.theme.gray400};
+    background-color: ${p => p.theme.gray200};
     border-radius: 4px;
     height: 3px;
     width: 3px;
@@ -1126,7 +1126,7 @@ const getDurationPillAlignment = ({
     default:
       return `
         right: ${space(0.75)};
-        color: ${spanBarHatch === true ? theme.gray500 : theme.white};
+        color: ${spanBarHatch === true ? theme.gray300 : theme.white};
       `;
   }
 };
@@ -1143,7 +1143,7 @@ const DurationPill = styled('div')<{
   transform: translateY(-50%);
   white-space: nowrap;
   font-size: ${p => p.theme.fontSizeExtraSmall};
-  color: ${p => (p.showDetail === true ? p.theme.gray400 : p.theme.gray500)};
+  color: ${p => (p.showDetail === true ? p.theme.gray200 : p.theme.gray300)};
 
   ${getDurationPillAlignment}
 
@@ -1172,7 +1172,7 @@ const MeasurementMarker = styled('div')`
   background: repeating-linear-gradient(to bottom, transparent 0 4px, black 4px 8px) 80%/2px
     100% no-repeat;
   z-index: ${zIndex.dividerLine};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;
 
 const StyledIconWarning = styled(IconWarning)`

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -198,7 +198,7 @@ export const getBackgroundColor = ({
   if (showDetail) {
     return theme.gray500;
   }
-  return showStriping ? theme.gray100 : theme.white;
+  return showStriping ? theme.backgroundSecondary : theme.white;
 };
 
 type SpanBarProps = {
@@ -932,7 +932,8 @@ export const SpanRowCellContainer = styled('div')<SpanRowCellProps>`
   user-select: none;
 
   &:hover > div[data-type='span-row-cell'] {
-    background-color: ${p => (p.showDetail ? p.theme.gray500 : p.theme.gray100)};
+    background-color: ${p =>
+      p.showDetail ? p.theme.gray500 : p.theme.backgroundSecondary};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -440,7 +440,7 @@ const TraceViewContainer = styled('div')`
 `;
 
 const SecondaryHeader = styled('div')`
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   display: flex;
 
   border-bottom: 1px solid ${p => p.theme.gray200};

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -443,7 +443,7 @@ const SecondaryHeader = styled('div')`
   background-color: ${p => p.theme.gray100};
   display: flex;
 
-  border-bottom: 1px solid ${p => p.theme.gray400};
+  border-bottom: 1px solid ${p => p.theme.gray200};
 `;
 
 const DividerSpacer = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/styles.tsx
@@ -44,8 +44,8 @@ export const SpanRowMessage = styled(SpanRow)`
   line-height: ${SPAN_ROW_HEIGHT}px;
   padding-left: ${space(1)};
   padding-right: ${space(1)};
-  color: ${p => p.theme.gray500};
-  background-color: ${p => p.theme.gray200};
+  color: ${p => p.theme.gray300};
+  background-color: ${p => p.theme.gray100};
   outline: 1px solid ${p => p.theme.border};
   font-size: ${p => p.theme.fontSizeSmall};
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/styles.tsx
@@ -45,7 +45,7 @@ export const SpanRowMessage = styled(SpanRow)`
   padding-left: ${space(1)};
   padding-right: ${space(1)};
   color: ${p => p.theme.gray300};
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   outline: 1px solid ${p => p.theme.border};
   font-size: ${p => p.theme.fontSizeSmall};
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
@@ -123,7 +123,7 @@ const Address = styled('span')<Partial<Props> & {canBeConverted: boolean}>`
 const Wrapper = styled('span')`
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSizeExtraSmall};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   letter-spacing: -0.25px;
   width: 100%;
   flex-grow: 0;

--- a/src/sentry/static/sentry/app/components/events/opsBreakdown.tsx
+++ b/src/sentry/static/sentry/app/components/events/opsBreakdown.tsx
@@ -258,7 +258,7 @@ class OpsBreakdown extends React.Component<Props> {
 }
 
 const StyledBreakdown = styled('div')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
   margin-bottom: ${space(4)};
 `;
@@ -299,7 +299,7 @@ const OpsName = styled('div')`
 `;
 
 const Dur = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const Pct = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
+++ b/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
@@ -133,7 +133,7 @@ const Measurements = styled('div')`
 `;
 
 const Container = styled('div')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
   margin-bottom: ${space(4)};
 `;

--- a/src/sentry/static/sentry/app/components/events/rootSpanStatus.tsx
+++ b/src/sentry/static/sentry/app/components/events/rootSpanStatus.tsx
@@ -75,7 +75,7 @@ class RootSpanStatus extends React.Component<Props> {
 }
 
 const Container = styled('div')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
   margin-bottom: ${space(4)};
 `;

--- a/src/sentry/static/sentry/app/components/events/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/styles.tsx
@@ -77,7 +77,7 @@ export const CauseHeader = styled('div')`
 
   & button,
   & h3 {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
     font-size: 14px;
     font-weight: 600;
     line-height: 1.2;

--- a/src/sentry/static/sentry/app/components/events/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/styles.tsx
@@ -5,7 +5,7 @@ import theme from 'app/utils/theme';
 
 const COLORS = {
   default: {
-    background: theme.gray100,
+    background: theme.backgroundSecondary,
     border: theme.border,
   },
   danger: {

--- a/src/sentry/static/sentry/app/components/fileChange.tsx
+++ b/src/sentry/static/sentry/app/components/fileChange.tsx
@@ -48,7 +48,7 @@ const Filename = styled('div')`
 `;
 
 const StyledFileIcon = styled(FileIcon)`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   border-radius: 3px;
 `;
 

--- a/src/sentry/static/sentry/app/components/footer.tsx
+++ b/src/sentry/static/sentry/app/components/footer.tsx
@@ -70,7 +70,7 @@ const LogoLink = styled(props => (
 
 const Build = styled('span')`
   font-size: ${p => p.theme.fontSizeRelativeSmall};
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   font-weight: bold;
   margin-left: ${space(1)};
 `;

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -46,7 +46,7 @@ const defaultStyles = {
   control: (_, state) => ({
     height: '100%',
     fontSize: '15px',
-    color: theme.gray800,
+    color: theme.gray500,
     display: 'flex',
     background: '#fff',
     border: `1px solid ${theme.border}`,
@@ -70,7 +70,7 @@ const defaultStyles = {
     ...(state.isDisabled && {
       borderColor: theme.border,
       background: theme.gray100,
-      color: theme.gray500,
+      color: theme.gray300,
       cursor: 'not-allowed',
     }),
     ...(!state.isSearchable && {
@@ -99,12 +99,12 @@ const defaultStyles = {
       ? theme.white
       : theme.textColor,
     backgroundColor: state.isFocused
-      ? theme.gray200
+      ? theme.gray100
       : state.isSelected
       ? theme.purple300
       : 'transparent',
     '&:active': {
-      backgroundColor: theme.gray200,
+      backgroundColor: theme.gray100,
     },
   }),
   valueContainer: provided => ({
@@ -153,8 +153,8 @@ const defaultStyles = {
     ...provided,
     lineHeight: '1.5',
     fontWeight: '600',
-    backgroundColor: theme.gray200,
-    color: theme.gray700,
+    backgroundColor: theme.gray100,
+    color: theme.gray500,
     marginBottom: 0,
     padding: `${space(1)} ${space(1.5)}`,
   }),

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -69,7 +69,7 @@ const defaultStyles = {
     }),
     ...(state.isDisabled && {
       borderColor: theme.border,
-      background: theme.gray100,
+      background: theme.backgroundSecondary,
       color: theme.gray300,
       cursor: 'not-allowed',
     }),
@@ -99,12 +99,12 @@ const defaultStyles = {
       ? theme.white
       : theme.textColor,
     backgroundColor: state.isFocused
-      ? theme.gray100
+      ? theme.backgroundSecondary
       : state.isSelected
       ? theme.purple300
       : 'transparent',
     '&:active': {
-      backgroundColor: theme.gray100,
+      backgroundColor: theme.backgroundSecondary,
     },
   }),
   valueContainer: provided => ({
@@ -153,7 +153,7 @@ const defaultStyles = {
     ...provided,
     lineHeight: '1.5',
     fontWeight: '600',
-    backgroundColor: theme.gray100,
+    backgroundColor: theme.backgroundSecondary,
     color: theme.gray500,
     marginBottom: 0,
     padding: `${space(1)} ${space(1.5)}`,

--- a/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
@@ -154,7 +154,7 @@ const StyledSelect = styled(SelectPicker)`
 
   &.Select.is-focused > .Select-control {
     border: 1px solid ${p => p.theme.border};
-    border-color: ${p => p.theme.gray700};
+    border-color: ${p => p.theme.gray500};
     box-shadow: rgba(209, 202, 216, 0.5) 0 0 0 3px;
   }
 
@@ -180,7 +180,7 @@ const StyledSelect = styled(SelectPicker)`
     height: ${p => p.height}px;
     line-height: ${p => p.height}px;
     &:focus {
-      border: 1px solid ${p => p.theme.gray700};
+      border: 1px solid ${p => p.theme.gray500};
     }
   }
 

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -347,7 +347,7 @@ class GridEditable<
     return (
       <GridRow>
         <GridBodyCellStatus>
-          <IconWarning color="gray500" size="lg" />
+          <IconWarning color="gray300" size="lg" />
         </GridBodyCellStatus>
       </GridRow>
     );

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -30,7 +30,7 @@ export const Header = styled('div')`
 export const HeaderTitle = styled('h4')`
   margin: 0;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 export const HeaderButtonContainer = styled('div')`
@@ -118,7 +118,7 @@ export const GridHeadCell = styled('th')<{isFirst: boolean}>`
   border-right: 1px solid transparent;
   border-left: 1px solid transparent;
   background-color: ${p => p.theme.gray100};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 600;
@@ -275,7 +275,7 @@ export const GridResizer = styled('div')<{dataRows: number}>`
   }
 
   &:hover::after {
-    background-color: ${p => p.theme.gray400};
+    background-color: ${p => p.theme.gray200};
   }
 
   /**

--- a/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/styles.tsx
@@ -117,7 +117,7 @@ export const GridHeadCell = styled('th')<{isFirst: boolean}>`
 
   border-right: 1px solid transparent;
   border-left: 1px solid transparent;
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   color: ${p => p.theme.gray400};
 
   font-size: ${p => p.theme.fontSizeSmall};
@@ -158,7 +158,7 @@ export const GridHeadCellStatic = styled('th')`
   display: flex;
   align-items: center;
   padding: 0 ${space(2)};
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 600;
   line-height: 1;

--- a/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssuesList.tsx
@@ -214,6 +214,7 @@ class ExternalIssueList extends AsyncComponent<Props, State> {
     const integrationIssues = this.renderIntegrationIssues(this.state.integrations);
     const pluginIssues = this.renderPluginIssues();
     const pluginActions = this.renderPluginActions();
+
     if (!sentryAppIssues && !integrationIssues && !pluginIssues && !pluginActions) {
       return (
         <React.Fragment>

--- a/src/sentry/static/sentry/app/components/group/seenInfo.tsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.tsx
@@ -96,7 +96,7 @@ class SeenInfo extends React.Component<Props> {
         {date ? (
           <TooltipWrapper>
             <Tooltip title={this.getTooltipTitle()} disableForVisualTest>
-              <IconInfo size="xs" color="gray500" />
+              <IconInfo size="xs" color="gray300" />
               <TimeSince date={date} disabledAbsoluteTooltip />
             </Tooltip>
           </TooltipWrapper>
@@ -144,7 +144,7 @@ const NotConfigured = styled('span')`
 const StyledDateTime = styled(DateTime)`
   display: block;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const DateWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueActions.tsx
@@ -200,7 +200,7 @@ class SentryAppExternalIssueActions extends React.Component<Props, State> {
 }
 
 const StyledSentryAppIcon = styled(SentryAppIcon)`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   width: ${space(3)};
   height: ${space(3)};
   cursor: pointer;
@@ -222,7 +222,7 @@ const IssueLinkContainer = styled('div')`
 `;
 
 const StyledIcon = styled('span')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   cursor: pointer;
 `;
 

--- a/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.tsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwnerHovercard.tsx
@@ -151,7 +151,7 @@ const CommitMessage = styled(({message = '', date, ...props}) => (
     <CommitDate date={date} />
   </div>
 ))`
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   margin-top: ${space(0.25)};
   hyphens: auto;
@@ -161,7 +161,7 @@ const CommitDate = styled(({date, ...props}) => (
   <div {...props}>{moment(date).fromNow()}</div>
 ))`
   margin-top: ${space(0.5)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const CommitReasonItem = styled('div')`
@@ -200,7 +200,7 @@ const ViewMoreButton = styled(p => (
   </Button>
 ))`
   border: none;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   padding: ${space(0.25)} ${space(0.5)};
   margin: ${space(1)} ${space(0.25)} ${space(0.25)} 0;

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners/suggestedAssignees.tsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners/suggestedAssignees.tsx
@@ -51,7 +51,7 @@ export {SuggestedAssignees};
 
 const StyledSmall = styled('small')`
   font-size: ${p => p.theme.fontSizeExtraSmall};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   line-height: 100%;
 `;
 

--- a/src/sentry/static/sentry/app/components/helpSearch.tsx
+++ b/src/sentry/static/sentry/app/components/helpSearch.tsx
@@ -64,7 +64,7 @@ const SectionHeading = styled('div')`
   grid-template-columns: max-content 1fr max-content;
   grid-gap: ${space(1)};
   align-items: center;
-  background: ${p => p.theme.gray200};
+  background: ${p => p.theme.gray100};
   padding: ${space(1)} ${space(2)};
 
   &:not(:first-of-type) {
@@ -74,14 +74,14 @@ const SectionHeading = styled('div')`
 
 const Count = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const Empty = styled('div')`
   display: flex;
   align-items: center;
   padding: ${space(2)};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
   border-top: 1px solid ${p => p.theme.innerBorder};
 `;

--- a/src/sentry/static/sentry/app/components/helpSearch.tsx
+++ b/src/sentry/static/sentry/app/components/helpSearch.tsx
@@ -64,7 +64,7 @@ const SectionHeading = styled('div')`
   grid-template-columns: max-content 1fr max-content;
   grid-gap: ${space(1)};
   align-items: center;
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   padding: ${space(1)} ${space(2)};
 
   &:not(:first-of-type) {

--- a/src/sentry/static/sentry/app/components/highlight.tsx
+++ b/src/sentry/static/sentry/app/components/highlight.tsx
@@ -44,7 +44,7 @@ const HighlightComponent = ({className, children, disabled, text}: Props) => {
 const Highlight = styled(HighlightComponent)`
   font-weight: normal;
   background-color: ${p => p.theme.yellow200};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;
 
 export default Highlight;

--- a/src/sentry/static/sentry/app/components/hovercard.tsx
+++ b/src/sentry/static/sentry/app/components/hovercard.tsx
@@ -235,7 +235,7 @@ const StyledHovercard = styled('div')<StyledHovercardProps>`
   /* Some hovercards overlap the toplevel header and sidebar, and we need to appear on top */
   z-index: ${p => p.theme.zIndex.hovercard};
   white-space: initial;
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   border: 1px solid ${p => p.theme.border};
   background: ${p => p.theme.white};
   background-clip: padding-box;

--- a/src/sentry/static/sentry/app/components/hovercard.tsx
+++ b/src/sentry/static/sentry/app/components/hovercard.tsx
@@ -260,7 +260,7 @@ const StyledHovercard = styled('div')<StyledHovercardProps>`
 
 const Header = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   border-bottom: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadiusTop};
   font-weight: 600;
@@ -311,7 +311,7 @@ const HovercardArrow = styled('span')<HovercardArrowProps>`
   &::after {
     border: 10px solid transparent;
     border-${getTipDirection}-color: ${p =>
-  p.tipColor || (p.placement === 'bottom' ? p.theme.gray100 : p.theme.white)};
+  p.tipColor || (p.placement === 'bottom' ? p.theme.backgroundSecondary : p.theme.white)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/idBadge/baseBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/baseBadge.tsx
@@ -84,7 +84,7 @@ const DisplayName = styled('span')`
 const Description = styled('div')`
   font-size: 0.875em;
   margin-top: ${space(0.25)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   line-height: 14px;
   ${overflowEllipsis};
 `;

--- a/src/sentry/static/sentry/app/components/idBadge/memberBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/memberBadge.tsx
@@ -100,7 +100,7 @@ const StyledNameAndEmail = styled('div')`
 const StyledEmail = styled('div')`
   font-size: 0.875em;
   margin-top: ${space(0.25)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   ${overflowEllipsis};
 `;
 

--- a/src/sentry/static/sentry/app/components/idBadge/userBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/userBadge.tsx
@@ -74,7 +74,7 @@ const StyledNameAndEmail = styled('div')`
 const StyledEmail = styled('div')`
   font-size: 0.875em;
   margin-top: ${space(0.25)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   ${overflowEllipsis};
 `;
 

--- a/src/sentry/static/sentry/app/components/inputInline.tsx
+++ b/src/sentry/static/sentry/app/components/inputInline.tsx
@@ -209,11 +209,11 @@ const Input = styled('div')<{
   &:focus,
   &:active {
     border: 1px solid ${p => (p.isDisabled ? 'transparent' : p.theme.border)};
-    background-color: ${p => (p.isDisabled ? 'transparent' : p.theme.gray300)};
+    background-color: ${p => (p.isDisabled ? 'transparent' : p.theme.gray200)};
   }
 `;
 const StyledIconEdit = styled(IconEdit)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   margin-left: ${space(0.5)};
 
   &:hover {

--- a/src/sentry/static/sentry/app/components/issueLink.tsx
+++ b/src/sentry/static/sentry/app/components/issueLink.tsx
@@ -109,7 +109,7 @@ const Title = styled('h3')`
   em {
     font-style: normal;
     font-weight: 400;
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
     font-size: 90%;
   }
 `;
@@ -128,7 +128,7 @@ const HovercardEventMessage = styled(EventMessage)`
 `;
 
 const GridHeader = styled('h5')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: 11px;
   margin-bottom: ${space(0.5)};
   text-transform: uppercase;

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
@@ -142,8 +142,8 @@ export const IntegrationLink = styled('a')`
   text-decoration: none;
   padding-bottom: ${space(0.25)};
   margin-left: ${space(1)};
-  color: ${p => p.theme.gray700};
-  border-bottom: 1px solid ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
+  border-bottom: 1px solid ${p => p.theme.gray500};
   cursor: pointer;
   line-height: 1;
   white-space: nowrap;
@@ -157,7 +157,7 @@ export const IntegrationLink = styled('a')`
 `;
 
 const StyledIcon = styled('span')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   cursor: pointer;
 `;
 

--- a/src/sentry/static/sentry/app/components/layouts/thirds.tsx
+++ b/src/sentry/static/sentry/app/components/layouts/thirds.tsx
@@ -69,7 +69,7 @@ export const Title = styled('h2')`
   font-size: ${p => p.theme.headerFontSize};
   font-weight: normal;
   line-height: 1.2;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   margin-top: ${space(3)};
   /* TODO(bootstrap) Remove important when bootstrap headings are removed */
   margin-bottom: 0 !important;

--- a/src/sentry/static/sentry/app/components/list/utils.tsx
+++ b/src/sentry/static/sentry/app/components/list/utils.tsx
@@ -20,7 +20,7 @@ const bulletStyle = (theme: Theme) => css`
     height: 6px;
     left: 5px;
     top: 10px;
-    border: 1px solid ${theme.gray700};
+    border: 1px solid ${theme.gray500};
   }
 `;
 
@@ -48,7 +48,7 @@ const numericStyle = (theme: Theme, isSolid = false) => css`
           height: 18px;
           font-weight: 600;
           font-size: 10px;
-          border: 1px solid ${theme.gray700};
+          border: 1px solid ${theme.gray500};
         `}
   }
   counter-reset: numberedList;

--- a/src/sentry/static/sentry/app/components/listGroup.tsx
+++ b/src/sentry/static/sentry/app/components/listGroup.tsx
@@ -41,7 +41,7 @@ const ListGroup = styled('ul')<ListGroupProps>`
     p.striped
       ? `
     & > li:nth-child(odd) {
-      background: ${p.theme.gray100};
+      background: ${p.theme.backgroundSecondary};
     }
   `
       : ''}

--- a/src/sentry/static/sentry/app/components/loadingMask.tsx
+++ b/src/sentry/static/sentry/app/components/loadingMask.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 const LoadingMask = styled('div')`
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};
   position: absolute;
   top: 0;

--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -199,7 +199,7 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
 
   return `
     ${common}
-    color: ${props.theme.gray700};
+    color: ${props.theme.gray500};
 
     &:hover {
       background: ${props.theme.gray100};
@@ -234,7 +234,7 @@ const MenuListItem = styled('li')<MenuListItemProps>`
 height: 1px;
 margin: ${space(0.5)} 0;
 overflow: hidden;
-background-color: ${p.theme.gray300};
+background-color: ${p.theme.gray200};
     `}
   ${p =>
     p.header &&
@@ -242,7 +242,7 @@ background-color: ${p.theme.gray300};
     padding: ${space(0.25)} ${space(1)};
     font-size: ${p.theme.fontSizeSmall};
     line-height: 1.4;
-    color: ${p.theme.gray500};
+    color: ${p.theme.gray300};
   `}
 
   ${getChildStyles}

--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -202,7 +202,7 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
     color: ${props.theme.gray500};
 
     &:hover {
-      background: ${props.theme.gray100};
+      background: ${props.theme.backgroundSecondary};
     }
   `;
 }

--- a/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/featureTourModal.tsx
@@ -221,7 +221,7 @@ const StepCounter = styled('div')`
   text-transform: uppercase;
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: bold;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 // Styled components that can be used to build tour content.

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
@@ -460,7 +460,7 @@ const Heading = styled('h1')`
 `;
 
 const Subtext = styled('p')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   margin-bottom: ${space(3)};
 `;
 
@@ -501,7 +501,7 @@ const StatusMessage = styled('div')<{status?: 'success' | 'error'}>`
   grid-gap: ${space(1)};
   align-items: center;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => (p.status === 'error' ? p.theme.red300 : p.theme.gray600)};
+  color: ${p => (p.status === 'error' ? p.theme.red300 : p.theme.gray400)};
 
   > :first-child {
     ${p => p.status === 'success' && `color: ${p.theme.green300}`};

--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
@@ -238,7 +238,7 @@ const Description = styled('div')`
 `;
 
 const Author = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const DisabledNotice = styled(({reason, ...p}: {reason: React.ReactNode}) => (

--- a/src/sentry/static/sentry/app/components/numberDragControl.tsx
+++ b/src/sentry/static/sentry/app/components/numberDragControl.tsx
@@ -84,8 +84,8 @@ const Wrapper = styled('div')<{isActive: boolean; isX: boolean}>`
       ? 'grid-template-columns: max-content max-content'
       : 'grid-template-rows: max-content max-content'};
   cursor: ${p => (p.isX ? 'ew-resize' : 'ns-resize')};
-  color: ${p => (p.isActive ? p.theme.gray800 : p.theme.gray500)};
-  background: ${p => p.isActive && p.theme.gray200};
+  color: ${p => (p.isActive ? p.theme.gray500 : p.theme.gray300)};
+  background: ${p => p.isActive && p.theme.gray100};
   border-radius: 2px;
 `;
 

--- a/src/sentry/static/sentry/app/components/numberDragControl.tsx
+++ b/src/sentry/static/sentry/app/components/numberDragControl.tsx
@@ -85,7 +85,7 @@ const Wrapper = styled('div')<{isActive: boolean; isX: boolean}>`
       : 'grid-template-rows: max-content max-content'};
   cursor: ${p => (p.isX ? 'ew-resize' : 'ns-resize')};
   color: ${p => (p.isActive ? p.theme.gray500 : p.theme.gray300)};
-  background: ${p => p.isActive && p.theme.gray100};
+  background: ${p => p.isActive && p.theme.backgroundSecondary};
   border-radius: 2px;
 `;
 

--- a/src/sentry/static/sentry/app/components/onboardingWizard/progressHeader.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/progressHeader.tsx
@@ -21,10 +21,10 @@ const ProgressHeader = ({allTasks, completedTasks}: Props) => (
       animateText
       value={(completedTasks.length / allTasks.length) * 100}
       progressEndcaps="round"
-      backgroundColor={theme.gray300}
+      backgroundColor={theme.gray200}
       textCss={() => css`
         font-size: 26px;
-        color: ${theme.gray500};
+        color: ${theme.gray300};
       `}
     />
     <HeadingText>
@@ -51,7 +51,7 @@ const HeadingText = styled('div')`
   }
 
   p {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
     margin: 0;
     line-height: 2rem;
   }

--- a/src/sentry/static/sentry/app/components/onboardingWizard/sidebar.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/sidebar.tsx
@@ -48,7 +48,7 @@ const Heading = styled(motion.div)`
   margin: 0;
   font-weight: normal;
   border-bottom: 1px solid ${p => p.theme.border};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   padding-bottom: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/task.tsx
@@ -170,7 +170,7 @@ const Description = styled('p')`
   padding-top: ${space(1)};
   font-size: ${p => p.theme.fontSizeSmall};
   line-height: 1.75rem;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   margin: 0;
 `;
 
@@ -218,12 +218,12 @@ const CTA = styled('div')`
 `;
 
 const SkipButton = styled(Button)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const ItemComplete = styled(Card)`
   cursor: pointer;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   padding: ${space(1)} ${space(1.5)};
   display: grid;
   grid-template-columns: max-content 1fr max-content 20px;
@@ -262,7 +262,7 @@ const completedItemAnimation = {
 };
 
 const CompletedDate = styled(motion.div)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 CompletedDate.defaultProps = {

--- a/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
@@ -249,7 +249,7 @@ const EventWaitingIndicator = styled(p => (
   </div>
 ))`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   display: grid;
   grid-template-columns: max-content max-content;
   grid-gap: ${space(1)};

--- a/src/sentry/static/sentry/app/components/organizations/backToIssues.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/backToIssues.tsx
@@ -14,8 +14,8 @@ const BackToIssues = styled(Link)`
   padding: ${space(1)};
   border-radius: 50%;
 
-  color: ${p => p.theme.gray700};
-  background: ${p => p.theme.gray300};
+  color: ${p => p.theme.gray500};
+  background: ${p => p.theme.gray200};
   transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
   z-index: 1;

--- a/src/sentry/static/sentry/app/components/organizations/backToIssues.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/backToIssues.tsx
@@ -15,13 +15,13 @@ const BackToIssues = styled(Link)`
   border-radius: 50%;
 
   color: ${p => p.theme.textColor};
-  background: ${p => p.theme.gray200};
+  background: ${p => p.theme.gray100};
   transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 
   z-index: 1;
 
   &:hover {
-    background: ${p => p.theme.gray100};
+    background: ${p => p.theme.backgroundSecondary};
     transform: scale(1.125);
   }
 `;

--- a/src/sentry/static/sentry/app/components/organizations/backToIssues.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/backToIssues.tsx
@@ -14,7 +14,7 @@ const BackToIssues = styled(Link)`
   padding: ${space(1)};
   border-radius: 50%;
 
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.textColor};
   background: ${p => p.theme.gray200};
   transition: all 0.3s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
@@ -101,14 +101,14 @@ class HeaderItem extends React.Component<Props> {
           <StyledChevron isOpen={isOpen}>
             <IconChevron
               direction="down"
-              color={isOpen ? 'gray700' : 'gray500'}
+              color={isOpen ? 'gray500' : 'gray300'}
               size="sm"
             />
           </StyledChevron>
         )}
         {locked && (
           <Tooltip title={lockedMessage || 'This selection is locked'} position="bottom">
-            <StyledLock color="gray500" />
+            <StyledLock color="gray300" />
           </Tooltip>
         )}
       </StyledHeaderItem>
@@ -119,9 +119,9 @@ class HeaderItem extends React.Component<Props> {
 // Infer props here because of styled/theme
 const getColor = p => {
   if (p.locked) {
-    return p.theme.gray500;
+    return p.theme.gray300;
   }
-  return p.isOpen || p.hasSelected ? p.theme.gray700 : p.theme.gray500;
+  return p.isOpen || p.hasSelected ? p.theme.gray500 : p.theme.gray300;
 };
 
 type ColorProps = {
@@ -187,7 +187,7 @@ const StyledChevron = styled('div')<StyledChevronProps>`
 `;
 
 const SettingsIconLink = styled(Link)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -195,7 +195,7 @@ const SettingsIconLink = styled(Link)`
   transition: 0.5s opacity ease-out;
 
   &:hover {
-    color: ${p => p.theme.gray700};
+    color: ${p => p.theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/organizations/headerSeparator.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerSeparator.tsx
@@ -4,7 +4,7 @@ import space from 'app/styles/space';
 
 const HeaderSeparator = styled('div')`
   width: 1px;
-  background-color: ${p => p.theme.gray300};
+  background-color: ${p => p.theme.gray200};
   margin: ${space(2)} 0;
 `;
 

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -399,9 +399,9 @@ const StyledHeaderItem = styled(HeaderItem)`
 `;
 
 const StyledLink = styled(Link)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 
   &:hover {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 `;

--- a/src/sentry/static/sentry/app/components/organizations/projectSelector/index.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/projectSelector/index.tsx
@@ -221,15 +221,15 @@ export default ProjectSelector;
 
 const Label = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const AddButton = styled(Button)`
   display: block;
   margin: 0 ${space(1)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   :hover {
-    color: ${p => p.theme.gray600};
+    color: ${p => p.theme.gray400};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/organizations/projectSelector/selectorItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/projectSelector/selectorItem.tsx
@@ -170,7 +170,7 @@ const BadgeWrapper = styled('div')<{isMulti: boolean}>`
 `;
 
 const StyledLink = styled(Link)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -178,7 +178,7 @@ const StyledLink = styled(Link)`
   opacity: 0.33;
   transition: 0.5s opacity ease-out;
   :hover {
-    color: ${p => p.theme.gray700};
+    color: ${p => p.theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/index.jsx
@@ -309,15 +309,15 @@ const StyledDateRangePicker = styled(DateRangePicker)`
   }
 
   .rdrNextPrevButton {
-    background-color: ${p => p.theme.gray300};
+    background-color: ${p => p.theme.gray200};
   }
 
   .rdrPprevButton i {
-    border-right-color: ${p => p.theme.gray700};
+    border-right-color: ${p => p.theme.gray500};
   }
 
   .rdrNextButton i {
-    border-left-color: ${p => p.theme.gray700};
+    border-left-color: ${p => p.theme.gray500};
   }
 `;
 
@@ -329,7 +329,7 @@ const TimeAndUtcPicker = styled('div')`
 `;
 
 const UtcPicker = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   display: flex;
   align-items: center;
   justify-content: flex-end;

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/selectorItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/selectorItem.tsx
@@ -42,12 +42,12 @@ const StyledSelectorItem = styled(SelectorItem)`
   padding: ${space(1)};
   align-items: center;
   flex: 1;
-  background-color: ${p => (p.selected ? p.theme.gray100 : 'transparent')};
+  background-color: ${p => (p.selected ? p.theme.backgroundSecondary : 'transparent')};
   font-weight: ${p => (p.selected ? 'bold' : 'normal')};
   border-bottom: 1px solid ${p => (p.last ? 'transparent' : p.theme.innerBorder)};
 
   &:hover {
-    background: ${p => p.theme.gray100};
+    background: ${p => p.theme.backgroundSecondary};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/timePicker.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/timePicker.jsx
@@ -95,7 +95,7 @@ const Input = styled('input')`
   &.rdrDateDisplayItem {
     width: 100%;
     padding-left: 5%;
-    background: ${p => p.theme.gray100};
+    background: ${p => p.theme.backgroundSecondary};
     border: 1px solid ${p => p.theme.border};
     color: ${p => p.theme.gray300};
     box-shadow: none;

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/timePicker.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/timePicker.jsx
@@ -85,7 +85,7 @@ const TimePicker = styled(
     grid-column-gap: 4%;
     align-items: center;
     font-size: 0.875em;
-    color: ${p => p.theme.gray600};
+    color: ${p => p.theme.gray400};
     width: 70%;
     padding: 0;
   }
@@ -97,7 +97,7 @@ const Input = styled('input')`
     padding-left: 5%;
     background: ${p => p.theme.gray100};
     border: 1px solid ${p => p.theme.border};
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
     box-shadow: none;
   }
 `;

--- a/src/sentry/static/sentry/app/components/pageHeading.tsx
+++ b/src/sentry/static/sentry/app/components/pageHeading.tsx
@@ -13,7 +13,7 @@ const PageHeading = styled('h1')<Props>`
   font-size: ${p => p.theme.headerFontSize};
   line-height: ${p => p.theme.headerFontSize};
   font-weight: normal;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   margin: 0;
   margin-bottom: ${p => p.withMargins && space(3)};
   margin-top: ${p => p.withMargins && space(1)};

--- a/src/sentry/static/sentry/app/components/pagination.tsx
+++ b/src/sentry/static/sentry/app/components/pagination.tsx
@@ -65,7 +65,7 @@ class Pagination extends React.Component<Props> {
               <IconChevron
                 direction="left"
                 size="sm"
-                color={previousDisabled ? 'gray400' : 'gray700'}
+                color={previousDisabled ? 'gray200' : 'gray500'}
               />
             }
             aria-label={t('Previous')}
@@ -80,7 +80,7 @@ class Pagination extends React.Component<Props> {
               <IconChevron
                 direction="right"
                 size="sm"
-                color={nextDisabled ? 'gray400' : 'gray700'}
+                color={nextDisabled ? 'gray200' : 'gray500'}
               />
             }
             aria-label={t('Next')}

--- a/src/sentry/static/sentry/app/components/panels/hintPanelItem.tsx
+++ b/src/sentry/static/sentry/app/components/panels/hintPanelItem.tsx
@@ -6,7 +6,7 @@ const HintPanelItem = styled('div')`
   display: flex;
   padding: ${space(2)};
   border-bottom: 1px solid ${p => p.theme.innerBorder};
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   font-size: ${p => p.theme.fontSizeMedium};
 
   h2 {

--- a/src/sentry/static/sentry/app/components/panels/panel.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panel.tsx
@@ -31,7 +31,7 @@ const Panel = styled(
   background: ${p => (p.dashedBorder ? p.theme.gray100 : '#fff')};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px
-    ${p => (p.dashedBorder ? 'dashed' + p.theme.gray500 : 'solid ' + p.theme.border)};
+    ${p => (p.dashedBorder ? 'dashed' + p.theme.gray300 : 'solid ' + p.theme.border)};
   box-shadow: ${p => (p.dashedBorder ? 'none' : p.theme.dropShadowLight)};
   margin-bottom: ${space(3)};
   position: relative;

--- a/src/sentry/static/sentry/app/components/panels/panel.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panel.tsx
@@ -28,7 +28,7 @@ const Panel = styled(
     );
   }
 )<PanelProps>`
-  background: ${p => (p.dashedBorder ? p.theme.gray100 : '#fff')};
+  background: ${p => (p.dashedBorder ? p.theme.backgroundSecondary : '#fff')};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px
     ${p => (p.dashedBorder ? 'dashed' + p.theme.gray300 : 'solid ' + p.theme.border)};

--- a/src/sentry/static/sentry/app/components/panels/panelFooter.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelFooter.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 const PanelFooter = styled('div')`
   border-top: 1px solid ${p => p.theme.border};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: 14px;
 `;
 

--- a/src/sentry/static/sentry/app/components/panels/panelHeader.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelHeader.tsx
@@ -36,7 +36,7 @@ const PanelHeader = styled('div')<Props>`
   text-transform: uppercase;
   border-bottom: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   line-height: 1;
   position: relative;
   ${getPadding};

--- a/src/sentry/static/sentry/app/components/panels/panelHeader.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelHeader.tsx
@@ -30,7 +30,7 @@ const PanelHeader = styled('div')<Props>`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  color: ${p => (p.lightText ? p.theme.gray500 : p.theme.gray600)};
+  color: ${p => (p.lightText ? p.theme.gray300 : p.theme.gray400)};
   font-size: 13px;
   font-weight: 600;
   text-transform: uppercase;

--- a/src/sentry/static/sentry/app/components/panels/panelTable.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelTable.tsx
@@ -148,7 +148,7 @@ const Wrapper = styled(Panel, {
 `;
 
 export const PanelTableHeader = styled('div')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: 13px;
   font-weight: 600;
   text-transform: uppercase;

--- a/src/sentry/static/sentry/app/components/panels/panelTable.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelTable.tsx
@@ -153,7 +153,7 @@ export const PanelTableHeader = styled('div')`
   font-weight: 600;
   text-transform: uppercase;
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   line-height: 1;
 `;
 

--- a/src/sentry/static/sentry/app/components/passwordStrength.tsx
+++ b/src/sentry/static/sentry/app/components/passwordStrength.tsx
@@ -78,7 +78,7 @@ const PasswordStrength = ({
 };
 
 const StrengthProgress = styled('div')`
-  background: ${theme.gray300};
+  background: ${theme.gray200};
   height: 8px;
   border-radius: 2px;
   overflow: hidden;
@@ -87,7 +87,7 @@ const StrengthProgress = styled('div')`
 const StrengthLabel = styled('div')`
   font-size: 0.8em;
   margin-top: ${space(0.25)};
-  color: ${theme.gray600};
+  color: ${theme.gray400};
 `;
 
 const ScoreText = styled('strong')`

--- a/src/sentry/static/sentry/app/components/pill.tsx
+++ b/src/sentry/static/sentry/app/components/pill.tsx
@@ -134,9 +134,9 @@ const PillValue = styled(PillName)`
   .external-icon {
     display: inline;
     margin: 0 0 0 ${space(1)};
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
     &:hover {
-      color: ${p => p.theme.gray700};
+      color: ${p => p.theme.gray500};
     }
   }
 `;

--- a/src/sentry/static/sentry/app/components/pill.tsx
+++ b/src/sentry/static/sentry/app/components/pill.tsx
@@ -99,7 +99,7 @@ const getPillValueStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
       `;
     default:
       return `
-        background: ${theme.gray100};
+        background: ${theme.backgroundSecondary};
         font-family: ${theme.text.familyMono};
       `;
   }

--- a/src/sentry/static/sentry/app/components/placeholder.tsx
+++ b/src/sentry/static/sentry/app/components/placeholder.tsx
@@ -32,7 +32,7 @@ const Placeholder = styled((props: Props) => {
   flex-shrink: 0;
   justify-content: center;
 
-  background-color: ${p => (p.error ? p.theme.red100 : p.theme.gray100)};
+  background-color: ${p => (p.error ? p.theme.red100 : p.theme.backgroundSecondary)};
   ${p => p.error && `color: ${p.theme.red200};`}
   width: ${p => p.width};
   height: ${p => p.height};

--- a/src/sentry/static/sentry/app/components/placeholder.tsx
+++ b/src/sentry/static/sentry/app/components/placeholder.tsx
@@ -32,7 +32,7 @@ const Placeholder = styled((props: Props) => {
   flex-shrink: 0;
   justify-content: center;
 
-  background-color: ${p => (p.error ? p.theme.red100 : p.theme.gray200)};
+  background-color: ${p => (p.error ? p.theme.red100 : p.theme.gray100)};
   ${p => p.error && `color: ${p.theme.red200};`}
   width: ${p => p.width};
   height: ${p => p.height};

--- a/src/sentry/static/sentry/app/components/platformPicker.jsx
+++ b/src/sentry/static/sentry/app/components/platformPicker.jsx
@@ -163,7 +163,7 @@ const NavContainer = styled('div')`
 const SearchBar = styled('div')`
   ${inputStyles};
   padding: 0 8px;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   display: flex;
   align-items: center;
   font-size: 15px;
@@ -214,7 +214,7 @@ const ClearButton = styled(p => (
   width: 22px;
   border-radius: 50%;
   background: #fff;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;
 
 const PlatformCard = styled(({platform, selected, onClear, ...props}) => (

--- a/src/sentry/static/sentry/app/components/progressRing.tsx
+++ b/src/sentry/static/sentry/app/components/progressRing.tsx
@@ -57,7 +57,7 @@ const Text = styled('div')<Omit<TextProps, 'theme'>>`
   justify-content: center;
   height: 100%;
   width: 100%;
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   padding-top: 1px;
   transition: color 100ms;
@@ -83,7 +83,7 @@ const ProgressRing = ({
   textCss,
   animateText = false,
   progressColor = theme.green300,
-  backgroundColor = theme.gray300,
+  backgroundColor = theme.gray200,
   progressEndcaps,
   ...p
 }: Props) => {

--- a/src/sentry/static/sentry/app/components/projects/bookmarkStar.tsx
+++ b/src/sentry/static/sentry/app/components/projects/bookmarkStar.tsx
@@ -77,10 +77,10 @@ BookmarkStar.propTypes = {
 const Star = styled(IconStar, {shouldForwardProp: p => p !== 'isBookmarked'})<{
   isBookmarked: boolean;
 }>`
-  color: ${p => (p.isBookmarked ? p.theme.yellow300 : p.theme.gray400)};
+  color: ${p => (p.isBookmarked ? p.theme.yellow300 : p.theme.gray200)};
 
   &:hover {
-    color: ${p => (p.isBookmarked ? p.theme.yellow200 : p.theme.gray500)};
+    color: ${p => (p.isBookmarked ? p.theme.yellow200 : p.theme.gray300)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/questionTooltip.tsx
+++ b/src/sentry/static/sentry/app/components/questionTooltip.tsx
@@ -17,10 +17,10 @@ const QuestionIconContainer = styled('span')<ContainerProps>`
 
   & svg {
     transition: 120ms color;
-    color: ${p => p.theme.gray400};
+    color: ${p => p.theme.gray200};
 
     &:hover {
-      color: ${p => p.theme.gray500};
+      color: ${p => p.theme.gray300};
     }
   }
 `;

--- a/src/sentry/static/sentry/app/components/releaseStats.tsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.tsx
@@ -40,7 +40,7 @@ ReleaseStats.propTypes = {
 };
 
 const ReleaseSummaryHeading = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeSmall};
   line-height: 1.2;
   font-weight: 600;

--- a/src/sentry/static/sentry/app/components/repoLabel.tsx
+++ b/src/sentry/static/sentry/app/components/repoLabel.tsx
@@ -16,7 +16,7 @@ const RepoLabel = styled('span')`
   display: inline-block;
   vertical-align: text-bottom;
   line-height: 1;
-  background: ${p => p.theme.gray400};
+  background: ${p => p.theme.gray200};
   padding: 3px;
   max-width: 86px;
   font-size: ${p => p.theme.fontSizeSmall};

--- a/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
+++ b/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
@@ -123,7 +123,7 @@ export default class RepositoryProjectPathConfigForm extends React.Component<Pro
 
 const StyledForm = styled(Form)`
   label {
-    color: ${p => p.theme.gray600};
+    color: ${p => p.theme.gray400};
     font-family: Rubik;
     font-size: 12px;
     font-weight: 500;

--- a/src/sentry/static/sentry/app/components/repositoryProjectPathConfigRow.tsx
+++ b/src/sentry/static/sentry/app/components/repositoryProjectPathConfigRow.tsx
@@ -93,7 +93,7 @@ const StyledButton = styled(Button)`
 const ProjectAndBranch = styled('div')`
   display: flex;
   flex-direction: row;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 //match the line eight of the badge

--- a/src/sentry/static/sentry/app/components/resolutionBox.tsx
+++ b/src/sentry/static/sentry/app/components/resolutionBox.tsx
@@ -85,7 +85,7 @@ ResolutionBox.propTypes = {
 };
 
 const StyledTimeSince = styled(TimeSince)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   margin-left: ${space(0.5)};
   font-size: ${p => p.theme.fontSizeSmall};
 `;

--- a/src/sentry/static/sentry/app/components/resourceCard.tsx
+++ b/src/sentry/static/sentry/app/components/resourceCard.tsx
@@ -44,7 +44,7 @@ const StyledImg = styled('img')`
 `;
 
 const StyledTitle = styled('div')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   font-size: ${p => p.theme.fontSizeLarge};
   text-align: center;
   font-weight: bold;

--- a/src/sentry/static/sentry/app/components/search/searchResult.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResult.jsx
@@ -166,7 +166,7 @@ const SearchDetail = styled('div')`
 
 const ExtraDetail = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   margin-top: ${space(0.5)};
 `;
 

--- a/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
@@ -19,7 +19,7 @@ const SearchResultWrapper = styled(props => (
     p.highlighted &&
     css`
       color: ${p.theme.purple300};
-      background: ${p.theme.gray100};
+      background: ${p.theme.backgroundSecondary};
     `};
 
   &:not(:first-child) {

--- a/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
+++ b/src/sentry/static/sentry/app/components/search/searchResultWrapper.jsx
@@ -11,7 +11,7 @@ const SearchResultWrapper = styled(props => (
 ))`
   cursor: pointer;
   display: block;
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   padding: 10px;
   scroll-margin: 120px;
 

--- a/src/sentry/static/sentry/app/components/searchBar.tsx
+++ b/src/sentry/static/sentry/app/components/searchBar.tsx
@@ -103,7 +103,7 @@ class SearchBar extends React.PureComponent<Props, State> {
               onChange={this.onQueryChange}
               width={width}
             />
-            <StyledIconSearch className="search-input-icon" size="sm" color="gray500" />
+            <StyledIconSearch className="search-input-icon" size="sm" color="gray300" />
             {this.state.query !== this.props.defaultQuery && (
               <SearchClearButton
                 type="button"
@@ -140,10 +140,10 @@ const SearchClearButton = styled(Button)`
   transform: translateY(-50%);
   right: 10px;
   font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
 
   &:hover {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/seenByList.tsx
+++ b/src/sentry/static/sentry/app/components/seenByList.tsx
@@ -64,7 +64,7 @@ const SeenByList = ({
       />
       <IconWrapper iconPosition={iconPosition}>
         <Tooltip title={iconTooltip}>
-          <IconShow size="sm" color="gray400" />
+          <IconShow size="sm" color="gray200" />
         </Tooltip>
       </IconWrapper>
     </SeenByWrapper>
@@ -80,7 +80,7 @@ const SeenByWrapper = styled('div')<{iconPosition: Props['iconPosition']}>`
 
 const IconWrapper = styled('div')<{iconPosition: Props['iconPosition']}>`
   background-color: transparent;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   height: 28px;
   width: 24px;
   line-height: 26px;

--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -690,7 +690,7 @@ const PrimaryItems = styled('div')`
   flex-direction: column;
   -ms-overflow-style: -ms-autohiding-scrollbar;
   @media (max-height: 675px) and (min-width: ${p => p.theme.breakpoints[1]}) {
-    border-bottom: 1px solid ${p => p.theme.gray600};
+    border-bottom: 1px solid ${p => p.theme.gray400};
     padding-bottom: ${space(1)};
     box-shadow: rgba(0, 0, 0, 0.15) 0px -10px 10px inset;
     &::-webkit-scrollbar {
@@ -698,7 +698,7 @@ const PrimaryItems = styled('div')`
       width: 8px;
     }
     &::-webkit-scrollbar-thumb {
-      background: ${p => p.theme.gray600};
+      background: ${p => p.theme.gray400};
       border-radius: 8px;
     }
   }
@@ -707,7 +707,7 @@ const PrimaryItems = styled('div')`
     flex-direction: row;
     height: 100%;
     align-items: center;
-    border-right: 1px solid ${p => p.theme.gray600};
+    border-right: 1px solid ${p => p.theme.gray400};
     padding-right: ${space(1)};
     margin-right: ${space(0.5)};
     box-shadow: rgba(0, 0, 0, 0.15) -10px 0px 10px inset;

--- a/src/sentry/static/sentry/app/components/sidebar/onboardingStatus.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/onboardingStatus.tsx
@@ -105,14 +105,14 @@ class OnboardingStatus extends React.Component<Props> {
 const Heading = styled('div')`
   transition: color 100ms;
   font-size: ${p => p.theme.gray100};
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   margin-bottom: ${space(0.25)};
 `;
 
 const Remaining = styled('div')`
   transition: color 100ms;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   display: grid;
   grid-template-columns: max-content max-content;
   grid-gap: ${space(0.75)};
@@ -143,7 +143,7 @@ const hoverCss = (p: {theme: Theme}) => css`
     color: ${p.theme.white};
   }
   ${Remaining} {
-    color: ${p.theme.gray400};
+    color: ${p.theme.gray200};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/sidebar/onboardingStatus.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/onboardingStatus.tsx
@@ -104,7 +104,7 @@ class OnboardingStatus extends React.Component<Props> {
 
 const Heading = styled('div')`
   transition: color 100ms;
-  font-size: ${p => p.theme.gray100};
+  font-size: ${p => p.theme.backgroundSecondary};
   color: ${p => p.theme.gray200};
   margin-bottom: ${space(0.25)};
 `;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.tsx
@@ -205,7 +205,7 @@ const SidebarDropdownActor = styled('button')`
       text-shadow: 0 0 6px rgba(255, 255, 255, 0.1);
     }
     ${UserNameOrEmail} {
-      color: ${p => p.theme.gray400};
+      color: ${p => p.theme.gray200};
     }
   }
 `;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/switchOrganization.tsx
@@ -89,7 +89,7 @@ export default SwitchOrganizationContainer;
 
 const StyledIconAdd = styled(IconAdd)`
   margin-right: ${space(1)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const MenuItemLabelWithIcon = styled('span')`
@@ -100,12 +100,12 @@ const MenuItemLabelWithIcon = styled('span')`
 `;
 
 const SubMenuCaret = styled('span')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   transition: 0.1s color linear;
 
   &:hover,
   &:active {
-    color: ${p => p.theme.gray600};
+    color: ${p => p.theme.gray400};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdownMenu.styled.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdownMenu.styled.tsx
@@ -5,7 +5,7 @@ import {Theme} from 'app/utils/theme';
 const SidebarDropdownMenu = (p: {theme: Theme}) => css`
   position: absolute;
   background: ${p.theme.white};
-  color: ${p.theme.gray800};
+  color: ${p.theme.gray500};
   border-radius: 4px;
   box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.08), 0 4px 20px 0 rgba(0, 0, 0, 0.3);
   padding: 5px 0;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
@@ -196,7 +196,7 @@ const StyledSidebarItem = styled(Link)`
 
   &:hover,
   &:focus {
-    color: ${p => p.theme.gray400};
+    color: ${p => p.theme.gray200};
   }
 
   &.focus-visible {

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarMenuItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarMenuItem.tsx
@@ -23,7 +23,7 @@ const SidebarMenuItem = ({to, children, href, ...props}: Props) => {
 const menuItemStyles = (
   p: React.ComponentProps<typeof SidebarMenuItemLink> & {theme: Theme}
 ) => css`
-  color: ${p.theme.gray800};
+  color: ${p.theme.gray500};
   cursor: pointer;
   display: flex;
   font-size: ${p.theme.fontSizeMedium};
@@ -37,7 +37,7 @@ const menuItemStyles = (
   &:active,
   &.focus-visible {
     background: ${p.theme.gray100};
-    color: ${p.theme.gray800};
+    color: ${p.theme.gray500};
     outline: none;
   }
 

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarMenuItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarMenuItem.tsx
@@ -36,7 +36,7 @@ const menuItemStyles = (
   &:hover,
   &:active,
   &.focus-visible {
-    background: ${p.theme.gray100};
+    background: ${p.theme.backgroundSecondary};
     color: ${p.theme.gray500};
     outline: none;
   }

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarOrgSummary.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarOrgSummary.tsx
@@ -37,7 +37,7 @@ const OrgSummary = styled('div')`
   overflow: hidden;
 `;
 const SummaryOrgName = styled('div')`
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   font-size: 16px;
   line-height: 1.1;
   font-weight: bold;
@@ -45,7 +45,7 @@ const SummaryOrgName = styled('div')`
   ${overflowEllipsis};
 `;
 const SummaryOrgDetails = styled('div')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: 14px;
   line-height: 1;
   ${overflowEllipsis};

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarPanel.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarPanel.tsx
@@ -110,13 +110,13 @@ const SidebarPanelBody = styled('div')<{hasHeader: boolean}>`
 `;
 
 const PanelClose = styled(IconClose)`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   cursor: pointer;
   position: relative;
   padding: ${space(0.75)};
 
   &:hover {
-    color: ${p => p.theme.gray800};
+    color: ${p => p.theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarPanel.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarPanel.tsx
@@ -81,7 +81,7 @@ const PanelContainer = styled('div')`
   display: flex;
   flex-direction: column;
   z-index: ${p => p.theme.zIndex.sidebarPanel};
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   color: ${p => p.theme.sidebar.background};
   border-right: 1px solid ${p => p.theme.border};
   box-shadow: 1px 0 2px rgba(0, 0, 0, 0.06);

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarPanelEmpty.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarPanelEmpty.tsx
@@ -4,7 +4,7 @@ const SidebarPanelEmpty = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   height: 100%;
   width: 100%;
   padding: 0 60px;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarPanelItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarPanelItem.tsx
@@ -61,7 +61,7 @@ const ImageBox = styled('div')`
 const Title = styled('div')<Pick<Props, 'hasSeen'>>`
   font-size: 15px;
   margin-bottom: 5px;
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   ${p => !p.hasSeen && 'font-weight: 600;'};
 
   .culprit {
@@ -78,5 +78,5 @@ const Text = styled('div')`
 `;
 
 const Message = styled(Text)`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -1268,7 +1268,7 @@ const Container = styled('div')<{isOpen: boolean}>`
   display: flex;
 
   .show-sidebar & {
-    background: ${p => p.theme.gray100};
+    background: ${p => p.theme.backgroundSecondary};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -61,7 +61,7 @@ const getInputButtonStyles = (p: {
   isActive?: boolean;
   collapseIntoEllipsisMenu?: number;
 }) => `
-  color: ${p.isActive ? theme.blue300 : theme.gray500};
+  color: ${p.isActive ? theme.blue300 : theme.gray300};
   margin-left: ${space(0.5)};
   width: 18px;
 
@@ -72,7 +72,7 @@ const getInputButtonStyles = (p: {
   }
 
   &:hover {
-    color: ${theme.gray600};
+    color: ${theme.gray400};
   }
 
   ${
@@ -85,7 +85,7 @@ const getDropdownElementStyles = (p: {showBelowMediaQuery: number; last?: boolea
   padding: 0 ${space(1)} ${p.last ? null : space(0.5)};
   margin-bottom: ${p.last ? null : space(0.5)};
   display: none;
-  color: ${theme.gray700};
+  color: ${theme.gray500};
   align-items: center;
   min-width: 190px;
   height: 38px;
@@ -1281,7 +1281,7 @@ const StyledForm = styled('form')`
 `;
 
 const StyledInput = styled('input')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   background: transparent;
   border: 0;
   outline: none;
@@ -1293,7 +1293,7 @@ const StyledInput = styled('input')`
   padding: 0 0 0 ${space(1)};
 
   &::placeholder {
-    color: ${p => p.theme.gray400};
+    color: ${p => p.theme.gray200};
   }
   &:focus {
     border-color: ${p => p.theme.border};
@@ -1347,5 +1347,5 @@ const SearchLabel = styled('label')`
   align-items: center;
   margin: 0;
   padding-left: ${space(1)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;

--- a/src/sentry/static/sentry/app/components/smartSearchBar/searchDropdown.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/searchDropdown.tsx
@@ -131,7 +131,7 @@ const Info = styled('div')`
   display: flex;
   padding: ${space(1)} ${space(2)};
   font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 
   &:not(:last-child) {
     border-bottom: 1px solid ${p => p.theme.innerBorder};
@@ -151,7 +151,7 @@ const SearchDropdownGroupTitle = styled('header')`
   align-items: center;
 
   background-color: ${p => p.theme.gray100};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-weight: normal;
   font-size: ${p => p.theme.fontSizeMedium};
 

--- a/src/sentry/static/sentry/app/components/smartSearchBar/searchDropdown.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/searchDropdown.tsx
@@ -150,7 +150,7 @@ const SearchDropdownGroupTitle = styled('header')`
   display: flex;
   align-items: center;
 
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   color: ${p => p.theme.gray300};
   font-weight: normal;
   font-size: ${p => p.theme.fontSizeMedium};
@@ -177,7 +177,7 @@ const SearchListItem = styled(ListItem)`
 
   &:hover,
   &.active {
-    background: ${p => p.theme.gray100};
+    background: ${p => p.theme.backgroundSecondary};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -414,7 +414,7 @@ const SecondaryCount = styled(({value, ...p}) => <Count {...p} value={value} />)
     content: '/';
     padding-left: ${space(0.25)};
     padding-right: 2px;
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/stream/groupChart.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.tsx
@@ -49,7 +49,7 @@ function GroupChart({
   } else {
     // Colors are custom to preserve historical appearance where the single series is
     // considerably darker than the two series results.
-    colors = [theme.gray500];
+    colors = [theme.gray300];
     emphasisColors = [theme.purple300];
     series.push({
       seriesName: t('Events'),

--- a/src/sentry/static/sentry/app/components/switch.tsx
+++ b/src/sentry/static/sentry/app/components/switch.tsx
@@ -98,7 +98,7 @@ const Toggle = styled('span')<StyleProps>`
   transform: translateX(${getTranslateX}px);
   width: ${getToggleSize}px;
   height: ${getToggleSize}px;
-  background: ${p => (p.isActive ? p.theme.green300 : p.theme.gray400)};
+  background: ${p => (p.isActive ? p.theme.green300 : p.theme.gray200)};
   opacity: ${p => (p.isDisabled ? 0.4 : null)};
 `;
 

--- a/src/sentry/static/sentry/app/components/tag.tsx
+++ b/src/sentry/static/sentry/app/components/tag.tsx
@@ -128,7 +128,7 @@ const IconWrapper = styled('span')`
 `;
 
 const Text = styled('span')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   max-width: 150px;
   overflow: hidden;
@@ -136,7 +136,7 @@ const Text = styled('span')`
   text-overflow: ellipsis;
   line-height: ${TAG_HEIGHT};
   a:hover & {
-    color: ${p => p.theme.gray800};
+    color: ${p => p.theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/tagDeprecated.tsx
+++ b/src/sentry/static/sentry/app/components/tagDeprecated.tsx
@@ -56,7 +56,7 @@ const Tag = styled(
   padding: ${p => (p.size === 'small' ? '0.1em 0.4em 0.2em' : '0.35em 0.8em 0.4em')};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   line-height: 1;
-  color: ${p => (p.priority ? p.theme.white : p.theme.gray800)};
+  color: ${p => (p.priority ? p.theme.white : p.theme.gray500)};
   text-align: center;
   white-space: nowrap;
   vertical-align: middle;
@@ -64,7 +64,7 @@ const Tag = styled(
   border-radius: ${p => (p.size === 'small' ? '0.25em' : '2em')};
   text-transform: lowercase;
   font-weight: ${p => (p.size === 'small' ? 'bold' : 'normal')};
-  background: ${p => getPriority(p)?.background ?? p.theme.gray300};
+  background: ${p => getPriority(p)?.background ?? p.theme.gray200};
   ${p => getBorder(p)};
   ${p => getMarginLeft(p)};
 `;

--- a/src/sentry/static/sentry/app/components/tagDistributionMeter.tsx
+++ b/src/sentry/static/sentry/app/components/tagDistributionMeter.tsx
@@ -244,14 +244,14 @@ const Title = styled('div')`
 `;
 
 const TitleType = styled('div')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   font-weight: bold;
   ${overflowEllipsis};
 `;
 
 const TitleDescription = styled('div')`
   display: flex;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   text-align: right;
 `;
 
@@ -263,7 +263,7 @@ const Label = styled('div')`
 const Percent = styled('div')`
   font-weight: bold;
   padding-left: ${space(0.5)};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;
 
 const OtherSegment = styled('span')`

--- a/src/sentry/static/sentry/app/components/tagsTable.tsx
+++ b/src/sentry/static/sentry/app/components/tagsTable.tsx
@@ -77,7 +77,7 @@ const StyledTable = styled('table')`
 
 const StyledTr = styled('tr')`
   &:nth-child(2n + 1) td {
-    background-color: ${p => p.theme.gray100};
+    background-color: ${p => p.theme.backgroundSecondary};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/tagsTable.tsx
+++ b/src/sentry/static/sentry/app/components/tagsTable.tsx
@@ -82,7 +82,7 @@ const StyledTr = styled('tr')`
 `;
 
 const TagKey = styled('td')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   padding: ${space(0.5)} ${space(1)};
   font-size: ${p => p.theme.fontSizeMedium};
   white-space: nowrap;

--- a/src/sentry/static/sentry/app/components/toolbar.tsx
+++ b/src/sentry/static/sentry/app/components/toolbar.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 const Toolbar = styled('div')`
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   border: 1px solid ${p => p.theme.border};
   border-bottom: none;
   border-radius: 3px 3px 0 0;

--- a/src/sentry/static/sentry/app/components/toolbarHeader.tsx
+++ b/src/sentry/static/sentry/app/components/toolbarHeader.tsx
@@ -4,7 +4,7 @@ const ToolbarHeader = styled('div')`
   font-size: 12px;
   text-transform: uppercase;
   font-weight: bold;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 export default ToolbarHeader;

--- a/src/sentry/static/sentry/app/components/versionHoverCard.tsx
+++ b/src/sentry/static/sentry/app/components/versionHoverCard.tsx
@@ -203,7 +203,7 @@ const VersionRepoLabel = styled(RepoLabel)`
 `;
 
 const StyledTimeSince = styled(TimeSince)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   position: absolute;
   left: 98px;
   width: 50%;

--- a/src/sentry/static/sentry/app/components/well.tsx
+++ b/src/sentry/static/sentry/app/components/well.tsx
@@ -14,7 +14,7 @@ type WellProps = Omit<React.HTMLProps<HTMLDivElement>, keyof Props> & Props;
 const Well = styled('div')<WellProps>`
   border: 1px solid ${p => p.theme.border};
   box-shadow: none;
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   padding: ${p => (p.hasImage ? '80px 30px' : '15px 20px')};
   margin-bottom: 20px;
   border-radius: 3px;

--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -12,7 +12,7 @@ const styles = (theme: Theme) => css`
   }
 
   abbr {
-    border-bottom: 1px dotted ${theme.gray500};
+    border-bottom: 1px dotted ${theme.gray300};
   }
 
   /**

--- a/src/sentry/static/sentry/app/styles/input.tsx
+++ b/src/sentry/static/sentry/app/styles/input.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 const inputStyles = (props: Props) =>
   css`
-    color: ${props.disabled ? props.theme.disabled : props.theme.gray800};
+    color: ${props.disabled ? props.theme.disabled : props.theme.gray500};
     display: block;
     width: 100%;
     background: #fff;
@@ -41,12 +41,12 @@ const inputStyles = (props: Props) =>
     }
 
     &::placeholder {
-      color: ${props.theme.gray500};
+      color: ${props.theme.gray300};
     }
 
     &[disabled] {
       background: ${props.theme.gray100};
-      color: ${props.theme.gray500};
+      color: ${props.theme.gray300};
       border: 1px solid ${props.theme.border};
       cursor: not-allowed;
 

--- a/src/sentry/static/sentry/app/styles/input.tsx
+++ b/src/sentry/static/sentry/app/styles/input.tsx
@@ -45,7 +45,7 @@ const inputStyles = (props: Props) =>
     }
 
     &[disabled] {
-      background: ${props.theme.gray100};
+      background: ${props.theme.backgroundSecondary};
       color: ${props.theme.gray300};
       border: 1px solid ${props.theme.border};
       cursor: not-allowed;

--- a/src/sentry/static/sentry/app/styles/organization.tsx
+++ b/src/sentry/static/sentry/app/styles/organization.tsx
@@ -23,6 +23,6 @@ export const HeaderTitle = styled('h4')`
   font-size: ${p => p.theme.headerFontSize};
   line-height: ${p => p.theme.headerFontSize};
   font-weight: normal;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   margin: 0;
 `;

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -69,7 +69,7 @@ type FieldFormatters = {
 export type FieldTypes = keyof FieldFormatters;
 
 const EmptyValueContainer = styled('span')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 const emptyValue = <EmptyValueContainer>{t('n/a')}</EmptyValueContainer>;
 

--- a/src/sentry/static/sentry/app/utils/discover/keyTransactionField.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/keyTransactionField.tsx
@@ -69,7 +69,7 @@ class KeyTransactionField extends React.Component<Props, State> {
 
     const star = (
       <StyledKey
-        color={isKeyTransaction ? 'yellow300' : 'gray400'}
+        color={isKeyTransaction ? 'yellow300' : 'gray200'}
         isSolid={isKeyTransaction}
         data-test-id="key-transaction-column"
       />

--- a/src/sentry/static/sentry/app/utils/discover/styles.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/styles.tsx
@@ -25,7 +25,7 @@ export const NumberContainer = styled('div')`
 `;
 
 export const StyledDateTime = styled(DateTime)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   ${overflowEllipsis};
 `;
 

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -82,23 +82,23 @@ const aliases = {
   /**
    * Inner borders, e.g. borders inside of a grid
    */
-  innerBorder: colors.gray200,
+  innerBorder: '#e7e1ec',
 
   /**
    * A color that denotes a "success", or something good
    */
-  success: colors.green300, // TODO(dark): colors.green200,
+  success: colors.green200,
 
   /**
    * A color that denotes an error, or something that is wrong
    */
-  error: colors.red300, // TODO(dark): colors.red300,
+  error: colors.red300,
 
-  /**red200
+  /**
    * A color that indicates something is disabled where user can not interact or use
    * it in the usual manner (implies that there is an "enabled" state)
    */
-  disabled: colors.gray200, // TODO(dark): colors.gray100,
+  disabled: colors.gray100,
 
   /**
    * Indicates that something is "active" or "selected"

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -87,7 +87,7 @@ const aliases = {
   /**
    * A color that denotes a "success", or something good
    */
-  success: colors.green200,
+  success: colors.green300,
 
   /**
    * A color that denotes an error, or something that is wrong

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -7,13 +7,10 @@ const colors = {
   black: '#1D1127',
 
   gray100: '#FAF9FB',
-  gray200: '#F2F0F5',
-  gray300: '#E7E1EC',
-  gray400: '#C6BECF',
-  gray500: '#9585A3',
-  gray600: '#645574',
-  gray700: '#4A3E56',
-  gray800: '#302839',
+  gray200: '#C6BECF',
+  gray300: '#9386A0',
+  gray400: '#776589',
+  gray500: '#2B1D38',
 
   yellow100: '#FDE8b4',
   yellow200: '#FFD577',
@@ -50,12 +47,12 @@ const aliases = {
   /**
    * Primary text color
    */
-  textColor: colors.gray800, // TODO(dark): colors.gray500
+  textColor: colors.gray500, // TODO(dark): colors.gray300
 
   /**
    * Text that should not have as much emphasis
    */
-  subText: colors.gray400,
+  subText: colors.gray200,
 
   /**
    * Background for the main content area of a page?
@@ -80,12 +77,12 @@ const aliases = {
   /**
    * Primary border color
    */
-  border: colors.gray400,
+  border: colors.gray200,
 
   /**
    * Inner borders, e.g. borders inside of a grid
    */
-  innerBorder: colors.gray300,
+  innerBorder: colors.gray200,
 
   /**
    * A color that denotes a "success", or something good
@@ -101,7 +98,7 @@ const aliases = {
    * A color that indicates something is disabled where user can not interact or use
    * it in the usual manner (implies that there is an "enabled" state)
    */
-  disabled: colors.gray400, // TODO(dark): colors.gray200,
+  disabled: colors.gray200, // TODO(dark): colors.gray100,
 
   /**
    * Indicates that something is "active" or "selected"
@@ -111,7 +108,7 @@ const aliases = {
   /**
    * Inactive
    */
-  inactive: colors.gray300,
+  inactive: colors.gray200,
 
   /**
    * Link color indicates that something is clickable
@@ -132,12 +129,12 @@ const aliases = {
   /**
    * Form placeholder text color
    */
-  formPlaceholder: colors.gray200,
+  formPlaceholder: colors.gray100,
 
   /**
    * Default form text color
    */
-  formText: colors.gray500,
+  formText: colors.gray300,
 
   /**
    *
@@ -147,12 +144,12 @@ const aliases = {
   /**
    * Color of lines that flow across the background of the chart to indicate axes levels
    */
-  chartLineColor: colors.gray200,
+  chartLineColor: colors.gray100,
 
   /**
    * Color for chart label text
    */
-  chartLabel: colors.gray300,
+  chartLabel: colors.gray200,
 } as const;
 
 const warning = {
@@ -164,7 +161,7 @@ const warning = {
 
 const alert = {
   muted: {
-    background: colors.gray400,
+    background: colors.gray200,
     backgroundLight: colors.gray100,
     border: aliases.border,
     iconColor: 'inherit',
@@ -209,7 +206,7 @@ const badge = {
 
 const tag = {
   default: {
-    background: colors.gray200,
+    background: colors.gray100,
     iconColor: colors.purple300,
   },
   promotion: {
@@ -238,7 +235,7 @@ const tag = {
   },
   white: {
     background: colors.white,
-    iconColor: colors.gray700,
+    iconColor: colors.gray500,
   },
 };
 
@@ -252,7 +249,7 @@ const generateButtonTheme = alias => ({
     backgroundActive: colors.white,
     border: '#d8d2de',
     borderActive: '#c9c0d1',
-    focusShadow: color(colors.gray300).alpha(0.5).string(),
+    focusShadow: color(colors.gray200).alpha(0.5).string(),
   },
   primary: {
     color: colors.white,
@@ -443,7 +440,7 @@ const theme = {
     getColorPalette: (length: number) =>
       CHART_PALETTE[Math.min(CHART_PALETTE.length - 1, length + 1)],
 
-    previousPeriod: colors.gray400,
+    previousPeriod: colors.gray200,
     symbolSize: 6,
   },
 

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -7,7 +7,7 @@ const colors = {
   black: '#1D1127',
 
   gray100: '#FAF9FB',
-  gray200: '#C6BECF',
+  gray200: '#F2F0F5',
   gray300: '#9386A0',
   gray400: '#776589',
   gray500: '#2B1D38',
@@ -43,6 +43,8 @@ const colors = {
   pink300: '#F05781',
 } as const;
 
+const backgroundSecondary = '#FAF9FB';
+
 const aliases = {
   /**
    * Primary text color
@@ -57,7 +59,7 @@ const aliases = {
   /**
    * Background for the main content area of a page?
    */
-  bodyBackground: colors.gray100,
+  bodyBackground: backgroundSecondary,
 
   /**
    * Primary background color
@@ -67,7 +69,7 @@ const aliases = {
   /**
    * Secondary background color used as a slight contrast against primary background
    */
-  backgroundSecondary: colors.gray100,
+  backgroundSecondary,
 
   /**
    * Background for the header of a page
@@ -139,7 +141,7 @@ const aliases = {
   /**
    *
    */
-  rowBackground: colors.gray100,
+  rowBackground: backgroundSecondary,
 
   /**
    * Color of lines that flow across the background of the chart to indicate axes levels

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -149,7 +149,7 @@ const aliases = {
   /**
    * Color of lines that flow across the background of the chart to indicate axes levels
    */
-  chartLineColor: colors.gray200,
+  chartLineColor: colors.gray100,
 
   /**
    * Color for chart label text

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -6,8 +6,8 @@ const colors = {
   white: '#FFFFFF',
   black: '#1D1127',
 
-  gray100: '#FAF9FB',
-  gray200: '#F2F0F5',
+  gray100: '#F2F0F5',
+  gray200: '#C6BECF',
   gray300: '#9386A0',
   gray400: '#776589',
   gray500: '#2B1D38',
@@ -43,6 +43,9 @@ const colors = {
   pink300: '#F05781',
 } as const;
 
+/**
+ * This is not in the gray palette because it should [generally] only be used for backgrounds
+ */
 const backgroundSecondary = '#FAF9FB';
 
 const aliases = {

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -47,12 +47,12 @@ const aliases = {
   /**
    * Primary text color
    */
-  textColor: colors.gray500, // TODO(dark): colors.gray300
+  textColor: colors.gray500,
 
   /**
    * Text that should not have as much emphasis
    */
-  subText: colors.gray200,
+  subText: colors.gray400,
 
   /**
    * Background for the main content area of a page?
@@ -98,7 +98,7 @@ const aliases = {
    * A color that indicates something is disabled where user can not interact or use
    * it in the usual manner (implies that there is an "enabled" state)
    */
-  disabled: colors.gray100,
+  disabled: colors.gray200,
 
   /**
    * Indicates that something is "active" or "selected"
@@ -113,12 +113,12 @@ const aliases = {
   /**
    * Link color indicates that something is clickable
    */
-  linkColor: colors.purple200,
+  linkColor: colors.purple300,
 
   /**
    * ...
    */
-  secondaryButton: colors.purple200,
+  secondaryButton: colors.purple300,
 
   /**
    * Gradient for sidebar
@@ -129,12 +129,12 @@ const aliases = {
   /**
    * Form placeholder text color
    */
-  formPlaceholder: colors.gray100,
+  formPlaceholder: colors.gray200,
 
   /**
    * Default form text color
    */
-  formText: colors.gray300,
+  formText: colors.gray500,
 
   /**
    *
@@ -144,12 +144,12 @@ const aliases = {
   /**
    * Color of lines that flow across the background of the chart to indicate axes levels
    */
-  chartLineColor: colors.gray100,
+  chartLineColor: colors.gray200,
 
   /**
    * Color for chart label text
    */
-  chartLabel: colors.gray200,
+  chartLabel: colors.gray300,
 } as const;
 
 const warning = {
@@ -162,7 +162,7 @@ const warning = {
 const alert = {
   muted: {
     background: colors.gray200,
-    backgroundLight: colors.gray100,
+    backgroundLight: aliases.backgroundSecondary,
     border: aliases.border,
     iconColor: 'inherit',
   },

--- a/src/sentry/static/sentry/app/views/alerts/details/activity/activity.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/activity/activity.tsx
@@ -172,7 +172,7 @@ class Activity extends React.Component<Props> {
 export default Activity;
 
 const StyledTimeSince = styled(TimeSince)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeSmall};
   margin-left: ${space(0.5)};
 `;

--- a/src/sentry/static/sentry/app/views/alerts/details/activity/activityPlaceholder.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/activity/activityPlaceholder.tsx
@@ -8,8 +8,8 @@ import theme from 'app/utils/theme';
 const ActivityPlaceholder = () => (
   <ActivityItem
     bubbleProps={{
-      backgroundColor: theme.gray100,
-      borderColor: theme.gray100,
+      backgroundColor: theme.backgroundSecondary,
+      borderColor: theme.backgroundSecondary,
     }}
   >
     {() => <Placeholder />}

--- a/src/sentry/static/sentry/app/views/alerts/details/activity/activityPlaceholder.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/activity/activityPlaceholder.tsx
@@ -8,8 +8,8 @@ import theme from 'app/utils/theme';
 const ActivityPlaceholder = () => (
   <ActivityItem
     bubbleProps={{
-      backgroundColor: theme.gray200,
-      borderColor: theme.gray200,
+      backgroundColor: theme.gray100,
+      borderColor: theme.gray100,
     }}
   >
     {() => <Placeholder />}

--- a/src/sentry/static/sentry/app/views/alerts/details/activity/dateDivider.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/activity/dateDivider.tsx
@@ -7,7 +7,7 @@ const DateDivider = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   margin: ${space(1.5)} 0;
 
   &:before,
@@ -16,7 +16,7 @@ const DateDivider = styled('div')`
     display: block;
     flex-grow: 1;
     height: 1px;
-    background-color: ${p => p.theme.gray300};
+    background-color: ${p => p.theme.gray200};
   }
 
   &:before {

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -427,6 +427,6 @@ const RuleDetails = styled('div')`
 
   & > span:nth-child(4n + 1),
   & > span:nth-child(4n + 2) {
-    background-color: ${p => p.theme.gray100};
+    background-color: ${p => p.theme.backgroundSecondary};
   }
 `;

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -356,7 +356,7 @@ const ChartActions = styled(PanelFooter)`
 `;
 
 const ChartParameters = styled('div')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
   display: grid;
   grid-auto-flow: column;
@@ -374,7 +374,7 @@ const ChartParameters = styled('div')`
     display: block;
     height: 70%;
     width: 1px;
-    background: ${p => p.theme.gray300};
+    background: ${p => p.theme.gray200};
     position: absolute;
     right: -${space(2)};
     top: 15%;

--- a/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/chart.tsx
@@ -189,7 +189,7 @@ const Chart = (props: Props) => {
             type: 'line',
             markLine: MarkLine({
               silent: true,
-              lineStyle: {color: theme.gray400},
+              lineStyle: {color: theme.gray200},
               data: [
                 {
                   yAxis: alertResolveThreshold,
@@ -200,7 +200,7 @@ const Chart = (props: Props) => {
                 show: true,
                 position: 'insideEndBottom',
                 formatter: 'CRITICAL RESOLUTION',
-                color: theme.gray400,
+                color: theme.gray200,
                 fontSize: 10,
               } as any, // TODO(ts): Color is not an option for label,
             }),

--- a/src/sentry/static/sentry/app/views/alerts/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/header.tsx
@@ -245,7 +245,7 @@ const ItemTitle = styled('h6')`
   font-size: ${p => p.theme.fontSizeSmall};
   margin-bottom: 0;
   text-transform: uppercase;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   letter-spacing: 0.1px;
 `;
 
@@ -268,7 +268,7 @@ const IncidentSubTitle = styled('div', {
 })<{loading: boolean}>`
   ${p => p.loading && 'opacity: 0'};
   font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const StyledStatus = styled(Status)`

--- a/src/sentry/static/sentry/app/views/alerts/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/header.tsx
@@ -180,7 +180,7 @@ export default class DetailsHeader extends React.Component<Props> {
 }
 
 const Header = styled('div')`
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   border-bottom: 1px solid ${p => p.theme.border};
 `;
 

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -82,7 +82,7 @@ class AlertListRow extends AsyncComponent<Props, State> {
     const isResolved = status === IncidentStatus.CLOSED;
     const isWarning = status === IncidentStatus.WARNING;
 
-    const color = isResolved ? theme.gray400 : isWarning ? theme.orange300 : theme.red200;
+    const color = isResolved ? theme.gray200 : isWarning ? theme.orange300 : theme.red200;
     const text = isResolved ? t('Resolved') : isWarning ? t('Warning') : t('Critical');
 
     return (

--- a/src/sentry/static/sentry/app/views/alerts/list/sparkLine.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/sparkLine.tsx
@@ -42,7 +42,7 @@ class SparkLine extends React.Component<Props> {
         <div data-test-id="incident-sparkline" className={className}>
           <Sparklines data={data} width={100} height={32}>
             <SparklinesLine
-              style={{stroke: theme.gray500, fill: 'none', strokeWidth: 2}}
+              style={{stroke: theme.gray300, fill: 'none', strokeWidth: 2}}
             />
           </Sparklines>
         </div>

--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -134,7 +134,7 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
                   >
                     {t('Created')}{' '}
                     <IconArrow
-                      color="gray500"
+                      color="gray300"
                       size="xs"
                       direction={sort.asc ? 'up' : 'down'}
                     />

--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -103,7 +103,7 @@ class RuleListRow extends React.Component<Props, State> {
 const RuleType = styled('div')`
   font-size: 12px;
   font-weight: 400;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   text-transform: uppercase;
 `;
 

--- a/src/sentry/static/sentry/app/views/auth/loginForm.jsx
+++ b/src/sentry/static/sentry/app/views/auth/loginForm.jsx
@@ -184,10 +184,10 @@ const ProviderWrapper = styled('div')`
 `;
 
 const LostPasswordLink = styled(Link)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 
   &:hover {
-    color: ${p => p.theme.gray800};
+    color: ${p => p.theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/auth/registerForm.jsx
+++ b/src/sentry/static/sentry/app/views/auth/registerForm.jsx
@@ -130,10 +130,10 @@ class RegisterForm extends React.Component {
 }
 
 const PrivacyPolicyLink = styled(ExternalLink)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 
   &:hover {
-    color: ${p => p.theme.gray800};
+    color: ${p => p.theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/exploreWidget.jsx
@@ -208,7 +208,7 @@ const ExploreButton = styled(props => {
   return <ExploreAction {...remaining} />;
 })`
   position: relative;
-  color: ${p => (p.isOpen ? p.theme.purple300 : p.theme.gray500)};
+  color: ${p => (p.isOpen ? p.theme.purple300 : p.theme.gray300)};
   padding: ${space(1)} ${space(2)};
   border-radius: 0 0 ${p => p.theme.borderRadius} 0;
   ${p => p.isOpen && `z-index: ${p.theme.zIndex.dropdownAutocomplete.actor}`};

--- a/src/sentry/static/sentry/app/views/dashboards/widget.jsx
+++ b/src/sentry/static/sentry/app/views/dashboards/widget.jsx
@@ -97,7 +97,7 @@ const StyledPanelBody = styled(PanelBody)`
 `;
 
 const Placeholder = styled('div')`
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   height: 237px;
 `;
 

--- a/src/sentry/static/sentry/app/views/discover/intro.tsx
+++ b/src/sentry/static/sentry/app/views/discover/intro.tsx
@@ -92,7 +92,7 @@ const IntroContainer = styled('div')`
   align-items: center;
   justify-content: center;
   font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   width: 100%;
   height: 100%;
   min-height: 420px;
@@ -121,5 +121,5 @@ const ExampleQuery = styled(Panel)`
 `;
 const ExampleQueryDescription = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
 `;

--- a/src/sentry/static/sentry/app/views/discover/result/table.tsx
+++ b/src/sentry/static/sentry/app/views/discover/result/table.tsx
@@ -328,7 +328,7 @@ const Grid = styled('div')<{visibleRows: number}>`
 ` as any;
 
 const Cell = styled('div')<{isOddRow: boolean; align: 'right' | 'left'}>`
-  ${p => !p.isOddRow && `background-color: ${p.theme.gray100};`};
+  ${p => !p.isOddRow && `background-color: ${p.theme.backgroundSecondary};`};
   ${p => `text-align: ${p.align};`};
   overflow: scroll;
   font-size: 14px;
@@ -348,7 +348,7 @@ const Cell = styled('div')<{isOddRow: boolean; align: 'right' | 'left'}>`
 ` as any;
 
 const TableHeader = styled(Cell)`
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   color: ${p => p.theme.gray400};
   border-top: none;
   border-bottom: 1px solid ${p => p.theme.border};

--- a/src/sentry/static/sentry/app/views/discover/result/table.tsx
+++ b/src/sentry/static/sentry/app/views/discover/result/table.tsx
@@ -349,7 +349,7 @@ const Cell = styled('div')<{isOddRow: boolean; align: 'right' | 'left'}>`
 
 const TableHeader = styled(Cell)`
   background: ${p => p.theme.gray100};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   border-top: none;
   border-bottom: 1px solid ${p => p.theme.border};
   &:first-of-type {

--- a/src/sentry/static/sentry/app/views/discover/result/utils.tsx
+++ b/src/sentry/static/sentry/app/views/discover/result/utils.tsx
@@ -333,11 +333,11 @@ export function getDisplayText(val: any): string {
 }
 
 const LightGray = styled('span')`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
 `;
 
 const DarkGray = styled('span')`
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
 `;
 
 /**

--- a/src/sentry/static/sentry/app/views/discover/sidebar/queryPanel.tsx
+++ b/src/sentry/static/sentry/app/views/discover/sidebar/queryPanel.tsx
@@ -19,7 +19,7 @@ export default class QueryPanel extends React.Component<QueryPanelProps> {
           <PageHeading>{title}</PageHeading>
 
           <QueryPanelCloseLink to="" onClick={onClose}>
-            <IconClose color="gray400" />
+            <IconClose color="gray200" />
           </QueryPanelCloseLink>
         </QueryPanelTitle>
         {this.props.children}

--- a/src/sentry/static/sentry/app/views/discover/styles.tsx
+++ b/src/sentry/static/sentry/app/views/discover/styles.tsx
@@ -127,7 +127,7 @@ export const BodyContent = styled('div')`
   padding: ${space(3)} ${space(4)} ${space(4)} ${space(4)};
   overflow-y: scroll;
   position: relative;
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
 `;
 
 export const LoadingContainer = styled('div')`
@@ -259,7 +259,8 @@ export const SavedQueryList = styled(Panel)`
 export const SavedQueryListItem = styled(PanelItem)<{isActive?: boolean | null}>`
   flex-direction: column;
   padding: 0;
-  background-color: ${(p: any) => (p.isActive ? p.theme.gray100 : p.theme.white)};
+  background-color: ${(p: any) =>
+    p.isActive ? p.theme.backgroundSecondary : p.theme.white};
 `;
 
 export const SavedQueryLink = styled(Link)`

--- a/src/sentry/static/sentry/app/views/discover/styles.tsx
+++ b/src/sentry/static/sentry/app/views/discover/styles.tsx
@@ -93,7 +93,7 @@ export const DocsSeparator = styled('div')`
 `;
 
 export const DocsLink = styled(ExternalLink)`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   &:hover {
     color: ${p => p.theme.blue300};
   }
@@ -143,7 +143,7 @@ export const SidebarTabs = styled((props: any) => <NavTabs {...props} underlined
 `;
 
 export const PlaceholderText = styled('div')`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   font-size: 15px;
 `;
 
@@ -169,7 +169,7 @@ export const SelectListItem = styled('div')`
 export const SidebarLabel = styled('label')`
   text-transform: uppercase;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 export const QueryFieldsContainer = styled('div')`
@@ -183,7 +183,7 @@ export const AddText = styled('span')`
   margin-left: 4px;
   font-size: 13px;
   line-height: 16px;
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
 `;
 
 const spin = keyframes`
@@ -208,7 +208,7 @@ export const ButtonSpinner = styled('div')`
 `;
 
 export const ResultSummary = styled('div')`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
@@ -235,12 +235,12 @@ export const ChartWrapper = styled(Panel)`
 export const ChartNote = styled('div')`
   text-align: center;
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   margin-bottom: ${space(3)};
 `;
 
 export const SavedQueryAction = styled(Link)`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   margin-left: ${space(2)};
   display: flex;
 `;
@@ -269,7 +269,7 @@ export const SavedQueryLink = styled(Link)`
 
 export const SavedQueryUpdated = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
 `;
 
 export const QueryPanelContainer = styled('div')`

--- a/src/sentry/static/sentry/app/views/events/events.jsx
+++ b/src/sentry/static/sentry/app/views/events/events.jsx
@@ -247,7 +247,7 @@ const PaginationWrapper = styled('div')`
 `;
 
 const RowDisplay = styled('div')`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
 `;
 
 export default withOrganization(Events);

--- a/src/sentry/static/sentry/app/views/events/eventsTable.jsx
+++ b/src/sentry/static/sentry/app/views/events/eventsTable.jsx
@@ -209,6 +209,6 @@ const EventTitle = styled(TableData)`
 `;
 
 const StyledDateTime = styled(DateTime)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   ${overflowEllipsis};
 `;

--- a/src/sentry/static/sentry/app/views/events/index.jsx
+++ b/src/sentry/static/sentry/app/views/events/index.jsx
@@ -97,7 +97,7 @@ export default withApi(withOrganization(withGlobalSelection(EventsContainer)));
 export {EventsContainer};
 
 const Body = styled('div')`
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   flex-direction: column;
   flex: 1;
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -321,7 +321,7 @@ const StyledHeaderActions = styled(Layout.HeaderActions)`
 `;
 
 const EventSubheading = styled('span')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   margin-left: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
@@ -111,7 +111,7 @@ const StyledLink = styled(Link)`
 `;
 
 const IssueCardBody = styled('div')`
-  background: ${p => p.theme.gray200};
+  background: ${p => p.theme.gray100};
   padding-top: ${space(1)};
 `;
 
@@ -121,11 +121,11 @@ const StyledSeenByList = styled(SeenByList)`
 
 const StyledShortId = styled(ShortId)`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;
 
 const IssueCardFooter = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeSmall};
   padding: ${space(0.5)} ${space(1)};
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
@@ -111,7 +111,7 @@ const StyledLink = styled(Link)`
 `;
 
 const IssueCardBody = styled('div')`
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   padding-top: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -361,7 +361,7 @@ export const StyledPageHeader = styled('div')`
   display: flex;
   align-items: flex-end;
   font-size: ${p => p.theme.headerFontSize};
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   justify-content: space-between;
   margin-bottom: ${space(2)};
 `;

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -90,7 +90,7 @@ class MiniGraph extends React.Component<Props> {
           if (errored) {
             return (
               <StyledGraphContainer>
-                <IconWarning color="gray500" size="md" />
+                <IconWarning color="gray300" size="md" />
               </StyledGraphContainer>
             );
           }
@@ -130,7 +130,7 @@ class MiniGraph extends React.Component<Props> {
                   show: false,
                 },
                 axisLabel: {
-                  color: theme.gray400,
+                  color: theme.gray200,
                   fontFamily: theme.text.family,
                   fontSize: 12,
                   formatter: (value: number) => axisLabelFormatter(value, yAxis, true),

--- a/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/queryList.tsx
@@ -308,7 +308,7 @@ const ContextMenu = ({children}) => (
 
 const MoreOptions = styled('span')`
   display: flex;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;
 
 const DropdownTarget = styled('div')`

--- a/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
@@ -113,7 +113,7 @@ const QueryDetail = styled('div')`
 `;
 
 const QueryCardBody = styled('div')`
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   max-height: 100px;
   height: 100%;
   overflow: hidden;

--- a/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/querycard.tsx
@@ -107,13 +107,13 @@ const QueryTitle = styled('div')`
 const QueryDetail = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   line-height: 1.5;
   ${overflowEllipsis};
 `;
 
 const QueryCardBody = styled('div')`
-  background: ${p => p.theme.gray200};
+  background: ${p => p.theme.gray100};
   max-height: 100px;
   height: 100%;
   overflow: hidden;
@@ -131,7 +131,7 @@ const DateSelected = styled('div')`
   display: grid;
   grid-column-gap: ${space(1)};
   ${overflowEllipsis};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;
 
 const DateStatus = styled('span')`

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
@@ -130,7 +130,7 @@ const Subtitle = styled('h4')`
   font-size: ${p => p.theme.fontSizeLarge};
   font-weight: normal;
   line-height: 1.4;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   margin: 0;
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -469,7 +469,7 @@ const ActionItem = styled('button')`
   line-height: 1.2;
 
   &:hover {
-    background: ${p => p.theme.gray100};
+    background: ${p => p.theme.backgroundSecondary};
   }
 
   &:last-child {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -462,7 +462,7 @@ const ActionItem = styled('button')`
 
   outline: none;
   border: 0;
-  border-bottom: 1px solid ${p => p.theme.border};
+  border-bottom: 1px solid ${p => p.theme.innerBorder};
 
   font-size: ${p => p.theme.fontSizeMedium};
   text-align: left;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -292,7 +292,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
             <Button
               aria-label={t('Drag to reorder')}
               onMouseDown={event => this.startDrag(event, i)}
-              icon={<IconGrabbable size="xs" color="gray700" />}
+              icon={<IconGrabbable size="xs" color="gray500" />}
               size="zero"
               borderless
             />
@@ -310,7 +310,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
             <Button
               aria-label={t('Remove column')}
               onClick={() => this.removeColumn(i)}
-              icon={<IconDelete color="gray500" />}
+              icon={<IconDelete color="gray300" />}
               borderless
             />
           ) : (

--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -510,7 +510,7 @@ const BlankSpace = styled('div')`
   /* Match the height of the select boxes */
   height: 37px;
   min-width: 50px;
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};
   display: flex;
   align-items: center;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -510,7 +510,7 @@ const BlankSpace = styled('div')`
   /* Match the height of the select boxes */
   height: 37px;
   min-width: 50px;
-  background: ${p => p.theme.gray200};
+  background: ${p => p.theme.gray100};
   border-radius: ${p => p.theme.borderRadius};
   display: flex;
   align-items: center;
@@ -518,7 +518,7 @@ const BlankSpace = styled('div')`
 
   &:after {
     content: '${t('No parameter')}';
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -426,7 +426,7 @@ class TableView extends React.Component<TableViewProps> {
 }
 
 const PrependHeader = styled('span')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 const StyledLink = styled(Link)`

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -160,7 +160,7 @@ class Tags extends React.Component<Props, State> {
     } else {
       return (
         <StyledError>
-          <StyledIconWarning color="gray500" size="lg" />
+          <StyledIconWarning color="gray300" size="lg" />
           {t('No tags found')}
         </StyledError>
       );
@@ -178,7 +178,7 @@ class Tags extends React.Component<Props, State> {
 }
 
 const StyledError = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   display: flex;
   align-items: center;
 `;

--- a/src/sentry/static/sentry/app/views/issueList/actions.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.tsx
@@ -656,7 +656,7 @@ const StyledFlex = styled('div')`
   padding-top: ${space(1)};
   padding-bottom: ${space(1)};
   align-items: center;
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   border-bottom: 1px solid ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
   margin-bottom: -1px;

--- a/src/sentry/static/sentry/app/views/issueList/actions.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.tsx
@@ -711,7 +711,7 @@ const GraphToggle = styled('a')<{active: boolean}>`
   &:hover,
   &:focus,
   &:active {
-    color: ${p => (p.active ? p.theme.gray700 : p.theme.disabled)};
+    color: ${p => (p.active ? p.theme.gray500 : p.theme.disabled)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -68,5 +68,5 @@ const StyledHeaderContent = styled(Layout.HeaderContent)`
 `;
 
 const StyledQueryCount = styled(QueryCount)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;

--- a/src/sentry/static/sentry/app/views/issueList/noGroupsHandler/noUnresolvedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/noGroupsHandler/noUnresolvedIssues.tsx
@@ -72,7 +72,7 @@ const Wrapper = styled('div')`
   flex-direction: column;
   align-items: center;
   text-align: center;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     font-size: ${p => p.theme.fontSizeMedium};

--- a/src/sentry/static/sentry/app/views/issueList/savedSearchSelector.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchSelector.tsx
@@ -141,7 +141,7 @@ const ButtonTitle = styled('span')`
 `;
 
 const SearchTitle = styled('strong')`
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   padding: 0;
   background: inherit;
 
@@ -151,19 +151,19 @@ const SearchTitle = styled('strong')`
 `;
 
 const SearchQuery = styled('code')`
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   padding: 0;
   background: inherit;
 `;
 
 const TooltipSearchQuery = styled('span')`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   font-weight: normal;
   font-family: ${p => p.theme.text.familyMono};
 `;
 
 const DeleteButton = styled(Button)`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   background: transparent;
   flex-shrink: 0;
   padding: ${space(1.5)} ${space(1.5)} ${space(1)} 0;

--- a/src/sentry/static/sentry/app/views/issueList/savedSearchSelector.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchSelector.tsx
@@ -183,7 +183,7 @@ const MenuItem = styled('li')<{last: boolean}>`
   padding: 0;
 
   & :hover {
-    background: ${p => p.theme.gray100};
+    background: ${p => p.theme.backgroundSecondary};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/issueList/sidebar.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/sidebar.tsx
@@ -168,15 +168,15 @@ const StyledIconClose = styled(IconClose)`
   position: absolute;
   top: 13px;
   right: 10px;
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
 
   &:hover {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 `;
 
 const StyledHeader = styled('h6')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   margin-bottom: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/issueList/tagFilter.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/tagFilter.tsx
@@ -200,6 +200,6 @@ const StreamTagFilter = styled('div')`
 `;
 
 const StyledHeader = styled('h6')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   margin-bottom: ${space(1)};
 `;

--- a/src/sentry/static/sentry/app/views/monitors/index.jsx
+++ b/src/sentry/static/sentry/app/views/monitors/index.jsx
@@ -7,7 +7,7 @@ import {PageContent} from 'app/styles/organization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 const Body = styled('div')`
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   flex-direction: column;
   flex: 1;
 `;

--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.tsx
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.tsx
@@ -222,7 +222,7 @@ class Onboarding extends React.Component<Props, State> {
 
 const OnboardingWrapper = styled('main')`
   flex-grow: 1;
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   padding-bottom: 50vh;
 `;
 

--- a/src/sentry/static/sentry/app/views/onboarding/onboarding.tsx
+++ b/src/sentry/static/sentry/app/views/onboarding/onboarding.tsx
@@ -251,7 +251,7 @@ const Header = styled('header')`
 const LogoSvg = styled(InlineSvg)`
   width: 130px;
   height: 30px;
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
 `;
 
 const ProgressBar = styled('div')`
@@ -283,7 +283,7 @@ const ProgressStep = styled('div')<{active: boolean}>`
 `;
 
 const ProgressStatus = styled(motion.div)`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeMedium};
   text-align: right;
   grid-column: 3;
@@ -314,7 +314,7 @@ const OnboardingStep = styled(motion.div)<{active: boolean}>`
     height: 30px;
     top: -5px;
     left: -30px;
-    background-color: ${p => (p.active ? p.theme.active : p.theme.gray500)};
+    background-color: ${p => (p.active ? p.theme.active : p.theme.gray300)};
     border-radius: 50%;
     color: #fff;
     font-size: 1.5rem;

--- a/src/sentry/static/sentry/app/views/onboarding/welcome.tsx
+++ b/src/sentry/static/sentry/app/views/onboarding/welcome.tsx
@@ -71,7 +71,7 @@ const ActionGroup = styled('div')`
 `;
 
 const SecondaryAction = styled('small')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 export default withOrganization(withConfig(OnboardingWelcome));

--- a/src/sentry/static/sentry/app/views/organizationActivity/activityFeedItem.tsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity/activityFeedItem.tsx
@@ -378,7 +378,7 @@ const Project = styled('span')`
 `;
 
 const Bubble = styled('div')<{clipped: boolean}>`
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   margin: ${space(0.5)} 0;
   padding: ${space(1)} ${space(2)};
   border: 1px solid ${p => p.theme.border};

--- a/src/sentry/static/sentry/app/views/organizationActivity/activityFeedItem.tsx
+++ b/src/sentry/static/sentry/app/views/organizationActivity/activityFeedItem.tsx
@@ -370,7 +370,7 @@ const ActivityAuthor = styled('span')`
 `;
 
 const Meta = styled('div')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   font-size: ${p => p.theme.fontSizeRelativeSmall};
 `;
 const Project = styled('span')`
@@ -421,6 +421,6 @@ const Bubble = styled('div')<{clipped: boolean}>`
 `;
 
 const StyledTimeSince = styled(TimeSince)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   padding-left: ${space(1)};
 `;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarTraceID/header.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarTraceID/header.tsx
@@ -35,10 +35,10 @@ const Wrapper = styled('div')`
   grid-gap: ${space(1)};
   align-items: center;
   font-size: ${p => p.theme.headerFontSize};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   h4 {
     font-size: ${p => p.theme.headerFontSize};
-    color: ${p => p.theme.gray700};
+    color: ${p => p.theme.gray500};
     font-weight: normal;
     margin-bottom: 0;
   }

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupTagValues.tsx
@@ -108,12 +108,12 @@ class GroupTagValues extends AsyncComponent<
               </GlobalSelectionLink>
               {tagValue.email && (
                 <StyledExternalLink href={`mailto:${tagValue.email}`}>
-                  <IconMail size="xs" color="gray500" />
+                  <IconMail size="xs" color="gray300" />
                 </StyledExternalLink>
               )}
               {isUrl(tagValue.value) && (
                 <StyledExternalLink href={tagValue.value}>
-                  <IconOpen size="xs" color="gray500" />
+                  <IconOpen size="xs" color="gray300" />
                 </StyledExternalLink>
               )}
             </ValueWrapper>

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
@@ -35,7 +35,7 @@ const UnhandledTag = styled((props: React.ComponentProps<typeof Tag>) => (
 ))`
   /* TODO(matej): There is going to be a major Tag component refactor which should make Tags look something like this - then we can remove these one-off styles */
   background-color: #ffecf0;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   text-transform: none;
   padding: 0 ${space(0.75)};
   height: 17px;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -485,7 +485,7 @@ const DisableWrapper = styled('div')`
 const CreatedContainer = styled('div')`
   text-transform: uppercase;
   padding-bottom: ${space(1)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-weight: 600;
   font-size: 12px;
 `;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/constants.tsx
@@ -7,9 +7,9 @@ export const LEARN_MORE = 'Learn More' as const;
 
 export const COLORS = {
   [INSTALLED]: 'success',
-  [NOT_INSTALLED]: 'gray500',
+  [NOT_INSTALLED]: 'gray300',
   [PENDING]: 'orange300',
-  [LEARN_MORE]: 'gray500',
+  [LEARN_MORE]: 'gray300',
 } as const;
 
 /**

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
@@ -230,7 +230,7 @@ export default class InstalledIntegration extends React.Component<Props> {
 }
 
 const StyledButton = styled(Button)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const IntegrationFlex = styled('div')`
@@ -245,7 +245,7 @@ const IntegrationItemBox = styled('div')`
 const IntegrationStatus = styled(
   (props: React.HTMLAttributes<HTMLElement> & {status: ObjectStatus}) => {
     const {status, ...p} = props;
-    const color = status === 'active' ? theme.success : theme.gray500;
+    const color = status === 'active' ? theme.success : theme.gray300;
     const titleText =
       status === 'active'
         ? t('This Integration can be disabled by clicking the Uninstall button')
@@ -264,12 +264,12 @@ const IntegrationStatus = styled(
 )`
   display: flex;
   align-items: center;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-weight: light;
   text-transform: capitalize;
   &:before {
     content: '|';
-    color: ${p => p.theme.gray400};
+    color: ${p => p.theme.gray200};
     margin-right: ${space(1)};
     font-weight: normal;
   }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedPlugin.tsx
@@ -195,7 +195,7 @@ const Container = styled('div')`
 `;
 
 const StyledButton = styled(Button)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const IntegrationFlex = styled('div')`

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.tsx
@@ -63,7 +63,7 @@ const IntegrationName = styled('div')`
 // as it sets width 100% which causes layout issues in the
 // integration list.
 const DomainName = styled('div')<StyledProps>`
-  color: ${p => (p.compact ? p.theme.gray400 : p.theme.gray600)};
+  color: ${p => (p.compact ? p.theme.gray200 : p.theme.gray400)};
   margin-left: ${p => (p.compact ? space(1) : 'inherit')};
   margin-top: ${p => (!p.compact ? space(0.25) : 'inherit')};
   font-size: 1.4rem;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -561,7 +561,7 @@ const EmptyResultsContainer = styled('div')`
 const EmptyResultsBody = styled('div')`
   font-size: 16px;
   line-height: 28px;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   padding-bottom: ${space(2)};
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -152,17 +152,17 @@ const IntegrationDetails = styled('div')`
 `;
 
 const StyledLink = styled(Link)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   &:before {
     content: '|';
-    color: ${p => p.theme.gray400};
+    color: ${p => p.theme.gray200};
     margin-right: ${space(0.75)};
     font-weight: normal;
   }
 `;
 
 const LearnMore = styled(Link)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 type PublishStatusProps = {status: SentryApp['status']; theme?: any};
@@ -171,13 +171,13 @@ const PublishStatus = styled(({status, ...props}: PublishStatusProps) => (
   <div {...props}>{t(`${status}`)}</div>
 ))`
   color: ${(props: PublishStatusProps) =>
-    props.status === 'published' ? props.theme.success : props.theme.gray500};
+    props.status === 'published' ? props.theme.success : props.theme.gray300};
   font-weight: light;
   margin-right: ${space(0.75)};
   text-transform: capitalize;
   &:before {
     content: '|';
-    color: ${p => p.theme.gray400};
+    color: ${p => p.theme.gray200};
     margin-right: ${space(0.75)};
     font-weight: normal;
   }
@@ -197,17 +197,17 @@ const CategoryTag = styled(
   display: flex;
   flex-direction: row;
   padding: 1px 10px;
-  background: ${p => (p.priority ? p.theme.purple200 : p.theme.gray300)};
+  background: ${p => (p.priority ? p.theme.purple200 : p.theme.gray200)};
   border-radius: 20px;
   font-size: ${space(1.5)};
   margin-right: ${space(1)};
   line-height: ${space(3)};
   text-align: center;
-  color: ${p => (p.priority ? p.theme.white : p.theme.gray700)};
+  color: ${p => (p.priority ? p.theme.white : p.theme.gray500)};
 `;
 
 const ResolveNowButton = styled(Button)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   background: #ffffff;
   float: right;
 `;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -197,7 +197,7 @@ const CategoryTag = styled(
   display: flex;
   flex-direction: row;
   padding: 1px 10px;
-  background: ${p => (p.priority ? p.theme.purple200 : p.theme.gray200)};
+  background: ${p => (p.priority ? p.theme.purple200 : p.theme.gray100)};
   border-radius: 20px;
   font-size: ${space(1.5)};
   margin-right: ${space(1)};
@@ -207,8 +207,7 @@ const CategoryTag = styled(
 `;
 
 const ResolveNowButton = styled(Button)`
-  color: ${p => p.theme.gray300};
-  background: #ffffff;
+  color: ${p => p.theme.gray400};
   float: right;
 `;
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/sentryAppDetailedView.tsx
@@ -316,10 +316,10 @@ const InstallButton = styled(Button)`
 `;
 
 const StyledUninstallButton = styled(Button)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   background: #ffffff;
 
-  border: ${p => `1px solid ${p.theme.gray500}`};
+  border: ${p => `1px solid ${p.theme.gray300}`};
   box-sizing: border-box;
   box-shadow: 0px 2px 1px rgba(0, 0, 0, 0.08);
   border-radius: 4px;

--- a/src/sentry/static/sentry/app/views/organizationStats/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/index.tsx
@@ -225,7 +225,7 @@ class OrganizationStatsContainer extends React.Component<Props, State> {
 
     const orgAccepted: Series = {
       seriesName: t('Accepted'),
-      color: theme.gray400,
+      color: theme.gray200,
       data: [],
     };
     const orgRejected: Series = {

--- a/src/sentry/static/sentry/app/views/organizationStats/projectTable.tsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/projectTable.tsx
@@ -93,7 +93,7 @@ const Percentage = styled(({children, ...props}: PercentageProps) => {
   return <div {...props}>{children}</div>;
 })`
   margin-top: ${space(0.25)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: 12px;
   line-height: 1.2;
 `;

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -100,7 +100,7 @@ class Chart extends React.Component<Props> {
           scale: true,
           max: dataMax,
           axisLabel: {
-            color: theme.gray400,
+            color: theme.gray200,
             formatter(value: number) {
               return axisLabelFormatter(value, data[0].seriesName);
             },
@@ -111,7 +111,7 @@ class Chart extends React.Component<Props> {
           scale: true,
           max: dataMax,
           axisLabel: {
-            color: theme.gray400,
+            color: theme.gray200,
             formatter(value: number) {
               return axisLabelFormatter(value, data[1].seriesName);
             },

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -84,7 +84,7 @@ class Container extends React.Component<Props> {
             if (errored) {
               return (
                 <ErrorPanel>
-                  <IconWarning color="gray500" size="lg" />
+                  <IconWarning color="gray300" size="lg" />
                 </ErrorPanel>
               );
             }

--- a/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanBar.tsx
@@ -296,7 +296,7 @@ class SpanBar extends React.Component<Props, State> {
           return {
             background: {
               // baseline
-              color: theme.gray700,
+              color: theme.gray500,
               width: normalizePadding(generateCSSWidth(bounds.background)),
             },
             foreground: {
@@ -336,7 +336,7 @@ class SpanBar extends React.Component<Props, State> {
       case 'baseline': {
         return {
           background: {
-            color: theme.gray700,
+            color: theme.gray500,
             width: normalizePadding(generateCSSWidth(bounds.background)),
           },
           foreground: undefined,
@@ -518,7 +518,7 @@ const ComparisonSpanBarRectangle = styled(SpanBarRectangle)<{spanBarHatch: boole
   position: absolute;
   left: 0;
   height: 16px;
-  ${p => getHatchPattern(p, theme.purple200, theme.gray700)}
+  ${p => getHatchPattern(p, theme.purple200, theme.gray500)}
 `;
 
 const ComparisonLabel = styled('div')`

--- a/src/sentry/static/sentry/app/views/performance/compare/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/spanDetail.tsx
@@ -288,7 +288,7 @@ const SpanBars = (props: {
         <SpanBarContainer>
           <SpanBarRectangle
             style={{
-              backgroundColor: theme.gray700,
+              backgroundColor: theme.gray500,
               width: generateCSSWidth(bounds.baseline),
               position: 'absolute',
               height: '16px',
@@ -296,7 +296,7 @@ const SpanBars = (props: {
           >
             <DurationPill
               durationDisplay={baselineDurationDisplay}
-              fontColors={{right: theme.gray700, inset: theme.white}}
+              fontColors={{right: theme.gray500, inset: theme.white}}
             >
               {getHumanDuration(getSpanDuration(baselineSpan))}
             </DurationPill>
@@ -315,7 +315,7 @@ const SpanBars = (props: {
           >
             <DurationPill
               durationDisplay={regressionDurationDisplay}
-              fontColors={{right: theme.gray700, inset: theme.gray700}}
+              fontColors={{right: theme.gray500, inset: theme.gray500}}
             >
               {getHumanDuration(getSpanDuration(regressionSpan))}
             </DurationPill>

--- a/src/sentry/static/sentry/app/views/performance/compare/traceView.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/traceView.tsx
@@ -20,7 +20,7 @@ const TraceView = (props: Props) => {
   if (!isTransactionEvent(baselineEvent) || !isTransactionEvent(regressionEvent)) {
     return (
       <EmptyMessage>
-        <IconWarning color="gray500" size="lg" />
+        <IconWarning color="gray300" size="lg" />
         <p>{t('One of the given events is not a transaction.')}</p>
       </EmptyMessage>
     );
@@ -32,7 +32,7 @@ const TraceView = (props: Props) => {
   if (!baselineTraceContext || !regressionTraceContext) {
     return (
       <EmptyMessage>
-        <IconWarning color="gray500" size="lg" />
+        <IconWarning color="gray300" size="lg" />
         <p>{t('There is no trace found in either of the given transactions.')}</p>
       </EmptyMessage>
     );

--- a/src/sentry/static/sentry/app/views/performance/compare/transactionSummary.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/transactionSummary.tsx
@@ -113,7 +113,7 @@ const EventRow = styled('div')`
 `;
 
 const Baseline = styled('div')`
-  background-color: ${p => p.theme.gray700};
+  background-color: ${p => p.theme.gray500};
   height: 100%;
   width: 4px;
 
@@ -155,11 +155,11 @@ const ContentTitle = styled('div')`
 `;
 
 const EventId = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const StyledLink = styled(Link)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 function shortEventId(value: string): string {

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -393,7 +393,7 @@ export const StyledPageHeader = styled('div')`
   align-items: center;
   justify-content: space-between;
   font-size: ${p => p.theme.headerFontSize};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   height: 40px;
   margin-bottom: ${space(1)};
 `;

--- a/src/sentry/static/sentry/app/views/performance/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/styles.tsx
@@ -27,7 +27,7 @@ export const HeaderTitle = styled('h3')`
   grid-gap: ${space(1)};
   font-size: ${p => p.theme.fontSizeLarge};
   font-weight: normal;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   padding-left: ${space(1)};
   line-height: 1.1;
   margin-bottom: 0;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -132,7 +132,7 @@ class DurationChart extends React.Component<Props> {
       },
       yAxis: {
         axisLabel: {
-          color: theme.gray400,
+          color: theme.gray200,
           // p50() coerces the axis to be time based
           formatter: (value: number) => axisLabelFormatter(value, 'p50()'),
         },
@@ -176,7 +176,7 @@ class DurationChart extends React.Component<Props> {
                 if (errored) {
                   return (
                     <ErrorPanel>
-                      <IconWarning color="gray500" size="lg" />
+                      <IconWarning color="gray300" size="lg" />
                     </ErrorPanel>
                   );
                 }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
@@ -116,7 +116,7 @@ class DurationPercentileChart extends AsyncComponent<Props, State> {
     // Don't call super as we don't really need issues for this.
     return (
       <ErrorPanel>
-        <IconWarning color="gray500" size="lg" />
+        <IconWarning color="gray300" size="lg" />
       </ErrorPanel>
     );
   }
@@ -141,7 +141,7 @@ class DurationPercentileChart extends AsyncComponent<Props, State> {
     const yAxis = {
       type: 'value' as const,
       axisLabel: {
-        color: theme.gray400,
+        color: theme.gray200,
         // Use p50() to force time formatting.
         formatter: (value: number) => axisLabelFormatter(value, 'p50()'),
       },

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
@@ -131,7 +131,7 @@ class KeyTransactionButton extends React.Component<Props, State> {
         icon={
           <IconStar
             size="xs"
-            color={isKeyTransaction ? 'yellow300' : 'gray400'}
+            color={isKeyTransaction ? 'yellow300' : 'gray200'}
             isSolid={!!isKeyTransaction}
           />
         }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
@@ -144,7 +144,7 @@ class LatencyChart extends AsyncComponent<Props, State> {
     // Don't call super as we don't really need issues for this.
     return (
       <ErrorPanel>
-        <IconWarning color="gray500" size="lg" />
+        <IconWarning color="gray300" size="lg" />
       </ErrorPanel>
     );
   }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
@@ -93,7 +93,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
         gridIndex: 0,
         axisLabel: {
           formatter: (value: number) => formatFloat(value, 1),
-          color: theme.gray400,
+          color: theme.gray200,
         },
         ...axisLineConfig,
       },
@@ -102,7 +102,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
         gridIndex: 1,
         axisLabel: {
           formatter: formatAbbreviatedNumber,
-          color: theme.gray400,
+          color: theme.gray200,
         },
         ...axisLineConfig,
       },
@@ -111,7 +111,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
         gridIndex: 2,
         axisLabel: {
           formatter: (value: number) => formatPercentage(value, 0),
-          color: theme.gray400,
+          color: theme.gray200,
         },
         ...axisLineConfig,
       },
@@ -193,7 +193,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
               if (errored) {
                 return (
                   <ErrorPanel>
-                    <IconWarning color="gray500" size="lg" />
+                    <IconWarning color="gray300" size="lg" />
                   </ErrorPanel>
                 );
               }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/statusBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/statusBreakdown.tsx
@@ -52,7 +52,7 @@ function StatusBreakdown({eventView, location, organization}: Props) {
           if (error) {
             return (
               <ErrorPanel height="125px">
-                <IconWarning color="gray500" size="lg" />
+                <IconWarning color="gray300" size="lg" />
               </ErrorPanel>
             );
           }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
@@ -139,7 +139,7 @@ class TrendChart extends React.Component<Props> {
       yAxis: {
         min: 0,
         axisLabel: {
-          color: theme.gray400,
+          color: theme.gray200,
           // p50() coerces the axis to be time based
           formatter: (value: number) => axisLabelFormatter(value, 'p50()'),
         },
@@ -181,7 +181,7 @@ class TrendChart extends React.Component<Props> {
                 if (errored) {
                   return (
                     <ErrorPanel>
-                      <IconWarning color="gray500" size="lg" />
+                      <IconWarning color="gray300" size="lg" />
                     </ErrorPanel>
                   );
                 }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -122,7 +122,7 @@ const UserMiseryContainer = styled('div')`
 
 const StatNumber = styled('div')`
   font-size: 32px;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 
   > div {
     text-align: left;

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/styles.tsx
@@ -29,7 +29,7 @@ export const CardSectionHeading = styled(SectionHeading)`
 
 export const Description = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 export const StatNumber = styled('div')`

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -235,7 +235,7 @@ class VitalCard extends React.Component<Props, State> {
       type: 'value' as const,
       max,
       axisLabel: {
-        color: theme.gray400,
+        color: theme.gray200,
         formatter: formatAbbreviatedNumber,
       },
     };
@@ -374,7 +374,7 @@ class VitalCard extends React.Component<Props, State> {
         show: false,
       },
       lineStyle: {
-        color: theme.gray700,
+        color: theme.gray500,
         type: 'solid',
       },
     });

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -598,7 +598,7 @@ const ItemTransactionDurationChange = styled('div')`
 `;
 
 const DurationChange = styled('span')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   margin: 0 ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -110,13 +110,13 @@ function getIntervalLine(
 
   const periodLine = {
     data: [] as any[],
-    color: theme.gray700,
+    color: theme.gray500,
     markLine: {
       data: [] as any[],
       label: {} as any,
       lineStyle: {
         normal: {
-          color: theme.gray700,
+          color: theme.gray500,
           type: 'dashed',
           width: 1,
         },
@@ -175,7 +175,7 @@ function getIntervalLine(
     label: {show: false},
     lineStyle: {
       normal: {
-        color: theme.gray700,
+        color: theme.gray500,
         type: 'solid',
         width: 2,
       },
@@ -299,7 +299,7 @@ class Chart extends React.Component<Props> {
         min: Math.max(0, yMin - yMargin),
         max: yMax + yMargin,
         axisLabel: {
-          color: theme.gray400,
+          color: theme.gray200,
           // p50() coerces the axis to be time based
           formatter: (value: number) => axisLabelFormatter(value, 'p50()'),
         },

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.tsx
@@ -357,6 +357,6 @@ const TeamSelectInput = styled('div')`
 `;
 
 const HelpText = styled('p')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   max-width: 700px;
 `;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/chart.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/chart.tsx
@@ -137,7 +137,7 @@ const Chart = ({firstEvent, stats, transactionStats}: Props) => {
         inside: true,
         lineHeight: 12,
         formatter: (value: number) => axisLabelFormatter(value, 'count()', true),
-        textBorderColor: theme.gray100,
+        textBorderColor: theme.backgroundSecondary,
         textBorderWidth: 1,
       },
       zlevel: theme.zIndex.header,

--- a/src/sentry/static/sentry/app/views/projectsDashboard/chart.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/chart.tsx
@@ -35,10 +35,10 @@ const Chart = ({firstEvent, stats, transactionStats}: Props) => {
       xAxisIndex: 1,
       yAxisIndex: 1,
       itemStyle: {
-        color: theme.gray400,
+        color: theme.gray200,
         opacity: 0.8,
         emphasis: {
-          color: theme.gray400,
+          color: theme.gray200,
           opacity: 1.0,
         },
       },
@@ -132,7 +132,7 @@ const Chart = ({firstEvent, stats, transactionStats}: Props) => {
         margin: 2,
         showMaxLabel: true,
         showMinLabel: false,
-        color: theme.gray400,
+        color: theme.gray200,
         fontFamily: theme.text.family,
         inside: true,
         lineHeight: 12,

--- a/src/sentry/static/sentry/app/views/projectsDashboard/deploys.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/deploys.tsx
@@ -114,7 +114,7 @@ const Environment = styled('div')`
 `;
 
 const DeployTime = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   overflow: hidden;
   text-align: right;
   text-overflow: ellipsis;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/noEvents.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/noEvents.tsx
@@ -30,5 +30,5 @@ const EmptyText = styled('div')<Props>`
   margin-left: 4px;
   margin-right: 4px;
   height: ${p => (p.seriesCount > 1 ? '90px' : '150px')};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
@@ -239,7 +239,7 @@ const SummaryLinks = styled('div')`
   a {
     color: ${p => p.theme.formText};
     :hover {
-      color: ${p => p.theme.gray600};
+      color: ${p => p.theme.gray400};
     }
   }
   em {

--- a/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
@@ -195,7 +195,7 @@ const ProjectCardContainer = createReactClass<ContainerProps, ContainerState>({
 
 const ChartContainer = styled('div')`
   position: relative;
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
 `;
 
 const CardHeader = styled('div')`
@@ -217,7 +217,7 @@ const StyledProjectCard = styled('div')`
 
 const LoadingCard = styled('div')`
   border: 1px solid transparent;
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   height: 334px;
 `;
 

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -107,7 +107,7 @@ class HealthChart extends React.Component<Props> {
           scale: true,
           axisLabel: {
             formatter: '{value}%',
-            color: theme.gray400,
+            color: theme.gray200,
           },
         };
       case YAxis.SESSION_DURATION:
@@ -115,7 +115,7 @@ class HealthChart extends React.Component<Props> {
           scale: true,
           axisLabel: {
             formatter: value => axisDuration(value * 1000),
-            color: theme.gray400,
+            color: theme.gray200,
           },
         };
       case YAxis.SESSIONS:

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChartContainer.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChartContainer.tsx
@@ -47,7 +47,7 @@ class ReleaseChartContainer extends React.Component<Props, State> {
             if (errored) {
               return (
                 <ErrorPanel>
-                  <IconWarning color="gray500" size="lg" />
+                  <IconWarning color="gray300" size="lg" />
                 </ErrorPanel>
               );
             }

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/commitAuthorBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/commitAuthorBreakdown.tsx
@@ -158,7 +158,7 @@ const StyledUserAvatar = styled(UserAvatar)`
 
 const AuthorName = styled('div')`
   font-weight: 600;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   padding-right: ${space(0.5)};
   ${overflowEllipsis};
 `;
@@ -171,13 +171,13 @@ const Stats = styled('div')`
 `;
 
 const Commits = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const Percent = styled('div')`
   min-width: 40px;
   text-align: right;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 const StyledButton = styled(Button)`

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/deploys.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/deploys.tsx
@@ -45,7 +45,7 @@ const Row = styled('div')`
   justify-content: space-between;
   margin-bottom: ${space(1)};
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 const StyledDeployBadge = styled(DeployBadge)`

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/projectReleaseDetails.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/projectReleaseDetails.tsx
@@ -78,7 +78,7 @@ const StyledTable = styled('table')`
 
 const StyledTr = styled('tr')`
   &:nth-child(2n + 1) td {
-    background-color: ${p => p.theme.gray100};
+    background-color: ${p => p.theme.backgroundSecondary};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/projectReleaseDetails.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/projectReleaseDetails.tsx
@@ -83,7 +83,7 @@ const StyledTr = styled('tr')`
 `;
 
 const TagKey = styled('td')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   padding: ${space(0.5)} ${space(1)};
   font-size: ${p => p.theme.fontSizeMedium};
   white-space: nowrap;
@@ -93,7 +93,7 @@ const TagKey = styled('td')`
 
 const TagValue = styled(TagKey)`
   text-align: right;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     width: 160px;
   }

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/totalCrashFreeUsers.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/totalCrashFreeUsers.tsx
@@ -72,7 +72,7 @@ const TotalCrashFreeUsers = ({crashFreeTimeBreakdown}: Props) => {
 
 const Timeline = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   line-height: 1;
 `;
 
@@ -111,7 +111,7 @@ const InnerRow = styled('div')`
 const Text = styled('div')<{bold?: boolean; right?: boolean}>`
   font-weight: ${p => (p.bold ? 600 : 400)};
   text-align: ${p => (p.right ? 'right' : 'left')};
-  color: ${p => (p.bold ? p.theme.gray600 : p.theme.gray500)};
+  color: ${p => (p.bold ? p.theme.gray400 : p.theme.gray300)};
   padding-bottom: ${space(0.25)};
   ${overflowEllipsis};
 `;

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
@@ -193,7 +193,7 @@ const StyledDeployBadge = styled(DeployBadge)`
 
 const ReleaseName = styled('div')`
   font-size: ${p => p.theme.headerFontSize};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   display: flex;
   align-items: center;
 `;
@@ -204,11 +204,11 @@ const IconWrapper = styled('span')`
 
   &,
   a {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
     display: flex;
     &:hover {
       cursor: pointer;
-      color: ${p => p.theme.gray700};
+      color: ${p => p.theme.gray500};
     }
   }
 `;

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseStat.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseStat.tsx
@@ -30,7 +30,7 @@ const Label = styled('div')<{hasHelp: boolean}>`
   font-weight: 600;
   font-size: ${p => p.theme.fontSizeSmall};
   text-transform: uppercase;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   line-height: 1.3;
   margin-bottom: ${space(0.25)};
   white-space: nowrap;
@@ -46,7 +46,7 @@ const StyledQuestionTooltip = styled(QuestionTooltip)`
 
 const Value = styled('div')`
   font-size: ${p => p.theme.fontSizeExtraLarge};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;
 
 export default ReleaseStat;

--- a/src/sentry/static/sentry/app/views/releases/detail/repositorySwitcher.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/repositorySwitcher.tsx
@@ -96,7 +96,7 @@ const StyledDropdownControl = styled(DropdownControl)<{
 
 const FilterText = styled('em')`
   font-style: normal;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   margin-right: ${space(0.5)};
 `;
 

--- a/src/sentry/static/sentry/app/views/releases/list/adoptionTooltip.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/adoptionTooltip.tsx
@@ -64,11 +64,11 @@ const Title = styled('div')`
   text-align: left;
 `;
 const Value = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   text-align: right;
 `;
 const Divider = styled('div')`
-  border-top: 1px solid ${p => p.theme.gray800};
+  border-top: 1px solid ${p => p.theme.gray500};
   margin: ${space(0.75)} -${space(2)} ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/releases/list/healthStatsChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/healthStatsChart.tsx
@@ -51,7 +51,7 @@ class HealthStatsChart extends React.Component<Props> {
       return null;
     }
 
-    const colors = [theme.gray500];
+    const colors = [theme.gray300];
     const emphasisColors = [theme.purple300];
     const series: Series[] = [
       {

--- a/src/sentry/static/sentry/app/views/releases/list/healthStatsPeriod.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/healthStatsPeriod.tsx
@@ -55,11 +55,11 @@ const Wrapper = styled('div')`
 `;
 
 const Period = styled(Link)<{selected: boolean}>`
-  color: ${p => (p.selected ? p.theme.gray600 : p.theme.gray500)};
+  color: ${p => (p.selected ? p.theme.gray400 : p.theme.gray300)};
 
   &:hover,
   &:focus {
-    color: ${p => (p.selected ? p.theme.gray600 : p.theme.gray500)};
+    color: ${p => (p.selected ? p.theme.gray400 : p.theme.gray300)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/releases/list/healthStatsSubject.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/healthStatsSubject.tsx
@@ -53,11 +53,11 @@ const Wrapper = styled('div')`
 `;
 
 const Title = styled(Link)<{selected: boolean}>`
-  color: ${p => (p.selected ? p.theme.gray600 : p.theme.gray500)};
+  color: ${p => (p.selected ? p.theme.gray400 : p.theme.gray300)};
 
   &:hover,
   &:focus {
-    color: ${p => (p.selected ? p.theme.gray600 : p.theme.gray500)};
+    color: ${p => (p.selected ? p.theme.gray400 : p.theme.gray300)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/releases/list/introBanner.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/introBanner.tsx
@@ -55,7 +55,7 @@ class IntroBanner extends React.Component<{}, State> {
 }
 
 const StyledBanner = styled(Banner)`
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   min-height: 200px;
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {

--- a/src/sentry/static/sentry/app/views/releases/list/notAvailable.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/notAvailable.tsx
@@ -6,7 +6,7 @@ const NotAvailable = () => {
 };
 
 const Wrapper = styled('div')`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
 `;
 
 export default NotAvailable;

--- a/src/sentry/static/sentry/app/views/releases/list/releaseCard.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseCard.tsx
@@ -197,7 +197,7 @@ const NewIssuesColumn = styled(RightAlignedColumn)`
 
 const ColumnTitle = styled('div')`
   text-transform: uppercase;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 600;
   margin-bottom: ${space(0.75)};

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/content.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/content.tsx
@@ -291,8 +291,8 @@ const StyledScoreBar = styled(ScoreBar)`
 const ChartWrapper = styled('div')`
   flex: 1;
   g > .barchart-rect {
-    background: ${p => p.theme.gray400};
-    fill: ${p => p.theme.gray400};
+    background: ${p => p.theme.gray200};
+    fill: ${p => p.theme.gray200};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/header.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/header.tsx
@@ -6,7 +6,7 @@ const Header = styled(PanelHeader)`
   border-top: 1px solid ${p => p.theme.border};
   border-top-left-radius: 0;
   border-top-right-radius: 0;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/account/accountAuthorizations.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountAuthorizations.tsx
@@ -146,6 +146,6 @@ const Url = styled('div')`
 `;
 
 const Scopes = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeRelativeSmall};
 `;

--- a/src/sentry/static/sentry/app/views/settings/account/accountSubscriptions.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSubscriptions.jsx
@@ -141,11 +141,11 @@ const SubscriptionName = styled('div')`
 const Description = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
   margin-top: ${space(0.75)};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 const SubscribedDescription = styled(Description)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 export default AccountSubscriptions;

--- a/src/sentry/static/sentry/app/views/settings/account/apiApplications/row.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiApplications/row.tsx
@@ -105,7 +105,7 @@ const ApplicationName = styled(Link)`
 `;
 
 const ClientId = styled('div')`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/account/apiTokenRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/apiTokenRow.tsx
@@ -94,7 +94,7 @@ const Time = styled('time')`
 const Heading = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   text-transform: uppercase;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   margin-bottom: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/eventIdFieldStatusIcon.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/eventIdFieldStatusIcon.tsx
@@ -43,9 +43,9 @@ const CloseIcon = styled('div')`
 `;
 
 const StyledIconClose = styled(IconClose)`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   :hover {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
   cursor: pointer;
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -223,10 +223,10 @@ const ToggleWrapper = styled('div')`
 
 const Toggle = styled(Button)`
   font-weight: 700;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   &:hover,
   &:focus {
-    color: ${p => p.theme.gray700};
+    color: ${p => p.theme.gray500};
   }
   > *:first-child {
     display: grid;

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/selectField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/selectField.tsx
@@ -67,7 +67,7 @@ class SelectField extends React.Component<Props> {
 export default SelectField;
 
 const Description = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const Wrapper = styled('div')<{isSelected?: boolean}>`

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
@@ -480,16 +480,16 @@ const Suggestion = styled('li')<{active: boolean}>`
   padding: ${space(1)} ${space(2)};
   font-size: ${p => p.theme.fontSizeMedium};
   cursor: pointer;
-  background: ${p => (p.active ? p.theme.gray200 : p.theme.white)};
+  background: ${p => (p.active ? p.theme.gray100 : p.theme.white)};
   :hover {
-    background: ${p => (p.active ? p.theme.gray200 : p.theme.gray100)};
+    background: ${p => (p.active ? p.theme.gray100 : p.theme.gray100)};
   }
 `;
 
 const SuggestionDescription = styled('div')`
   display: flex;
   overflow: hidden;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 const SuggestionsOverlay = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/sourceField.tsx
@@ -480,9 +480,10 @@ const Suggestion = styled('li')<{active: boolean}>`
   padding: ${space(1)} ${space(2)};
   font-size: ${p => p.theme.fontSizeMedium};
   cursor: pointer;
-  background: ${p => (p.active ? p.theme.gray100 : p.theme.white)};
+  background: ${p => (p.active ? p.theme.backgroundSecondary : p.theme.white)};
   :hover {
-    background: ${p => (p.active ? p.theme.gray100 : p.theme.gray100)};
+    background: ${p =>
+      p.active ? p.theme.backgroundSecondary : p.theme.backgroundSecondary};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/organizationRules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/organizationRules.tsx
@@ -95,7 +95,7 @@ const Header = styled('div')`
 `;
 
 const Wrapper = styled('div')<{isCollapsed?: boolean; contentHeight?: string}>`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   background: ${p => p.theme.gray100};
   ${p => !p.contentHeight && `padding: ${space(1)} ${space(2)}`};
   ${p => !p.isCollapsed && ` border-bottom: 1px solid ${p.theme.border}`};

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/organizationRules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/organizationRules.tsx
@@ -96,7 +96,7 @@ const Header = styled('div')`
 
 const Wrapper = styled('div')<{isCollapsed?: boolean; contentHeight?: string}>`
   color: ${p => p.theme.gray200};
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   ${p => !p.contentHeight && `padding: ${space(1)} ${space(2)}`};
   ${p => !p.isCollapsed && ` border-bottom: 1px solid ${p.theme.border}`};
   ${p =>

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/rules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/rules.tsx
@@ -86,7 +86,7 @@ const List = styled('ul')<{
     p.isDisabled &&
     `
       color: ${p.theme.gray200};
-      background: ${p.theme.gray100};
+      background: ${p.theme.backgroundSecondary};
   `}
 `;
 
@@ -98,7 +98,7 @@ const ListItem = styled('li')`
   padding: ${space(1)} ${space(2)};
   border-bottom: 1px solid ${p => p.theme.border};
   &:hover {
-    background-color: ${p => p.theme.gray100};
+    background-color: ${p => p.theme.backgroundSecondary};
   }
   &:last-child {
     border-bottom: 0;

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/rules.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/rules.tsx
@@ -85,7 +85,7 @@ const List = styled('ul')<{
   ${p =>
     p.isDisabled &&
     `
-      color: ${p.theme.gray400};
+      color: ${p.theme.gray200};
       background: ${p.theme.gray100};
   `}
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
@@ -51,7 +51,7 @@ const EmptyMessage = styled(
           padding: ${space(4)} 15%;
         `};
   flex-direction: column;
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   font-size: ${p =>
     p.size && p.size === 'large' ? p.theme.fontSizeExtraLarge : p.theme.fontSizeLarge};
 `;
@@ -66,7 +66,7 @@ EmptyMessage.propTypes = {
 };
 
 const IconWrapper = styled('div')`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   margin-bottom: ${space(1)};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/choiceMapperField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/choiceMapperField.jsx
@@ -261,7 +261,7 @@ const LabelColumn = styled('div')`
 const HeadingItem = styled('div')`
   font-size: 0.8em;
   text-transform: uppercase;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 const Actions = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
@@ -104,7 +104,7 @@ const RadioLineText = styled('div', {shouldForwardProp})<{disabled?: boolean}>`
 `;
 
 const Description = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeRelativeSmall};
   line-height: 1.4em;
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/rangeSlider.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/rangeSlider.tsx
@@ -260,7 +260,7 @@ const Slider = styled('input')<{hasLabel: boolean}>`
     width: 100%;
     height: 3px;
     cursor: pointer;
-    background: ${p => p.theme.gray300};
+    background: ${p => p.theme.gray200};
     border-radius: 3px;
     border: 0;
   }
@@ -269,7 +269,7 @@ const Slider = styled('input')<{hasLabel: boolean}>`
     width: 100%;
     height: 3px;
     cursor: pointer;
-    background: ${p => p.theme.gray300};
+    background: ${p => p.theme.gray200};
     border-radius: 3px;
     border: 0;
   }
@@ -278,7 +278,7 @@ const Slider = styled('input')<{hasLabel: boolean}>`
     width: 100%;
     height: 3px;
     cursor: pointer;
-    background: ${p => p.theme.gray300};
+    background: ${p => p.theme.gray200};
     border-radius: 3px;
     border: 0;
   }
@@ -323,13 +323,13 @@ const Slider = styled('input')<{hasLabel: boolean}>`
   }
 
   &::-ms-fill-lower {
-    background: ${p => p.theme.gray300};
+    background: ${p => p.theme.gray200};
     border: 0;
     border-radius: 50%;
   }
 
   &::-ms-fill-upper {
-    background: ${p => p.theme.gray300};
+    background: ${p => p.theme.gray200};
     border: 0;
     border-radius: 50%;
   }
@@ -338,31 +338,31 @@ const Slider = styled('input')<{hasLabel: boolean}>`
     outline: none;
 
     &::-webkit-slider-runnable-track {
-      background: ${p => p.theme.gray400};
+      background: ${p => p.theme.gray200};
     }
 
     &::-ms-fill-upper {
-      background: ${p => p.theme.gray400};
+      background: ${p => p.theme.gray200};
     }
 
     &::-ms-fill-lower {
-      background: ${p => p.theme.gray400};
+      background: ${p => p.theme.gray200};
     }
   }
 
   &[disabled] {
     &::-webkit-slider-thumb {
-      background: ${p => p.theme.gray400};
+      background: ${p => p.theme.gray200};
       cursor: default;
     }
 
     &::-moz-range-thumb {
-      background: ${p => p.theme.gray400};
+      background: ${p => p.theme.gray200};
       cursor: default;
     }
 
     &::-ms-thumb {
-      background: ${p => p.theme.gray400};
+      background: ${p => p.theme.gray200};
       cursor: default;
     }
 
@@ -383,7 +383,7 @@ const Slider = styled('input')<{hasLabel: boolean}>`
 const Label = styled('label')`
   font-size: 14px;
   margin-bottom: ${p => p.theme.grid}px;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 const SliderAndInputWrapper = styled('div')<{showCustomInput?: boolean}>`

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldControl.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldControl.tsx
@@ -79,7 +79,7 @@ const FieldControlErrorWrapper = styled('div')<{inline?: boolean}>`
 `;
 
 const FieldControlStyled = styled('div')<{alignRight?: boolean}>`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   display: flex;
   flex: 1;
   flex-direction: column;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldHelp.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldHelp.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import space from 'app/styles/space';
 
 const FieldHelp = styled('div')<{stacked?: boolean; inline?: boolean}>`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: 14px;
   margin-top: ${p => (p.stacked && !p.inline ? 0 : space(1))};
   line-height: 1.4;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldLabel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldLabel.tsx
@@ -6,7 +6,7 @@ import space from 'app/styles/space';
 const shouldForwardProp = p => p !== 'disabled' && isPropValid(p);
 
 const FieldLabel = styled('div', {shouldForwardProp})<{disabled?: boolean}>`
-  color: ${p => (!p.disabled ? p.theme.gray800 : p.theme.gray500)};
+  color: ${p => (!p.disabled ? p.theme.gray500 : p.theme.gray300)};
   display: grid;
   grid-gap: ${space(0.5)};
   grid-template-columns: repeat(2, max-content);

--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -157,7 +157,7 @@ export class RenderField extends React.Component<RenderProps, State> {
           <DeleteButtonWrapper>
             <Button
               onClick={() => handleDelete(index)}
-              icon={<IconDelete color="gray500" />}
+              icon={<IconDelete color="gray300" />}
               size="small"
               type="button"
               aria-label={t('Delete')}

--- a/src/sentry/static/sentry/app/views/settings/components/forms/richListField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/richListField.jsx
@@ -249,8 +249,8 @@ const Item = styled('li')`
 
 const ItemButton = styled(Button)`
   margin-left: 10px;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   &:hover {
-    color: ${p => (p.disabled ? p.theme.gray500 : p.theme.button.default.color)};
+    color: ${p => (p.disabled ? p.theme.gray300 : p.theme.button.default.color)};
   }
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/tableField.tsx
@@ -189,7 +189,7 @@ export default class TableField extends React.Component<Props> {
 const HeaderLabel = styled('div')`
   font-size: 0.8em;
   text-transform: uppercase;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 const HeaderContainer = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/components/forms/textCopyInput.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/textCopyInput.jsx
@@ -15,7 +15,7 @@ const Wrapper = styled('div')`
 
 const StyledInput = styled('input')`
   ${inputStyles};
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   border-right-width: 0;
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
@@ -23,7 +23,7 @@ const StyledInput = styled('input')`
 
   &:hover,
   &:focus {
-    background-color: ${p => p.theme.gray100};
+    background-color: ${p => p.theme.backgroundSecondary};
     border-right-width: 0;
   }
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/crumb.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/crumb.jsx
@@ -7,7 +7,7 @@ const Crumb = styled('div')`
   align-items: center;
   position: relative;
   font-size: 18px;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   padding-right: ${space(1)};
   cursor: pointer;
   white-space: nowrap;
@@ -17,7 +17,7 @@ const Crumb = styled('div')`
   }
 
   &:hover {
-    color: ${p => p.theme.gray800};
+    color: ${p => p.theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/divider.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/divider.jsx
@@ -7,7 +7,7 @@ import {IconChevron} from 'app/icons';
 const StyledDivider = styled('span')`
   display: inline-block;
   margin-left: 6px;
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.gray200};
   position: relative;
   top: -1px;
 

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.jsx
@@ -102,9 +102,9 @@ const CrumbLink = styled(Link)`
     box-shadow: ${p => p.theme.blue300} 0 2px 0;
   }
 
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   &:hover {
-    color: ${p => p.theme.gray800};
+    color: ${p => p.theme.gray500};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/settingsLayout.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsLayout.tsx
@@ -142,11 +142,11 @@ const NavMenuToggle = styled(Button)`
   display: none;
   margin: -${space(1)} ${space(1)} -${space(1)} -${space(1)};
   padding: ${space(1)};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   &:hover,
   &:focus,
   &:active {
-    color: ${p => p.theme.gray800};
+    color: ${p => p.theme.gray500};
   }
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: block;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.tsx
@@ -35,13 +35,13 @@ const SettingsNavItem = ({badge, label, index, id, ...props}: Props) => {
 
 const StyledNavItem = styled(Link)`
   display: block;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: 14px;
   line-height: 30px;
   position: relative;
 
   &.active {
-    color: ${p => p.theme.gray800};
+    color: ${p => p.theme.gray500};
 
     &:before {
       background: ${p => p.theme.purple300};
@@ -51,7 +51,7 @@ const StyledNavItem = styled(Link)`
   &:hover,
   &:focus,
   &:active {
-    color: ${p => p.theme.gray800};
+    color: ${p => p.theme.gray500};
     outline: none;
   }
 

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigationGroup.tsx
@@ -60,7 +60,7 @@ const NavSection = styled('div')`
 `;
 
 const SettingsHeading = styled('div')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: 12px;
   font-weight: 600;
   text-transform: uppercase;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsSearch/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsSearch/index.tsx
@@ -62,7 +62,7 @@ const SearchInputWrapper = styled('div')`
 `;
 
 const SearchInputIcon = styled(IconSearch)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   position: absolute;
   left: 10px;
   top: 8px;
@@ -86,6 +86,6 @@ const SearchInput = styled('input')`
   }
 
   &::placeholder {
-    color: ${p => p.theme.gray500};
+    color: ${p => p.theme.gray300};
   }
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsWrapper.tsx
@@ -75,7 +75,7 @@ const StyledSettingsWrapper = styled('div')`
   display: flex;
   flex: 1;
   font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.gray800};
+  color: ${p => p.theme.gray500};
   margin-bottom: -${space(3)}; /* to account for footer margin top */
   line-height: 1;
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -124,7 +124,7 @@ const AggregateHeader = styled('div')`
   grid-gap: ${space(1)};
   text-transform: uppercase;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-weight: bold;
   margin-bottom: ${space(1)};
 `;
@@ -133,10 +133,10 @@ const PresetButton = styled(Button)<{disabled: boolean}>`
   ${p =>
     p.disabled &&
     css`
-      color: ${p.theme.gray700};
+      color: ${p.theme.gray500};
       &:hover,
       &:focus {
-        color: ${p.theme.gray800};
+        color: ${p.theme.gray500};
       }
     `}
 `;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -224,7 +224,7 @@ class RuleConditionsForm extends React.PureComponent<Props, State> {
                     ...base,
                     '.all-environment-note': {
                       ...(!state.isSelected && !state.isFocused
-                        ? {color: theme.gray600}
+                        ? {color: theme.gray400}
                         : {}),
                       fontSize: theme.fontSizeSmall,
                     },
@@ -262,8 +262,8 @@ const StyledSearchBar = styled(SearchBar)`
 
 const SearchEventTypeNote = styled('div')`
   font: ${p => p.theme.fontSizeExtraSmall} ${p => p.theme.text.familyMono};
-  color: ${p => p.theme.gray600};
-  background: ${p => p.theme.gray200};
+  color: ${p => p.theme.gray400};
+  background: ${p => p.theme.gray100};
   border-radius: 2px;
   padding: ${space(0.5)} ${space(0.75)};
   margin: 0 ${space(0.5)} 0 ${space(1)};

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -263,7 +263,7 @@ const StyledSearchBar = styled(SearchBar)`
 const SearchEventTypeNote = styled('div')`
   font: ${p => p.theme.fontSizeExtraSmall} ${p => p.theme.text.familyMono};
   color: ${p => p.theme.gray400};
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   border-radius: 2px;
   padding: ${space(0.5)} ${space(0.75)};
   margin: 0 ${space(0.5)} 0 ${space(1)};

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -105,7 +105,7 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
     const selectLabel = (label: string) => ({
       ':before': {
         content: `"${label}"`,
-        color: theme.gray500,
+        color: theme.gray300,
         fontWeight: 600,
       },
     });
@@ -138,7 +138,7 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
                     ...base,
                     '.all-environment-note': {
                       ...(!state.isSelected && !state.isFocused
-                        ? {color: theme.gray600}
+                        ? {color: theme.gray400}
                         : {}),
                       fontSize: theme.fontSizeSmall,
                     },
@@ -310,8 +310,8 @@ const StyledSearchBar = styled(SearchBar)`
 
 const SearchEventTypeNote = styled('div')`
   font: ${p => p.theme.fontSizeExtraSmall} ${p => p.theme.text.familyMono};
-  color: ${p => p.theme.gray600};
-  background: ${p => p.theme.gray200};
+  color: ${p => p.theme.gray400};
+  background: ${p => p.theme.gray100};
   border-radius: 2px;
   padding: ${space(0.5)} ${space(0.75)};
   margin: 0 ${space(0.5)} 0 ${space(1)};

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -311,7 +311,7 @@ const StyledSearchBar = styled(SearchBar)`
 const SearchEventTypeNote = styled('div')`
   font: ${p => p.theme.fontSizeExtraSmall} ${p => p.theme.text.familyMono};
   color: ${p => p.theme.gray400};
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   border-radius: 2px;
   padding: ${space(0.5)} ${space(0.75)};
   margin: 0 ${space(0.5)} 0 ${space(1)};

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -341,7 +341,7 @@ class ActionsPanel extends React.PureComponent<Props> {
               type="button"
               disabled={disabled || loading}
               size="small"
-              icon={<IconAdd isCircled color="gray500" />}
+              icon={<IconAdd isCircled color="gray300" />}
               onClick={this.handleAddAction}
             >
               {t('Add New Action')}

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/index.tsx
@@ -249,7 +249,7 @@ const StatsHeader = styled('h6')`
   margin-bottom: ${space(1)};
   font-size: 12px;
   text-transform: uppercase;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 const StyledFooter = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -348,5 +348,5 @@ const StyledErrorsOnlyButton = styled(Button)`
 
 const StyledIconOpen = styled(IconOpen)`
   margin-left: 6px;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDetails.tsx
@@ -411,7 +411,7 @@ const TokenItem = styled('div')`
 `;
 
 const CreatedTitle = styled('span')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   margin-bottom: 2px;
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/actionButtons.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/actionButtons.tsx
@@ -98,7 +98,7 @@ const ButtonHolder = styled('div')`
 `;
 
 const StyledButton = styled(Button)`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;
 
 export default ActionButtons;

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/actionButtons.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/actionButtons.tsx
@@ -98,7 +98,7 @@ const ButtonHolder = styled('div')`
 `;
 
 const StyledButton = styled(Button)`
-  color: ${p => p.theme.gray300};
+  color: ${p => p.theme.gray400};
 `;
 
 export default ActionButtons;

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationRow/index.tsx
@@ -122,7 +122,7 @@ const PublishStatus = styled(({status, ...props}: PublishStatusProps) => (
   </CenterFlex>
 ))`
   color: ${(props: PublishStatusProps) =>
-    props.status === 'published' ? props.theme.success : props.theme.gray500};
+    props.status === 'published' ? props.theme.success : props.theme.gray300};
   font-weight: light;
   margin-right: ${space(0.75)};
 `;

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -116,7 +116,7 @@ const SubscriptionGridItemWrapper = styled('div')`
 const SubscriptionDescription = styled('div')`
   font-size: 12px;
   line-height: 1;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   white-space: nowrap;
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -100,7 +100,7 @@ const SubscriptionGridItem = styled('div')<{disabled: boolean}>`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   opacity: ${({disabled}: {disabled: boolean}) => (disabled ? 0.3 : 1)};
   border-radius: 3px;
   flex: 1;

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -154,7 +154,7 @@ const FilterHeader = styled('h2')`
   border-top-right-radius: 4px;
   border-bottom: 1px solid ${p => p.theme.border};
   background: ${p => p.theme.gray100};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   text-transform: uppercase;
   font-size: ${p => p.theme.fontSizeExtraSmall};
   padding: ${space(1)};

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -153,7 +153,7 @@ const FilterHeader = styled('h2')`
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
   border-bottom: 1px solid ${p => p.theme.border};
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   color: ${p => p.theme.gray400};
   text-transform: uppercase;
   font-size: ${p => p.theme.fontSizeExtraSmall};

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -185,7 +185,7 @@ const UserName = styled('div')`
 
 const Description = styled('div')`
   display: block;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: 14px;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -365,7 +365,7 @@ class OrganizationMemberDetail extends AsyncView<Props, State> {
 export default withOrganization(OrganizationMemberDetail);
 
 const ExtraHeaderText = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-weight: normal;
   font-size: ${p => p.theme.fontSizeLarge};
 `;
@@ -386,7 +386,7 @@ const Details = styled('div')`
 const DetailLabel = styled('div')`
   font-weight: bold;
   margin-bottom: ${space(0.5)};
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
 `;
 
 const OverflowWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMemberRow.jsx
@@ -255,7 +255,7 @@ const UserName = styled('div')`
 `;
 
 const Email = styled('div')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   font-size: ${p => p.theme.fontSizeMedium};
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -267,7 +267,7 @@ const StyledMembersFilter = styled(MembersFilter)`
     height: 16px;
     width: 16px;
     border: 8px solid transparent;
-    border-bottom-color: ${p => p.theme.gray100};
+    border-bottom-color: ${p => p.theme.backgroundSecondary};
   }
 
   &:before {

--- a/src/sentry/static/sentry/app/views/settings/organizationRelay/list/cardHeader.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRelay/list/cardHeader.tsx
@@ -72,12 +72,12 @@ const Name = styled('div')`
 `;
 
 const MainInfo = styled('div')`
-  color: ${p => p.theme.gray700};
+  color: ${p => p.theme.gray500};
   display: grid;
   grid-gap: ${space(1)};
 `;
 
 const Date = styled('small')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   font-size: ${p => p.theme.fontSizeMedium};
 `;

--- a/src/sentry/static/sentry/app/views/settings/organizationRelay/modals/add/terminal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRelay/modals/add/terminal.tsx
@@ -17,7 +17,7 @@ const Terminal = ({command}: Props) => (
 export default Terminal;
 
 const Wrapper = styled('div')`
-  background: ${p => p.theme.gray800};
+  background: ${p => p.theme.gray500};
   padding: ${space(1.5)} ${space(3)};
   font-family: ${p => p.theme.text.familyMono};
   color: ${p => p.theme.white};
@@ -28,5 +28,5 @@ const Wrapper = styled('div')`
 `;
 
 const Prompt = styled('div')`
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
 `;

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersChart.tsx
@@ -29,13 +29,13 @@ type State = {
 type RawStats = Record<string, [timestamp: number, value: number][]>;
 
 const STAT_OPS = {
-  'browser-extensions': {title: t('Browser Extension'), color: theme.gray400},
+  'browser-extensions': {title: t('Browser Extension'), color: theme.gray200},
   cors: {title: 'CORS', color: theme.orange400},
   'error-message': {title: t('Error Message'), color: theme.purple300},
-  'discarded-hash': {title: t('Discarded Issue'), color: theme.gray300},
+  'discarded-hash': {title: t('Discarded Issue'), color: theme.gray200},
   'invalid-csp': {title: t('Invalid CSP'), color: theme.blue300},
   'ip-address': {title: t('IP Address'), color: theme.red200},
-  'legacy-browsers': {title: t('Legacy Browser'), color: theme.gray300},
+  'legacy-browsers': {title: t('Legacy Browser'), color: theme.gray200},
   localhost: {title: t('Localhost'), color: theme.blue300},
   'release-version': {title: t('Release'), color: theme.purple200},
   'web-crawlers': {title: t('Web Crawler'), color: theme.red300},
@@ -124,7 +124,7 @@ class ProjectFiltersChart extends React.Component<Props, State> {
     const hasError = !isLoading && error;
     const hasLoaded = !isLoading && !error;
     const colors = formattedData
-      ? formattedData.map(series => series.color || theme.gray400)
+      ? formattedData.map(series => series.color || theme.gray200)
       : undefined;
 
     return (

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -417,7 +417,7 @@ const FilterTitle = styled('div')`
 `;
 
 const FilterDescription = styled('div')`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: 12px;
   line-height: 1;
   white-space: nowrap;

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -380,7 +380,7 @@ const FilterGrid = styled('div')`
 const FilterGridItem = styled('div')`
   display: flex;
   align-items: center;
-  background: ${p => p.theme.gray100};
+  background: ${p => p.theme.backgroundSecondary};
   border-radius: 3px;
   flex: 1;
   padding: 12px;

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyStats.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyStats.tsx
@@ -111,7 +111,7 @@ class KeyStats extends React.Component<Props, State> {
               isGroupedByDate
               series={this.state.series}
               height={150}
-              colors={[theme.gray400, theme.red300]}
+              colors={[theme.gray200, theme.red300]}
               stacked
               labelYAxisExtents
             />

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/list/keyRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/list/keyRow.tsx
@@ -113,7 +113,7 @@ const StyledClippedBox = styled(ClippedBox)`
 `;
 
 const PanelHeaderLink = styled(Link)`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 const Title = styled('div')<{disabled: boolean}>`

--- a/src/sentry/static/sentry/app/views/settings/project/projectTeams.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectTeams.tsx
@@ -177,7 +177,7 @@ const StyledCreateTeamLink = styled(Link)`
     p.disabled &&
     css`
       cursor: not-allowed;
-      color: ${p.theme.gray500};
+      color: ${p.theme.gray300};
       opacity: 0.6;
     `};
 `;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/alertTypeChooser.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/alertTypeChooser.tsx
@@ -165,7 +165,7 @@ const ExampleHeading = styled('div')`
   text-transform: uppercase;
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: bold;
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   margin-bottom: ${space(2)};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -509,7 +509,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                   <StepContainer>
                     <ChevronContainer>
                       <IconChevron
-                        color="gray400"
+                        color="gray200"
                         isCircled
                         direction="right"
                         size="sm"
@@ -598,7 +598,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                     <StepContainer>
                       <ChevronContainer>
                         <IconChevron
-                          color="gray400"
+                          color="gray200"
                           isCircled
                           direction="right"
                           size="sm"
@@ -664,7 +664,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                     <ChevronContainer>
                       <IconChevron
                         isCircled
-                        color="gray400"
+                        color="gray200"
                         direction="right"
                         size="sm"
                       />
@@ -757,7 +757,7 @@ const StepConnector = styled('div')`
   height: 100%;
   top: 28px;
   left: 19px;
-  border-right: 1px ${p => p.theme.gray500} dashed;
+  border-right: 1px ${p => p.theme.gray300} dashed;
 `;
 
 const StepLead = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -329,7 +329,7 @@ const RuleRow = styled('div')`
 `;
 
 const RuleRowContainer = styled('div')`
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px ${p => p.theme.innerBorder} solid;
 `;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
@@ -155,7 +155,7 @@ type HasBorderProp = {
 };
 
 const RuleType = styled('div')<RowSpansProp>`
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   font-size: ${p => p.theme.fontSizeSmall};
   font-weight: bold;
   text-transform: uppercase;
@@ -197,7 +197,7 @@ const ConditionsWithHeader = styled('div')`
 const MatchTypeHeader = styled('div')`
   font-weight: bold;
   text-transform: uppercase;
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.gray300};
   margin-bottom: ${space(1)};
 `;
 
@@ -220,8 +220,8 @@ const TriggerDescription = styled('div')`
 `;
 
 const StatusBadge = styled('div')`
-  background-color: ${p => p.theme.gray300};
-  color: ${p => p.theme.gray700};
+  background-color: ${p => p.theme.gray200};
+  color: ${p => p.theme.gray500};
   text-transform: uppercase;
   padding: ${space(0.25)} ${space(0.5)};
   font-weight: 600;

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -161,7 +161,7 @@ const TimeAndSizeWrapper = styled('div')`
   display: flex;
   font-size: ${p => p.theme.fontSizeSmall};
   margin-top: ${space(1)};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   align-items: center;
 `;
 
@@ -186,7 +186,7 @@ const Name = styled('div')`
 
 const Description = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
   @media (max-width: ${p => p.theme.breakpoints[2]}) {
     line-height: 1.7;
   }

--- a/src/sentry/static/sentry/app/views/settings/projectSourceMaps/detail/sourceMapsArtifactRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSourceMaps/detail/sourceMapsArtifactRow.tsx
@@ -130,7 +130,7 @@ const TimeWrapper = styled('div')`
   grid-gap: ${space(0.5)};
   grid-template-columns: min-content 1fr;
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray600};
+  color: ${p => p.theme.gray400};
 `;
 
 export default SourceMapsArtifactRow;

--- a/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
@@ -289,13 +289,13 @@ const HomePanelBody = styled(PanelBody)`
     li {
       line-height: 1.6;
       /* Bullet color */
-      color: ${p => p.theme.gray400};
+      color: ${p => p.theme.gray200};
     }
   }
 `;
 
 const HomeIcon = styled('div')<{color?: string}>`
-  background: ${p => p.theme[p.color || 'gray500']};
+  background: ${p => p.theme[p.color || 'gray300']};
   color: ${p => p.theme.white};
   width: ${HOME_ICON_SIZE}px;
   height: ${HOME_ICON_SIZE}px;


### PR DESCRIPTION
Continuation of the simplication of theme colors for dark mode. This changes all uses of gray colors:

- 100 -> 100
- 200 -> 100
- 300 -> 200
- 400 -> 200
- 500 -> 300
- 600 -> 400
- 700 -> 500
- 800-> 500