### PR TITLE
fix(discover): Allow creating alerts on measurements from discover

### DIFF
--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -214,8 +214,15 @@ function incompatibleYAxis(eventView: EventView): boolean {
   const isNumericParameter = aggregation.parameters.some(
     param => param.kind === 'value' && param.dataType === 'number'
   );
+  // There are other measurements possible, but for the time being, only allow alerting
+  // on the predefined set of measurements for alerts.
+  const allowedParameters = [
+    '',
+    ...yAxisConfig.fields,
+    ...(yAxisConfig.measurementKeys ?? []),
+  ];
   const invalidParameter =
-    !isNumericParameter && !['', ...yAxisConfig.fields].includes(column.function[1]);
+    !isNumericParameter && !allowedParameters.includes(column.function[1]);
 
   return invalidFunction || invalidParameter;
 }

--- a/tests/js/spec/components/createAlertButton.spec.jsx
+++ b/tests/js/spec/components/createAlertButton.spec.jsx
@@ -120,6 +120,20 @@ describe('CreateAlertButton', () => {
     expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(0);
   });
 
+  it('should allow yAxis with a measurement as the parameter', () => {
+    const eventView = EventView.fromSavedQuery({
+      ...DEFAULT_EVENT_VIEW,
+      query: 'event.type:transaction',
+      yAxis: 'p75(measurements.fcp)',
+      fields: [...DEFAULT_EVENT_VIEW.fields, 'p75(measurements.fcp)'],
+      projects: [2],
+    });
+    expect(eventView.getYAxis()).toBe('p75(measurements.fcp)');
+    const wrapper = generateWrappedComponent(organization, eventView);
+    wrapper.simulate('click');
+    expect(onIncompatibleQueryMock).toHaveBeenCalledTimes(0);
+  });
+
   it('should warn with multiple errors, missing event.type and project', () => {
     const eventView = EventView.fromSavedQuery({
       ...ALL_VIEWS.find(view => view.name === 'Errors by URL'),


### PR DESCRIPTION
Creating an alert on a pXX column with measurements as the argument should not
error. The new pre built web vitals query currently errors when you try to
create an alert from it when one of the measurement aggregates is selected. This
change adds the predefined list of measurements as valid arguments to aggregate
functions to alert on.