### PR TITLE
ref(py3): Make TagType really sortable

### DIFF
--- a/tests/sentry/tagstore/test_types.py
+++ b/tests/sentry/tagstore/test_types.py
@@ -8,3 +8,11 @@ def test_pickle():
     for cls in [TagKey, TagValue, GroupTagKey, GroupTagValue]:
         value = cls(**{name: 1 for name in cls.__slots__})
         pickle.loads(pickle.dumps(value)) == value
+
+
+def test_sorting():
+    for cls in [TagKey, TagValue, GroupTagKey, GroupTagValue]:
+        value1 = cls(**{name: 1 for name in cls.__slots__})
+        value2 = cls(**{name: 2 for name in cls.__slots__})
+
+        assert value1 < value2


### PR DESCRIPTION
Before these were purely sorted by object id 😬 

This fixes a python 3 error, but also actually fixes tag sorting