### PR TITLE
feat(release-health-chart): Add release session specific terms descriptions chart

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.tsx
@@ -489,6 +489,32 @@ const ChartContainer = styled('div')`
   .echarts-for-react div:first-of-type {
     width: 100% !important;
   }
+
+  /* Tooltip description styling */
+  .tooltip-description {
+    color: ${p => p.theme.white};
+    border-radius: ${p => p.theme.borderRadius};
+    background: #000;
+    opacity: 0.9;
+    padding: 5px 10px;
+    position: relative;
+    font-weight: bold;
+    font-size: ${p => p.theme.fontSizeSmall};
+    line-height: 1.4;
+    font-family: ${p => p.theme.text.family};
+    :after {
+      content: '';
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      width: 0;
+      height: 0;
+      border-left: 5px solid transparent;
+      border-right: 5px solid transparent;
+      border-top: 5px solid #000;
+      transform: translateX(-50%);
+    }
+  }
 `;
 
 const BaseChartWithTheme = withTheme(BaseChart);

--- a/src/sentry/static/sentry/app/components/globalSelectionLink.tsx
+++ b/src/sentry/static/sentry/app/components/globalSelectionLink.tsx
@@ -37,7 +37,7 @@ export default class GlobalSelectionLink extends React.Component<Props> {
     const {location} = this.context;
     const {to} = this.props;
 
-    const globalQuery = extractSelectionParameters(location.query);
+    const globalQuery = extractSelectionParameters(location?.query);
     const hasGlobalQuery = Object.keys(globalQuery).length > 0;
     const query =
       typeof to === 'object' && to.query ? {...globalQuery, ...to.query} : globalQuery;

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -317,81 +317,75 @@ class Chart extends React.Component<Props> {
     };
 
     return (
-      <React.Fragment>
-        <ChartZoom
-          router={router}
-          period={statsPeriod}
-          projects={project}
-          environments={environment}
-        >
-          {zoomRenderProps => {
-            const smoothedSeries = smoothedResults
-              ? smoothedResults.map(values => {
-                  return {
-                    ...values,
-                    color: lineColor.default,
-                    lineStyle: {
-                      opacity: 1,
-                    },
-                  };
-                })
-              : [];
+      <ChartZoom
+        router={router}
+        period={statsPeriod}
+        projects={project}
+        environments={environment}
+      >
+        {zoomRenderProps => {
+          const smoothedSeries = smoothedResults
+            ? smoothedResults.map(values => {
+                return {
+                  ...values,
+                  color: lineColor.default,
+                  lineStyle: {
+                    opacity: 1,
+                  },
+                };
+              })
+            : [];
 
-            const intervalSeries = getIntervalLine(
-              smoothedResults || [],
-              intervalRatio,
-              transaction
-            );
+          const intervalSeries = getIntervalLine(
+            smoothedResults || [],
+            intervalRatio,
+            transaction
+          );
 
-            return (
-              <ReleaseSeries
-                start={start}
-                end={end}
-                queryExtra={queryExtra}
-                period={statsPeriod}
-                utc={utc}
-                projects={isNaN(transactionProject) ? project : [transactionProject]}
-                environments={environment}
-                memoized
-              >
-                {({releaseSeries}) => (
-                  <TransitionChart loading={loading} reloading={reloading}>
-                    <TransparentLoadingMask visible={reloading} />
-                    {getDynamicText({
-                      value: (
-                        <LineChart
-                          {...zoomRenderProps}
-                          {...chartOptions}
-                          onLegendSelectChanged={this.handleLegendSelectChanged}
-                          series={[
-                            ...smoothedSeries,
-                            ...releaseSeries,
-                            ...intervalSeries,
-                          ]}
-                          seriesOptions={{
-                            showSymbol: false,
-                          }}
-                          legend={legend}
-                          toolBox={{
-                            show: false,
-                          }}
-                          grid={{
-                            left: '10px',
-                            right: '10px',
-                            top: '40px',
-                            bottom: '0px',
-                          }}
-                        />
-                      ),
-                      fixed: 'Duration Chart',
-                    })}
-                  </TransitionChart>
-                )}
-              </ReleaseSeries>
-            );
-          }}
-        </ChartZoom>
-      </React.Fragment>
+          return (
+            <ReleaseSeries
+              start={start}
+              end={end}
+              queryExtra={queryExtra}
+              period={statsPeriod}
+              utc={utc}
+              projects={isNaN(transactionProject) ? project : [transactionProject]}
+              environments={environment}
+              memoized
+            >
+              {({releaseSeries}) => (
+                <TransitionChart loading={loading} reloading={reloading}>
+                  <TransparentLoadingMask visible={reloading} />
+                  {getDynamicText({
+                    value: (
+                      <LineChart
+                        {...zoomRenderProps}
+                        {...chartOptions}
+                        onLegendSelectChanged={this.handleLegendSelectChanged}
+                        series={[...smoothedSeries, ...releaseSeries, ...intervalSeries]}
+                        seriesOptions={{
+                          showSymbol: false,
+                        }}
+                        legend={legend}
+                        toolBox={{
+                          show: false,
+                        }}
+                        grid={{
+                          left: '10px',
+                          right: '10px',
+                          top: '40px',
+                          bottom: '0px',
+                        }}
+                      />
+                    ),
+                    fixed: 'Duration Chart',
+                  })}
+                </TransitionChart>
+              )}
+            </ReleaseSeries>
+          );
+        }}
+      </ChartZoom>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -13,9 +13,14 @@ import {defined} from 'app/utils';
 import {axisDuration} from 'app/utils/discover/charts';
 import {getExactDuration} from 'app/utils/formatters';
 import {decodeList} from 'app/utils/queryString';
+<<<<<<< HEAD
 import theme from 'app/utils/theme';
+=======
+import {PlatformKey} from 'app/data/platformCategories';
+>>>>>>> parent 2a30ac698d80403fdb6d9b7b4a11dd2e45e9f902
 
 import {YAxis} from './releaseChartControls';
+import {sessionTerm, getSessionTermDescription} from '../../../utils/sessionTerm';
 
 type Props = {
   reloading: boolean;
@@ -24,6 +29,7 @@ type Props = {
   zoomRenderProps: any;
   yAxis: YAxis;
   location: Location;
+  platform: PlatformKey;
   shouldRecalculateVisibleSeries: boolean;
   onVisibleSeriesRecalculated: () => void;
 };
@@ -59,7 +65,7 @@ class HealthChart extends React.Component<Props> {
     const {timeseriesData, location, shouldRecalculateVisibleSeries} = this.props;
 
     const otherAreasThanHealthyArePositive = timeseriesData
-      .filter(s => s.seriesName !== 'Healthy')
+      .filter(s => s.seriesName !== sessionTerm.healthy)
       .some(s => s.data.some(d => d.value > 0));
     const alreadySomethingUnselected = !!decodeList(location.query.unselectedSeries);
 
@@ -162,6 +168,27 @@ class HealthChart extends React.Component<Props> {
     }
   }
 
+  getLegendTooltipDescription(serieName: string) {
+    const {platform} = this.props;
+
+    switch (serieName) {
+      case sessionTerm.crashed:
+        return getSessionTermDescription('crashed', platform);
+      case sessionTerm.abnormal:
+        return getSessionTermDescription('abnormal', platform);
+      case sessionTerm.errored:
+        return getSessionTermDescription('errored', platform);
+      case sessionTerm.healthy:
+        return getSessionTermDescription('healthy', platform);
+      case sessionTerm['crash-free-users']:
+        return getSessionTermDescription('crash-free-users', platform);
+      case sessionTerm['crash-free-sessions']:
+        return getSessionTermDescription('crash-free-sessions', platform);
+      default:
+        return '';
+    }
+  }
+
   render() {
     const {utc, timeseriesData, zoomRenderProps, location} = this.props;
 
@@ -182,6 +209,27 @@ class HealthChart extends React.Component<Props> {
       },
       data: timeseriesData.map(d => d.seriesName).reverse(),
       selected: getSeriesSelection(location),
+      tooltip: {
+        show: true,
+        formatter: (params: {
+          $vars: string[];
+          componentType: string;
+          legendIndex: number;
+          name: string;
+        }): string => {
+          const serieNameDesc = this.getLegendTooltipDescription(params.name);
+
+          if (!serieNameDesc) {
+            return '';
+          }
+
+          return [
+            '<div class="tooltip-description">',
+            `<div>${serieNameDesc}</div>`,
+            '</div>',
+          ].join('');
+        },
+      },
     };
 
     return (

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -8,19 +8,21 @@ import LineChart from 'app/components/charts/lineChart';
 import StackedAreaChart from 'app/components/charts/stackedAreaChart';
 import {getSeriesSelection} from 'app/components/charts/utils';
 import {parseStatsPeriod} from 'app/components/organizations/timeRangeSelector/utils';
+import {PlatformKey} from 'app/data/platformCategories';
 import {Series} from 'app/types/echarts';
 import {defined} from 'app/utils';
 import {axisDuration} from 'app/utils/discover/charts';
 import {getExactDuration} from 'app/utils/formatters';
 import {decodeList} from 'app/utils/queryString';
-<<<<<<< HEAD
 import theme from 'app/utils/theme';
-=======
-import {PlatformKey} from 'app/data/platformCategories';
->>>>>>> parent 2a30ac698d80403fdb6d9b7b4a11dd2e45e9f902
+
+import {
+  getSessionTermDescription,
+  SessionTerm,
+  sessionTerm,
+} from '../../../utils/sessionTerm';
 
 import {YAxis} from './releaseChartControls';
-import {sessionTerm, getSessionTermDescription} from '../../../utils/sessionTerm';
 
 type Props = {
   reloading: boolean;
@@ -173,17 +175,17 @@ class HealthChart extends React.Component<Props> {
 
     switch (serieName) {
       case sessionTerm.crashed:
-        return getSessionTermDescription('crashed', platform);
+        return getSessionTermDescription(SessionTerm.CRASHED, platform);
       case sessionTerm.abnormal:
-        return getSessionTermDescription('abnormal', platform);
+        return getSessionTermDescription(SessionTerm.ABNORMAL, platform);
       case sessionTerm.errored:
-        return getSessionTermDescription('errored', platform);
+        return getSessionTermDescription(SessionTerm.ERRORED, platform);
       case sessionTerm.healthy:
-        return getSessionTermDescription('healthy', platform);
+        return getSessionTermDescription(SessionTerm.HEALTHY, platform);
       case sessionTerm['crash-free-users']:
-        return getSessionTermDescription('crash-free-users', platform);
+        return getSessionTermDescription(SessionTerm.CRASH_FREE_USERS, platform);
       case sessionTerm['crash-free-sessions']:
-        return getSessionTermDescription('crash-free-sessions', platform);
+        return getSessionTermDescription(SessionTerm.CRASH_FREE_SESSIONS, platform);
       default:
         return '';
     }
@@ -217,15 +219,15 @@ class HealthChart extends React.Component<Props> {
           legendIndex: number;
           name: string;
         }): string => {
-          const serieNameDesc = this.getLegendTooltipDescription(params.name);
+          const seriesNameDesc = this.getLegendTooltipDescription(params.name);
 
-          if (!serieNameDesc) {
+          if (!seriesNameDesc) {
             return '';
           }
 
           return [
             '<div class="tooltip-description">',
-            `<div>${serieNameDesc}</div>`,
+            `<div>${seriesNameDesc}</div>`,
             '</div>',
           ].join('');
         },

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChartContainer.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChartContainer.tsx
@@ -5,11 +5,12 @@ import ChartZoom from 'app/components/charts/chartZoom';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
+import {PlatformKey} from 'app/data/platformCategories';
 import {IconWarning} from 'app/icons';
 import {GlobalSelection} from 'app/types';
-import {PlatformKey} from 'app/data/platformCategories';
 
 import {ReleaseStatsRequestRenderProps} from '../releaseStatsRequest';
+
 import HealthChart from './healthChart';
 import {YAxis} from './releaseChartControls';
 

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChartContainer.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChartContainer.tsx
@@ -7,9 +7,9 @@ import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {IconWarning} from 'app/icons';
 import {GlobalSelection} from 'app/types';
+import {PlatformKey} from 'app/data/platformCategories';
 
 import {ReleaseStatsRequestRenderProps} from '../releaseStatsRequest';
-
 import HealthChart from './healthChart';
 import {YAxis} from './releaseChartControls';
 
@@ -20,6 +20,7 @@ type Props = Omit<
   selection: GlobalSelection;
   yAxis: YAxis;
   router: ReactRouter.InjectedRouter;
+  platform: PlatformKey;
 };
 
 type State = {
@@ -36,41 +37,49 @@ class ReleaseChartContainer extends React.Component<Props, State> {
   };
 
   render() {
-    const {loading, errored, reloading, chartData, selection, yAxis, router} = this.props;
+    const {
+      loading,
+      errored,
+      reloading,
+      chartData,
+      selection,
+      yAxis,
+      router,
+      platform,
+    } = this.props;
     const {shouldRecalculateVisibleSeries} = this.state;
     const {datetime} = selection;
     const {utc, period, start, end} = datetime;
 
     return (
-      <React.Fragment>
-        <ChartZoom router={router} period={period} utc={utc} start={start} end={end}>
-          {zoomRenderProps => {
-            if (errored) {
-              return (
-                <ErrorPanel>
-                  <IconWarning color="gray300" size="lg" />
-                </ErrorPanel>
-              );
-            }
-
+      <ChartZoom router={router} period={period} utc={utc} start={start} end={end}>
+        {zoomRenderProps => {
+          if (errored) {
             return (
-              <TransitionChart loading={loading} reloading={reloading}>
-                <TransparentLoadingMask visible={reloading} />
-                <HealthChart
-                  utc={utc}
-                  timeseriesData={chartData}
-                  zoomRenderProps={zoomRenderProps}
-                  reloading={reloading}
-                  yAxis={yAxis}
-                  location={router.location}
-                  shouldRecalculateVisibleSeries={shouldRecalculateVisibleSeries}
-                  onVisibleSeriesRecalculated={this.handleVisibleSeriesRecalculated}
-                />
-              </TransitionChart>
+              <ErrorPanel>
+                <IconWarning color="gray300" size="lg" />
+              </ErrorPanel>
             );
-          }}
-        </ChartZoom>
-      </React.Fragment>
+          }
+
+          return (
+            <TransitionChart loading={loading} reloading={reloading}>
+              <TransparentLoadingMask visible={reloading} />
+              <HealthChart
+                utc={utc}
+                timeseriesData={chartData}
+                zoomRenderProps={zoomRenderProps}
+                reloading={reloading}
+                yAxis={yAxis}
+                location={router.location}
+                shouldRecalculateVisibleSeries={shouldRecalculateVisibleSeries}
+                onVisibleSeriesRecalculated={this.handleVisibleSeriesRecalculated}
+                platform={platform}
+              />
+            </TransitionChart>
+          );
+        }}
+      </ChartZoom>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
@@ -5,11 +5,11 @@ import {Location} from 'history';
 import {Client} from 'app/api';
 import EventsChart from 'app/components/charts/eventsChart';
 import {Panel} from 'app/components/panels';
+import {PlatformKey} from 'app/data/platformCategories';
 import {t} from 'app/locale';
 import {GlobalSelection, Organization, ReleaseMeta} from 'app/types';
 import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
-import {PlatformKey} from 'app/data/platformCategories';
 
 import {ReleaseStatsRequestRenderProps} from '../releaseStatsRequest';
 

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
@@ -9,6 +9,7 @@ import {t} from 'app/locale';
 import {GlobalSelection, Organization, ReleaseMeta} from 'app/types';
 import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
+import {PlatformKey} from 'app/data/platformCategories';
 
 import {ReleaseStatsRequestRenderProps} from '../releaseStatsRequest';
 
@@ -23,6 +24,7 @@ import {getReleaseEventView} from './utils';
 type Props = Omit<ReleaseStatsRequestRenderProps, 'crashFreeTimeBreakdown'> & {
   releaseMeta: ReleaseMeta;
   selection: GlobalSelection;
+  platform: PlatformKey;
   yAxis: YAxis;
   eventType: EventType;
   onYAxisChange: (yAxis: YAxis) => void;
@@ -148,10 +150,20 @@ class ReleaseChartContainer extends React.Component<Props> {
   }
 
   renderHealthChart() {
-    const {loading, errored, reloading, chartData, selection, yAxis, router} = this.props;
+    const {
+      loading,
+      errored,
+      reloading,
+      chartData,
+      selection,
+      yAxis,
+      router,
+      platform,
+    } = this.props;
 
     return (
       <HealthChartContainer
+        platform={platform}
         loading={loading}
         errored={errored}
         reloading={reloading}

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -277,6 +277,7 @@ class ReleaseOverview extends AsyncView<Props> {
                         version={version}
                         hasDiscover={hasDiscover}
                         hasPerformance={hasPerformance}
+                        platform={project.platform}
                       />
                     )}
                     <Issues

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/releaseStatsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/releaseStatsRequest.tsx
@@ -19,6 +19,7 @@ import {defined, percent} from 'app/utils';
 import {getExactDuration} from 'app/utils/formatters';
 
 import {displayCrashFreePercent, getCrashFreePercent, roundDuration} from '../../utils';
+import {sessionTerm} from '../../utils/sessionTerm';
 
 import {EventType, YAxis} from './chart/releaseChartControls';
 import {getInterval, getReleaseEventView} from './chart/utils';
@@ -28,9 +29,7 @@ const omitIgnoredProps = (props: Props) =>
     ['api', 'version', 'orgId', 'projectSlug', 'location', 'children'].includes(key)
   );
 
-type ChartData = {
-  [key: string]: Series;
-};
+type ChartData = Record<string, Series>;
 
 type Data = {
   chartData: Series[];
@@ -246,7 +245,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
     // here we can configure colors of the chart
     const chartData: ChartData = {
       crashed: {
-        seriesName: t('Crashed'),
+        seriesName: sessionTerm.crashed,
         data: [],
         color: CHART_PALETTE[3][0],
         areaStyle: {
@@ -259,7 +258,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         },
       },
       abnormal: {
-        seriesName: t('Abnormal'),
+        seriesName: sessionTerm.abnormal,
         data: [],
         color: CHART_PALETTE[3][1],
         areaStyle: {
@@ -272,7 +271,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         },
       },
       errored: {
-        seriesName: t('Errored'),
+        seriesName: sessionTerm.errored,
         data: [],
         color: CHART_PALETTE[3][2],
         areaStyle: {
@@ -285,7 +284,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         },
       },
       healthy: {
-        seriesName: t('Healthy'),
+        seriesName: sessionTerm.healthy,
         data: [],
         color: CHART_PALETTE[3][3],
         areaStyle: {
@@ -328,12 +327,12 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
   ): Omit<Data, 'crashFreeTimeBreakdown'> {
     const chartData: ChartData = {
       users: {
-        seriesName: t('Crash Free Users'),
+        seriesName: sessionTerm['crash-free-users'],
         data: [],
         color: CHART_PALETTE[1][0],
       },
       sessions: {
-        seriesName: t('Crash Free Sessions'),
+        seriesName: sessionTerm['crash-free-sessions'],
         data: [],
         color: CHART_PALETTE[1][1],
       },

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
@@ -31,6 +31,7 @@ import {getSessionTermDescription} from '../utils/sessionTerm';
 
 import ReleaseActions from './releaseActions';
 import ReleaseStat from './releaseStat';
+import {getSessionTermDescription, sessionTerm} from '../utils/sessionTerm';
 
 type Props = {
   location: Location;
@@ -119,7 +120,11 @@ const ReleaseHeader = ({
           </ReleaseStat>
           {hasHealthData && (
             <ReleaseStat
+<<<<<<< HEAD
               label={t('Crashes')}
+=======
+              label={sessionTerm.crashes}
+>>>>>>> parent 2a30ac698d80403fdb6d9b7b4a11dd2e45e9f902
               help={getSessionTermDescription('crashes', project.platform)}
             >
               <Count value={sessionsCrashed} />

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
@@ -27,11 +27,10 @@ import {getAggregateAlias} from 'app/utils/discover/fields';
 import {formatAbbreviatedNumber, formatVersion} from 'app/utils/formatters';
 import {getTermHelp} from 'app/views/performance/data';
 
-import {getSessionTermDescription} from '../utils/sessionTerm';
+import {getSessionTermDescription, SessionTerm, sessionTerm} from '../utils/sessionTerm';
 
 import ReleaseActions from './releaseActions';
 import ReleaseStat from './releaseStat';
-import {getSessionTermDescription, sessionTerm} from '../utils/sessionTerm';
 
 type Props = {
   location: Location;
@@ -54,7 +53,8 @@ const ReleaseHeader = ({
 }: Props) => {
   const {version, newGroups, url, lastDeploy, dateCreated} = release;
   const {commitCount, commitFilesChanged, releaseFileCount} = releaseMeta;
-  const {hasHealthData, sessionsCrashed} = project.healthData;
+  const {hasHealthData} = project;
+  const {sessionsCrashed} = project.healthData;
 
   const releasePath = `/organizations/${organization.slug}/releases/${encodeURIComponent(
     version
@@ -120,12 +120,8 @@ const ReleaseHeader = ({
           </ReleaseStat>
           {hasHealthData && (
             <ReleaseStat
-<<<<<<< HEAD
-              label={t('Crashes')}
-=======
               label={sessionTerm.crashes}
->>>>>>> parent 2a30ac698d80403fdb6d9b7b4a11dd2e45e9f902
-              help={getSessionTermDescription('crashes', project.platform)}
+              help={getSessionTermDescription(SessionTerm.CRASHES, project.platform)}
             >
               <Count value={sessionsCrashed} />
             </ReleaseStat>

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseStat.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseStat.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 const ReleaseStat = ({label, children, help}: Props) => (
   <Wrapper>
-    <Label hasHelp={!!help}>
+    <Label>
       {label}
       {help && <StyledQuestionTooltip title={help} size="xs" position="bottom" />}
     </Label>
@@ -26,7 +26,7 @@ const Wrapper = styled('div')`
   }
 `;
 
-const Label = styled('div')<{hasHelp: boolean}>`
+const Label = styled('div')`
   font-weight: 600;
   font-size: ${p => p.theme.fontSizeSmall};
   text-transform: uppercase;

--- a/src/sentry/static/sentry/app/views/releases/utils/sessionTerm.tsx
+++ b/src/sentry/static/sentry/app/views/releases/utils/sessionTerm.tsx
@@ -1,6 +1,17 @@
 import {PlatformKey} from 'app/data/platformCategories';
 import {t} from 'app/locale';
 
+export const sessionTerm = {
+  crashes: t('Crashes'),
+  crashed: t('Crashed'),
+  abnormal: t('Abnormal'),
+  'crash-free-users': t('Crash Free Users'),
+  'crash-free-sessions': t('Crash Free Sessions'),
+  healthy: t('Healthy'),
+  errored: t('Errored'),
+  unhandled: t('Unhandled'),
+};
+
 const commonTermsDescription = {
   crashes: t('Number of sessions with a crashed state'),
   'crash-free-users': t('Number of unique users with non-crashed sessions'),

--- a/src/sentry/static/sentry/app/views/releases/utils/sessionTerm.tsx
+++ b/src/sentry/static/sentry/app/views/releases/utils/sessionTerm.tsx
@@ -1,48 +1,72 @@
 import {PlatformKey} from 'app/data/platformCategories';
 import {t} from 'app/locale';
 
+export enum SessionTerm {
+  CRASHES = 'crashes',
+  CRASHED = 'crashed',
+  ABNORMAL = 'abnormal',
+  CRASH_FREE_USERS = 'crash-free-users',
+  CRASH_FREE_SESSIONS = 'crash-free-sessions',
+  HEALTHY = 'healthy',
+  ERRORED = 'errored',
+  UNHANDLED = 'unhandled',
+}
+
 export const sessionTerm = {
-  crashes: t('Crashes'),
-  crashed: t('Crashed'),
-  abnormal: t('Abnormal'),
-  'crash-free-users': t('Crash Free Users'),
-  'crash-free-sessions': t('Crash Free Sessions'),
-  healthy: t('Healthy'),
-  errored: t('Errored'),
-  unhandled: t('Unhandled'),
+  [SessionTerm.CRASHES]: t('Crashes'),
+  [SessionTerm.CRASHED]: t('Crashed'),
+  [SessionTerm.ABNORMAL]: t('Abnormal'),
+  [SessionTerm.CRASH_FREE_USERS]: t('Crash Free Users'),
+  [SessionTerm.CRASH_FREE_SESSIONS]: t('Crash Free Sessions'),
+  [SessionTerm.HEALTHY]: t('Healthy'),
+  [SessionTerm.ERRORED]: t('Errored'),
+  [SessionTerm.UNHANDLED]: t('Unhandled'),
 };
 
-const commonTermsDescription = {
-  crashes: t('Number of sessions with a crashed state'),
-  'crash-free-users': t('Number of unique users with non-crashed sessions'),
-  'crash-free-sessions': t('Number of non-crashed sessions'),
+// This should never be used directly (except in tests)
+export const commonTermsDescription = {
+  [SessionTerm.CRASHES]: t('Number of sessions with a crashed state'),
+  [SessionTerm.CRASH_FREE_USERS]: t('Number of unique users with non-crashed sessions'),
+  [SessionTerm.CRASH_FREE_SESSIONS]: t('Number of non-crashed sessions'),
 };
 
-const mobileTermsDescription = {
-  crashed: t(
+// This should never be used directly (except in tests)
+export const mobileTermsDescription = {
+  [SessionTerm.CRASHED]: t(
     'The process was terminated due to an unhandled exception or a request to the server that ended with an error'
   ),
-  'crash-free-sessions': t('Number of unique sessions that did not experience a crash'),
-  abnormal: t(
+  [SessionTerm.CRASH_FREE_SESSIONS]: t('Number of unique sessions that did not crash'),
+  [SessionTerm.ABNORMAL]: t(
     'An unknown session exit. Like due to loss of power or killed by the operating system'
   ),
-  healthy: t('A session without any errors'),
-  errored: t('A crash which experienced errors'),
-  unhandled: t('Not handled by user code'),
+  [SessionTerm.HEALTHY]: t('A session without any errors'),
+  [SessionTerm.ERRORED]: t('A crash which experienced errors'),
+  [SessionTerm.UNHANDLED]: t('Not handled by user code'),
 };
 
-const desktopTermDescriptions = {
-  crashed: t('The application crashed with a hard crashed (eg. segfault)'),
-  abnormal: t(
+// This should never be used directly (except in tests)
+export const desktopTermDescriptions = {
+  crashed: t('The application crashed with a hard crash (eg. segfault)'),
+  [SessionTerm.ABNORMAL]: t(
     'The application did not properly end the session, for example, due to force-quit'
   ),
-  healthy: t('The application exited normally and did not observe any errors'),
-  errored: t('The application exited normally but observed error events while running'),
-  unhandled: t('The application crashed with a hard crashed'),
+  [SessionTerm.HEALTHY]: t(
+    'The application exited normally and did not observe any errors'
+  ),
+  [SessionTerm.ERRORED]: t(
+    'The application exited normally but observed error events while running'
+  ),
+  [SessionTerm.UNHANDLED]: t('The application crashed with a hard crash'),
 };
 
 function getTermDescriptions(platform: PlatformKey | null) {
-  const technology = platform?.includes('javascript') ? platform.split('-')[0] : platform;
+  const technology =
+    platform === 'react-native' ||
+    platform === 'java-spring' ||
+    platform === 'apple-ios' ||
+    platform === 'dotnet-aspnetcore'
+      ? platform
+      : platform?.split('-')[0];
 
   switch (technology) {
     case 'dotnet':
@@ -56,7 +80,7 @@ function getTermDescriptions(platform: PlatformKey | null) {
       return {
         ...commonTermsDescription,
         ...mobileTermsDescription,
-        crashes: t(
+        [SessionTerm.CRASHES]: t(
           'A request that resulted in an unhandled exception and hence a Server Error response'
         ),
       };
@@ -67,30 +91,32 @@ function getTermDescriptions(platform: PlatformKey | null) {
       return {
         ...commonTermsDescription,
         ...mobileTermsDescription,
-        crashed: t('An unhandled exception that resulted in the application crashing'),
+        [SessionTerm.CRASHED]: t(
+          'An unhandled exception that resulted in the application crashing'
+        ),
       };
 
     case 'apple': {
       return {
         ...commonTermsDescription,
         ...mobileTermsDescription,
-        crashed: t('An error that resulted in the application crashing'),
+        [SessionTerm.CRASHED]: t('An error that resulted in the application crashing'),
       };
     }
     case 'node':
     case 'javascript':
       return {
         ...commonTermsDescription,
-        crashed: t(
-          "During session an error with mechanism.handled===false occured which is 'onerror' on 'unhandledrejection' handler"
+        [SessionTerm.CRASHED]: t(
+          "During the session an error with mechanism.handled===false occurred calling the 'onerror' on 'unhandledrejection' handler"
         ),
-        abnormal: t('Non applicable for Javascript'),
-        healthy: t('No errors captured during session life-time'),
-        errored: t(
-          'During the session at least one error occurred that did not bubble up to the global handlers, not resulting in the application loading process crashing.'
+        [SessionTerm.ABNORMAL]: t('Non applicable for Javascript'),
+        [SessionTerm.HEALTHY]: t('No errors were captured during session life-time'),
+        [SessionTerm.ERRORED]: t(
+          'During the session at least one error occurred that did not bubble up to the global handler. The application loading process did not crash'
         ),
-        unhandled:
-          "An error bubbled up to the global 'onerror' or 'onunhandledrejection' handler",
+        [SessionTerm.UNHANDLED]:
+          "An error was captured by the global 'onerror' or 'onunhandledrejection' handler",
       };
     case 'apple-ios':
     case 'minidump':
@@ -103,22 +129,23 @@ function getTermDescriptions(platform: PlatformKey | null) {
       return {
         ...commonTermsDescription,
         ...desktopTermDescriptions,
-        crashed: t('The application had an unrecovable error (a panic)'),
+        [SessionTerm.CRASHED]: t('The application had an unrecovable error (a panic)'),
       };
     default:
       return {
         ...commonTermsDescription,
-        crashed: t('Number of users who experienced an unhandled error'),
-        abnormal: t('An unknown session exit'),
-        healthy: mobileTermsDescription.healthy,
-        errored: mobileTermsDescription.errored,
-        unhandled: mobileTermsDescription.unhandled,
+        [SessionTerm.CRASHED]: t('Number of users who experienced an unhandled error'),
+        [SessionTerm.ABNORMAL]: t('An unknown session exit'),
+        [SessionTerm.HEALTHY]: mobileTermsDescription.healthy,
+        [SessionTerm.ERRORED]: mobileTermsDescription.errored,
+        [SessionTerm.UNHANDLED]: mobileTermsDescription.unhandled,
       };
   }
 }
 
-type Term = keyof ReturnType<typeof getTermDescriptions>;
-
-export function getSessionTermDescription(term: Term, platform: PlatformKey) {
+export function getSessionTermDescription(
+  term: SessionTerm,
+  platform: PlatformKey | null
+) {
   return getTermDescriptions(platform)[term];
 }

--- a/tests/js/spec/views/releases/detail/releaseHeader.spec.tsx
+++ b/tests/js/spec/views/releases/detail/releaseHeader.spec.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {PlatformKey} from 'app/data/platformCategories';
+import EventView from 'app/utils/discover/eventView';
+import {DEFAULT_EVENT_VIEW} from 'app/views/eventsV2/data';
+import ReleaseHeader from 'app/views/releases/detail/releaseHeader';
+import {
+  getSessionTermDescription,
+  SessionTerm,
+  sessionTerm,
+} from 'app/views/releases/utils/sessionTerm';
+
+describe('ReleaseHeader', function () {
+  const {organization} = initializeOrg();
+  // @ts-ignore Cannot find name TestStubs
+  const release = TestStubs.Release();
+  // @ts-ignore Cannot find name TestStubs
+  const location = TestStubs.location();
+  // @ts-ignore Cannot find name TestStubs
+  const routerContext = TestStubs.routerContext();
+
+  const eventView = EventView.fromSavedQuery(DEFAULT_EVENT_VIEW);
+  const platform: PlatformKey = 'javascript';
+
+  it('renders release header', function () {
+    const wrapper = mountWithTheme(
+      <ReleaseHeader
+        location={location}
+        organization={organization}
+        releaseEventView={eventView}
+        release={release}
+        project={{...release.projects[0], platform}}
+        releaseMeta={{
+          commitCount: 0,
+          commitFilesChanged: 0,
+          deployCount: 0,
+          version: 'sentry-android-shop@1.2.0',
+          projects: release.projects,
+          versionInfo: {
+            buildHash: null,
+            version: {
+              raw: '1.2.0',
+            },
+            description: '1.2.0',
+            package: 'sentry-android-shop',
+          },
+          released: '2020-11-20T22:57:15.647000Z',
+          releaseFileCount: 0,
+        }}
+        refetchData={jest.fn()}
+      />,
+      routerContext
+    );
+
+    const releaseStats = wrapper.find('ReleaseStat');
+    const releaseStatsCrashes = releaseStats.at(1);
+
+    const {label, help} = releaseStatsCrashes.props();
+
+    expect(label).toEqual(sessionTerm.crashes);
+    expect(help).toEqual(getSessionTermDescription(SessionTerm.CRASHES, platform));
+  });
+});

--- a/tests/js/spec/views/releases/utils/sessionTerm.spec.tsx
+++ b/tests/js/spec/views/releases/utils/sessionTerm.spec.tsx
@@ -488,7 +488,7 @@ describe('Release Health Session Term', function () {
       'node-express'
     );
     expect(crashedSessionTerm).toEqual(
-      "During session an error with mechanism.handled===false occurred which is 'onerror' on 'unhandledrejection' handler"
+      "During the session an error with mechanism.handled===false occurred calling the 'onerror' on 'unhandledrejection' handler"
     );
 
     // Crash Free Users
@@ -536,7 +536,7 @@ describe('Release Health Session Term', function () {
       'node-express'
     );
     expect(unhandledSessionTerm).toEqual(
-      "An error bubbled up to the global 'onerror' or 'onunhandledrejection' handler"
+      "An error was captured by the global 'onerror' or 'onunhandledrejection' handler"
     );
   });
 
@@ -554,7 +554,7 @@ describe('Release Health Session Term', function () {
       'javascript'
     );
     expect(crashedSessionTerm).toEqual(
-      "During session an error with mechanism.handled===false occurred which is 'onerror' on 'unhandledrejection' handler"
+      "During the session an error with mechanism.handled===false occurred calling the 'onerror' on 'unhandledrejection' handler"
     );
 
     // Crash Free Users
@@ -602,7 +602,7 @@ describe('Release Health Session Term', function () {
       'javascript'
     );
     expect(unhandledSessionTerm).toEqual(
-      "An error bubbled up to the global 'onerror' or 'onunhandledrejection' handler"
+      "An error was captured by the global 'onerror' or 'onunhandledrejection' handler"
     );
   });
 

--- a/tests/js/spec/views/releases/utils/sessionTerm.spec.tsx
+++ b/tests/js/spec/views/releases/utils/sessionTerm.spec.tsx
@@ -1,0 +1,884 @@
+import {
+  commonTermsDescription,
+  desktopTermDescriptions,
+  getSessionTermDescription,
+  mobileTermsDescription,
+  SessionTerm,
+} from 'app/views/releases/utils/sessionTerm';
+
+describe('Release Health Session Term', function () {
+  it('dotnet terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(SessionTerm.CRASHES, 'dotnet');
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(SessionTerm.CRASHED, 'dotnet');
+    expect(crashedSessionTerm).toEqual(mobileTermsDescription.crashed);
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'dotnet'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'dotnet'
+    );
+    expect(crashFreeSessionTerm).toEqual(mobileTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(SessionTerm.ABNORMAL, 'dotnet');
+    expect(abnormalSessionTerm).toEqual(mobileTermsDescription.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(SessionTerm.HEALTHY, 'dotnet');
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(SessionTerm.ERRORED, 'dotnet');
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'dotnet'
+    );
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
+  });
+
+  it('java terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(SessionTerm.CRASHES, 'java');
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(SessionTerm.CRASHED, 'java');
+    expect(crashedSessionTerm).toEqual(mobileTermsDescription.crashed);
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'java'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'java'
+    );
+    expect(crashFreeSessionTerm).toEqual(mobileTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(SessionTerm.ABNORMAL, 'java');
+    expect(abnormalSessionTerm).toEqual(mobileTermsDescription.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(SessionTerm.HEALTHY, 'java');
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(SessionTerm.ERRORED, 'java');
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(SessionTerm.UNHANDLED, 'java');
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
+  });
+
+  it('java-spring terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHES,
+      'java-spring'
+    );
+    expect(crashesSessionTerm).toEqual(
+      'A request that resulted in an unhandled exception and hence a Server Error response'
+    );
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHED,
+      'java-spring'
+    );
+    expect(crashedSessionTerm).toEqual(mobileTermsDescription.crashed);
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'java-spring'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'java-spring'
+    );
+    expect(crashFreeSessionTerm).toEqual(mobileTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(
+      SessionTerm.ABNORMAL,
+      'java-spring'
+    );
+    expect(abnormalSessionTerm).toEqual(mobileTermsDescription.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(
+      SessionTerm.HEALTHY,
+      'java-spring'
+    );
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(
+      SessionTerm.ERRORED,
+      'java-spring'
+    );
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'java-spring'
+    );
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
+  });
+
+  it('dotnet-aspnetcore terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHES,
+      'dotnet-aspnetcore'
+    );
+    expect(crashesSessionTerm).toEqual(
+      'A request that resulted in an unhandled exception and hence a Server Error response'
+    );
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHED,
+      'dotnet-aspnetcore'
+    );
+    expect(crashedSessionTerm).toEqual(mobileTermsDescription.crashed);
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'dotnet-aspnetcore'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'dotnet-aspnetcore'
+    );
+    expect(crashFreeSessionTerm).toEqual(mobileTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(
+      SessionTerm.ABNORMAL,
+      'dotnet-aspnetcore'
+    );
+    expect(abnormalSessionTerm).toEqual(mobileTermsDescription.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(
+      SessionTerm.HEALTHY,
+      'dotnet-aspnetcore'
+    );
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(
+      SessionTerm.ERRORED,
+      'dotnet-aspnetcore'
+    );
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'dotnet-aspnetcore'
+    );
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
+  });
+
+  it('android terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(SessionTerm.CRASHES, 'android');
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(SessionTerm.CRASHED, 'android');
+    expect(crashedSessionTerm).toEqual(
+      'An unhandled exception that resulted in the application crashing'
+    );
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'android'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'android'
+    );
+    expect(crashFreeSessionTerm).toEqual(mobileTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(
+      SessionTerm.ABNORMAL,
+      'android'
+    );
+    expect(abnormalSessionTerm).toEqual(mobileTermsDescription.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(SessionTerm.HEALTHY, 'android');
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(SessionTerm.ERRORED, 'android');
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'android'
+    );
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
+  });
+
+  it('cordova terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(SessionTerm.CRASHES, 'cordova');
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(SessionTerm.CRASHED, 'cordova');
+    expect(crashedSessionTerm).toEqual(
+      'An unhandled exception that resulted in the application crashing'
+    );
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'cordova'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'cordova'
+    );
+    expect(crashFreeSessionTerm).toEqual(mobileTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(
+      SessionTerm.ABNORMAL,
+      'cordova'
+    );
+    expect(abnormalSessionTerm).toEqual(mobileTermsDescription.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(SessionTerm.HEALTHY, 'cordova');
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(SessionTerm.ERRORED, 'cordova');
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'cordova'
+    );
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
+  });
+
+  it('react-native terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHES,
+      'react-native'
+    );
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHED,
+      'react-native'
+    );
+    expect(crashedSessionTerm).toEqual(
+      'An unhandled exception that resulted in the application crashing'
+    );
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'react-native'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'react-native'
+    );
+    expect(crashFreeSessionTerm).toEqual(mobileTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(
+      SessionTerm.ABNORMAL,
+      'react-native'
+    );
+    expect(abnormalSessionTerm).toEqual(mobileTermsDescription.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(
+      SessionTerm.HEALTHY,
+      'react-native'
+    );
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(
+      SessionTerm.ERRORED,
+      'react-native'
+    );
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'react-native'
+    );
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
+  });
+
+  it('flutter terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(SessionTerm.CRASHES, 'flutter');
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(SessionTerm.CRASHED, 'flutter');
+    expect(crashedSessionTerm).toEqual(
+      'An unhandled exception that resulted in the application crashing'
+    );
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'flutter'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'flutter'
+    );
+    expect(crashFreeSessionTerm).toEqual(mobileTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(
+      SessionTerm.ABNORMAL,
+      'flutter'
+    );
+    expect(abnormalSessionTerm).toEqual(mobileTermsDescription.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(SessionTerm.HEALTHY, 'flutter');
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(SessionTerm.ERRORED, 'flutter');
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'flutter'
+    );
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
+  });
+
+  it('apple terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHES,
+      'apple-macos'
+    );
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHED,
+      'apple-macos'
+    );
+    expect(crashedSessionTerm).toEqual(
+      'An error that resulted in the application crashing'
+    );
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'apple-macos'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'apple-macos'
+    );
+    expect(crashFreeSessionTerm).toEqual(mobileTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(
+      SessionTerm.ABNORMAL,
+      'apple-macos'
+    );
+    expect(abnormalSessionTerm).toEqual(mobileTermsDescription.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(
+      SessionTerm.HEALTHY,
+      'apple-macos'
+    );
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(
+      SessionTerm.ERRORED,
+      'apple-macos'
+    );
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'apple-macos'
+    );
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
+  });
+
+  it('node-express terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHES,
+      'node-express'
+    );
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHED,
+      'node-express'
+    );
+    expect(crashedSessionTerm).toEqual(
+      "During session an error with mechanism.handled===false occurred which is 'onerror' on 'unhandledrejection' handler"
+    );
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'node-express'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'node-express'
+    );
+    expect(crashFreeSessionTerm).toEqual(commonTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(
+      SessionTerm.ABNORMAL,
+      'node-express'
+    );
+    expect(abnormalSessionTerm).toEqual('Non applicable for Javascript');
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(
+      SessionTerm.HEALTHY,
+      'node-express'
+    );
+    expect(healthySessionTerm).toEqual(
+      'No errors were captured during session life-time'
+    );
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(
+      SessionTerm.ERRORED,
+      'node-express'
+    );
+    expect(erroredSessionTerm).toEqual(
+      'During the session at least one error occurred that did not bubble up to the global handler. The application loading process did not crash'
+    );
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'node-express'
+    );
+    expect(unhandledSessionTerm).toEqual(
+      "An error bubbled up to the global 'onerror' or 'onunhandledrejection' handler"
+    );
+  });
+
+  it('javascript terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHES,
+      'javascript'
+    );
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHED,
+      'javascript'
+    );
+    expect(crashedSessionTerm).toEqual(
+      "During session an error with mechanism.handled===false occurred which is 'onerror' on 'unhandledrejection' handler"
+    );
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'javascript'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'javascript'
+    );
+    expect(crashFreeSessionTerm).toEqual(commonTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(
+      SessionTerm.ABNORMAL,
+      'javascript'
+    );
+    expect(abnormalSessionTerm).toEqual('Non applicable for Javascript');
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(
+      SessionTerm.HEALTHY,
+      'javascript'
+    );
+    expect(healthySessionTerm).toEqual(
+      'No errors were captured during session life-time'
+    );
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(
+      SessionTerm.ERRORED,
+      'javascript'
+    );
+    expect(erroredSessionTerm).toEqual(
+      'During the session at least one error occurred that did not bubble up to the global handler. The application loading process did not crash'
+    );
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'javascript'
+    );
+    expect(unhandledSessionTerm).toEqual(
+      "An error bubbled up to the global 'onerror' or 'onunhandledrejection' handler"
+    );
+  });
+
+  it('rust terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(SessionTerm.CRASHES, 'rust');
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(SessionTerm.CRASHED, 'rust');
+    expect(crashedSessionTerm).toEqual(
+      'The application had an unrecovable error (a panic)'
+    );
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'rust'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'rust'
+    );
+    expect(crashFreeSessionTerm).toEqual(commonTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(SessionTerm.ABNORMAL, 'rust');
+    expect(abnormalSessionTerm).toEqual(desktopTermDescriptions.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(SessionTerm.HEALTHY, 'rust');
+    expect(healthySessionTerm).toEqual(desktopTermDescriptions.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(SessionTerm.ERRORED, 'rust');
+    expect(erroredSessionTerm).toEqual(desktopTermDescriptions.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(SessionTerm.UNHANDLED, 'rust');
+    expect(unhandledSessionTerm).toEqual(desktopTermDescriptions.unhandled);
+  });
+
+  it('apple-ios terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHES,
+      'apple-ios'
+    );
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASHED,
+      'apple-ios'
+    );
+    expect(crashedSessionTerm).toEqual(desktopTermDescriptions.crashed);
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'apple-ios'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'apple-ios'
+    );
+    expect(crashFreeSessionTerm).toEqual(commonTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(
+      SessionTerm.ABNORMAL,
+      'apple-ios'
+    );
+    expect(abnormalSessionTerm).toEqual(desktopTermDescriptions.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(
+      SessionTerm.HEALTHY,
+      'apple-ios'
+    );
+    expect(healthySessionTerm).toEqual(desktopTermDescriptions.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(
+      SessionTerm.ERRORED,
+      'apple-ios'
+    );
+    expect(erroredSessionTerm).toEqual(desktopTermDescriptions.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'apple-ios'
+    );
+    expect(unhandledSessionTerm).toEqual(desktopTermDescriptions.unhandled);
+  });
+
+  it('minidump terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(SessionTerm.CRASHES, 'minidump');
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(SessionTerm.CRASHED, 'minidump');
+    expect(crashedSessionTerm).toEqual(desktopTermDescriptions.crashed);
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'minidump'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'minidump'
+    );
+    expect(crashFreeSessionTerm).toEqual(commonTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(
+      SessionTerm.ABNORMAL,
+      'minidump'
+    );
+    expect(abnormalSessionTerm).toEqual(desktopTermDescriptions.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(SessionTerm.HEALTHY, 'minidump');
+    expect(healthySessionTerm).toEqual(desktopTermDescriptions.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(SessionTerm.ERRORED, 'minidump');
+    expect(erroredSessionTerm).toEqual(desktopTermDescriptions.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'minidump'
+    );
+    expect(unhandledSessionTerm).toEqual(desktopTermDescriptions.unhandled);
+  });
+
+  it('native terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(SessionTerm.CRASHES, 'native');
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(SessionTerm.CRASHED, 'native');
+    expect(crashedSessionTerm).toEqual(desktopTermDescriptions.crashed);
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'native'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'native'
+    );
+    expect(crashFreeSessionTerm).toEqual(commonTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(SessionTerm.ABNORMAL, 'native');
+    expect(abnormalSessionTerm).toEqual(desktopTermDescriptions.abnormal);
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(SessionTerm.HEALTHY, 'native');
+    expect(healthySessionTerm).toEqual(desktopTermDescriptions.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(SessionTerm.ERRORED, 'native');
+    expect(erroredSessionTerm).toEqual(desktopTermDescriptions.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'native'
+    );
+    expect(unhandledSessionTerm).toEqual(desktopTermDescriptions.unhandled);
+  });
+
+  it('python terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(SessionTerm.CRASHES, 'python');
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(SessionTerm.CRASHED, 'python');
+    expect(crashedSessionTerm).toEqual(
+      'Number of users who experienced an unhandled error'
+    );
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      'python'
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      'python'
+    );
+    expect(crashFreeSessionTerm).toEqual(commonTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(SessionTerm.ABNORMAL, 'python');
+    expect(abnormalSessionTerm).toEqual('An unknown session exit');
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(SessionTerm.HEALTHY, 'python');
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(SessionTerm.ERRORED, 'python');
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(
+      SessionTerm.UNHANDLED,
+      'python'
+    );
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
+  });
+
+  it('default terms', function () {
+    // Crashes
+    const crashesSessionTerm = getSessionTermDescription(SessionTerm.CRASHES, null);
+    expect(crashesSessionTerm).toEqual(commonTermsDescription.crashes);
+
+    // Crashed
+    const crashedSessionTerm = getSessionTermDescription(SessionTerm.CRASHED, null);
+    expect(crashedSessionTerm).toEqual(
+      'Number of users who experienced an unhandled error'
+    );
+
+    // Crash Free Users
+    const crashFreeUsersSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_USERS,
+      null
+    );
+    expect(crashFreeUsersSessionTerm).toEqual(commonTermsDescription['crash-free-users']);
+
+    // Crash Free Sessions
+    const crashFreeSessionTerm = getSessionTermDescription(
+      SessionTerm.CRASH_FREE_SESSIONS,
+      null
+    );
+    expect(crashFreeSessionTerm).toEqual(commonTermsDescription['crash-free-sessions']);
+
+    // Abnormal
+    const abnormalSessionTerm = getSessionTermDescription(SessionTerm.ABNORMAL, null);
+    expect(abnormalSessionTerm).toEqual('An unknown session exit');
+
+    // Healthy
+    const healthySessionTerm = getSessionTermDescription(SessionTerm.HEALTHY, null);
+    expect(healthySessionTerm).toEqual(mobileTermsDescription.healthy);
+
+    // Errored
+    const erroredSessionTerm = getSessionTermDescription(SessionTerm.ERRORED, null);
+    expect(erroredSessionTerm).toEqual(mobileTermsDescription.errored);
+
+    // Unhandled
+    const unhandledSessionTerm = getSessionTermDescription(SessionTerm.UNHANDLED, null);
+    expect(unhandledSessionTerm).toEqual(mobileTermsDescription.unhandled);
+  });
+});


### PR DESCRIPTION
depends on this PR https://github.com/getsentry/sentry/pull/22190

closes: https://app.asana.com/0/1182975495223897/1199086736853687


Some screenshots:

![image](https://user-images.githubusercontent.com/29228205/100369187-dff04500-3004-11eb-8d5b-3c9423a1643f.png)

![image](https://user-images.githubusercontent.com/29228205/100369202-e67ebc80-3004-11eb-845b-5611c04dced8.png)


ps: I will add some extra info (a number or percentage) to some of the translations in a follow-up PR


