### PR TITLE
fix(ci) Pin phabricator lower

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -105,7 +105,7 @@ cssselect==1.0.3
 setproctitle>=1.1.7,<1.2.0
 
 # sentry-plugins specific dependencies
-phabricator>=0.6.0,<1.0
+phabricator>=0.6.0,<0.8
 
 # test dependencies, but unable to move to requirements-test until sentry.utils.pytest and similar are moved to tests/
 mock==3.0.5 ; python_version < "3.3"


### PR DESCRIPTION
Phabricator released a new version today that requires a higher version of requests than we are using. Upgrading requests is higher risk than pinning this lower.