### PR TITLE
ref(group-list): Improvements + add useFilteredStats prop in the StreamGroup Component

### DIFF
--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -57,6 +57,7 @@ class GroupList extends React.Component<Props, State> {
     groups: [],
     pageLinks: null,
   };
+
   componentDidMount() {
     this.fetchData();
   }

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -83,7 +83,7 @@ class StreamGroup extends React.Component<Props, State> {
     return {
       data: {
         ...data,
-        filtered: useFilteredStats ? data.filtered : undefined,
+        filtered: useFilteredStats ? data.filtered : null,
       },
     };
   }
@@ -98,7 +98,7 @@ class StreamGroup extends React.Component<Props, State> {
       this.setState({
         data: {
           ...data,
-          filtered: nextProps.useFilteredStats ? data.filtered : undefined,
+          filtered: nextProps.useFilteredStats ? data.filtered : null,
         },
       });
     }

--- a/src/sentry/static/sentry/app/components/stream/groupChart.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.tsx
@@ -24,7 +24,7 @@ function GroupChart({
     ? data.filtered
       ? data.filtered.stats[statsPeriod]
       : data.stats[statsPeriod]
-    : null;
+    : [];
 
   const secondaryStats: TimeseriesValue[] | null =
     statsPeriod && data.filtered ? data.stats[statsPeriod] : null;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -748,25 +748,30 @@ export type InboxDetails = {
   };
 };
 
+type GroupFiltered = {
+  count: string;
+  stats: Record<string, TimeseriesValue[]>;
+  lastSeen: string;
+  firstSeen: string;
+  userCount: number;
+};
+
 // TODO(ts): incomplete
-export type Group = {
+export type Group = GroupFiltered & {
   id: string;
   latestEvent: Event;
   activity: any[]; // TODO(ts)
   annotations: string[];
   assignedTo: User;
-  count: string;
   culprit: string;
   currentRelease: any; // TODO(ts)
   firstRelease: any; // TODO(ts)
-  firstSeen: string;
   hasSeen: boolean;
   isBookmarked: boolean;
   isUnhandled: boolean;
   isPublic: boolean;
   isSubscribed: boolean;
   lastRelease: any; // TODO(ts)
-  lastSeen: string;
   level: Level;
   logger: string;
   metadata: EventMetadata;
@@ -781,16 +786,14 @@ export type Group = {
   seenBy: User[];
   shareId: string;
   shortId: string;
-  stats: Record<string, TimeseriesValue[]>;
   status: string;
   statusDetails: ResolutionStatusDetails;
   tags: Pick<Tag, 'key' | 'name' | 'totalValues'>[];
   title: string;
   type: EventOrGroupType;
-  userCount: number;
   userReportCount: number;
-  subscriptionDetails: SubscriptionDetails | null;
-  filtered?: any; // TODO(ts)
+  subscriptionDetails: {disabled?: boolean; reason?: string} | null;
+  filtered: GroupFiltered | null;
   lifetime?: any; // TODO(ts)
   inbox?: InboxDetails | null;
 };

--- a/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
+++ b/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
@@ -59,19 +59,28 @@ describe('Release Issues', function () {
       <Issues {...props} selection={{datetime: {period: '24h'}}} />
     );
 
+    await tick();
+
+    wrapper.update();
     expect(wrapper.find('EmptyStateWarning').text()).toBe(
       'No new issues in this release for the last 14 days.'
     );
+
+    wrapper2.update();
     expect(wrapper2.find('EmptyStateWarning').text()).toBe(
       'No new issues in this release for the last 24 hours.'
     );
 
     filterIssues(wrapper, 'resolved');
+    await tick();
+    wrapper.update();
     expect(wrapper.find('EmptyStateWarning').text()).toBe(
       'No resolved issues in this release.'
     );
 
     filterIssues(wrapper2, 'unhandled');
+    await tick();
+    wrapper2.update();
     expect(wrapper2.find('EmptyStateWarning').text()).toBe(
       'No unhandled issues in this release for the last 24 hours.'
     );


### PR DESCRIPTION
closes: https://app.asana.com/0/1182975495223897/1198508136204975/f


**Problem:**
When hovering over the data in the events and users column, not all of the information was being displayed, which is not consistent with what we displayed on the problem list page.

**Solution:**
By passing the boolean prop `useFilteredStats` in the `StreamGroup` component, it will also display `data.filtered ` if available. `data.filtered ` comes from the eventPayload of different endpoints
