### PR TITLE
ref(dashboards): Delete dashboards synchronously

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -11,7 +11,7 @@ from sentry.api.serializers.rest_framework import (
     ListField,
     ValidationError,
 )
-from sentry.models import ObjectStatus, DashboardWidget
+from sentry.models import DashboardWidget
 
 
 def remove_widgets(dashboard_widgets, widget_data):
@@ -92,9 +92,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardEndpoint):
         :pparam int dashboard_id: the id of the dashboard.
         :auth: required
         """
-
-        dashboard.status = ObjectStatus.PENDING_DELETION
-        dashboard.save()
+        dashboard.delete()
 
         return self.respond(status=204)
 

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -5,7 +5,6 @@ import six
 from django.core.urlresolvers import reverse
 from sentry.models import (
     Dashboard,
-    ObjectStatus,
     DashboardWidget,
     DashboardWidgetQuery,
     DashboardWidgetDisplayTypes,
@@ -110,7 +109,14 @@ class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCas
     def test_delete(self):
         response = self.client.delete(self.url(self.dashboard.id))
         assert response.status_code == 204
-        assert Dashboard.objects.get(id=self.dashboard.id).status == ObjectStatus.PENDING_DELETION
+
+        assert self.client.get(self.url(self.dashboard.id)).status_code == 404
+
+        assert not Dashboard.objects.filter(id=self.dashboard.id).exists()
+        assert not DashboardWidget.objects.filter(id=self.widget_1.id).exists()
+        assert not DashboardWidget.objects.filter(id=self.widget_2.id).exists()
+        assert not DashboardWidgetQuery.objects.filter(widget_id=self.widget_1.id).exists()
+        assert not DashboardWidgetQuery.objects.filter(widget_id=self.widget_2.id).exists()
 
     def test_dashboard_does_not_exist(self):
         response = self.client.delete(self.url(1234567890))


### PR DESCRIPTION
Closes VIS-389.

Deleting dashboards will only mark those dashboards to be deleted. It doesn't look like there's a deletion clean up job to actually remove them. 