### PR TITLE
ref(ui): Remove extra border+spacing on bottom panel alerts

### DIFF
--- a/src/sentry/static/sentry/app/components/panels/panelAlert.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelAlert.tsx
@@ -23,6 +23,12 @@ const PanelAlert = styled(({icon, ...props}: Props) => (
   padding: ${space(2)};
   border-radius: 0;
   box-shadow: none;
+
+  &:last-child {
+    border-bottom: none;
+    margin: 0;
+    border-radius: 0 0 4px 4px;
+  }
 `;
 
 PanelAlert.propTypes = {


### PR DESCRIPTION
Fixes this situation

![image](https://user-images.githubusercontent.com/1421724/98890397-bd7cfa00-2450-11eb-8037-6e721d70d576.png)

To be like this

![image](https://user-images.githubusercontent.com/1421724/98890411-c2da4480-2450-11eb-8af7-7a24d48fcad2.png)
