### PR TITLE
style(metric_alerts): Query field fixed width

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -25,6 +25,10 @@ import {PRESET_AGGREGATES} from './presets';
 
 type Props = Omit<FormField['props'], 'children'> & {
   organization: Organization;
+  /**
+   * Optionally set a width for each column of selector
+   */
+  columnWidth?: number;
 };
 
 const getFieldOptionConfig = (dataset: Dataset) => {
@@ -79,7 +83,7 @@ const help = ({name, model}: {name: string; model: FormModel}) => {
   );
 };
 
-const MetricField = ({organization, ...props}: Props) => (
+const MetricField = ({organization, columnWidth, ...props}: Props) => (
   <FormField help={help} {...props}>
     {({onChange, value, model}) => {
       const dataset = model.getValue('dataset');
@@ -105,17 +109,27 @@ const MetricField = ({organization, ...props}: Props) => (
             <div>{t('Function')}</div>
             {numParameters > 0 && <div>{t('Parameter')}</div>}
           </AggregateHeader>
-          <QueryField
+          <StyledQueryField
             filterPrimaryOptions={option => option.value.kind === FieldValueKind.FUNCTION}
             fieldOptions={fieldOptions}
             fieldValue={fieldValue}
             onChange={v => onChange(generateFieldAsString(v), {})}
+            columnWidth={columnWidth}
+            gridColumns={numParameters}
           />
         </React.Fragment>
       );
     }}
   </FormField>
 );
+
+const StyledQueryField = styled(QueryField)<{gridColumns: number; columnWidth?: number}>`
+  ${p =>
+    p.columnWidth &&
+    css`
+      width: ${(p.gridColumns + 1) * p.columnWidth}px;
+    `}
+`;
 
 const AggregateHeader = styled('div')`
   display: grid;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -274,7 +274,7 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
                 }}
                 inline={false}
                 flexibleControlStateSize
-                columnWidth={250}
+                columnWidth={200}
                 required
               />
               <FormRowText>over</FormRowText>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -271,11 +271,10 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
                 disabled={disabled}
                 style={{
                   ...formElemBaseStyle,
-                  flex: 6,
-                  minWidth: 300,
                 }}
                 inline={false}
                 flexibleControlStateSize
+                columnWidth={250}
                 required
               />
               <FormRowText>over</FormRowText>
@@ -283,7 +282,6 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
                 name="timeWindow"
                 style={{
                   ...formElemBaseStyle,
-                  flex: 1,
                   minWidth: 150,
                 }}
                 choices={Object.entries(TIME_WINDOW_MAP)}


### PR DESCRIPTION
Added an ability to specify fixed width on the `<MetricField>` in the metric alert builder. This eliminates unnecessary whitespace in the metric selector and makes the sentence `{function} over {timewindow}` easier to read.

**Before:**
![image](https://user-images.githubusercontent.com/9372512/99562833-92d1fa80-2996-11eb-915d-82d5b3d7d599.png)


**After:**
![image](https://user-images.githubusercontent.com/9372512/99563115-f2c8a100-2996-11eb-8f8a-6e336ba7ca03.png)
