### PR TITLE
feat(perf-view): Lock down transaction summary and vitals to a single…

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -153,7 +153,7 @@ class TransactionSummary extends React.Component<Props, State> {
   }
 
   render() {
-    const {organization, location} = this.props;
+    const {organization, projects, location} = this.props;
     const {eventView} = this.state;
     const transactionName = getTransactionName(location);
     if (!eventView || transactionName === undefined) {
@@ -169,9 +169,25 @@ class TransactionSummary extends React.Component<Props, State> {
     }
     const [totalsView, emptyValues] = this.getTotalsEventView(organization, eventView);
 
+    const shouldForceProject = eventView.project.length === 1;
+    const forceProject = shouldForceProject
+      ? projects.find(p => parseInt(p.id, 10) === eventView.project[0])
+      : undefined;
+    const projectSlugs = eventView.project
+      .map(projectId => projects.find(p => parseInt(p.id, 10) === projectId))
+      .filter((p: Project | undefined): p is Project => p !== undefined)
+      .map(p => p.slug);
+
     return (
       <SentryDocumentTitle title={this.getDocumentTitle()} objSlug={organization.slug}>
-        <GlobalSelectionHeader>
+        <GlobalSelectionHeader
+          lockedMessageSubject={t('transaction')}
+          shouldForceProject={shouldForceProject}
+          forceProject={forceProject}
+          specificProjectSlugs={projectSlugs}
+          disableMultipleProjectSelection
+          showProjectSettingsLink
+        >
           <StyledPageContent>
             <LightWeightNoProjectMessage organization={organization}>
               <DiscoverQuery

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/index.tsx
@@ -83,6 +83,15 @@ class TransactionVitals extends React.Component<Props> {
       return null;
     }
 
+    const shouldForceProject = eventView.project.length === 1;
+    const forceProject = shouldForceProject
+      ? projects.find(p => parseInt(p.id, 10) === eventView.project[0])
+      : undefined;
+    const projectSlugs = eventView.project
+      .map(projectId => projects.find(p => parseInt(p.id, 10) === projectId))
+      .filter((p: Project | undefined): p is Project => p !== undefined)
+      .map(p => p.slug);
+
     return (
       <SentryDocumentTitle title={this.getDocumentTitle()} objSlug={organization.slug}>
         <Feature
@@ -90,7 +99,14 @@ class TransactionVitals extends React.Component<Props> {
           organization={organization}
           renderDisabled={this.renderNoAccess}
         >
-          <GlobalSelectionHeader>
+          <GlobalSelectionHeader
+            lockedMessageSubject={t('transaction')}
+            shouldForceProject={shouldForceProject}
+            forceProject={forceProject}
+            specificProjectSlugs={projectSlugs}
+            disableMultipleProjectSelection
+            showProjectSettingsLink
+          >
             <StyledPageContent>
               <LightWeightNoProjectMessage organization={organization}>
                 <RumContent


### PR DESCRIPTION
… project

When on the transaction summary and transaction vitals page, the global
selection header currently allows the user to change projects. This always
almost leads to a broken page as the same transaction name almost never
translate across projects, leading to broken states. This change locks down
the global selection header so users cannot change the project.

# Screenshot

[
![Screen Shot 2020-11-18 at 6 08 13 PM](https://user-images.githubusercontent.com/10239353/99599308-160c4400-29c9-11eb-85a2-8797c1f7c004.png)
](url)

Fixes VIS-320