### PR TITLE
fix(jira): revert change for persisting reporter

### DIFF
--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -139,7 +139,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         else:
             external_issue.update(**defaults)
 
-        installation.store_issue_last_defaults(group.project, request.user, request.data)
+        installation.store_issue_last_defaults(group.project_id, request.data)
         try:
             installation.after_link_issue(external_issue, data=request.data)
         except IntegrationFormError as exc:
@@ -231,7 +231,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
                 user=request.user,
                 sender=self.__class__,
             )
-        installation.store_issue_last_defaults(group.project, request.user, request.data)
+        installation.store_issue_last_defaults(group.project_id, request.data)
 
         self.create_issue_activity(request, group, installation, external_issue)
 

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -143,7 +143,7 @@ class IntegrationIssueConfigSerializer(IntegrationSerializer):
             data["linkIssueConfig"] = config
 
         if self.action == "create":
-            config = installation.get_create_issue_config(self.group, user, params=self.params)
+            config = installation.get_create_issue_config(self.group, params=self.params)
             data["createIssueConfig"] = config
 
         return data

--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -28,11 +28,9 @@ class BitbucketIssueBasicMixin(IssueBasicMixin):
     def get_persisted_default_config_fields(self):
         return ["repo"]
 
-    def get_create_issue_config(self, group, user, **kwargs):
+    def get_create_issue_config(self, group, **kwargs):
         kwargs["link_referrer"] = "bitbucket_integration"
-        fields = super(BitbucketIssueBasicMixin, self).get_create_issue_config(
-            group, user, **kwargs
-        )
+        fields = super(BitbucketIssueBasicMixin, self).get_create_issue_config(group, **kwargs)
         default_repo, repo_choices = self.get_repository_choices(group, **kwargs)
 
         org = group.organization

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -76,9 +76,9 @@ class ExampleIntegration(IntegrationInstallation, IssueSyncMixin):
     def get_persisted_default_config_fields(self):
         return ["project", "issueType"]
 
-    def get_create_issue_config(self, group, user, **kwargs):
+    def get_create_issue_config(self, group, **kwargs):
         kwargs["link_referrer"] = "example_integration"
-        fields = super(ExampleIntegration, self).get_create_issue_config(group, user, **kwargs)
+        fields = super(ExampleIntegration, self).get_create_issue_config(group, **kwargs)
         default = self.get_project_defaults(group.project_id)
         example_project_field = self.generate_example_project_field(default)
         return fields + [example_project_field]

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -39,9 +39,9 @@ class GitHubIssueBasic(IssueBasicMixin):
     def create_default_repo_choice(self, default_repo):
         return (default_repo, default_repo.split("/")[1])
 
-    def get_create_issue_config(self, group, user, **kwargs):
+    def get_create_issue_config(self, group, **kwargs):
         kwargs["link_referrer"] = "github_integration"
-        fields = super(GitHubIssueBasic, self).get_create_issue_config(group, user, **kwargs)
+        fields = super(GitHubIssueBasic, self).get_create_issue_config(group, **kwargs)
         default_repo, repo_choices = self.get_repository_choices(group, **kwargs)
 
         assignees = self.get_allowed_assignees(default_repo) if default_repo else []

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -40,10 +40,10 @@ class GitlabIssueBasic(IssueBasicMixin):
             return ("", "")
         return (project["id"], project["name_with_namespace"])
 
-    def get_create_issue_config(self, group, user, **kwargs):
+    def get_create_issue_config(self, group, **kwargs):
         default_project, project_choices = self.get_projects_and_default(group, **kwargs)
         kwargs["link_referrer"] = "gitlab_integration"
-        fields = super(GitlabIssueBasic, self).get_create_issue_config(group, user, **kwargs)
+        fields = super(GitlabIssueBasic, self).get_create_issue_config(group, **kwargs)
 
         org = group.organization
         autocomplete_url = reverse(

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -5,7 +5,6 @@ import six
 from collections import defaultdict
 
 from sentry import features
-from sentry.models.useroption import UserOption
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.models import Activity, ExternalIssue, Group, GroupLink, GroupStatus, Organization
 from sentry.utils.http import absolute_uri
@@ -50,7 +49,7 @@ class IssueBasicMixin(object):
             output.extend(["", "```", body, "```"])
         return "\n".join(output)
 
-    def get_create_issue_config(self, group, user, **kwargs):
+    def get_create_issue_config(self, group, **kwargs):
         """
         These fields are used to render a form for the user,
         and are then passed in the format of:
@@ -95,25 +94,14 @@ class IssueBasicMixin(object):
         """
         return []
 
-    def get_persisted_user_default_config_fields(self):
-        """
-        Returns a list of field names that should have their last used values
-        persisted on a per-project, per-user basis.
-        """
-        return []
-
-    def _get_defaults_user_option_key(self):
-        provider = self.org_integration.integration.provider
-        return "issues:defaults:{}".format(provider)
-
-    def store_issue_last_defaults(self, project, user, data):
+    def store_issue_last_defaults(self, project_id, data):
         """
         Stores the last used field defaults on a per-project basis. This
         accepts a dict of values that will be filtered to keys returned by
         ``get_persisted_default_config_fields`` which will automatically be
         merged into the associated field config object as the default.
 
-        >>> integ.store_issue_last_defaults(project, user, {'externalProject': 2})
+        >>> integ.store_issue_last_defaults(1, {'externalProject': 2})
 
         When the integration is serialized these values will automatically be
         merged into the field configuration objects.
@@ -122,44 +110,16 @@ class IssueBasicMixin(object):
               differentiation is made between the two field configs.
         """
         persisted_fields = self.get_persisted_default_config_fields()
-        if persisted_fields:
-            project_defaults = {k: v for k, v in six.iteritems(data) if k in persisted_fields}
-            self.org_integration.config.setdefault("project_issue_defaults", {}).setdefault(
-                six.text_type(project.id), {}
-            ).update(project_defaults)
-            self.org_integration.save()
+        if not persisted_fields:
+            return
 
-        user_persisted_fields = self.get_persisted_user_default_config_fields()
-        if user_persisted_fields:
-            user_defaults = {}
-            defaults_user_option_key = self._get_defaults_user_option_key()
-            user_defaults.update(
-                UserOption.objects.get_value(
-                    user=user, key=defaults_user_option_key, default={}, project=project
-                )
-            )
-            user_defaults.update(
-                {k: v for k, v in six.iteritems(data) if k in user_persisted_fields}
-            )
-            UserOption.objects.set_value(
-                user=user, key=defaults_user_option_key, value=user_defaults, project=project
-            )
+        defaults = {k: v for k, v in six.iteritems(data) if k in persisted_fields}
 
-    def get_defaults(self, project, user):
-        project_defaults = self.get_project_defaults(project.id)
+        self.org_integration.config.setdefault("project_issue_defaults", {}).setdefault(
+            six.text_type(project_id), {}
+        ).update(defaults)
+        self.org_integration.save()
 
-        defaults_user_option_key = self._get_defaults_user_option_key()
-        user_defaults = UserOption.objects.get_value(
-            user=user, key=defaults_user_option_key, default={}, project=project
-        )
-
-        defaults = {}
-        defaults.update(project_defaults)
-        defaults.update(user_defaults)
-
-        return defaults
-
-    # TODO(saif): Make private and move all usages over to `get_defaults`
     def get_project_defaults(self, project_id):
         return self.org_integration.config.get("project_issue_defaults", {}).get(
             six.text_type(project_id), {}

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -78,7 +78,6 @@ class JiraApiClient(ApiClient):
     SEARCH_URL = "/rest/api/2/search/"
     VERSIONS_URL = "/rest/api/2/project/%s/versions"
     USERS_URL = "/rest/api/2/user/assignable/search"
-    USER_URL = "/rest/api/2/user"
     SERVER_INFO_URL = "/rest/api/2/serverInfo"
     ASSIGN_URL = "/rest/api/2/issue/%s/assignee"
     TRANSITION_URL = "/rest/api/2/issue/%s/transitions"
@@ -199,10 +198,6 @@ class JiraApiClient(ApiClient):
             self.USERS_URL, params={"issueKey": issue_key, self.query_field(): email}
         )
 
-    def get_user(self, user_id):
-        user_id_field = self.user_id_field()
-        return self.get_cached(self.USER_URL, params={user_id_field: user_id})
-
     def create_issue(self, raw_form_data):
         data = {"fields": raw_form_data}
         return self.post(self.CREATE_URL, data=data)
@@ -226,20 +221,3 @@ class JiraApiClient(ApiClient):
     def get_email(self, account_id):
         user = self.get_cached(self.EMAIL_URL, params={"accountId": account_id})
         return user.get("email")
-
-    def format_user(self, user_response):
-        user_id_field = self.user_id_field()
-        if user_id_field not in user_response:
-            return None
-
-        # The name field can be blank in jira-cloud, and the id_field varies by
-        # jira-cloud and jira-server
-        name = user_response.get("name", "")
-        email = user_response.get("emailAddress")
-
-        display = "%s %s%s" % (
-            user_response.get("displayName", name),
-            "- %s " % email if email else "",
-            "(%s)" % name if name else "",
-        )
-        return user_response[user_id_field], display.strip()

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -535,12 +535,12 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             )
         return meta
 
-    def get_create_issue_config(self, group, user, **kwargs):
+    def get_create_issue_config(self, group, **kwargs):
         kwargs["link_referrer"] = "jira_integration"
-        fields = super(JiraIntegration, self).get_create_issue_config(group, user, **kwargs)
+        fields = super(JiraIntegration, self).get_create_issue_config(group, **kwargs)
         params = kwargs.get("params", {})
 
-        defaults = self.get_defaults(group.project, user)
+        defaults = self.get_project_defaults(group.project_id)
         project_id = params.get("project", defaults.get("project"))
         client = self.get_client()
         try:
@@ -639,17 +639,6 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 field["choices"] = self.make_choices(client.get_versions(meta["key"]))
             elif field["name"] == "labels":
                 field["default"] = defaults.get("labels", "")
-            elif field["name"] == "reporter":
-                reporter_id = defaults.get("reporter", "")
-                if not reporter_id:
-                    continue
-                reporter_info = client.get_user(reporter_id)
-                reporter_tuple = client.format_user(reporter_info)
-                if not reporter_tuple:
-                    continue
-                reporter_id, reporter_label = reporter_tuple
-                field["default"] = reporter_id
-                field["choices"] = [(reporter_id, reporter_label)]
 
         return fields
 

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -6,7 +6,6 @@ from rest_framework.response import Response
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.models import Integration
-from sentry.utils.compat import filter
 
 
 class JiraSearchEndpoint(IntegrationEndpoint):
@@ -16,6 +15,19 @@ class JiraSearchEndpoint(IntegrationEndpoint):
         return Integration.objects.get(
             organizations=organization, id=integration_id, provider=self.provider
         )
+
+    def _get_formatted_user(self, id_field, user):
+        # The name field can be blank in jira-cloud, and the id_field varies by
+        # jira-cloud and jira-server
+        name = user.get("name", "")
+        email = user.get("emailAddress")
+
+        display = "%s %s%s" % (
+            user.get("displayName", name),
+            "- %s " % email if email else "",
+            "(%s)" % name if name else "",
+        )
+        return {"value": user[id_field], "label": display.strip()}
 
     def get(self, request, organization, integration_id):
         try:
@@ -54,8 +66,12 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             except (ApiUnauthorized, ApiError):
                 return Response({"detail": "Unable to fetch users from Jira"}, status=400)
 
-            user_tuples = filter(None, [jira_client.format_user(user) for user in response])
-            users = [{"value": user_id, "label": display} for user_id, display in user_tuples]
+            user_id_field = jira_client.user_id_field()
+            users = [
+                self._get_formatted_user(user_id_field, user)
+                for user in response
+                if user_id_field in user
+            ]
             return Response(users)
 
         # TODO(jess): handle other autocomplete urls

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -87,9 +87,9 @@ class VstsIssueSync(IssueSyncMixin):
 
         return default_item_type, item_tuples
 
-    def get_create_issue_config(self, group, user, **kwargs):
+    def get_create_issue_config(self, group, **kwargs):
         kwargs["link_referrer"] = "vsts_integration"
-        fields = super(VstsIssueSync, self).get_create_issue_config(group, user, **kwargs)
+        fields = super(VstsIssueSync, self).get_create_issue_config(group, **kwargs)
         # Azure/VSTS has BOTH projects and repositories. A project can have many repositories.
         # Workitems (issues) are associated with the project not the repository.
         default_project, project_choices = self.get_project_choices(group, **kwargs)

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -55,7 +55,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                     "name": provider.name,
                     "canAdd": provider.can_add,
                     "canDisable": provider.can_disable,
-                    "features": [f.value for f in provider.features],
+                    "features": sorted([f.value for f in provider.features]),
                     "aspects": provider.metadata.aspects,
                 },
                 "linkIssueConfig": [
@@ -95,7 +95,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                     "name": provider.name,
                     "canAdd": provider.can_add,
                     "canDisable": provider.can_disable,
-                    "features": [f.value for f in provider.features],
+                    "features": sorted([f.value for f in provider.features]),
                     "aspects": provider.metadata.aspects,
                 },
                 "createIssueConfig": [

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -141,7 +141,7 @@ class BitbucketIssueTest(APITestCase):
         }
         self.org_integration.save()
         installation = self.integration.get_installation(self.organization.id)
-        fields = installation.get_create_issue_config(self.group, self.user)
+        fields = installation.get_create_issue_config(self.group)
         for field in fields:
             if field["name"] == "repo":
                 repo_field = field
@@ -177,7 +177,7 @@ class BitbucketIssueTest(APITestCase):
         )
 
         installation = self.integration.get_installation(self.organization.id)
-        fields = installation.get_create_issue_config(self.group, self.user)
+        fields = installation.get_create_issue_config(self.group)
         repo_field = [field for field in fields if field["name"] == "repo"][0]
         assert repo_field["default"] == ""
         assert repo_field["choices"] == []
@@ -191,7 +191,7 @@ class BitbucketIssueTest(APITestCase):
         )
 
         installation = self.integration.get_installation(self.organization.id)
-        assert installation.get_create_issue_config(self.group, self.user) == [
+        assert installation.get_create_issue_config(self.group) == [
             {
                 "name": "repo",
                 "required": True,

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -186,7 +186,7 @@ class GitHubIssueBasicTest(TestCase):
             },
         )
 
-        resp = self.integration.get_create_issue_config(group=event.group, user=self.user)
+        resp = self.integration.get_create_issue_config(group=event.group)
         assert resp[0]["choices"] == [(u"getsentry/sentry", u"sentry")]
 
         responses.add(
@@ -197,7 +197,7 @@ class GitHubIssueBasicTest(TestCase):
 
         # create an issue
         data = {"params": {"repo": "getsentry/hello"}}
-        resp = self.integration.get_create_issue_config(group=event.group, user=self.user, **data)
+        resp = self.integration.get_create_issue_config(group=event.group, **data)
         assert resp[0]["choices"] == [
             (u"getsentry/hello", u"hello"),
             (u"getsentry/sentry", u"sentry"),
@@ -298,7 +298,7 @@ class GitHubIssueBasicTest(TestCase):
             }
         }
         org_integration.save()
-        fields = self.integration.get_create_issue_config(group, self.user)
+        fields = self.integration.get_create_issue_config(group)
         for field in fields:
             if field["name"] == "repo":
                 repo_field = field
@@ -339,7 +339,7 @@ class GitHubIssueBasicTest(TestCase):
         event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
         )
-        fields = self.integration.get_create_issue_config(event.group, self.user)
+        fields = self.integration.get_create_issue_config(event.group)
         repo_field = [field for field in fields if field["name"] == "repo"][0]
         assignee_field = [field for field in fields if field["name"] == "assignee"][0]
 

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -62,7 +62,7 @@ class GitlabIssuesTest(GitLabTestCase):
                 {"name_with_namespace": "getsentry / hello", "id": 22},
             ],
         )
-        assert self.installation.get_create_issue_config(self.group, self.user) == [
+        assert self.installation.get_create_issue_config(self.group) == [
             {
                 "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
                 "name": "project",
@@ -238,7 +238,7 @@ class GitlabIssuesTest(GitLabTestCase):
             u"https://example.gitlab.com/api/v4/projects/%s" % project_id,
             json={"path_with_namespace": project_name, "id": project_id},
         )
-        assert self.installation.get_create_issue_config(self.group, self.user) == [
+        assert self.installation.get_create_issue_config(self.group) == [
             {
                 "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
                 "name": "project",
@@ -302,7 +302,7 @@ class GitlabIssuesTest(GitLabTestCase):
             u"https://example.gitlab.com/api/v4/projects/%s" % project_id,
             json={"name_with_namespace": project_name, "id": project_id},
         )
-        assert self.installation.get_create_issue_config(self.group, self.user) == [
+        assert self.installation.get_create_issue_config(self.group) == [
             {
                 "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
                 "name": "project",
@@ -351,7 +351,7 @@ class GitlabIssuesTest(GitLabTestCase):
             % self.installation.model.metadata["group_id"],
             json=[],
         )
-        assert self.installation.get_create_issue_config(self.group, self.user) == [
+        assert self.installation.get_create_issue_config(self.group) == [
             {
                 "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
                 "name": "project",

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -474,7 +474,7 @@ class JiraIntegrationTest(APITestCase):
             return MockJiraApiClient()
 
         with mock.patch.object(installation, "get_client", get_client):
-            assert installation.get_create_issue_config(group, self.user) == [
+            assert installation.get_create_issue_config(group) == [
                 {
                     "default": "10000",
                     "choices": [("10000", "EX"), ("10001", "ABC")],
@@ -613,9 +613,7 @@ class JiraIntegrationTest(APITestCase):
             return MockJiraApiClient()
 
         with mock.patch.object(installation, "get_client", get_client):
-            fields = installation.get_create_issue_config(
-                group, self.user, params={"project": "10000"}
-            )
+            fields = installation.get_create_issue_config(group, params={"project": "10000"})
             project_field = [field for field in fields if field["name"] == "project"][0]
 
             assert project_field == {
@@ -650,7 +648,7 @@ class JiraIntegrationTest(APITestCase):
             return MockJiraApiClient()
 
         with mock.patch.object(installation, "get_client", get_client):
-            fields = installation.get_create_issue_config(group, self.user)
+            fields = installation.get_create_issue_config(group)
             project_field = [field for field in fields if field["name"] == "project"][0]
 
             assert project_field == {
@@ -687,7 +685,7 @@ class JiraIntegrationTest(APITestCase):
             return MockJiraApiClient()
 
         with mock.patch.object(installation, "get_client", get_client):
-            fields = installation.get_create_issue_config(group, self.user)
+            fields = installation.get_create_issue_config(group)
             label_field = [field for field in fields if field["name"] == "labels"][0]
 
             assert label_field == {
@@ -718,7 +716,7 @@ class JiraIntegrationTest(APITestCase):
             body="{}",
         )
         with pytest.raises(IntegrationError):
-            installation.get_create_issue_config(event.group, self.user)
+            installation.get_create_issue_config(event.group)
 
     @responses.activate
     def test_get_create_issue_config__no_issue_config(self):
@@ -750,7 +748,7 @@ class JiraIntegrationTest(APITestCase):
             body="",
         )
         with pytest.raises(IntegrationError):
-            installation.get_create_issue_config(event.group, self.user)
+            installation.get_create_issue_config(event.group)
 
     def test_get_link_issue_config(self):
         org = self.organization

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -564,7 +564,7 @@ class JiraIntegrationTest(APITestCase):
 
         with mock.patch.object(installation, "get_client", get_client):
             # Initially all fields are present
-            fields = installation.get_create_issue_config(group, self.user)
+            fields = installation.get_create_issue_config(group)
             field_names = [field["name"] for field in fields]
             assert field_names == [
                 "project",
@@ -579,7 +579,7 @@ class JiraIntegrationTest(APITestCase):
             installation.org_integration.config = {"issues_ignored_fields": ["customfield_10200"]}
             # After ignoring "customfield_10200", it no longer shows up
             installation.org_integration.save()
-            fields = installation.get_create_issue_config(group, self.user)
+            fields = installation.get_create_issue_config(group)
             field_names = [field["name"] for field in fields]
             assert field_names == [
                 "project",

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -148,26 +148,21 @@ class IssueDefaultTest(TestCase):
     def test_store_issue_last_defaults_partial_update(self):
         assert "project" in self.installation.get_persisted_default_config_fields()
         assert "issueType" in self.installation.get_persisted_default_config_fields()
-        self.installation.store_issue_last_defaults(
-            self.project, self.user, {"project": "xyz", "issueType": "BUG"}
-        )
-        self.installation.store_issue_last_defaults(
-            self.project, self.user, {"issueType": "FEATURE"}
-        )
+        self.installation.store_issue_last_defaults(1, {"project": "xyz", "issueType": "BUG"})
+        self.installation.store_issue_last_defaults(1, {"issueType": "FEATURE"})
         # {} is commonly triggered by "link issue" flow
-        self.installation.store_issue_last_defaults(self.project, self.user, {})
-        assert self.installation.get_project_defaults(self.project.id) == {
+        self.installation.store_issue_last_defaults(1, {})
+        assert self.installation.get_project_defaults(1) == {
             "project": "xyz",
             "issueType": "FEATURE",
         }
 
     def test_store_issue_last_defaults_multiple_projects(self):
         assert "project" in self.installation.get_persisted_default_config_fields()
-        other_project = self.create_project(name="Foo", slug="foo", teams=[self.team])
-        self.installation.store_issue_last_defaults(self.project, self.user, {"project": "xyz"})
-        self.installation.store_issue_last_defaults(other_project, self.user, {"project": "abc"})
-        assert self.installation.get_project_defaults(self.project.id) == {"project": "xyz"}
-        assert self.installation.get_project_defaults(other_project.id) == {"project": "abc"}
+        self.installation.store_issue_last_defaults(1, {"project": "xyz"})
+        self.installation.store_issue_last_defaults(2, {"project": "abc"})
+        assert self.installation.get_project_defaults(1) == {"project": "xyz"}
+        assert self.installation.get_project_defaults(2) == {"project": "abc"}
 
     def test_annotations(self):
         label = self.installation.get_issue_display_name(self.external_issue)

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -455,7 +455,7 @@ class VstsIssueFormTest(VstsIssueBase):
     def test_default_project(self):
         self.mock_categories("project-2-id")
         self.update_issue_defaults({"project": "project-2-id"})
-        fields = self.integration.get_create_issue_config(self.group, self.user)
+        fields = self.integration.get_create_issue_config(self.group)
 
         self.assert_project_field(
             fields, "project-2-id", [("project-1-id", "project_1"), ("project-2-id", "project_2")]
@@ -465,7 +465,7 @@ class VstsIssueFormTest(VstsIssueBase):
     def test_default_project_and_category(self):
         self.mock_categories("project-2-id")
         self.update_issue_defaults({"project": "project-2-id", "work_item_type": "Task"})
-        fields = self.integration.get_create_issue_config(self.group, self.user)
+        fields = self.integration.get_create_issue_config(self.group)
 
         self.assert_project_field(
             fields, "project-2-id", [("project-1-id", "project_1"), ("project-2-id", "project_2")]
@@ -491,7 +491,7 @@ class VstsIssueFormTest(VstsIssueBase):
             json={"id": "project-3-id", "name": "project_3"},
         )
         self.update_issue_defaults({"project": "project-3-id"})
-        fields = self.integration.get_create_issue_config(self.group, self.user)
+        fields = self.integration.get_create_issue_config(self.group)
 
         self.assert_project_field(
             fields,
@@ -511,7 +511,7 @@ class VstsIssueFormTest(VstsIssueBase):
             status=404,
         )
         self.update_issue_defaults({"project": "project-3-id"})
-        fields = self.integration.get_create_issue_config(self.group, self.user)
+        fields = self.integration.get_create_issue_config(self.group)
 
         self.assert_project_field(
             fields, None, [("project-1-id", "project_1"), ("project-2-id", "project_2")]
@@ -525,7 +525,7 @@ class VstsIssueFormTest(VstsIssueBase):
         )
 
         with pytest.raises(IntegrationError):
-            self.integration.get_create_issue_config(self.group, self.user)
+            self.integration.get_create_issue_config(self.group)
 
     @responses.activate
     def test_default_project_no_projects(self):
@@ -535,6 +535,6 @@ class VstsIssueFormTest(VstsIssueBase):
             "https://fabrikam-fiber-inc.visualstudio.com/_apis/projects",
             json={"value": [], "count": 0},
         )
-        fields = self.integration.get_create_issue_config(self.group, self.user)
+        fields = self.integration.get_create_issue_config(self.group)
 
         self.assert_project_field(fields, None, [])


### PR DESCRIPTION
This reverts https://github.com/getsentry/sentry/pull/21589 which is causing the following error:
`{"errorMessages":["Either the 'username' or the 'key' query parameters need to be provided"],"errors":{}}`

Sentry error here: https://sentry.io/share/issue/3532ee5963314ef9bc10d52c04420e42/

@saifelse  Feel free to make a follow-up PR that implements your original PR while handling this error.

Fixes SENTRY-JDS