### PR TITLE
ref(ui): Rename `<StyledSettingsPageHeading>`

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsPageHeader.tsx
@@ -23,7 +23,7 @@ type Props = {
   tabs?: React.ReactNode;
 };
 
-class SettingsPageHeading extends React.Component<Props> {
+class UnstyledSettingsPageHeader extends React.Component<Props> {
   static propTypes = {
     icon: PropTypes.node,
     title: PropTypes.node.isRequired,
@@ -88,11 +88,11 @@ const Action = styled('div')<{tabs?: React.ReactNode}>`
   ${p => (p.tabs ? `margin-top: ${space(2)}` : null)};
 `;
 
-const StyledSettingsPageHeading = styled(SettingsPageHeading)<
+const SettingsPageHeader = styled(UnstyledSettingsPageHeader)<
   Omit<React.HTMLProps<HTMLDivElement>, keyof Props> & Props
 >`
   font-size: 14px;
   margin-top: -${space(4)};
 `;
 
-export default StyledSettingsPageHeading;
+export default SettingsPageHeader;

--- a/tests/js/spec/views/settings/organizationTeams.spec.jsx
+++ b/tests/js/spec/views/settings/organizationTeams.spec.jsx
@@ -48,7 +48,7 @@ describe('OrganizationTeams', function () {
       const wrapper = createWrapper();
 
       // Click "Create Team" in Panel Header
-      wrapper.find('SettingsPageHeading Button').simulate('click');
+      wrapper.find('SettingsPageHeader Button').simulate('click');
 
       // action creator to open "create team modal" is called
       expect(openCreateTeamModal).toHaveBeenCalledWith(


### PR DESCRIPTION
Change from `Heading` -> `Header` to match file name. Also change default export to match file name. This will help LSP with auto importing. Otherwise, previously, the TS server would auto import via the default export name `StyledSettingsPageHeading`.