### PR TITLE
ref(ui): Refactor `alerts/utils` to prevent circular import

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/utils/getIncidentDiscoverUrl.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils/getIncidentDiscoverUrl.tsx
@@ -1,0 +1,60 @@
+import {NewQuery, Project} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+import {getAggregateAlias} from 'app/utils/discover/fields';
+import {Dataset} from 'app/views/settings/incidentRules/types';
+import {getStartEndFromStats} from 'app/views/alerts/utils';
+import {Incident, IncidentStats} from 'app/views/alerts/types';
+/**
+ * Gets the URL for a discover view of the incident with the following default
+ * parameters:
+ *
+ * - Ordered by the incident aggregate, descending
+ * - yAxis maps to the aggregate
+ * - The following fields are displayed:
+ *   - For Error dataset alerts: [issue, count(), count_unique(user)]
+ *   - For Transaction dataset alerts: [transaction, count()]
+ * - Start and end are scoped to the same period as the alert rule
+ */
+export function getIncidentDiscoverUrl(opts: {
+  orgSlug: string;
+  projects: Project[];
+  incident?: Incident;
+  stats?: IncidentStats;
+  extraQueryParams?: Partial<NewQuery>;
+}) {
+  const {orgSlug, projects, incident, stats, extraQueryParams} = opts;
+
+  if (!projects || !projects.length || !incident || !stats) {
+    return '';
+  }
+
+  const timeWindowString = `${incident.alertRule.timeWindow}m`;
+  const {start, end} = getStartEndFromStats(stats);
+
+  const discoverQuery: NewQuery = {
+    id: undefined,
+    name: (incident && incident.title) || '',
+    orderby: `-${getAggregateAlias(incident.alertRule.aggregate)}`,
+    yAxis: incident.alertRule.aggregate,
+    query: incident?.discoverQuery ?? '',
+    projects: projects
+      .filter(({slug}) => incident.projects.includes(slug))
+      .map(({id}) => Number(id)),
+    version: 2,
+    fields:
+      incident.alertRule.dataset === Dataset.ERRORS
+        ? ['issue', 'count()', 'count_unique(user)']
+        : ['transaction', incident.alertRule.aggregate],
+    start,
+    end,
+    ...extraQueryParams,
+  };
+
+  const discoverView = EventView.fromSavedQuery(discoverQuery);
+  const {query, ...toObject} = discoverView.getResultsViewUrlTarget(orgSlug);
+
+  return {
+    query: {...query, interval: timeWindowString},
+    ...toObject,
+  };
+}

--- a/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
@@ -13,7 +13,7 @@ import {
 import {PRESET_AGGREGATES} from 'app/views/settings/incidentRules/presets';
 import {IssueAlertRule} from 'app/types/alerts';
 
-import {Incident, IncidentStats, IncidentStatus} from './types';
+import {Incident, IncidentStats, IncidentStatus} from '../types';
 
 export function fetchIncident(
   api: Client,

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/presets.tsx
@@ -1,11 +1,12 @@
 import {t} from 'app/locale';
-import {Incident, IncidentStats} from 'app/views/alerts/types';
 import {Project} from 'app/types';
 import Link from 'app/components/links/link';
 import {DisplayModes} from 'app/utils/discover/types';
 import {tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {Incident, IncidentStats} from 'app/views/alerts/types';
+import {getStartEndFromStats} from 'app/views/alerts/utils';
+import {getIncidentDiscoverUrl} from 'app/views/alerts/utils/getIncidentDiscoverUrl';
 import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
-import {getIncidentDiscoverUrl, getStartEndFromStats} from 'app/views/alerts/utils';
 
 import {Dataset} from './types';
 

--- a/tests/js/spec/views/alerts/utils.spec.jsx
+++ b/tests/js/spec/views/alerts/utils.spec.jsx
@@ -1,7 +1,7 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {Dataset} from 'app/views/settings/incidentRules/types';
-import {getIncidentDiscoverUrl} from 'app/views/alerts/utils';
+import {getIncidentDiscoverUrl} from 'app/views/alerts/utils/getIncidentDiscoverUrl';
 
 describe('Alert utils', function () {
   const {org, projects} = initializeOrg();

--- a/tests/js/spec/views/settings/incidentRules/presets.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/presets.spec.jsx
@@ -1,19 +1,17 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {DisplayModes} from 'app/utils/discover/types';
-import {Dataset} from 'app/views/settings/incidentRules/types';
-import {PRESET_AGGREGATES} from 'app/views/settings/incidentRules/presets';
-import {getIncidentDiscoverUrl} from 'app/views/alerts/utils';
+import {getIncidentDiscoverUrl} from 'app/views/alerts/utils/getIncidentDiscoverUrl';
 import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
+import {PRESET_AGGREGATES} from 'app/views/settings/incidentRules/presets';
+import {Dataset} from 'app/views/settings/incidentRules/types';
 
 jest.mock('app/views/performance/transactionSummary/utils', () => ({
   transactionSummaryRouteWithQuery: jest.fn(),
 }));
 
-jest.mock('app/views/alerts/utils', () => {
-  const actual = jest.requireActual('app/views/alerts/utils');
+jest.mock('app/views/alerts/utils/getIncidentDiscoverUrl', () => {
   return {
-    ...actual,
     getIncidentDiscoverUrl: jest.fn(),
   };
 });


### PR DESCRIPTION
This refactors `alerts/utils` into a directory, and splits out `getIncidentDiscoverUrl` into a separate module because there is a circular import with `incidentRules/presets`

This is required for https://github.com/getsentry/sentry/pull/22104 as resorting of imports causes a test to fail.