### PR TITLE
feat(workflow): Change default query for inbox issue stream

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 const queries = [
   ['is:inbox', t('Inbox')],
-  ['is:unresolved', t('Backlog')],
+  ['!is:inbox is:unresolved', t('Backlog')],
   ['is:ignored', t('Ignored')],
   ['is:resolved', t('Resolved')],
 ];

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -255,7 +255,17 @@ class IssueListOverview extends React.Component<Props, State> {
     }
 
     const {query} = this.props.location.query;
-    return typeof query === 'undefined' ? DEFAULT_QUERY : (query as string);
+
+    if (query !== undefined) {
+      return query as string;
+    }
+
+    // TODO(workflow): set inbox as new default query
+    if (this.props.organization.features.includes('inbox')) {
+      return 'is:inbox';
+    }
+
+    return DEFAULT_QUERY;
   }
 
   getSort(): string {


### PR DESCRIPTION
Also adds `!is:inbox` to the backlog view, do i need another flag for negative search?