### PR TITLE
fix(stacktrace-linking): fixes issue when filename is missing

### DIFF
--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -95,6 +95,8 @@ export default class AsyncComponent<
   // should `renderError` render the `detail` attribute of a 400 error
   shouldRenderBadRequests = false;
 
+  shouldRaiseRequestErrorToParent = false;
+
   constructor(props: P, context: any) {
     super(props, context);
 
@@ -400,6 +402,7 @@ export default class AsyncComponent<
     return <LoadingIndicator />;
   }
 
+  //void if subclass throws an error
   renderError(error?: Error, disableLog = false, disableReport = false): React.ReactNode {
     const {errors} = this.state;
 
@@ -439,6 +442,10 @@ export default class AsyncComponent<
       if (badRequests.length) {
         return <LoadingError message={badRequests.join('\n')} />;
       }
+    }
+
+    if (this.shouldRaiseRequestErrorToParent) {
+      throw error;
     }
 
     return (

--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -92,7 +92,8 @@ export default class AsyncComponent<
   // and it will need to handle any additional "reloading" states
   shouldReload = false;
 
-  shouldRaiseRequestErrorToParent = false;
+  // should `renderError` render the `detail` attribute of a 400 error
+  shouldRenderBadRequests = false;
 
   constructor(props: P, context: any) {
     super(props, context);

--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -92,9 +92,6 @@ export default class AsyncComponent<
   // and it will need to handle any additional "reloading" states
   shouldReload = false;
 
-  // should `renderError` render the `detail` attribute of a 400 error
-  shouldRenderBadRequests = false;
-
   shouldRaiseRequestErrorToParent = false;
 
   constructor(props: P, context: any) {
@@ -402,7 +399,6 @@ export default class AsyncComponent<
     return <LoadingIndicator />;
   }
 
-  //void if subclass throws an error
   renderError(error?: Error, disableLog = false, disableReport = false): React.ReactNode {
     const {errors} = this.state;
 
@@ -442,10 +438,6 @@ export default class AsyncComponent<
       if (badRequests.length) {
         return <LoadingError message={badRequests.join('\n')} />;
       }
-    }
-
-    if (this.shouldRaiseRequestErrorToParent) {
-      throw error;
     }
 
     return (

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
@@ -92,7 +92,8 @@ const Context = ({
               )}
               {organization?.features.includes('integrations-stacktrace-link') &&
                 isActive &&
-                isExpanded && (
+                isExpanded &&
+                frame.filename && (
                   <ErrorBoundary mini>
                     <StacktraceLink
                       key={index}

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -37,8 +37,6 @@ type State = AsyncComponent['state'] & {
 };
 
 class StacktraceLink extends AsyncComponent<Props, State> {
-  shouldRenderBadRequests = true;
-  shouldRaiseRequestErrorToParent = true;
   get project() {
     // we can't use the withProject HoC on an the issue page
     // so we ge around that by using the withProjects HoC
@@ -114,6 +112,11 @@ class StacktraceLink extends AsyncComponent<Props, State> {
         {startSession: true}
       );
     }
+  }
+
+  // let the ErrorBoundary handle errors by raising it
+  renderError(): React.ReactNode {
+    throw new Error('Error loading endpoints');
   }
 
   renderLoading() {

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -37,7 +37,6 @@ type State = AsyncComponent['state'] & {
 };
 
 class StacktraceLink extends AsyncComponent<Props, State> {
-  shouldRenderBadRequests = true;
   get project() {
     // we can't use the withProject HoC on an the issue page
     // so we ge around that by using the withProjects HoC
@@ -114,6 +113,12 @@ class StacktraceLink extends AsyncComponent<Props, State> {
       );
     }
   }
+
+  renderError() {
+    //let the ErrorBoundary parent handle errors instead of AsyncComponent
+    throw new Error('Error ocurred loading endpoints');
+  }
+
   renderLoading() {
     //TODO: Add loading
     return null;

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -37,6 +37,7 @@ type State = AsyncComponent['state'] & {
 };
 
 class StacktraceLink extends AsyncComponent<Props, State> {
+  shouldRenderBadRequests = true;
   get project() {
     // we can't use the withProject HoC on an the issue page
     // so we ge around that by using the withProjects HoC

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -37,6 +37,8 @@ type State = AsyncComponent['state'] & {
 };
 
 class StacktraceLink extends AsyncComponent<Props, State> {
+  shouldRenderBadRequests = true;
+  shouldRaiseRequestErrorToParent = true;
   get project() {
     // we can't use the withProject HoC on an the issue page
     // so we ge around that by using the withProjects HoC
@@ -112,11 +114,6 @@ class StacktraceLink extends AsyncComponent<Props, State> {
         {startSession: true}
       );
     }
-  }
-
-  renderError() {
-    //let the ErrorBoundary parent handle errors instead of AsyncComponent
-    throw new Error('Error ocurred loading endpoints');
   }
 
   renderLoading() {


### PR DESCRIPTION
This fixes the problem where we get a 400 error trying to load up the stack trace config if the file name is missing.
1. Don't load the `StacktraceLink` component if `frame.filename` is missing
2. Overwrite `AsyncComponent` error handling behavior to let the parent error boundary component handle errors so an error doesn't generate a popup

![Screen Shot 2020-11-20 at 10 52 07 AM](https://user-images.githubusercontent.com/8533851/99838845-9bedd380-2b1e-11eb-9250-9c59f7807c1b.png)
