### PR TITLE
fix(workflow): Revert inbox backlog query, revert default query

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 const queries = [
   ['is:inbox', t('Inbox')],
-  ['is:unresolved', t('Backlog')],
+  ['is:unresolved', t('Unresolved')],
   ['is:ignored', t('Ignored')],
 ];
 

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -15,9 +15,8 @@ type Props = {
 
 const queries = [
   ['is:inbox', t('Inbox')],
-  ['!is:inbox is:unresolved', t('Backlog')],
+  ['is:unresolved', t('Backlog')],
   ['is:ignored', t('Ignored')],
-  ['is:resolved', t('Resolved')],
 ];
 
 function IssueListHeader({query, queryCount, queryMaxCount, onTabChange}: Props) {

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -259,11 +259,6 @@ class IssueListOverview extends React.Component<Props, State> {
       return query as string;
     }
 
-    // TODO(workflow): set inbox as new default query
-    if (this.props.organization.features.includes('inbox')) {
-      return 'is:inbox';
-    }
-
     return DEFAULT_QUERY;
   }
 


### PR DESCRIPTION
- Before, if you had inbox feature, your default view would be the inbox. No longer.
- Changes the backlog query back to normal. `is:unresolved`
- Removes the "resolved" inbox tab.