### PR TITLE
feat(slack): let link unfurling link to specific event

### DIFF
--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -27,6 +27,14 @@ _org_slug_regexp = re.compile(r"^https?\://[^/]+/organizations/([^/]+)/")
 
 
 def unfurl_issues(integration, url_by_issue_id, event_id_by_url=None):
+    """
+    Returns a map of the attachments used in the response we send to Slack
+    for a particular issue by the URL of the yet-unfurled links a user included
+    in their Slack message.
+
+    url_by_issue_id: a map with URL as the value and the issue ID as the key
+    event_id_by_url: a map with the event ID in a URL as the value and the URL as the key
+    """
     group_by_id = {
         g.id: g
         for g in Group.objects.filter(
@@ -88,10 +96,11 @@ class SlackEventEndpoint(Endpoint):
 
     def _parse_url(self, link):
         """
-        Extracts event type and id from a url.
+        Extracts event type, issue id, and event id from a url.
         :param link: Url to parse to information from
-        :return: If successful, a tuple containing the event_type and id. If we
-        were unsuccessful at matching, a tuple containing two None values
+        :return: If successful, a tuple containing the event_type, issue id, and event id.
+        The event ID is optional and will be None if the link isn't to an event
+        If we were unsuccessful at matching, a tuple containing three None values
         """
         match = _link_regexp.match(link)
         if not match:

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -189,7 +189,9 @@ def build_upgrade_notice_attachment(group):
     }
 
 
-def build_group_attachment(group, event=None, tags=None, identity=None, actions=None, rules=None):
+def build_group_attachment(
+    group, event=None, tags=None, identity=None, actions=None, rules=None, link_to_event=False
+):
     # XXX(dcramer): options are limited to 100 choices, even when nested
     status = group.get_status()
 
@@ -303,10 +305,15 @@ def build_group_attachment(group, event=None, tags=None, identity=None, actions=
             footer += u" (+{} other)".format(len(rules) - 1)
 
     obj = event if event is not None else group
+    if event and link_to_event:
+        title_link = group.get_absolute_url(params={"referrer": "slack"}, event_id=event.event_id)
+    else:
+        title_link = group.get_absolute_url(params={"referrer": "slack"})
+
     return {
         "fallback": u"[{}] {}".format(project.slug, obj.title),
         "title": build_attachment_title(obj),
-        "title_link": group.get_absolute_url(params={"referrer": "slack"}),
+        "title_link": title_link,
         "text": text,
         "fields": fields,
         "mrkdwn_in": ["text"],

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -325,12 +325,14 @@ class Group(Model):
         )
         super(Group, self).save(*args, **kwargs)
 
-    def get_absolute_url(self, params=None):
+    def get_absolute_url(self, params=None, event_id=None):
         # Built manually in preference to django.core.urlresolvers.reverse,
         # because reverse has a measured performance impact.
-        url = u"organizations/{org}/issues/{id}/{params}".format(
+        event_path = u"events/{}/".format(event_id) if event_id else ""
+        url = u"organizations/{org}/issues/{id}/{event_path}{params}".format(
             org=urlquote(self.organization.slug),
             id=self.id,
+            event_path=event_path,
             params="?" + urlencode(params) if params else "",
         )
         return absolute_uri(url)

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -284,6 +284,53 @@ class BuildIncidentAttachmentTest(TestCase):
             "footer_icon": u"http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
         }
 
+        assert build_group_attachment(group, event, link_to_event=True) == {
+            "color": "#E03E2F",
+            "text": "",
+            "actions": [
+                {"name": "status", "text": "Resolve", "type": "button", "value": "resolved"},
+                {"text": "Ignore", "type": "button", "name": "status", "value": "ignored"},
+                {
+                    "option_groups": [
+                        {
+                            "text": "Teams",
+                            "options": [
+                                {
+                                    "text": u"#mariachi-band",
+                                    "value": u"team:" + six.text_type(self.team.id),
+                                }
+                            ],
+                        },
+                        {
+                            "text": "People",
+                            "options": [
+                                {
+                                    "text": u"foo@example.com",
+                                    "value": u"user:" + six.text_type(self.user.id),
+                                }
+                            ],
+                        },
+                    ],
+                    "text": "Select Assignee...",
+                    "selected_options": [None],
+                    "type": "select",
+                    "name": "assign",
+                },
+            ],
+            "mrkdwn_in": ["text"],
+            "title": event.title,
+            "fields": [],
+            "footer": u"BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",
+            "ts": to_timestamp(ts),
+            "title_link": u"http://testserver/organizations/rowdy-tiger/issues/{}/events/{}/".format(
+                group.id, event.event_id
+            )
+            + "?referrer=slack",
+            "callback_id": '{"issue":' + six.text_type(group.id) + "}",
+            "fallback": u"[{}] {}".format(self.project.slug, event.title),
+            "footer_icon": u"http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
+        }
+
     def test_build_group_attachment_color_no_event_error_fallback(self):
         group_with_no_events = self.create_group(project=self.project)
         assert build_group_attachment(group_with_no_events)["color"] == "#E03E2F"

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -234,3 +234,14 @@ class GroupTest(TestCase, SnubaTestCase):
             group = self.create_group(id=group_id, project=project)
             actual = group.get_absolute_url(params)
             assert actual == expected
+
+    def test_get_absolute_url_event(self):
+        project = self.create_project()
+        event = self.store_event(
+            data={"fingerprint": ["group1"], "timestamp": self.min_ago}, project_id=project.id
+        )
+        group = event.group
+        url = u"http://testserver/organizations/{}/issues/{}/events/{}/".format(
+            project.organization.slug, group.id, event.event_id
+        )
+        assert url == group.get_absolute_url(event_id=event.event_id)


### PR DESCRIPTION
This PR allows users to unfurl slack links to a specific event. We will then show the message for that event in the alert rule message as well as a link to the event. The behavior for alert rule messages is unchanged such that we still just link to the issue.

Example unfurling with two different events on the same issue:

![Screen Shot 2020-11-11 at 2 57 36 PM](https://user-images.githubusercontent.com/8533851/98873994-40d92400-242e-11eb-99b3-69df71a1fa0e.png)

One caveat, as mentioned in a comment, is that if a user pastes multiple links to different events for the same issue in one message, we will only unfurl one of them. This is because we grouped the URLs by the issue ID. It would definitely be possible to refactor things more to allow it but it seems unlikely that users are going to paste multiple events for the same issue in a single message so it's probably fine to leave as is.