### PR TITLE
fix(workflow): Add missing is_api_token to alert created event

### DIFF
--- a/src/sentry/analytics/events/alert_created.py
+++ b/src/sentry/analytics/events/alert_created.py
@@ -12,6 +12,7 @@ class AlertCreatedEvent(analytics.Event):
         analytics.Attribute("organization_id"),
         analytics.Attribute("rule_id"),
         analytics.Attribute("rule_type"),
+        analytics.Attribute("is_api_token"),
     )
 
 


### PR DESCRIPTION
Missed this in #21917 