### PR TITLE
build(gha): Replace eslint action with workflow

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -2,20 +2,29 @@
 
 # TODO: There are some meta files that we potentially could ignore for both front/backend,
 # as well as some configuration files that should trigger both
-frontend:
+frontend_lintable: &frontend_lintable
   - '**/*.[tj]{s,sx}'
   - '**/*.less'
   - '**/tsconfig*.json'
-  - 'yarn.lock'
   - '{package,now,vercel}.json'
+  - '.github/workflows/js-*.yml'
+
+frontend: &frontend
+  - *frontend_lintable
+  - 'yarn.lock'
   - '.eslint*'
   - 'docs-ui/**'
   - 'src/sentry/static/sentry/**'
   - 'tests/js/**'
-  - '.github/workflows/js-*.yml'
 
-backend:
+frontend_modified_lintable:
+  - added|modified: *frontend_lintable
+
+backend_lintable: &backend_lintable
   - '**/*.py'
+
+backend: &backend
+  - *backend_lintable
   - 'src/sentry/!(static)/**'
   - 'requirements-*.txt'
   - 'migrations_lockfile.txt'

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           # because we want to lint + fix + commit, we need to checkout the HEAD sha (otherwise
           # it checks out the merge commit and we will not be able to commit to it)
-          ref: ${{ github.event.pull_request.head.sha || 'master' }}
+          ref: ${{ github.event.pull_request.head.ref || 'master' }}
 
       - name: Check for frontend file changes
         uses: getsentry/paths-filter@v2
@@ -81,8 +81,8 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions@sentry.io"
           git add -A
-          git commit -m "chore: Automatic eslint fix ${GITHUB_SHA}" || exit 0
-          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
+          git commit -m "chore: Automatic eslint fix (${GITHUB_SHA})" || exit 0
+          git push origin
 
       - name: tsc
         if: steps.changes.outputs.frontend == 'true'

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -15,14 +15,18 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          # because we want to lint + fix + commit, we need to checkout the HEAD sha (otherwise
+          # it checks out the merge commit and we will not be able to commit to it)
+          ref: ${{ github.event.pull_request.head.sha || 'master' }}
 
       - name: Check for frontend file changes
         uses: getsentry/paths-filter@v2
         id: changes
         with:
+          list-files: shell
           token: ${{ github.token }}
           filters: .github/file-filters.yml
-
 
       - uses: volta-cli/action@v1
         if: steps.changes.outputs.frontend == 'true'
@@ -55,14 +59,34 @@ jobs:
           echo "::add-matcher::.github/tsc.json"
           echo "::add-matcher::.github/eslint-stylish.json"
 
-      - name: eslint + fix
-        uses: getsentry/action-eslint-fix@v2
-        if: steps.changes.outputs.frontend == 'true'
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Lint entire frontend if this is on main branch
+      - name: eslint
+        if: github.ref == 'refs/heads/master' && steps.changes.outputs.frontend == 'true'
+        run: |
+          # Run relax config on main branch (and stricter config for changed files)
+          yarn lint -c .eslintrc.relax.js
+          yarn lint:css
+
+      # Otherwise if it's not main branch, only lint modified files
+      - name: eslint (changed files only)
+        if: github.ref != 'refs/heads/master' && steps.changes.outputs.frontend == 'true'
+        run: |
+          yarn eslint --fix ${{ steps.changes.outputs.frontend_modified_lintable_files }}
+
+      # Otherwise if it's not main branch, only lint modified files
+      - name: Commit any eslint fixed files
+        if: github.ref != 'refs/heads/master' && steps.changes.outputs.frontend == 'true'
+        continue-on-error: true
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions@sentry.io"
+          git add -A
+          git commit -m "style(): Auto eslint fix ${GITHUB_SHA}" || exit 0
+          git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
 
       - name: tsc
         if: steps.changes.outputs.frontend == 'true'
+        continue-on-error: true
         run: |
           yarn tsc -p config/tsconfig.build.json
 

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -81,7 +81,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions@sentry.io"
           git add -A
-          git commit -m "style(): Auto eslint fix ${GITHUB_SHA}" || exit 0
+          git commit -m "chore: Automatic eslint fix ${GITHUB_SHA}" || exit 0
           git push origin "HEAD:${{ github.event.pull_request.head.ref }}"
 
       - name: tsc


### PR DESCRIPTION
This replaces the external eslint action with steps defined in the workflow. This also fixes an issue where the eslint action was not erroring when there were only formatting errors that were auto fixed.