### PR TITLE
test(acceptance): Fix flaky "issue details python" snapshot

### DIFF
--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -51,6 +51,8 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         return event
 
     def test_python_event(self):
+        self.create_sample_event(platform="python")
+        self.create_sample_event(platform="python")
         event = self.create_sample_event(platform="python")
         self.page.visit_issue(self.org.slug, event.group.id)
 

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -10,7 +10,6 @@ from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.utils.samples import load_data
 from tests.acceptance.page_objects.issue_details import IssueDetailsPage
 
-event_time = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
 now = datetime.utcnow().replace(tzinfo=pytz.utc)
 
 
@@ -52,7 +51,7 @@ class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
         return event
 
     def test_python_event(self):
-        event = self.create_sample_event(platform="python", time=event_time)
+        event = self.create_sample_event(platform="python")
         self.page.visit_issue(self.org.slug, event.group.id)
 
         # Wait for tag bars to load


### PR DESCRIPTION
This is the only issue details snapshot that is flaky (it happens with the
"last seen" marker on the sidebar). The other tests dont use this `time`
arg, so it should be ok to remove