### PR TITLE
fix(similarity): Show grouping component id if no name is available

### DIFF
--- a/src/sentry/static/sentry/app/components/issueDiff/renderGroupingInfo.tsx
+++ b/src/sentry/static/sentry/app/components/issueDiff/renderGroupingInfo.tsx
@@ -30,8 +30,9 @@ function renderComponent(component: EventGroupComponent): string[] {
     return [];
   }
 
-  const {name, hint} = component;
-  const title = name && hint ? `${name} (${hint})` : name;
+  const {name, id, hint} = component;
+  const name_or_id = name || id;
+  const title = name_or_id && hint ? `${name_or_id} (${hint})` : name_or_id;
   const rv = title ? [title] : [];
 
   if (component.values) {


### PR DESCRIPTION
This is supposed to show `frame`, `module` and `function` labels here, instead of what looks like a flat list with too much indentation:

![image](https://user-images.githubusercontent.com/837573/98840851-9968eb00-2447-11eb-8466-796505bf7582.png)
