### PR TITLE
fix(issues-ui) - Environment selector to show all environments to superusers

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleEnvironmentSelector.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import uniq from 'lodash/uniq';
 
 import {analytics} from 'app/utils/analytics';
+import ConfigStore from 'app/stores/configStore';
 import getRouteStringFromRoutes from 'app/utils/getRouteStringFromRoutes';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import {t} from 'app/locale';
@@ -193,11 +194,12 @@ class MultipleEnvironmentSelector extends React.PureComponent<Props, State> {
 
   getEnvironments() {
     const {projects, selectedProjects} = this.props;
+    const config = ConfigStore.getConfig();
     let environments: Project['environments'] = [];
     projects.forEach(function (project) {
       const projectId = parseInt(project.id, 10);
-
       // Include environments from:
+      // - all projects if the user is a superuser
       // - the requested projects
       // - all member projects if 'my projects' (empty list) is selected.
       // - all projects if -1 is the only selected project.
@@ -205,7 +207,8 @@ class MultipleEnvironmentSelector extends React.PureComponent<Props, State> {
         (selectedProjects.length === 1 &&
           selectedProjects[0] === ALL_ACCESS_PROJECTS &&
           project.hasAccess) ||
-        (selectedProjects.length === 0 && project.isMember) ||
+        (selectedProjects.length === 0 &&
+          (project.isMember || config.user.isSuperuser)) ||
         selectedProjects.includes(projectId)
       ) {
         environments = environments.concat(project.environments);

--- a/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
+++ b/tests/js/spec/components/organizations/multipleEnvironmentSelector.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 
+import ConfigStore from 'app/stores/configStore';
 import MultipleEnvironmentSelector from 'app/components/organizations/multipleEnvironmentSelector';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 
@@ -123,6 +124,151 @@ describe('MultipleEnvironmentSelector', function () {
 
   it('shows member project environments when there are no projects selected', async function () {
     wrapper.setProps({selectedProjects: []});
+    wrapper.update();
+
+    await wrapper.find('MultipleEnvironmentSelector HeaderItem').simulate('click');
+    const items = wrapper.find('MultipleEnvironmentSelector GlobalSelectionHeaderRow');
+
+    expect(items.length).toEqual(3);
+    expect(items.at(0).text()).toBe('production');
+    expect(items.at(1).text()).toBe('staging');
+    expect(items.at(2).text()).toBe('dev');
+  });
+
+  it('shows My Projects/all environments (superuser - no team belonging)', async function () {
+    ConfigStore.config = {
+      user: {
+        isSuperuser: true,
+      },
+    };
+    // "My Projects" view
+    wrapper.setProps({selectedProjects: []});
+    // This user is member of no project
+    wrapper.setProps({
+      projects: [
+        TestStubs.Project({
+          id: '1',
+          slug: 'first',
+          environments: ['production', 'staging'],
+          isMember: false,
+        }),
+        TestStubs.Project({
+          id: '2',
+          slug: 'second',
+          environments: ['dev'],
+          isMember: false,
+        }),
+      ],
+    });
+    wrapper.update();
+
+    await wrapper.find('MultipleEnvironmentSelector HeaderItem').simulate('click');
+    const items = wrapper.find('MultipleEnvironmentSelector GlobalSelectionHeaderRow');
+
+    expect(items.length).toEqual(3);
+    expect(items.at(0).text()).toBe('production');
+    expect(items.at(1).text()).toBe('staging');
+    expect(items.at(2).text()).toBe('dev');
+  });
+
+  it('shows My Projects/all environments (superuser - belongs one team)', async function () {
+    // XXX: Ideally, "My Projects" and "All Projects" should be different if a superuser
+    // was to belong to at least one project
+    ConfigStore.config = {
+      user: {
+        isSuperuser: true,
+      },
+    };
+    // "My Projects" view
+    wrapper.setProps({selectedProjects: []});
+    // This user is member of one project
+    wrapper.setProps({
+      projects: [
+        TestStubs.Project({
+          id: '1',
+          slug: 'first',
+          environments: ['production', 'staging'],
+        }),
+        TestStubs.Project({
+          id: '2',
+          slug: 'second',
+          environments: ['dev'],
+          isMember: false,
+        }),
+      ],
+    });
+    wrapper.update();
+
+    await wrapper.find('MultipleEnvironmentSelector HeaderItem').simulate('click');
+    const items = wrapper.find('MultipleEnvironmentSelector GlobalSelectionHeaderRow');
+
+    expect(items.length).toEqual(3);
+    expect(items.at(0).text()).toBe('production');
+    expect(items.at(1).text()).toBe('staging');
+    expect(items.at(2).text()).toBe('dev');
+  });
+
+  it('shows All Projects/all environments (superuser - no team belonging)', async function () {
+    ConfigStore.config = {
+      user: {
+        isSuperuser: true,
+      },
+    };
+    // "All Projects" view
+    wrapper.setProps({selectedProjects: [-1]});
+    // This user is member of one project
+    wrapper.setProps({
+      projects: [
+        TestStubs.Project({
+          id: '1',
+          slug: 'first',
+          environments: ['production', 'staging'],
+        }),
+        TestStubs.Project({
+          id: '2',
+          slug: 'second',
+          environments: ['dev'],
+          isMember: false,
+        }),
+      ],
+    });
+    wrapper.update();
+
+    await wrapper.find('MultipleEnvironmentSelector HeaderItem').simulate('click');
+    const items = wrapper.find('MultipleEnvironmentSelector GlobalSelectionHeaderRow');
+
+    expect(items.length).toEqual(3);
+    expect(items.at(0).text()).toBe('production');
+    expect(items.at(1).text()).toBe('staging');
+    expect(items.at(2).text()).toBe('dev');
+  });
+
+  it('shows All Projects/all environments (superuser - belongs one team)', async function () {
+    // XXX: Ideally, "My Projects" and "All Projects" should be different if a superuser
+    // was to belong to at least one project
+    ConfigStore.config = {
+      user: {
+        isSuperuser: true,
+      },
+    };
+    // "All Projects" view
+    wrapper.setProps({selectedProjects: [-1]});
+    // This user is member of one project
+    wrapper.setProps({
+      projects: [
+        TestStubs.Project({
+          id: '1',
+          slug: 'first',
+          environments: ['production', 'staging'],
+        }),
+        TestStubs.Project({
+          id: '2',
+          slug: 'second',
+          environments: ['dev'],
+          isMember: false,
+        }),
+      ],
+    });
     wrapper.update();
 
     await wrapper.find('MultipleEnvironmentSelector HeaderItem').simulate('click');


### PR DESCRIPTION
Superusers accessing a customer's organization do not belong to any specific team.
Nevertheless, the superuser should not only see all projects but all environments
associated to those projects.

This change fixes the above.

Fixes [ISSUE-860](https://getsentry.atlassian.net/browse/ISSUE-860?atlOrigin=eyJpIjoiZThlNGE5YmYzMTZhNGFiZmFlZTlkNjNkODlmY2NhNWUiLCJwIjoiaiJ9)