### PR TITLE
fix(phabricator) use six.text_type for Phabricator

### DIFF
--- a/src/sentry_plugins/phabricator/plugin.py
+++ b/src/sentry_plugins/phabricator/plugin.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import six
+
 from django.conf.urls import url
 from rest_framework.response import Response
 
@@ -226,8 +228,8 @@ class PhabricatorPlugin(CorePluginMixin, IssuePlugin2):
         api = self.get_api(group.project)
         try:
             data = api.maniphest.createtask(
-                title=form_data["title"].encode("utf-8"),
-                description=form_data["description"].encode("utf-8"),
+                title=six.text_type(form_data["title"]),
+                description=six.text_type(form_data["description"]),
                 ownerPHID=form_data.get("assignee"),
                 projectPHIDs=form_data.get("tags"),
             )


### PR DESCRIPTION
Using `.encode("utf-8")` will convert the string to binary which we don't want and breaks things