### PR TITLE
feat(workflow): Alert rule created with api token (WOR-371)

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -94,7 +94,12 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 data=rule.get_audit_log_data(),
             )
             alert_rule_created.send_robust(
-                user=request.user, project=project, rule=rule, rule_type="issue", sender=self
+                user=request.user,
+                project=project,
+                rule=rule,
+                rule_type="issue",
+                sender=self,
+                is_api_token=request.auth is not None,
             )
 
             return Response(serialize(rule, request.user))

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -116,6 +116,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
                     sender=self,
                     referrer=referrer,
                     session_id=session_id,
+                    is_api_token=request.auth is not None,
                 )
                 return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 

--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -276,7 +276,7 @@ def record_inbound_filter_toggled(project, **kwargs):
 
 @alert_rule_created.connect(weak=False)
 def record_alert_rule_created(
-    user, project, rule, rule_type, referrer=None, session_id=None, **kwargs
+    user, project, rule, rule_type, is_api_token, referrer=None, session_id=None, **kwargs
 ):
     if rule_type == "issue" and rule.label == DEFAULT_RULE_LABEL and rule.data == DEFAULT_RULE_DATA:
         return
@@ -301,6 +301,7 @@ def record_alert_rule_created(
         rule_type=rule_type,
         referrer=referrer,
         session_id=session_id,
+        is_api_token=is_api_token,
     )
 
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -86,7 +86,9 @@ save_search_created = BetterSignal(providing_args=["project", "user"])
 inbound_filter_toggled = BetterSignal(providing_args=["project"])
 sso_enabled = BetterSignal(providing_args=["organization", "user", "provider"])
 data_scrubber_enabled = BetterSignal(providing_args=["organization"])
-alert_rule_created = BetterSignal(providing_args=["project", "rule", "user", "rule_type"])
+alert_rule_created = BetterSignal(
+    providing_args=["project", "rule", "user", "rule_type", "is_api_token"]
+)
 repo_linked = BetterSignal(providing_args=["repo", "user"])
 release_created = BetterSignal(providing_args=["release"])
 deploy_created = BetterSignal(providing_args=["deploy"])

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -531,6 +531,7 @@ class FeatureAdoptionTest(TestCase, SnubaTestCase):
             rule=rule,
             rule_type="issue",
             sender=type(self.project),
+            is_api_token=False,
         )
         feature_complete = FeatureAdoption.objects.get_by_slug(
             organization=self.organization, slug="alert_rules"

--- a/tests/sentry/receivers/test_onboarding.py
+++ b/tests/sentry/receivers/test_onboarding.py
@@ -294,6 +294,7 @@ class OrganizationOnboardingTaskTest(TestCase):
             user=self.user,
             rule_type="issue",
             sender=type(Rule),
+            is_api_token=False,
         )
         task = OrganizationOnboardingTask.objects.get(
             organization=self.organization,
@@ -378,6 +379,7 @@ class OrganizationOnboardingTaskTest(TestCase):
             user=self.user,
             rule_type="issue",
             sender=type(Rule),
+            is_api_token=False,
         )
 
         assert (


### PR DESCRIPTION
From my understanding (and local testing), `request.auth` is where you can get the api token scopes etc when using an api token, for a regular user it is None.

This will allow us to filter out rules created via api token from analytics