### PR TITLE
fix(async-csv): Validate query before starting export

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -4,10 +4,10 @@ import six
 from django.core.exceptions import ValidationError
 from rest_framework import serializers
 from rest_framework.response import Response
-from rest_framework.exceptions import ParseError
 from sentry import features
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationDataExportPermission
+from sentry.api.event_search import get_filter, InvalidSearchQuery
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.models import Environment
@@ -18,11 +18,69 @@ from sentry.utils.snuba import MAX_FIELDS
 from ..base import ExportQueryType
 from ..models import ExportedData
 from ..tasks import assemble_download
+from ..processors.discover import DiscoverProcessor
 
 
 class DataExportQuerySerializer(serializers.Serializer):
     query_type = serializers.ChoiceField(choices=ExportQueryType.as_str_choices(), required=True)
     query_info = serializers.JSONField(required=True)
+
+    def validate(self, data):
+        organization = self.context["organization"]
+        query_info = data["query_info"]
+
+        # Validate the project field, if provided
+        # A PermissionDenied error will be raised in `get_projects_by_id` if the request is invalid
+        project_query = query_info.get("project")
+        if project_query:
+            get_projects_by_id = self.context["get_projects_by_id"]
+            # Coerce the query into a set
+            if isinstance(project_query, list):
+                projects = get_projects_by_id(set(map(int, project_query)))
+            else:
+                projects = get_projects_by_id({int(project_query)})
+            query_info["project"] = [project.id for project in projects]
+
+        # Discover Pre-processing
+        if data["query_type"] == ExportQueryType.DISCOVER_STR:
+            # coerce the fields into a list as needed
+            fields = query_info.get("field", [])
+            if not isinstance(fields, list):
+                fields = [fields]
+
+            if len(fields) > MAX_FIELDS:
+                detail = "You can export up to {0} fields at a time. Please delete some and try again.".format(
+                    MAX_FIELDS
+                )
+                raise serializers.ValidationError(detail)
+
+            query_info["field"] = fields
+
+            if "project" not in query_info:
+                projects = self.context["get_projects"]()
+                query_info["project"] = [project.id for project in projects]
+
+            # make sure to fix the export start/end times to ensure consistent results
+            start, end = get_date_range_from_params(query_info)
+            if "statsPeriod" in query_info:
+                del query_info["statsPeriod"]
+            if "statsPeriodStart" in query_info:
+                del query_info["statsPeriodStart"]
+            if "statsPeriodEnd" in query_info:
+                del query_info["statsPeriodEnd"]
+            query_info["start"] = start.isoformat()
+            query_info["end"] = end.isoformat()
+
+            # validate the query string by trying to parse it
+            processor = DiscoverProcessor(
+                discover_query=query_info, organization_id=organization.id,
+            )
+            try:
+                get_filter(query_info["query"], processor.params)
+            except InvalidSearchQuery as err:
+                raise serializers.ValidationError(six.text_type(err))
+
+        return data
 
 
 class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
@@ -46,53 +104,19 @@ class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
         limit = request.data.get("limit")
 
         # Validate the data export payload
-        serializer = DataExportQuerySerializer(data=request.data)
+        serializer = DataExportQuerySerializer(
+            data=request.data,
+            context={
+                "organization": organization,
+                "get_projects_by_id": lambda project_query: self._get_projects_by_id(
+                    project_query, request, organization
+                ),
+                "get_projects": lambda: self.get_projects(request, organization),
+            },
+        )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
         data = serializer.validated_data
-
-        # Validate the project field, if provided
-        # A PermissionDenied error will be raised in `_get_projects_by_id` if the request is invalid
-        project_query = data["query_info"].get("project")
-        if project_query:
-            # Coerce the query into a set
-            if isinstance(project_query, list):
-                projects = self._get_projects_by_id(
-                    set(map(int, project_query)), request, organization
-                )
-            else:
-                projects = self._get_projects_by_id({int(project_query)}, request, organization)
-            data["query_info"]["project"] = [project.id for project in projects]
-
-        # Discover Pre-processing
-        if data["query_type"] == ExportQueryType.DISCOVER_STR:
-            query_info = data["query_info"]
-
-            fields = query_info.get("field", [])
-            if not isinstance(fields, list):
-                fields = [fields]
-
-            if len(fields) > MAX_FIELDS:
-                detail = "You can export up to {0} fields at a time. Please delete some and try again.".format(
-                    MAX_FIELDS
-                )
-                raise ParseError(detail=detail)
-
-            query_info["field"] = fields
-
-            if "project" not in query_info:
-                projects = self.get_projects(request, organization)
-                query_info["project"] = [project.id for project in projects]
-
-            start, end = get_date_range_from_params(query_info)
-            if "statsPeriod" in query_info:
-                del query_info["statsPeriod"]
-            if "statsPeriodStart" in query_info:
-                del query_info["statsPeriodStart"]
-            if "statsPeriodEnd" in query_info:
-                del query_info["statsPeriodEnd"]
-            query_info["start"] = start.isoformat()
-            query_info["end"] = end.isoformat()
 
         try:
             # If this user has sent a sent a request with the same payload and organization,

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -119,7 +119,7 @@ class DataExportEndpoint(OrganizationEndpoint, EnvironmentMixin):
         data = serializer.validated_data
 
         try:
-            # If this user has sent a sent a request with the same payload and organization,
+            # If this user has sent a request with the same payload and organization,
             # we return them the latest one that is NOT complete (i.e. don't start another)
             query_type = ExportQueryType.from_str(data["query_type"])
             data_export, created = ExportedData.objects.get_or_create(

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -13,25 +13,33 @@ from sentry.testutils import APITestCase
 class DataExportTest(APITestCase):
     endpoint = "sentry-api-0-organization-data-export"
     method = "post"
-    payload = {"query_type": ExportQueryType.ISSUES_BY_TAG_STR, "query_info": {"env": "test"}}
 
     def setUp(self):
         self.user = self.create_user("user1@example.com")
-        self.organization = self.create_organization(owner=self.user)
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
         self.login_as(user=self.user)
+        self.issue_payload = {
+            "query_type": ExportQueryType.ISSUES_BY_TAG_STR,
+            "query_info": {"env": "test", "project": [self.project.id]},
+        }
+        self.discover_payload = {
+            "query_type": ExportQueryType.DISCOVER_STR,
+            "query_info": {"field": ["id"], "query": "", "project": [self.project.id]},
+        }
 
     def test_authorization(self):
         with self.feature({"organizations:discover-query": False}):
             # Without the discover-query feature, the endpoint should 404
-            self.get_valid_response(self.organization.slug, status_code=404, **self.payload)
+            self.get_valid_response(self.org.slug, status_code=404, **self.issue_payload)
         # Without project permissions, the endpoint should 403
-        modified_payload = {"query_type": self.payload["query_type"], "query_info": {"project": -5}}
+        modified_payload = self.issue_payload.copy()
+        modified_payload["query_info"] = {"project": -5}
         with self.feature("organizations:discover-query"):
-            self.get_valid_response(self.organization.slug, status_code=403, **modified_payload)
+            self.get_valid_response(self.org.slug, status_code=403, **modified_payload)
         # With the right permissions, the endpoint should 201
-        discover_payload = {"query_type": "Discover", "query_info": self.payload["query_info"]}
         with self.feature("organizations:discover-query"):
-            self.get_valid_response(self.organization.slug, status_code=201, **discover_payload)
+            self.get_valid_response(self.org.slug, status_code=201, **self.issue_payload)
 
     def test_new_export(self):
         """
@@ -39,9 +47,7 @@ class DataExportTest(APITestCase):
         and an appropriate response object
         """
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(
-                self.organization.slug, status_code=201, **self.payload
-            )
+            response = self.get_valid_response(self.org.slug, status_code=201, **self.issue_payload)
         data_export = ExportedData.objects.get(id=response.data["id"])
         assert response.data == {
             "id": data_export.id,
@@ -53,7 +59,10 @@ class DataExportTest(APITestCase):
             "dateCreated": data_export.date_added,
             "dateFinished": None,
             "dateExpired": None,
-            "query": {"type": self.payload["query_type"], "info": self.payload["query_info"]},
+            "query": {
+                "type": self.issue_payload["query_type"],
+                "info": self.issue_payload["query_info"],
+            },
             "status": ExportStatus.Early,
             "checksum": None,
             "fileName": None,
@@ -65,10 +74,10 @@ class DataExportTest(APITestCase):
         are routed to the same ExportedData object, with a 200 status code
         """
         with self.feature("organizations:discover-query"):
-            response1 = self.get_response(self.organization.slug, **self.payload)
+            response1 = self.get_response(self.org.slug, **self.issue_payload)
         data_export = ExportedData.objects.get(id=response1.data["id"])
         with self.feature("organizations:discover-query"):
-            response2 = self.get_valid_response(self.organization.slug, **self.payload)
+            response2 = self.get_valid_response(self.org.slug, **self.issue_payload)
         assert response2.data == {
             "id": data_export.id,
             "user": {
@@ -93,14 +102,10 @@ class DataExportTest(APITestCase):
         Ensures that if a single field is passed, we convert it to a list before making
         a snuba query.
         """
-        payload = {
-            "query_type": ExportQueryType.DISCOVER_STR,
-            "query_info": {"env": "test", "field": "id"},
-        }
-        result_query_info = payload["query_info"].copy()
-        result_query_info["field"] = [result_query_info["field"]]
+        payload = self.discover_payload.copy()
+        payload["query_info"].update({"field": "id"})
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(self.organization.slug, status_code=201, **payload)
+            response = self.get_valid_response(self.org.slug, status_code=201, **payload)
         data_export = ExportedData.objects.get(id=response.data["id"])
         # because we passed a single string as the field, we should convert it into a list
         # this happens when the user selects only a single field and it results in a string
@@ -112,14 +117,14 @@ class DataExportTest(APITestCase):
         Ensures that if too many fields are requested, returns a 400 status code with the
         corresponding error message.
         """
-        payload = {
-            "query_type": ExportQueryType.DISCOVER_STR,
-            "query_info": {"env": "test", "field": ["id"] * (MAX_FIELDS + 1)},
-        }
+        payload = self.discover_payload.copy()
+        payload["query_info"].update({"field": ["id"] * (MAX_FIELDS + 1)})
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(self.organization.slug, status_code=400, **payload)
+            response = self.get_valid_response(self.org.slug, status_code=400, **payload)
         assert response.data == {
-            "detail": "You can export up to 20 fields at a time. Please delete some and try again."
+            "non_field_errors": [
+                "You can export up to 20 fields at a time. Please delete some and try again."
+            ]
         }
 
     @freeze_time("2020-05-19 14:00:00")
@@ -127,12 +132,10 @@ class DataExportTest(APITestCase):
         """
         Ensures that statsPeriod is converted to start/end.
         """
-        payload = {
-            "query_type": ExportQueryType.DISCOVER_STR,
-            "query_info": {"env": "test", "statsPeriod": "24h"},
-        }
+        payload = self.discover_payload.copy()
+        payload["query_info"].update({"statsPeriod": "24h"})
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(self.organization.slug, status_code=201, **payload)
+            response = self.get_valid_response(self.org.slug, status_code=201, **payload)
         data_export = ExportedData.objects.get(id=response.data["id"])
         query_info = data_export.query_info
         assert parse_datetime_string(query_info["start"]) == parse_datetime_string(
@@ -150,12 +153,10 @@ class DataExportTest(APITestCase):
         """
         Ensures that statsPeriodStart and statsPeriodEnd is converted to start/end.
         """
-        payload = {
-            "query_type": ExportQueryType.DISCOVER_STR,
-            "query_info": {"env": "test", "statsPeriodStart": "1w", "statsPeriodEnd": "5d"},
-        }
+        payload = self.discover_payload.copy()
+        payload["query_info"].update({"statsPeriodStart": "1w", "statsPeriodEnd": "5d"})
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(self.organization.slug, status_code=201, **payload)
+            response = self.get_valid_response(self.org.slug, status_code=201, **payload)
         data_export = ExportedData.objects.get(id=response.data["id"])
         query_info = data_export.query_info
         assert parse_datetime_string(query_info["start"]) == parse_datetime_string(
@@ -172,16 +173,10 @@ class DataExportTest(APITestCase):
         """
         Ensures that start/end is preserved
         """
-        payload = {
-            "query_type": ExportQueryType.DISCOVER_STR,
-            "query_info": {
-                "env": "test",
-                "start": "2020-05-18T14:00:00",
-                "end": "2020-05-19T14:00:00",
-            },
-        }
+        payload = self.discover_payload.copy()
+        payload["query_info"].update({"start": "2020-05-18T14:00:00", "end": "2020-05-19T14:00:00"})
         with self.feature("organizations:discover-query"):
-            response = self.get_valid_response(self.organization.slug, status_code=201, **payload)
+            response = self.get_valid_response(self.org.slug, status_code=201, **payload)
         data_export = ExportedData.objects.get(id=response.data["id"])
         query_info = data_export.query_info
         assert parse_datetime_string(query_info["start"]) == parse_datetime_string(
@@ -193,3 +188,13 @@ class DataExportTest(APITestCase):
         assert "statsPeriod" not in query_info
         assert "statsPeriodStart" not in query_info
         assert "statsPeriodSEnd" not in query_info
+
+    def test_validates_query_info(self):
+        """
+        Ensures that bad queries are rejected.
+        """
+        payload = self.discover_payload.copy()
+        payload["query_info"].update({"query": "foo:"})
+        with self.feature("organizations:discover-query"):
+            response = self.get_valid_response(self.org.slug, status_code=400, **payload)
+        assert response.data == {"non_field_errors": ["Empty string after 'foo:'"]}


### PR DESCRIPTION
Data exports do not validate the query prior to scheduling the task. This means
that if an invalid query was submitted, it'd propogate up as an error in the
data export. This change makes sure to validate the query prior to scheduling
the task.

Closes VIS-311