### PR TITLE
fix(getThreadException): Fix getThreadException issue

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/getThreadException.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/getThreadException.tsx
@@ -1,5 +1,6 @@
 import {Thread} from 'app/types/events';
 import {Event, ExceptionType} from 'app/types';
+import {defined} from 'app/utils';
 
 function getThreadException(thread: Thread, event: Event): ExceptionType | undefined {
   const exceptionEntry = event.entries.find(entry => entry.type === 'exception');
@@ -15,7 +16,7 @@ function getThreadException(thread: Thread, event: Event): ExceptionType | undef
     return undefined;
   }
 
-  if (exceptionDataValues.length === 1 && !exceptionDataValues[0].threadId) {
+  if (exceptionDataValues.length === 1 && !defined(exceptionDataValues[0].threadId)) {
     return exceptionData;
   }
 


### PR DESCRIPTION
**Problem**
The ThreadID is of type number and it can be 0. We are checking if the value is `null` or `undefined` by using `!` and this is causing some problems as` !0` equals true.

**Solution**
This PR introduces our utility function `defined`,  fixing the bug.
