### PR TITLE
fix(net): Gracefully handle invalid DNS names

### DIFF
--- a/src/sentry/net/socket.py
+++ b/src/sentry/net/socket.py
@@ -93,7 +93,7 @@ def is_safe_hostname(hostname):
             # Only one bad apple will spoil the entire lookup, so be nice.
             if not is_ipaddress_allowed(address[0]):
                 return False
-    except socket.gaierror:
+    except (socket.gaierror, UnicodeError):
         # If we fail to resolve, automatically bad
         return False
 


### PR DESCRIPTION
If a hostname can't be IDNA encoded, it raises a UnicodeError, so we want to handle this the same way as a failed DNS lookup.