### PR TITLE
ref(ui): use prism-sentry theme for code snippets

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "parseurl": "^1.3.2",
     "platformicons": "^3.2.2",
     "po-catalog-loader": "2.0.0",
-    "prismjs": "^1.21.0",
+    "prism-sentry": "^1.0.0",
     "prop-types": "^15.6.0",
     "query-string": "6.6.0",
     "react": "16.14.0",

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.tsx
@@ -1,7 +1,7 @@
 import {browserHistory, WithRouterProps} from 'react-router';
 import React from 'react';
 import styled from '@emotion/styled';
-import 'prismjs/themes/prism-tomorrow.css';
+import 'prism-sentry/index.css';
 
 import {Client} from 'app/api';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12132,7 +12132,12 @@ pretty-hrtime@^1.0.3:
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
 
-prismjs@^1.21.0, prismjs@^1.8.4:
+prism-sentry@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prism-sentry/-/prism-sentry-1.0.0.tgz#bc8d7a18e86bf88d59117ed178cd8bed71e53b7b"
+  integrity sha512-MaJJdKOjz0cUS6Wz5OmP4ngJxkovZdb81KcFvoSQoIBYsNsQwVMvWm48TiWrwpZdawpGJMNxSkUt3XNXlDzB7w==
+
+prismjs@^1.8.4:
   version "1.21.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.21.0.tgz#36c086ec36b45319ec4218ee164c110f9fc015a3"
   integrity sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==


### PR DESCRIPTION
This removes the 'prismjs' dependency and default theme in favor of a new custom Sentry-branded theme.

### Before

<img width="1413" alt="Screen Shot 2020-11-17 at 11 18 46 AM" src="https://user-images.githubusercontent.com/30713/99439076-95b2e980-28c9-11eb-8c5c-4cd951c34727.png">

### After

<img width="1413" alt="Screen Shot 2020-11-17 at 11 14 02 AM" src="https://user-images.githubusercontent.com/30713/99439133-a6fbf600-28c9-11eb-92f7-ac514b33df75.png">
