### PR TITLE
fix(workflow): Inbox html event annotation tag to set innerhtml

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
@@ -117,7 +117,7 @@ function EventOrGroupExtraDetails({data, showAssignee, params, organization}: Pr
       {annotations &&
         annotations.map((annotation, key) =>
           hasInbox ? (
-            <InboxEventAnnotation key={key} annotation={annotation} />
+            <InboxEventAnnotation key={key} htmlAnnotation={annotation} />
           ) : (
             <AnnotationNoMargin
               dangerouslySetInnerHTML={{

--- a/src/sentry/static/sentry/app/components/group/inboxBadges/eventAnnotation.tsx
+++ b/src/sentry/static/sentry/app/components/group/inboxBadges/eventAnnotation.tsx
@@ -9,13 +9,22 @@ import Tag from 'app/components/tag';
  */
 
 type Props = {
-  annotation: string;
+  annotation?: string;
+  htmlAnnotation?: string;
   to?: {
     pathname: string;
     query: Query;
   };
 };
 
-const EventAnnotation = ({annotation, to}: Props) => <Tag to={to}>{annotation}</Tag>;
+const EventAnnotation = ({annotation, htmlAnnotation, to}: Props) => (
+  <Tag to={to}>
+    {htmlAnnotation ? (
+      <span dangerouslySetInnerHTML={{__html: htmlAnnotation}} />
+    ) : (
+      annotation
+    )}
+  </Tag>
+);
 
 export default EventAnnotation;


### PR DESCRIPTION
This fixes an issue where event annotations sent as html elements with links were rendering as strings instead of elements. It was a regression and this fixes it.