### PR TITLE
fix(dashboards): Re-word dashboard creation error

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -60,6 +60,6 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                     organization_id=organization.id, title=result["title"], created_by=request.user
                 )
         except IntegrityError:
-            return Response("This dashboard already exists", status=409)
+            return Response("Dashboard title already taken", status=409)
 
         return Response(serialize(dashboard, request.user), status=201)

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -67,4 +67,4 @@ class OrganizationDashboardsTest(APITestCase):
     def test_integrity_error(self):
         response = self.client.post(self.url, data={"title": self.dashboard_1.title})
         assert response.status_code == 409
-        assert response.data == "This dashboard already exists"
+        assert response.data == "Dashboard title already taken"


### PR DESCRIPTION
The dashboard creation error should reflect that dashboard titles are unique
![Screen Shot 2020-11-23 at 4 07 27 PM](https://user-images.githubusercontent.com/139499/100015624-46c3f300-2da6-11eb-9fb2-7bf709319ed6.png)
