### PR TITLE
ref(list): Styles for li only change to affect direct children only

### DIFF
--- a/src/sentry/static/sentry/app/components/list/utils.tsx
+++ b/src/sentry/static/sentry/app/components/list/utils.tsx
@@ -3,7 +3,7 @@ import {css} from '@emotion/core';
 import {Theme} from 'app/utils/theme';
 
 const commonSymbolStyle = css`
-  li {
+  & > li {
     padding-left: 34px;
     :before {
       border-radius: 50%;
@@ -14,7 +14,7 @@ const commonSymbolStyle = css`
 
 const bulletStyle = (theme: Theme) => css`
   ${commonSymbolStyle}
-  li:before {
+  & > li:before {
     content: '';
     width: 6px;
     height: 6px;
@@ -26,7 +26,7 @@ const bulletStyle = (theme: Theme) => css`
 
 const numericStyle = (theme: Theme, isSolid = false) => css`
   ${commonSymbolStyle}
-  li:before {
+  & > li:before {
     counter-increment: numberedList;
     content: counter(numberedList);
     display: flex;


### PR DESCRIPTION
The `li` styles for the `<List>` component were previously applied to all descendant `li`'s, not just direct children. This caused all list items to inherit their parent's styling such as this search dropdown unintentionally having colored numeric list styling:

![image](https://user-images.githubusercontent.com/9372512/98593091-a9929600-22a0-11eb-8d78-c80c6311df92.png)

After applying the list styling only to direct children it behaves like this:

![image](https://user-images.githubusercontent.com/9372512/98593262-e3fc3300-22a0-11eb-9ad6-36d1105ebdfd.png)

