### PR TITLE
perf: Collapse latestDeploys in project component

### DIFF
--- a/src/sentry/static/sentry/app/utils/projects.tsx
+++ b/src/sentry/static/sentry/app/utils/projects.tsx
@@ -411,7 +411,11 @@ async function fetchProjects(
     cursor?: typeof cursor;
     per_page?: number;
     all_projects?: number;
-  } = {};
+    collapse: string[];
+  } = {
+    // Never return latestDeploys project property from api
+    collapse: ['latestDeploys'],
+  };
 
   if (slugs && slugs.length) {
     query.query = slugs.map(slug => `slug:${slug}`).join(' ');

--- a/tests/js/spec/utils/projects.spec.jsx
+++ b/tests/js/spec/utils/projects.spec.jsx
@@ -116,6 +116,7 @@ describe('utils.projects', function () {
         expect.objectContaining({
           query: {
             query: 'slug:a slug:b',
+            collapse: ['latestDeploys'],
           },
         })
       );
@@ -181,6 +182,7 @@ describe('utils.projects', function () {
         expect.objectContaining({
           query: {
             query: 'slug:a slug:b',
+            collapse: ['latestDeploys'],
           },
         })
       );
@@ -253,7 +255,9 @@ describe('utils.projects', function () {
       expect(request).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          query: {},
+          query: {
+            collapse: ['latestDeploys'],
+          },
         })
       );
 
@@ -317,6 +321,7 @@ describe('utils.projects', function () {
         expect.objectContaining({
           query: {
             query: 'test',
+            collapse: ['latestDeploys'],
           },
         })
       );
@@ -374,6 +379,7 @@ describe('utils.projects', function () {
         expect.objectContaining({
           query: {
             query: 'test',
+            collapse: ['latestDeploys'],
           },
         })
       );
@@ -463,6 +469,7 @@ describe('utils.projects', function () {
         url: '/organizations/org-slug/projects/',
         query: {
           all_projects: '1',
+          collapse: ['latestDeploys'],
         },
         body: mockProjects,
       });
@@ -488,7 +495,7 @@ describe('utils.projects', function () {
       expect(request).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          query: {all_projects: 1},
+          query: {all_projects: 1, collapse: ['latestDeploys']},
         })
       );
 

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -108,7 +108,7 @@ describe('IncidentsList', function () {
     expect(projectMock).toHaveBeenLastCalledWith(
       expect.anything(),
       expect.objectContaining({
-        query: {query: 'slug:a slug:b slug:c'},
+        query: expect.objectContaining({query: 'slug:a slug:b slug:c'}),
       })
     );
     expect(items.at(0).find('IdBadge').prop('project')).toMatchObject({

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -68,7 +68,7 @@ describe('OrganizationRuleList', () => {
     expect(projectMock).toHaveBeenLastCalledWith(
       expect.anything(),
       expect.objectContaining({
-        query: {query: 'slug:earth'},
+        query: expect.objectContaining({query: 'slug:earth'}),
       })
     );
     expect(items.at(0).find('IdBadge').prop('project')).toMatchObject({


### PR DESCRIPTION
We added this query to the initial all_projects query in #22116

This adds it to all queries made using the `<Projects>` component. The only place latestDeploys is required is https://github.com/getsentry/sentry/blob/144b6ef8e573811578b2d252d427f3c6bdc6e584/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx#L43

This change will shorten the projects query for large orgs with many deploys.