### PR TITLE
fix(integrations): only throw error if identity is required

### DIFF
--- a/src/sentry/integrations/msteams/integration.py
+++ b/src/sentry/integrations/msteams/integration.py
@@ -96,6 +96,7 @@ class MsTeamsIntegrationProvider(IntegrationProvider):
                 "expires_at": token_data["expires_at"],
                 "service_url": service_url,
             },
+            # TODO: Use user id for external_id in user_identity
             "user_identity": {"type": "msteams", "external_id": team_id, "scopes": [], "data": {}},
         }
         return integration

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -269,10 +269,8 @@ class FinishPipelineTestCase(IntegrationTestCase):
         for org_integration in org_integrations:
             assert org_integration.default_auth_id == identity.id
 
-    def test_different_user_same_external_id(self, *args):
-        self.provider = GitlabIntegrationProvider
+    def test_different_user_same_external_id_no_default_needed(self, *args):
         new_user = self.create_user()
-        self.provider.needs_default_identity = True
         integration = Integration.objects.create(
             provider=self.provider.key,
             external_id=self.external_id,
@@ -292,17 +290,14 @@ class FinishPipelineTestCase(IntegrationTestCase):
                 "type": self.provider.key,
                 "external_id": "AccountId",
                 "scopes": [],
-                "data": {
-                    "access_token": "token12345",
-                    "expires_in": "123456789",
-                    "refresh_token": "refresh12345",
-                    "token_type": "typetype",
-                },
+                "data": {},
             },
         }
         resp = self.pipeline.finish_pipeline()
-        assert not OrganizationIntegration.objects.filter(integration_id=integration.id)
-        assert "account is linked to a different Sentry user" in six.text_type(resp.content)
+        self.assertDialogSuccess(resp)
+        assert OrganizationIntegration.objects.filter(
+            integration_id=integration.id, organization=self.organization.id
+        ).exists()
 
     @patch("sentry.mediators.plugins.Migrator.call")
     def test_disabled_plugin_when_fully_migrated(self, call, *args):
@@ -323,3 +318,47 @@ class FinishPipelineTestCase(IntegrationTestCase):
         self.pipeline.finish_pipeline()
 
         assert call.called
+
+
+@patch(
+    "sentry.integrations.gitlab.GitlabIntegrationProvider.build_integration",
+    side_effect=naive_build_integration,
+)
+class GitlabFinishPipelineTest(IntegrationTestCase):
+    provider = GitlabIntegrationProvider
+
+    def setUp(self):
+        super(GitlabFinishPipelineTest, self).setUp()
+        self.external_id = "dummy_id-123"
+
+    def tearDown(self):
+        super(GitlabFinishPipelineTest, self).tearDown()
+
+    def test_different_user_same_external_id(self, *args):
+        new_user = self.create_user()
+        self.setUp()
+        integration = Integration.objects.create(
+            provider=self.provider.key,
+            external_id=self.external_id,
+            metadata={"url": "https://example.com"},
+        )
+        identity_provider = IdentityProvider.objects.create(
+            external_id=self.external_id, type=self.provider.key
+        )
+        Identity.objects.create(
+            idp_id=identity_provider.id, external_id="AccountId", user_id=new_user.id
+        )
+        self.pipeline.state.data = {
+            "external_id": self.external_id,
+            "name": "Name",
+            "metadata": {"url": "https://example.com"},
+            "user_identity": {
+                "type": self.provider.key,
+                "external_id": "AccountId",
+                "scopes": [],
+                "data": {},
+            },
+        }
+        resp = self.pipeline.finish_pipeline()
+        assert not OrganizationIntegration.objects.filter(integration_id=integration.id)
+        assert "account is linked to a different Sentry user" in six.text_type(resp.content)


### PR DESCRIPTION
This PR fixes an issue where we attempt to throw an error for an identity linked to another user (and end up getting another error). We only need to raise this error in cases where we use a default identity for the integration. In cases where we don't have a default identity, such as MsTeams or Slack, the user can link the identity later (which will unlink any other identities without breaking the integration). We don't need to do it during the installation step. This is a follow up to https://github.com/getsentry/sentry/pull/21916.

Fixes: SENTRY-JGH