### PR TITLE
fix(user): allow all time zones

### DIFF
--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -27,7 +27,7 @@ delete_logger = logging.getLogger("sentry.deletions.api")
 
 def _get_timezone_choices():
     results = []
-    for tz in pytz.common_timezones:
+    for tz in pytz.all_timezones:
         now = datetime.now(pytz.timezone(tz))
         offset = now.strftime("%z")
         results.append((int(offset), tz, "(UTC%s) %s" % (offset, tz)))


### PR DESCRIPTION
This fixes a bug when picking certain uncommon time zones such as `Asia/Rangoon`:

![Screen Shot 2020-11-12 at 4 49 07 PM](https://user-images.githubusercontent.com/8533851/99014150-01323b00-2507-11eb-9ad4-a3ee140019b4.png)

The fix is to use the full-time zone list for validation instead of just common time zones.
