### PR TITLE
fix(workflow): Fix bug with collapse=stats when the org has `unhandled-issue-flag` active

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -344,7 +344,7 @@ class GroupSerializerBase(Serializer):
         merge_list_dictionaries(annotations_by_group_id, local_annotations_by_group_id)
 
         snuba_stats = {}
-        if has_unhandled_flag:
+        if has_unhandled_flag and seen_stats:
             snuba_stats = self._get_group_snuba_stats(item_list, seen_stats)
 
         for item in item_list:

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -98,9 +98,10 @@ class GroupSerializerBase(Serializer):
         # but it has to be at least 14 days, and not more than 90 days ago.
         # Fallback to the 30 days ago if we are not able to calculate the value.
         last_seen = None
-        for item in seen_stats.values():
-            if last_seen is None or (item["last_seen"] and last_seen > item["last_seen"]):
-                last_seen = item["last_seen"]
+        if seen_stats:
+            for item in seen_stats.values():
+                if last_seen is None or (item["last_seen"] and last_seen > item["last_seen"]):
+                    last_seen = item["last_seen"]
 
         if last_seen is None:
             return datetime.now(pytz.utc) - timedelta(days=30)
@@ -344,7 +345,7 @@ class GroupSerializerBase(Serializer):
         merge_list_dictionaries(annotations_by_group_id, local_annotations_by_group_id)
 
         snuba_stats = {}
-        if has_unhandled_flag and seen_stats:
+        if has_unhandled_flag:
             snuba_stats = self._get_group_snuba_stats(item_list, seen_stats)
 
         for item in item_list:

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -899,6 +899,12 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert "lifetime" not in response.data[0]
         assert "filtered" not in response.data[0]
 
+    def test_has_unhandled_flag_bug(self):
+        # There was a bug where we tried to access attributes on seen_stats if this feature is active
+        # but seen_stats could be null when we collapse stats.
+        with self.feature("organizations:unhandled-issue-flag"):
+            self.test_collapse_stats()
+
 
 class GroupUpdateTest(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-group-index"


### PR DESCRIPTION
If an org has this feature (like Sentry does), this code path uses seen_stats to calculate a start date. However, if stats are collapsed, `seen_stats` will be None and this will fail.

I've added a check for whether seen_stats is none and I am wondering a little whether I should change the way we calculate start...as going forward seen_stats will likely always be null and we may not want to always fall back to 30 days ago. It might even be better to start including this with the stats instead?

Fixes SENTRY-JF7
https://sentry.io/organizations/sentry/issues/2022032565/