### PR TITLE
feat(integrations): stop loading configOrganization on integration detail page

### DIFF
--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -120,8 +120,20 @@ class VercelIntegration(IntegrationInstallation):
                     create_project_instruction.format(add_project_link),
                     install_source_code_integration.format(source_code_link),
                 ]
-            }
+            },
+            "integration_detail": {"uninstallationUrl": self.get_manage_url()},
         }
+
+    def get_manage_url(self):
+        slug = self.get_slug()
+        configuration_id = self.get_configuration_id()
+        if configuration_id:
+            if self.metadata["installation_type"] == "team":
+                dashboard_url = u"https://vercel.com/dashboard/%s/" % slug
+            else:
+                dashboard_url = "https://vercel.com/dashboard/"
+            return u"%sintegrations/%s" % (dashboard_url, configuration_id)
+        return None
 
     def get_client(self):
         access_token = self.metadata["access_token"]
@@ -161,15 +173,6 @@ class VercelIntegration(IntegrationInstallation):
             for p in vercel_client.get_projects()
         ]
 
-        manage_url = None
-        configuration_id = self.get_configuration_id()
-        if configuration_id:
-            if self.metadata["installation_type"] == "team":
-                dashboard_url = u"https://vercel.com/dashboard/%s/" % slug
-            else:
-                dashboard_url = "https://vercel.com/dashboard/"
-            manage_url = u"%s/integrations/%s" % (dashboard_url, configuration_id)
-
         proj_fields = ["id", "platform", "name", "slug"]
         sentry_projects = map(
             lambda proj: {key: proj[key] for key in proj_fields},
@@ -199,7 +202,6 @@ class VercelIntegration(IntegrationInstallation):
                     "text": _("Complete on Vercel"),
                 },
                 "iconType": "vercel",
-                "manageUrl": manage_url,
             }
         ]
 

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1001,6 +1001,9 @@ export type Integration = {
     configure_integration?: {
       instructions: string[];
     };
+    integration_detail?: {
+      uninstallationUrl?: string;
+    };
   };
 };
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
@@ -22,8 +22,6 @@ import theme from 'app/utils/theme';
 import AddIntegrationButton from './addIntegrationButton';
 import IntegrationItem from './integrationItem';
 
-const CONFIGURABLE_FEATURES = ['commits', 'alert-rule'];
-
 export type Props = {
   organization: Organization;
   provider: IntegrationProvider;
@@ -39,22 +37,6 @@ export type Props = {
 };
 
 export default class InstalledIntegration extends React.Component<Props> {
-  /**
-   * Integrations have additional configuration when any of the conditions are
-   * met:
-   *
-   * - The Integration has organization-specific configuration options.
-   * - The Integration has configurable features
-   */
-  hasConfiguration() {
-    const {integration, provider} = this.props;
-
-    return (
-      integration.configOrganization.length > 0 ||
-      provider.features.filter(f => CONFIGURABLE_FEATURES.includes(f)).length > 0
-    );
-  }
-
   handleReAuthIntegration = (integration: IntegrationWithConfig) => {
     this.props.onReAuthIntegration(integration);
   };
@@ -171,24 +153,16 @@ export default class InstalledIntegration extends React.Component<Props> {
                 </Tooltip>
               )}
               <Tooltip
-                disabled={this.hasConfiguration() && hasAccess}
+                disabled={hasAccess}
                 position="left"
-                title={
-                  !this.hasConfiguration()
-                    ? t('Integration not configurable')
-                    : t(
-                        'You must be an organization owner, manager or admin to configure'
-                      )
-                }
+                title={t(
+                  'You must be an organization owner, manager or admin to configure'
+                )}
               >
                 <StyledButton
                   borderless
                   icon={<IconSettings />}
-                  disabled={
-                    !this.hasConfiguration() ||
-                    !hasAccess ||
-                    integration.status !== 'active'
-                  }
+                  disabled={!hasAccess || integration.status !== 'active'}
                   to={`/settings/${organization.slug}/integrations/${provider.key}/${integration.id}/`}
                   data-test-id="integration-configure-button"
                 >

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
@@ -10,12 +10,7 @@ import Tooltip from 'app/components/tooltip';
 import {IconDelete, IconFlag, IconSettings, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {
-  IntegrationProvider,
-  IntegrationWithConfig,
-  Organization,
-  ObjectStatus,
-} from 'app/types';
+import {IntegrationProvider, Integration, Organization, ObjectStatus} from 'app/types';
 import {SingleIntegrationEvent} from 'app/utils/integrationUtil';
 import theme from 'app/utils/theme';
 
@@ -25,10 +20,10 @@ import IntegrationItem from './integrationItem';
 export type Props = {
   organization: Organization;
   provider: IntegrationProvider;
-  integration: IntegrationWithConfig;
-  onRemove: (integration: IntegrationWithConfig) => void;
-  onDisable: (integration: IntegrationWithConfig) => void;
-  onReAuthIntegration: (integration: IntegrationWithConfig) => void;
+  integration: Integration;
+  onRemove: (integration: Integration) => void;
+  onDisable: (integration: Integration) => void;
+  onReAuthIntegration: (integration: Integration) => void;
   trackIntegrationEvent: (
     options: Pick<SingleIntegrationEvent, 'eventKey' | 'eventName'>
   ) => void; //analytics callback
@@ -37,7 +32,7 @@ export type Props = {
 };
 
 export default class InstalledIntegration extends React.Component<Props> {
-  handleReAuthIntegration = (integration: IntegrationWithConfig) => {
+  handleReAuthIntegration = (integration: Integration) => {
     this.props.onReAuthIntegration(integration);
   };
 
@@ -48,7 +43,7 @@ export default class InstalledIntegration extends React.Component<Props> {
     });
   };
 
-  getRemovalBodyAndText(aspects: IntegrationWithConfig['provider']['aspects']) {
+  getRemovalBodyAndText(aspects: Integration['provider']['aspects']) {
     if (aspects && aspects.removal_dialog) {
       return {
         body: aspects.removal_dialog.body,
@@ -64,7 +59,7 @@ export default class InstalledIntegration extends React.Component<Props> {
     }
   }
 
-  handleRemove(integration: IntegrationWithConfig) {
+  handleRemove(integration: Integration) {
     this.props.onRemove(integration);
     this.props.trackIntegrationEvent({
       eventKey: 'integrations.uninstall_completed',

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -10,8 +10,7 @@ import Button from 'app/components/button';
 import {IconFlag, IconOpen, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {IntegrationWithConfig, IntegrationProvider} from 'app/types';
-import {ProjectMapperType} from 'app/views/settings/components/forms/type';
+import {Integration, IntegrationProvider} from 'app/types';
 import {sortArray} from 'app/utils';
 import {isSlackWorkspaceApp, getReauthAlertText} from 'app/utils/integrationUtil';
 import withOrganization from 'app/utils/withOrganization';
@@ -21,7 +20,7 @@ import AddIntegrationButton from './addIntegrationButton';
 import InstalledIntegration from './installedIntegration';
 
 type State = {
-  configurations: IntegrationWithConfig[];
+  configurations: Integration[];
   information: {providers: IntegrationProvider[]};
 };
 
@@ -38,7 +37,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
       ],
       [
         'configurations',
-        `/organizations/${orgId}/integrations/?provider_key=${integrationSlug}`,
+        `/organizations/${orgId}/integrations/?provider_key=${integrationSlug}&includeConfig=0`,
       ],
     ];
 
@@ -115,7 +114,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     return this.metadata.features;
   }
 
-  onInstall = (integration: IntegrationWithConfig) => {
+  onInstall = (integration: Integration) => {
     // Merge the new integration into the list. If we're updating an
     // integration overwrite the old integration.
     const keyedItems = keyBy(this.state.configurations, i => i.id);
@@ -127,7 +126,7 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     this.setState({configurations});
   };
 
-  onRemove = (integration: IntegrationWithConfig) => {
+  onRemove = (integration: Integration) => {
     const {orgId} = this.props.params;
 
     const origIntegrations = [...this.state.configurations];
@@ -146,31 +145,21 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
     this.api.request(`/organizations/${orgId}/integrations/${integration.id}/`, options);
   };
 
-  onDisable = (integration: IntegrationWithConfig) => {
+  onDisable = (integration: Integration) => {
     let url: string;
 
-    //TODO: Clean up hack for Vercel
-    if (integration.provider.key === 'vercel') {
-      // kind of a hack since this isn't what the url was stored for
-      // but it's exactly what we need and contains the configuration id
-      // e.g. https://vercel.com/dashboard/<team>/integrations/icfg_ySlF4UDnHcIPrAAXjGEiwtxo
-      const field = integration.configOrganization.find(
-        config => config.type === 'project_mapper'
-      );
-
-      if (field) {
-        const mappingField = field as ProjectMapperType;
-        url = mappingField.manageUrl || '';
-        window.open(url, '_blank');
-      }
-      return;
-    }
-
-    const [domainName, orgName] = integration.domainName.split('/');
-    if (integration.accountType === 'User') {
-      url = `https://${domainName}/settings/installations/`;
+    // some integrations have a custom uninstalltion URL we show
+    const uninstallationUrl =
+      integration.dynamicDisplayInformation?.integration_detail?.uninstallationUrl;
+    if (uninstallationUrl) {
+      url = uninstallationUrl;
     } else {
-      url = `https://${domainName}/organizations/${orgName}/settings/installations/`;
+      const [domainName, orgName] = integration.domainName.split('/');
+      if (integration.accountType === 'User') {
+        url = `https://${domainName}/settings/installations/`;
+      } else {
+        url = `https://${domainName}/organizations/${orgName}/settings/installations/`;
+      }
     }
 
     window.open(url, '_blank');

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -153,7 +153,6 @@ export type ProjectMapperType = {
     allowedDomain: string;
   };
   iconType: string;
-  manageUrl?: string;
 };
 
 //selects a sentry project with avatars

--- a/tests/js/spec/views/organizationIntegrations/integrationDetailedView.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationDetailedView.spec.jsx
@@ -59,7 +59,7 @@ describe('IntegrationDetailedView', function () {
         },
       ],
       [
-        `/organizations/${org.slug}/integrations/?provider_key=bitbucket`,
+        `/organizations/${org.slug}/integrations/?provider_key=bitbucket&includeConfig=0`,
         [
           {
             accountType: null,

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -477,3 +477,19 @@ class VercelIntegrationTest(IntegrationTestCase):
             ).encode("utf-8")
             in resp.content
         )
+
+    @responses.activate
+    def test_get_dynamic_display_information(self):
+        with self.tasks():
+            self.assert_setup_flow()
+        integration = Integration.objects.get(provider=self.provider.key)
+        installation = integration.get_installation(self.organization.id)
+        dynamic_display_info = installation.get_dynamic_display_information()
+        instructions = dynamic_display_info["configure_integration"]["instructions"]
+        assert len(instructions) == 2
+        assert "Don't have a project yet?" in instructions[0]
+        assert "configure your repositories." in instructions[1]
+        assert (
+            dynamic_display_info["integration_detail"]["uninstallationUrl"]
+            == "https://vercel.com/dashboard/integrations/my_config_id"
+        )

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -247,43 +247,43 @@ class VercelIntegrationTest(IntegrationTestCase):
             "project_mappings": [[project_id, "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H"]]
         }
 
-        req_params = json.loads(responses.calls[6].request.body)
+        req_params = json.loads(responses.calls[7].request.body)
         assert req_params["name"] == "SENTRY_ORG_%s" % uuid
         assert req_params["value"] == org.slug
 
-        req_params = json.loads(responses.calls[7].request.body)
+        req_params = json.loads(responses.calls[8].request.body)
         assert req_params["name"] == "SENTRY_PROJECT_%s" % uuid
         assert req_params["value"] == self.project.slug
 
-        req_params = json.loads(responses.calls[8].request.body)
+        req_params = json.loads(responses.calls[9].request.body)
         assert req_params["name"] == "NEXT_PUBLIC_SENTRY_DSN_%s" % uuid
         assert req_params["value"] == enabled_dsn
 
-        req_params = json.loads(responses.calls[9].request.body)
+        req_params = json.loads(responses.calls[10].request.body)
         assert req_params["name"] == "SENTRY_AUTH_TOKEN_%s" % uuid
         assert req_params["value"] == sentry_auth_token
 
-        req_params = json.loads(responses.calls[11].request.body)
+        req_params = json.loads(responses.calls[12].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == "sec_0"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[13].request.body)
+        req_params = json.loads(responses.calls[14].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == "sec_1"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[15].request.body)
+        req_params = json.loads(responses.calls[16].request.body)
         assert req_params["key"] == "NEXT_PUBLIC_SENTRY_DSN"
         assert req_params["value"] == "sec_2"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[17].request.body)
+        req_params = json.loads(responses.calls[18].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
         assert req_params["value"] == "sec_3"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[19].request.body)
+        req_params = json.loads(responses.calls[20].request.body)
         assert req_params["key"] == "VERCEL_GITHUB_COMMIT_SHA"
         assert req_params["value"] == ""
         assert req_params["target"] == "production"
@@ -373,27 +373,27 @@ class VercelIntegrationTest(IntegrationTestCase):
             "project_mappings": [[project_id, "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H"]]
         }
 
-        req_params = json.loads(responses.calls[12].request.body)
+        req_params = json.loads(responses.calls[13].request.body)
         assert req_params["key"] == "SENTRY_ORG"
         assert req_params["value"] == "sec_0"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[15].request.body)
+        req_params = json.loads(responses.calls[16].request.body)
         assert req_params["key"] == "SENTRY_PROJECT"
         assert req_params["value"] == "sec_1"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[18].request.body)
+        req_params = json.loads(responses.calls[19].request.body)
         assert req_params["key"] == "NEXT_PUBLIC_SENTRY_DSN"
         assert req_params["value"] == "sec_2"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[21].request.body)
+        req_params = json.loads(responses.calls[22].request.body)
         assert req_params["key"] == "SENTRY_AUTH_TOKEN"
         assert req_params["value"] == "sec_3"
         assert req_params["target"] == "production"
 
-        req_params = json.loads(responses.calls[23].request.body)
+        req_params = json.loads(responses.calls[24].request.body)
         assert req_params["key"] == "VERCEL_GITHUB_COMMIT_SHA"
         assert req_params["value"] == ""
         assert req_params["target"] == "production"


### PR DESCRIPTION
This PR stops loading the `configOrganization` on the integration detail page for first-party integrations. The reason for this change is because if the integration is broken, it can prevent the integration detail page from rendering. The `configOrganization` stores the list of fields for the configure organization view so we shouldn't need it on the integration detail page. However, we did have to move the uninstallation link for Vercel to the `dynamicDisplayInformation` field since we do need that on the integration detail page.