### PR TITLE
ref(stacktrace-link): Rename configuration columns

### DIFF
--- a/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
+++ b/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
@@ -54,7 +54,7 @@ class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
             query = query.exclude(id=self.instance.id)
         if query.exists():
             raise serializers.ValidationError(
-                "Code path config already exists with this project and input path"
+                "Code path config already exists with this project and stack trace root."
             )
         return attrs
 

--- a/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
+++ b/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
@@ -54,7 +54,7 @@ class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
             query = query.exclude(id=self.instance.id)
         if query.exists():
             raise serializers.ValidationError(
-                "Code path config already exists with this project and stack trace root."
+                "Code path config already exists with this project and stack trace root"
             )
         return attrs
 

--- a/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
+++ b/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
@@ -75,7 +75,7 @@ export default class RepositoryProjectPathConfigForm extends React.Component<Pro
           name: 'stackRoot',
           type: 'string',
           required: false,
-          label: t('Input Path'),
+          label: t('Stack Trace Root'),
           placeholder: t('Type root path of your stack traces'),
           inline: false,
           showHelpInTooltip: true,
@@ -87,12 +87,12 @@ export default class RepositoryProjectPathConfigForm extends React.Component<Pro
           name: 'sourceRoot',
           type: 'string',
           required: false,
-          label: t('Output Path'),
+          label: t('Source Code Root'),
           placeholder: t('Type root path of your source code'),
           inline: false,
           showHelpInTooltip: true,
           help: t(
-            'When a rule matches, the input path is replaced with this path to get the path in your repository. Leaving this empty means replacing the input path with an empty string.'
+            'When a rule matches, the stack trace root is replaced with this path to get the path in your repository. Leaving this empty means replacing the stack trace root with an empty string.'
           ),
         },
       ],

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -217,7 +217,7 @@ const Layout = styled('div')`
   width: 100%;
   align-items: center;
   grid-template-columns: 4.5fr 2.5fr 2.5fr 1.6fr;
-  grid-template-areas: 'name-repo output-path input-path button';
+  grid-template-areas: 'name-repo input-path output-path button';
 `;
 
 const HeaderLayout = styled(Layout)`

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -141,8 +141,8 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
           <PanelHeader disablePadding hasButtons>
             <HeaderLayout>
               <NameRepoColumn>{t('Code Path Mappings')}</NameRepoColumn>
-              <OutputPathColumn>{t('Output Path')}</OutputPathColumn>
-              <InputPathColumn>{t('Input Path')}</InputPathColumn>
+              <InputPathColumn>{t('Stack Trace Root')}</InputPathColumn>
+              <OutputPathColumn>{t('Source Code Root')}</OutputPathColumn>
               <ButtonColumn>
                 <AddButton
                   onClick={() => this.openModal()}

--- a/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
@@ -154,7 +154,9 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
         response = self.make_post()
         assert response.status_code == 400
         assert response.data == {
-            "nonFieldErrors": [u"Code path config already exists with this project and input path"]
+            "nonFieldErrors": [
+                u"Code path config already exists with this project and stack trace root"
+            ]
         }
 
     def test_space_in_stack_root(self):


### PR DESCRIPTION
**UI Changes**

* Update column names to be clearer 
    * `input_path` -> `stack trace root`
    * `output_path` -> `source code root`
* Swap order of columns in table so that `stack trace root` is first

> ![Screen Shot 2020-11-16 at 10 50 05 AM](https://user-images.githubusercontent.com/15368179/99295015-b6ac0980-27f9-11eb-81a9-3b6e832b447a.png)
