### PR TITLE
feat(jira): Persist reporter field as a per-user default

### DIFF
--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -139,7 +139,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         else:
             external_issue.update(**defaults)
 
-        installation.store_issue_last_defaults(group.project_id, request.data)
+        installation.store_issue_last_defaults(group.project, request.user, request.data)
         try:
             installation.after_link_issue(external_issue, data=request.data)
         except IntegrationFormError as exc:
@@ -231,7 +231,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
                 user=request.user,
                 sender=self.__class__,
             )
-        installation.store_issue_last_defaults(group.project_id, request.data)
+        installation.store_issue_last_defaults(group.project, request.user, request.data)
 
         self.create_issue_activity(request, group, installation, external_issue)
 

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -143,7 +143,7 @@ class IntegrationIssueConfigSerializer(IntegrationSerializer):
             data["linkIssueConfig"] = config
 
         if self.action == "create":
-            config = installation.get_create_issue_config(self.group, params=self.params)
+            config = installation.get_create_issue_config(self.group, user, params=self.params)
             data["createIssueConfig"] = config
 
         return data

--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -28,9 +28,11 @@ class BitbucketIssueBasicMixin(IssueBasicMixin):
     def get_persisted_default_config_fields(self):
         return ["repo"]
 
-    def get_create_issue_config(self, group, **kwargs):
+    def get_create_issue_config(self, group, user, **kwargs):
         kwargs["link_referrer"] = "bitbucket_integration"
-        fields = super(BitbucketIssueBasicMixin, self).get_create_issue_config(group, **kwargs)
+        fields = super(BitbucketIssueBasicMixin, self).get_create_issue_config(
+            group, user, **kwargs
+        )
         default_repo, repo_choices = self.get_repository_choices(group, **kwargs)
 
         org = group.organization

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -76,9 +76,9 @@ class ExampleIntegration(IntegrationInstallation, IssueSyncMixin):
     def get_persisted_default_config_fields(self):
         return ["project", "issueType"]
 
-    def get_create_issue_config(self, group, **kwargs):
+    def get_create_issue_config(self, group, user, **kwargs):
         kwargs["link_referrer"] = "example_integration"
-        fields = super(ExampleIntegration, self).get_create_issue_config(group, **kwargs)
+        fields = super(ExampleIntegration, self).get_create_issue_config(group, user, **kwargs)
         default = self.get_project_defaults(group.project_id)
         example_project_field = self.generate_example_project_field(default)
         return fields + [example_project_field]

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -76,6 +76,9 @@ class ExampleIntegration(IntegrationInstallation, IssueSyncMixin):
     def get_persisted_default_config_fields(self):
         return ["project", "issueType"]
 
+    def get_persisted_user_default_config_fields(self):
+        return ["assignedTo", "reportedBy"]
+
     def get_create_issue_config(self, group, user, **kwargs):
         kwargs["link_referrer"] = "example_integration"
         fields = super(ExampleIntegration, self).get_create_issue_config(group, user, **kwargs)

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -39,9 +39,9 @@ class GitHubIssueBasic(IssueBasicMixin):
     def create_default_repo_choice(self, default_repo):
         return (default_repo, default_repo.split("/")[1])
 
-    def get_create_issue_config(self, group, **kwargs):
+    def get_create_issue_config(self, group, user, **kwargs):
         kwargs["link_referrer"] = "github_integration"
-        fields = super(GitHubIssueBasic, self).get_create_issue_config(group, **kwargs)
+        fields = super(GitHubIssueBasic, self).get_create_issue_config(group, user, **kwargs)
         default_repo, repo_choices = self.get_repository_choices(group, **kwargs)
 
         assignees = self.get_allowed_assignees(default_repo) if default_repo else []

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -40,10 +40,10 @@ class GitlabIssueBasic(IssueBasicMixin):
             return ("", "")
         return (project["id"], project["name_with_namespace"])
 
-    def get_create_issue_config(self, group, **kwargs):
+    def get_create_issue_config(self, group, user, **kwargs):
         default_project, project_choices = self.get_projects_and_default(group, **kwargs)
         kwargs["link_referrer"] = "gitlab_integration"
-        fields = super(GitlabIssueBasic, self).get_create_issue_config(group, **kwargs)
+        fields = super(GitlabIssueBasic, self).get_create_issue_config(group, user, **kwargs)
 
         org = group.organization
         autocomplete_url = reverse(

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -102,10 +102,6 @@ class IssueBasicMixin(object):
         """
         return []
 
-    def _get_defaults_user_option_key(self):
-        provider = self.org_integration.integration.provider
-        return "issues:defaults:{}".format(provider)
-
     def store_issue_last_defaults(self, project, user, data):
         """
         Stores the last used field defaults on a per-project basis. This
@@ -131,26 +127,20 @@ class IssueBasicMixin(object):
 
         user_persisted_fields = self.get_persisted_user_default_config_fields()
         if user_persisted_fields:
-            user_defaults = {}
-            defaults_user_option_key = self._get_defaults_user_option_key()
-            user_defaults.update(
-                UserOption.objects.get_value(
-                    user=user, key=defaults_user_option_key, default={}, project=project
-                )
+            user_defaults = {k: v for k, v in six.iteritems(data) if k in user_persisted_fields}
+            user_option_key = dict(user=user, key="issue:defaults", project=project)
+            new_user_defaults = UserOption.objects.get_value(default={}, **user_option_key)
+            new_user_defaults.setdefault(self.org_integration.integration.provider, {}).update(
+                user_defaults
             )
-            user_defaults.update(
-                {k: v for k, v in six.iteritems(data) if k in user_persisted_fields}
-            )
-            UserOption.objects.set_value(
-                user=user, key=defaults_user_option_key, value=user_defaults, project=project
-            )
+            UserOption.objects.set_value(value=new_user_defaults, **user_option_key)
 
     def get_defaults(self, project, user):
         project_defaults = self.get_project_defaults(project.id)
 
-        defaults_user_option_key = self._get_defaults_user_option_key()
-        user_defaults = UserOption.objects.get_value(
-            user=user, key=defaults_user_option_key, default={}, project=project
+        user_option_key = dict(user=user, key="issue:defaults", project=project)
+        user_defaults = UserOption.objects.get_value(default={}, **user_option_key).get(
+            self.org_integration.integration.provider, {}
         )
 
         defaults = {}

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -78,6 +78,7 @@ class JiraApiClient(ApiClient):
     SEARCH_URL = "/rest/api/2/search/"
     VERSIONS_URL = "/rest/api/2/project/%s/versions"
     USERS_URL = "/rest/api/2/user/assignable/search"
+    USER_URL = "/rest/api/2/user"
     SERVER_INFO_URL = "/rest/api/2/serverInfo"
     ASSIGN_URL = "/rest/api/2/issue/%s/assignee"
     TRANSITION_URL = "/rest/api/2/issue/%s/transitions"
@@ -198,6 +199,10 @@ class JiraApiClient(ApiClient):
             self.USERS_URL, params={"issueKey": issue_key, self.query_field(): email}
         )
 
+    def get_user(self, user_id):
+        user_id_field = self.user_id_field()
+        return self.get_cached(self.USER_URL, params={user_id_field: user_id})
+
     def create_issue(self, raw_form_data):
         data = {"fields": raw_form_data}
         return self.post(self.CREATE_URL, data=data)
@@ -221,3 +226,20 @@ class JiraApiClient(ApiClient):
     def get_email(self, account_id):
         user = self.get_cached(self.EMAIL_URL, params={"accountId": account_id})
         return user.get("email")
+
+    def format_user(self, user_response):
+        user_id_field = self.user_id_field()
+        if user_id_field not in user_response:
+            return None
+
+        # The name field can be blank in jira-cloud, and the id_field varies by
+        # jira-cloud and jira-server
+        name = user_response.get("name", "")
+        email = user_response.get("emailAddress")
+
+        display = "%s %s%s" % (
+            user_response.get("displayName", name),
+            "- %s " % email if email else "",
+            "(%s)" % name if name else "",
+        )
+        return user_response[user_id_field], display.strip()

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -235,20 +235,3 @@ class JiraApiClient(ApiClient):
     def get_email(self, account_id):
         user = self.get_cached(self.EMAIL_URL, params={"accountId": account_id})
         return user.get("email")
-
-    def format_user(self, user_response):
-        user_id_field = self.user_id_field()
-        if user_id_field not in user_response:
-            return None
-
-        # The name field can be blank in jira-cloud, and the id_field varies by
-        # jira-cloud and jira-server
-        name = user_response.get("name", "")
-        email = user_response.get("emailAddress")
-
-        display = "%s %s%s" % (
-            user_response.get("displayName", name),
-            "- %s " % email if email else "",
-            "(%s)" % name if name else "",
-        )
-        return user_response[user_id_field], display.strip()

--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -58,11 +58,17 @@ class JiraCloud(object):
         """
         return "accountId"
 
-    def query_field(self):
+    def user_query_param(self):
         """
         Jira-Cloud requires GDPR compliant API usage so we have to use query
         """
         return "query"
+
+    def user_id_get_param(self):
+        """
+        Jira-Cloud requires GDPR compliant API usage so we have to use accountId
+        """
+        return "accountId"
 
 
 class JiraApiClient(ApiClient):
@@ -117,11 +123,14 @@ class JiraApiClient(ApiClient):
         request_spec["headers"]["x-atlassian-force-account-id"] = "true"
         return self._request(**request_spec)
 
+    def user_id_get_param(self):
+        return self.jira_style.user_id_get_param()
+
     def user_id_field(self):
         return self.jira_style.user_id_field()
 
-    def query_field(self):
-        return self.jira_style.query_field()
+    def user_query_param(self):
+        return self.jira_style.user_query_param()
 
     def get_issue(self, issue_id):
         return self.get(self.ISSUE_URL % (issue_id,))
@@ -191,17 +200,17 @@ class JiraApiClient(ApiClient):
         # Jira Server wants a project key, while cloud is indifferent.
         project_key = self.get_project_key_for_id(project)
         return self.get_cached(
-            self.USERS_URL, params={"project": project_key, self.query_field(): username}
+            self.USERS_URL, params={"project": project_key, self.user_query_param(): username}
         )
 
     def search_users_for_issue(self, issue_key, email):
         return self.get_cached(
-            self.USERS_URL, params={"issueKey": issue_key, self.query_field(): email}
+            self.USERS_URL, params={"issueKey": issue_key, self.user_query_param(): email}
         )
 
     def get_user(self, user_id):
-        user_id_field = self.user_id_field()
-        return self.get_cached(self.USER_URL, params={user_id_field: user_id})
+        user_id_get_param = self.user_id_get_param()
+        return self.get_cached(self.USER_URL, params={user_id_get_param: user_id})
 
     def create_issue(self, raw_form_data):
         data = {"fields": raw_form_data}

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -535,12 +535,12 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             )
         return meta
 
-    def get_create_issue_config(self, group, **kwargs):
+    def get_create_issue_config(self, group, user, **kwargs):
         kwargs["link_referrer"] = "jira_integration"
-        fields = super(JiraIntegration, self).get_create_issue_config(group, **kwargs)
+        fields = super(JiraIntegration, self).get_create_issue_config(group, user, **kwargs)
         params = kwargs.get("params", {})
 
-        defaults = self.get_project_defaults(group.project_id)
+        defaults = self.get_defaults(group.project, user)
         project_id = params.get("project", defaults.get("project"))
         client = self.get_client()
         try:
@@ -639,6 +639,17 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 field["choices"] = self.make_choices(client.get_versions(meta["key"]))
             elif field["name"] == "labels":
                 field["default"] = defaults.get("labels", "")
+            elif field["name"] == "reporter":
+                reporter_id = defaults.get("reporter", "")
+                if not reporter_id:
+                    continue
+                reporter_info = client.get_user(reporter_id)
+                reporter_tuple = client.format_user(reporter_info)
+                if not reporter_tuple:
+                    continue
+                reporter_id, reporter_label = reporter_tuple
+                field["default"] = reporter_id
+                field["choices"] = [(reporter_id, reporter_label)]
 
         return fields
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -643,7 +643,11 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                 reporter_id = defaults.get("reporter", "")
                 if not reporter_id:
                     continue
-                reporter_info = client.get_user(reporter_id)
+                try:
+                    reporter_info = client.get_user(reporter_id)
+                except ApiError as exc:
+                    self.get_logger().exception(six.text_type(exc))
+                    continue
                 reporter_tuple = client.format_user(reporter_info)
                 if not reporter_tuple:
                     continue

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -30,6 +30,7 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.decorators import classproperty
 
 from .client import JiraApiClient, JiraCloud
+from .utils import build_user_choice
 
 logger = logging.getLogger("sentry.integrations.jira")
 
@@ -645,10 +646,18 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                     continue
                 try:
                     reporter_info = client.get_user(reporter_id)
-                except ApiError as exc:
-                    self.get_logger().exception(six.text_type(exc))
+                except ApiError as e:
+                    logger.info(
+                        "jira.get-create-issue-config.no-matching-reporter",
+                        extra={
+                            "integration_id": self.model.id,
+                            "organization_id": self.organization_id,
+                            "persisted_reporter_id": reporter_id,
+                            "error": six.text_type(e),
+                        },
+                    )
                     continue
-                reporter_tuple = client.format_user(reporter_info)
+                reporter_tuple = build_user_choice(reporter_info, client.user_id_field())
                 if not reporter_tuple:
                     continue
                 reporter_id, reporter_label = reporter_tuple

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.models import Integration
+from sentry.utils.compat import filter
 
 
 class JiraSearchEndpoint(IntegrationEndpoint):
@@ -15,19 +16,6 @@ class JiraSearchEndpoint(IntegrationEndpoint):
         return Integration.objects.get(
             organizations=organization, id=integration_id, provider=self.provider
         )
-
-    def _get_formatted_user(self, id_field, user):
-        # The name field can be blank in jira-cloud, and the id_field varies by
-        # jira-cloud and jira-server
-        name = user.get("name", "")
-        email = user.get("emailAddress")
-
-        display = "%s %s%s" % (
-            user.get("displayName", name),
-            "- %s " % email if email else "",
-            "(%s)" % name if name else "",
-        )
-        return {"value": user[id_field], "label": display.strip()}
 
     def get(self, request, organization, integration_id):
         try:
@@ -66,12 +54,8 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             except (ApiUnauthorized, ApiError):
                 return Response({"detail": "Unable to fetch users from Jira"}, status=400)
 
-            user_id_field = jira_client.user_id_field()
-            users = [
-                self._get_formatted_user(user_id_field, user)
-                for user in response
-                if user_id_field in user
-            ]
+            user_tuples = filter(None, [jira_client.format_user(user) for user in response])
+            users = [{"value": user_id, "label": display} for user_id, display in user_tuples]
             return Response(users)
 
         # TODO(jess): handle other autocomplete urls

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -8,6 +8,8 @@ from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, Int
 from sentry.models import Integration
 from sentry.utils.compat import filter
 
+from .utils import build_user_choice
+
 
 class JiraSearchEndpoint(IntegrationEndpoint):
     provider = "jira"
@@ -54,7 +56,9 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             except (ApiUnauthorized, ApiError):
                 return Response({"detail": "Unable to fetch users from Jira"}, status=400)
 
-            user_tuples = filter(None, [jira_client.format_user(user) for user in response])
+            user_tuples = filter(
+                None, [build_user_choice(user, jira_client.user_id_field()) for user in response]
+            )
             users = [{"value": user_id, "label": display} for user_id, display in user_tuples]
             return Response(users)
 

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -1,0 +1,22 @@
+from __future__ import absolute_import
+
+
+def build_user_choice(user_response, user_id_field):
+    """
+    Build an (id, label) tuple from the given Jira REST API User resource,
+    or return None if a tuple could not be built.
+    """
+    if user_id_field not in user_response:
+        return None
+
+    # The name field can be blank in jira-cloud, and the id_field varies by
+    # jira-cloud and jira-server
+    name = user_response.get("name", "")
+    email = user_response.get("emailAddress")
+
+    display = "%s %s%s" % (
+        user_response.get("displayName", name),
+        "- %s " % email if email else "",
+        "(%s)" % name if name else "",
+    )
+    return user_response[user_id_field], display.strip()

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -148,8 +148,14 @@ class JiraServer(object):
         """
         return "name"
 
-    def query_field(self):
+    def user_query_param(self):
         """
         Jira-Server doesn't require GDPR compliant API usage so we can use `username`
+        """
+        return "username"
+
+    def user_id_get_param(self):
+        """
+        Jira-Server doesn't require compliant API usage so we can use `username
         """
         return "username"

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -87,9 +87,9 @@ class VstsIssueSync(IssueSyncMixin):
 
         return default_item_type, item_tuples
 
-    def get_create_issue_config(self, group, **kwargs):
+    def get_create_issue_config(self, group, user, **kwargs):
         kwargs["link_referrer"] = "vsts_integration"
-        fields = super(VstsIssueSync, self).get_create_issue_config(group, **kwargs)
+        fields = super(VstsIssueSync, self).get_create_issue_config(group, user, **kwargs)
         # Azure/VSTS has BOTH projects and repositories. A project can have many repositories.
         # Workitems (issues) are associated with the project not the repository.
         default_project, project_choices = self.get_project_choices(group, **kwargs)

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -55,7 +55,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                     "name": provider.name,
                     "canAdd": provider.can_add,
                     "canDisable": provider.can_disable,
-                    "features": sorted([f.value for f in provider.features]),
+                    "features": [f.value for f in provider.features],
                     "aspects": provider.metadata.aspects,
                 },
                 "linkIssueConfig": [
@@ -95,7 +95,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                     "name": provider.name,
                     "canAdd": provider.can_add,
                     "canDisable": provider.can_disable,
-                    "features": sorted([f.value for f in provider.features]),
+                    "features": [f.value for f in provider.features],
                     "aspects": provider.metadata.aspects,
                 },
                 "createIssueConfig": [

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -55,7 +55,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                     "name": provider.name,
                     "canAdd": provider.can_add,
                     "canDisable": provider.can_disable,
-                    "features": [f.value for f in provider.features],
+                    "features": sorted([f.value for f in provider.features]),
                     "aspects": provider.metadata.aspects,
                 },
                 "linkIssueConfig": [
@@ -95,7 +95,7 @@ class GroupIntegrationDetailsTest(APITestCase):
                     "name": provider.name,
                     "canAdd": provider.can_add,
                     "canDisable": provider.can_disable,
-                    "features": [f.value for f in provider.features],
+                    "features": sorted([f.value for f in provider.features]),
                     "aspects": provider.metadata.aspects,
                 },
                 "createIssueConfig": [

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -141,7 +141,7 @@ class BitbucketIssueTest(APITestCase):
         }
         self.org_integration.save()
         installation = self.integration.get_installation(self.organization.id)
-        fields = installation.get_create_issue_config(self.group)
+        fields = installation.get_create_issue_config(self.group, self.user)
         for field in fields:
             if field["name"] == "repo":
                 repo_field = field
@@ -177,7 +177,7 @@ class BitbucketIssueTest(APITestCase):
         )
 
         installation = self.integration.get_installation(self.organization.id)
-        fields = installation.get_create_issue_config(self.group)
+        fields = installation.get_create_issue_config(self.group, self.user)
         repo_field = [field for field in fields if field["name"] == "repo"][0]
         assert repo_field["default"] == ""
         assert repo_field["choices"] == []
@@ -191,7 +191,7 @@ class BitbucketIssueTest(APITestCase):
         )
 
         installation = self.integration.get_installation(self.organization.id)
-        assert installation.get_create_issue_config(self.group) == [
+        assert installation.get_create_issue_config(self.group, self.user) == [
             {
                 "name": "repo",
                 "required": True,

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -186,7 +186,7 @@ class GitHubIssueBasicTest(TestCase):
             },
         )
 
-        resp = self.integration.get_create_issue_config(group=event.group)
+        resp = self.integration.get_create_issue_config(group=event.group, user=self.user)
         assert resp[0]["choices"] == [(u"getsentry/sentry", u"sentry")]
 
         responses.add(
@@ -197,7 +197,7 @@ class GitHubIssueBasicTest(TestCase):
 
         # create an issue
         data = {"params": {"repo": "getsentry/hello"}}
-        resp = self.integration.get_create_issue_config(group=event.group, **data)
+        resp = self.integration.get_create_issue_config(group=event.group, user=self.user, **data)
         assert resp[0]["choices"] == [
             (u"getsentry/hello", u"hello"),
             (u"getsentry/sentry", u"sentry"),
@@ -298,7 +298,7 @@ class GitHubIssueBasicTest(TestCase):
             }
         }
         org_integration.save()
-        fields = self.integration.get_create_issue_config(group)
+        fields = self.integration.get_create_issue_config(group, self.user)
         for field in fields:
             if field["name"] == "repo":
                 repo_field = field
@@ -339,7 +339,7 @@ class GitHubIssueBasicTest(TestCase):
         event = self.store_event(
             data={"event_id": "a" * 32, "timestamp": self.min_ago}, project_id=self.project.id
         )
-        fields = self.integration.get_create_issue_config(event.group)
+        fields = self.integration.get_create_issue_config(event.group, self.user)
         repo_field = [field for field in fields if field["name"] == "repo"][0]
         assignee_field = [field for field in fields if field["name"] == "assignee"][0]
 

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -62,7 +62,7 @@ class GitlabIssuesTest(GitLabTestCase):
                 {"name_with_namespace": "getsentry / hello", "id": 22},
             ],
         )
-        assert self.installation.get_create_issue_config(self.group) == [
+        assert self.installation.get_create_issue_config(self.group, self.user) == [
             {
                 "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
                 "name": "project",
@@ -238,7 +238,7 @@ class GitlabIssuesTest(GitLabTestCase):
             u"https://example.gitlab.com/api/v4/projects/%s" % project_id,
             json={"path_with_namespace": project_name, "id": project_id},
         )
-        assert self.installation.get_create_issue_config(self.group) == [
+        assert self.installation.get_create_issue_config(self.group, self.user) == [
             {
                 "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
                 "name": "project",
@@ -302,7 +302,7 @@ class GitlabIssuesTest(GitLabTestCase):
             u"https://example.gitlab.com/api/v4/projects/%s" % project_id,
             json={"name_with_namespace": project_name, "id": project_id},
         )
-        assert self.installation.get_create_issue_config(self.group) == [
+        assert self.installation.get_create_issue_config(self.group, self.user) == [
             {
                 "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
                 "name": "project",
@@ -351,7 +351,7 @@ class GitlabIssuesTest(GitLabTestCase):
             % self.installation.model.metadata["group_id"],
             json=[],
         )
-        assert self.installation.get_create_issue_config(self.group) == [
+        assert self.installation.get_create_issue_config(self.group, self.user) == [
             {
                 "url": "/extensions/gitlab/search/baz/%d/" % self.installation.model.id,
                 "name": "project",

--- a/tests/sentry/integrations/jira/__init__.py
+++ b/tests/sentry/integrations/jira/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -474,7 +474,7 @@ class JiraIntegrationTest(APITestCase):
             return MockJiraApiClient()
 
         with mock.patch.object(installation, "get_client", get_client):
-            assert installation.get_create_issue_config(group) == [
+            assert installation.get_create_issue_config(group, self.user) == [
                 {
                     "default": "10000",
                     "choices": [("10000", "EX"), ("10001", "ABC")],
@@ -564,7 +564,7 @@ class JiraIntegrationTest(APITestCase):
 
         with mock.patch.object(installation, "get_client", get_client):
             # Initially all fields are present
-            fields = installation.get_create_issue_config(group)
+            fields = installation.get_create_issue_config(group, self.user)
             field_names = [field["name"] for field in fields]
             assert field_names == [
                 "project",
@@ -579,7 +579,7 @@ class JiraIntegrationTest(APITestCase):
             installation.org_integration.config = {"issues_ignored_fields": ["customfield_10200"]}
             # After ignoring "customfield_10200", it no longer shows up
             installation.org_integration.save()
-            fields = installation.get_create_issue_config(group)
+            fields = installation.get_create_issue_config(group, self.user)
             field_names = [field["name"] for field in fields]
             assert field_names == [
                 "project",
@@ -613,7 +613,9 @@ class JiraIntegrationTest(APITestCase):
             return MockJiraApiClient()
 
         with mock.patch.object(installation, "get_client", get_client):
-            fields = installation.get_create_issue_config(group, params={"project": "10000"})
+            fields = installation.get_create_issue_config(
+                group, self.user, params={"project": "10000"}
+            )
             project_field = [field for field in fields if field["name"] == "project"][0]
 
             assert project_field == {
@@ -648,7 +650,7 @@ class JiraIntegrationTest(APITestCase):
             return MockJiraApiClient()
 
         with mock.patch.object(installation, "get_client", get_client):
-            fields = installation.get_create_issue_config(group)
+            fields = installation.get_create_issue_config(group, self.user)
             project_field = [field for field in fields if field["name"] == "project"][0]
 
             assert project_field == {
@@ -685,7 +687,7 @@ class JiraIntegrationTest(APITestCase):
             return MockJiraApiClient()
 
         with mock.patch.object(installation, "get_client", get_client):
-            fields = installation.get_create_issue_config(group)
+            fields = installation.get_create_issue_config(group, self.user)
             label_field = [field for field in fields if field["name"] == "labels"][0]
 
             assert label_field == {
@@ -716,7 +718,7 @@ class JiraIntegrationTest(APITestCase):
             body="{}",
         )
         with pytest.raises(IntegrationError):
-            installation.get_create_issue_config(event.group)
+            installation.get_create_issue_config(event.group, self.user)
 
     @responses.activate
     def test_get_create_issue_config__no_issue_config(self):
@@ -748,7 +750,7 @@ class JiraIntegrationTest(APITestCase):
             body="",
         )
         with pytest.raises(IntegrationError):
-            installation.get_create_issue_config(event.group)
+            installation.get_create_issue_config(event.group, self.user)
 
     def test_get_link_issue_config(self):
         org = self.organization

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -12,7 +12,7 @@ from exam import fixture
 from sentry.utils.compat.mock import Mock
 
 from sentry.integrations.jira import JiraIntegrationProvider
-from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.models import (
     ExternalIssue,
     Integration,
@@ -26,6 +26,7 @@ from sentry.utils.signing import sign
 from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.testutils.helpers.datetime import iso_format, before_now
 
+from .testutils import EXAMPLE_JIRA_CLOUD_USER
 
 SAMPLE_CREATE_META_RESPONSE = """
 {
@@ -99,6 +100,20 @@ SAMPLE_CREATE_META_RESPONSE = """
                 {"value": "Feature 1", "id": "10105"},
                 {"value": "Feature 2", "id": "10106"}
               ]
+            },
+            "reporter": {
+              "operations": [
+                "set"
+              ],
+              "name": "Reporter",
+              "required": true,
+              "autoCompleteUrl": "https://saifelse.atlassian.net/rest/api/2/user/search?query=",
+              "hasDefaultValue": true,
+              "key": "reporter",
+              "schema": {
+                "type": "user",
+                "system": "reporter"
+              }
             }
           }
         }
@@ -433,6 +448,12 @@ class MockJiraApiClient(object):
     def user_id_field(self):
         return "accountId"
 
+    def get_user(self, user_id):
+        user = json.loads(EXAMPLE_JIRA_CLOUD_USER)
+        if user["accountId"] == user_id:
+            return user
+        raise ApiError("no user found")
+
 
 class JiraIntegrationTest(APITestCase):
     @fixture
@@ -542,7 +563,69 @@ class JiraIntegrationTest(APITestCase):
                     "default": "",
                     "choices": [("Feature 1", "Feature 1"), ("Feature 2", "Feature 2")],
                 },
+                {
+                    "choices": [],
+                    "label": "Reporter",
+                    "name": "reporter",
+                    "required": True,
+                    "url": reverse(
+                        "sentry-extensions-jira-search", args=[org.slug, self.integration.id]
+                    ),
+                    "type": "select",
+                },
             ]
+
+    def test_get_create_issue_config_with_persisted_reporter(self):
+        org = self.organization
+        self.login_as(self.user)
+        event = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "message",
+                "timestamp": self.min_ago,
+                "stacktrace": copy.deepcopy(DEFAULT_EVENT_DATA["stacktrace"]),
+            },
+            project_id=self.project.id,
+        )
+        group = event.group
+        installation = self.integration.get_installation(org.id)
+
+        def get_client():
+            return MockJiraApiClient()
+
+        # When persisted reporter matches a user JIRA knows about, a default is picked.
+        installation.store_issue_last_defaults(
+            self.project, self.user, {"reporter": json.loads(EXAMPLE_JIRA_CLOUD_USER)["accountId"]}
+        )
+        with mock.patch.object(installation, "get_client", get_client):
+            create_issue_config = installation.get_create_issue_config(group, self.user)
+        reporter_field = [field for field in create_issue_config if field["name"] == "reporter"][0]
+        assert reporter_field == {
+            "name": "reporter",
+            "url": reverse("sentry-extensions-jira-search", args=[org.slug, self.integration.id]),
+            "required": True,
+            "choices": [("012345:00000000-1111-2222-3333-444444444444", "Saif Hakim")],
+            "default": "012345:00000000-1111-2222-3333-444444444444",
+            "label": "Reporter",
+            "type": "select",
+        }
+
+        # When persisted reporter does not match a user JIRA knows about, field is left blank.
+        installation.store_issue_last_defaults(
+            self.project, self.user, {"reporter": "invalid-reporter-id"}
+        )
+
+        with mock.patch.object(installation, "get_client", get_client):
+            create_issue_config = installation.get_create_issue_config(group, self.user)
+        reporter_field = [field for field in create_issue_config if field["name"] == "reporter"][0]
+        assert reporter_field == {
+            "name": "reporter",
+            "url": reverse("sentry-extensions-jira-search", args=[org.slug, self.integration.id]),
+            "required": True,
+            "choices": [],
+            "label": "Reporter",
+            "type": "select",
+        }
 
     def test_get_create_issue_config_with_ignored_fields(self):
         org = self.organization
@@ -574,6 +657,7 @@ class JiraIntegrationTest(APITestCase):
                 "labels",
                 "customfield_10200",
                 "customfield_10300",
+                "reporter",
             ]
 
             installation.org_integration.config = {"issues_ignored_fields": ["customfield_10200"]}
@@ -588,6 +672,7 @@ class JiraIntegrationTest(APITestCase):
                 "issuetype",
                 "labels",
                 "customfield_10300",
+                "reporter",
             ]
 
     def test_get_create_issue_config_with_default_and_param(self):

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -8,7 +8,7 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.integrations.jira.notify_action import JiraCreateTicketAction
 from sentry.models import ExternalIssue, Rule
 
-from test_integration import SAMPLE_CREATE_META_RESPONSE, SAMPLE_GET_ISSUE_RESPONSE
+from .test_integration import SAMPLE_CREATE_META_RESPONSE, SAMPLE_GET_ISSUE_RESPONSE
 
 
 class JiraCreateTicketActionTest(RuleTestCase):

--- a/tests/sentry/integrations/jira/test_utils.py
+++ b/tests/sentry/integrations/jira/test_utils.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+
+from sentry.integrations.jira.utils import build_user_choice
+from sentry.testutils import TestCase
+from sentry.utils import json
+from .testutils import EXAMPLE_JIRA_SERVER_USER, EXAMPLE_JIRA_CLOUD_USER
+
+
+class BuildUserChoiceTest(TestCase):
+    def test_jira_server(self):
+        user_response = json.loads(EXAMPLE_JIRA_SERVER_USER)
+        assert build_user_choice(user_response, user_id_field="name") == (
+            "bob",
+            "Bobby - bob@example.org (bob)",
+        )
+
+    def test_jira_cloud(self):
+        user_response = json.loads(EXAMPLE_JIRA_CLOUD_USER)
+        assert build_user_choice(user_response, user_id_field="accountId") == (
+            "012345:00000000-1111-2222-3333-444444444444",
+            "Saif Hakim",
+        )
+
+    def test_unexpected_id(self):
+        user_response = json.loads(EXAMPLE_JIRA_CLOUD_USER)
+        assert build_user_choice(user_response, user_id_field="name") is None

--- a/tests/sentry/integrations/jira/testutils.py
+++ b/tests/sentry/integrations/jira/testutils.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import
+
+
+EXAMPLE_JIRA_SERVER_USER = """
+{
+    "name": "bob",
+    "displayName": "Bobby",
+    "emailAddress": "bob@example.org"
+}
+"""
+
+
+EXAMPLE_JIRA_CLOUD_USER = """
+{
+  "active": true,
+  "avatarUrls": {
+    "24x24": "https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAB-6.png",
+    "16x16": "https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAB-6.png",
+    "48x48": "https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAB-6.png",
+    "32x32": "https://secure.gravatar.com/avatar/0123456789abcdef0123456789abcdef?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FAB-6.png"
+  },
+  "displayName": "Saif Hakim",
+  "accountType": "atlassian",
+  "timeZone": "America/Los_Angeles",
+  "locale": "en_US",
+  "emailAddress": "",
+  "self": "https://example.atlassian.net/rest/api/2/user?accountId=012345:00000000-1111-2222-3333-444444444444",
+  "accountId": "012345:00000000-1111-2222-3333-444444444444"
+}
+"""

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -148,21 +148,26 @@ class IssueDefaultTest(TestCase):
     def test_store_issue_last_defaults_partial_update(self):
         assert "project" in self.installation.get_persisted_default_config_fields()
         assert "issueType" in self.installation.get_persisted_default_config_fields()
-        self.installation.store_issue_last_defaults(1, {"project": "xyz", "issueType": "BUG"})
-        self.installation.store_issue_last_defaults(1, {"issueType": "FEATURE"})
+        self.installation.store_issue_last_defaults(
+            self.project, self.user, {"project": "xyz", "issueType": "BUG"}
+        )
+        self.installation.store_issue_last_defaults(
+            self.project, self.user, {"issueType": "FEATURE"}
+        )
         # {} is commonly triggered by "link issue" flow
-        self.installation.store_issue_last_defaults(1, {})
-        assert self.installation.get_project_defaults(1) == {
+        self.installation.store_issue_last_defaults(self.project, self.user, {})
+        assert self.installation.get_project_defaults(self.project.id) == {
             "project": "xyz",
             "issueType": "FEATURE",
         }
 
     def test_store_issue_last_defaults_multiple_projects(self):
         assert "project" in self.installation.get_persisted_default_config_fields()
-        self.installation.store_issue_last_defaults(1, {"project": "xyz"})
-        self.installation.store_issue_last_defaults(2, {"project": "abc"})
-        assert self.installation.get_project_defaults(1) == {"project": "xyz"}
-        assert self.installation.get_project_defaults(2) == {"project": "abc"}
+        other_project = self.create_project(name="Foo", slug="foo", teams=[self.team])
+        self.installation.store_issue_last_defaults(self.project, self.user, {"project": "xyz"})
+        self.installation.store_issue_last_defaults(other_project, self.user, {"project": "abc"})
+        assert self.installation.get_project_defaults(self.project.id) == {"project": "xyz"}
+        assert self.installation.get_project_defaults(other_project.id) == {"project": "abc"}
 
     def test_annotations(self):
         label = self.installation.get_issue_display_name(self.external_issue)

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -455,7 +455,7 @@ class VstsIssueFormTest(VstsIssueBase):
     def test_default_project(self):
         self.mock_categories("project-2-id")
         self.update_issue_defaults({"project": "project-2-id"})
-        fields = self.integration.get_create_issue_config(self.group)
+        fields = self.integration.get_create_issue_config(self.group, self.user)
 
         self.assert_project_field(
             fields, "project-2-id", [("project-1-id", "project_1"), ("project-2-id", "project_2")]
@@ -465,7 +465,7 @@ class VstsIssueFormTest(VstsIssueBase):
     def test_default_project_and_category(self):
         self.mock_categories("project-2-id")
         self.update_issue_defaults({"project": "project-2-id", "work_item_type": "Task"})
-        fields = self.integration.get_create_issue_config(self.group)
+        fields = self.integration.get_create_issue_config(self.group, self.user)
 
         self.assert_project_field(
             fields, "project-2-id", [("project-1-id", "project_1"), ("project-2-id", "project_2")]
@@ -491,7 +491,7 @@ class VstsIssueFormTest(VstsIssueBase):
             json={"id": "project-3-id", "name": "project_3"},
         )
         self.update_issue_defaults({"project": "project-3-id"})
-        fields = self.integration.get_create_issue_config(self.group)
+        fields = self.integration.get_create_issue_config(self.group, self.user)
 
         self.assert_project_field(
             fields,
@@ -511,7 +511,7 @@ class VstsIssueFormTest(VstsIssueBase):
             status=404,
         )
         self.update_issue_defaults({"project": "project-3-id"})
-        fields = self.integration.get_create_issue_config(self.group)
+        fields = self.integration.get_create_issue_config(self.group, self.user)
 
         self.assert_project_field(
             fields, None, [("project-1-id", "project_1"), ("project-2-id", "project_2")]
@@ -525,7 +525,7 @@ class VstsIssueFormTest(VstsIssueBase):
         )
 
         with pytest.raises(IntegrationError):
-            self.integration.get_create_issue_config(self.group)
+            self.integration.get_create_issue_config(self.group, self.user)
 
     @responses.activate
     def test_default_project_no_projects(self):
@@ -535,6 +535,6 @@ class VstsIssueFormTest(VstsIssueBase):
             "https://fabrikam-fiber-inc.visualstudio.com/_apis/projects",
             json={"value": [], "count": 0},
         )
-        fields = self.integration.get_create_issue_config(self.group)
+        fields = self.integration.get_create_issue_config(self.group, self.user)
 
         self.assert_project_field(fields, None, [])


### PR DESCRIPTION
This is a re-application of #21589, which was reverted via #21853 due to
incorrect handling of Jira Server. The REST API for Jira Server shows that
the /rest/api/2/user endpoint expects the parameter `username` not
`name`, despite the field on the User object being `name`:
https://docs.atlassian.com/software/jira/docs/api/REST/8.13.1/#api/2/user-getUser
The API is also now called defensively to avoid breaking the integration
in case there are cases where this is incorrect.

In addition to fixing this bug, instead of using a `UserOption` with a dynamic
key, the static key "issue:defaults" is used but the value scopes the
integration by keying the defaults on the provider. E.g. for `JiraIntegration`,
a user may have the `UserOption(key="issue:defaults")` with value
`{"jira": {"reporter": "userid"}}`

Resolves #21588