### PR TITLE
feat(grouping): Trim C# unity function names

### DIFF
--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -100,8 +100,27 @@ def trim_function_name(function, platform, normalize_lambdas=True):
     a trimmed version that can be stored in `function_name`.  This is only used
     if the client did not supply a value itself already.
     """
-    if get_behavior_family_for_platform(platform) != "native":
-        return function
+    if platform == "csharp":
+        return trim_csharp_function_name(function)
+    if get_behavior_family_for_platform(platform) == "native":
+        return trim_native_function_name(function, normalize_lambdas=normalize_lambdas)
+    return function
+
+
+def trim_csharp_function_name(function):
+    """This trims off signatures from C# frames.  This takes advantage of the
+    Unity not emitting any return values and using a space before the argument
+    list.
+
+    Note that there is disagreement between Unity and the main .NET SDK about
+    the function names.  The Unity SDK emits the entire function with module
+    in the `function` name similar to native, the .NET SDK emits it in individual
+    parts of the frame.
+    """
+    return function.split(" (", 1)[0]
+
+
+def trim_native_function_name(function, normalize_lambdas=True):
     if function in ("<redacted>", "<unknown>"):
         return function
 

--- a/tests/sentry/grouping/grouping_inputs/unity.json
+++ b/tests/sentry/grouping/grouping_inputs/unity.json
@@ -1,0 +1,87 @@
+{
+  "culprit": "SampleScript.cs in SampleScript.ThrowNull ()",
+  "event_id": "0462551de2bd442bb938fb8c282c5359",
+  "environment": "production",
+  "platform": "csharp",
+  "logger": "",
+  "fingerprint": [
+    "{{ default }}"
+  ],
+  "exception": {
+    "values": [
+      {
+        "stacktrace": {
+          "frames": [
+            {
+              "function": "UnityEngine.EventSystems.EventSystem:Update",
+              "raw_function": "UnityEngine.EventSystems.EventSystem:Update()",
+              "abs_path": "/Applications/Unity/Hub/Editor/2019.4.11f1/Unity.app/Contents/Resources/PackageManager/BuiltInPackages/com.unity.ugui/Runtime/EventSystem/EventSystem.cs",
+              "filename": "EventSystem.cs",
+              "lineno": 377,
+              "in_app": false
+            },
+            {
+              "function": "UnityEngine.EventSystems.ExecuteEvents.Execute[T]",
+              "raw_function": "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)",
+              "abs_path": "/Applications/Unity/Hub/Editor/2019.4.11f1/Unity.app/Contents/Resources/PackageManager/BuiltInPackages/com.unity.ugui/Runtime/EventSystem/ExecuteEvents.cs",
+              "filename": "ExecuteEvents.cs",
+              "lineno": 261,
+              "in_app": false
+            },
+            {
+              "function": "UnityEngine.EventSystems.ExecuteEvents.Execute",
+              "raw_function": "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)",
+              "abs_path": "/Applications/Unity/Hub/Editor/2019.4.11f1/Unity.app/Contents/Resources/PackageManager/BuiltInPackages/com.unity.ugui/Runtime/EventSystem/ExecuteEvents.cs",
+              "filename": "ExecuteEvents.cs",
+              "lineno": 50,
+              "in_app": false
+            },
+            {
+              "function": "UnityEngine.UI.Button.OnPointerClick",
+              "raw_function": "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)",
+              "abs_path": "/Applications/Unity/Hub/Editor/2019.4.11f1/Unity.app/Contents/Resources/PackageManager/BuiltInPackages/com.unity.ugui/Runtime/UI/Core/Button.cs",
+              "filename": "Button.cs",
+              "lineno": 110,
+              "in_app": false
+            },
+            {
+              "function": "UnityEngine.UI.Button.Press",
+              "raw_function": "UnityEngine.UI.Button.Press ()",
+              "abs_path": "/Applications/Unity/Hub/Editor/2019.4.11f1/Unity.app/Contents/Resources/PackageManager/BuiltInPackages/com.unity.ugui/Runtime/UI/Core/Button.cs",
+              "filename": "Button.cs",
+              "lineno": 68,
+              "in_app": false
+            },
+            {
+              "function": "UnityEngine.Events.UnityEvent.Invoke",
+              "raw_function": "UnityEngine.Events.UnityEvent.Invoke ()",
+              "abs_path": "/Users/bokken/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent/UnityEvent_0.cs",
+              "filename": "UnityEvent_0.cs",
+              "lineno": 58,
+              "in_app": false
+            },
+            {
+              "function": "UnityEngine.Events.InvokableCall.Invoke",
+              "raw_function": "UnityEngine.Events.InvokableCall.Invoke ()",
+              "abs_path": "/Users/bokken/buildslave/unity/build/Runtime/Export/UnityEvent/UnityEvent.cs",
+              "filename": "UnityEvent.cs",
+              "lineno": 166,
+              "in_app": false
+            },
+            {
+              "function": "SampleScript.ThrowNull",
+              "raw_function": "SampleScript.ThrowNull ()",
+              "abs_path": "Assets/SampleScript.cs",
+              "filename": "SampleScript.cs",
+              "lineno": 123,
+              "in_app": true
+            }
+          ]
+        },
+        "type": "NullReferenceException",
+        "value": "Object reference not set to an instance of an object"
+      }
+    ]
+  },
+  "release": "0.1"
+}

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/unity.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/unity.pysnap
@@ -1,0 +1,61 @@
+---
+created: '2020-11-08T21:03:24.490578Z'
+creator: sentry
+source: tests/sentry/grouping/similarity/test_features.py
+---
+similarity:2020-07-23:stacktrace:frames-ident: [["filename","samplescript.cs"],["function","SampleScript.ThrowNull ()"]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","button.cs"],["function","UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"]],[["filename","button.cs"],["function","UnityEngine.UI.Button.Press ()"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","button.cs"],["function","UnityEngine.UI.Button.Press ()"]],[["filename","unityevent_0.cs"],["function","UnityEngine.Events.UnityEvent.Invoke ()"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","eventsystem.cs"],["function","UnityEngine.EventSystems.EventSystem:Update()"]],[["filename","executeevents.cs"],["function","UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","executeevents.cs"],["function","UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"]],[["filename","button.cs"],["function","UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","executeevents.cs"],["function","UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"]],[["filename","executeevents.cs"],["function","UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","unityevent.cs"],["function","UnityEngine.Events.InvokableCall.Invoke ()"]],[["filename","samplescript.cs"],["function","SampleScript.ThrowNull ()"]]]
+similarity:2020-07-23:stacktrace:frames-pairs: [[["filename","unityevent_0.cs"],["function","UnityEngine.Events.UnityEvent.Invoke ()"]],[["filename","unityevent.cs"],["function","UnityEngine.Events.InvokableCall.Invoke ()"]]]
+similarity:2020-07-23:type:ident-shingle: "NullReferenceException"
+similarity:2020-07-23:value:character-5-shingle: " an i"
+similarity:2020-07-23:value:character-5-shingle: " an o"
+similarity:2020-07-23:value:character-5-shingle: " inst"
+similarity:2020-07-23:value:character-5-shingle: " not "
+similarity:2020-07-23:value:character-5-shingle: " obje"
+similarity:2020-07-23:value:character-5-shingle: " of a"
+similarity:2020-07-23:value:character-5-shingle: " refe"
+similarity:2020-07-23:value:character-5-shingle: " set "
+similarity:2020-07-23:value:character-5-shingle: " to a"
+similarity:2020-07-23:value:character-5-shingle: "Objec"
+similarity:2020-07-23:value:character-5-shingle: "an in"
+similarity:2020-07-23:value:character-5-shingle: "an ob"
+similarity:2020-07-23:value:character-5-shingle: "ance "
+similarity:2020-07-23:value:character-5-shingle: "bject"
+similarity:2020-07-23:value:character-5-shingle: "ce no"
+similarity:2020-07-23:value:character-5-shingle: "ce of"
+similarity:2020-07-23:value:character-5-shingle: "ct re"
+similarity:2020-07-23:value:character-5-shingle: "e not"
+similarity:2020-07-23:value:character-5-shingle: "e of "
+similarity:2020-07-23:value:character-5-shingle: "ect r"
+similarity:2020-07-23:value:character-5-shingle: "efere"
+similarity:2020-07-23:value:character-5-shingle: "ence "
+similarity:2020-07-23:value:character-5-shingle: "erenc"
+similarity:2020-07-23:value:character-5-shingle: "et to"
+similarity:2020-07-23:value:character-5-shingle: "f an "
+similarity:2020-07-23:value:character-5-shingle: "feren"
+similarity:2020-07-23:value:character-5-shingle: "insta"
+similarity:2020-07-23:value:character-5-shingle: "ject "
+similarity:2020-07-23:value:character-5-shingle: "n ins"
+similarity:2020-07-23:value:character-5-shingle: "n obj"
+similarity:2020-07-23:value:character-5-shingle: "nce n"
+similarity:2020-07-23:value:character-5-shingle: "nce o"
+similarity:2020-07-23:value:character-5-shingle: "not s"
+similarity:2020-07-23:value:character-5-shingle: "nstan"
+similarity:2020-07-23:value:character-5-shingle: "o an "
+similarity:2020-07-23:value:character-5-shingle: "objec"
+similarity:2020-07-23:value:character-5-shingle: "of an"
+similarity:2020-07-23:value:character-5-shingle: "ot se"
+similarity:2020-07-23:value:character-5-shingle: "refer"
+similarity:2020-07-23:value:character-5-shingle: "rence"
+similarity:2020-07-23:value:character-5-shingle: "set t"
+similarity:2020-07-23:value:character-5-shingle: "stanc"
+similarity:2020-07-23:value:character-5-shingle: "t ref"
+similarity:2020-07-23:value:character-5-shingle: "t set"
+similarity:2020-07-23:value:character-5-shingle: "t to "
+similarity:2020-07-23:value:character-5-shingle: "tance"
+similarity:2020-07-23:value:character-5-shingle: "to an"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/unity.pysnap
@@ -1,0 +1,138 @@
+---
+created: '2020-11-08T21:03:18.367322Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "ca611011ce2c949c4371754b1754bba9"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            filename*
+              "EventSystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+            lineno (function takes precedence)
+              377
+          frame (non app frame)
+            filename*
+              "ExecuteEvents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+            lineno (function takes precedence)
+              261
+          frame (non app frame)
+            filename*
+              "ExecuteEvents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+            lineno (function takes precedence)
+              50
+          frame (non app frame)
+            filename*
+              "Button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+            lineno (function takes precedence)
+              110
+          frame (non app frame)
+            filename*
+              "Button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+            lineno (function takes precedence)
+              68
+          frame (non app frame)
+            filename*
+              "UnityEvent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+            lineno (function takes precedence)
+              58
+          frame (non app frame)
+            filename*
+              "UnityEvent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+            lineno (function takes precedence)
+              166
+          frame*
+            filename*
+              "SampleScript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+            lineno (function takes precedence)
+              123
+        type*
+          "NullReferenceException"
+        value (stacktrace and type take precedence)
+          "Object reference not set to an instance of an object"
+--------------------------------------------------------------------------
+system:
+  hash: "48fa46727e0f07477677a70d1e921f3f"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              "EventSystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+            lineno (function takes precedence)
+              377
+          frame*
+            filename*
+              "ExecuteEvents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+            lineno (function takes precedence)
+              261
+          frame*
+            filename*
+              "ExecuteEvents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+            lineno (function takes precedence)
+              50
+          frame*
+            filename*
+              "Button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+            lineno (function takes precedence)
+              110
+          frame*
+            filename*
+              "Button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+            lineno (function takes precedence)
+              68
+          frame*
+            filename*
+              "UnityEvent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+            lineno (function takes precedence)
+              58
+          frame*
+            filename*
+              "UnityEvent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+            lineno (function takes precedence)
+              166
+          frame*
+            filename*
+              "SampleScript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+            lineno (function takes precedence)
+              123
+        type*
+          "NullReferenceException"
+        value (stacktrace and type take precedence)
+          "Object reference not set to an instance of an object"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/unity.pysnap
@@ -1,0 +1,138 @@
+---
+created: '2020-11-08T21:03:06.179453Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "ca611011ce2c949c4371754b1754bba9"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            filename*
+              "EventSystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+            lineno (function takes precedence)
+              377
+          frame (non app frame)
+            filename*
+              "ExecuteEvents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+            lineno (function takes precedence)
+              261
+          frame (non app frame)
+            filename*
+              "ExecuteEvents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+            lineno (function takes precedence)
+              50
+          frame (non app frame)
+            filename*
+              "Button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+            lineno (function takes precedence)
+              110
+          frame (non app frame)
+            filename*
+              "Button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+            lineno (function takes precedence)
+              68
+          frame (non app frame)
+            filename*
+              "UnityEvent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+            lineno (function takes precedence)
+              58
+          frame (non app frame)
+            filename*
+              "UnityEvent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+            lineno (function takes precedence)
+              166
+          frame*
+            filename*
+              "SampleScript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+            lineno (function takes precedence)
+              123
+        type*
+          "NullReferenceException"
+        value (stacktrace and type take precedence)
+          "Object reference not set to an instance of an object"
+--------------------------------------------------------------------------
+system:
+  hash: "48fa46727e0f07477677a70d1e921f3f"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              "EventSystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+            lineno (function takes precedence)
+              377
+          frame*
+            filename*
+              "ExecuteEvents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+            lineno (function takes precedence)
+              261
+          frame*
+            filename*
+              "ExecuteEvents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+            lineno (function takes precedence)
+              50
+          frame*
+            filename*
+              "Button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+            lineno (function takes precedence)
+              110
+          frame*
+            filename*
+              "Button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+            lineno (function takes precedence)
+              68
+          frame*
+            filename*
+              "UnityEvent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+            lineno (function takes precedence)
+              58
+          frame*
+            filename*
+              "UnityEvent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+            lineno (function takes precedence)
+              166
+          frame*
+            filename*
+              "SampleScript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+            lineno (function takes precedence)
+              123
+        type*
+          "NullReferenceException"
+        value (stacktrace and type take precedence)
+          "Object reference not set to an instance of an object"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/unity.pysnap
@@ -1,0 +1,102 @@
+---
+created: '2020-11-08T21:03:11.581515Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "a12d579fed7636c2a5d2fae110c95ce5"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            filename*
+              "eventsystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+          frame (non app frame)
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+          frame (non app frame)
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+          frame (non app frame)
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+          frame (non app frame)
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+          frame (non app frame)
+            filename*
+              "unityevent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+          frame (non app frame)
+            filename*
+              "unityevent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+          frame*
+            filename*
+              "samplescript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+        type*
+          "NullReferenceException"
+--------------------------------------------------------------------------
+system:
+  hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              "eventsystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+          frame*
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+          frame*
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+          frame*
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+          frame*
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+          frame*
+            filename*
+              "unityevent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+          frame*
+            filename*
+              "unityevent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+          frame*
+            filename*
+              "samplescript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+        type*
+          "NullReferenceException"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/unity.pysnap
@@ -1,0 +1,106 @@
+---
+created: '2020-11-08T21:03:08.888447Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "a12d579fed7636c2a5d2fae110c95ce5"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            filename*
+              "eventsystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+          frame (non app frame)
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+          frame (non app frame)
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+          frame (non app frame)
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+          frame (non app frame)
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+          frame (non app frame)
+            filename*
+              "unityevent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+          frame (non app frame)
+            filename*
+              "unityevent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+          frame*
+            filename*
+              "samplescript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+        type*
+          "NullReferenceException"
+        value (ignored because stacktrace takes precedence)
+          "Object reference not set to an instance of an object"
+--------------------------------------------------------------------------
+system:
+  hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              "eventsystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+          frame*
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+          frame*
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+          frame*
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+          frame*
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+          frame*
+            filename*
+              "unityevent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+          frame*
+            filename*
+              "unityevent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+          frame*
+            filename*
+              "samplescript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+        type*
+          "NullReferenceException"
+        value (ignored because stacktrace takes precedence)
+          "Object reference not set to an instance of an object"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/unity.pysnap
@@ -1,0 +1,106 @@
+---
+created: '2020-11-08T21:03:21.457954Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "a12d579fed7636c2a5d2fae110c95ce5"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            filename*
+              "eventsystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+          frame (non app frame)
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+          frame (non app frame)
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+          frame (non app frame)
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+          frame (non app frame)
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+          frame (non app frame)
+            filename*
+              "unityevent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+          frame (non app frame)
+            filename*
+              "unityevent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+          frame*
+            filename*
+              "samplescript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+        type*
+          "NullReferenceException"
+        value (ignored because stacktrace takes precedence)
+          "Object reference not set to an instance of an object"
+--------------------------------------------------------------------------
+system:
+  hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              "eventsystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+          frame*
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+          frame*
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+          frame*
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+          frame*
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+          frame*
+            filename*
+              "unityevent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+          frame*
+            filename*
+              "unityevent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+          frame*
+            filename*
+              "samplescript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+        type*
+          "NullReferenceException"
+        value (ignored because stacktrace takes precedence)
+          "Object reference not set to an instance of an object"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/unity.pysnap
@@ -1,0 +1,106 @@
+---
+created: '2020-11-08T21:03:14.672603Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "a12d579fed7636c2a5d2fae110c95ce5"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            filename*
+              "eventsystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+          frame (non app frame)
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+          frame (non app frame)
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+          frame (non app frame)
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+          frame (non app frame)
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+          frame (non app frame)
+            filename*
+              "unityevent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+          frame (non app frame)
+            filename*
+              "unityevent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+          frame*
+            filename*
+              "samplescript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+        type*
+          "NullReferenceException"
+        value (ignored because stacktrace takes precedence)
+          "Object reference not set to an instance of an object"
+--------------------------------------------------------------------------
+system:
+  hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              "eventsystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+          frame*
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+          frame*
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+          frame*
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+          frame*
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+          frame*
+            filename*
+              "unityevent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+          frame*
+            filename*
+              "unityevent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+          frame*
+            filename*
+              "samplescript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+        type*
+          "NullReferenceException"
+        value (ignored because stacktrace takes precedence)
+          "Object reference not set to an instance of an object"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/unity.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/unity.pysnap
@@ -1,0 +1,106 @@
+---
+created: '2020-11-08T21:03:02.656886Z'
+creator: sentry
+source: tests/sentry/grouping/test_variants.py
+---
+app:
+  hash: "a12d579fed7636c2a5d2fae110c95ce5"
+  component:
+    app*
+      exception*
+        stacktrace*
+          frame (non app frame)
+            filename*
+              "eventsystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+          frame (non app frame)
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+          frame (non app frame)
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+          frame (non app frame)
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+          frame (non app frame)
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+          frame (non app frame)
+            filename*
+              "unityevent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+          frame (non app frame)
+            filename*
+              "unityevent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+          frame*
+            filename*
+              "samplescript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+        type*
+          "NullReferenceException"
+        value (ignored because stacktrace takes precedence)
+          "Object reference not set to an instance of an object"
+--------------------------------------------------------------------------
+system:
+  hash: "c0dbeebf0430b3310ad1f7ceb48553a6"
+  component:
+    system*
+      exception*
+        stacktrace*
+          frame*
+            filename*
+              "eventsystem.cs"
+            function*
+              "UnityEngine.EventSystems.EventSystem:Update()"
+          frame*
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)"
+          frame*
+            filename*
+              "executeevents.cs"
+            function*
+              "UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData)"
+          frame*
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData)"
+          frame*
+            filename*
+              "button.cs"
+            function*
+              "UnityEngine.UI.Button.Press ()"
+          frame*
+            filename*
+              "unityevent_0.cs"
+            function*
+              "UnityEngine.Events.UnityEvent.Invoke ()"
+          frame*
+            filename*
+              "unityevent.cs"
+            function*
+              "UnityEngine.Events.InvokableCall.Invoke ()"
+          frame*
+            filename*
+              "samplescript.cs"
+            function*
+              "SampleScript.ThrowNull ()"
+        type*
+          "NullReferenceException"
+        value (ignored because stacktrace takes precedence)
+          "Object reference not set to an instance of an object"

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -93,8 +93,22 @@ from sentry.stacktraces.functions import (
         ["<lambda_7156c3ceaa11256748687ab67e3ef4cd>::operator()", "<lambda>::operator()"],
     ],
 )
-def test_trim_function_name(input, output):
+def test_trim_native_function_name(input, output):
     assert trim_function_name(input, "native") == output
+
+
+@pytest.mark.parametrize(
+    "input,output",
+    [
+        ["UnityEngine.Events.InvokableCall.Invoke ()", "UnityEngine.Events.InvokableCall.Invoke"],
+        [
+            "UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor)",
+            "UnityEngine.EventSystems.ExecuteEvents.Execute[T]",
+        ],
+    ],
+)
+def test_trim_csharp_function_name(input, output):
+    assert trim_function_name(input, "csharp") == output
 
 
 def replace_group(value, start):


### PR DESCRIPTION
This implements function name trimming for .NET.  This looks like a general .NET
change however it really only affects the Unity SDK as the .NET SDK does not emit
function names like this.  The actual .NET SDK sends the parsed function in
`function`, the containing class in `module` and the raw function signature in
`context_line` (in violation of the protocol).

This change so far now only affects the Unity SDK which does send the function
name like native does.

Because this introduces a trimmed function name into the frame it would affect
grouping.  Because of this the inverse change is applied to the grouping algorithm
for now.  Future grouping algorithms might change over to the trimmed function
name instead.