### PR TITLE
fix(metric_alerts): Disable metric selector when form is disabled

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -62,6 +62,7 @@ type Props = {
    */
   inFieldLabels?: boolean;
   onChange: (fieldValue: QueryFieldValue) => void;
+  disabled?: boolean;
 };
 
 // Type for completing generics in react-select
@@ -281,7 +282,7 @@ class QueryField extends React.Component<Props> {
   }
 
   renderParameterInputs(parameters: ParameterDescription[]): React.ReactNode[] {
-    const {inFieldLabels} = this.props;
+    const {disabled, inFieldLabels} = this.props;
     const inputs = parameters.map((descriptor: ParameterDescription, index: number) => {
       if (descriptor.kind === 'column' && descriptor.options.length > 0) {
         return (
@@ -294,6 +295,7 @@ class QueryField extends React.Component<Props> {
             required={descriptor.required}
             onChange={this.handleFieldParameterChange}
             inFieldLabel={inFieldLabels ? t('Parameter: ') : undefined}
+            disabled={disabled}
           />
         );
       }
@@ -305,6 +307,7 @@ class QueryField extends React.Component<Props> {
           required: descriptor.required,
           value: descriptor.value,
           onUpdate: handler,
+          disabled,
         };
         switch (descriptor.dataType) {
           case 'number':
@@ -357,7 +360,13 @@ class QueryField extends React.Component<Props> {
   }
 
   render() {
-    const {className, takeFocus, filterPrimaryOptions, inFieldLabels} = this.props;
+    const {
+      className,
+      takeFocus,
+      filterPrimaryOptions,
+      inFieldLabels,
+      disabled,
+    } = this.props;
     const {field, fieldOptions, parameterDescriptions} = this.getFieldData();
 
     const allFieldOptions = filterPrimaryOptions
@@ -371,6 +380,7 @@ class QueryField extends React.Component<Props> {
       value: field,
       onChange: this.handleFieldChange,
       inFieldLabel: inFieldLabels ? t('Function: ') : undefined,
+      disabled,
     };
     if (takeFocus && field === null) {
       selectProps.autoFocus = true;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -86,7 +86,7 @@ const help = ({name, model}: {name: string; model: FormModel}) => {
 
 const MetricField = ({organization, columnWidth, inFieldLabels, ...props}: Props) => (
   <FormField help={help} {...props}>
-    {({onChange, value, model}) => {
+    {({onChange, value, model, disabled}) => {
       const dataset = model.getValue('dataset');
 
       const fieldOptionsConfig = getFieldOptionConfig(dataset);
@@ -121,6 +121,7 @@ const MetricField = ({organization, columnWidth, inFieldLabels, ...props}: Props
             columnWidth={columnWidth}
             gridColumns={numParameters}
             inFieldLabels={inFieldLabels}
+            disabled={disabled}
           />
         </React.Fragment>
       );


### PR DESCRIPTION
Previously we didn't pass in a disabled prop to the `MetricField` which meant non-admins could still tinker with the field (couldn't save the rule though). Quick fix to pass the disabled prop down to the `SelectControls`

**Before:**
![image](https://user-images.githubusercontent.com/9372512/99850567-978bdf80-2b4b-11eb-9fcf-50e25e2f8493.png)

**After:**
![image](https://user-images.githubusercontent.com/9372512/99851239-d53d3800-2b4c-11eb-995b-41ea0e13548d.png)


shoutout to @Zylphrex for showing us this a while back