### PR TITLE
ref(py3): Handle ThreadedExecutor submission ordering

### DIFF
--- a/tests/sentry/utils/test_concurrent.py
+++ b/tests/sentry/utils/test_concurrent.py
@@ -171,6 +171,17 @@ def test_synchronous_executor():
         assert False, "expected future to raise"
 
 
+def test_threaded_same_priority_Tasks():
+    executor = ThreadedExecutor(worker_count=1)
+
+    def callable():
+        pass
+
+    # Test that we can correctly submit multiple tasks
+    executor.submit(callable)
+    executor.submit(callable)
+
+
 def test_threaded_executor():
     executor = ThreadedExecutor(worker_count=1, maxsize=3)
 


### PR DESCRIPTION
Some elements of this tuple could not be compared in python3 (func partials), so we change this over to a `namedtuple` and implement our own sorting of just the priority.

This also adds a test to verify this behavior