### PR TITLE
fix(releases): Explicitly filter transactions list by event type

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -107,7 +107,7 @@ class ReleaseOverview extends AsyncView<Props> {
       id: undefined,
       version: 2,
       name: `Release ${formatVersion(version)}`,
-      query: `release:${version}`,
+      query: `event.type:transactions release:${version}`,
       fields: ['transaction', 'failure_rate()', 'epm()', 'p50()'],
       orderby: 'epm',
       range: period,


### PR DESCRIPTION
Without explicitly filtering on transactions, the open in discover button can
bring the user to some confusing queries. For example, other event types can
appear in the chart/meta because they're not being filtered out but is not
appearing in the table because the `p50()` column is causing them to not appear.