### PR TITLE
fix(ui): Prevent issue actions jitter on select

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/ignore.tsx
+++ b/src/sentry/static/sentry/app/components/actions/ignore.tsx
@@ -145,7 +145,7 @@ export default class IgnoreActions extends React.Component<Props, State> {
           windowChoices={IGNORE_WINDOWS}
         />
         <div className="btn-group">
-          <ActionLink
+          <StyledActionLink
             {...actionLinkProps}
             title={t('Ignore')}
             className={linkClassName}
@@ -153,9 +153,9 @@ export default class IgnoreActions extends React.Component<Props, State> {
           >
             <StyledIconNot size="xs" />
             {t('Ignore')}
-          </ActionLink>
+          </StyledActionLink>
 
-          <DropdownLink
+          <StyledDropdownLink
             caret
             className={linkClassName}
             title=""
@@ -290,7 +290,7 @@ export default class IgnoreActions extends React.Component<Props, State> {
                 </MenuItem>
               </DropdownLink>
             </li>
-          </DropdownLink>
+          </StyledDropdownLink>
         </div>
       </div>
     );
@@ -310,4 +310,13 @@ const StyledIconNot = styled(IconNot)`
 const SoloIconNot = styled(IconNot)`
   position: relative;
   top: 1px;
+`;
+
+const StyledActionLink = styled(ActionLink)`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledDropdownLink = styled(DropdownLink)`
+  transition: none;
 `;

--- a/src/sentry/static/sentry/app/components/actions/ignore.tsx
+++ b/src/sentry/static/sentry/app/components/actions/ignore.tsx
@@ -315,6 +315,7 @@ const SoloIconNot = styled(IconNot)`
 const StyledActionLink = styled(ActionLink)`
   display: flex;
   align-items: center;
+  transition: none;
 `;
 
 const StyledDropdownLink = styled(DropdownLink)`

--- a/src/sentry/static/sentry/app/components/actions/resolve.tsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.tsx
@@ -246,6 +246,7 @@ const StyledIconCheckmark = styled(IconCheckmark)`
 const StyledActionLink = styled(ActionLink)`
   display: flex;
   align-items: center;
+  transition: none;
 `;
 
 const StyledDropdownLink = styled(DropdownLink)`

--- a/src/sentry/static/sentry/app/components/actions/resolve.tsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.tsx
@@ -158,7 +158,7 @@ class ResolveActions extends React.Component<Props, State> {
         />
         <Tooltip disabled={!projectFetchError} title={t('Error fetching project')}>
           <div className="btn-group">
-            <ActionLink
+            <StyledActionLink
               {...actionLinkProps}
               title={t('Resolve')}
               className={buttonClass}
@@ -166,9 +166,9 @@ class ResolveActions extends React.Component<Props, State> {
             >
               <StyledIconCheckmark size="xs" />
               {t('Resolve')}
-            </ActionLink>
+            </StyledActionLink>
 
-            <DropdownLink
+            <StyledDropdownLink
               key="resolve-dropdown"
               caret
               className={buttonClass}
@@ -228,7 +228,7 @@ class ResolveActions extends React.Component<Props, State> {
                   </ActionLink>
                 </Tooltip>
               </MenuItem>
-            </DropdownLink>
+            </StyledDropdownLink>
           </div>
         </Tooltip>
       </div>
@@ -241,6 +241,15 @@ const StyledIconCheckmark = styled(IconCheckmark)`
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     display: none;
   }
+`;
+
+const StyledActionLink = styled(ActionLink)`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledDropdownLink = styled(DropdownLink)`
+  transition: none;
 `;
 
 export default ResolveActions;


### PR DESCRIPTION
The icons jump a bit and the buttons all had different transition times because there's some element removal and adding happening. This should remove all transitions and get the icons to align when selected.

Before
![Kapture 2020-11-06 at 12 24 08](https://user-images.githubusercontent.com/1400464/98411489-fe2cdb80-202a-11eb-8945-d6ddb5416bee.gif)
