### PR TITLE
fix(ownership) Fix rules being dropped

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ownerInput.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ownerInput.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import TextareaAutosize from 'react-autosize-textarea';
 
 import {Client} from 'app/api';
-import memberListStore from 'app/stores/memberListStore';
+import MemberListStore from 'app/stores/memberListStore';
 import ProjectsStore from 'app/stores/projectsStore';
 import Button from 'app/components/button';
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
@@ -105,7 +105,7 @@ class OwnerInput extends React.Component<Props, State> {
   };
 
   mentionableUsers() {
-    return memberListStore.getAll().map(member => ({
+    return MemberListStore.getAll().map(member => ({
       id: member.id,
       display: member.email,
       email: member.email,
@@ -133,9 +133,10 @@ class OwnerInput extends React.Component<Props, State> {
   };
 
   handleAddRule = (rule: string) => {
+    const {initialText} = this.props;
     this.setState(
       ({text}) => ({
-        text: text + '\n' + rule,
+        text: (text || initialText) + '\n' + rule,
       }),
       this.handleUpdateOwnership
     );

--- a/tests/js/spec/views/ownershipInput.spec.jsx
+++ b/tests/js/spec/views/ownershipInput.spec.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {openMenu, findOption} from 'sentry-test/select';
 
 import OwnerInput from 'app/views/settings/project/projectOwnership/ownerInput';
+import MemberListStore from 'app/stores/memberListStore';
 
 jest.mock('jquery');
 describe('Project Ownership Input', function () {
@@ -17,13 +19,20 @@ describe('Project Ownership Input', function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/members/',
       method: 'GET',
-      body: [TestStubs.Members()],
+      body: TestStubs.Members(),
     });
     put = MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/ownership/`,
       method: 'PUT',
       body: {raw: 'url:src @dummy@example.com'},
     });
+    MemberListStore.loadInitialData([
+      TestStubs.User({id: '1', email: 'bob@example.com'}),
+    ]);
+  });
+
+  afterEach(function () {
+    MemberListStore.init();
   });
 
   it('renders', function () {
@@ -52,5 +61,46 @@ describe('Project Ownership Input', function () {
     expect(put).toHaveBeenCalled();
 
     expect(wrapper.find(OwnerInput)).toSnapshot();
+  });
+
+  it('updates on add preserving existing text', async function () {
+    const wrapper = mountWithTheme(
+      <OwnerInput
+        params={{orgId: org.slug, projectId: project.slug}}
+        organization={org}
+        initialText="url:src @dummy@example.com"
+        project={project}
+      />,
+      TestStubs.routerContext()
+    );
+
+    // Set a path, as path is selected bu default.
+    const pathInput = wrapper.find('RuleBuilder BuilderInput');
+    pathInput.simulate('change', {target: {value: 'file.js'}});
+
+    // Select the user.
+    let userSelect = wrapper.find('RuleBuilder SelectOwners');
+    openMenu(userSelect, {control: true});
+    await wrapper.update();
+
+    // Because this menu is async we can't use selectByValue()
+    userSelect = wrapper.find('RuleBuilder SelectOwners');
+    findOption(userSelect, {value: 'user:1'}, {control: true})
+      .at(0)
+      .simulate('mouseDown');
+    await wrapper.update();
+
+    // Add the new rule.
+    const button = wrapper.find('RuleBuilder AddButton button');
+    button.simulate('click');
+
+    expect(put).toHaveBeenCalledWith(
+      '/projects/org-slug/project-slug/ownership/',
+      expect.objectContaining({
+        data: {
+          raw: 'url:src @dummy@example.com' + '\n' + 'path:file.js bob@example.com',
+        },
+      })
+    );
   });
 });

--- a/tests/js/spec/views/ownershipInput.spec.jsx
+++ b/tests/js/spec/views/ownershipInput.spec.jsx
@@ -81,6 +81,7 @@ describe('Project Ownership Input', function () {
     // Select the user.
     let userSelect = wrapper.find('RuleBuilder SelectOwners');
     openMenu(userSelect, {control: true});
+    await tick();
     await wrapper.update();
 
     // Because this menu is async we can't use selectByValue()


### PR DESCRIPTION
When I removed the duplicate state I neglected to coalesce the initialText prop with state. This caused rules to be dropped if the add button was clicked before any changes were made in the text box.