### PR TITLE
build(ci): Fix merge base for visual snapshots

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -23,8 +23,6 @@ jobs:
     name: frontend tests
     runs-on: ubuntu-16.04
     timeout-minutes: 20
-    outputs:
-      merge-base: ${{ steps.merge-base.outputs.sha }}
 
     env:
       VISUAL_HTML_ENABLE: 1
@@ -37,15 +35,6 @@ jobs:
           # forks to access secrets safely by only running workflows from the main branch.
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          # fetch all history so we can use `git merge-base`
-          fetch-depth: 0
-
-      # Because of pull_request_target event, `github.event.pull_request.base` will refer to latest commit on main branch
-      - name: Get merge base
-        if: github.event.pull_request.head.ref != ''
-        id: merge-base
-        run: |
-          echo "::set-output name=sha::$(git merge-base origin/master ${{ github.event.pull_request.head.ref }})"
 
       - uses: actions/checkout@v2
         name: Checkout sentry (push)
@@ -192,11 +181,29 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      # We need to checkout the repository so that we can fetch the merge base from git
+      - uses: actions/checkout@v2
+        name: Checkout sentry
+        if: github.event.pull_request.head.ref != ''
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # fetch all history so we can use `git merge-base`
+          fetch-depth: 0
+
+      # Because of pull_request_target event, `github.event.pull_request.base` will refer to latest
+      # commit on main branch when opening the PR
+      - name: Get merge base
+        if: github.event.pull_request.head.ref != ''
+        id: merge-base
+        run: |
+          echo "::set-output name=sha::$(git merge-base origin/master ${{ github.event.pull_request.head.ref }})"
+
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: getsentry/action-visual-snapshot@fix-merge-base
+        uses: getsentry/action-visual-snapshot@v2
         with:
-          merge-base: ${{ needs.frontend.outputs.merge-base }}
+          merge-base: ${{ steps.merge-base.outputs.sha }}
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gcs-bucket: 'sentry-visual-snapshots'

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -23,6 +23,8 @@ jobs:
     name: frontend tests
     runs-on: ubuntu-16.04
     timeout-minutes: 20
+    outputs:
+      merge-base: ${{ steps.merge-base.outputs.sha }}
 
     env:
       VISUAL_HTML_ENABLE: 1
@@ -35,6 +37,15 @@ jobs:
           # forks to access secrets safely by only running workflows from the main branch.
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          # fetch all history so we can use `git merge-base`
+          fetch-depth: 0
+
+      # Because of pull_request_target event, `github.event.pull_request.base` will refer to latest commit on main branch
+      - name: Get merge base
+        if: github.event.pull_request.head.ref != ''
+        id: merge-base
+        run: |
+          echo "::set-output name=sha::$(git merge-base origin/master ${{ github.event.pull_request.head.ref }})"
 
       - uses: actions/checkout@v2
         name: Checkout sentry (push)
@@ -183,8 +194,9 @@ jobs:
     steps:
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: getsentry/action-visual-snapshot@v2
+        uses: getsentry/action-visual-snapshot@fix-merge-base
         with:
+          merge-base: ${{ needs.frontend.outputs.merge-base }}
           api-token: ${{ secrets.VISUAL_SNAPSHOT_SECRET }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           gcs-bucket: 'sentry-visual-snapshots'


### PR DESCRIPTION
When we moved from the workflow trigger event `pull_request` to `pull_request_target` (which we changed to allow forks to run Visual Snapshots), it resulted in a change of the pull request base SHA. Instead of relying on the github context for the merge base, we should use `git merge-base` to find the base sha.

The merge base SHA is then used to use a three-way comparison for PRs (comparing the PR head SHA against latest master and the merge base).