### PR TITLE
fix(perf-view) Apply conditions to related issues

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -489,7 +489,7 @@ export const FIELD_TAGS = Object.freeze(
 // Allows for a less strict field key definition in cases we are returning custom strings as fields
 export type LooseFieldKey = FieldKey | string | '';
 
-// This list should be removed with the tranaction-events feature flag.
+// This list contains fields/functions that are available with performance-view feature.
 export const TRACING_FIELDS = [
   'avg',
   'sum',

--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -128,6 +128,10 @@ export class QueryResults {
     return this.tagValues[tag];
   }
 
+  getTagKeys() {
+    return Object.keys(this.tagValues);
+  }
+
   hasTag(tag: string) {
     const tags = this.getTagValues(tag);
     return tags && tags.length;

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -308,6 +308,12 @@ describe('utils/tokenizeSearch', function () {
       results.removeTag('b');
       expect(results.formatString()).toEqual('( ( a:a OR c:c ) )');
     });
+
+    it('can return the tag keys', function () {
+      const results = new QueryResults(['tag:value', 'other:value', 'additional text']);
+
+      expect(results.getTagKeys()).toEqual(['tag', 'other']);
+    });
   });
 
   describe('stringifyQueryObject()', function () {

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -7,7 +7,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import ProjectsStore from 'app/stores/projectsStore';
 import TransactionSummary from 'app/views/performance/transactionSummary';
 
-function initializeData({features: additionalFeatures = []} = {}) {
+function initializeData({features: additionalFeatures = [], query = {}} = {}) {
   const features = ['discover-basic', 'performance-view', ...additionalFeatures];
   const organization = TestStubs.Organization({
     features,
@@ -22,6 +22,7 @@ function initializeData({features: additionalFeatures = []} = {}) {
           transaction: '/performance',
           project: 1,
           transactionCursor: '1:0:0',
+          ...query,
         },
       },
     },
@@ -354,5 +355,26 @@ describe('Performance > TransactionSummary', function () {
         transactionCursor: '2:0:0',
       },
     });
+  });
+
+  it('forwards conditions to related issues', async function () {
+    const issueGet = MockApiClient.addMockResponse({
+      url:
+        '/organizations/org-slug/issues/?limit=5&project=1&query=tag%3Avalue%20is%3Aunresolved%20transaction%3A%2Fperformance&sort=new&statsPeriod=14d',
+      body: [],
+    });
+
+    const initialData = initializeData({query: {query: 'tag:value'}});
+    const wrapper = mountWithTheme(
+      <TransactionSummary
+        organization={initialData.organization}
+        location={initialData.router.location}
+      />,
+      initialData.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    expect(issueGet).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
We should be forwarding relevant conditions to the related issues box. This lets the user only see issues relevant to their release/environment/tag conditions.

Fixes VIS-400