### PR TITLE
fix(release): Fetch before pushing latest version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,4 +79,4 @@ jobs:
         run: |
           git checkout master
           ./scripts/bump-version.sh '' $(date -d "$(echo $RELEASE_VERSION | sed -e 's/^\([0-9]\{2\}\)\.\([0-9]\{1,2\}\)\.[0-9]\+$/20\1-\2-1/') 1 month" +%y.%-m.0.dev0)
-          git diff --quiet || git commit -anm 'meta: Bump new development version' && git pull && git push
+          git diff --quiet || git commit -anm 'meta: Bump new development version' && git pull --rebase && git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,4 +79,4 @@ jobs:
         run: |
           git checkout master
           ./scripts/bump-version.sh '' $(date -d "$(echo $RELEASE_VERSION | sed -e 's/^\([0-9]\{2\}\)\.\([0-9]\{1,2\}\)\.[0-9]\+$/20\1-\2-1/') 1 month" +%y.%-m.0.dev0)
-          git diff --quiet || git commit -anm 'meta: Bump new development version' && git push
+          git diff --quiet || git commit -anm 'meta: Bump new development version' && git pull && git push


### PR DESCRIPTION
Fixes the

```
! [rejected]          master -> master (fetch first)
```
error at the version bump stage when the release takes a while.
