### PR TITLE
fix(dashboards): Re-word error when renaming dashboard to a taken title

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -62,9 +62,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardEndpoint):
         try:
             with transaction.atomic():
                 serializer.save()
-        except IntegrityError as err:
-            return self.respond(
-                {"Dashboard with that title already exists. {}".format(err)}, status=409
-            )
+        except IntegrityError:
+            return self.respond({"Dashboard with that title already exists."}, status=409)
 
         return self.respond(serialize(dashboard, request.user), status=200)

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -182,6 +182,14 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             title="Dashboard Hello", organization=self.organization, id=self.dashboard.id
         ).exists()
 
+    def test_rename_dashboard_title_taken(self):
+        Dashboard.objects.create(
+            title="Dashboard 2", created_by=self.user, organization=self.organization
+        )
+        response = self.client.put(self.url(self.dashboard.id), data={"title": "Dashboard 2"})
+        assert response.status_code == 409, response.data
+        assert response.data == [u"Dashboard with that title already exists."]
+
     def test_add_widget(self):
         data = {
             "title": "First dashboard",

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -188,7 +188,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         )
         response = self.client.put(self.url(self.dashboard.id), data={"title": "Dashboard 2"})
         assert response.status_code == 409, response.data
-        assert response.data == [u"Dashboard with that title already exists."]
+        assert list(response.data) == [u"Dashboard with that title already exists."]
 
     def test_add_widget(self):
         data = {


### PR DESCRIPTION
When renaming a dashboard to a title that's already taken, an integrity error is propduced, and is propagated to the frontend; which is ungood.

![Screen Shot 2020-11-23 at 4 57 00 PM](https://user-images.githubusercontent.com/139499/100021002-c35acf80-2dae-11eb-9f29-82bf09c1f004.png)
