### PR TITLE
build(gha): Reduce backend test instances, change acceptance grouping

### DIFF
--- a/.github/workflows/acceptance-py3.6.yml
+++ b/.github/workflows/acceptance-py3.6.yml
@@ -18,7 +18,7 @@ jobs:
 
     env:
       MIGRATIONS_TEST_MIGRATE: 1
-      TEST_GROUP_STRATEGY: individual
+      TEST_GROUP_STRATEGY: roundrobin
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/acceptance-py3.6.yml
+++ b/.github/workflows/acceptance-py3.6.yml
@@ -18,6 +18,7 @@ jobs:
 
     env:
       MIGRATIONS_TEST_MIGRATE: 1
+      TEST_GROUP_STRATEGY: individual
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -96,7 +96,6 @@ jobs:
 
     env:
       VISUAL_SNAPSHOT_ENABLE: 1
-      TEST_GROUP_STRATEGY: individual
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -96,7 +96,7 @@ jobs:
 
     env:
       VISUAL_SNAPSHOT_ENABLE: 1
-      TEST_GROUP_STRATEGY: individual
+      TEST_GROUP_STRATEGY: roundrobin
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -96,6 +96,7 @@ jobs:
 
     env:
       VISUAL_SNAPSHOT_ENABLE: 1
+      TEST_GROUP_STRATEGY: individual
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/backend-test-py2.7.yml
+++ b/.github/workflows/backend-test-py2.7.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        instance: [0, 1, 2]
+        instance: [0, 1]
 
     env:
       MIGRATIONS_TEST_MIGRATE: 1

--- a/.github/workflows/backend-test-py3.6.yml
+++ b/.github/workflows/backend-test-py3.6.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        instance: [0, 1, 2]
+        instance: [0, 1]
 
     env:
       MIGRATIONS_TEST_MIGRATE: 1

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -278,7 +278,7 @@ def pytest_collection_modifyitems(config, items):
 
     total_groups = int(os.environ.get("TOTAL_TEST_GROUPS", 1))
     current_group = int(os.environ.get("TEST_GROUP", 0))
-    grouping_strategy = os.environ.get("TEST_GROUP_STRATEGY", "individual")
+    grouping_strategy = os.environ.get("TEST_GROUP_STRATEGY", "file")
 
     accepted, keep, discard = [], [], []
 

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -282,7 +282,7 @@ def pytest_collection_modifyitems(config, items):
 
     accepted, keep, discard = [], [], []
 
-    for item in enumerate(items):
+    for index, item in enumerate(items):
         # XXX: For some reason tests in `tests/acceptance` are not being
         # marked as snuba, so deselect test cases not a subclass of SnubaTestCase
         if os.environ.get("RUN_SNUBA_TESTS_ONLY"):

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -278,11 +278,11 @@ def pytest_collection_modifyitems(config, items):
 
     total_groups = int(os.environ.get("TOTAL_TEST_GROUPS", 1))
     current_group = int(os.environ.get("TEST_GROUP", 0))
-    grouping_strategy = os.environ.get("TEST_GROUP_STRATEGY", "file")
+    grouping_strategy = os.environ.get("TEST_GROUP_STRATEGY", "individual")
 
     accepted, keep, discard = [], [], []
 
-    for index, item in enumerate(items):
+    for item in enumerate(items):
         # XXX: For some reason tests in `tests/acceptance` are not being
         # marked as snuba, so deselect test cases not a subclass of SnubaTestCase
         if os.environ.get("RUN_SNUBA_TESTS_ONLY"):


### PR DESCRIPTION
* Reduce backend tests instances from 3 -> 2
  * Our slowest tests take around 18m, where as these backend tests take around 10m, to be more efficient with concurrent test runs we want tests to have similar durations.
* Change the acceptance test grouping strategy to be per test case instead of per file. This ensures (for now) a better balancing of our tests. Otherwise, there was one test instance that ran our 2 slowest test suites (issue details and eventsv2) and would always finish 4-5 minutes after the fastest acceptance suite. With round robin, we distribute tests between all 3 instances.
  * Previous acceptance test runs per instance would roughly take around 14m, 18m, and 16m