### PR TITLE
fix(ownership) Fix incorrect logic in ownership modal

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/modal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/modal.tsx
@@ -57,7 +57,7 @@ class ProjectOwnershipModal extends AsyncComponent<Props, State> {
 
   renderBody() {
     const {ownership, urlTagData, eventData} = this.state;
-    if (!ownership || !urlTagData || !eventData) {
+    if (!ownership && !urlTagData && !eventData) {
       return null;
     }
     const urls = urlTagData
@@ -68,7 +68,7 @@ class ProjectOwnershipModal extends AsyncComponent<Props, State> {
       : [];
 
     // pull frame data out of exception or the stacktrace
-    const entry = (eventData.entries as Entry[]).find(({type}) =>
+    const entry = (eventData?.entries as Entry[]).find(({type}) =>
       ['exception', 'stacktrace'].includes(type)
     );
 
@@ -95,7 +95,7 @@ class ProjectOwnershipModal extends AsyncComponent<Props, State> {
         <p>{t('Match against Issue Data: (globbing syntax *, ? supported)')}</p>
         <OwnerInput
           {...this.props}
-          initialText={ownership.raw || ''}
+          initialText={ownership?.raw || ''}
           urls={urls}
           paths={paths}
         />

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ruleBuilder.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ruleBuilder.tsx
@@ -187,7 +187,7 @@ class RuleBuilder extends React.Component<Props, State> {
             priority="primary"
             disabled={!isValid}
             onClick={this.handleAddRule}
-            icon={<IconAdd size="xs" isCircled />}
+            icon={<IconAdd isCircled />}
             size="small"
           />
         </BuilderBar>


### PR DESCRIPTION
I made a mistake with the logic, instead of bailing if one thing is missing it should bail if all are missing. I've also increased the size of the + icon as it was comically small before.