### PR TITLE
fix: Make sure we always pull latest clickhouse in devservices.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1530,6 +1530,7 @@ SENTRY_DEVSERVICES = {
     },
     "clickhouse": {
         "image": "yandex/clickhouse-server:20.3.9.70",
+        "pull": True,
         "ports": {"9000/tcp": 9000, "9009/tcp": 9009, "8123/tcp": 8123},
         "ulimits": [{"name": "nofile", "soft": 262144, "hard": 262144}],
         "volumes": {


### PR DESCRIPTION
I just ran into an error caused by using an old version of Clickhouse. Most other core services use
pull, so updating Clickhouse to do so too.