### PR TITLE
fix(integrations): identity missing

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -116,37 +116,41 @@ class IntegrationPipeline(Pipeline):
                 if not created:
                     identity_model.update(**identity_data)
             except IntegrityError:
-                # If the external_id is already used for a different user or
-                # the user already has a different external_id remove those
-                # identities and recreate it, except in the case of Identities
-                # being used for login.
-                if idp.type in ("github", "vsts", "google"):
-                    try:
-                        other_identity = Identity.objects.get(
-                            idp=idp, external_id=identity["external_id"]
-                        )
-                    except Identity.DoesNotExist:
-                        # The user is linked to a different external_id. It's ok to relink
-                        # here because they'll still be able to log in with the new external_id.
-                        pass
-                    else:
-                        # The external_id is linked to a different user. If that user doesn't
-                        # have a password, we don't delete the link as it may lock them out.
-                        if not other_identity.user.has_usable_password():
-                            proper_name = idp.get_provider().name
-                            return self._dialog_response(
-                                {
-                                    "error": _(
-                                        "The provided %(proper_name)s account is linked to a different Sentry user. "
-                                        "To continue linking the current Sentry user, please use a different %(proper_name)s account."
-                                    )
-                                    % ({"proper_name": proper_name})
-                                },
-                                False,
+                # If the external_id is already used for a different user then throw an error
+                # otherwise we have the same user with a new external id
+                # and we update the identity with the new external_id and identity data
+                try:
+                    matched_identity = Identity.objects.get(
+                        idp=idp, external_id=identity["external_id"]
+                    )
+                except Identity.DoesNotExist:
+                    # The user is linked to a different external_id. It's ok to relink
+                    # here because they'll still be able to log in with the new external_id.
+                    identity_model = Identity.update_external_id_and_defaults(
+                        idp, identity["external_id"], self.request.user, identity_data
+                    )
+                else:
+                    self.get_logger().info(
+                        "finish_pipeline.identity_linked_different_user",
+                        {
+                            "idp_id": idp.id,
+                            "external_id": identity["external_id"],
+                            "object_id": matched_identity.id,
+                            "user_id": self.request.user.id,
+                        },
+                    )
+                    # The external_id is linked to a different user.
+                    proper_name = idp.get_provider().name
+                    return self._dialog_response(
+                        {
+                            "error": _(
+                                "The provided %(proper_name)s account is linked to a different Sentry user. "
+                                "To continue linking the current Sentry user, please use a different %(proper_name)s account."
                             )
-                identity_model = Identity.reattach(
-                    idp, identity["external_id"], self.request.user, identity_data
-                )
+                            % ({"proper_name": proper_name})
+                        },
+                        False,
+                    )
 
         default_auth_id = None
         if self.provider.needs_default_identity:

--- a/src/sentry/models/identity.py
+++ b/src/sentry/models/identity.py
@@ -108,3 +108,19 @@ class Identity(Model):
             },
         )
         return identity_model
+
+    @classmethod
+    def update_external_id_and_defaults(cls, idp, external_id, user, defaults):
+        query = Identity.objects.filter(user=user, idp=idp)
+        query.update(external_id=external_id, **defaults)
+        identity_model = query.first()
+        logger.info(
+            "updated-identity",
+            extra={
+                "external_id": external_id,
+                "idp_id": idp.id,
+                "user_id": user.id,
+                "identity_id": identity_model.id,
+            },
+        )
+        return identity_model

--- a/src/sentry/models/identity.py
+++ b/src/sentry/models/identity.py
@@ -111,6 +111,10 @@ class Identity(Model):
 
     @classmethod
     def update_external_id_and_defaults(cls, idp, external_id, user, defaults):
+        """
+        Updates the identity object for a given user and identity provider
+        with the new external id and other fields related to the identity status
+        """
         query = Identity.objects.filter(user=user, idp=idp)
         query.update(external_id=external_id, **defaults)
         identity_model = query.first()

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import six
+
 from sentry.utils.compat.mock import patch
 
 from sentry.models import IdentityProvider, Identity, Integration, OrganizationIntegration
@@ -224,6 +226,82 @@ class FinishPipelineTestCase(IntegrationTestCase):
             organization_id=self.organization.id, integration_id=integration.id
         )
         assert org_integration.default_auth_id == identity.id
+
+    def test_new_external_id_same_user(self, *args):
+        # we need to make sure any other org_integrations have the same
+        # identity that we use for the new one
+        self.provider.needs_default_identity = True
+        integration = Integration.objects.create(
+            provider=self.provider.key,
+            external_id=self.external_id,
+            metadata={"url": "https://example.com"},
+        )
+        identity_provider = IdentityProvider.objects.create(
+            external_id=self.external_id, type="plugin"
+        )
+        identity = Identity.objects.create(
+            idp_id=identity_provider.id, external_id="AccountId", user_id=self.user.id
+        )
+        org2 = self.create_organization(owner=self.user)
+        integration.add_organization(org2, default_auth_id=identity.id)
+        self.pipeline.state.data = {
+            "external_id": self.external_id,
+            "name": "Name",
+            "metadata": {"url": "https://example.com"},
+            "user_identity": {
+                "type": "plugin",
+                "external_id": "new_external_id",
+                "scopes": [],
+                "data": {
+                    "access_token": "token12345",
+                    "expires_in": "123456789",
+                    "refresh_token": "refresh12345",
+                    "token_type": "typetype",
+                },
+            },
+        }
+        resp = self.pipeline.finish_pipeline()
+        self.assertDialogSuccess(resp)
+
+        org_integrations = OrganizationIntegration.objects.filter(integration_id=integration.id)
+        identity = Identity.objects.get(idp_id=identity_provider.id, external_id="new_external_id")
+        for org_integration in org_integrations:
+            assert org_integration.default_auth_id == identity.id
+
+    def test_different_user_same_external_id(self, *args):
+        new_user = self.create_user()
+        # self.create_member(organization=self.organization, user=new_user, role="admin")
+        self.provider.needs_default_identity = True
+        integration = Integration.objects.create(
+            provider=self.provider.key,
+            external_id=self.external_id,
+            metadata={"url": "https://example.com"},
+        )
+        identity_provider = IdentityProvider.objects.create(
+            external_id=self.external_id, type="gitlab"  # need to use a real provider here
+        )
+        Identity.objects.create(
+            idp_id=identity_provider.id, external_id="AccountId", user_id=new_user.id
+        )
+        self.pipeline.state.data = {
+            "external_id": self.external_id,
+            "name": "Name",
+            "metadata": {"url": "https://example.com"},
+            "user_identity": {
+                "type": "gitlab",
+                "external_id": "AccountId",
+                "scopes": [],
+                "data": {
+                    "access_token": "token12345",
+                    "expires_in": "123456789",
+                    "refresh_token": "refresh12345",
+                    "token_type": "typetype",
+                },
+            },
+        }
+        resp = self.pipeline.finish_pipeline()
+        assert not OrganizationIntegration.objects.filter(integration_id=integration.id)
+        assert "account is linked to a different Sentry user" in six.text_type(resp.content)
 
     @patch("sentry.mediators.plugins.Migrator.call")
     def test_disabled_plugin_when_fully_migrated(self, call, *args):

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -272,7 +272,6 @@ class FinishPipelineTestCase(IntegrationTestCase):
     def test_different_user_same_external_id(self, *args):
         self.provider = GitlabIntegrationProvider
         new_user = self.create_user()
-        # self.create_member(organization=self.organization, user=new_user, role="admin")
         self.provider.needs_default_identity = True
         integration = Integration.objects.create(
             provider=self.provider.key,


### PR DESCRIPTION
This fixes a bug caused when a Gitlab (or other integrations) are installed on multiple orgs but with a different user (either a  different Sentry user or a different Gitlab user). The root of the problem that we end up deleting and recreating the `Identity`:
https://github.com/getsentry/sentry/blob/2520046f4ba1f929974672a1f23a9d02bd22d2d0/src/sentry/integrations/pipeline.py#L147-L149

This code path is hit when we try to create an `Identity` object  that generates an `IntegrityError` if either of the two uniqueness constraints is violated:
https://github.com/getsentry/sentry/blob/2520046f4ba1f929974672a1f23a9d02bd22d2d0/src/sentry/models/identity.py#L78

The two uniqueness violations come from two situations:
1. A user who already linked their identity with Gitlab account is attempting another installation with a different Gitlab account (but same integration)
2. A user is attempting a Gitlab installation logged in on a Gitlab account that's already linked to another user

The intention of `reattach` call is to let an existing `Identity` object get updated with a new `external_id` or `user` if that has been changed. We delete old rows that match that `user` or `external_id`:

https://github.com/getsentry/sentry/blob/2520046f4ba1f929974672a1f23a9d02bd22d2d0/src/sentry/models/identity.py#L91-L92

The issue is that any other `OrganizationIntegration` rows for that integration have a `default_auth_id` that points to an `Identity` object that no longer exists.

The solution I have is the following:
1. If we hit an `IntegrityError` when creating the `Identity`, query if we have an `Identity` object for that identity provider (1 to 1 with an integration) and that `external_id`
2. If that exists, throw an error saying that the Gitlab user is already linked  to a different Sentry user
3. If that doesn't exist, update the existing  `Identity`  object with the new `external_id`  and other fields related to that identity (but don't update the user).

The reason why we want to throw an error for the user being linked to a different account is that we don't want the `Identity` object to reference a new user that might not be part of the organization that has the existing installation.