### PR TITLE
fix(releases): Sort by failing transactions by default

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -391,7 +391,7 @@ function getTransactionsListSort(
   location: Location
 ): {selectedSort: DropdownOption; sortOptions: DropdownOption[]} {
   const sortOptions = getDropdownOptions();
-  const urlParam = decodeScalar(location.query.showTransactions) || 'tpm';
+  const urlParam = decodeScalar(location.query.showTransactions) || 'failure_count';
   const selectedSort = sortOptions.find(opt => opt.value === urlParam) || sortOptions[0];
   return {selectedSort, sortOptions};
 }


### PR DESCRIPTION
Sorting by throughput does not surface interesting transactions, change the
default to sort by failure count.