### PR TITLE
feat(ui): Show settings gear next to selected project

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
@@ -399,6 +399,7 @@ class GlobalSelectionHeader extends React.Component<Props, State> {
                     shouldForceProject={shouldForceProject}
                     forceProject={forceProject}
                     projects={loadingProjects ? projects : memberProjects}
+                    selectedProjects={selectedProjects}
                     isGlobalSelectionReady={isGlobalSelectionReady}
                     isLoadingProjects={!initiallyLoaded}
                     nonMemberProjects={nonMemberProjects}

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
@@ -191,7 +191,7 @@ const SettingsIconLink = styled(Link)`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: ${space(1)};
+  padding: ${space(1)} ${space(1)} ${space(1)} 0;
   transition: 0.5s opacity ease-out;
 
   &:hover {
@@ -200,7 +200,7 @@ const SettingsIconLink = styled(Link)`
 `;
 
 const StyledLock = styled(IconLock)`
-  margin-top: ${space(0.75)};
+  margin: ${space(0.75)} ${space(0.75)} 0 0;
   stroke-width: 1.5;
 `;
 

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 
 import Tooltip from 'app/components/tooltip';
 import {IconChevron, IconClose, IconInfo, IconLock, IconSettings} from 'app/icons';
-import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 
 type DefaultProps = {
@@ -81,7 +80,14 @@ class HeaderItem extends React.Component<Props> {
         {...textColorProps}
       >
         <IconContainer {...textColorProps}>{icon}</IconContainer>
-        <Content>{children}</Content>
+        <Content>
+          <div>{children}</div>
+          {settingsLink && (
+            <SettingsIconLink to={settingsLink}>
+              <IconSettings />
+            </SettingsIconLink>
+          )}
+        </Content>
         {hint && (
           <Hint>
             <Tooltip title={hint} position="bottom">
@@ -91,11 +97,6 @@ class HeaderItem extends React.Component<Props> {
         )}
         {hasSelected && !locked && allowClear && (
           <StyledClose {...textColorProps} onClick={this.handleClear} />
-        )}
-        {settingsLink && (
-          <SettingsIconLink to={settingsLink}>
-            <IconSettings />
-          </SettingsIconLink>
         )}
         {!locked && !loading && (
           <StyledChevron isOpen={isOpen}>
@@ -147,9 +148,15 @@ const StyledHeaderItem = styled('div', {
 `;
 
 const Content = styled('div')`
+  display: flex;
   flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
   margin-right: ${space(1.5)};
-  ${overflowEllipsis};
+  div {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 `;
 
 const IconContainer = styled('span', {shouldForwardProp: isPropValid})<ColorProps>`
@@ -188,10 +195,11 @@ const StyledChevron = styled('div')<StyledChevronProps>`
 
 const SettingsIconLink = styled(Link)`
   color: ${p => p.theme.gray300};
-  display: flex;
   align-items: center;
+  display: inline-flex;
   justify-content: space-between;
-  padding: ${space(1)} ${space(1)} ${space(1)} 0;
+  margin-right: ${space(1.5)};
+  margin-left: ${space(1.0)};
   transition: 0.5s opacity ease-out;
 
   &:hover {
@@ -200,7 +208,7 @@ const SettingsIconLink = styled(Link)`
 `;
 
 const StyledLock = styled(IconLock)`
-  margin: ${space(0.75)} ${space(0.75)} 0 0;
+  margin-top: ${space(0.75)};
   stroke-width: 1.5;
 `;
 

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
@@ -81,7 +81,7 @@ class HeaderItem extends React.Component<Props> {
       >
         <IconContainer {...textColorProps}>{icon}</IconContainer>
         <Content>
-          <div>{children}</div>
+          <StyledContent>{children}</StyledContent>
           {settingsLink && (
             <SettingsIconLink to={settingsLink}>
               <IconSettings />
@@ -153,10 +153,11 @@ const Content = styled('div')`
   white-space: nowrap;
   overflow: hidden;
   margin-right: ${space(1.5)};
-  div {
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
+`;
+
+const StyledContent = styled('div')`
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const IconContainer = styled('span', {shouldForwardProp: isPropValid})<ColorProps>`

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -288,6 +288,12 @@ export default class MultipleProjectSelector extends React.PureComponent {
                   isOpen={isOpen}
                   onClear={this.handleClear}
                   allowClear={multi}
+                  forceProject={forceProject}
+                  settingsLink={
+                    selectedProjects.length === 1
+                      ? `/settings/${organization.slug}/projects/${selected[0]?.slug}/`
+                      : ''
+                  }
                   {...getActorProps()}
                 >
                   {title}

--- a/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleProjectSelector.jsx
@@ -288,7 +288,6 @@ export default class MultipleProjectSelector extends React.PureComponent {
                   isOpen={isOpen}
                   onClear={this.handleClear}
                   allowClear={multi}
-                  forceProject={forceProject}
                   settingsLink={
                     selectedProjects.length === 1
                       ? `/settings/${organization.slug}/projects/${selected[0]?.slug}/`


### PR DESCRIPTION
Show settings gear next to selected project.

<img width="1208" alt="Screen Shot 2020-11-22 at 7 01 09 PM" src="https://user-images.githubusercontent.com/20312973/99926217-ce9df480-2cf5-11eb-8573-e19f9b1c2c9e.png">

If multiple projects are selected, there won't be a settings gear.

<img width="406" alt="Screen Shot 2020-11-22 at 7 01 30 PM" src="https://user-images.githubusercontent.com/20312973/99926221-d2ca1200-2cf5-11eb-90f7-d085a58aedb8.png">
