### PR TITLE
feat(auto tickets): Don't create ticket if one already exists

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -866,7 +866,7 @@ SENTRY_FEATURES = {
     # management integrations)
     "organizations:integrations-incident-management": True,
     # Allow orgs to automatically create Tickets in Issue Alerts
-    "organizations:integrations-ticket-rules": False,
+    "organizations:integrations-ticket-rules": True,
     # Allow orgs to install AzureDevops with limited scopes
     "organizations:integrations-vsts-limited-scopes": False,
     # Allow orgs to use the stacktrace linking feature

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -866,7 +866,7 @@ SENTRY_FEATURES = {
     # management integrations)
     "organizations:integrations-incident-management": True,
     # Allow orgs to automatically create Tickets in Issue Alerts
-    "organizations:integrations-ticket-rules": True,
+    "organizations:integrations-ticket-rules": False,
     # Allow orgs to install AzureDevops with limited scopes
     "organizations:integrations-vsts-limited-scopes": False,
     # Allow orgs to use the stacktrace linking feature

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -162,8 +162,9 @@ class JiraCreateTicketAction(TicketEventAction):
             """Create the Jira ticket for a given event"""
 
             # HACK to get fixVersion in the correct format
-            if not isinstance(self.data["fixVersions"], list):
-                self.data["fixVersions"] = [self.data["fixVersions"]]
+            if self.data.get("fixVersions"):
+                if not isinstance(self.data["fixVersions"], list):
+                    self.data["fixVersions"] = [self.data["fixVersions"]]
 
             if self.data.get("dynamic_form_fields"):
                 del self.data["dynamic_form_fields"]
@@ -171,6 +172,15 @@ class JiraCreateTicketAction(TicketEventAction):
             if not self.has_linked_issue(event, integration):
                 resp = installation.create_issue(self.data)
                 self.create_link(resp["key"], integration, installation, event)
+            else:
+                logger.info(
+                    "jira.rule_trigger.link_already_exists",
+                    extra={
+                        "rule_id": self.rule.id,
+                        "project_id": self.project.id,
+                        "group_id": event.group.id,
+                    },
+                )
             return
 
         key = u"jira:{}".format(integration.id)

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -6,7 +6,6 @@ import six
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
-<<<<<<< HEAD
 from sentry.integrations.jira.utils import (
     transform_jira_fields_to_form_fields,
     transform_jira_choices_to_strings,
@@ -17,6 +16,7 @@ from sentry.rules.actions.base import TicketEventAction
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
+from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger("sentry.rules")
 
@@ -151,6 +151,7 @@ class JiraCreateTicketAction(TicketEventAction):
             self.rule.label, absolute_uri(rule_url),
         )
 
+    @transaction_start("JiraCreateTicketAction.after")
     def after(self, event, state):
         organization = self.project.organization
         integration = self.get_integration()

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -6,14 +6,16 @@ import six
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
+<<<<<<< HEAD
 from sentry.integrations.jira.utils import (
     transform_jira_fields_to_form_fields,
     transform_jira_choices_to_strings,
 )
-from sentry.models import ExternalIssue
+from sentry.models import ExternalIssue, GroupLink
 from sentry.models.integration import Integration
 from sentry.rules.actions.base import TicketEventAction
 from sentry.shared_integrations.exceptions import IntegrationError
+from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger("sentry.rules")
@@ -160,15 +162,16 @@ class JiraCreateTicketAction(TicketEventAction):
         def create_issue(event, futures):
             """Create the Jira ticket for a given event"""
 
-            # TODO check if a Jira ticket already exists for the given event's issue. if it does, skip creating it
-            resp = installation.create_issue(self.data)
-            ExternalIssue.objects.create(
-                organization_id=organization.id,
-                integration_id=integration.id,
-                key=resp["key"],
-                title=event.title,
-                description=installation.get_group_description(event.group, event),
-            )
+            linked = GroupLink.objects.filter(
+                project_id=self.project.id,
+                group_id=event.group.id,
+                linked_type=GroupLink.LinkedType.issue,
+            ).values_list("data", flat=True)
+
+            if not linked or json.loads(linked[0])["provider"] != self.provider:
+                # if multiple tickets are being created via one rule or same criteria
+                resp = installation.create_issue(self.data)
+                self.create_link(resp["key"], integration, installation, event)
             return
 
         key = u"jira:{}".format(integration.id)

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -161,6 +161,13 @@ class JiraCreateTicketAction(TicketEventAction):
         def create_issue(event, futures):
             """Create the Jira ticket for a given event"""
 
+            # HACK to get fixVersion in the correct format
+            if not isinstance(self.data["fixVersions"], list):
+                self.data["fixVersions"] = [self.data["fixVersions"]]
+
+            if self.data.get("dynamic_form_fields"):
+                del self.data["dynamic_form_fields"]
+
             if not self.has_linked_issue(event, integration):
                 resp = installation.create_issue(self.data)
                 self.create_link(resp["key"], integration, installation, event)

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -5,7 +5,8 @@ import logging
 from django import forms
 
 from sentry.rules.actions.base import TicketEventAction
-from sentry.models import ExternalIssue
+from sentry.models import GroupLink
+from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger("sentry.rules")
@@ -36,7 +37,7 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
         return self.label.format(name=self.get_integration_name())
 
     def generate_footer(self, rule_url):
-        return u"\nThis ticket was automatically created by Sentry via [{}]({})".format(
+        return u"\nThis work item was automatically created by Sentry via [{}]({})".format(
             self.rule.label, absolute_uri(rule_url),
         )
 
@@ -49,15 +50,16 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
         def create_issue(event, futures):
             """Create an Azure DevOps work item for a given event"""
 
-            # TODO check if an Azure DevOps work item already exists for the given event's issue. if it does, skip creating it
-            resp = installation.create_issue(self.data)
-            ExternalIssue.objects.create(
-                organization_id=organization.id,
-                integration_id=integration.id,
-                key=resp["metadata"]["display_name"],
-                title=event.title,
-                description=installation.get_group_description(event.group, event),
-            )
+            linked = GroupLink.objects.filter(
+                project_id=self.project.id,
+                group_id=event.group.id,
+                linked_type=GroupLink.LinkedType.issue,
+            ).values_list("data", flat=True)
+
+            if not linked or json.loads(linked[0])["provider"] != self.provider:
+                # if multiple tickets are being created via one rule or same criteria
+                resp = installation.create_issue(self.data)
+                self.create_link(resp["metadata"]["display_name"], integration, installation, event)
             return
 
         key = u"vsts:{}".format(integration.id)

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -53,6 +53,15 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
             if not self.has_linked_issue(event, integration):
                 resp = installation.create_issue(self.data)
                 self.create_link(resp["metadata"]["display_name"], integration, installation, event)
+            else:
+                logger.info(
+                    "vsts.rule_trigger.link_already_exists",
+                    extra={
+                        "rule_id": self.rule.id,
+                        "project_id": self.project.id,
+                        "group_id": event.group.id,
+                    },
+                )
             return
 
         key = u"vsts:{}".format(integration.id)

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -8,6 +8,7 @@ from sentry.rules.actions.base import TicketEventAction
 from sentry.models import GroupLink
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
+from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger("sentry.rules")
 
@@ -41,6 +42,7 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
             self.rule.label, absolute_uri(rule_url),
         )
 
+    @transaction_start("AzureDevopsCreateTicketAction.after")
     def after(self, event, state):
         organization = self.project.organization
         integration = self.get_integration()
@@ -55,7 +57,6 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
                 group_id=event.group.id,
                 linked_type=GroupLink.LinkedType.issue,
             ).values_list("data", flat=True)
-
             if not linked or json.loads(linked[0])["provider"] != self.provider:
                 # if multiple tickets are being created via one rule or same criteria
                 resp = installation.create_issue(self.data)

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -105,12 +105,11 @@ class TicketEventAction(IntegrationEventAction):
             project_id=self.project.id,
             group_id=event.group.id,
             linked_type=GroupLink.LinkedType.issue,
-        ).values("linked_id")
+        ).values_list("linked_id", flat=True)
 
-        integration_ids = [
-            ExternalIssue.objects.get(id=link["linked_id"]).integration_id for link in linked_issues
-        ]
-        return integration.id in integration_ids
+        return ExternalIssue.objects.filter(
+            id__in=linked_issues, integration_id=integration.id,
+        ).exists()
 
     def create_link(self, key, integration, installation, event):
         external_issue = ExternalIssue.objects.create(

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -100,6 +100,18 @@ class TicketEventAction(IntegrationEventAction):
             rule_url
         )
 
+    def has_linked_issue(self, event, integration):
+        linked_issues = GroupLink.objects.filter(
+            project_id=self.project.id,
+            group_id=event.group.id,
+            linked_type=GroupLink.LinkedType.issue,
+        ).values("linked_id")
+
+        integration_ids = [
+            ExternalIssue.objects.get(id=link["linked_id"]).integration_id for link in linked_issues
+        ]
+        return integration.id in integration_ids
+
     def create_link(self, key, integration, installation, event):
         external_issue = ExternalIssue.objects.create(
             organization_id=self.project.organization.id,

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -82,10 +82,6 @@ class IntegrationEventAction(EventAction):
     def get_form_instance(self):
         return self.form_cls(self.data, integrations=self.get_integrations())
 
-    def get_linked_issue(self):
-        # check if the issue exists already or not
-        pass
-
 
 class TicketEventAction(IntegrationEventAction):
     """Shared ticket actions"""

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -42,6 +42,7 @@ class JiraCreateTicketActionTest(RuleTestCase):
                 "jira_integration": self.integration.id,
                 "jira_project": "10000",
                 "issue_type": "Bug",
+                "fixVersions": "[10000]",
             }
         )
         jira_rule.rule = Rule.objects.create(project=self.project, label="test rule",)
@@ -113,6 +114,7 @@ class JiraCreateTicketActionTest(RuleTestCase):
                 "jira_integration": self.integration.id,
                 "jira_project": "10000",
                 "issue_type": "Bug",
+                "fixVersions": "[10000]",
             }
         )
         jira_rule.rule = Rule.objects.create(project=self.project, label="test rule",)

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -81,6 +81,47 @@ class JiraCreateTicketActionTest(RuleTestCase):
         external_issue = ExternalIssue.objects.get(key="APP-123")
         assert external_issue
 
+    @responses.activate
+    def test_doesnt_create_issue(self):
+        """Don't create an issue if one already exists on the event for the given integration"""
+
+        event = self.get_event()
+        external_issue = ExternalIssue.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            key="APP-123",
+            title=event.title,
+            description="Fix this.",
+        )
+        GroupLink.objects.create(
+            group_id=event.group.id,
+            project_id=self.project.id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=external_issue.id,
+            relationship=GroupLink.Relationship.references,
+            data={"provider": self.integration.provider},
+        )
+        jira_rule = self.get_rule(
+            data={
+                "title": "example summary",
+                "description": "example bug report",
+                "issuetype": "1",
+                "project": "10000",
+                "customfield_10200": "sad",
+                "customfield_10300": ["Feature 1", "Feature 2"],
+                "labels": "bunnies",
+                "jira_integration": self.integration.id,
+                "jira_project": "10000",
+                "issue_type": "Bug",
+            }
+        )
+        jira_rule.rule = Rule.objects.create(project=self.project, label="test rule",)
+
+        results = list(jira_rule.after(event=event, state=self.get_state()))
+        assert len(results) == 1
+        results[0].callback(event, futures=[])
+        assert len(responses.calls) == 1
+
     def test_render_label(self):
         rule = self.get_rule(
             data={
@@ -120,44 +161,3 @@ class JiraCreateTicketActionTest(RuleTestCase):
 
         form = rule.get_form_instance()
         assert form.is_valid()
-
-    @responses.activate
-    def test_doesnt_create_issue(self):
-        """Don't create an issue if one already exists on the event"""
-
-        event = self.get_event()
-        external_issue = ExternalIssue.objects.create(
-            organization_id=self.organization.id,
-            integration_id=self.integration.id,
-            key="APP-123",
-            title=event.title,
-            description="Fix this.",
-        )
-        GroupLink.objects.create(
-            group_id=event.group.id,
-            project_id=self.project.id,
-            linked_type=GroupLink.LinkedType.issue,
-            linked_id=external_issue.id,
-            relationship=GroupLink.Relationship.references,
-            data={"provider": self.integration.provider},
-        )
-        jira_rule = self.get_rule(
-            data={
-                "title": "example summary",
-                "description": "example bug report",
-                "issuetype": "1",
-                "project": "10000",
-                "customfield_10200": "sad",
-                "customfield_10300": ["Feature 1", "Feature 2"],
-                "labels": "bunnies",
-                "jira_integration": self.integration.id,
-                "jira_project": "10000",
-                "issue_type": "Bug",
-            }
-        )
-        jira_rule.rule = Rule.objects.create(project=self.project, label="test rule",)
-
-        results = list(jira_rule.after(event=event, state=self.get_state()))
-        assert len(results) == 1
-        results[0].callback(event, futures=[])
-        assert len(responses.calls) == 0

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import responses
 
 from sentry.integrations.jira.notify_action import JiraCreateTicketAction
-from sentry.models import Integration, ExternalIssue, Rule
+from sentry.models import Integration, ExternalIssue, GroupLink, Rule
 from sentry.testutils.cases import RuleTestCase
 from sentry.utils import json
 
@@ -120,3 +120,44 @@ class JiraCreateTicketActionTest(RuleTestCase):
 
         form = rule.get_form_instance()
         assert form.is_valid()
+
+    @responses.activate
+    def test_doesnt_create_issue(self):
+        """Don't create an issue if one already exists on the event"""
+
+        event = self.get_event()
+        external_issue = ExternalIssue.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            key="APP-123",
+            title=event.title,
+            description="Fix this.",
+        )
+        GroupLink.objects.create(
+            group_id=event.group.id,
+            project_id=self.project.id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=external_issue.id,
+            relationship=GroupLink.Relationship.references,
+            data={"provider": self.integration.provider},
+        )
+        jira_rule = self.get_rule(
+            data={
+                "title": "example summary",
+                "description": "example bug report",
+                "issuetype": "1",
+                "project": "10000",
+                "customfield_10200": "sad",
+                "customfield_10300": ["Feature 1", "Feature 2"],
+                "labels": "bunnies",
+                "jira_integration": self.integration.id,
+                "jira_project": "10000",
+                "issue_type": "Bug",
+            }
+        )
+        jira_rule.rule = Rule.objects.create(project=self.project, label="test rule",)
+
+        results = list(jira_rule.after(event=event, state=self.get_state()))
+        assert len(results) == 1
+        results[0].callback(event, futures=[])
+        assert len(responses.calls) == 0

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -9,7 +9,7 @@ from sentry.testutils.cases import RuleTestCase
 from sentry.integrations.vsts.notify_action import AzureDevopsCreateTicketAction
 from sentry.integrations.vsts.integration import VstsIntegration
 
-from sentry.models import ExternalIssue, Identity, IdentityProvider, Integration, Rule
+from sentry.models import ExternalIssue, GroupLink, Identity, IdentityProvider, Integration, Rule
 
 from .testutils import WORK_ITEM_RESPONSE
 
@@ -68,3 +68,39 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase):
 
         external_issue = ExternalIssue.objects.get(key="Fabrikam-Fiber-Git#309")
         assert external_issue
+
+    @responses.activate
+    def test_doesnt_create_issue(self):
+        """Don't create an issue if one already exists on the event"""
+
+        event = self.get_event()
+        external_issue = ExternalIssue.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.model.id,
+            key="TEST#6",
+            title=event.title,
+            description="Fix this.",
+        )
+        GroupLink.objects.create(
+            group_id=event.group.id,
+            project_id=self.project.id,
+            linked_type=GroupLink.LinkedType.issue,
+            linked_id=external_issue.id,
+            relationship=GroupLink.Relationship.references,
+            data={"provider": self.integration.model.provider},
+        )
+        azuredevops_rule = self.get_rule(
+            data={
+                "title": "Hello",
+                "description": "Fix this.",
+                "project": "0987654321",
+                "work_item_type": "Microsoft.VSTS.WorkItemTypes.Task",
+                "vsts_integration": self.integration.model.id,
+            }
+        )
+        azuredevops_rule.rule = Rule.objects.create(project=self.project, label="test rule")
+
+        results = list(azuredevops_rule.after(event=event, state=self.get_state()))
+        assert len(results) == 1
+        results[0].callback(event, futures=[])
+        assert len(responses.calls) == 0


### PR DESCRIPTION
Since a rule may fire on an issue that already has a linked issue for that provider, we don't want to make duplicate tickets. This also creates the link in the Sentry issue to the external issue via the `GroupLink` instance that is created and used to check if one already exists.

<img width="330" alt="Screen Shot 2020-11-12 at 3 54 12 PM" src="https://user-images.githubusercontent.com/29959063/99122480-3f853400-25b3-11eb-8627-b9b69afd14ea.png">
