### PR TITLE
fix(vitals): Default to slow lcp view when clicking through to releases

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
@@ -205,7 +205,10 @@ class VitalsChart extends React.Component<Props> {
                   <ReleaseSeries
                     start={start}
                     end={end}
-                    queryExtra={queryExtra}
+                    queryExtra={{
+                      ...queryExtra,
+                      showTransactions: 'slow_lcp',
+                    }}
                     period={statsPeriod}
                     utc={utc}
                     projects={project}

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
@@ -89,7 +89,7 @@ const ReleaseChartControls = ({
     },
     {
       value: YAxis.FAILED_TRANSACTIONS,
-      label: t('Failed Transactions'),
+      label: t('Failed Transaction Count'),
       disabled: !hasPerformance,
       hidden: !hasPerformance,
       tooltip: noPerformanceTooltip,
@@ -110,7 +110,7 @@ const ReleaseChartControls = ({
     },
     {
       value: YAxis.ALL_TRANSACTIONS,
-      label: t('All Transactions'),
+      label: t('Transaction Count'),
       disabled: !hasPerformance,
       hidden: !hasPerformance,
       tooltip: noPerformanceTooltip,

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -362,12 +362,12 @@ function getDropdownOptions(): DropdownOption[] {
     },
     {
       sort: {kind: 'desc', field: 'p50'},
-      value: 'p50',
+      value: 'slow',
       label: t('Slow Transactions'),
     },
     {
       sort: {kind: 'desc', field: 'p75_measurements_lcp'},
-      value: 'p75_lcp',
+      value: 'slow_lcp',
       label: t('Slow LCP'),
     },
     {


### PR DESCRIPTION
Clicking on the release series on the vitals summary page takes you to the
releases, but the transactions list still shows the top failing transaction.
Since the user is coming from the vitals summary view, we should default to
showing the slowest transactions in terms of LCP.

Closes VIS-397