### PR TITLE
fix(releases): Add tpm filter to sort orders that are prone to noise

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -10,7 +10,7 @@ import {t} from 'app/locale';
 import AsyncView from 'app/views/asyncView';
 import withOrganization from 'app/utils/withOrganization';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
-import {Organization, GlobalSelection, ReleaseProject} from 'app/types';
+import {NewQuery, Organization, GlobalSelection, ReleaseProject} from 'app/types';
 import {Client} from 'app/api';
 import withApi from 'app/utils/withApi';
 import {getUtcDateString} from 'app/utils/dates';
@@ -111,35 +111,35 @@ class ReleaseOverview extends AsyncView<Props> {
     const {environments, datetime} = selection;
     const {start, end, period} = datetime;
 
+    const baseQuery: NewQuery = {
+      id: undefined,
+      version: 2,
+      name: `Release ${formatVersion(version)}`,
+      query: `event.type:transaction release:${version}`,
+      fields: ['transaction', 'failure_count()', 'epm()', 'p50()'],
+      orderby: '-failure_count',
+      range: period,
+      environment: environments,
+      projects: [projectId],
+      start: start ? getUtcDateString(start) : undefined,
+      end: end ? getUtcDateString(end) : undefined,
+    };
+
     switch (selectedSort.value) {
       case 'p75_lcp':
         return EventView.fromSavedQuery({
-          id: undefined,
-          version: 2,
-          name: `Release ${formatVersion(version)}`,
-          query: `event.type:transaction release:${version} has:measurements.lcp`,
+          ...baseQuery,
+          query: `event.type:transaction release:${version} epm():>0.01 has:measurements.lcp`,
           fields: ['transaction', 'failure_count()', 'epm()', 'p75(measurements.lcp)'],
           orderby: 'p75_measurements_lcp',
-          range: period,
-          environment: environments,
-          projects: [projectId],
-          start: start ? getUtcDateString(start) : undefined,
-          end: end ? getUtcDateString(end) : undefined,
+        });
+      case 'p50':
+        return EventView.fromSavedQuery({
+          ...baseQuery,
+          query: `event.type:transaction release:${version} epm():>0.01`,
         });
       default:
-        return EventView.fromSavedQuery({
-          id: undefined,
-          version: 2,
-          name: `Release ${formatVersion(version)}`,
-          query: `event.type:transaction release:${version}`,
-          fields: ['transaction', 'failure_count()', 'epm()', 'p50()'],
-          orderby: '-failure_count',
-          range: period,
-          environment: environments,
-          projects: [projectId],
-          start: start ? getUtcDateString(start) : undefined,
-          end: end ? getUtcDateString(end) : undefined,
-        });
+        return EventView.fromSavedQuery(baseQuery);
     }
   }
 


### PR DESCRIPTION
Sorts on p50() and p75(measurements.lcp) are prone to noise due to low counts.
Adding an filter on the throughput helps reduce the noice.