### PR TITLE
feat(workflow): Don't wait for saved searches before loading issues

### DIFF
--- a/src/sentry/static/sentry/app/components/pagination.tsx
+++ b/src/sentry/static/sentry/app/components/pagination.tsx
@@ -51,8 +51,8 @@ class Pagination extends React.Component<Props> {
     }
 
     const location = this.context.location;
-    const path = this.props.to || location.pathname;
-    const query = location.query;
+    const path = this.props.to || location?.pathname;
+    const query = location?.query;
     const links = parseLinkHeader(pageLinks);
     const previousDisabled = links.previous.results === false;
     const nextDisabled = links.next.results === false;

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -142,12 +142,10 @@ class IssueListOverview extends React.Component<Props, State> {
       success: this.onRealtimePoll,
     });
 
+    this.fetchData();
+    this.fetchSavedSearches();
     this.fetchTags();
     this.fetchMemberList();
-
-    // Start by getting searches first so if the user is on a saved search
-    // or they have a pinned search we load the correct data the first time.
-    this.fetchSavedSearches();
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
@@ -191,14 +189,6 @@ class IssueListOverview extends React.Component<Props, State> {
     if (!isEqual(prevProps.selection.projects, this.props.selection.projects)) {
       this.fetchMemberList();
       this.fetchTags();
-    }
-
-    // Wait for saved searches to load before we attempt to fetch stream data
-    if (this.props.savedSearchLoading) {
-      return;
-    } else if (prevProps.savedSearchLoading) {
-      this.fetchData();
-      return;
     }
 
     const prevQuery = prevProps.location.query;

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -1251,7 +1251,7 @@ describe('IssueList', function () {
         // Each property change after the first will actually cause two new
         // fetchData calls, one from the property change and another from a
         // change in this.state.issuesLoading going from false to true.
-        expect(fetchDataMock).toHaveBeenCalledTimes(2 * i + 1);
+        expect(fetchDataMock).toHaveBeenCalledTimes(2 * i + 3);
       }
     });
 
@@ -1336,11 +1336,6 @@ describe('IssueList', function () {
   describe('render states', function () {
     beforeEach(function () {
       wrapper = mountWithTheme(<IssueListOverview {...props} />);
-    });
-
-    it('displays the loading icon', function () {
-      wrapper.setState({savedSearchLoading: true});
-      expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
     });
 
     it('displays an error', function () {


### PR DESCRIPTION
I tried pinned searches and saved searches and both seem to work without waiting.

