### PR TITLE
fix(ui): Fix Alert Rule table alignment

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -8,18 +8,17 @@ import {IconCheckmark, IconArrow} from 'app/icons';
 import {Organization, Project} from 'app/types';
 import {IssueAlertRule} from 'app/types/alerts';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import {Panel, PanelTable, PanelTableHeader} from 'app/components/panels';
+import {PanelTable, PanelTableHeader} from 'app/components/panels';
 import AsyncComponent from 'app/components/asyncComponent';
-import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import ExternalLink from 'app/components/links/externalLink';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import Link from 'app/components/links/link';
-import LoadingIndicator from 'app/components/loadingIndicator';
 import * as Layout from 'app/components/layouts/thirds';
 import Pagination from 'app/components/pagination';
 import Projects from 'app/utils/projects';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import {addErrorMessage} from 'app/actionCreators/indicator';
+import space from 'app/styles/space';
 
 import AlertHeader from '../list/header';
 import {isIssueAlert} from '../utils';
@@ -63,14 +62,21 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
     }
 
     return (
-      <EmptyMessage
-        size="medium"
-        icon={<IconCheckmark isCircled size="48" />}
-        title={t('No alert rules exist for these projects.')}
-        description={tct('Learn more about [link:Alerts]', {
-          link: <ExternalLink href={DOCS_URL} />,
-        })}
-      />
+      <React.Fragment>
+        {
+          <IconWrapper>
+            <IconCheckmark isCircled size="48" />
+          </IconWrapper>
+        }
+        {<Title>{t('No alert rules exist for these projects.')}</Title>}
+        {
+          <Description>
+            {tct('Learn more about [link:Alerts]', {
+              link: <ExternalLink href={DOCS_URL} />,
+            })}
+          </Description>
+        }
+      </React.Fragment>
     );
   }
 
@@ -114,56 +120,51 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
     return (
       <Layout.Body>
         <Layout.Main fullWidth>
-          {loading ? (
-            <LoadingIndicator />
-          ) : (
-            <StyledPanel>
-              <StyledPanelTable
-                headers={[
-                  t('Type'),
-                  t('Alert Name'),
-                  t('Project'),
-                  t('Created By'),
-                  // eslint-disable-next-line react/jsx-key
-                  <StyledSortLink
-                    to={{
-                      pathname: `/organizations/${orgId}/alerts/rules/`,
-                      query: {
-                        ...query,
-                        asc: sort.asc ? undefined : '1',
-                      },
-                    }}
-                  >
-                    {t('Created')}{' '}
-                    <IconArrow
-                      color="gray300"
-                      size="xs"
-                      direction={sort.asc ? 'up' : 'down'}
-                    />
-                  </StyledSortLink>,
-                  t('Actions'),
-                ]}
-                isEmpty={false}
+          <StyledPanelTable
+            headers={[
+              t('Type'),
+              t('Alert Name'),
+              t('Project'),
+              t('Created By'),
+              // eslint-disable-next-line react/jsx-key
+              <StyledSortLink
+                to={{
+                  pathname: `/organizations/${orgId}/alerts/rules/`,
+                  query: {
+                    ...query,
+                    asc: sort.asc ? undefined : '1',
+                  },
+                }}
               >
-                <Projects orgId={orgId} slugs={Array.from(allProjectsFromIncidents)}>
-                  {({initiallyLoaded, projects}) =>
-                    ruleList.map(rule => (
-                      <RuleListRow
-                        // Metric and issue alerts can have the same id
-                        key={`${isIssueAlert(rule) ? 'metric' : 'issue'}-${rule.id}`}
-                        projectsLoaded={initiallyLoaded}
-                        projects={projects as Project[]}
-                        rule={rule}
-                        orgId={orgId}
-                        onDelete={this.handleDeleteRule}
-                      />
-                    ))
-                  }
-                </Projects>
-              </StyledPanelTable>
-              {this.tryRenderEmpty()}
-            </StyledPanel>
-          )}
+                {t('Created')}{' '}
+                <IconArrow
+                  color="gray300"
+                  size="xs"
+                  direction={sort.asc ? 'up' : 'down'}
+                />
+              </StyledSortLink>,
+              t('Actions'),
+            ]}
+            isLoading={loading}
+            isEmpty={ruleList?.length === 0}
+            emptyMessage={this.tryRenderEmpty()}
+          >
+            <Projects orgId={orgId} slugs={Array.from(allProjectsFromIncidents)}>
+              {({initiallyLoaded, projects}) =>
+                ruleList.map(rule => (
+                  <RuleListRow
+                    // Metric and issue alerts can have the same id
+                    key={`${isIssueAlert(rule) ? 'metric' : 'issue'}-${rule.id}`}
+                    projectsLoaded={initiallyLoaded}
+                    projects={projects as Project[]}
+                    rule={rule}
+                    orgId={orgId}
+                    onDelete={this.handleDeleteRule}
+                  />
+                ))
+              }
+            </Projects>
+          </StyledPanelTable>
           <Pagination pageLinks={ruleListPageLinks} />
         </Layout.Main>
       </Layout.Body>
@@ -226,28 +227,35 @@ const StyledPanelTable = styled(PanelTable)`
   ${PanelTableHeader} {
     line-height: normal;
   }
-  grid-template-columns: 65px 1.5fr minmax(150px, 1fr) 1fr minmax(150px, 1fr) 92px;
-  border-radius: 4px 4px 0 0;
-  border: 0;
+  grid-template-columns: auto 1.5fr 1fr 1fr 1fr auto;
+  height: 100%;
   width: 100%;
   margin-bottom: 0;
   align-items: center;
   text-overflow: ellipsis;
   white-space: nowrap;
-  display: grid;
   overflow: auto;
   ::-webkit-scrollbar {
     display: none;
   }
+  ${p =>
+    p.emptyMessage &&
+    `svg:not([data-test-id='icon-check-mark']) {
+    display: none;`}
 `;
 
-const StyledPanel = styled(Panel)`
-  ${StyledPanelTable} {
-    border-radius: 4px 4px 0 0;
-  }
-  border-radius: ${p => p.theme.borderRadius};
-  ${EmptyMessage} {
-    border-top: 1px solid ${p => p.theme.border};
-  }
-  overflow: auto;
+const IconWrapper = styled('span')`
+  color: ${p => p.theme.gray200};
+  display: block;
+`;
+
+const Title = styled('strong')`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  margin-bottom: ${space(1)};
+`;
+
+const Description = styled('span')`
+  font-size: ${p => p.theme.fontSizeLarge};
+  display: block;
+  margin: 0;
 `;

--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -227,6 +227,7 @@ const StyledPanelTable = styled(PanelTable)`
   ${PanelTableHeader} {
     line-height: normal;
   }
+  font-size: ${p => p.theme.fontSizeMedium};
   grid-template-columns: auto 1.5fr 1fr 1fr 1fr auto;
   margin-bottom: 0;
   white-space: nowrap;

--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -228,16 +228,8 @@ const StyledPanelTable = styled(PanelTable)`
     line-height: normal;
   }
   grid-template-columns: auto 1.5fr 1fr 1fr 1fr auto;
-  height: 100%;
-  width: 100%;
   margin-bottom: 0;
-  align-items: center;
-  text-overflow: ellipsis;
   white-space: nowrap;
-  overflow: auto;
-  ::-webkit-scrollbar {
-    display: none;
-  }
   ${p =>
     p.emptyMessage &&
     `svg:not([data-test-id='icon-check-mark']) {

--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -5,7 +5,6 @@ import memoize from 'lodash/memoize';
 
 import {t, tct} from 'app/locale';
 import {IconDelete, IconSettings} from 'app/icons';
-import {PanelItem} from 'app/components/panels';
 import {Project} from 'app/types';
 import {IssueAlertRule} from 'app/types/alerts';
 import Access from 'app/components/acl/access';
@@ -16,10 +15,8 @@ import ErrorBoundary from 'app/components/errorBoundary';
 import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
-import space from 'app/styles/space';
 
 import {isIssueAlert} from '../utils';
-import {TableLayout} from './styles';
 
 type Props = {
   rule: IssueAlertRule;
@@ -49,56 +46,80 @@ class RuleListRow extends React.Component<Props, State> {
 
     return (
       <ErrorBoundary>
-        <AlertRulesPanelItem>
-          <TableLayout>
-            <RuleType>{isIssueAlert(rule) ? t('Issue') : t('Metric')}</RuleType>
-            <Title>
-              <Link to={link}>{rule.name}</Link>
-            </Title>
-            <ProjectBadge
-              avatarSize={18}
-              project={!projectsLoaded ? {slug} : this.getProject(slug, projects)}
-            />
-            <CreatedBy>{rule?.createdBy?.name ?? '-'}</CreatedBy>
-            <div>{dateCreated}</div>
-            <Access access={['project:write']}>
-              {({hasAccess}) => (
-                <ButtonBar gap={1}>
-                  <Confirm
-                    disabled={!hasAccess}
-                    message={tct(
-                      "Are you sure you want to delete [name]? You won't be able to view the history of this alert once it's deleted.",
-                      {
-                        name: rule.name,
-                      }
-                    )}
-                    header={t('Delete Alert Rule?')}
-                    priority="danger"
-                    confirmText={t('Delete Rule')}
-                    onConfirm={() => onDelete(slug, rule)}
-                  >
-                    <Button
-                      type="button"
-                      icon={<IconDelete />}
-                      size="small"
-                      title={t('Delete')}
-                    />
-                  </Confirm>
+        <Column>
+          <RuleType>{isIssueAlert(rule) ? t('Issue') : t('Metric')}</RuleType>
+        </Column>
+        <Column>
+          <Title>
+            <Link to={link}>{rule.name}</Link>
+          </Title>
+        </Column>
+        <Column>
+          <ProjectBadge
+            avatarSize={18}
+            project={!projectsLoaded ? {slug} : this.getProject(slug, projects)}
+          />
+        </Column>
+        <Column>
+          <CreatedBy>{rule?.createdBy?.name ?? '-'}</CreatedBy>
+        </Column>
+        <Column>
+          <div>{dateCreated}</div>
+        </Column>
+        <RightColumn>
+          <Access access={['project:write']}>
+            {({hasAccess}) => (
+              <ButtonBar gap={1}>
+                <Confirm
+                  disabled={!hasAccess}
+                  message={tct(
+                    "Are you sure you want to delete [name]? You won't be able to view the history of this alert once it's deleted.",
+                    {
+                      name: rule.name,
+                    }
+                  )}
+                  header={t('Delete Alert Rule?')}
+                  priority="danger"
+                  confirmText={t('Delete Rule')}
+                  onConfirm={() => onDelete(slug, rule)}
+                >
                   <Button
+                    type="button"
+                    icon={<IconDelete />}
                     size="small"
-                    icon={<IconSettings />}
-                    title={t('Edit')}
-                    to={link}
+                    title={t('Delete')}
                   />
-                </ButtonBar>
-              )}
-            </Access>
-          </TableLayout>
-        </AlertRulesPanelItem>
+                </Confirm>
+                <Button
+                  size="small"
+                  icon={<IconSettings />}
+                  title={t('Edit')}
+                  to={link}
+                />
+              </ButtonBar>
+            )}
+          </Access>
+        </RightColumn>
       </ErrorBoundary>
     );
   }
 }
+
+const Column = styled('div')`
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  padding: 20px 16px 20px 16px;
+  overflow: hidden;
+  ${overflowEllipsis}
+`;
+
+const RightColumn = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding: 16px;
+`;
 
 const RuleType = styled('div')`
   font-size: 12px;
@@ -115,13 +136,9 @@ const CreatedBy = styled('div')`
   ${overflowEllipsis}
 `;
 
-const AlertRulesPanelItem = styled(PanelItem)`
-  font-size: ${p => p.theme.fontSizeMedium};
-  padding: ${space(1.5)} ${space(2)};
-`;
-
 const ProjectBadge = styled(IdBadge)`
   flex-shrink: 0;
+  padding: 2px;
 `;
 
 export default RuleListRow;

--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -15,6 +15,7 @@ import ErrorBoundary from 'app/components/errorBoundary';
 import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
+import space from 'app/styles/space';
 
 import {isIssueAlert} from '../utils';
 
@@ -106,23 +107,22 @@ class RuleListRow extends React.Component<Props, State> {
 }
 
 const Column = styled('div')`
-  font-size: 14px;
+  font-size: ${p => p.theme.fontSizeMedium};
   display: flex;
-  align-items: center;
-  padding: 20px 16px 20px 16px;
-  overflow: hidden;
-  ${overflowEllipsis}
+  flex-direction: column;
+  align-items: flex-start;
+  height: 100%;
 `;
 
 const RightColumn = styled('div')`
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   align-items: center;
-  padding: 16px;
+  padding: ${space(1.5)} ${space(2)};
 `;
 
 const RuleType = styled('div')`
-  font-size: 12px;
+  font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 400;
   color: ${p => p.theme.gray300};
   text-transform: uppercase;
@@ -138,7 +138,6 @@ const CreatedBy = styled('div')`
 
 const ProjectBadge = styled(IdBadge)`
   flex-shrink: 0;
-  padding: 2px;
 `;
 
 export default RuleListRow;

--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import styled from '@emotion/styled';
+import {css} from '@emotion/core';
 import memoize from 'lodash/memoize';
 
 import {t, tct} from 'app/locale';
@@ -47,26 +48,16 @@ class RuleListRow extends React.Component<Props, State> {
 
     return (
       <ErrorBoundary>
-        <Column>
-          <RuleType>{isIssueAlert(rule) ? t('Issue') : t('Metric')}</RuleType>
-        </Column>
-        <Column>
-          <Title>
-            <Link to={link}>{rule.name}</Link>
-          </Title>
-        </Column>
-        <Column>
-          <ProjectBadge
-            avatarSize={18}
-            project={!projectsLoaded ? {slug} : this.getProject(slug, projects)}
-          />
-        </Column>
-        <Column>
-          <CreatedBy>{rule?.createdBy?.name ?? '-'}</CreatedBy>
-        </Column>
-        <Column>
-          <div>{dateCreated}</div>
-        </Column>
+        <RuleType>{isIssueAlert(rule) ? t('Issue') : t('Metric')}</RuleType>
+        <Title>
+          <Link to={link}>{rule.name}</Link>
+        </Title>
+        <ProjectBadge
+          avatarSize={18}
+          project={!projectsLoaded ? {slug} : this.getProject(slug, projects)}
+        />
+        <CreatedBy>{rule?.createdBy?.name ?? '-'}</CreatedBy>
+        <div>{dateCreated}</div>
         <RightColumn>
           <Access access={['project:write']}>
             {({hasAccess}) => (
@@ -106,8 +97,7 @@ class RuleListRow extends React.Component<Props, State> {
   }
 }
 
-const Column = styled('div')`
-  font-size: ${p => p.theme.fontSizeMedium};
+const columnCss = css`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -126,14 +116,17 @@ const RuleType = styled('div')`
   font-weight: 400;
   color: ${p => p.theme.gray300};
   text-transform: uppercase;
+  ${columnCss}
 `;
 
 const Title = styled('div')`
   ${overflowEllipsis}
+  ${columnCss}
 `;
 
 const CreatedBy = styled('div')`
   ${overflowEllipsis}
+  ${columnCss}
 `;
 
 const ProjectBadge = styled(IdBadge)`

--- a/src/sentry/static/sentry/app/views/alerts/rules/styles.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/styles.tsx
@@ -4,7 +4,7 @@ import space from 'app/styles/space';
 
 const TableLayout = styled('div')`
   display: grid;
-  grid-template-columns: 60px 1.5fr 200px 1fr 1fr 92px;
+  grid-template-columns: 60px 1.5fr 1fr 1fr 1fr 92px;
   grid-column-gap: ${space(1.5)};
   width: 100%;
   align-items: center;

--- a/src/sentry/static/sentry/app/views/alerts/rules/styles.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/styles.tsx
@@ -4,7 +4,7 @@ import space from 'app/styles/space';
 
 const TableLayout = styled('div')`
   display: grid;
-  grid-template-columns: 60px 1.5fr 1fr 1fr 1fr 92px;
+  grid-template-columns: 60px 1.5fr 200px 1fr 1fr 92px;
   grid-column-gap: ${space(1.5)};
   width: 100%;
   align-items: center;

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -55,8 +55,8 @@ describe('OrganizationRuleList', () => {
   it('displays list', async () => {
     const wrapper = await createWrapper();
 
-    const items = wrapper.find('AlertRulesPanelItem');
-    expect(items).toHaveLength(1);
+    const items = wrapper.find('Column');
+    expect(items).toHaveLength(5);
     expect(items.find('RuleType').text()).toBe('Issue');
     expect(items.find('Title').text()).toBe('First Issue Alert');
     expect(items.find('CreatedBy').text()).toBe('Samwise');
@@ -71,7 +71,7 @@ describe('OrganizationRuleList', () => {
         query: {query: 'slug:earth'},
       })
     );
-    expect(items.at(0).find('IdBadge').prop('project')).toMatchObject({
+    expect(items.find('IdBadge').prop('project')).toMatchObject({
       slug: 'earth',
     });
   });

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -55,8 +55,7 @@ describe('OrganizationRuleList', () => {
   it('displays list', async () => {
     const wrapper = await createWrapper();
 
-    const items = wrapper.find('Column');
-    expect(items).toHaveLength(5);
+    const items = wrapper.find('div');
     expect(items.find('RuleType').text()).toBe('Issue');
     expect(items.find('Title').text()).toBe('First Issue Alert');
     expect(items.find('CreatedBy').text()).toBe('Samwise');

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -55,10 +55,9 @@ describe('OrganizationRuleList', () => {
   it('displays list', async () => {
     const wrapper = await createWrapper();
 
-    const items = wrapper.find('div');
-    expect(items.find('RuleType').text()).toBe('Issue');
-    expect(items.find('Title').text()).toBe('First Issue Alert');
-    expect(items.find('CreatedBy').text()).toBe('Samwise');
+    expect(wrapper.find('RuleType').text()).toBe('Issue');
+    expect(wrapper.find('Title').text()).toBe('First Issue Alert');
+    expect(wrapper.find('CreatedBy').text()).toBe('Samwise');
 
     // GlobalSelectionHeader loads projects + the Projects render-prop
     // component to load projects for all rows.
@@ -70,7 +69,7 @@ describe('OrganizationRuleList', () => {
         query: {query: 'slug:earth'},
       })
     );
-    expect(items.find('IdBadge').prop('project')).toMatchObject({
+    expect(wrapper.find('IdBadge').prop('project')).toMatchObject({
       slug: 'earth',
     });
   });


### PR DESCRIPTION
Fix Alert Rule Table alignment for the Project column.

**Before**
<img width="1189" alt="Screen Shot 2020-11-16 at 3 34 21 PM" src="https://user-images.githubusercontent.com/20312973/99325741-cba19080-282b-11eb-9c5c-82a3e1ce66e6.png">

**After**
<img width="1181" alt="Screen Shot 2020-11-16 at 4 50 02 PM" src="https://user-images.githubusercontent.com/20312973/99325755-d2300800-282b-11eb-97ad-bbc9323825b2.png">

**_Edit_**

Looked into `<PanelTable>` and that seemed to work much better. Also fixed at smaller widths:

![alert-table-alignment](https://user-images.githubusercontent.com/20312973/99522684-d0109b00-294a-11eb-870b-25a6101beb67.gif)
