### PR TITLE
feat(metric_alerts): Move chart controls and total events to bottom of chart

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/events.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.tsx
@@ -11,6 +11,7 @@ import {
   OrganizationSummary,
   MultiSeriesEventsStats,
 } from 'app/types';
+import {LocationQuery} from 'app/utils/discover/eventView';
 
 type Options = {
   organization: OrganizationSummary;
@@ -95,6 +96,7 @@ export type EventQuery = {
   query: string;
   per_page?: number;
   referrer?: string;
+  environment?: string[];
 };
 
 export type TagSegment = {
@@ -134,7 +136,7 @@ export async function fetchTagFacets(
 export async function fetchTotalCount(
   api: Client,
   orgSlug: String,
-  query: EventQuery
+  query: EventQuery & LocationQuery
 ): Promise<number> {
   const urlParams = pick(query, Object.values(URL_PARAM));
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -114,8 +114,8 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
     });
 
     return (
-      <StyledPanel>
-        <PanelBody>
+      <Panel>
+        <StyledPanelBody>
           <List symbol="colored-numeric">
             <StyledListItem>{t('Select the events you want to alert on')}</StyledListItem>
             <FormRow>
@@ -318,15 +318,16 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
             </FormRow>
             {this.props.thresholdChart}
           </List>
-        </PanelBody>
-      </StyledPanel>
+        </StyledPanelBody>
+      </Panel>
     );
   }
 }
 
-const StyledPanel = styled(Panel)`
-  /* Sticky graph panel cannot have margin-bottom */
-  padding: ${space(1)};
+const StyledPanelBody = styled(PanelBody)`
+  h4 {
+    margin-bottom: ${space(1)};
+  }
 `;
 
 const SearchContainer = styled('div')`
@@ -339,13 +340,13 @@ const StyledSearchBar = styled(SearchBar)`
 
 const StyledListItem = styled(ListItem)`
   font-size: ${p => p.theme.fontSizeExtraLarge};
-  margin: ${space(2)} ${space(2)} 0 ${space(2)};
+  margin: ${space(3)} ${space(3)} 0 ${space(3)};
 `;
 
 const FormRow = styled('div')`
   display: flex;
   flex-direction: row;
-  padding: ${space(1.5)};
+  padding: ${space(1.5)} ${space(3)};
   align-items: flex-end;
   flex-wrap: wrap;
 `;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -369,7 +369,3 @@ const PeriodSelectControl = styled(SelectControl)`
   text-transform: none;
   border: 0;
 `;
-
-// const ChartWrapper = styled('div')`
-//   padding: 0 ${space(1.5)};
-// `;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -31,10 +31,10 @@ type State = {
 };
 
 const CHART_GRID = {
-  left: space(1),
-  right: space(1),
+  left: space(2),
+  right: space(2),
   top: space(4),
-  bottom: space(1),
+  bottom: space(2),
 };
 
 // Colors to use for trigger thresholds

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -25,6 +25,10 @@ describe('Incident Rules Details', function () {
       body: null,
     });
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-meta/',
+      body: {count: 5},
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/alert-rules/available-actions/',
       body: [
         {

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -41,6 +41,10 @@ describe('Incident Rules Form', function () {
       body: TestStubs.EventsStats(),
     });
     MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-meta/',
+      body: {count: 5},
+    });
+    MockApiClient.addMockResponse({
       url: '/organizations/org-slug/alert-rules/available-actions/',
       body: [
         {

--- a/tests/js/spec/views/settings/incidentRules/triggersChart.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/triggersChart.spec.jsx
@@ -11,6 +11,7 @@ jest.mock('app/components/charts/lineChart');
 
 describe('Incident Rules Create', () => {
   let eventStatsMock;
+  let eventCountsMock;
   let api;
 
   beforeEach(() => {
@@ -20,6 +21,10 @@ describe('Incident Rules Create', () => {
     eventStatsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: TestStubs.EventsStats(),
+    });
+    eventCountsMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-meta/',
+      body: {count: 5},
     });
   });
 
@@ -53,6 +58,18 @@ describe('Incident Rules Create', () => {
           query: 'event.type:error',
           statsPeriod: '1d',
           yAxis: 'count()',
+        },
+      })
+    );
+
+    expect(eventCountsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {
+          project: ['2'],
+          query: 'event.type:error',
+          statsPeriod: '1d',
+          environment: [],
         },
       })
     );
@@ -103,6 +120,18 @@ describe('Incident Rules Create', () => {
           query: 'event.type:error',
           statsPeriod: '1d',
           yAxis: 'count()',
+        },
+      })
+    );
+
+    expect(eventCountsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: {
+          project: ['2'],
+          query: 'event.type:error',
+          statsPeriod: '1d',
+          environment: [],
         },
       })
     );

--- a/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
@@ -147,6 +147,10 @@ describe('ProjectAlertsCreate', function () {
           url: '/organizations/org-slug/events-stats/',
           body: TestStubs.EventsStats(),
         });
+        MockApiClient.addMockResponse({
+          url: '/organizations/org-slug/events-meta/',
+          body: {count: 5},
+        });
       });
       it('forces user to select Metric or Issue alert', async function () {
         const {wrapper} = createWrapper({


### PR DESCRIPTION
Added a total events display and moved the time period selector to the bottom of the chart to match the mocks. 

**Here's how it looks in the GUI filters UI:**
<img width="1182" alt="Screen Shot 2020-11-12 at 9 13 53 PM" src="https://user-images.githubusercontent.com/9372512/99101995-6dff1100-25ab-11eb-9aee-b447aa84c49b.png">

**Here's how it looks in the current metric builder UI:**
<img width="1183" alt="Screen Shot 2020-11-12 at 9 14 02 PM" src="https://user-images.githubusercontent.com/9372512/99102004-72c3c500-25ab-11eb-89ad-8eded44ed8dd.png">
