### PR TITLE
ref(stacktrace-link): Actionable error message

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -47,6 +47,8 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
 
         for config in configs:
             if not filepath.startswith(config.stack_root):
+                result["config"] = serialize(config, request.user)
+                result["error"] = "stack_root_mismatch"
                 continue
 
             link = get_link(config, filepath, config.default_branch, commitId)
@@ -56,6 +58,8 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
             # case it means we could not find a match for the
             # configuration
             result["sourceUrl"] = link
+            if not link:
+                result["error"] = "file_not_found"
 
             # if we found a match, we can break
             break

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -38,7 +38,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
             return Response({"detail": "Filepath is required"}, status=400)
 
         commitId = request.GET.get("commitId")
-        result = {"config": None}
+        result = {"config": None, "sourceUrl": None}
 
         # xxx(meredith): if there are ever any changes to this query, make
         # sure that we are still ordering by `id` because we want to make sure
@@ -46,14 +46,14 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         configs = RepositoryProjectPathConfig.objects.filter(project=project)
 
         for config in configs:
+            result["config"] = serialize(config, request.user)
+
             if not filepath.startswith(config.stack_root):
-                result["config"] = serialize(config, request.user)
                 result["error"] = "stack_root_mismatch"
                 continue
 
             link = get_link(config, filepath, config.default_branch, commitId)
 
-            result["config"] = serialize(config, request.user)
             # it's possible for the link to be None, and in that
             # case it means we could not find a match for the
             # configuration

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -158,6 +158,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
 }
 
 export default withProjects(withOrganization(StacktraceLink));
+export {StacktraceLink};
 
 export const CodeMappingButtonContainer = styled(OpenInContainer)`
   justify-content: space-between;

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -91,7 +91,8 @@ class StacktraceLink extends AsyncComponent<Props, State> {
           view: 'stacktrace_issue_details',
           provider: provider.key,
         },
-        this.props.organization
+        this.props.organization,
+        {startSession: true}
       );
     }
   }
@@ -107,7 +108,8 @@ class StacktraceLink extends AsyncComponent<Props, State> {
           provider: provider.key,
           error_reason: error,
         },
-        this.props.organization
+        this.props.organization,
+        {startSession: true}
       );
     }
   }

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -111,18 +111,31 @@ type IntegrationCategorySelectEvent = {
   category: string;
 };
 
+type IntegrationStacktraceLinkEvent = {
+  eventKey:
+    | 'integrations.stacktrace_link_clicked'
+    | 'integrations.reconfigure_stacktrace_setup';
+  eventName:
+    | 'Integrations: Stacktrace Link Clicked'
+    | 'Integrations: Reconfigure Stacktrace Setup';
+  provider: string;
+  error_reason?: 'file_not_found' | 'stack_root_mismatch';
+};
+
 type IntegrationsEventParams = (
   | MultipleIntegrationsEvent
   | SingleIntegrationEvent
   | IntegrationSearchEvent
   | IntegrationCategorySelectEvent
+  | IntegrationStacktraceLinkEvent
 ) & {
   view?:
     | 'external_install'
     | 'legacy_integrations'
     | 'plugin_details'
     | 'integrations_directory'
-    | 'integrations_directory_integration_detail';
+    | 'integrations_directory_integration_detail'
+    | 'stacktrace_issue_details';
   project_id?: string;
 } & Parameters<Hooks['analytics:track-event']>[0];
 

--- a/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -51,7 +51,7 @@ class ConfigureIntegration extends AsyncView<Props, State> {
 
   componentDidMount() {
     const {location} = this.props;
-    const value = location.query.tab === 'repos' ? 'repos' : 'codeMappings';
+    const value = location.query.tab === 'codeMappings' ? 'codeMappings' : 'repos';
     // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({tab: value});
   }

--- a/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -49,6 +49,13 @@ class ConfigureIntegration extends AsyncView<Props, State> {
     ];
   }
 
+  componentDidMount() {
+    const {location} = this.props;
+    const value = location.query.tab === 'repos' ? 'repos' : 'codeMappings';
+    // eslint-disable-next-line react/no-did-mount-set-state
+    this.setState({tab: value});
+  }
+
   onRequestSuccess({stateKey, data}) {
     if (stateKey !== 'integration') {
       return;

--- a/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {StacktraceLink} from 'app/components/events/interfaces/stacktraceLink';
+
+describe('StacktraceLink', function () {
+  const org = TestStubs.Organization();
+  const project = TestStubs.Project();
+  const event = TestStubs.Event({projectID: project.id});
+  const integration = TestStubs.GitHubIntegration();
+  const repo = TestStubs.Repository({integrationId: integration.id});
+
+  const frame = {filename: '/sentry/app.py', lineNo: 233};
+  const config = TestStubs.RepositoryProjectPathConfig(project, repo, integration);
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders source url link', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      query: {file: frame.filename, commitId: 'master'},
+      body: {config, sourceUrl: 'https://something.io'},
+    });
+    const wrapper = mountWithTheme(
+      <StacktraceLink
+        frame={frame}
+        event={event}
+        projects={[project]}
+        organization={org}
+        lineNo={frame.lineNo}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.state('match').sourceUrl).toEqual('https://something.io');
+    expect(wrapper.find('OpenInName').text()).toEqual('GitHub');
+  });
+
+  it('renders file_not_found message', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      query: {file: frame.filename, commitId: 'master'},
+      body: {config, sourceUrl: null, error: 'file_not_found'},
+    });
+    const wrapper = mountWithTheme(
+      <StacktraceLink
+        frame={frame}
+        event={event}
+        projects={[project]}
+        organization={org}
+        lineNo={frame.lineNo}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.state('match').sourceUrl).toBeFalsy();
+    expect(wrapper.find('CodeMappingButtonContainer').text()).toContain(
+      'Could not find source file, check your repository and source code root.'
+    );
+  });
+
+  it('renders stack_root_mismatch message', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      query: {file: frame.filename, commitId: 'master'},
+      body: {config, sourceUrl: null, error: 'stack_root_mismatch'},
+    });
+    const wrapper = mountWithTheme(
+      <StacktraceLink
+        frame={frame}
+        event={event}
+        projects={[project]}
+        organization={org}
+        lineNo={frame.lineNo}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.state('match').sourceUrl).toBeFalsy();
+    expect(wrapper.find('CodeMappingButtonContainer').text()).toContain(
+      'Error matching your configuration, check your stack trace root.'
+    );
+  });
+});

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -65,7 +65,7 @@ class ProjectStacktraceLinkTest(APITestCase):
         assert response.status_code == 200, response.content
         assert not response.data["config"]
 
-    def test_config_but_no_source_url(self):
+    def test_file_not_found_error(self):
         self.login_as(user=self.user)
         url = u"{}?file={}".format(self.url, self.filepath)
 
@@ -93,6 +93,37 @@ class ProjectStacktraceLinkTest(APITestCase):
             "defaultBranch": None,
         }
         assert not response.data["sourceUrl"]
+        assert response.data["error"] == "file_not_found"
+
+    def test_stack_root_mismatch_error(self):
+        self.login_as(user=self.user)
+        url = u"{}?file={}".format(self.url, "wrong/file/path")
+
+        response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        assert response.data["config"] == {
+            "id": six.text_type(self.config.id),
+            "projectId": six.text_type(self.project.id),
+            "projectSlug": self.project.slug,
+            "repoId": six.text_type(self.repo.id),
+            "repoName": self.repo.name,
+            "provider": {
+                "aspects": {},
+                "features": ["commits", "issue-basic"],
+                "name": "Example",
+                "canDisable": False,
+                "key": "example",
+                "slug": "example",
+                "canAdd": True,
+            },
+            "sourceRoot": self.config.source_root,
+            "stackRoot": self.config.stack_root,
+            "integrationId": six.text_type(self.integration.id),
+            "defaultBranch": None,
+        }
+        assert not response.data["sourceUrl"]
+        assert response.data["error"] == "stack_root_mismatch"
 
     def test_config_and_source_url(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
**Context:**
When setting up a stack trace linking configuration, it's possible to set it up wrong or need to multiple configs, depending on your needs and overall setup. Currently if something is wrong, we display "No Match" which isn't super helpful. 

This PR adds more helpful language to tell you what is wrong, along with a button that links back to your code mapping configuration settings.

**Before**
> ![Screen Shot 2020-11-16 at 5 33 38 PM](https://user-images.githubusercontent.com/15368179/99329552-56d25480-2833-11eb-8edd-2de0149e694b.png)


**Error Cases (After)**
I've added an `error` attribute to the response that can be used to render the appropriate text, depending on the error.

`stack_root_mismatch`: There is a configuration setup for the project, but the filename in the stack trace did not match with the configuration `stack_root`. (I also had to add the `config` in the response for this case since we weren't doing that before) 
https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/project_stacktrace_link.py#L49
> ![Screen Shot 2020-11-16 at 4 42 04 PM](https://user-images.githubusercontent.com/15368179/99328284-98adcb80-2830-11eb-9c22-d02cc62a9f16.png)

`file_not_found`: There is a configuration, the root matched, but when we made the request to the external service (e.g. GitHub) we go a `404`.
> ![Screen Shot 2020-11-16 at 4 41 40 PM](https://user-images.githubusercontent.com/15368179/99328287-99def880-2830-11eb-8991-01b07b757910.png)


**Todo**
- [x] tests
- [x] analytics on "Configure Code Mapping"