### PR TITLE
fix(integrations): include params with cached head request

### DIFF
--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -300,7 +300,10 @@ class BaseApiClient(object):
         return self.request("HEAD", *args, **kwargs)
 
     def head_cached(self, path, *args, **kwargs):
-        key = self.get_cache_prefix() + md5_text(self.build_url(path)).hexdigest()
+        query = ""
+        if kwargs.get("params", None):
+            query = json.dumps(kwargs.get("params"), sort_keys=True)
+        key = self.get_cache_prefix() + md5_text(self.build_url(path), query).hexdigest()
 
         result = cache.get(key)
         if result is None:

--- a/tests/sentry/integrations/test_client.py
+++ b/tests/sentry/integrations/test_client.py
@@ -94,6 +94,20 @@ class ApiClientTest(TestCase):
         ApiClient().get_cached("http://example.com", params={"param": "different"})
         assert len(responses.calls) == 2
 
+    @responses.activate
+    def test_head_cached_query_param(self):
+        responses.add(responses.HEAD, "http://example.com?param=val", json={})
+        responses.add(responses.HEAD, "http://example.com?param=different", json={})
+
+        ApiClient().head_cached("http://example.com", params={"param": "val"})
+        assert len(responses.calls) == 1
+
+        ApiClient().head_cached("http://example.com", params={"param": "val"})
+        assert len(responses.calls) == 1
+
+        ApiClient().head_cached("http://example.com", params={"param": "different"})
+        assert len(responses.calls) == 2
+
 
 class OAuthProvider(OAuth2Provider):
     key = "oauth"


### PR DESCRIPTION
We should be adding the params when we cache the head request, otherwise the caching doesn't work as expected for the double requests in https://github.com/getsentry/sentry/pull/21909.

What's currently happening is that when we make a request with a `commitId` and `404`, we retry with the default branch (`master` in this case). If we are successful with the `master` branch we cache the `200`. 

But since it's only caching the path, the next time we try and make a request with the `commitId`, it thinks we had a `200` because the rest of the path matches and we don't end up retrying the request with default branch like we should. This means that the `source_url` that we return includes the `commitId` but it will actually `404` when someone tries to click on it. 