### PR TITLE
fix(integrations): Prevent ValueError

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_components.py
+++ b/src/sentry/api/endpoints/sentry_app_components.py
@@ -27,7 +27,7 @@ class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
 class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
     @add_integration_platform_metric_tag
     def get(self, request, organization):
-        project_id = request.GET["projectId"]
+        project_id = request.GET.get("projectId")
         if not project_id:
             return Response([], status=404)
 

--- a/src/sentry/api/endpoints/sentry_app_components.py
+++ b/src/sentry/api/endpoints/sentry_app_components.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from rest_framework.response import Response
+from rest_framework.serializers import ValidationError
 
 from sentry.api.bases import (
     OrganizationEndpoint,
@@ -29,7 +30,7 @@ class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
         project_id = request.GET.get("projectId")
         if not project_id:
-            return Response([], status=404)
+            raise ValidationError("Required parameter 'projectId' is missing")
 
         try:
             project = Project.objects.get(id=project_id, organization_id=organization.id)

--- a/src/sentry/api/endpoints/sentry_app_components.py
+++ b/src/sentry/api/endpoints/sentry_app_components.py
@@ -27,10 +27,12 @@ class SentryAppComponentsEndpoint(SentryAppBaseEndpoint):
 class OrganizationSentryAppComponentsEndpoint(OrganizationEndpoint):
     @add_integration_platform_metric_tag
     def get(self, request, organization):
+        project_id = request.GET["projectId"]
+        if not project_id:
+            return Response([], status=404)
+
         try:
-            project = Project.objects.get(
-                id=request.GET["projectId"], organization_id=organization.id
-            )
+            project = Project.objects.get(id=project_id, organization_id=organization.id)
         except Project.DoesNotExist:
             return Response([], status=404)
 

--- a/src/sentry/static/sentry/app/actionCreators/sentryAppComponents.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/sentryAppComponents.tsx
@@ -7,11 +7,6 @@ export async function fetchSentryAppComponents(
   orgSlug: string,
   projectId: string
 ): Promise<SentryAppComponent[]> {
-  // Short-circuit if the API would just 404.
-  if (!projectId) {
-    return [];
-  }
-
   const componentsUri = `/organizations/${orgSlug}/sentry-app-components/?projectId=${projectId}`;
 
   const res = await api.requestPromise(componentsUri);

--- a/src/sentry/static/sentry/app/actionCreators/sentryAppComponents.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/sentryAppComponents.tsx
@@ -7,6 +7,11 @@ export async function fetchSentryAppComponents(
   orgSlug: string,
   projectId: string
 ): Promise<SentryAppComponent[]> {
+  // Short-circuit if the API would just 404.
+  if (!projectId) {
+    return [];
+  }
+
   const componentsUri = `/organizations/${orgSlug}/sentry-app-components/?projectId=${projectId}`;
 
   const res = await api.requestPromise(componentsUri);

--- a/src/sentry/static/sentry/app/utils/withApi.tsx
+++ b/src/sentry/static/sentry/app/utils/withApi.tsx
@@ -22,8 +22,8 @@ type OptionProps = {
 };
 
 /**
- * HoC that provides "api" client when mounted, and clears API requests when
- * component is unmounted
+ * React Higher-Order Component (HoC) that provides "api" client when mounted,
+ * and clears API requests when component is unmounted.
  */
 const withApi = <P extends InjectedApiProps>(
   WrappedComponent: React.ComponentType<P>,

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {browserHistory} from 'react-router';
 import {RouteComponentProps} from 'react-router/lib/Router';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -133,7 +133,17 @@ class GroupEventDetails extends React.Component<Props, State> {
       `/projects/${orgSlug}/${projSlug}/releases/completion/`
     );
     fetchSentryAppInstallations(api, orgSlug);
-    fetchSentryAppComponents(api, orgSlug, projectId);
+
+    // TODO(marcos): Sometimes GlobalSelectionStore cannot pick a project.
+    if (projectId) {
+      fetchSentryAppComponents(api, orgSlug, projectId);
+    } else {
+      Sentry.withScope(scope => {
+        scope.setExtra('props', this.props);
+        scope.setExtra('state', this.state);
+        Sentry.captureMessage('Project ID was not set');
+      });
+    }
 
     const releasesCompletion = await releasesCompletionPromise;
     this.setState({releasesCompletion});

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -124,8 +124,8 @@ class OrganizationSentryAppComponentsTest(APITestCase):
     def test_project_missing(self, run):
         response = self.get_response(self.org.slug)
 
-        assert response.status_code == 404
-        assert response.data == []
+        assert response.status_code == 400
+        assert response.data[0] == "Required parameter 'projectId' is missing"
 
     @patch("sentry.mediators.sentry_app_components.Preparer.run")
     def test_filter_by_type(self, run):

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -121,6 +121,13 @@ class OrganizationSentryAppComponentsTest(APITestCase):
         assert response.data == []
 
     @patch("sentry.mediators.sentry_app_components.Preparer.run")
+    def test_project_missing(self, run):
+        response = self.get_response(self.org.slug)
+
+        assert response.status_code == 404
+        assert response.data == []
+
+    @patch("sentry.mediators.sentry_app_components.Preparer.run")
     def test_filter_by_type(self, run):
         sentry_app = self.create_sentry_app(schema={"elements": [{"type": "alert-rule"}]})
 

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -2,15 +2,15 @@ from __future__ import absolute_import
 
 import six
 
-from django.core.urlresolvers import reverse
-from sentry.utils.compat.mock import patch, call
-
+from sentry.constants import SentryAppInstallationStatus
 from sentry.coreapi import APIError
 from sentry.testutils import APITestCase
-from sentry.constants import SentryAppInstallationStatus
+from sentry.utils.compat.mock import patch, call
 
 
 class SentryAppComponentsTest(APITestCase):
+    endpoint = "sentry-api-0-sentry-app-components"
+
     def setUp(self):
         self.superuser = self.create_user(email="a@example.com", is_superuser=True)
         self.user = self.create_user(email="boop@example.com")
@@ -25,14 +25,11 @@ class SentryAppComponentsTest(APITestCase):
 
         self.component = self.sentry_app.components.first()
 
-        self.url = reverse("sentry-api-0-sentry-app-components", args=[self.sentry_app.slug])
-
         self.login_as(user=self.user)
 
     def test_retrieves_all_components(self):
-        response = self.client.get(self.url, format="json")
+        response = self.get_valid_response(self.sentry_app.slug)
 
-        assert response.status_code == 200
         assert response.data[0] == {
             "uuid": six.text_type(self.component.uuid),
             "type": "issue-link",
@@ -46,6 +43,8 @@ class SentryAppComponentsTest(APITestCase):
 
 
 class OrganizationSentryAppComponentsTest(APITestCase):
+    endpoint = "sentry-api-0-org-sentry-app-components"
+
     def setUp(self):
         self.user = self.create_user()
         self.org = self.create_organization(owner=self.user)
@@ -81,17 +80,12 @@ class OrganizationSentryAppComponentsTest(APITestCase):
         self.component2 = self.sentry_app2.components.first()
         self.component3 = self.sentry_app3.components.first()
 
-        self.url = u"{}?projectId={}".format(
-            reverse("sentry-api-0-org-sentry-app-components", args=[self.org.slug]), self.project.id
-        )
-
         self.login_as(user=self.user)
 
     @patch("sentry.mediators.sentry_app_components.Preparer.run")
     def test_retrieves_all_components_for_installed_apps(self, run):
-        response = self.client.get(self.url, format="json")
+        response = self.get_valid_response(self.org.slug, qs_params={"projectId": self.project.id})
 
-        assert response.status_code == 200
         assert self.component3.uuid not in [d["uuid"] for d in response.data]
         assert response.data == [
             {
@@ -121,12 +115,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
         org = self.create_organization(owner=self.create_user())
         project = self.create_project(organization=org)
 
-        response = self.client.get(
-            "{}?projectId={}".format(
-                reverse("sentry-api-0-org-sentry-app-components", args=[self.org.slug]), project.id
-            ),
-            format="json",
-        )
+        response = self.get_response(self.org.slug, qs_params={"projectId": project.id})
 
         assert response.status_code == 404
         assert response.data == []
@@ -139,7 +128,9 @@ class OrganizationSentryAppComponentsTest(APITestCase):
 
         component = sentry_app.components.first()
 
-        response = self.client.get(u"{}&filter=alert-rule".format(self.url), format="json")
+        response = self.get_valid_response(
+            self.org.slug, qs_params={"projectId": self.project.id, "filter": "alert-rule"}
+        )
 
         assert response.data == [
             {
@@ -156,7 +147,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
 
     @patch("sentry.mediators.sentry_app_components.Preparer.run")
     def test_prepares_each_component(self, run):
-        self.client.get(self.url, format="json")
+        self.get_valid_response(self.org.slug, qs_params={"projectId": self.project.id})
 
         calls = [
             call(component=self.component1, install=self.install1, project=self.project),
@@ -169,7 +160,7 @@ class OrganizationSentryAppComponentsTest(APITestCase):
     def test_component_prep_errors_are_isolated(self, run):
         run.side_effect = [APIError(), self.component2]
 
-        response = self.client.get(self.url, format="json")
+        response = self.get_valid_response(self.org.slug, qs_params={"projectId": self.project.id})
 
         # Does not include self.component1 data, because it raised an exception
         # during preparation.


### PR DESCRIPTION
Short-circuit and return a 404 when the `projectId` query parameter is not set. 
This doesn't address the real issue, which is why is `project.id` not defined in groupEventDetails?

Fixes https://sentry.io/organizations/sentry/issues/1328607044/