### PR TITLE
feat(select): Added new label style

### DIFF
--- a/docs-ui/components/form-fields.stories.js
+++ b/docs-ui/components/form-fields.stories.js
@@ -268,6 +268,28 @@ SelectFieldGrouped.story = {
   name: 'SelectField grouped',
 };
 
+export const SelectFieldInFieldLabel = withInfo({
+  text: 'Select Control w/ Label In Field',
+  propTablesExclude: [Form],
+})(() => (
+  <Form>
+    <SelectField
+      name="select"
+      label="Select With Label In Field"
+      inFieldLabel="Label: "
+      choices={[
+        ['choice_one', 'Choice One'],
+        ['choice_two', 'Choice Two'],
+        ['choice_three', 'Choice Three'],
+      ]}
+    />
+  </Form>
+));
+
+SelectFieldInFieldLabel.story = {
+  name: 'SelectField label in field',
+};
+
 export const NonInlineField = withInfo({
   text: 'Radio Group used w/ FormField',
   propTablesExclude: [Form],

--- a/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
@@ -24,6 +24,7 @@ export default class SelectField extends React.Component {
     multiple: PropTypes.bool,
     escapeMarkup: PropTypes.bool,
     small: PropTypes.bool,
+    inFieldLabel: PropTypes.string,
   };
 
   static defaultProps = {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -105,14 +105,6 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
       border: 'none',
     };
 
-    const selectLabel = (label: string) => ({
-      ':before': {
-        content: `"${label}"`,
-        color: theme.gray300,
-        fontWeight: 600,
-      },
-    });
-
     return (
       <StyledPanel>
         <PanelBody>
@@ -130,12 +122,7 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
                 styles={{
                   singleValue: (base: any) => ({
                     ...base,
-                    ...selectLabel(t('Env: ')),
                     '.all-environment-note': {display: 'none'},
-                  }),
-                  placeholder: (base: any) => ({
-                    ...base,
-                    ...selectLabel(t('Env: ')),
                   }),
                   option: (base: any, state: any) => ({
                     ...base,
@@ -152,6 +139,7 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
                 isClearable
                 inline={false}
                 flexibleControlStateSize
+                inFieldLabel={t('Env: ')}
               />
               <Feature requireAll features={['organizations:performance-view']}>
                 <FormField
@@ -174,16 +162,7 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
                     return (
                       <SelectControl
                         value={mappedValue}
-                        styles={{
-                          singleValue: (base: any) => ({
-                            ...base,
-                            ...selectLabel(t('Data Source: ')),
-                          }),
-                          placeholder: (base: any) => ({
-                            ...base,
-                            ...selectLabel(t('Data Source: ')),
-                          }),
-                        }}
+                        inFieldLabel={t('Data Source: ')}
                         onChange={optionObj => {
                           const optionValue = optionObj.value;
                           onChange(optionValue, {});


### PR DESCRIPTION
Recently used a style of select control where the label existed within the field for the metric alert builder:

![image](https://user-images.githubusercontent.com/9372512/99302000-c4bf5180-281c-11eb-8af2-876cd9a92ef6.png)

Thought it would be best to generalize this and let `SelectControl` maintain the styles for these "inFieldLabels".

- Migrated the styles from the metric alert rule condition form to the `<SelectControl>` component
- Added a storybook entry for it

Storybook:
![image](https://user-images.githubusercontent.com/9372512/99301751-67c39b80-281c-11eb-989b-79ad381b584c.png)
