### PR TITLE
fix(ui): Use titlecase for 'Last edited' in transactions

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsHeader.tsx
@@ -79,7 +79,7 @@ class ResultsHeader extends React.Component<Props, State> {
     }
     return (
       <Subtitle>
-        {t('Created by:')} {createdBy} | {t('Last Edited:')} {lastEdit}
+        {t('Created by:')} {createdBy} | {t('Last edited:')} {lastEdit}
       </Subtitle>
     );
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1421724/99743539-bfffd500-2a8a-11eb-8785-663a1c948bab.png)


I fixed the 'Last Edited' to be lowercase