### PR TITLE
fix(ui) Fix chart split line

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/yAxis.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/yAxis.tsx
@@ -17,7 +17,8 @@ export default function YAxis({theme, ...props}: Props): EChartOption.YAxis {
     },
     splitLine: {
       lineStyle: {
-        color: theme.chartLineColor,
+        color: theme.gray100,
+        opacity: 0.3,
       },
     },
     ...props,

--- a/src/sentry/static/sentry/app/components/charts/components/yAxis.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/yAxis.tsx
@@ -17,7 +17,7 @@ export default function YAxis({theme, ...props}: Props): EChartOption.YAxis {
     },
     splitLine: {
       lineStyle: {
-        color: theme.gray100,
+        color: theme.chartLineColor,
         opacity: 0.3,
       },
     },


### PR DESCRIPTION
It had way too much constrast with gray100. Instead of adding a colour we can use opacity to drop the contrast on this.