### PR TITLE
feat(ui): Fix Event entries error banner to use theme colors

### DIFF
--- a/src/sentry/static/sentry/app/components/events/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/styles.tsx
@@ -9,9 +9,8 @@ const COLORS = {
     border: theme.border,
   },
   danger: {
-    background: theme.red100,
-    // TODO(theme) This pink is non-standard
-    border: '#e7c0bc',
+    background: theme.alert.error.backgroundLight,
+    border: theme.alert.error.border,
   },
 } as const;
 


### PR DESCRIPTION
This fixes the Error banner at the top of Issue Details to use the alert theme colors.