### PR TITLE
ref(span): Update list of browser JS SDKs

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -609,6 +609,8 @@ export function isEventFromBrowserJavaScriptSDK(event: SentryTransactionEvent): 
     'sentry.javascript.react',
     'sentry.javascript.gatsby',
     'sentry.javascript.ember',
+    'sentry.javascript.vue',
+    'sentry.javascript.angular',
   ].includes(sdkName.toLowerCase());
 }
 


### PR DESCRIPTION
Update list of browser JS SDKs to include:

-  Vue SDK (upcoming - https://github.com/getsentry/sentry-javascript/pull/2953)
- Angular (already released)

Certain cosmetic changes for the span view are enabled based on the SDK that the event is sourced from.

-----

For Vue (before this PR):

![image](https://user-images.githubusercontent.com/139499/98829766-96e6a100-2407-11eb-8483-ca06e47b329e.png)
