### PR TITLE
fix(issue-details): Switch labels for absolute/relative addrs toggle

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
@@ -66,7 +66,7 @@ const TogglableAddress = ({
     <Wrapper>
       {canBeConverted && (
         <AddressIconTooltip
-          title={isAbsolute ? t('Switch to absolute') : t('Switch to relative')}
+          title={isAbsolute ? t('Switch to relative') : t('Switch to absolute')}
           containerDisplayMode="inline-flex"
         >
           <AddressToggleIcon onClick={onToggle} size="xs" color="purple300" />


### PR DESCRIPTION
The labels for toggling between absolute and relative addresses are swapped. This fixes the order, showing "Switch to absolute" when relative addresses are shown, and vice versa.