### PR TITLE
feat(flag): Add feature flags for performance landing changes

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -891,6 +891,10 @@ SENTRY_FEATURES = {
     # Prefix host with organization ID when giving users DSNs (can be
     # customized with SENTRY_ORG_SUBDOMAIN_TEMPLATE)
     "organizations:org-subdomains": False,
+    # Enable the new Performance Landing page
+    "organizations:performance-landing-v2": False,
+    # Enable the views for performance vitals
+    "organizations:performance-vitals-overview": False,
     # Enable the new Project Detail page
     "organizations:project-detail": False,
     # Enable the new Related Events feature

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -107,6 +107,8 @@ default_manager.add("organizations:inbox", OrganizationFeature)  # NOQA
 default_manager.add("organizations:unhandled-issue-flag", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members-rate-limits", OrganizationFeature)  # NOQA
 default_manager.add("organizations:dashboards-v2", OrganizationFeature)  # NOQA
+default_manager.add("organizations:performance-landing-v2", OrganizationFeature)  # NOQA
+default_manager.add("organizations:performance-vitals-overview", OrganizationFeature)  # NOQA
 
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.


### PR DESCRIPTION
### Summary

This adds two feature flags, one for the upcoming performance landing v2, and one for the interim changes to add vitals overview.