### PR TITLE
fix(workflow): UserFeedback pagination data fetching 

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupUserFeedback.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupUserFeedback.tsx
@@ -45,7 +45,11 @@ class GroupUserFeedback extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (!isEqual(prevProps.params, this.props.params)) {
+    if (
+      !isEqual(prevProps.params, this.props.params) ||
+      prevProps.location.pathname !== this.props.location.pathname ||
+      prevProps.location.search !== this.props.location.search
+    ) {
       this.fetchData();
     }
   }
@@ -97,7 +101,7 @@ class GroupUserFeedback extends React.Component<Props, State> {
                 issueId={group.id}
               />
             ))}
-            <Pagination pageLinks={this.state.pageLinks} />
+            <Pagination pageLinks={this.state.pageLinks} {...this.props} />
           </div>
         </div>
       );


### PR DESCRIPTION
This fixes an issue where user feedback on the issue page wasn't fetching more data when clicking on the next page/prev page pagination buttons.

Reported in:
[ISSUE-1035](https://getsentry.atlassian.net/browse/ISSUE-1035)