### PR TITLE
fix(ui): Fix media query for Safari <= 13

### DIFF
--- a/src/sentry/static/sentry/app/utils/matchMedia.tsx
+++ b/src/sentry/static/sentry/app/utils/matchMedia.tsx
@@ -35,10 +35,17 @@ export function setupColorScheme(): void {
   }
 
   // Watch for changes in preferred color scheme
-  window
-    .matchMedia('(prefers-color-scheme: light)')
-    .addEventListener('change', handleColorSchemeChange);
-  window
-    .matchMedia('(prefers-color-scheme: dark)')
-    .addEventListener('change', handleColorSchemeChange);
+  const lightMediaQuery = window.matchMedia('(prefers-color-scheme: light)');
+
+  const darkMediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+  try {
+    lightMediaQuery.addEventListener('change', handleColorSchemeChange);
+    darkMediaQuery.addEventListener('change', handleColorSchemeChange);
+  } catch (err) {
+    // Safari 13 (maybe lower too) does not support `addEventListener`
+    // `addListener` is deprecated
+    lightMediaQuery.addListener(handleColorSchemeChange);
+    darkMediaQuery.addListener(handleColorSchemeChange);
+  }
 }


### PR DESCRIPTION
This fixes a bug introduced in #21915 with dark mode media query. `addListener` is deprecated, however Safari does not support the newer method `addEventListener`.

Fixes JAVASCRIPT-236A