### PR TITLE
feat(integrations): Add button to RuleNode for Ticket Rules

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -38,7 +38,7 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
             if hasattr(node, "form_fields"):
                 context["formFields"] = node.form_fields
 
-            if can_create_tickets and node.id in TICKET_ACTIONS:
+            if node.id in TICKET_ACTIONS:
                 context["actionType"] = "ticket"
             # It is possible for a project to have no services. In that scenario we do
             # not want the front end to render the action as the action does not have

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -38,6 +38,8 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
             if hasattr(node, "form_fields"):
                 context["formFields"] = node.form_fields
 
+            if can_create_tickets and node.id in TICKET_ACTIONS:
+                context["actionType"] = "ticket"
             # It is possible for a project to have no services. In that scenario we do
             # not want the front end to render the action as the action does not have
             # options.

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -35,7 +35,7 @@ class JiraNotifyServiceForm(forms.Form):
 
 class JiraCreateTicketAction(TicketEventAction):
     form_cls = JiraNotifyServiceForm
-    label = u"""Create a Jira issue in {jira_integration} """
+    label = u"""Create a Jira issue in {jira_integration} with these """
     prompt = "Create a Jira issue"
     provider = "jira"
     integration_key = "jira_integration"
@@ -59,40 +59,6 @@ class JiraCreateTicketAction(TicketEventAction):
         dynamic_fields = self.get_dynamic_form_fields()
         if dynamic_fields:
             self.form_fields.update(dynamic_fields)
-            self.label = self.get_label_form(dynamic_fields)
-
-    @staticmethod
-    def get_label_form(data):
-        """
-        Get the rule as a string. Use human-readable values when available and
-        construct the the label by parts because there are so many optional
-        fields.
-
-        :return: String
-        """
-
-        labels = ["Create a Jira issue in {jira_integration} "]
-
-        # if data.get("project"):
-        #     labels.append("and {project} project")
-        # if data.get("issuetype"):
-        #     labels.append("of type {issuetype}")
-        # if data.get("components"):
-        #     labels.append("with components {components}")
-        # if data.get("duedate"):
-        #     labels.append("and due date {duedate}")
-        # if data.get("fixVersions"):
-        #     labels.append("with fixVersions {fixVersions}")
-        # if data.get("assignee"):
-        #     labels.append("assigned to {assignee}")
-        # if data.get("reporter"):
-        #     labels.append("reported by {reporter}")
-        # if data.get("labels"):
-        #     labels.append("with the labels {labels}")
-        # if data.get("priority"):
-        #     labels.append("priority {priority}")
-
-        return " ".join(labels)
 
     def render_label(self):
         # Make a copy of data.
@@ -102,7 +68,7 @@ class JiraCreateTicketAction(TicketEventAction):
         kwargs.update({"jira_integration": self.get_integration_name()})
 
         # Only add values when they exist.
-        return self.get_label_form(self.data).format(**kwargs)
+        return self.label.format(**kwargs)
 
     def get_dynamic_form_fields(self):
         """
@@ -130,7 +96,6 @@ class JiraCreateTicketAction(TicketEventAction):
                     dynamic_form_fields = transform_jira_fields_to_form_fields(fields)
                     self.data["dynamic_form_fields"] = dynamic_form_fields
                     # TODO should I wipe out the rest of the data?
-                    dynamic_form_fields["rule_type"] = "jira"
                     return dynamic_form_fields
         return None
 

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -35,8 +35,8 @@ class JiraNotifyServiceForm(forms.Form):
 
 class JiraCreateTicketAction(TicketEventAction):
     form_cls = JiraNotifyServiceForm
-    label = u"""Create a Jira ticket in the {jira_integration} account"""
-    prompt = "Create a Jira ticket"
+    label = u"""Create a Jira issue in {jira_integration} """
+    prompt = "Create a Jira issue"
     provider = "jira"
     integration_key = "jira_integration"
 
@@ -71,26 +71,26 @@ class JiraCreateTicketAction(TicketEventAction):
         :return: String
         """
 
-        labels = ["Create a Jira ticket in the {jira_integration} account"]
+        labels = ["Create a Jira issue in {jira_integration} "]
 
-        if data.get("project"):
-            labels.append("and {project} project")
-        if data.get("issuetype"):
-            labels.append("of type {issuetype}")
-        if data.get("components"):
-            labels.append("with components {components}")
-        if data.get("duedate"):
-            labels.append("and due date {duedate}")
-        if data.get("fixVersions"):
-            labels.append("with fixVersions {fixVersions}")
-        if data.get("assignee"):
-            labels.append("assigned to {assignee}")
-        if data.get("reporter"):
-            labels.append("reported by {reporter}")
-        if data.get("labels"):
-            labels.append("with the labels {labels}")
-        if data.get("priority"):
-            labels.append("priority {priority}")
+        # if data.get("project"):
+        #     labels.append("and {project} project")
+        # if data.get("issuetype"):
+        #     labels.append("of type {issuetype}")
+        # if data.get("components"):
+        #     labels.append("with components {components}")
+        # if data.get("duedate"):
+        #     labels.append("and due date {duedate}")
+        # if data.get("fixVersions"):
+        #     labels.append("with fixVersions {fixVersions}")
+        # if data.get("assignee"):
+        #     labels.append("assigned to {assignee}")
+        # if data.get("reporter"):
+        #     labels.append("reported by {reporter}")
+        # if data.get("labels"):
+        #     labels.append("with the labels {labels}")
+        # if data.get("priority"):
+        #     labels.append("priority {priority}")
 
         return " ".join(labels)
 
@@ -130,6 +130,7 @@ class JiraCreateTicketAction(TicketEventAction):
                     dynamic_form_fields = transform_jira_fields_to_form_fields(fields)
                     self.data["dynamic_form_fields"] = dynamic_form_fields
                     # TODO should I wipe out the rest of the data?
+                    dynamic_form_fields["rule_type"] = "jira"
                     return dynamic_form_fields
         return None
 

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -22,7 +22,7 @@ class AzureDevopsNotifyServiceForm(forms.Form):
 
 class AzureDevopsCreateTicketAction(TicketEventAction):
     form_cls = AzureDevopsNotifyServiceForm
-    label = u"TODO Create a {name} AzureDevops workitem"
+    label = u"TODO Create a {name} Azure DevOps work item with these "
     prompt = "Create an Azure DevOps work item"
     provider = "vsts"
     integration_key = "vsts_integration"

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -22,7 +22,7 @@ class AzureDevopsNotifyServiceForm(forms.Form):
 
 class AzureDevopsCreateTicketAction(TicketEventAction):
     form_cls = AzureDevopsNotifyServiceForm
-    label = u"TODO Create a {name} Azure DevOps work item with these "
+    label = u"TODO Create an Azure DevOps work item in {name} with these "
     prompt = "Create an Azure DevOps work item"
     provider = "vsts"
     integration_key = "vsts_integration"

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 import styled from '@emotion/styled';
 
-import {addSuccessMessage, addErrorMessage} from 'app/actionCreators/indicator';
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import AsyncComponent from 'app/components/asyncComponent';
-import IssueSyncListElement from 'app/components/issueSyncListElement';
 import ExternalIssueForm from 'app/components/group/externalIssueForm';
-import IntegrationItem from 'app/views/organizationIntegrations/integrationItem';
+import IssueSyncListElement from 'app/components/issueSyncListElement';
 import NavTabs from 'app/components/navTabs';
 import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Group, GroupIntegration} from 'app/types';
+import IntegrationItem from 'app/views/organizationIntegrations/integrationItem';
 
 type Props = AsyncComponent['props'] & {
   configurations: GroupIntegration[];

--- a/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueActions.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 import styled from '@emotion/styled';
 
-import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {addSuccessMessage, addErrorMessage} from 'app/actionCreators/indicator';
 import AsyncComponent from 'app/components/asyncComponent';
-import ExternalIssueForm from 'app/components/group/externalIssueForm';
 import IssueSyncListElement from 'app/components/issueSyncListElement';
+import ExternalIssueForm from 'app/components/group/externalIssueForm';
+import IntegrationItem from 'app/views/organizationIntegrations/integrationItem';
 import NavTabs from 'app/components/navTabs';
 import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Group, GroupIntegration} from 'app/types';
-import IntegrationItem from 'app/views/organizationIntegrations/integrationItem';
 
 type Props = AsyncComponent['props'] & {
   configurations: GroupIntegration[];

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -19,10 +19,7 @@ import {
 } from 'app/types/alerts';
 import Input from 'app/views/settings/components/forms/controls/input';
 import MemberTeamFields from 'app/views/settings/projectAlerts/issueEditor/memberTeamFields';
-import ExternalLink from 'app/components/links/externalLink';
 import TicketRuleForm from 'app/views/settings/projectAlerts/issueEditor/ticketRuleForm';
-import {Organization, Project} from 'app/types';
-import {IconDelete} from 'app/icons';
 
 type FormField = {
   // Type of form fields

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -310,29 +310,29 @@ class RuleNode extends React.Component<Props, State> {
             {data && <input type="hidden" name="id" value={data.id} />}
             {this.renderRow()}
             {ticketRule && (
-              <Button
-                size="small"
-                icon={<IconSettings size="xs" />}
-                onClick={() => this.openModal()}
-              >
-                {
-                  <Modal
-                    show={this.state.showModal}
-                    onHide={this.closeModal}
-                    animation={false}
-                    enforceFocus={false}
-                    backdrop="static"
-                  >
-                    <Modal.Header closeButton>
-                      <Modal.Title>Issue Link Settings</Modal.Title>
-                    </Modal.Header>
-                    <Modal.Body>
-                      replace me with an ExternalIssueForm in API-1448
-                    </Modal.Body>
-                  </Modal>
-                }
-                Issue Link Settings
-              </Button>
+              <React.Fragment>
+                <Button
+                  size="small"
+                  icon={<IconSettings size="xs" />}
+                  onClick={() => this.openModal()}
+                >
+                  Issue Link Settings
+                </Button>
+                <Modal
+                  show={this.state.showModal}
+                  onHide={this.closeModal}
+                  animation={false}
+                  enforceFocus={false}
+                  backdrop="static"
+                >
+                  <Modal.Header closeButton>
+                    <Modal.Title>Issue Link Settings</Modal.Title>
+                  </Modal.Header>
+                  <Modal.Body>
+                    replace me with an ExternalIssueForm in API-1448
+                  </Modal.Body>
+                </Modal>
+              </React.Fragment>
             )}
           </Rule>
           <DeleteButton

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import Modal from 'react-bootstrap/lib/Modal';
 
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
@@ -21,8 +20,9 @@ import {
 import Input from 'app/views/settings/components/forms/controls/input';
 import MemberTeamFields from 'app/views/settings/projectAlerts/issueEditor/memberTeamFields';
 import ExternalLink from 'app/components/links/externalLink';
+import TicketRuleForm from 'app/views/settings/projectAlerts/issueEditor/ticketRuleForm';
 import {Organization, Project} from 'app/types';
-import {IconDelete, IconSettings} from 'app/icons';
+import {IconDelete} from 'app/icons';
 
 type FormField = {
   // Type of form fields
@@ -197,18 +197,6 @@ class RuleNode extends React.Component<Props, State> {
     return getFieldTypes[fieldConfig.type](name, fieldConfig);
   };
 
-  openModal = () => {
-    this.setState({
-      showModal: true,
-    });
-  };
-
-  closeModal = () => {
-    this.setState({
-      showModal: false,
-    });
-  };
-
   renderRow() {
     const {data, node} = this.props;
 
@@ -309,31 +297,7 @@ class RuleNode extends React.Component<Props, State> {
           <Rule>
             {data && <input type="hidden" name="id" value={data.id} />}
             {this.renderRow()}
-            {ticketRule && (
-              <React.Fragment>
-                <Button
-                  size="small"
-                  icon={<IconSettings size="xs" />}
-                  onClick={() => this.openModal()}
-                >
-                  Issue Link Settings
-                </Button>
-                <Modal
-                  show={this.state.showModal}
-                  onHide={this.closeModal}
-                  animation={false}
-                  enforceFocus={false}
-                  backdrop="static"
-                >
-                  <Modal.Header closeButton>
-                    <Modal.Title>Issue Link Settings</Modal.Title>
-                  </Modal.Header>
-                  <Modal.Body>
-                    replace me with an ExternalIssueForm in API-1448
-                  </Modal.Body>
-                </Modal>
-              </React.Fragment>
-            )}
+            {ticketRule && <TicketRuleForm showModal={this.state.showModal} />}
           </Rule>
           <DeleteButton
             disabled={disabled}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -39,14 +39,7 @@ type Props = {
   onPropertyChange: (rowIndex: number, name: string, value: string) => void;
 };
 
-type State = {
-  showModal: boolean;
-};
-
-class RuleNode extends React.Component<Props, State> {
-  state: State = {
-    showModal: false,
-  };
+class RuleNode extends React.Component<Props> {
   handleDelete = () => {
     const {index, onDelete} = this.props;
     onDelete(index);
@@ -294,7 +287,7 @@ class RuleNode extends React.Component<Props, State> {
           <Rule>
             {data && <input type="hidden" name="id" value={data.id} />}
             {this.renderRow()}
-            {ticketRule && <TicketRuleForm showModal={this.state.showModal} />}
+            {ticketRule && <TicketRuleForm />}
           </Rule>
           <DeleteButton
             disabled={disabled}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -42,17 +42,14 @@ type Props = {
   onPropertyChange: (rowIndex: number, name: string, value: string) => void;
 };
 
-class RuleNode extends React.Component<Props, State> {
-  constructor(props: Props, context) {
-    super(props, context);
+type State = {
+  showModal: boolean;
+};
 
-    this.state = {
-      showModal: false,
-      action: 'create',
-      // selectedIntegration: null,
-      // ...this.getDefaultState(),
-    };
-  }
+class RuleNode extends React.Component<Props, State> {
+  state: State = {
+    showModal: false,
+  };
   handleDelete = () => {
     const {index, onDelete} = this.props;
     onDelete(index);
@@ -200,17 +197,15 @@ class RuleNode extends React.Component<Props, State> {
     return getFieldTypes[fieldConfig.type](name, fieldConfig);
   };
 
-  openModal = (formFields: any) => {
+  openModal = () => {
     this.setState({
       showModal: true,
-      formFields,
     });
   };
 
   closeModal = () => {
     this.setState({
       showModal: false,
-      selectedIntegration: null,
     });
   };
 
@@ -240,57 +235,23 @@ class RuleNode extends React.Component<Props, State> {
       if (key === 'value' && data && (data.match === 'is' || data.match === 'ns')) {
         return null;
       }
-
-      let formPart;
-      if (formFields.hasOwnProperty('rule_type')) {
-        formPart = this.getField(key, formFields[key]);
-
-        return (
-          <React.Fragment>
-            <Separator key={key}>{formPart}</Separator>
-            with these
-            <SettingsButton
-              size="small"
-              icon={<IconSettings size="xs" />}
-              onClick={() => this.openModal(formFields)}
-            >
-              {
-                <Modal
-                  show={this.state.showModal}
-                  onHide={this.closeModal}
-                  animation={false}
-                  enforceFocus={false}
-                  backdrop="static"
-                >
-                  <Modal.Header closeButton>
-                    <Modal.Title>Issue Link Settings</Modal.Title>
-                  </Modal.Header>
-                  <Modal.Body>
-                    replace me with an ExternalIssueForm in API-1448
-                  </Modal.Body>
-                </Modal>
-              }
-              Issue Link Settings
-            </SettingsButton>
-          </React.Fragment>
-        );
-      } else if (formFields && formFields.hasOwnProperty(key)) {
-        formPart = this.getField(key, formFields[key]);
-      } else {
-        formPart = part;
-      }
-
-      return <Separator key={key}>{formPart}</Separator>;
+      return (
+        <Separator key={key}>
+          {formFields && formFields.hasOwnProperty(key)
+            ? this.getField(key, formFields[key])
+            : part}
+        </Separator>
+      );
     });
 
     const [title, ...inputs] = parts;
 
     // We return this so that it can be a grid
     return (
-      <Rule>
+      <React.Fragment>
         {title}
         {inputs}
-      </Rule>
+      </React.Fragment>
     );
   }
 
@@ -339,13 +300,41 @@ class RuleNode extends React.Component<Props, State> {
   }
 
   render() {
-    const {data, disabled} = this.props;
+    const {data, disabled, node} = this.props;
+    const ticketRule = node?.hasOwnProperty('actionType');
 
     return (
       <RuleRowContainer>
         <RuleRow>
-          {data && <input type="hidden" name="id" value={data.id} />}
-          {this.renderRow()}
+          <Rule>
+            {data && <input type="hidden" name="id" value={data.id} />}
+            {this.renderRow()}
+            {ticketRule && (
+              <Button
+                size="small"
+                icon={<IconSettings size="xs" />}
+                onClick={() => this.openModal()}
+              >
+                {
+                  <Modal
+                    show={this.state.showModal}
+                    onHide={this.closeModal}
+                    animation={false}
+                    enforceFocus={false}
+                    backdrop="static"
+                  >
+                    <Modal.Header closeButton>
+                      <Modal.Title>Issue Link Settings</Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                      replace me with an ExternalIssueForm in API-1448
+                    </Modal.Body>
+                  </Modal>
+                }
+                Issue Link Settings
+              </Button>
+            )}
+          </Rule>
           <DeleteButton
             disabled={disabled}
             label={t('Delete Node')}
@@ -400,10 +389,6 @@ const Rule = styled('div')`
   align-items: center;
   flex: 1;
   flex-wrap: wrap;
-`;
-
-const SettingsButton = styled(Button)`
-  margin-left: ${space(1)};
 `;
 
 const DeleteButton = styled(Button)`

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import Modal from 'react-bootstrap/lib/Modal';
 
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
@@ -20,11 +21,8 @@ import {
 import Input from 'app/views/settings/components/forms/controls/input';
 import MemberTeamFields from 'app/views/settings/projectAlerts/issueEditor/memberTeamFields';
 import ExternalLink from 'app/components/links/externalLink';
-import {GroupIntegration, Organization, Project} from 'app/types'
-import {IconDelete} from 'app/icons';
-import Modal from 'react-bootstrap/lib/Modal'
-import NavTabs from 'app/components/navTabs'
-import ExternalIssueForm from 'app/components/group/externalIssueForm'
+import {Organization, Project} from 'app/types';
+import {IconDelete, IconSettings} from 'app/icons';
 
 type FormField = {
   // Type of form fields
@@ -44,7 +42,17 @@ type Props = {
   onPropertyChange: (rowIndex: number, name: string, value: string) => void;
 };
 
-class RuleNode extends React.Component<Props> {
+class RuleNode extends React.Component<Props, State> {
+  constructor(props: Props, context) {
+    super(props, context);
+
+    this.state = {
+      showModal: false,
+      action: 'create',
+      // selectedIntegration: null,
+      // ...this.getDefaultState(),
+    };
+  }
   handleDelete = () => {
     const {index, onDelete} = this.props;
     onDelete(index);
@@ -195,15 +203,13 @@ class RuleNode extends React.Component<Props> {
   openModal = (formFields: any) => {
     this.setState({
       showModal: true,
-      formFields: formFields,
-      action: 'create',
+      formFields,
     });
   };
 
   closeModal = () => {
     this.setState({
       showModal: false,
-      action: null,
       selectedIntegration: null,
     });
   };
@@ -219,7 +225,6 @@ class RuleNode extends React.Component<Props> {
         </Separator>
       );
     }
-    // TODO be able to render a button
 
     const {label, formFields} = node;
 
@@ -237,55 +242,45 @@ class RuleNode extends React.Component<Props> {
       }
 
       let formPart;
-      if (formFields && formFields.hasOwnProperty(key)) {
-        formPart = this.getField(key, formFields[key])
-      } else if (formFields["type"] === "modalButton") {
-        formPart = <Button
-          onClick={() => this.openModal(formFields)}
-        >
-          {
-            <Modal
-              show={this.state.showModal}
-              onHide={this.closeModal}
-              animation={false}
-              enforceFocus={false}
-              backdrop="static"
+      if (formFields.hasOwnProperty('rule_type')) {
+        formPart = this.getField(key, formFields[key]);
+
+        return (
+          <React.Fragment>
+            <Separator key={key}>{formPart}</Separator>
+            with these
+            <SettingsButton
+              size="small"
+              icon={<IconSettings size="xs" />}
+              onClick={() => this.openModal(formFields)}
             >
-              <Modal.Header closeButton>
-                <Modal.Title>{`${selectedIntegration.provider.name} Issue`}</Modal.Title>
-              </Modal.Header>
-              <NavTabs underlined>
-                <li className={action === 'create' ? 'active' : ''}>
-                  <a onClick={() => this.handleClick('create')}>{t('Create')}</a>
-                </li>
-                <li className={action === 'link' ? 'active' : ''}>
-                  <a onClick={() => this.handleClick('link')}>{t('Link')}</a>
-                </li>
-              </NavTabs>
-              <Modal.Body>
-                {action && (
-                  <ExternalIssueForm
-                    // need the key here so React will re-render
-                    // with a new action prop
-                    key={action}
-                    group={this.props.group}
-                    integration={selectedIntegration}
-                    action={action}
-                    onSubmitSuccess={(_, onSuccess) => this.linkIssueSuccess(onSuccess)}
-                  />
-                )}
-              </Modal.Body>
-            </Modal>
-          )}
-        </Button>;
+              {
+                <Modal
+                  show={this.state.showModal}
+                  onHide={this.closeModal}
+                  animation={false}
+                  enforceFocus={false}
+                  backdrop="static"
+                >
+                  <Modal.Header closeButton>
+                    <Modal.Title>Issue Link Settings</Modal.Title>
+                  </Modal.Header>
+                  <Modal.Body>
+                    replace me with an ExternalIssueForm in API-1448
+                  </Modal.Body>
+                </Modal>
+              }
+              Issue Link Settings
+            </SettingsButton>
+          </React.Fragment>
+        );
+      } else if (formFields && formFields.hasOwnProperty(key)) {
+        formPart = this.getField(key, formFields[key]);
       } else {
         formPart = part;
       }
 
-
-      return (
-        <Separator key={key}>{ formPart }</Separator>
-      );
+      return <Separator key={key}>{formPart}</Separator>;
     });
 
     const [title, ...inputs] = parts;
@@ -405,6 +400,10 @@ const Rule = styled('div')`
   align-items: center;
   flex: 1;
   flex-wrap: wrap;
+`;
+
+const SettingsButton = styled(Button)`
+  margin-left: ${space(1)};
 `;
 
 const DeleteButton = styled(Button)`

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Modal from 'react-bootstrap/lib/Modal';
+
+import Button from 'app/components/button';
+import {IconSettings} from 'app/icons';
+
+type State = {
+  showModal: boolean;
+};
+
+class TicketRuleForm extends React.Component<State> {
+  state: State = {
+    showModal: false,
+  };
+
+  openModal = () => {
+    this.setState({
+      showModal: true,
+    });
+  };
+
+  closeModal = () => {
+    this.setState({
+      showModal: false,
+    });
+  };
+
+  render() {
+    return (
+      <React.Fragment>
+        <Button
+          size="small"
+          icon={<IconSettings size="xs" />}
+          onClick={() => this.openModal()}
+        >
+          Issue Link Settings
+        </Button>
+        <Modal
+          show={this.state.showModal}
+          onHide={this.closeModal}
+          animation={false}
+          enforceFocus={false}
+          backdrop="static"
+        >
+          <Modal.Header closeButton>
+            <Modal.Title>Issue Link Settings</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>replace me with an ExternalIssueForm in API-1448</Modal.Body>
+        </Modal>
+      </React.Fragment>
+    );
+  }
+}
+
+export default TicketRuleForm;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -4,12 +4,14 @@ import Modal from 'react-bootstrap/lib/Modal';
 import Button from 'app/components/button';
 import {IconSettings} from 'app/icons';
 
+type Props = {};
+
 type State = {
   showModal: boolean;
 };
 
-class TicketRuleForm extends React.Component<State> {
-  state: State = {
+class TicketRuleForm extends React.Component<Props, State> {
+  state = {
     showModal: false,
   };
 

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -136,11 +136,7 @@ class JiraCreateTicketActionTest(RuleTestCase):
                 },
             }
         )
-
-        assert (
-            rule.render_label()
-            == """Create a Jira ticket in the Jira Cloud account and Example project of type Bug"""
-        )
+        assert rule.render_label() == """Create a Jira issue in Jira Cloud with these """
 
     def test_render_label_without_integration(self):
         deleted_id = self.integration.id
@@ -148,7 +144,7 @@ class JiraCreateTicketActionTest(RuleTestCase):
 
         rule = self.get_rule(data={"jira_integration": deleted_id})
 
-        assert rule.render_label() == "Create a Jira ticket in the [removed] account"
+        assert rule.render_label() == "Create a Jira issue in [removed] with these "
 
     @responses.activate
     def test_invalid_integration(self):


### PR DESCRIPTION
For actions that will create a ticket/work item based on a rule, we want to render a button which will launch a modal (which doesn't exist yet) that the user will fill out similar to the existing manual issue creation modal. 

**Before**
<img width="1138" alt="Screen Shot 2020-11-18 at 12 01 49 PM" src="https://user-images.githubusercontent.com/29959063/99609393-ab590980-29c4-11eb-8aa8-7b9f1be1c81d.png">

**After**
<img width="1143" alt="Screen Shot 2020-11-18 at 4 57 02 PM" src="https://user-images.githubusercontent.com/29959063/99607041-d12fdf80-29bf-11eb-9e87-ae2aebf9a914.png">
