### PR TITLE
fix(ui): Adjust layout on release detail

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/artifacts/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/artifacts/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router/lib/Router';
 
 import AlertLink from 'app/components/alertLink';
-import {Main} from 'app/components/layouts/thirds';
+import {Body, Main} from 'app/components/layouts/thirds';
 import {t, tct} from 'app/locale';
 import {Organization} from 'app/types';
 import {formatVersion} from 'app/utils/formatters';
@@ -38,18 +38,20 @@ class ReleaseArtifacts extends AsyncView<Props> {
     const {params, organization} = this.props;
 
     return (
-      <Main fullWidth>
-        <AlertLink
-          to={`/settings/${organization.slug}/projects/${
-            project.slug
-          }/source-maps/${encodeURIComponent(params.release)}/`}
-          priority="info"
-        >
-          {tct('Artifacts were moved to [sourceMaps] in Settings.', {
-            sourceMaps: <u>{t('Source Maps')}</u>,
-          })}
-        </AlertLink>
-      </Main>
+      <Body>
+        <Main fullWidth>
+          <AlertLink
+            to={`/settings/${organization.slug}/projects/${
+              project.slug
+            }/source-maps/${encodeURIComponent(params.release)}/`}
+            priority="info"
+          >
+            {tct('Artifacts were moved to [sourceMaps] in Settings.', {
+              sourceMaps: <u>{t('Source Maps')}</u>,
+            })}
+          </AlertLink>
+        </Main>
+      </Body>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/releases/detail/commits.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/commits.tsx
@@ -3,6 +3,7 @@ import {RouteComponentProps} from 'react-router/lib/Router';
 
 import {Client} from 'app/api';
 import CommitRow from 'app/components/commitRow';
+import {Body, Main} from 'app/components/layouts/thirds';
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
@@ -115,6 +116,14 @@ class Commits extends AsyncView<Props, State> {
         )}
         {this.renderContent()}
       </React.Fragment>
+    );
+  }
+
+  renderComponent() {
+    return (
+      <Body>
+        <Main fullWidth>{super.renderComponent()}</Main>
+      </Body>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/releases/detail/filesChanged.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/filesChanged.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {Client} from 'app/api';
 import FileChange from 'app/components/fileChange';
-import {Main} from 'app/components/layouts/thirds';
+import {Body, Main} from 'app/components/layouts/thirds';
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t, tn} from 'app/locale';
@@ -133,7 +133,11 @@ class FilesChanged extends AsyncView<Props, State> {
   }
 
   renderComponent() {
-    return <Main fullWidth>{super.renderComponent()}</Main>;
+    return (
+      <Body>
+        <Main fullWidth>{super.renderComponent()}</Main>
+      </Body>
+    );
   }
 }
 

--- a/src/sentry/static/sentry/app/views/releases/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.tsx
@@ -154,19 +154,17 @@ class ReleasesDetail extends AsyncView<Props, State> {
             releaseMeta={releaseMeta}
             refetchData={this.fetchData}
           />
-          <Body>
-            <ReleaseContext.Provider
-              value={{
-                release,
-                project,
-                deploys,
-                releaseMeta,
-                refetchData: this.fetchData,
-              }}
-            >
-              {this.props.children}
-            </ReleaseContext.Provider>
-          </Body>
+          <ReleaseContext.Provider
+            value={{
+              release,
+              project,
+              deploys,
+              releaseMeta,
+              refetchData: this.fetchData,
+            }}
+          >
+            {this.props.children}
+          </ReleaseContext.Provider>
         </StyledPageContent>
       </LightWeightNoProjectMessage>
     );
@@ -283,10 +281,6 @@ const ProjectsFooterMessage = styled('div')`
   align-items: center;
   grid-template-columns: min-content 1fr;
   grid-gap: ${space(1)};
-`;
-
-const Body = styled('div')`
-  padding: ${space(2)} ${space(4)};
 `;
 
 export {ReleaseContext, ReleasesDetailContainer};

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {browserHistory} from 'react-router';
 import {RouteComponentProps} from 'react-router/lib/Router';
-import styled from '@emotion/styled';
 import {Location, LocationDescriptor, Query} from 'history';
 
 import {restoreRelease} from 'app/actionCreators/release';
@@ -10,7 +9,6 @@ import Feature from 'app/components/acl/feature';
 import TransactionsList, {DropdownOption} from 'app/components/discover/transactionsList';
 import {Body, Main, Side} from 'app/components/layouts/thirds';
 import {t} from 'app/locale';
-import space from 'app/styles/space';
 import {GlobalSelection, NewQuery, Organization, ReleaseProject} from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import {TableDataRow} from 'app/utils/discover/discoverQuery';
@@ -221,7 +219,7 @@ class ReleaseOverview extends AsyncView<Props> {
               hasPerformance={hasPerformance}
             >
               {({crashFreeTimeBreakdown, ...releaseStatsProps}) => (
-                <StyledBody>
+                <Body>
                   <Main>
                     {isReleaseArchived(release) && (
                       <ReleaseArchivedNotice
@@ -308,7 +306,7 @@ class ReleaseOverview extends AsyncView<Props> {
                       />
                     )}
                   </Side>
-                </StyledBody>
+                </Body>
               )}
             </ReleaseStatsRequest>
           );
@@ -399,7 +397,3 @@ function getTransactionsListSort(
 }
 
 export default withApi(withGlobalSelection(withOrganization(ReleaseOverview)));
-
-const StyledBody = styled(Body)`
-  margin: -${space(2)} -${space(4)};
-`;

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseStat.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseStat.tsx
@@ -14,7 +14,7 @@ const ReleaseStat = ({label, children, help}: Props) => (
   <Wrapper>
     <Label hasHelp={!!help}>
       {label}
-      {help && <StyledQuestionTooltip title={help} size="xs" position="top" />}
+      {help && <StyledQuestionTooltip title={help} size="xs" position="bottom" />}
     </Label>
     <Value>{children}</Value>
   </Wrapper>

--- a/src/sentry/static/sentry/app/views/releases/detail/withRepositories/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/withRepositories/index.tsx
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/react';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
+import {Body, Main} from 'app/components/layouts/thirds';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {t} from 'app/locale';
 import {Repository} from 'app/types';
@@ -115,7 +116,13 @@ const withRepositories = <P extends Props>(WrappedComponent: React.ComponentType
       }
 
       if (!repositories.length) {
-        return <NoRepoConnected orgId={this.props.params.orgId} />;
+        return (
+          <Body>
+            <Main fullWidth>
+              <NoRepoConnected orgId={this.props.params.orgId} />
+            </Main>
+          </Body>
+        );
       }
 
       if (activeRepository === undefined) {


### PR DESCRIPTION
The old markup didn't play nicely with the new `layouts/thirds` and the white background didn't go all the way to the bottom.

![image](https://user-images.githubusercontent.com/9060071/99977627-2f383a80-2da5-11eb-9f20-0bf279915fbb.png)