### PR TITLE
fix(releases): Remove sort by transaction from list and update copy

### DIFF
--- a/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
+++ b/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
@@ -64,10 +64,6 @@ type Props = {
   trendView: TrendView;
   organization: Organization;
   /**
-   * The prefix to use on the dropdown button.
-   */
-  dropdownTitle: string;
-  /**
    * The currently selected option on the dropdown.
    */
   selected: DropdownOption;
@@ -120,14 +116,7 @@ class TransactionsList extends React.Component<Props> {
   };
 
   renderHeader(): React.ReactNode {
-    const {
-      eventView,
-      organization,
-      dropdownTitle,
-      selected,
-      options,
-      handleDropdownChange,
-    } = this.props;
+    const {eventView, organization, selected, options, handleDropdownChange} = this.props;
 
     return (
       <Header>
@@ -137,7 +126,7 @@ class TransactionsList extends React.Component<Props> {
             <StyledDropdownButton
               {...getActorProps()}
               isOpen={isOpen}
-              prefix={dropdownTitle}
+              prefix={t('Filter')}
               size="small"
             >
               {selected.label}

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -224,7 +224,6 @@ class ReleaseOverview extends AsyncView<Props> {
                         organization={organization}
                         eventView={releaseEventView}
                         trendView={releaseTrendView}
-                        dropdownTitle={t('Show')}
                         selected={selectedSort}
                         options={sortOptions}
                         handleDropdownChange={this.handleTransactionsListSortChange}
@@ -323,11 +322,6 @@ function generateTransactionLinkFn(
 
 function getDropdownOptions(): DropdownOption[] {
   return [
-    {
-      sort: {kind: 'asc', field: 'transaction'},
-      value: 'name',
-      label: t('Transactions'),
-    },
     {
       sort: {kind: 'desc', field: 'failure_rate'},
       value: 'failure_rate',


### PR DESCRIPTION
Removed the option to sort by transaction name from the transactions list
dropdown and update the copy for the dropdown.