### PR TITLE
fix(trends): Fix default query reappearing in edge case

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -232,8 +232,10 @@ class DefaultTrends extends React.Component<DefaultTrendsProps> {
     const conditions = tokenizeSearch(queryString || '');
 
     if (queryString || this.hasPushedDefaults) {
+      this.hasPushedDefaults = true;
       return <React.Fragment>{children}</React.Fragment>;
     } else {
+      this.hasPushedDefaults = true;
       conditions.setTagValues('tpm()', ['>0.01']);
       conditions.setTagValues('transaction.duration', ['>0', `<${DEFAULT_MAX_DURATION}`]);
     }
@@ -250,7 +252,6 @@ class DefaultTrends extends React.Component<DefaultTrendsProps> {
         view: FilterViews.TRENDS,
       },
     });
-    this.hasPushedDefaults = true;
     return null;
   }
 }


### PR DESCRIPTION
### Summary

There was an edge case where if you navigated from another performance tab and completely removed the query, it would reappear the first time. This fixes it so the query no longer reappears by fixing the default trends to be also ignored if someone came to the page with a query.