### PR TITLE
feat(Linked Issues): Add verical scroll for overflow & hide card onClick

### DIFF
--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -161,6 +161,7 @@ class ExternalIssueActions extends AsyncComponent<Props, State> {
               </Container>
             }
             onOpen={unlinked.length === 1 ? () => this.openModal(unlinked[0]) : undefined}
+            showHoverCard={this.state.showModal ? false : undefined}
           />
         )}
         {selectedIntegration && (

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
@@ -20,6 +20,7 @@ type Props = {
   integrationType?: string;
   hoverCardHeader?: React.ReactNode;
   hoverCardBody?: React.ReactNode;
+  showHoverCard?: boolean;
 };
 
 class IssueSyncListElement extends React.Component<Props> {
@@ -34,6 +35,17 @@ class IssueSyncListElement extends React.Component<Props> {
     hoverCardHeader: PropTypes.node,
     hoverCardBody: PropTypes.node,
   };
+
+  hoverCardRef = React.createRef<Hovercard>();
+
+  componentDidUpdate(nextProps) {
+    if (
+      this.props.showHoverCard !== nextProps.showHoverCard &&
+      nextProps.showHoverCard === undefined
+    ) {
+      this.hoverCardRef.current && this.hoverCardRef.current.handleToggleOff();
+    }
+  }
 
   isLinked(): boolean {
     return !!(this.props.externalIssueLink && this.props.externalIssueId);
@@ -104,6 +116,7 @@ class IssueSyncListElement extends React.Component<Props> {
         <ClassNames>
           {({css}) => (
             <Hovercard
+              ref={this.hoverCardRef}
               containerClassName={css`
                 display: flex;
                 align-items: center;
@@ -111,6 +124,8 @@ class IssueSyncListElement extends React.Component<Props> {
               `}
               header={this.props.hoverCardHeader}
               body={this.props.hoverCardBody}
+              bodyClassName="issue-list-body"
+              show={this.props.showHoverCard}
             >
               {this.getIcon()}
               {this.getLink()}

--- a/src/sentry/static/sentry/less/sentry-hovercard.less
+++ b/src/sentry/static/sentry/less/sentry-hovercard.less
@@ -100,7 +100,7 @@
   }
 
   .issue-list-body {
-    height: 300px;
+    max-height: 300px;
     overflow-y: auto;
   }
 }

--- a/src/sentry/static/sentry/less/sentry-hovercard.less
+++ b/src/sentry/static/sentry/less/sentry-hovercard.less
@@ -68,7 +68,7 @@
   }
 
   h6 {
-    color: @50 !important;
+    color: @50  !important;
     font-size: 11px !important;
     margin-bottom: 4px !important;
     text-transform: uppercase;
@@ -97,5 +97,10 @@
       font-size: 12px;
       color: @70;
     }
+  }
+
+  .issue-list-body {
+    height: 300px;
+    overflow-y: auto;
   }
 }


### PR DESCRIPTION
## Objective
Some users have so many integrations of the same provider that it makes the HoverCard larger than the height of the screen. So in this PR, I added a maximum height and a vertical scrollbar when the HoverCard overflows. 

Also this PR fixes a broken behaviour where the HoverCard is visible after the modal pops up bc the mouse is hovering over the HoverCard. Expected behaviour is to hide the HoverCard on click.

## UI
<img width="1440" alt="Screen Shot 2020-11-12 at 5 18 26 PM" src="https://user-images.githubusercontent.com/10491193/99016244-8a4b7100-250b-11eb-8c25-dcd53ef20018.png">
