### PR TITLE
feat(ui): Stacktrace hovercard improvements

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
@@ -30,6 +30,7 @@ type Props = {
   emptySourceNotation?: boolean;
   hasAssembly?: boolean;
   expandable?: boolean;
+  hideStacktraceLink?: boolean;
 };
 
 const Context = ({
@@ -40,6 +41,7 @@ const Context = ({
   hasAssembly = false,
   expandable = false,
   emptySourceNotation = false,
+  hideStacktraceLink = false,
   registers,
   components,
   frame,
@@ -80,7 +82,7 @@ const Context = ({
           const hasComponents = isActive && components.length > 0;
           return (
             <StyledContextLine key={index} line={line} isActive={isActive}>
-              {hasComponents && (
+              {!hideStacktraceLink && hasComponents && (
                 <ErrorBoundary mini>
                   <OpenInContextLine
                     key={index}
@@ -91,6 +93,7 @@ const Context = ({
                 </ErrorBoundary>
               )}
               {organization?.features.includes('integrations-stacktrace-link') &&
+                !hideStacktraceLink &&
                 isActive &&
                 isExpanded &&
                 frame.filename && (

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
@@ -49,6 +49,7 @@ type Props = {
   isFrameAfterLastNonApp?: boolean;
   includeSystemFrames?: boolean;
   isExpanded?: boolean;
+  hideStacktraceLink?: boolean;
 };
 
 type State = {
@@ -59,6 +60,7 @@ export class Line extends React.Component<Props, State> {
   static defaultProps = {
     isExpanded: false,
     emptySourceNotation: false,
+    hideStacktraceLink: false,
   };
 
   // isExpanded can be initialized to true via parent component;
@@ -348,6 +350,7 @@ export class Line extends React.Component<Props, State> {
           hasAssembly={this.hasAssembly()}
           expandable={this.isExpandable()}
           isExpanded={this.state.isExpanded}
+          hideStacktraceLink={this.props.hideStacktraceLink}
         />
       </StyledLi>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
@@ -19,6 +19,7 @@ type Props = {
   event: Event;
   newestFirst?: boolean;
   className?: string;
+  hideStacktraceLink?: boolean;
 } & typeof defaultProps;
 
 type State = {
@@ -122,6 +123,7 @@ export default class StacktraceContent extends React.Component<Props, State> {
       expandFirstFrame,
       platform,
       includeSystemFrames,
+      hideStacktraceLink,
     } = this.props;
     const {showingAbsoluteAddresses, showCompleteFunctionName} = this.state;
 
@@ -209,6 +211,7 @@ export default class StacktraceContent extends React.Component<Props, State> {
             includeSystemFrames={includeSystemFrames}
             onFunctionNameToggle={this.handleToggleFunctionName}
             showCompleteFunctionName={showCompleteFunctionName}
+            hideStacktraceLink={hideStacktraceLink}
           />
         );
       }

--- a/src/sentry/static/sentry/app/components/stacktracePreview.tsx
+++ b/src/sentry/static/sentry/app/components/stacktracePreview.tsx
@@ -64,7 +64,7 @@ class StacktracePreview extends React.Component<Props, State> {
       );
     }
 
-    if (event && stacktrace) {
+    if (event) {
       return (
         <div onClick={this.handleStacktracePreviewClick}>
           <StacktraceContent


### PR DESCRIPTION
- don't expand the first frame by default
- hide "Open this line in ..."
- show "No stack trace" message