### PR TITLE
feat(metric_alerts): Use in-field labels for query field selector

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -56,6 +56,11 @@ type Props = {
    * list, as tag items in the list may be used as parameters to functions.
    */
   filterPrimaryOptions?: (option: SelectValue<FieldValue>) => boolean;
+  /**
+   * Whether or not to add labels inside of the input fields, currently only
+   * used for the metric alert builder.
+   */
+  inFieldLabels?: boolean;
   onChange: (fieldValue: QueryFieldValue) => void;
 };
 
@@ -276,6 +281,7 @@ class QueryField extends React.Component<Props> {
   }
 
   renderParameterInputs(parameters: ParameterDescription[]): React.ReactNode[] {
+    const {inFieldLabels} = this.props;
     const inputs = parameters.map((descriptor: ParameterDescription, index: number) => {
       if (descriptor.kind === 'column' && descriptor.options.length > 0) {
         return (
@@ -287,6 +293,7 @@ class QueryField extends React.Component<Props> {
             value={descriptor.value}
             required={descriptor.required}
             onChange={this.handleFieldParameterChange}
+            inFieldLabel={inFieldLabels ? t('Parameter: ') : undefined}
           />
         );
       }
@@ -350,7 +357,7 @@ class QueryField extends React.Component<Props> {
   }
 
   render() {
-    const {className, takeFocus, filterPrimaryOptions} = this.props;
+    const {className, takeFocus, filterPrimaryOptions, inFieldLabels} = this.props;
     const {field, fieldOptions, parameterDescriptions} = this.getFieldData();
 
     const allFieldOptions = filterPrimaryOptions
@@ -363,6 +370,7 @@ class QueryField extends React.Component<Props> {
       placeholder: t('(Required)'),
       value: field,
       onChange: this.handleFieldChange,
+      inFieldLabel: inFieldLabels ? t('Function: ') : undefined,
     };
     if (takeFocus && field === null) {
       selectProps.autoFocus = true;
@@ -395,7 +403,7 @@ class QueryField extends React.Component<Props> {
       <Container className={className} gridColumns={parameters.length + 1}>
         <SelectControl
           {...selectProps}
-          styles={styles}
+          styles={!inFieldLabels ? styles : undefined}
           components={{
             Option: ({label, data, ...props}: OptionProps<OptionType>) => (
               <components.Option label={label} {...(props as any)}>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -29,6 +29,7 @@ type Props = Omit<FormField['props'], 'children'> & {
    * Optionally set a width for each column of selector
    */
   columnWidth?: number;
+  inFieldLabels?: boolean;
 };
 
 const getFieldOptionConfig = (dataset: Dataset) => {
@@ -83,7 +84,7 @@ const help = ({name, model}: {name: string; model: FormModel}) => {
   );
 };
 
-const MetricField = ({organization, columnWidth, ...props}: Props) => (
+const MetricField = ({organization, columnWidth, inFieldLabels, ...props}: Props) => (
   <FormField help={help} {...props}>
     {({onChange, value, model}) => {
       const dataset = model.getValue('dataset');
@@ -105,10 +106,13 @@ const MetricField = ({organization, columnWidth, ...props}: Props) => (
 
       return (
         <React.Fragment>
-          <AggregateHeader>
-            <div>{t('Function')}</div>
-            {numParameters > 0 && <div>{t('Parameter')}</div>}
-          </AggregateHeader>
+          {!inFieldLabels && (
+            <AggregateHeader>
+              <div>{t('Function')}</div>
+              {numParameters > 0 && <div>{t('Parameter')}</div>}
+              {numParameters > 1 && <div>{t('Value')}</div>}
+            </AggregateHeader>
+          )}
           <StyledQueryField
             filterPrimaryOptions={option => option.value.kind === FieldValueKind.FUNCTION}
             fieldOptions={fieldOptions}
@@ -116,6 +120,7 @@ const MetricField = ({organization, columnWidth, ...props}: Props) => (
             onChange={v => onChange(generateFieldAsString(v), {})}
             columnWidth={columnWidth}
             gridColumns={numParameters}
+            inFieldLabels={inFieldLabels}
           />
         </React.Fragment>
       );

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -275,6 +275,7 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
                 inline={false}
                 flexibleControlStateSize
                 columnWidth={200}
+                inFieldLabels
                 required
               />
               <FormRowText>over</FormRowText>


### PR DESCRIPTION
For consistency on the metric alert builder, changed the type of labels from an aggregate header on the metric selector, to an in-field label.

**Before:**
![image](https://user-images.githubusercontent.com/9372512/99558976-4a184280-2992-11eb-8bb9-504a1304073d.png)

**After:**
![image](https://user-images.githubusercontent.com/9372512/99558862-27862980-2992-11eb-9b64-dc80a375ee5b.png)
