### PR TITLE
ref(ui): Replace deprecatedTag component with Tag component

### DIFF
--- a/src/sentry/static/sentry/app/components/debugFileFeature.tsx
+++ b/src/sentry/static/sentry/app/components/debugFileFeature.tsx
@@ -2,10 +2,17 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
+<<<<<<< HEAD
 import Tag from 'app/components/tagDeprecated';
 import Tooltip from 'app/components/tooltip';
 import {IconCheckmark, IconClose} from 'app/icons';
 import {t} from 'app/locale';
+=======
+import {IconCheckmark, IconClose} from 'app/icons';
+import {t} from 'app/locale';
+import Tag from 'app/components/tag';
+import space from 'app/styles/space';
+>>>>>>> replaced debugFileFeature tagDeprecated with new tag
 
 const FEATURE_TOOLTIPS = {
   symtab: t(
@@ -27,48 +34,24 @@ type Props = {
   available?: boolean;
 };
 
-const DebugFileFeature = ({available, feature}: Props) => {
-  let icon: React.ReactNode = null;
-
+const DebugFileFeature = ({available = true, feature}: Props) => {
+  const tooltipText = FEATURE_TOOLTIPS[feature];
   if (available === true) {
-    icon = (
-      <IconWrapper>
-        <IconCheckmark size="sm" color="green300" />
-      </IconWrapper>
-    );
-  } else if (available === false) {
-    icon = (
-      <IconWrapper>
-        <IconClose size="sm" color="red300" />
-      </IconWrapper>
+    return (
+      <StyledTag type="success" tooltipText={tooltipText} icon={<IconCheckmark />}>
+        {feature}
+      </StyledTag>
     );
   }
 
   return (
-    <Tooltip title={FEATURE_TOOLTIPS[feature]}>
-      <Tag inline>
-        {icon}
-        {feature}
-      </Tag>
-    </Tooltip>
+    <StyledTag type="error" tooltipText={tooltipText} icon={<IconClose />}>
+      {feature}
+    </StyledTag>
   );
 };
-
-DebugFileFeature.defaultProps = {
-  available: true,
-};
-
-DebugFileFeature.propTypes = {
-  available: PropTypes.bool,
-  feature: PropTypes.oneOf(Object.keys(FEATURE_TOOLTIPS)).isRequired,
-};
-
-DebugFileFeature.defaultProps = {
-  available: true,
-};
-
-const IconWrapper = styled('span')`
-  margin-right: 1ex;
-`;
-
 export default DebugFileFeature;
+
+const StyledTag = styled(Tag)`
+  margin-left: ${space(1)};
+`;

--- a/src/sentry/static/sentry/app/components/debugFileFeature.tsx
+++ b/src/sentry/static/sentry/app/components/debugFileFeature.tsx
@@ -1,18 +1,10 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
-<<<<<<< HEAD
-import Tag from 'app/components/tagDeprecated';
-import Tooltip from 'app/components/tooltip';
-import {IconCheckmark, IconClose} from 'app/icons';
-import {t} from 'app/locale';
-=======
-import {IconCheckmark, IconClose} from 'app/icons';
-import {t} from 'app/locale';
 import Tag from 'app/components/tag';
+import {IconCheckmark, IconClose} from 'app/icons';
+import {t} from 'app/locale';
 import space from 'app/styles/space';
->>>>>>> replaced debugFileFeature tagDeprecated with new tag
 
 const FEATURE_TOOLTIPS = {
   symtab: t(

--- a/src/sentry/static/sentry/app/components/deployBadge.tsx
+++ b/src/sentry/static/sentry/app/components/deployBadge.tsx
@@ -1,14 +1,23 @@
 import React from 'react';
-import styled from '@emotion/styled';
 
+<<<<<<< HEAD
+=======
+import {t} from 'app/locale';
+import {Deploy} from 'app/types';
+import Tag from 'app/components/tag';
+>>>>>>> replaced deployBadge tagDeprecated with new tag
 import Link from 'app/components/links/link';
 import Tag from 'app/components/tagDeprecated';
 import {IconOpen} from 'app/icons';
+<<<<<<< HEAD
 import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Deploy} from 'app/types';
 import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+=======
+import {stringifyQueryObject, QueryResults} from 'app/utils/tokenizeSearch';
+>>>>>>> replaced deployBadge tagDeprecated with new tag
 
 type Props = {
   deploy: Deploy;
@@ -22,10 +31,9 @@ const DeployBadge = ({deploy, orgSlug, projectId, version, className}: Props) =>
   const shouldLinkToIssues = !!orgSlug && !!version;
 
   const badge = (
-    <Badge className={className}>
-      <Label>{deploy.environment}</Label>
-      {shouldLinkToIssues && <Icon size="xs" />}
-    </Badge>
+    <Tag className={className} type="highlight" icon={shouldLinkToIssues && <IconOpen />}>
+      {deploy.environment}
+    </Tag>
   );
 
   if (!shouldLinkToIssues) {
@@ -48,24 +56,5 @@ const DeployBadge = ({deploy, orgSlug, projectId, version, className}: Props) =>
     </Link>
   );
 };
-
-const Badge = styled(Tag)`
-  background-color: ${p => p.theme.textColor};
-  color: ${p => p.theme.background};
-  font-size: ${p => p.theme.fontSizeSmall};
-  align-items: center;
-  height: 20px;
-`;
-
-const Label = styled('span')`
-  max-width: 100px;
-  line-height: 20px;
-  ${overflowEllipsis}
-`;
-
-const Icon = styled(IconOpen)`
-  margin-left: ${space(0.5)};
-  flex-shrink: 0;
-`;
 
 export default DeployBadge;

--- a/src/sentry/static/sentry/app/components/deployBadge.tsx
+++ b/src/sentry/static/sentry/app/components/deployBadge.tsx
@@ -1,23 +1,11 @@
 import React from 'react';
 
-<<<<<<< HEAD
-=======
-import {t} from 'app/locale';
-import {Deploy} from 'app/types';
-import Tag from 'app/components/tag';
->>>>>>> replaced deployBadge tagDeprecated with new tag
 import Link from 'app/components/links/link';
-import Tag from 'app/components/tagDeprecated';
+import Tag from 'app/components/tag';
 import {IconOpen} from 'app/icons';
-<<<<<<< HEAD
 import {t} from 'app/locale';
-import overflowEllipsis from 'app/styles/overflowEllipsis';
-import space from 'app/styles/space';
 import {Deploy} from 'app/types';
 import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
-=======
-import {stringifyQueryObject, QueryResults} from 'app/utils/tokenizeSearch';
->>>>>>> replaced deployBadge tagDeprecated with new tag
 
 type Props = {
   deploy: Deploy;

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/level.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/level.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import styled from '@emotion/styled';
 
 import Highlight from 'app/components/highlight';
-import Tag from 'app/components/tagDeprecated';
+import Tag from 'app/components/tag';
 import {t} from 'app/locale';
-import {Color} from 'app/utils/theme';
 
 import {BreadcrumbLevelType} from './types';
 
@@ -17,27 +15,27 @@ const Level = React.memo(({level, searchTerm = ''}: Props) => {
   switch (level) {
     case BreadcrumbLevelType.FATAL:
       return (
-        <StyledTag color="red300">
+        <Tag type="error">
           <Highlight text={searchTerm}>{t('fatal')}</Highlight>
-        </StyledTag>
+        </Tag>
       );
     case BreadcrumbLevelType.ERROR:
       return (
-        <StyledTag color="red300">
+        <Tag type="error">
           <Highlight text={searchTerm}>{t('error')}</Highlight>
-        </StyledTag>
+        </Tag>
       );
     case BreadcrumbLevelType.INFO:
       return (
-        <StyledTag color="blue300">
+        <Tag type="info">
           <Highlight text={searchTerm}>{t('info')}</Highlight>
-        </StyledTag>
+        </Tag>
       );
     case BreadcrumbLevelType.WARNING:
       return (
-        <StyledTag color="orange400">
+        <Tag type="warning">
           <Highlight text={searchTerm}>{t('warning')}</Highlight>
-        </StyledTag>
+        </Tag>
       );
     default:
       return (
@@ -49,9 +47,3 @@ const Level = React.memo(({level, searchTerm = ''}: Props) => {
 });
 
 export default Level;
-
-// TODO(style): Update the tag component with the new colors
-const StyledTag = styled(Tag)<{color: Color}>`
-  background-color: ${p => p.theme[p.color]};
-  color: ${p => p.theme.white};
-`;

--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
@@ -281,9 +281,7 @@ const Indicator = styled(p => <CircleIndicator size={7} {...p} />)`
 `;
 
 const Features = styled('div')`
-  margin-left: -${space(0.5)};
-  margin-right: -${space(0.5)};
-  margin-bottom: -${space(0.5)};
+  margin: -${space(0.5)};
 `;
 
 const StyledTag = styled(Tag)`

--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
@@ -5,20 +5,12 @@ import Access from 'app/components/acl/access';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import CircleIndicator from 'app/components/circleIndicator';
-import Tag from 'app/components/tagDeprecated';
+import Tag from 'app/components/tag';
 import {IconFlag} from 'app/icons';
 import {t, tct} from 'app/locale';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import space from 'app/styles/space';
-<<<<<<< HEAD
 import {IntegrationFeature, Organization, SentryApp} from 'app/types';
-=======
-import {t, tct} from 'app/locale';
-import AsyncComponent from 'app/components/asyncComponent';
-import marked, {singleLineRenderer} from 'app/utils/marked';
-import {IconFlag} from 'app/icons';
-import Tag from 'app/components/tag';
->>>>>>> replaced sentryAppDetailsModal tagDeprecated with new tag
 import {toPermissions} from 'app/utils/consolidatedScopes';
 import {
   getIntegrationFeatureGate,

--- a/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppDetailsModal.tsx
@@ -10,7 +10,15 @@ import {IconFlag} from 'app/icons';
 import {t, tct} from 'app/locale';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import space from 'app/styles/space';
+<<<<<<< HEAD
 import {IntegrationFeature, Organization, SentryApp} from 'app/types';
+=======
+import {t, tct} from 'app/locale';
+import AsyncComponent from 'app/components/asyncComponent';
+import marked, {singleLineRenderer} from 'app/utils/marked';
+import {IconFlag} from 'app/icons';
+import Tag from 'app/components/tag';
+>>>>>>> replaced sentryAppDetailsModal tagDeprecated with new tag
 import {toPermissions} from 'app/utils/consolidatedScopes';
 import {
   getIntegrationFeatureGate,
@@ -162,7 +170,7 @@ export default class SentryAppDetailsModal extends AsyncComponent<Props, State> 
 
           <HeadingInfo>
             <Name>{sentryApp.name}</Name>
-            <div>{features.length && this.featureTags(features)}</div>
+            {!!features.length && <Features>{this.featureTags(features)}</Features>}
           </HeadingInfo>
         </Heading>
 
@@ -218,7 +226,6 @@ const Heading = styled('div')`
 const HeadingInfo = styled('div')`
   display: grid;
   grid-template-rows: max-content max-content;
-  grid-gap: ${space(0.5)};
   align-items: start;
 `;
 
@@ -255,12 +262,6 @@ const DisabledNotice = styled(({reason, ...p}: {reason: React.ReactNode}) => (
   font-size: 0.9em;
 `;
 
-const StyledTag = styled(Tag)`
-  &:not(:first-child) {
-    margin-left: ${space(0.5)};
-  }
-`;
-
 const Text = styled('p')`
   margin: 0px 6px;
 `;
@@ -285,4 +286,14 @@ const Title = styled('p')`
 const Indicator = styled(p => <CircleIndicator size={7} {...p} />)`
   margin-top: 7px;
   color: ${p => p.theme.success};
+`;
+
+const Features = styled('div')`
+  margin-left: -${space(0.5)};
+  margin-right: -${space(0.5)};
+  margin-bottom: -${space(0.5)};
+`;
+
+const StyledTag = styled(Tag)`
+  padding: ${space(0.5)};
 `;

--- a/src/sentry/static/sentry/app/components/tag.tsx
+++ b/src/sentry/static/sentry/app/components/tag.tsx
@@ -53,7 +53,7 @@ function Tag({
   ...props
 }: Props) {
   const iconsProps = {
-    size: '12px',
+    size: '11px',
     color: theme.tag[type].iconColor as Color,
   };
 
@@ -120,16 +120,16 @@ const Background = styled('div')<{type: keyof Theme['tag']}>`
   height: ${TAG_HEIGHT};
   border-radius: ${TAG_HEIGHT};
   background-color: ${p => p.theme.tag[p.type].background};
-  padding: 0 ${space(0.75)};
+  padding: 0 ${space(1)};
 `;
 
 const IconWrapper = styled('span')`
-  margin-right: 3px;
+  margin-right: ${space(0.5)};
 `;
 
 const Text = styled('span')`
   color: ${p => p.theme.gray500};
-  font-size: 13px;
+  font-size: ${p => p.theme.fontSizeSmall};
   max-width: 150px;
   overflow: hidden;
   white-space: nowrap;
@@ -141,7 +141,7 @@ const Text = styled('span')`
 `;
 
 const DismissButton = styled(Button)`
-  margin-left: 3px;
+  margin-left: ${space(0.5)};
   border: none;
 `;
 

--- a/src/sentry/static/sentry/app/components/tag.tsx
+++ b/src/sentry/static/sentry/app/components/tag.tsx
@@ -125,6 +125,7 @@ const Background = styled('div')<{type: keyof Theme['tag']}>`
 
 const IconWrapper = styled('span')`
   margin-right: ${space(0.5)};
+  display: inline-flex;
 `;
 
 const Text = styled('span')`

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
@@ -2,11 +2,24 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'app/components/acl/feature';
-import Tag from 'app/components/tagDeprecated';
+import Tag from 'app/components/tag';
 import Tooltip from 'app/components/tooltip';
 import {IconSubtract} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
+
+// TODO(matej): remove "unhandled-issue-flag" feature flag once testing is over (otherwise this won't ever be rendered in a shared event)
+const UnhandledTag = () => (
+  <Feature features={['unhandled-issue-flag']}>
+    <TagWrapper>
+      <Tooltip title={t('An unhandled error was detected in this Issue.')}>
+        <Tag type="error" icon={<IconSubtract size="xs" color="red200" isCircled />}>
+          {t('Unhandled')}
+        </Tag>
+      </Tooltip>
+    </TagWrapper>
+  </Feature>
+);
 
 const TagWrapper = styled('div')`
   margin-right: ${space(1)};
@@ -15,40 +28,6 @@ const TagWrapper = styled('div')`
 const TagAndMessageWrapper = styled('div')`
   display: flex;
   align-items: center;
-`;
-
-// TODO(matej): remove "unhandled-issue-flag" feature flag once testing is over (otherwise this won't ever be rendered in a shared event)
-const UnhandledTag = styled((props: React.ComponentProps<typeof Tag>) => (
-  <Feature features={['unhandled-issue-flag']}>
-    <TagWrapper>
-      <Tooltip title={t('An unhandled error was detected in this Issue.')}>
-        <Tag
-          priority="error"
-          icon={<IconSubtract size="xs" color="red200" isCircled />}
-          {...props}
-        >
-          {t('Unhandled')}
-        </Tag>
-      </Tooltip>
-    </TagWrapper>
-  </Feature>
-))`
-  /* TODO(matej): There is going to be a major Tag component refactor which should make Tags look something like this - then we can remove these one-off styles */
-  background-color: #ffecf0;
-  color: ${p => p.theme.gray500};
-  text-transform: none;
-  padding: 0 ${space(0.75)};
-  height: 17px;
-
-  & > span {
-    margin-right: 0 ${space(0.5)};
-  }
-
-  & > span,
-  & svg {
-    height: 11px;
-    width: 10px;
-  }
 `;
 
 export default UnhandledTag;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
@@ -4,12 +4,8 @@ import styled from '@emotion/styled';
 import Feature from 'app/components/acl/feature';
 import Tag from 'app/components/tag';
 import Tooltip from 'app/components/tooltip';
-<<<<<<< HEAD
-import {IconSubtract} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-=======
->>>>>>> removed unhandled tag icon
 
 // TODO(matej): remove "unhandled-issue-flag" feature flag once testing is over (otherwise this won't ever be rendered in a shared event)
 function UnhandledTag() {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/unhandledTag.tsx
@@ -4,22 +4,25 @@ import styled from '@emotion/styled';
 import Feature from 'app/components/acl/feature';
 import Tag from 'app/components/tag';
 import Tooltip from 'app/components/tooltip';
+<<<<<<< HEAD
 import {IconSubtract} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
+=======
+>>>>>>> removed unhandled tag icon
 
 // TODO(matej): remove "unhandled-issue-flag" feature flag once testing is over (otherwise this won't ever be rendered in a shared event)
-const UnhandledTag = () => (
-  <Feature features={['unhandled-issue-flag']}>
-    <TagWrapper>
-      <Tooltip title={t('An unhandled error was detected in this Issue.')}>
-        <Tag type="error" icon={<IconSubtract size="xs" color="red200" isCircled />}>
-          {t('Unhandled')}
-        </Tag>
-      </Tooltip>
-    </TagWrapper>
-  </Feature>
-);
+function UnhandledTag() {
+  return (
+    <Feature features={['unhandled-issue-flag']}>
+      <TagWrapper>
+        <Tooltip title={t('An unhandled error was detected in this Issue.')}>
+          <Tag type="error">{t('Unhandled')}</Tag>
+        </Tooltip>
+      </TagWrapper>
+    </Feature>
+  );
+}
 
 const TagWrapper = styled('div')`
   margin-right: ${space(1)};

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -8,6 +8,7 @@ import Alert, {Props as AlertProps} from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import ExternalLink from 'app/components/links/externalLink';
 import {Panel} from 'app/components/panels';
+import Tag from 'app/components/tag';
 import Tooltip from 'app/components/tooltip';
 import {IconClose, IconDocs, IconGeneric, IconGithub, IconProject} from 'app/icons';
 import {t} from 'app/locale';
@@ -28,7 +29,6 @@ import {
 } from 'app/utils/integrationUtil';
 import marked, {singleLineRenderer} from 'app/utils/marked';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
-import Tag from 'app/components/tag';
 
 import RequestIntegrationButton from './integrationRequest/RequestIntegrationButton';
 import IntegrationStatus from './integrationStatus';

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/abstractIntegrationDetailedView.tsx
@@ -8,7 +8,6 @@ import Alert, {Props as AlertProps} from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import ExternalLink from 'app/components/links/externalLink';
 import {Panel} from 'app/components/panels';
-import Tag from 'app/components/tagDeprecated';
 import Tooltip from 'app/components/tooltip';
 import {IconClose, IconDocs, IconGeneric, IconGithub, IconProject} from 'app/icons';
 import {t} from 'app/locale';
@@ -29,6 +28,7 @@ import {
 } from 'app/utils/integrationUtil';
 import marked, {singleLineRenderer} from 'app/utils/marked';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import Tag from 'app/components/tag';
 
 import RequestIntegrationButton from './integrationRequest/RequestIntegrationButton';
 import IntegrationStatus from './integrationStatus';

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRow.tsx
@@ -183,6 +183,7 @@ const PublishStatus = styled(({status, ...props}: PublishStatusProps) => (
   }
 `;
 
+// TODO(Priscila): Replace this component with the Tag component
 const CategoryTag = styled(
   ({
     priority: _priority,

--- a/src/sentry/static/sentry/app/views/settings/account/accountEmails.jsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountEmails.jsx
@@ -7,7 +7,7 @@ import AlertLink from 'app/components/alertLink';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
-import Tag from 'app/components/tagDeprecated';
+import Tag from 'app/components/tag';
 import accountEmailsFields from 'app/data/forms/accountEmails';
 import {IconDelete, IconStack} from 'app/icons';
 import {t} from 'app/locale';
@@ -51,8 +51,8 @@ class EmailRow extends React.Component {
       <EmailItem>
         <EmailTags>
           {email}
-          {!isVerified && <Tag priority="warning">{t('Unverified')}</Tag>}
-          {isPrimary && <Tag priority="success">{t('Primary')}</Tag>}
+          {!isVerified && <Tag type="warning">{t('Unverified')}</Tag>}
+          {isPrimary && <Tag type="success">{t('Primary')}</Tag>}
         </EmailTags>
         <ButtonBar gap={1}>
           {!isPrimary && isVerified && (

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
@@ -7,18 +7,12 @@ import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
 import Button from 'app/components/button';
 import Hovercard from 'app/components/hovercard';
-<<<<<<< HEAD
 import {PanelItem} from 'app/components/panels';
-import Tag from 'app/components/tagDeprecated';
+import Tag from 'app/components/tag';
 import {IconLock} from 'app/icons';
 import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
-=======
-import SentryTypes from 'app/sentryTypes';
-import {IconLock} from 'app/icons';
-import Tag from 'app/components/tag';
->>>>>>> replaced providerItem tagDeprecated with new tag
 import {descopeFeatureName} from 'app/utils';
 
 export default class ProviderItem extends React.PureComponent {

--- a/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationAuth/providerItem.jsx
@@ -7,12 +7,18 @@ import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
 import Button from 'app/components/button';
 import Hovercard from 'app/components/hovercard';
+<<<<<<< HEAD
 import {PanelItem} from 'app/components/panels';
 import Tag from 'app/components/tagDeprecated';
 import {IconLock} from 'app/icons';
 import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
+=======
+import SentryTypes from 'app/sentryTypes';
+import {IconLock} from 'app/icons';
+import Tag from 'app/components/tag';
+>>>>>>> replaced providerItem tagDeprecated with new tag
 import {descopeFeatureName} from 'app/utils';
 
 export default class ProviderItem extends React.PureComponent {
@@ -153,7 +159,7 @@ const LockedFeature = ({provider, features, className}) => (
       />
     }
   >
-    <Tag icon={<IconLock size="xs" />}>disabled</Tag>
+    <Tag icon={<IconLock />}>{t('disabled')}</Tag>
   </DisabledHovercard>
 );
 

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -8,25 +8,16 @@ import Button from 'app/components/button';
 import Checkbox from 'app/components/checkbox';
 import DateTime from 'app/components/dateTime';
 import DropdownButton from 'app/components/dropdownButton';
-<<<<<<< HEAD
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
-=======
-import Tag from 'app/components/tag';
->>>>>>> replaced requestLog tagDeprecated with new tag
 import ExternalLink from 'app/components/links/externalLink';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
-import Tag from 'app/components/tagDeprecated';
+import Tag from 'app/components/tag';
 import {IconChevron, IconFlag, IconOpen} from 'app/icons';
 import {t} from 'app/locale';
-<<<<<<< HEAD
 import space from 'app/styles/space';
 import {SentryApp, SentryAppSchemaIssueLink, SentryAppWebhookRequest} from 'app/types';
-import {Theme} from 'app/utils/theme';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
-=======
-import {SentryApp, SentryAppWebhookRequest, SentryAppSchemaIssueLink} from 'app/types';
->>>>>>> replaced requestLog tagDeprecated with new tag
 
 const ALL_EVENTS = t('All Events');
 const MAX_PER_PAGE = 10;

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -8,17 +8,25 @@ import Button from 'app/components/button';
 import Checkbox from 'app/components/checkbox';
 import DateTime from 'app/components/dateTime';
 import DropdownButton from 'app/components/dropdownButton';
+<<<<<<< HEAD
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
+=======
+import Tag from 'app/components/tag';
+>>>>>>> replaced requestLog tagDeprecated with new tag
 import ExternalLink from 'app/components/links/externalLink';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import Tag from 'app/components/tagDeprecated';
 import {IconChevron, IconFlag, IconOpen} from 'app/icons';
 import {t} from 'app/locale';
+<<<<<<< HEAD
 import space from 'app/styles/space';
 import {SentryApp, SentryAppSchemaIssueLink, SentryAppWebhookRequest} from 'app/types';
 import {Theme} from 'app/utils/theme';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
+=======
+import {SentryApp, SentryAppWebhookRequest, SentryAppSchemaIssueLink} from 'app/types';
+>>>>>>> replaced requestLog tagDeprecated with new tag
 
 const ALL_EVENTS = t('All Events');
 const MAX_PER_PAGE = 10;
@@ -78,16 +86,16 @@ const getEventTypes = memoize((app: SentryApp) => {
 });
 
 const ResponseCode = ({code}: {code: number}) => {
-  let priority: keyof Theme['alert'] = 'error';
+  let type: React.ComponentProps<typeof Tag>['type'] = 'error';
   if (code <= 399 && code >= 300) {
-    priority = 'warning';
+    type = 'warning';
   } else if (code <= 299 && code >= 100) {
-    priority = 'success';
+    type = 'success';
   }
 
   return (
     <div>
-      <Tag priority={priority}>{code === 0 ? 'timeout' : code}</Tag>
+      <Tag type={type}>{code === 0 ? 'timeout' : code}</Tag>
     </div>
   );
 };

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -85,9 +85,9 @@ const ResponseCode = ({code}: {code: number}) => {
   }
 
   return (
-    <div>
-      <Tag type={type}>{code === 0 ? 'timeout' : code}</Tag>
-    </div>
+    <Tags>
+      <StyledTag type={type}>{code === 0 ? 'timeout' : code}</StyledTag>
+    </Tags>
   );
 };
 
@@ -356,4 +356,13 @@ const StyledErrorsOnlyButton = styled(Button)`
 const StyledIconOpen = styled(IconOpen)`
   margin-left: 6px;
   color: ${p => p.theme.subText};
+`;
+
+const Tags = styled('div')`
+  margin: -${space(0.5)};
+`;
+
+const StyledTag = styled(Tag)`
+  padding: ${space(0.5)};
+  display: inline-flex;
 `;

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -6,13 +6,9 @@ import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import SelectControl from 'app/components/forms/selectControl';
 import HookOrDefault from 'app/components/hookOrDefault';
-<<<<<<< HEAD
 import {PanelItem} from 'app/components/panels';
 import RoleSelectControl from 'app/components/roleSelectControl';
-import Tag from 'app/components/tagDeprecated';
-=======
 import Tag from 'app/components/tag';
->>>>>>> replaced inviteRequestRow tagDeprecated with new tag
 import Tooltip from 'app/components/tooltip';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -6,9 +6,13 @@ import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import SelectControl from 'app/components/forms/selectControl';
 import HookOrDefault from 'app/components/hookOrDefault';
+<<<<<<< HEAD
 import {PanelItem} from 'app/components/panels';
 import RoleSelectControl from 'app/components/roleSelectControl';
 import Tag from 'app/components/tagDeprecated';
+=======
+import Tag from 'app/components/tag';
+>>>>>>> replaced inviteRequestRow tagDeprecated with new tag
 import Tooltip from 'app/components/tooltip';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
@@ -50,7 +54,7 @@ const InviteRequestRow = ({
   const hookRenderer: InviteModalRenderFunc = ({sendInvites, canSend, headerInfo}) => (
     <StyledPanelItem>
       <div>
-        <h5 style={{marginBottom: '3px'}}>
+        <h5 style={{marginBottom: space(0.5)}}>
           <UserName>{inviteRequest.email}</UserName>
         </h5>
         {inviteRequest.inviteStatus === 'requested_to_be_invited' ? (
@@ -68,9 +72,11 @@ const InviteRequestRow = ({
             </Description>
           )
         ) : (
-          <Tooltip title={t('This user has asked to join your organization.')}>
-            <JoinRequestIndicator size="small">{t('Join request')}</JoinRequestIndicator>
-          </Tooltip>
+          <JoinRequestIndicator
+            tooltipText={t('This user has asked to join your organization.')}
+          >
+            {t('Join request')}
+          </JoinRequestIndicator>
         )}
       </div>
 
@@ -165,8 +171,6 @@ InviteRequestRow.propTypes = {
 };
 
 const JoinRequestIndicator = styled(Tag)`
-  padding: ${space(0.5)} ${space(0.75)};
-  font-size: 10px;
   text-transform: uppercase;
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -152,7 +152,7 @@ const DescriptionText = styled('span')`
 const FeatureTags = styled('div')`
   display: inline-flex;
   flex-wrap: wrap;
-  margin: -4px;
+  margin: -${space(0.5)};
 `;
 
 const StyledTag = styled(Tag)`

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -85,14 +85,14 @@ const DebugFileRow = ({
             </FeatureTags>
           )}
           {showDetails && (
-            <Details>
+            <div>
               {/* there will be more stuff here in the future */}
               {codeId && (
                 <DetailsItem>
                   {t('Code ID')}: {codeId}
                 </DetailsItem>
               )}
-            </Details>
+            </div>
           )}
         </Description>
       </Column>
@@ -211,8 +211,6 @@ const Description = styled('div')`
     line-height: 1.7;
   }
 `;
-
-const Details = styled('div')``;
 
 const DetailsItem = styled('div')`
   ${overflowEllipsis}

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -7,7 +7,7 @@ import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import Confirm from 'app/components/confirm';
 import FileSize from 'app/components/fileSize';
-import Tag from 'app/components/tagDeprecated';
+import Tag from 'app/components/tag';
 import TimeSince from 'app/components/timeSince';
 import Tooltip from 'app/components/tooltip';
 import {IconClock, IconDelete, IconDownload} from 'app/icons';
@@ -69,16 +69,21 @@ const DebugFileRow = ({
             : objectName}
         </Name>
         <Description>
-          {symbolType === 'proguard' && cpuName === 'any'
-            ? t('proguard mapping')
-            : `${cpuName} (${symbolType}${fileType ? ` ${fileType}` : ''})`}
+          <DescriptionText>
+            {symbolType === 'proguard' && cpuName === 'any'
+              ? t('proguard mapping')
+              : `${cpuName} (${symbolType}${fileType ? ` ${fileType}` : ''})`}
+          </DescriptionText>
 
-          {features &&
-            features.map(feature => (
-              <Tooltip key={feature} title={getFeatureTooltip(feature)}>
-                <Tag inline>{feature}</Tag>
-              </Tooltip>
-            ))}
+          {features && (
+            <FeatureTags>
+              {features.map(feature => (
+                <StyledTag key={feature} tooltipText={getFeatureTooltip(feature)}>
+                  {feature}
+                </StyledTag>
+              ))}
+            </FeatureTags>
+          )}
           {showDetails && (
             <Details>
               {/* there will be more stuff here in the future */}
@@ -138,6 +143,21 @@ const DebugFileRow = ({
     </React.Fragment>
   );
 };
+
+const DescriptionText = styled('span')`
+  display: inline-flex;
+  margin: 0 ${space(1)} ${space(1)} 0;
+`;
+
+const FeatureTags = styled('div')`
+  display: inline-flex;
+  flex-wrap: wrap;
+  margin: -4px;
+`;
+
+const StyledTag = styled(Tag)`
+  padding: ${space(0.5)};
+`;
 
 const Column = styled('div')`
   display: flex;

--- a/tests/js/spec/components/deployBadge.spec.jsx
+++ b/tests/js/spec/components/deployBadge.spec.jsx
@@ -17,8 +17,8 @@ describe('DeployBadge', function () {
   it('renders', function () {
     const wrapper = mountWithTheme(<DeployBadge deploy={deploy} />);
 
-    expect(wrapper.find('Badge').text()).toEqual('production');
-    expect(wrapper.find('Icon').length).toEqual(0);
+    expect(wrapper.find('Tag').text()).toEqual('production');
+    expect(wrapper.find('IconOpen').length).toEqual(0);
   });
 
   it('renders with icon and link', function () {
@@ -37,7 +37,7 @@ describe('DeployBadge', function () {
       pathname: '/organizations/sentry/issues/',
       query: {project: projectId, environment: 'production', query: 'release:1.2.3'},
     });
-    expect(wrapper.find('Badge').text()).toEqual('production');
-    expect(wrapper.find('Icon').length).toEqual(1);
+    expect(wrapper.find('Tag').text()).toEqual('production');
+    expect(wrapper.find('IconOpen').length).toEqual(1);
   });
 });


### PR DESCRIPTION
Below you can see the before and after of replacements in places that are not very common in the UI:

**RequestLog:**

_Before:_

![image](https://user-images.githubusercontent.com/29228205/99796332-951a8d00-2b2d-11eb-90fe-7376bfbc4eb3.png)


_After:_

![image](https://user-images.githubusercontent.com/29228205/99796207-5b498680-2b2d-11eb-9e60-ad35a7bda8f2.png)


**DebugFileRow**

_Before:_

![image](https://user-images.githubusercontent.com/29228205/99794412-6949d800-2b2a-11eb-9c1f-97c5ed325bfe.png)

_After:_

![image](https://user-images.githubusercontent.com/29228205/99794490-88e10080-2b2a-11eb-860f-7924daabbd8f.png)


**UnhandledTag**

_Before:_

![image](https://user-images.githubusercontent.com/29228205/99794177-11ab6c80-2b2a-11eb-9747-1d4a3834c512.png)

_After:_

![image](https://user-images.githubusercontent.com/29228205/99794268-3273c200-2b2a-11eb-88bc-917f76b1e09f.png)


**ProviderItem**

_Before:_

![image](https://user-images.githubusercontent.com/29228205/99793541-20ddea80-2b29-11eb-8a85-aa31466ea5d3.png)

_After:_

![image](https://user-images.githubusercontent.com/29228205/99793340-cfcdf680-2b28-11eb-9ac6-18bfdb757f74.png)

**Sentry App Details Modal**

_Before:_

![image](https://user-images.githubusercontent.com/29228205/99792866-05261480-2b28-11eb-8bd1-c4594d5063a3.png)


_After:_

![image](https://user-images.githubusercontent.com/29228205/99792465-68637700-2b27-11eb-9f5a-9ac0751a7da6.png)

**Invitation Row**

_Before:_

![image](https://user-images.githubusercontent.com/29228205/99791375-d27b1c80-2b25-11eb-9756-454e24a24f80.png)


_After:_

![image](https://user-images.githubusercontent.com/29228205/99791206-9778e900-2b25-11eb-8dc7-e8208587eaae.png)

