### PR TITLE
style(dropdown): SelectControl min-height 40px

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -54,7 +54,7 @@ const defaultStyles = {
     boxShadow: `inset ${theme.dropShadowLight}`,
     transition: 'border 0.1s linear',
     alignItems: 'center',
-    minHeight: '36px',
+    minHeight: '40px',
     '&:hover': {
       borderColor: theme.border,
     },

--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -1,24 +1,24 @@
 import React, {CSSProperties} from 'react';
-import styled from '@emotion/styled';
-import cloneDeep from 'lodash/cloneDeep';
 // eslint import checks can't find types in the flow code.
 // eslint-disable-next-line import/named
-import {components, SingleValueProps, OptionProps} from 'react-select';
+import {components, OptionProps, SingleValueProps} from 'react-select';
+import styled from '@emotion/styled';
+import cloneDeep from 'lodash/cloneDeep';
 
-import Input from 'app/views/settings/components/forms/controls/input';
-import SelectControl from 'app/components/forms/selectControl';
-import {SelectValue} from 'app/types';
-import {t} from 'app/locale';
 import Badge from 'app/components/badge';
+import SelectControl from 'app/components/forms/selectControl';
+import {t} from 'app/locale';
 import space from 'app/styles/space';
+import {SelectValue} from 'app/types';
 import {
-  ColumnType,
   AggregateParameter,
+  ColumnType,
   QueryFieldValue,
   ValidateColumnTypes,
 } from 'app/utils/discover/fields';
+import Input from 'app/views/settings/components/forms/controls/input';
 
-import {FieldValueKind, FieldValue, FieldValueColumns} from './types';
+import {FieldValue, FieldValueColumns, FieldValueKind} from './types';
 
 type FieldOptions = Record<string, SelectValue<FieldValue>>;
 
@@ -510,13 +510,13 @@ class BufferedInput extends React.Component<InputProps, InputState> {
 // Set a min-width to allow shrinkage in grid.
 const StyledInput = styled(Input)`
   /* Match the height of the select boxes */
-  height: 40px;
+  height: 41px;
   min-width: 50px;
 `;
 
 const BlankSpace = styled('div')`
   /* Match the height of the select boxes */
-  height: 40px;
+  height: 41px;
   min-width: 50px;
   background: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};

--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -510,13 +510,13 @@ class BufferedInput extends React.Component<InputProps, InputState> {
 // Set a min-width to allow shrinkage in grid.
 const StyledInput = styled(Input)`
   /* Match the height of the select boxes */
-  height: 37px;
+  height: 40px;
   min-width: 50px;
 `;
 
 const BlankSpace = styled('div')`
   /* Match the height of the select boxes */
-  height: 37px;
+  height: 40px;
   min-width: 50px;
   background: ${p => p.theme.backgroundSecondary};
   border-radius: ${p => p.theme.borderRadius};

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/thresholdControl.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/thresholdControl.tsx
@@ -110,7 +110,7 @@ class ThresholdControl extends React.Component<Props, State> {
           ]}
           onChange={this.handleTypeChange}
         />
-        <Input
+        <StyledInput
           disabled={disabled}
           name={`${type}Threshold`}
           placeholder={placeholder}
@@ -134,9 +134,14 @@ class ThresholdControl extends React.Component<Props, State> {
   }
 }
 
+const StyledInput = styled(Input)`
+  /* Match the height of the select controls */
+  height: 40px;
+`;
+
 const DragContainer = styled('div')`
   position: absolute;
-  top: 6px;
+  top: 4px;
   right: 12px;
 `;
 


### PR DESCRIPTION
Was commissioned by @robinrendle to create more uniformity within our dropdown components (dropdown, selectcontrol). Currently, searchbars and dropdowns are 40px height by default, but the select control is 36px. 

This can cause default height differences that have to be manually overridden or else the UI ends up like this:
![Screen Shot 2020-11-23 at 12 24 11 PM](https://user-images.githubusercontent.com/9372512/99995296-284eff00-2d88-11eb-9386-6b1e8cd943f5.png)
![Screen Shot 2020-11-23 at 12 24 28 PM](https://user-images.githubusercontent.com/9372512/99995315-2dac4980-2d88-11eb-8e8f-e3ec338c0535.png)

Set min-height of the SelectControl to 40px to match searchbars and dropdowns:
![Screen Shot 2020-11-23 at 12 17 59 PM](https://user-images.githubusercontent.com/9372512/99995414-57657080-2d88-11eb-8493-6060272eb840.png)
![Screen Shot 2020-11-23 at 12 24 35 PM](https://user-images.githubusercontent.com/9372512/99995424-592f3400-2d88-11eb-9112-915713cea341.png)

I clicked around a few pages of the app and couldn't find any height mismatches, but let me know if this style changes creates height problems elsewhere.
