### PR TITLE
feat(integration-dashboard): adds metric alert events to integration dashboard

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/sentryApplicationDashboard/requestLog.tsx
@@ -62,7 +62,15 @@ const getEventTypes = memoize((app: SentryApp) => {
     ...(app.events.includes('issue')
       ? ['issue.created', 'issue.resolved', 'issue.ignored', 'issue.assigned']
       : []),
-    ...(app.isAlertable ? ['event_alert.triggered'] : []),
+    ...(app.isAlertable
+      ? [
+          'event_alert.triggered',
+          'metric_alert.open',
+          'metric_alert.resolved',
+          'metric_alert.critical',
+          'metric_alert.warning',
+        ]
+      : []),
     ...issueLinkEvents,
   ];
 

--- a/src/sentry/utils/sentryappwebhookrequests.py
+++ b/src/sentry/utils/sentryappwebhookrequests.py
@@ -20,6 +20,10 @@ EXTENDED_VALID_EVENTS = VALID_EVENTS + (
     "installation.created",
     "installation.deleted",
     "select_options.requested",
+    "metric_alert.open",
+    "metric_alert.resolved",
+    "metric_alert.critical",
+    "metric_alert.warning",
 )
 
 


### PR DESCRIPTION
Adds the following events to the integration dasbhoard:

- metric_alert.open
- metric_alert.resolved
- metric_alert.critical
- metric_alert.warning

Ex in UI:

![Screen Shot 2020-11-23 at 2 50 01 PM](https://user-images.githubusercontent.com/8533851/100024201-31959700-2d9b-11eb-9c8e-ae2aee31bb67.png)
