### PR TITLE
fix(releases): Do not show transactions with 0 failures

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -139,6 +139,11 @@ class ReleaseOverview extends AsyncView<Props> {
           ...baseQuery,
           query: `event.type:transaction release:${version} epm():>0.01`,
         });
+      case 'failure_count':
+        return EventView.fromSavedQuery({
+          ...baseQuery,
+          query: `event.type:transaction release:${version} failure_count():>0`,
+        });
       default:
         return EventView.fromSavedQuery(baseQuery);
     }


### PR DESCRIPTION
The current transactions list on the release details page sorts by failure
count. However if there are no failures, transactions with a failure count of
0 is surfaced. This can be confusing at first glance as there isn't actually a
failed transaction. This change ensures that if a transaction appears in this
list, it has at least 1 failed transaction.