### PR TITLE
feat(web-vitals): Visually indicate failed measurement marks

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/measurementsPanel.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/measurementsPanel.tsx
@@ -51,14 +51,13 @@ class MeasurementsPanel extends React.PureComponent<Props> {
             names.includes(vital.slug)
           );
 
-          const failedThreshold =
-            records.find(record => {
-              const value = marks[record.slug];
-              if (typeof value === 'number') {
-                return value >= record.failureThreshold;
-              }
-              return false;
-            }) !== undefined;
+          const failedThreshold = records.some(record => {
+            const value = marks[record.slug];
+            if (typeof value === 'number') {
+              return value >= record.failureThreshold;
+            }
+            return false;
+          });
 
           const hoverMeasurementName = names.join('');
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/measurementsPanel.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/measurementsPanel.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {SentryTransactionEvent} from 'app/types';
 import {defined} from 'app/utils';
 import {
-  WEB_VITAL_DETAILS,
   WEB_VITAL_ACRONYMS,
   LONG_WEB_VITAL_NAMES,
 } from 'app/views/performance/transactionVitals/constants';
@@ -37,7 +36,7 @@ class MeasurementsPanel extends React.PureComponent<Props> {
           width: `calc(${toPercent(1 - dividerPosition)} - 0.5px)`,
         }}
       >
-        {Array.from(measurements).map(([timestamp, marks]) => {
+        {Array.from(measurements).map(([timestamp, verticalMark]) => {
           const bounds = getMeasurementBounds(timestamp, generateBounds);
 
           const shouldDisplay = defined(bounds.left) && defined(bounds.width);
@@ -46,18 +45,7 @@ class MeasurementsPanel extends React.PureComponent<Props> {
             return null;
           }
 
-          const names = Object.keys(marks);
-          const records = Object.values(WEB_VITAL_DETAILS).filter(vital =>
-            names.includes(vital.slug)
-          );
-
-          const failedThreshold = records.some(record => {
-            const value = marks[record.slug];
-            if (typeof value === 'number') {
-              return value >= record.failureThreshold;
-            }
-            return false;
-          });
+          const names = Object.keys(verticalMark.marks);
 
           const hoverMeasurementName = names.join('');
 
@@ -81,7 +69,7 @@ class MeasurementsPanel extends React.PureComponent<Props> {
                 return (
                   <LabelContainer
                     key={label}
-                    failedThreshold={failedThreshold}
+                    failedThreshold={verticalMark.failedThreshold}
                     label={label}
                     tooltipLabel={tooltipLabel}
                     left={toPercent(bounds.left || 0)}

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -377,14 +377,13 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
             names.includes(vital.slug)
           );
 
-          const failedThreshold =
-            records.find(record => {
-              const value = marks[record.slug];
-              if (typeof value === 'number') {
-                return value >= record.failureThreshold;
-              }
-              return false;
-            }) !== undefined;
+          const failedThreshold = records.some(record => {
+            const value = marks[record.slug];
+            if (typeof value === 'number') {
+              return value >= record.failureThreshold;
+            }
+            return false;
+          });
 
           const measurementName = names.join('');
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -11,6 +11,7 @@ import Tooltip from 'app/components/tooltip';
 import {TableDataRow} from 'app/utils/discover/discoverQuery';
 import {IconChevron, IconWarning} from 'app/icons';
 import globalTheme from 'app/utils/theme';
+import {WEB_VITAL_DETAILS} from 'app/views/performance/transactionVitals/constants';
 
 import {
   toPercent,
@@ -361,7 +362,9 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
 
     return (
       <React.Fragment>
-        {Array.from(measurements).map(([timestamp, names]) => {
+        {Array.from(measurements).map(([timestamp, marks]) => {
+          const names = Object.keys(marks);
+
           const bounds = getMeasurementBounds(timestamp, generateBounds);
 
           const shouldDisplay = defined(bounds.left) && defined(bounds.width);
@@ -369,6 +372,19 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
           if (!shouldDisplay || !bounds.isSpanVisibleInView) {
             return null;
           }
+
+          const records = Object.values(WEB_VITAL_DETAILS).filter(vital =>
+            names.includes(vital.slug)
+          );
+
+          const failedThreshold =
+            records.find(record => {
+              const value = marks[record.slug];
+              if (typeof value === 'number') {
+                return value >= record.failureThreshold;
+              }
+              return false;
+            }) !== undefined;
 
           const measurementName = names.join('');
 
@@ -380,6 +396,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
                     style={{
                       left: `clamp(0%, ${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
                     }}
+                    failedThreshold={failedThreshold}
                     onMouseEnter={() => {
                       hoveringMeasurement(measurementName);
                     }}
@@ -1164,14 +1181,18 @@ export const SpanBarRectangle = styled('div')<{spanBarHatch: boolean}>`
   ${p => getHatchPattern(p, '#dedae3', '#f4f2f7')}
 `;
 
-const MeasurementMarker = styled('div')`
+const MeasurementMarker = styled('div')<{failedThreshold: boolean}>`
   position: absolute;
   top: 0;
   height: ${SPAN_ROW_HEIGHT}px;
   user-select: none;
   width: 1px;
-  background: repeating-linear-gradient(to bottom, transparent 0 4px, black 4px 8px) 80%/2px
-    100% no-repeat;
+  background: repeating-linear-gradient(
+      to bottom,
+      transparent 0 4px,
+      ${p => (p.failedThreshold ? p.theme.red300 : 'black')} 4px 8px
+    )
+    80%/2px 100% no-repeat;
   z-index: ${zIndex.dividerLine};
   color: ${p => p.theme.gray500};
 `;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -11,7 +11,6 @@ import Tooltip from 'app/components/tooltip';
 import {TableDataRow} from 'app/utils/discover/discoverQuery';
 import {IconChevron, IconWarning} from 'app/icons';
 import globalTheme from 'app/utils/theme';
-import {WEB_VITAL_DETAILS} from 'app/views/performance/transactionVitals/constants';
 
 import {
   toPercent,
@@ -362,8 +361,8 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
 
     return (
       <React.Fragment>
-        {Array.from(measurements).map(([timestamp, marks]) => {
-          const names = Object.keys(marks);
+        {Array.from(measurements).map(([timestamp, verticalMark]) => {
+          const names = Object.keys(verticalMark.marks);
 
           const bounds = getMeasurementBounds(timestamp, generateBounds);
 
@@ -372,18 +371,6 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
           if (!shouldDisplay || !bounds.isSpanVisibleInView) {
             return null;
           }
-
-          const records = Object.values(WEB_VITAL_DETAILS).filter(vital =>
-            names.includes(vital.slug)
-          );
-
-          const failedThreshold = records.some(record => {
-            const value = marks[record.slug];
-            if (typeof value === 'number') {
-              return value >= record.failureThreshold;
-            }
-            return false;
-          });
 
           const measurementName = names.join('');
 
@@ -395,7 +382,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
                     style={{
                       left: `clamp(0%, ${toPercent(bounds.left || 0)}, calc(100% - 1px))`,
                     }}
-                    failedThreshold={failedThreshold}
+                    failedThreshold={verticalMark.failedThreshold}
                     onMouseEnter={() => {
                       hoveringMeasurement(measurementName);
                     }}


### PR DESCRIPTION
If the measurement marks have any failing web vitals, then indicate the measurement mark to be failing a threshold.

![Screen Shot 2020-11-10 at 3 22 49 PM](https://user-images.githubusercontent.com/139499/98729375-d0b49a80-2368-11eb-9dc3-1715711f664f.png)

