### PR TITLE
fix(integrations): delete identity on uninstallation of integration

### DIFF
--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -234,7 +234,6 @@ class UserDetailsEndpoint(UserEndpoint):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        hard_delete = True
         is_current_user = request.user.id == user.id
 
         if hard_delete:

--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -234,6 +234,7 @@ class UserDetailsEndpoint(UserEndpoint):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
+        hard_delete = True
         is_current_user = request.user.id == user.id
 
         if hard_delete:

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -386,7 +386,7 @@ def delete_organization_integration(object_id, transaction_id=None, actor_id=Non
     if instance.default_auth_id:
         log_info = {
             "integration_id": instance.integration_id,
-            "id": instance.default_auth_id,
+            "identity_id": instance.default_auth_id,
         }
         try:
             identity = Identity.objects.get(id=instance.default_auth_id)

--- a/src/sentry/tasks/deletion.py
+++ b/src/sentry/tasks/deletion.py
@@ -391,6 +391,8 @@ def delete_organization_integration(object_id, transaction_id=None, actor_id=Non
         try:
             identity = Identity.objects.get(id=instance.default_auth_id)
         except Identity.DoesNotExist:
+            # the identity may not exist for a variety of reasons but for debugging puproses
+            # we should keep track
             logger.info("delete_organization_integration.identity_does_not_exist", extra=log_info)
         else:
             identity.delete()

--- a/tests/sentry/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_details.py
@@ -2,7 +2,13 @@ from __future__ import absolute_import
 
 import six
 
-from sentry.models import Integration, OrganizationIntegration, Repository
+from sentry.models import (
+    Integration,
+    OrganizationIntegration,
+    Repository,
+    Identity,
+    IdentityProvider,
+)
 from sentry.testutils import APITestCase
 
 
@@ -12,11 +18,19 @@ class OrganizationIntegrationDetailsTest(APITestCase):
 
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user, name="baz")
-        self.integration = Integration.objects.create(provider="example", name="Example")
-        self.integration.add_organization(self.org, self.user)
+        self.integration = Integration.objects.create(
+            provider="gitlab", name="Gitlab", external_id="gitlab:1"
+        )
+        self.identity = Identity.objects.create(
+            idp=IdentityProvider.objects.create(type="gitlab", config={}, external_id="gitlab:1"),
+            user=self.user,
+            external_id="base_id",
+            data={},
+        )
+        self.integration.add_organization(self.org, self.user, default_auth_id=self.identity.id)
 
         self.repo = Repository.objects.create(
-            provider="example",
+            provider="gitlab",
             name="getsentry/sentry",
             organization_id=self.org.id,
             integration_id=self.integration.id,
@@ -43,6 +57,7 @@ class OrganizationIntegrationDetailsTest(APITestCase):
             assert not OrganizationIntegration.objects.filter(
                 integration=self.integration, organization=self.org
             ).exists()
+            assert not Identity.objects.filter(user=self.user).exists()
 
             # make sure repo is dissociated from integration
             assert Repository.objects.get(id=self.repo.id).integration_id is None
@@ -59,3 +74,16 @@ class OrganizationIntegrationDetailsTest(APITestCase):
         )
 
         assert org_integration.config == config
+
+    def test_removal_default_identity_already_removed(self):
+        with self.tasks():
+            self.identity.delete()
+            response = self.client.delete(self.path, format="json")
+
+            assert response.status_code == 204, response.content
+            assert Integration.objects.filter(id=self.integration.id).exists()
+
+            # Ensure Organization integrations are removed
+            assert not OrganizationIntegration.objects.filter(
+                integration=self.integration, organization=self.org
+            ).exists()


### PR DESCRIPTION
This PR will ensure that we delete the `Identity` that's referenced by the `OrganizationIntegration.default_auth_id` for certain integrations such as Gitlab. This is now necessary because a recent PR (https://github.com/getsentry/sentry/pull/21916) added stricter checks on installing an integration if there is an `Identity` object that points to an `Integration` with a different user and different organization. Before this change, uninstalling the integration on the organization does not delete the `Identity` row. This means that even after uninstalling the integration on the other org, the user might be blocked from installing it on a different org. By deleting what would be a floating `Identity` row, we can ensure that we don't block installation.