### PR TITLE
feat(workflow): Return inbox details on group unresolve

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -306,6 +306,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         :auth: required
         """
         projects = self.get_projects(request, organization)
+        has_inbox = features.has("organizations:inbox", organization, actor=request.user)
         if len(projects) > 1 and not features.has(
             "organizations:global-views", organization, actor=request.user
         ):
@@ -320,7 +321,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             projects,
             self.get_environments(request, organization),
         )
-        return update_groups(request, projects, organization.id, search_fn)
+        return update_groups(request, projects, organization.id, search_fn, has_inbox)
 
     @rate_limit_endpoint(limit=10, window=1)
     def delete(self, request, organization):

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -690,7 +690,7 @@ def update_groups(request, projects, organization_id, search_fn, has_inbox=False
                 group.resolved_at = now
                 remove_group_from_inbox(group)
                 if has_inbox:
-                    result["inbox"] = False
+                    result["inbox"] = None
 
                 assigned_to = self_subscribe_and_assign_issue(acting_user, group)
                 if assigned_to is not None:
@@ -743,7 +743,7 @@ def update_groups(request, projects, organization_id, search_fn, has_inbox=False
                 for group in group_ids:
                     remove_group_from_inbox(group)
                 if has_inbox:
-                    result["inbox"] = False
+                    result["inbox"] = None
 
                 ignore_duration = (
                     statusDetails.pop("ignoreDuration", None)

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -498,7 +498,7 @@ def rate_limit_endpoint(limit=1, window=1):
 
 
 @track_update_groups
-def update_groups(request, projects, organization_id, search_fn, has_inbox):
+def update_groups(request, projects, organization_id, search_fn, has_inbox=False):
     group_ids = request.GET.getlist("id")
     if group_ids:
         group_list = Group.objects.filter(

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -49,7 +49,7 @@ from sentry.models import (
     User,
     UserOption,
 )
-from sentry.models.groupinbox import add_group_to_inbox
+from sentry.models.groupinbox import add_group_to_inbox, get_inbox_details
 from sentry.models.group import looks_like_short_id
 from sentry.api.issue_search import convert_query_values, InvalidSearchQuery, parse_search_query
 from sentry.signals import (
@@ -498,7 +498,7 @@ def rate_limit_endpoint(limit=1, window=1):
 
 
 @track_update_groups
-def update_groups(request, projects, organization_id, search_fn):
+def update_groups(request, projects, organization_id, search_fn, has_inbox):
     group_ids = request.GET.getlist("id")
     if group_ids:
         group_list = Group.objects.filter(
@@ -689,6 +689,8 @@ def update_groups(request, projects, organization_id, search_fn):
                 group.status = GroupStatus.RESOLVED
                 group.resolved_at = now
                 remove_group_from_inbox(group)
+                if has_inbox:
+                    result["inbox"] = False
 
                 assigned_to = self_subscribe_and_assign_issue(acting_user, group)
                 if assigned_to is not None:
@@ -733,11 +735,15 @@ def update_groups(request, projects, organization_id, search_fn):
             if new_status == GroupStatus.UNRESOLVED:
                 for group in group_list:
                     add_group_to_inbox(group, GroupInboxReason.MANUAL)
+                if has_inbox:
+                    result["inbox"] = get_inbox_details([group_list[0]])[group_list[0].id]
                 result["statusDetails"] = {}
             elif new_status == GroupStatus.IGNORED:
                 metrics.incr("group.ignored", skip_internal=True)
                 for group in group_ids:
                     remove_group_from_inbox(group)
+                if has_inbox:
+                    result["inbox"] = False
 
                 ignore_duration = (
                     statusDetails.pop("ignoreDuration", None)

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -31,7 +31,6 @@ from sentry.models import (
     GroupAssignee,
     GroupBookmark,
     GroupEnvironment,
-    GroupInbox,
     GroupLink,
     GroupMeta,
     GroupResolution,
@@ -48,6 +47,7 @@ from sentry.models import (
     UserOptionValue,
     Organization,
 )
+from sentry.models.groupinbox import get_inbox_details
 from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tsdb.snuba import SnubaTSDB
 from sentry.utils import snuba
@@ -938,20 +938,6 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
 
         return None
 
-    def _get_inbox_details(self, item_list):
-        group_ids = [g.id for g in item_list]
-        group_inboxes = GroupInbox.objects.filter(group__in=group_ids)
-        inbox_stats = {
-            gi.group_id: {
-                "reason": gi.reason,
-                "reason_details": gi.reason_details,
-                "date_added": gi.date_added,
-            }
-            for gi in group_inboxes
-        }
-
-        return inbox_stats
-
     def query_tsdb(self, group_ids, query_params, conditions=None, environment_ids=None, **kwargs):
         return snuba_tsdb.get_range(
             model=snuba_tsdb.models.group,
@@ -974,7 +960,7 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
                 else None
             )
             if self._expand("inbox"):
-                inbox_stats = self._get_inbox_details(item_list)
+                inbox_stats = get_inbox_details(item_list)
             for item in item_list:
                 if filtered_stats:
                     attrs[item].update({"filtered_stats": filtered_stats[item.id]})

--- a/src/sentry/models/groupinbox.py
+++ b/src/sentry/models/groupinbox.py
@@ -53,3 +53,18 @@ def remove_group_from_inbox(group):
         group_inbox.delete()
     except GroupInbox.DoesNotExist:
         pass
+
+
+def get_inbox_details(group_list):
+    group_ids = [g.id for g in group_list]
+    group_inboxes = GroupInbox.objects.filter(group__in=group_ids)
+    inbox_stats = {
+        gi.group_id: {
+            "reason": gi.reason,
+            "reason_details": gi.reason_details,
+            "date_added": gi.date_added,
+        }
+        for gi in group_inboxes
+    }
+
+    return inbox_stats

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1829,7 +1829,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             response = self.get_valid_response(
                 qs_params={"id": [group1.id, group2.id]}, status="resolved"
             )
-        assert response.data["inbox"] is False
+        assert response.data["inbox"] is None
         assert not GroupInbox.objects.filter(group=group1).exists()
         assert not GroupInbox.objects.filter(group=group2).exists()
 


### PR DESCRIPTION
We currently can resolve/ignore a group which removes it from the inbox and returns `inbox: false`. This change allows us to unresolve/unignore and display the inbox label again `inbox: reason`.