### PR TITLE
fix(metric_alerts): Jump to latest offset when starting devserver.

### DIFF
--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -27,6 +27,8 @@ _DEFAULT_DAEMONS = {
         "query-subscription-consumer",
         "--commit-batch-size",
         "1",
+        "--force-offset-reset",
+        "latest",
     ],
 }
 

--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -361,6 +361,12 @@ def post_process_forwarder(**options):
     type=click.Choice(["earliest", "latest"]),
     help="Position in the commit log topic to begin reading from when no prior offset has been recorded.",
 )
+@click.option(
+    "--force-offset-reset",
+    default=None,
+    type=click.Choice(["earliest", "latest"]),
+    help="Force subscriptions to start from a particular offset",
+)
 @log_options()
 @configuration
 def query_subscription_consumer(**options):
@@ -371,6 +377,7 @@ def query_subscription_consumer(**options):
         topic=options["topic"],
         commit_batch_size=options["commit_batch_size"],
         initial_offset_reset=options["initial_offset_reset"],
+        force_offset_reset=options["force_offset_reset"],
     )
 
     def handler(signum, frame):

--- a/src/sentry/snuba/query_subscription_consumer.py
+++ b/src/sentry/snuba/query_subscription_consumer.py
@@ -105,16 +105,19 @@ class QuerySubscriptionConsumer(object):
         self.offsets.clear()
 
         def on_assign(consumer, partitions):
+            updated_partitions = []
             for partition in partitions:
                 if self.resolve_partition_force_offset:
                     partition = self.resolve_partition_force_offset(partition)
-                    self.consumer.assign([partition])
+                    updated_partitions.append(partition)
 
                 if partition.offset == OFFSET_INVALID:
                     updated_offset = None
                 else:
                     updated_offset = partition.offset
                 self.offsets[partition.partition] = updated_offset
+            if updated_partitions:
+                self.consumer.assign(updated_partitions)
             logger.info(
                 "query-subscription-consumer.on_assign",
                 extra={


### PR DESCRIPTION
In dev we don't really want to process a lot of queued up pending subscription values. Just jump to
the latest offset when we restart devserver.

Will implement the same thing in snuba for the subscription consumer there.