### PR TITLE
build(ci): Rename acceptance py 3.6 workflow

### DIFF
--- a/.github/workflows/acceptance-py3.6.yml
+++ b/.github/workflows/acceptance-py3.6.yml
@@ -1,4 +1,4 @@
-name: acceptance
+name: acceptance [py3.6]
 on:
   push:
     branches:
@@ -7,7 +7,6 @@ on:
   pull_request:
 
 jobs:
-  # TODO(billy): Currently, keeping name the same because of `required` status checks
   py3-acceptance:
     name: python3.6 acceptance
     runs-on: ubuntu-16.04


### PR DESCRIPTION
Rename this workflow to differentiate from the 2.7 acceptance workflow. The job name is going to remain the same to be consistent w/ 2.7 jobs