### PR TITLE
hack(devservices): A hacky workaround to make docker on mac work again

### DIFF
--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -9,6 +9,14 @@ from six import text_type
 from sentry.utils.compat import map
 
 
+# Work around a stupid docker issue: https://github.com/docker/for-mac/issues/5025
+RAW_SOCKET_HACK_PATH = os.path.expanduser(
+    "~/Library/Containers/com.docker.docker/Data/docker.raw.sock"
+)
+if os.path.exists(RAW_SOCKET_HACK_PATH):
+    os.environ["DOCKER_HOST"] = "unix://" + RAW_SOCKET_HACK_PATH
+
+
 def get_docker_client():
     import docker
 


### PR DESCRIPTION
This works around https://github.com/docker/for-mac/issues/5025 and
https://github.com/docker/docker-py/issues/2696