### PR TITLE
perf: Add collapse latestDeploys flag to projects endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -29,6 +29,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         :auth: required
         """
         stats_period = request.GET.get("statsPeriod")
+        collapse = request.GET.getlist("collapse", [])
         if stats_period not in (None, "", "24h", "14d", "30d"):
             return Response(
                 {"error": {"params": {"stats_period": {"message": ERR_INVALID_STATS_PERIOD}}}},
@@ -98,7 +99,9 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
 
         if get_all_projects:
             queryset = queryset.order_by("slug").select_related("organization")
-            return Response(serialize(list(queryset), request.user, ProjectSummarySerializer()))
+            return Response(
+                serialize(list(queryset), request.user, ProjectSummarySerializer(collapse=collapse))
+            )
         else:
 
             def serialize_on_result(result):
@@ -108,6 +111,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
                     environment_id=environment_id,
                     stats_period=stats_period,
                     transaction_stats=transaction_stats,
+                    collapse=collapse,
                 )
                 return serialize(result, request.user, serializer)
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -54,6 +54,8 @@ STATS_PERIOD_CHOICES = {
 
 _PROJECT_SCOPE_PREFIX = "projects:"
 
+LATEST_DEPLOYS_KEY = "latestDeploys"
+
 
 @register(Project)
 class ProjectSerializer(Serializer):
@@ -442,11 +444,11 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             for release in bulk_fetch_project_latest_releases(item_list)
         }
 
-        if not self._collapse("latestDeploys"):
+        if not self._collapse(LATEST_DEPLOYS_KEY):
             deploys_by_project = self.get_deploys_by_project(item_list)
         for item in item_list:
             attrs[item]["latest_release"] = latest_release_versions.get(item.id)
-            if not self._collapse("latestDeploys"):
+            if not self._collapse(LATEST_DEPLOYS_KEY):
                 attrs[item]["deploys"] = deploys_by_project.get(item.id)
             attrs[item]["environments"] = environments_by_project.get(item.id, [])
             attrs[item]["has_user_reports"] = item.id in projects_with_user_reports
@@ -473,8 +475,8 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
             "latestRelease": attrs["latest_release"],
             "hasUserReports": attrs["has_user_reports"],
         }
-        if not self._collapse("latestDeploys"):
-            context["latestDeploys"] = attrs["deploys"]
+        if not self._collapse(LATEST_DEPLOYS_KEY):
+            context[LATEST_DEPLOYS_KEY] = attrs["deploys"]
         if "stats" in attrs:
             context["stats"] = attrs["stats"]
         if "transactionStats" in attrs:

--- a/src/sentry/static/sentry/app/actionCreators/organization.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/organization.tsx
@@ -59,6 +59,7 @@ export async function fetchOrganizationDetails(
           uncancelableApi.requestPromise(`/organizations/${slug}/projects/`, {
             query: {
               all_projects: 1,
+              collapse: 'latestDeploys',
             },
           }),
           uncancelableApi.requestPromise(`/organizations/${slug}/teams/`),

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -214,7 +214,7 @@ export type Project = {
   plugins: Plugin[];
   processingIssues: number;
   relayPiiConfig: string;
-  latestDeploys: Record<string, Pick<Deploy, 'dateFinished' | 'version'>> | null;
+  latestDeploys?: Record<string, Pick<Deploy, 'dateFinished' | 'version'>> | null;
   builtinSymbolSources?: string[];
   stats?: TimeseriesValue[];
   transactionStats?: TimeseriesValue[];

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -159,6 +159,16 @@ class OrganizationProjectsTest(APITestCase):
         # Verify all projects in the org are returned in sorted order
         self.check_valid_response(response, sorted_projects)
 
+    def test_all_projects_collapse(self):
+        self.login_as(user=self.user)
+        project_bar = self.create_project(teams=[self.team], name="bar", slug="bar")
+        sorted_projects = [project_bar]
+
+        response = self.client.get(self.path + "?all_projects=1&collapse=latestDeploy")
+        # Verify all projects in the org are returned in sorted order
+        self.check_valid_response(response, sorted_projects)
+        assert response.data[0].get("latestDeploy") is None
+
     def test_user_projects(self):
         self.foo_user = self.create_user("foo@example.com")
         self.login_as(user=self.foo_user)

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -167,7 +167,7 @@ class OrganizationProjectsTest(APITestCase):
         response = self.client.get(self.path + "?all_projects=1&collapse=latestDeploy")
         # Verify all projects in the org are returned in sorted order
         self.check_valid_response(response, sorted_projects)
-        assert response.data[0].get("latestDeploy") is None
+        assert "latestDeploy" not in response.data[0]
 
     def test_user_projects(self):
         self.foo_user = self.create_user("foo@example.com")


### PR DESCRIPTION
On some large orgs, when fetching `https://sentry.io/api/0/organizations/:orgId/projects/?all_projects=1` this api can take up to 5 seconds with latestDeploy taking nearly all of it.

This endpoint is blocking on the issues details page adding 5 seconds of load time to first page load.

This PR adds the ability to not return `latestDeploys` property via a "collapse" query param. 
`https://sentry.io/api/0/organizations/:orgId/projects/?all_projects=1&collapse=latestDeploy`

Only the project list page uses latestDeploy and it doesn't use it from this particular store. I think latestDeploys was added to the shared serializer, even though the field wasn't always used.