### PR TITLE
feat(ui): Disable auto syncing of dark mode

### DIFF
--- a/src/sentry/static/sentry/app/stores/configStore.tsx
+++ b/src/sentry/static/sentry/app/stores/configStore.tsx
@@ -12,6 +12,7 @@ type ConfigStoreInterface = {
   get<K extends keyof Config>(key: K): Config[K];
   set<K extends keyof Config>(key: K, value: Config[K]): void;
   getConfig(): Config;
+  updateTheme(theme: 'light' | 'dark'): void;
   loadInitialData(config: Config): void;
 };
 
@@ -29,11 +30,6 @@ const configStoreConfig: Reflux.StoreDefinition & ConfigStoreInterface = {
   },
 
   set(key, value) {
-    // TODO(dark): Dark mode is currently staff only
-    if (key === 'theme' && !this.config.user?.isStaff) {
-      return;
-    }
-
     this.config = {
       ...this.config,
       [key]: value,
@@ -41,15 +37,39 @@ const configStoreConfig: Reflux.StoreDefinition & ConfigStoreInterface = {
     this.trigger({[key]: value});
   },
 
+  /**
+   * This is only called by media query listener so that we can control
+   * the auto switching of color schemes without affecting manual toggle
+   */
+  updateTheme(theme) {
+    // TODO(dark): Dark mode is currently staff only
+    if (!this.config.user?.isStaff) {
+      return;
+    }
+
+    // TODO(dark): Add this as a user preference
+    // @ts-ignore
+    if (!this.config.user?.options.enableDarkMode) {
+      return;
+    }
+
+    this.set('theme', theme);
+  },
+
   getConfig() {
     return this.config;
   },
 
   loadInitialData(config): void {
+    // TODO(dark): Remove staff requirement and add dark mode user preference
+    const shouldUseDarkMode =
+      // @ts-ignore
+      config.user?.isStaff && config.user?.options.enableDarkMode && prefersDark();
+
     this.config = {
       ...config,
       features: new Set(config.features || []),
-      theme: config.user?.isStaff && prefersDark() ? 'dark' : 'light', // TODO(dark): Remove staff requirement
+      theme: shouldUseDarkMode ? 'dark' : 'light',
     };
 
     // Language code is passed from django

--- a/src/sentry/static/sentry/app/utils/matchMedia.tsx
+++ b/src/sentry/static/sentry/app/utils/matchMedia.tsx
@@ -20,7 +20,7 @@ function handleColorSchemeChange(e: MediaQueryListEvent): void {
   const isDark = e.media === '(prefers-color-scheme: dark)' && e.matches;
   const type = isDark ? 'dark' : 'light';
   changeFavicon(type);
-  ConfigStore.set('theme', type);
+  ConfigStore.updateTheme(type);
 }
 
 export function prefersDark(): boolean {
@@ -31,7 +31,7 @@ export function setupColorScheme(): void {
   // Set favicon to dark on load if necessary)
   if (prefersDark()) {
     changeFavicon('dark');
-    ConfigStore.set('theme', 'dark');
+    ConfigStore.updateTheme('dark');
   }
 
   // Watch for changes in preferred color scheme


### PR DESCRIPTION
There has been a few complaints, so we are going to disable the auto syncing of dark mode while allowing manual toggle. I have intentionally left some code that will always evaluate to false, but will be added as a user option in the future.