### PR TITLE
ref(stacktrace-link): Fall back to default_branch

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -7,14 +7,14 @@ from sentry.models import RepositoryProjectPathConfig
 from sentry.api.serializers import serialize
 
 
-def get_link(config, filepath, version):
+def get_link(config, filepath, default, version=None):
     oi = config.organization_integration
     integration = oi.integration
     install = integration.get_installation(oi.organization_id)
 
     formatted_path = filepath.replace(config.stack_root, config.source_root)
 
-    return install.get_stacktrace_link(config.repository, formatted_path, version)
+    return install.get_stacktrace_link(config.repository, formatted_path, default, version)
 
 
 class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
@@ -47,9 +47,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
             if not filepath.startswith(config.stack_root):
                 continue
 
-            version = commitId or config.default_branch
-
-            link = get_link(config, filepath, version)
+            link = get_link(config, filepath, config.default_branch, commitId)
 
             result["config"] = serialize(config, request.user)
             # it's possible for the link to be None, and in that

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -140,7 +140,7 @@ class ExampleIntegration(IntegrationInstallation, IssueSyncMixin):
     def get_issue_display_name(self, external_issue):
         return "display name: %s" % external_issue.key
 
-    def get_stacktrace_link(self, repo, path, version):
+    def get_stacktrace_link(self, repo, path, default, version):
         pass
 
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -115,8 +115,9 @@ class GitHubClientMixin(ApiClient):
 
     @transaction_start("GitHubClientMixin.check_file")
     def check_file(self, repo, path, version):
+        repo_name = repo.name
         return self.head_cached(
-            path="/repos/{}/contents/{}".format(repo, path), params={"ref": version}
+            path="/repos/{}/contents/{}".format(repo_name, path), params={"ref": version}
         )
 
 

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -114,8 +114,8 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
         file_exists = self.check_file(repo.name, filepath, default)
         if file_exists:
             return self.format_source_url(repo.name, filepath, default)
-        else:
-            return None
+
+        return None
 
     def get_unmigratable_repositories(self):
         accessible_repos = self.get_repositories()

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -98,24 +98,10 @@ class GitHubIntegration(IntegrationInstallation, GitHubIssueBasic, RepositoryMix
     def search_issues(self, query):
         return self.get_client().search_issues(query)
 
-    def format_source_url(self, repo_name, filepath, branch):
+    def format_source_url(self, repo, filepath, branch):
         # Must format the url ourselves since `check_file` is a head request
         # "https://github.com/octokit/octokit.rb/blob/master/README.md"
-        return u"https://github.com/{}/blob/{}/{}".format(repo_name, branch, filepath)
-
-    def get_stacktrace_link(self, repo, filepath, default, version):
-        # If the version exists (we have a specific commit sha to point
-        # to), try to find that first.
-        if version:
-            file_exists = self.check_file(repo.name, filepath, version)
-            if file_exists:
-                return self.format_source_url(repo.name, filepath, version)
-
-        file_exists = self.check_file(repo.name, filepath, default)
-        if file_exists:
-            return self.format_source_url(repo.name, filepath, default)
-
-        return None
+        return u"https://github.com/{}/blob/{}/{}".format(repo.name, branch, filepath)
 
     def get_unmigratable_repositories(self):
         accessible_repos = self.get_repositories()

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -243,12 +243,13 @@ class GitLabApiClient(ApiClient):
         return self.get(path)
 
     @transaction_start("GitLabApiClient.check_file")
-    def check_file(self, project_id, path, ref):
+    def check_file(self, repo, path, ref):
         """Fetch a file for stacktrace linking
 
         See https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
         Path requires file path and ref
         """
         self.base_url = self.metadata["base_url"]
+        project_id = repo.config["project_id"]
         request_path = GitLabApiClientPath.file.format(project=project_id, path=path)
         return self.head_cached(request_path, params={"ref": ref})

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -92,27 +92,13 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
         resp = self.get_client().search_group_projects(group, query)
         return [{"identifier": repo["id"], "name": repo["name_with_namespace"]} for repo in resp]
 
-    def format_source_url(self, repo_name, filepath, branch):
+    def format_source_url(self, repo, filepath, branch):
         base_url = self.model.metadata["base_url"]
+        repo_name = repo.config["path"]
 
         # Must format the url ourselves since `check_file` is a head request
         # "https://gitlab.com/gitlab-org/gitlab/blob/master/README.md"
         return u"{}/{}/blob/{}/{}".format(base_url, repo_name, branch, filepath)
-
-    def get_stacktrace_link(self, repo, filepath, default, version):
-        project_id = repo.config["project_id"]
-        repo_name = repo.config["path"]
-
-        if version:
-            file_exists = self.check_file(project_id, filepath, version)
-            if file_exists:
-                return self.format_source_url(repo_name, filepath, version)
-
-        file_exists = self.check_file(project_id, filepath, default)
-        if file_exists:
-            return self.format_source_url(repo_name, filepath, default)
-
-        return None
 
     def search_projects(self, query):
         client = self.get_client()

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -111,8 +111,8 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
         file_exists = self.check_file(project_id, filepath, default)
         if file_exists:
             return self.format_source_url(repo_name, filepath, default)
-        else:
-            return None
+
+        return None
 
     def search_projects(self, query):
         client = self.get_client()

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -92,7 +92,8 @@ class GitlabIntegration(IntegrationInstallation, GitlabIssueBasic, RepositoryMix
         resp = self.get_client().search_group_projects(group, query)
         return [{"identifier": repo["id"], "name": repo["name_with_namespace"]} for repo in resp]
 
-    def get_stacktrace_link(self, repo, filepath, version):
+    def get_stacktrace_link(self, repo, filepath, default, version):
+        # (TODO):meredith retry with default
         project_id = repo.config["project_id"]
         repo_name = repo.config["path"]
         try:

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -19,7 +19,7 @@ class RepositoryMixin(object):
     def check_file(self, repo, filepath, branch):
         """
         Calls the client's `check_file` method to see if the file exists.
-        Returns `True` if it does, and `False` if we 404.
+        Returns the link to the file if it's exists, otherwise return `None`.
 
         So far only GitHub and GitLab have this implemented, both of which
         give use back 404s. If for some reason an integration gives back
@@ -34,7 +34,7 @@ class RepositoryMixin(object):
         except ApiError as e:
             if e.code != 404:
                 raise
-            return False
+            return None
 
         return self.format_source_url(repo, filepath, branch)
 
@@ -44,7 +44,7 @@ class RepositoryMixin(object):
         request was successful.
 
         Uses the version first, and re-tries with the default branch if we 404
-        trying to use the version (commit sha)
+        trying to use the version (commit sha).
 
         If no file was found return `None`, and re-raise for non "Not Found" errors
 
@@ -56,7 +56,7 @@ class RepositoryMixin(object):
 
         source_url = self.check_file(repo, filepath, default)
 
-        return source_url if source_url else None
+        return source_url
 
     def get_repositories(self, query=None):
         """

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -36,7 +36,7 @@ class RepositoryMixin(object):
                 raise
             return False
 
-        return True
+        return self.format_source_url(repo, filepath, branch)
 
     def get_stacktrace_link(self, repo, filepath, default, version):
         """
@@ -50,15 +50,13 @@ class RepositoryMixin(object):
 
         """
         if version:
-            file_exists = self.check_file(repo, filepath, version)
-            if file_exists:
-                return self.format_source_url(repo, filepath, version)
+            source_url = self.check_file(repo, filepath, version)
+            if source_url:
+                return source_url
 
-        file_exists = self.check_file(repo, filepath, default)
-        if file_exists:
-            return self.format_source_url(repo, filepath, default)
+        source_url = self.check_file(repo, filepath, default)
 
-        return None
+        return source_url if source_url else None
 
     def get_repositories(self, query=None):
         """

--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -9,12 +9,16 @@ class RepositoryMixin(object):
     # dynamically given a search query
     repo_search = False
 
-    def get_stacktrace_link(self, repo, path, version):
+    def get_stacktrace_link(self, repo, path, default, version):
         """
         Handle formatting and returning back the stack trace link if the client
         request was successful.
 
+        Uses the version first, and re-tries with the default branch if we 404
+        trying to use the version (commit sha)
+
         If no file was found return `None`, and re-raise for non "Not Found" errors
+
         """
         raise NotImplementedError
 

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -5,7 +5,7 @@ from sentry.utils.compat import mock
 
 from sentry.testutils import TestCase
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.models import Integration
+from sentry.models import Integration, Repository
 
 
 class GitHubAppsClientTest(TestCase):
@@ -17,6 +17,14 @@ class GitHubAppsClientTest(TestCase):
             name="Github Test Org",
             external_id="1",
             metadata={"access_token": None, "expires_at": None},
+        )
+        self.repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="integrations:github",
+            external_id=123,
+            integration_id=integration.id,
         )
 
         install = integration.get_installation(organization_id="123")
@@ -53,16 +61,17 @@ class GitHubAppsClientTest(TestCase):
             content_type="application/json",
         )
 
-        repo = "getsentry/sentry"
         path = "/src/sentry/integrations/github/client.py"
         version = "master"
-        url = "https://api.github.com/repos/{}/contents/{}?ref={}".format(repo, path, version)
+        url = "https://api.github.com/repos/{}/contents/{}?ref={}".format(
+            self.repo.name, path, version
+        )
 
         responses.add(
             method=responses.HEAD, url=url, json={"text": 200},
         )
 
-        resp = self.client.check_file(repo, path, version)
+        resp = self.client.check_file(self.repo, path, version)
         assert resp.status_code == 200
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
@@ -75,13 +84,14 @@ class GitHubAppsClientTest(TestCase):
             content_type="application/json",
         )
 
-        repo = "getsentry/sentry"
         path = "/src/santry/integrations/github/client.py"
         version = "master"
-        url = u"https://api.github.com/repos/{}/contents/{}?ref={}".format(repo, path, version)
+        url = u"https://api.github.com/repos/{}/contents/{}?ref={}".format(
+            self.repo.name, path, version
+        )
 
         responses.add(method=responses.HEAD, url=url, status=404)
 
         with self.assertRaises(ApiError):
-            self.client.check_file(repo, path, version)
+            self.client.check_file(self.repo, path, version)
         assert responses.calls[1].response.status_code == 404

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -252,12 +252,13 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
         path = "README.md"
         version = "master"
+        default = "master"
         responses.add(
             responses.HEAD,
             self.base_url + u"/repos/{}/contents/{}?ref={}".format(repo.name, path, version),
         )
         installation = integration.get_installation(self.organization)
-        result = installation.get_stacktrace_link(repo, path, version)
+        result = installation.get_stacktrace_link(repo, path, default, version)
 
         assert result == "https://github.com/Test-Organization/foo/blob/master/README.md"
 
@@ -277,15 +278,47 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
         path = "README.md"
         version = "master"
+        default = "master"
         responses.add(
             responses.HEAD,
             self.base_url + u"/repos/{}/contents/{}?ref={}".format(repo.name, path, version),
             status=404,
         )
         installation = integration.get_installation(self.organization)
-        result = installation.get_stacktrace_link(repo, path, version)
+        result = installation.get_stacktrace_link(repo, path, default, version)
 
         assert not result
+
+    @responses.activate
+    def test_get_stacktrace_link_use_default_if_version_404(self):
+        self.assert_setup_flow()
+        integration = Integration.objects.get(provider=self.provider.key)
+
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="Test-Organization/foo",
+            url="https://github.com/Test-Organization/foo",
+            provider="integrations:github",
+            external_id=123,
+            config={"name": "Test-Organization/foo"},
+            integration_id=integration.id,
+        )
+        path = "README.md"
+        version = "12345678"
+        default = "master"
+        responses.add(
+            responses.HEAD,
+            self.base_url + u"/repos/{}/contents/{}?ref={}".format(repo.name, path, version),
+            status=404,
+        )
+        responses.add(
+            responses.HEAD,
+            self.base_url + u"/repos/{}/contents/{}?ref={}".format(repo.name, path, default),
+        )
+        installation = integration.get_installation(self.organization)
+        result = installation.get_stacktrace_link(repo, path, default, version)
+
+        assert result == "https://github.com/Test-Organization/foo/blob/master/README.md"
 
     @responses.activate
     def test_get_message_from_error(self):

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -251,7 +251,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
 
         path = "README.md"
-        version = "master"
+        version = "1234567"
         default = "master"
         responses.add(
             responses.HEAD,
@@ -260,7 +260,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         installation = integration.get_installation(self.organization)
         result = installation.get_stacktrace_link(repo, path, default, version)
 
-        assert result == "https://github.com/Test-Organization/foo/blob/master/README.md"
+        assert result == "https://github.com/Test-Organization/foo/blob/1234567/README.md"
 
     @responses.activate
     def test_get_stacktrace_link_file_doesnt_exists(self):

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -25,6 +25,7 @@ class GitlabRefreshAuthTest(GitLabTestCase):
             "created_at": 1536798907,
             "scope": "api",
         }
+        self.repo = self.create_repo(name="Test-Org/foo", external_id=123)
         self.original_identity_data = dict(self.client.identity.data)
         self.gitlab_id = 123
 
@@ -137,7 +138,7 @@ class GitlabRefreshAuthTest(GitLabTestCase):
             json={"text": 200},
         )
 
-        resp = self.client.check_file(self.gitlab_id, path, ref)
+        resp = self.client.check_file(self.repo, path, ref)
         assert responses.calls[0].response.status_code == 200
         assert resp.status_code == 200
 
@@ -153,5 +154,5 @@ class GitlabRefreshAuthTest(GitLabTestCase):
             status=404,
         )
         with self.assertRaises(ApiError):
-            self.client.check_file(self.gitlab_id, path, ref)
+            self.client.check_file(self.repo, path, ref)
         assert responses.calls[0].response.status_code == 404

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -215,16 +215,17 @@ class GitlabIntegrationTest(IntegrationTestCase):
 
         filepath = "README.md"
         ref = "master"
-        version = None
+        version = "12345678"
         responses.add(
             responses.HEAD,
             u"https://gitlab.example.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
-                external_id, filepath, ref
+                external_id, filepath, version
             ),
         )
-        source_url = installation.get_stacktrace_link(repo, "README.md", version, ref)
+        source_url = installation.get_stacktrace_link(repo, "README.md", ref, version)
         assert (
-            source_url == "https://gitlab.example.com/getsentry/example-repo/blob/master/README.md"
+            source_url
+            == "https://gitlab.example.com/getsentry/example-repo/blob/12345678/README.md"
         )
 
     @responses.activate


### PR DESCRIPTION
**Context:**
Currently we render `No Match` if we cannot find the source url to link someone from their Sentry stack trace to their source code. (Majority of initial UI work: https://github.com/getsentry/sentry/pull/21690). 

We attempt to get the specific commit for that version of code (if we can find it) but currently we have a problem handling multi-repo commits set ups. This is leading to all `No Match`'s for sentry's codebase. 

**This PR:**
Instead of just giving back nothing, this PR adds in trying to get the source url once more, but instead of using the commit sha (or version), use the default branch that is specified in the configuration. 

**In the future:**
We should potentially communicate to the user when we are falling back on the default in case the are confused why the source url is taking them to a different version of code than that of the stack trace.

_Additionally_ the UI will be improved beyond the current "No Match". That is temporary :)