### PR TITLE
fix(web-vitals): Fix Discover drilldown when measurement values do not exist.

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -294,6 +294,12 @@ function generateAdditionalConditions(
           ? String(value)
           : String(value).trim();
 
+      if (column.field.startsWith('measurements.') && !nextValue) {
+        // Do not add measurement conditions if nextValue is falsey.
+        // It's expected that nextValue is a numeric value.
+        return;
+      }
+
       switch (column.field) {
         case 'timestamp':
           // normalize the "timestamp" field to ensure the payload works

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -294,7 +294,7 @@ function generateAdditionalConditions(
           ? String(value)
           : String(value).trim();
 
-      if (column.field.startsWith('measurements.') && !nextValue) {
+      if (isMeasurement(column.field) && !nextValue) {
         // Do not add measurement conditions if nextValue is falsey.
         // It's expected that nextValue is a numeric value.
         return;

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -332,7 +332,10 @@ describe('getExpandedResults()', function () {
   });
 
   it('applies provided additional conditions', () => {
-    const view = new EventView(state);
+    const view = new EventView({
+      ...state,
+      fields: [...state.fields, {field: 'measurements.lcp'}, {field: 'measurements.fcp'}],
+    });
     let result = getExpandedResults(view, {extra: 'condition'}, {});
     expect(result.query).toEqual('event.type:error extra:condition');
 
@@ -361,6 +364,14 @@ describe('getExpandedResults()', function () {
     // Includes null
     result = getExpandedResults(view, {}, {custom_tag: null});
     expect(result.query).toEqual('event.type:error custom_tag:""');
+
+    // Handles measurements while ignoring null values
+    result = getExpandedResults(
+      view,
+      {},
+      {'measurements.lcp': 2, 'measurements.fcp': null}
+    );
+    expect(result.query).toEqual('event.type:error measurements.lcp:2');
   });
 
   it('removes any aggregates in either search conditions or extra conditions', () => {


### PR DESCRIPTION
Drilldown in a Discover query where measurement values are `null` will be appended to the search conditions. This should not occur.

Drilldown:

<img width="1676" alt="Screen Shot 2020-11-10 at 12 07 14 PM" src="https://user-images.githubusercontent.com/139499/98707874-86bebb00-234e-11eb-991d-b6fabaffafff.png">

After drilldown: 
<img width="1688" alt="Screen Shot 2020-11-10 at 12 07 25 PM" src="https://user-images.githubusercontent.com/139499/98707878-86bebb00-234e-11eb-8aba-ecbe94cc32f3.png">

