### PR TITLE
feat(performance): Always sort by Key Transaction

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -187,7 +187,8 @@ class Table extends React.Component<Props, State> {
             };
           }
           const currentSort = eventView.sortForField(field, tableMeta);
-          const canSort = isFieldSortable(field, tableMeta);
+          const canSort =
+            isFieldSortable(field, tableMeta) && field.field !== 'key_transaction';
 
           return (
             <SortLink
@@ -254,20 +255,13 @@ class Table extends React.Component<Props, State> {
   getSortedEventView() {
     const {eventView} = this.props;
 
-    // We special case sort by key transactions here to include
-    // the transaction name and project as the secondary sorts.
-    const keyTransactionSort = eventView.sorts.find(
-      sort => sort.field === 'key_transaction'
-    );
-    if (keyTransactionSort) {
-      const sorts = ['key_transaction', 'transaction', 'project'].map(field => ({
-        field,
-        kind: keyTransactionSort.kind,
-      }));
-      return eventView.withSorts(sorts);
-    }
-
-    return eventView;
+    return eventView.withSorts([
+      {
+        field: 'key_transaction',
+        kind: 'desc',
+      },
+      ...eventView.sorts,
+    ]);
   }
 
   render() {


### PR DESCRIPTION
- This makes the user sort the secondary sort, and will always sort by
  key transaction
- This disables key transaction as something user's can sort