### PR TITLE
feat(ui): Update `gray100` to use inner border color

### DIFF
--- a/src/sentry/static/sentry/app/components/tagDeprecated.tsx
+++ b/src/sentry/static/sentry/app/components/tagDeprecated.tsx
@@ -64,7 +64,7 @@ const Tag = styled(
   border-radius: ${p => (p.size === 'small' ? '0.25em' : '2em')};
   text-transform: lowercase;
   font-weight: ${p => (p.size === 'small' ? 'bold' : 'normal')};
-  background: ${p => getPriority(p)?.background ?? p.theme.gray200};
+  background: ${p => getPriority(p)?.background ?? p.theme.gray100};
   ${p => getBorder(p)};
   ${p => getMarginLeft(p)};
 `;

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -6,7 +6,7 @@ const colors = {
   white: '#FFFFFF',
   black: '#1D1127',
 
-  gray100: '#F2F0F5',
+  gray100: '#E7E1EC',
   gray200: '#C6BECF',
   gray300: '#9386A0',
   gray400: '#776589',
@@ -87,7 +87,7 @@ const aliases = {
   /**
    * Inner borders, e.g. borders inside of a grid
    */
-  innerBorder: '#e7e1ec',
+  innerBorder: colors.gray100,
 
   /**
    * A color that denotes a "success", or something good


### PR DESCRIPTION
This updates `gray100` to use the color we were using for `innerBorder`