### PR TITLE
fix(vitals): Hide untrustworthy web vitals from span view

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -625,7 +625,7 @@ export function getMeasurements(event: SentryTransactionEvent): Map<number, stri
 
   const {measurements = {}} = event;
 
-  const displaybleMarks = Object.keys(measurements)
+  const displayableMarks = Object.keys(measurements)
     .filter(name => name.startsWith('mark.'))
     .filter(markName => {
       const vitalName = markName.slice('mark.'.length);
@@ -645,7 +645,7 @@ export function getMeasurements(event: SentryTransactionEvent): Map<number, stri
 
   const mergedMeasurements = new Map<number, string[]>();
 
-  displaybleMarks.forEach(mark => {
+  displayableMarks.forEach(mark => {
     const name = mark.name.slice('mark.'.length);
 
     if (mergedMeasurements.has(mark.timestamp)) {

--- a/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
+++ b/src/sentry/static/sentry/app/components/events/realUserMonitoring.tsx
@@ -98,9 +98,9 @@ class RealUserMonitoring extends React.Component<Props> {
         <SectionHeading>{t('Web Vitals')}</SectionHeading>
         <Measurements>
           {measurements.map(name => (
-            <div key={name}>
+            <React.Fragment key={name}>
               {this.renderMeasurement(name, event.measurements![name])}
-            </div>
+            </React.Fragment>
           ))}
         </Measurements>
       </Container>


### PR DESCRIPTION
Web vital data from the SDK from sometimes contain discrepancies between the
web vital and the corresponding timestamp. This can be due to the fact that the
web vital is not measured relative to the start of the transaction, instead, it
is started by the browser. This can lead to confusing/untrustworthy
visualizations on the span view. There has been an update in the SDK in order to
amend such data. This change makes an effort to detect such discrepancies and
choosing to hide the data when it happens.