### PR TITLE
ref(ui): Make request for saved searches first

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -142,12 +142,11 @@ class IssueListOverview extends React.Component<Props, State> {
       success: this.onRealtimePoll,
     });
 
-    this.fetchTags();
-    this.fetchMemberList();
-
     // Start by getting searches first so if the user is on a saved search
     // or they have a pinned search we load the correct data the first time.
     this.fetchSavedSearches();
+    this.fetchTags();
+    this.fetchMemberList();
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {


### PR DESCRIPTION
The saved search request blocks the first page load issue search query. We make 2 additional requests to sentry.io right before it and in some cases that puts us up to the 6 request browser limit. 

See the stalled time for the `/organizations/:org/searches/` api where stalled time is what this PR would possibly reduce
![image](https://user-images.githubusercontent.com/1400464/99219284-25a14800-2791-11eb-8d45-f6a0989e4852.png)

Docs 🤷‍♂️ https://developers.google.com/web/tools/chrome-devtools/network/reference?utm_source=devtools#timing-explanation

