### PR TITLE
fix(ui): Add autocomplete for Teams

### DIFF
--- a/src/sentry/static/sentry/app/utils/withIssueTags.tsx
+++ b/src/sentry/static/sentry/app/utils/withIssueTags.tsx
@@ -87,7 +87,9 @@ const withIssueTags = <P extends InjectedTagsProps>(
         .filter(team => team.isMember)
         .map(team => `#${team.name}`);
       const allAssigned = usernames.concat(teamnames);
-      allAssigned.unshift('me') && usernames.unshift('me');
+      allAssigned.unshift('me');
+      usernames.unshift('me');
+
       this.setState({
         tags: {
           ...tags,

--- a/src/sentry/static/sentry/app/utils/withIssueTags.tsx
+++ b/src/sentry/static/sentry/app/utils/withIssueTags.tsx
@@ -30,14 +30,6 @@ const getUsername = ({isManaged, username, email}: User) => {
   }
 };
 
-const getTeamName = ({name, isMember}: Team) => {
-  if (isMember) {
-    return name;
-  } else {
-    return null;
-  }
-};
-
 /**
  * HOC for getting tags and many useful issue attributes as 'tags' for use
  * in autocomplete selectors or condition builders.
@@ -89,28 +81,26 @@ const withIssueTags = <P extends InjectedTagsProps>(
     },
 
     setAssigned() {
-      if (this.state.tags.assigned) {
-        const {tags, users, teams} = this.state;
-        const usernames: string[] = users.map(getUsername);
-        const teamnames: string[] = teams
-          .filter(getTeamName)
-          .map(team => `#${team.name}`);
-        const allAssigned = usernames.concat(teamnames);
-        allAssigned.unshift('me') && usernames.unshift('me');
-        this.setState({
-          tags: {
-            ...tags,
-            assigned: {
-              ...tags.assigned,
-              values: allAssigned,
-            },
-            bookmarks: {
-              ...tags.bookmarks,
-              values: usernames,
-            },
+      const {tags, users, teams} = this.state;
+      const usernames: string[] = users.map(getUsername);
+      const teamnames: string[] = teams
+        .filter(team => team.isMember)
+        .map(team => `#${team.name}`);
+      const allAssigned = usernames.concat(teamnames);
+      allAssigned.unshift('me') && usernames.unshift('me');
+      this.setState({
+        tags: {
+          ...tags,
+          assigned: {
+            ...tags.assigned,
+            values: allAssigned,
           },
-        });
-      }
+          bookmarks: {
+            ...tags.bookmarks,
+            values: usernames,
+          },
+        },
+      });
     },
 
     render() {

--- a/src/sentry/static/sentry/app/views/issueList/searchBar.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/searchBar.tsx
@@ -35,7 +35,7 @@ const SEARCH_ITEMS: SearchItem[] = [
   },
   {
     title: t('Assigned'),
-    desc: 'assigned:[me|user@example.com]',
+    desc: 'assigned:[me|user@example.com|#team-example]',
     value: 'assigned:',
     type: 'default',
   },

--- a/tests/js/spec/utils/withIssueTags.spec.jsx
+++ b/tests/js/spec/utils/withIssueTags.spec.jsx
@@ -4,6 +4,7 @@ import {mount} from 'sentry-test/enzyme';
 
 import MemberListStore from 'app/stores/memberListStore';
 import TagStore from 'app/stores/tagStore';
+import TeamStore from 'app/stores/teamStore';
 import withIssueTags from 'app/utils/withIssueTags';
 
 describe('withIssueTags HoC', function () {
@@ -37,7 +38,7 @@ describe('withIssueTags HoC', function () {
     expect(tagsProp['stack.filename']).toBeTruthy();
   });
 
-  it('updates the assigned and bookmark tags with users', async function () {
+  it('updates the assigned tags with users and teams, and bookmark tags with users', async function () {
     const MyComponent = () => null;
     const Container = withIssueTags(MyComponent);
     const wrapper = mount(<Container other="value" />);
@@ -53,6 +54,9 @@ describe('withIssueTags HoC', function () {
     expect(tagsProp.assigned.values).toEqual(['me']);
 
     const users = [TestStubs.User(), TestStubs.User({username: 'joe@example.com'})];
+    TeamStore.loadInitialData([
+      {slug: 'best-team-na', name: 'best-team-na', isMember: true},
+    ]);
     MemberListStore.loadInitialData(users);
     await wrapper.update();
 
@@ -61,6 +65,7 @@ describe('withIssueTags HoC', function () {
       'me',
       'foo@example.com',
       'joe@example.com',
+      '#best-team-na',
     ]);
     expect(tagsProp.bookmarks.values).toEqual([
       'me',


### PR DESCRIPTION
Add autocomplete for Teams using the assigned key in Issue search.

<img width="499" alt="Screen Shot 2020-11-22 at 5 30 00 AM" src="https://user-images.githubusercontent.com/20312973/99908508-e8105380-2c97-11eb-864d-75f191cd2950.png">
<img width="465" alt="Screen Shot 2020-11-22 at 5 30 10 AM" src="https://user-images.githubusercontent.com/20312973/99908509-e9418080-2c97-11eb-8813-5fa766c6b032.png">
