### PR TITLE
fix(py3): sort teams in msteams

### DIFF
--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -590,11 +590,8 @@ def build_group_ignore_card(group, event, rules, integration):
 
 
 def build_group_assign_card(group, event, rules, integration):
-    teams = [
-        {"title": u"#{}".format(u.slug), "value": u"team:{}".format(u.id)}
-        for u in group.project.teams.all()
-    ]
-    teams.sort()
+    teams_list = group.project.teams.all().order_by("slug")
+    teams = [{"title": u"#{}".format(u.slug), "value": u"team:{}".format(u.id)} for u in teams_list]
     teams = [{"title": "Me", "value": ME}] + teams
     title_card = {
         "type": "TextBlock",


### PR DESCRIPTION
Running the current code in Python 3 generates the following the error:
```
TypeError: '<' not supported between instances of 'dict' and 'dict'
```
This is because we are trying to sort items that are dictionaries. The easy solution is to just sort the teams by the slug before creating the dictionary.