### PR TITLE
ref(ui): Remove `<footer>` from server views

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -4,13 +4,13 @@
 # as well as some configuration files that should trigger both
 frontend_lintable: &frontend_lintable
   - '**/*.[tj]{s,sx}'
-  - '**/*.less'
   - '**/tsconfig*.json'
   - '{package,now,vercel}.json'
   - '.github/workflows/js-*.yml'
 
 frontend: &frontend
   - *frontend_lintable
+  - '**/*.less'
   - 'yarn.lock'
   - '.eslint*'
   - 'docs-ui/**'

--- a/src/sentry/static/sentry/app/components/footer.tsx
+++ b/src/sentry/static/sentry/app/components/footer.tsx
@@ -9,27 +9,17 @@ import Hook from 'app/components/hook';
 import getDynamicText from 'app/utils/getDynamicText';
 import space from 'app/styles/space';
 
-function Footer() {
+type Props = {
+  className?: string;
+};
+
+function Footer({className}: Props) {
   const config = ConfigStore.getConfig();
   return (
-    <footer>
-      <div className="container">
-        <div className="pull-right">
-          <FooterLink className="hidden-xs" href="/api/">
-            {t('API')}
-          </FooterLink>
-          <FooterLink href="/docs/">{t('Docs')}</FooterLink>
-          <FooterLink className="hidden-xs" href="https://github.com/getsentry/sentry">
-            {t('Contribute')}
-          </FooterLink>
-          {config.isOnPremise && (
-            <FooterLink className="hidden-xs" href="/out/">
-              {t('Migrate to SaaS')}
-            </FooterLink>
-          )}
-        </div>
+    <footer className={className}>
+      <div>
         {config.isOnPremise && (
-          <div className="version pull-left">
+          <React.Fragment>
             {'Sentry '}
             {getDynamicText({
               fixed: 'Acceptance Test',
@@ -41,16 +31,40 @@ function Footer() {
                 value: config.version.build.substring(0, 7),
               })}
             </Build>
-          </div>
+          </React.Fragment>
         )}
-        <LogoLink />
-        <Hook name="footer" />
       </div>
+      <LogoLink />
+      <Links>
+        <FooterLink className="hidden-xs" href="/api/">
+          {t('API')}
+        </FooterLink>
+        <FooterLink href="/docs/">{t('Docs')}</FooterLink>
+        <FooterLink className="hidden-xs" href="https://github.com/getsentry/sentry">
+          {t('Contribute')}
+        </FooterLink>
+        {config.isOnPremise && (
+          <FooterLink className="hidden-xs" href="/out/">
+            {t('Migrate to SaaS')}
+          </FooterLink>
+        )}
+      </Links>
+      <Hook name="footer" />
     </footer>
   );
 }
 
+const Links = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: max-content;
+  align-items: center;
+  justify-self: flex-end;
+  gap: ${space(2)};
+`;
+
 const FooterLink = styled(ExternalLink)`
+  color: ${p => p.theme.subText};
   &.focus-visible {
     outline: none;
     box-shadow: ${p => p.theme.blue300} 0 2px 0;
@@ -62,6 +76,7 @@ const LogoLink = styled(props => (
     <IconSentry size="xl" />
   </a>
 ))`
+  color: ${p => p.theme.subText};
   display: block;
   width: 32px;
   height: 32px;
@@ -70,9 +85,22 @@ const LogoLink = styled(props => (
 
 const Build = styled('span')`
   font-size: ${p => p.theme.fontSizeRelativeSmall};
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.subText};
   font-weight: bold;
   margin-left: ${space(1)};
 `;
 
-export default Footer;
+const StyledFooter = styled(Footer)`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  color: ${p => p.theme.subText};
+  border-top: 1px solid ${p => p.theme.border};
+  padding: ${space(4)};
+  margin-top: 20px;
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    display: none;
+  }
+`;
+
+export default StyledFooter;

--- a/src/sentry/static/sentry/app/components/footer.tsx
+++ b/src/sentry/static/sentry/app/components/footer.tsx
@@ -36,17 +36,13 @@ function Footer({className}: Props) {
       </div>
       <LogoLink />
       <Links>
-        <FooterLink className="hidden-xs" href="/api/">
-          {t('API')}
-        </FooterLink>
+        <FooterLink href="/api/">{t('API')}</FooterLink>
         <FooterLink href="/docs/">{t('Docs')}</FooterLink>
-        <FooterLink className="hidden-xs" href="https://github.com/getsentry/sentry">
+        <FooterLink href="https://github.com/getsentry/sentry">
           {t('Contribute')}
         </FooterLink>
         {config.isOnPremise && (
-          <FooterLink className="hidden-xs" href="/out/">
-            {t('Migrate to SaaS')}
-          </FooterLink>
+          <FooterLink href="/out/">{t('Migrate to SaaS')}</FooterLink>
         )}
       </Links>
       <Hook name="footer" />

--- a/src/sentry/static/sentry/app/styles/organization.tsx
+++ b/src/sentry/static/sentry/app/styles/organization.tsx
@@ -9,6 +9,11 @@ export const PageContent = styled('div')`
   flex: 1;
   padding: ${space(2)} ${space(4)} ${space(3)};
   margin-bottom: -20px; /* <footer> has margin-top: 20px; */
+
+  /* No footer at smallest breakpoint */
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    margin-bottom: 0;
+  }
 `;
 
 export const PageHeader = styled('div')`

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1424,15 +1424,6 @@ span.val {
       }
     }
   }
-
-  footer {
-    margin-top: 0;
-
-    .container {
-      padding-left: 30px;
-      padding-right: 30px;
-    }
-  }
 }
 
 /**

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -114,10 +114,6 @@ body.narrow {
       }
     }
   }
-
-  footer {
-    display: none;
-  }
 }
 
 body.auth {

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -302,48 +302,6 @@ body.auth {
 }
 
 /**
-* Footer
-* ============================================================================
-*/
-
-footer {
-  line-height: 30px;
-  text-align: center;
-  color: @gray;
-  border-top: 1px solid @trim;
-  padding: 28px 0;
-  margin-top: 20px;
-
-  .container {
-    // Ensure dropdowns inside application views
-    // don't stack under footer content.
-    position: static;
-  }
-
-  .pull-right {
-    a {
-      margin-left: 20px;
-    }
-  }
-
-  a {
-    color: @gray;
-
-    &:hover {
-      color: @gray-dark;
-    }
-  }
-
-  .icon-sentry-logo {
-    color: @gray;
-    font-size: 28px;
-    width: 32px;
-    margin: 0 auto;
-    display: block;
-  }
-}
-
-/**
 * Windowed
 * ============================================================================
 */
@@ -404,7 +362,6 @@ footer {
     padding: 0 !important;
   }
 
-  #CModal,
   footer {
     display: none;
   }
@@ -568,9 +525,5 @@ footer {
         padding: 20px;
       }
     }
-  }
-
-  .app > footer {
-    display: none;
   }
 }

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -63,20 +63,6 @@
         {% block content %}{% endblock %}
       </div>
     </div>
-    <footer>
-      <div class="container">
-        {% block footer %}
-        <div class="pull-right">
-          <a href="https://docs.sentry.io/api/">{% trans "API" %}</a>
-          <a href="https://docs.sentry.io">{% trans "Docs" %}</a>
-          <a href="https://github.com/getsentry/sentry" rel="noreferrer">{% trans "Contribute" %}</a>
-          {% if ONPREMISE %}<a href="/out/">{% trans "Migrate to SaaS" %}</a>{% endif %}
-        </div>
-        {% if ONPREMISE %}<div class="version pull-left">Sentry {{ sentry_version.current }} ({{ sentry_version.build }}) {% if sentry_version.update_available %}<a href="#" title="You're running an old version of Sentry, did you know {{ sentry_version.latest }} is available?" class="tip icon-circle-arrow-up">&nbsp;</a>{% endif %}</div>{% endif %}
-        <a href="/" class="icon-sentry-logo"></a>
-        {% endblock %}
-      </div>
-    </footer>
   </div>
   {% endblock %}
 

--- a/tests/js/spec/views/organizationActivity/index.spec.jsx
+++ b/tests/js/spec/views/organizationActivity/index.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import OrganizationActivity from 'app/views/organizationActivity';
@@ -30,7 +30,7 @@ describe('OrganizationActivity', function () {
   });
 
   it('renders', function () {
-    const wrapper = mount(<OrganizationActivity {...params} />, routerContext);
+    const wrapper = mountWithTheme(<OrganizationActivity {...params} />, routerContext);
 
     expect(wrapper.find('ActivityItem')).toHaveLength(2);
   });
@@ -40,7 +40,7 @@ describe('OrganizationActivity', function () {
       url: '/organizations/org-slug/activity/',
       body: [],
     });
-    const wrapper = mount(<OrganizationActivity {...params} />, routerContext);
+    const wrapper = mountWithTheme(<OrganizationActivity {...params} />, routerContext);
 
     expect(wrapper.find('ActivityItem')).toHaveLength(0);
     expect(wrapper.find('EmptyStateWarning')).toHaveLength(1);
@@ -52,7 +52,7 @@ describe('OrganizationActivity', function () {
       body: [],
       statusCode: 404,
     });
-    const wrapper = mount(<OrganizationActivity {...params} />, routerContext);
+    const wrapper = mountWithTheme(<OrganizationActivity {...params} />, routerContext);
 
     expect(wrapper.find('ActivityItem')).toHaveLength(0);
     expect(wrapper.find('EmptyStateWarning')).toHaveLength(1);


### PR DESCRIPTION
* Removes `<footer>` from `layout.html` - it does not seem to be used anywhere? The remaining server templates extend from templates that either don't use it, or have the `.narrow` classname on `body` (which hides footer)
* Refactors `app/components/footer` to be a styled component, fixes some layout issues on smallest breakpoint