### PR TITLE
ref(ui): Use SettingsNavigation on /manage/

### DIFF
--- a/src/sentry/static/sentry/app/views/admin/adminLayout.tsx
+++ b/src/sentry/static/sentry/app/views/admin/adminLayout.tsx
@@ -2,60 +2,63 @@ import DocumentTitle from 'react-document-title';
 import React from 'react';
 import styled from '@emotion/styled';
 
+import SettingsNavigation from 'app/views/settings/components/settingsNavigation';
 import space from 'app/styles/space';
-import ListLink from 'app/components/links/listLink';
 
 const AdminLayout: React.FC = ({children}) => (
   <DocumentTitle title="Sentry Admin">
     <Page>
-      <div>
-        <h6 className="nav-header">System</h6>
-        <ul className="nav nav-stacked">
-          <ListLink index to="/manage/">
-            Overview
-          </ListLink>
-          <ListLink index to="/manage/buffer/">
-            Buffer
-          </ListLink>
-          <ListLink index to="/manage/queue/">
-            Queue
-          </ListLink>
-          <ListLink index to="/manage/quotas/">
-            Quotas
-          </ListLink>
-          <ListLink index to="/manage/status/environment/">
-            Environment
-          </ListLink>
-          <ListLink index to="/manage/status/packages/">
-            Packages
-          </ListLink>
-          <ListLink index to="/manage/status/mail/">
-            Mail
-          </ListLink>
-          <ListLink index to="/manage/status/warnings/">
-            Warnings
-          </ListLink>
-          <ListLink index to="/manage/settings/">
-            Settings
-          </ListLink>
-        </ul>
-        <h6 className="nav-header">Manage</h6>
-        <ul className="nav nav-stacked">
-          <ListLink to="/manage/organizations/">Organizations</ListLink>
-          <ListLink to="/manage/projects/">Projects</ListLink>
-          <ListLink to="/manage/users/">Users</ListLink>
-        </ul>
-      </div>
-      <div>{children}</div>
+      <NavWrapper>
+        <SettingsNavigation
+          stickyTop="0"
+          navigationObjects={[
+            {
+              name: 'System Status',
+              items: [
+                {path: '/manage/', index: true, title: 'Overview'},
+                {path: '/manage/buffer/', title: 'Buffer'},
+                {path: '/manage/queue/', title: 'Queue'},
+                {path: '/manage/quotas/', title: 'Quotas'},
+                {path: '/manage/status/environment/', title: 'Environment'},
+                {path: '/manage/status/packages/', title: 'Packages'},
+                {path: '/manage/status/mail/', title: 'Mail'},
+                {path: '/manage/status/warnings/', title: 'Warnings'},
+                {path: '/manage/settings/', title: 'Settings'},
+              ],
+            },
+            {
+              name: 'Manage',
+              items: [
+                {path: '/manage/organizations/', title: 'Organizations'},
+                {path: '/manage/projects/', title: 'Projects'},
+                {path: '/manage/users/', title: 'Users'},
+              ],
+            },
+          ]}
+        />
+      </NavWrapper>
+      <Content>{children}</Content>
     </Page>
   </DocumentTitle>
 );
 
+const NavWrapper = styled('div')`
+  flex-shrink: 0;
+  flex-grow: 0;
+  width: ${p => p.theme.settings.sidebarWidth};
+  background: ${p => p.theme.white};
+  border-right: 1px solid ${p => p.theme.border};
+`;
+
 const Page = styled('div')`
-  display: grid;
-  grid-template-columns: 200px 1fr;
-  margin: ${space(4)};
+  display: flex;
   flex-grow: 1;
+  margin-bottom: -20px;
+`;
+
+const Content = styled('div')`
+  flex-grow: 1;
+  padding: ${space(4)};
 `;
 
 export default AdminLayout;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
@@ -15,6 +15,10 @@ type DefaultProps = {
    * Additional navigation elements driven from hooks
    */
   hooks: React.ReactElement[];
+  /**
+   * How far from the top of the page should the navigation be when stickied.
+   */
+  stickyTop: string;
 };
 
 type Props = DefaultProps &
@@ -29,6 +33,7 @@ class SettingsNavigation extends React.Component<Props> {
   static defaultProps: DefaultProps = {
     hooks: [],
     hookConfigs: [],
+    stickyTop: '70px',
   };
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
@@ -42,11 +47,11 @@ class SettingsNavigation extends React.Component<Props> {
   }
 
   render() {
-    const {navigationObjects, hooks, hookConfigs, ...otherProps} = this.props;
+    const {navigationObjects, hooks, hookConfigs, stickyTop, ...otherProps} = this.props;
     const navWithHooks = navigationObjects.concat(hookConfigs);
 
     return (
-      <PositionStickyWrapper>
+      <PositionStickyWrapper stickyTop={stickyTop}>
         {navWithHooks.map(config => (
           <SettingsNavigationGroup key={config.name} {...otherProps} {...config} />
         ))}
@@ -56,15 +61,15 @@ class SettingsNavigation extends React.Component<Props> {
   }
 }
 
-const PositionStickyWrapper = styled('div')`
+const PositionStickyWrapper = styled('div')<{stickyTop: string}>`
   padding: ${space(4)};
   padding-right: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     position: sticky;
-    top: 70px;
+    top: ${p => p.stickyTop};
     overflow: scroll;
-    height: calc(100vh - 70px);
+    height: calc(100vh - ${p => p.stickyTop});
     -ms-overflow-style: none;
     scrollbar-width: none;
 


### PR DESCRIPTION
This is a bit more consisent IMO

![image](https://user-images.githubusercontent.com/1421724/98933817-01deb900-2496-11eb-9e5e-6dd64cf5f0bb.png)

vs the old

![image](https://user-images.githubusercontent.com/1421724/98933847-0c00b780-2496-11eb-9704-81522577b3c5.png)
