### PR TITLE
chore(py3): Convert celerybeat tasks with large timedeltas to crontabs instead.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 
 import sentry
+from sentry.utils.celery import crontab_with_minute_jitter
 from sentry.utils.types import type_from_value
 
 from datetime import timedelta
@@ -664,7 +665,7 @@ CELERYBEAT_SCHEDULE = {
     },
     "collect-project-platforms": {
         "task": "sentry.tasks.collect_project_platforms",
-        "schedule": timedelta(days=1),
+        "schedule": crontab_with_minute_jitter(hour=3),
         "options": {"expires": 3600 * 24},
     },
     "update-user-reports": {
@@ -691,7 +692,7 @@ CELERYBEAT_SCHEDULE = {
     },
     "schedule-vsts-integration-subscription-check": {
         "task": "sentry.tasks.integrations.kickoff_vsts_subscription_check",
-        "schedule": timedelta(hours=6),
+        "schedule": crontab_with_minute_jitter(hour="*/6"),
         "options": {"expires": 60 * 25},
     },
     "process_pending_incident_snapshots": {

--- a/src/sentry/utils/celery.py
+++ b/src/sentry/utils/celery.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+
+from random import randint
+
+from celery.schedules import crontab
+
+
+def crontab_with_minute_jitter(*args, **kwargs):
+    kwargs["minute"] = randint(0, 59)
+    return crontab(*args, **kwargs)


### PR DESCRIPTION
As part of Py3 we want to stop storing the db file for celerybeat. Most tasks with large
timedeltas are more suited to crontabs anyway, so converting these to crontabs, and adding jitter to
help prevent them all running at the same time.