### PR TITLE
fix(ui): Fix login page for SPA

### DIFF
--- a/src/sentry/static/sentry/app/main.tsx
+++ b/src/sentry/static/sentry/app/main.tsx
@@ -1,23 +1,54 @@
 import {CacheProvider} from '@emotion/core'; // This is needed to set "speedy" = false (for percy)
+import {ThemeProvider} from 'emotion-theming';
 import {cache} from 'emotion'; // eslint-disable-line emotion/no-vanilla
 import React from 'react';
 import {Router, browserHistory} from 'react-router';
 
-import routes from 'app/routes';
+import {Config} from 'app/types';
 import {loadPreferencesState} from 'app/actionCreators/preferences';
+import ConfigStore from 'app/stores/configStore';
+import GlobalStyles from 'app/styles/global';
+import routes from 'app/routes';
+import theme, {darkTheme, Theme} from 'app/utils/theme';
+import withConfig from 'app/utils/withConfig';
 
-class Main extends React.Component {
+type Props = {
+  config: Config;
+};
+
+type State = {
+  theme: Theme;
+};
+
+class Main extends React.Component<Props, State> {
+  state = {
+    theme: ConfigStore.get('theme') === 'dark' ? darkTheme : theme,
+  };
+
   componentDidMount() {
     loadPreferencesState();
   }
 
+  componentDidUpdate(prevProps: Props) {
+    const {config} = this.props;
+    if (config.theme !== prevProps.config.theme) {
+      // eslint-disable-next-line
+      this.setState({
+        theme: config.theme === 'dark' ? darkTheme : theme,
+      });
+    }
+  }
+
   render() {
     return (
-      <CacheProvider value={cache}>
-        <Router history={browserHistory}>{routes()}</Router>
-      </CacheProvider>
+      <ThemeProvider<Theme> theme={this.state.theme}>
+        <GlobalStyles theme={this.state.theme} />
+        <CacheProvider value={cache}>
+          <Router history={browserHistory}>{routes()}</Router>
+        </CacheProvider>
+      </ThemeProvider>
     );
   }
 }
 
-export default Main;
+export default withConfig(Main);

--- a/src/sentry/static/sentry/app/views/app/index.tsx
+++ b/src/sentry/static/sentry/app/views/app/index.tsx
@@ -1,6 +1,5 @@
 import $ from 'jquery';
 import {RouteComponentProps} from 'react-router/lib/Router';
-import {ThemeProvider} from 'emotion-theming';
 import {browserHistory} from 'react-router';
 import Cookies from 'js-cookie';
 import PropTypes from 'prop-types';
@@ -22,13 +21,11 @@ import AlertActions from 'app/actions/alertActions';
 import ConfigStore from 'app/stores/configStore';
 import ErrorBoundary from 'app/components/errorBoundary';
 import GlobalModal from 'app/components/globalModal';
-import GlobalStyles from 'app/styles/global';
 import HookStore from 'app/stores/hookStore';
 import Indicators from 'app/components/indicators';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import NewsletterConsent from 'app/views/newsletterConsent';
 import OrganizationsStore from 'app/stores/organizationsStore';
-import theme, {darkTheme, Theme} from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 import withConfig from 'app/utils/withConfig';
 
@@ -61,7 +58,6 @@ type State = {
   error: boolean;
   needsUpgrade: boolean;
   newsletterConsentPrompt: boolean;
-  theme: Theme;
   user?: Config['user'];
 };
 
@@ -75,7 +71,6 @@ class App extends React.Component<Props, State> {
     error: false,
     needsUpgrade: ConfigStore.get('user')?.isSuperuser && ConfigStore.get('needsUpgrade'),
     newsletterConsentPrompt: ConfigStore.get('user')?.flags?.newsletter_consent_prompt,
-    theme: ConfigStore.get('theme') === 'dark' ? darkTheme : theme,
   };
 
   getChildContext() {
@@ -199,10 +194,6 @@ class App extends React.Component<Props, State> {
       newState.user = config.user;
     }
 
-    if (config.theme !== undefined) {
-      newState.theme = config.theme === 'dark' ? darkTheme : theme;
-    }
-
     if (Object.keys(newState).length > 0) {
       this.setState(newState);
     }
@@ -263,15 +254,12 @@ class App extends React.Component<Props, State> {
     }
 
     return (
-      <ThemeProvider<Theme> theme={this.state.theme}>
-        <GlobalStyles theme={this.state.theme} />
-        <div className="main-container" tabIndex={-1} ref={this.mainContainerRef}>
-          <GlobalModal onClose={this.handleGlobalModalClose} />
-          <SystemAlerts className="messages-container" />
-          <Indicators className="indicators-container" />
-          <ErrorBoundary>{this.renderBody()}</ErrorBoundary>
-        </div>
-      </ThemeProvider>
+      <div className="main-container" tabIndex={-1} ref={this.mainContainerRef}>
+        <GlobalModal onClose={this.handleGlobalModalClose} />
+        <SystemAlerts className="messages-container" />
+        <Indicators className="indicators-container" />
+        <ErrorBoundary>{this.renderBody()}</ErrorBoundary>
+      </div>
     );
   }
 }


### PR DESCRIPTION
The login page in our SPA mode (e.g. Vercel and `yarn dev-ui`) is broken because the lack of emotion theme. This regressed in https://github.com/getsentry/sentry/pull/21915

We did not move `<AuthLayout>` under the `app/views/app` route because it (`<App>`) expects the user to be logged in.  Instead move `<ThemeProvider>`  back into `app/main` where there is no such expectation.