### PR TITLE
fix(integrations): Fix requests assertions

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -629,7 +629,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         anti_gravity = {"priority": -150, "fixVersions": -125, "components": -100, "security": -50}
 
         dynamic_fields = list(issue_type_meta["fields"].keys())
-        dynamic_fields.sort(key=lambda f: anti_gravity.get(f) or 0)
+        dynamic_fields.sort(key=lambda f: anti_gravity.get(f) or f)
 
         # build up some dynamic fields based on required shit.
         for field in dynamic_fields:

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 from __future__ import absolute_import, print_function, unicode_literals
 
 import six
@@ -58,6 +59,7 @@ class Fixtures(object):
 
     @cached_property
     def group(self):
+        # こんにちは konichiwa
         return self.create_group(message="\u3053\u3093\u306b\u3061\u306f")
 
     @cached_property

--- a/src/sentry/utils/pytest/fixtures.py
+++ b/src/sentry/utils/pytest/fixtures.py
@@ -216,6 +216,7 @@ def default_environment(factories, default_project):
 @pytest.mark.django_db
 @pytest.fixture(scope="function")
 def default_group(factories, default_project):
+    # こんにちは konichiwa
     return factories.create_group(project=default_project, message="\u3053\u3093\u306b\u3061\u306f")
 
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -77,7 +77,7 @@ SAMPLE_CREATE_META_RESPONSE = """
                 "type": "string"
               }
             },
-            "issuetype": {
+           "issuetype": {
               "required": true,
               "name": "Issue Type",
               "key": "issuetype",
@@ -523,21 +523,23 @@ class JiraIntegrationTest(APITestCase):
         with mock.patch.object(installation, "get_client", get_client):
             assert installation.get_create_issue_config(group, self.user) == [
                 {
-                    "default": "10000",
-                    "choices": [("10000", "EX"), ("10001", "ABC")],
-                    "type": "select",
                     "name": "project",
-                    "label": "Jira Project",
+                    "default": "10000",
                     "updatesForm": True,
+                    "choices": [("10000", "EX"), ("10001", "ABC")],
+                    "label": "Jira Project",
+                    "type": "select",
                 },
                 {
                     "default": "message",
+                    "required": True,
                     "type": "string",
                     "name": "title",
                     "label": "Title",
-                    "required": True,
                 },
                 {
+                    "autosize": True,
+                    "name": "description",
                     "default": (
                         "Sentry Issue: [%s|%s]\n\n{code}\n"
                         "Stacktrace (most recent call first):\n\n  "
@@ -550,53 +552,51 @@ class JiraIntegrationTest(APITestCase):
                             group.get_absolute_url(params={"referrer": "jira_integration"})
                         ),
                     ),
-                    "type": "textarea",
-                    "name": "description",
                     "label": "Description",
-                    "autosize": True,
                     "maxRows": 10,
+                    "type": "textarea",
                 },
                 {
-                    "default": "1",
-                    "choices": [("1", "Bug")],
-                    "type": "select",
-                    "name": "issuetype",
-                    "label": "Issue Type",
-                    "updatesForm": True,
                     "required": True,
+                    "name": "issuetype",
+                    "default": "1",
+                    "updatesForm": True,
+                    "choices": [("1", "Bug")],
+                    "label": "Issue Type",
+                    "type": "select",
                 },
                 {
+                    "multiple": True,
+                    "name": "customfield_10300",
+                    "default": "",
+                    "required": False,
+                    "choices": [("Feature 1", "Feature 1"), ("Feature 2", "Feature 2")],
+                    "label": "Feature",
+                    "type": "select",
+                },
+                {
+                    "name": "reporter",
+                    "url": reverse(
+                        "sentry-extensions-jira-search", args=[org.slug, self.integration.id]
+                    ),
+                    "required": True,
+                    "choices": [],
+                    "label": "Reporter",
+                    "type": "select",
+                },
+                {
+                    "default": "",
                     "required": False,
                     "type": "text",
                     "name": "labels",
                     "label": "Labels",
-                    "default": "",
                 },
                 {
-                    "required": False,
-                    "type": "select",
                     "name": "customfield_10200",
-                    "label": "Mood",
                     "default": "",
-                    "choices": [("sad", "sad"), ("happy", "happy")],
-                },
-                {
-                    "multiple": True,
                     "required": False,
-                    "type": "select",
-                    "name": "customfield_10300",
-                    "label": "Feature",
-                    "default": "",
-                    "choices": [("Feature 1", "Feature 1"), ("Feature 2", "Feature 2")],
-                },
-                {
-                    "choices": [],
-                    "label": "Reporter",
-                    "name": "reporter",
-                    "required": True,
-                    "url": reverse(
-                        "sentry-extensions-jira-search", args=[org.slug, self.integration.id]
-                    ),
+                    "choices": [("sad", "sad"), ("happy", "happy")],
+                    "label": "Mood",
                     "type": "select",
                 },
             ]
@@ -680,10 +680,10 @@ class JiraIntegrationTest(APITestCase):
                 "title",
                 "description",
                 "issuetype",
-                "labels",
-                "customfield_10200",
                 "customfield_10300",
                 "reporter",
+                "labels",
+                "customfield_10200",
             ]
 
             installation.org_integration.config = {"issues_ignored_fields": ["customfield_10200"]}
@@ -696,9 +696,9 @@ class JiraIntegrationTest(APITestCase):
                 "title",
                 "description",
                 "issuetype",
-                "labels",
                 "customfield_10300",
                 "reporter",
+                "labels",
             ]
 
     def test_get_create_issue_config_with_default_and_param(self):

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -51,32 +51,6 @@ SAMPLE_CREATE_META_RESPONSE = """
           "name": "Bug",
           "subtask": false,
           "fields": {
-            "summary": {
-              "hasDefaultValue": false,
-              "key": "summary",
-              "name": "Summary",
-              "operations": [
-                "set"
-              ],
-              "required": true,
-              "schema": {
-                "system": "summary",
-                "type": "string"
-              }
-            },
-            "description": {
-              "hasDefaultValue": false,
-              "key": "description",
-              "name": "Description",
-              "operations": [
-                "set"
-              ],
-              "required": false,
-              "schema": {
-                "system": "description",
-                "type": "string"
-              }
-            },
            "issuetype": {
               "required": true,
               "name": "Issue Type",
@@ -566,22 +540,20 @@ class JiraIntegrationTest(APITestCase):
                     "type": "select",
                 },
                 {
+                    "name": "customfield_10200",
+                    "default": "",
+                    "required": False,
+                    "choices": [("sad", "sad"), ("happy", "happy")],
+                    "label": "Mood",
+                    "type": "select",
+                },
+                {
                     "multiple": True,
                     "name": "customfield_10300",
                     "default": "",
                     "required": False,
                     "choices": [("Feature 1", "Feature 1"), ("Feature 2", "Feature 2")],
                     "label": "Feature",
-                    "type": "select",
-                },
-                {
-                    "name": "reporter",
-                    "url": reverse(
-                        "sentry-extensions-jira-search", args=[org.slug, self.integration.id]
-                    ),
-                    "required": True,
-                    "choices": [],
-                    "label": "Reporter",
                     "type": "select",
                 },
                 {
@@ -592,11 +564,13 @@ class JiraIntegrationTest(APITestCase):
                     "label": "Labels",
                 },
                 {
-                    "name": "customfield_10200",
-                    "default": "",
-                    "required": False,
-                    "choices": [("sad", "sad"), ("happy", "happy")],
-                    "label": "Mood",
+                    "name": "reporter",
+                    "url": reverse(
+                        "sentry-extensions-jira-search", args=[org.slug, self.integration.id]
+                    ),
+                    "required": True,
+                    "choices": [],
+                    "label": "Reporter",
                     "type": "select",
                 },
             ]
@@ -680,10 +654,10 @@ class JiraIntegrationTest(APITestCase):
                 "title",
                 "description",
                 "issuetype",
-                "customfield_10300",
-                "reporter",
-                "labels",
                 "customfield_10200",
+                "customfield_10300",
+                "labels",
+                "reporter",
             ]
 
             installation.org_integration.config = {"issues_ignored_fields": ["customfield_10200"]}
@@ -697,8 +671,8 @@ class JiraIntegrationTest(APITestCase):
                 "description",
                 "issuetype",
                 "customfield_10300",
-                "reporter",
                 "labels",
+                "reporter",
             ]
 
     def test_get_create_issue_config_with_default_and_param(self):

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -51,6 +51,32 @@ SAMPLE_CREATE_META_RESPONSE = """
           "name": "Bug",
           "subtask": false,
           "fields": {
+            "summary": {
+              "hasDefaultValue": false,
+              "key": "summary",
+              "name": "Summary",
+              "operations": [
+                "set"
+              ],
+              "required": true,
+              "schema": {
+                "system": "summary",
+                "type": "string"
+              }
+            },
+            "description": {
+              "hasDefaultValue": false,
+              "key": "description",
+              "name": "Description",
+              "operations": [
+                "set"
+              ],
+              "required": false,
+              "schema": {
+                "system": "description",
+                "type": "string"
+              }
+            },
             "issuetype": {
               "required": true,
               "name": "Issue Type",

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -51,6 +51,32 @@ SAMPLE_CREATE_META_RESPONSE = """
           "name": "Bug",
           "subtask": false,
           "fields": {
+            "summary": {
+              "hasDefaultValue": false,
+              "key": "summary",
+              "name": "Summary",
+              "operations": [
+                "set"
+              ],
+              "required": true,
+              "schema": {
+                "system": "summary",
+                "type": "string"
+              }
+            },
+            "description": {
+              "hasDefaultValue": false,
+              "key": "description",
+              "name": "Description",
+              "operations": [
+                "set"
+              ],
+              "required": false,
+              "schema": {
+                "system": "description",
+                "type": "string"
+              }
+            },
            "issuetype": {
               "required": true,
               "name": "Issue Type",

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -75,9 +75,11 @@ class JiraCreateTicketActionTest(RuleTestCase):
 
         # Trigger rule callback
         results[0].callback(event, futures=[])
-        data = json.loads(responses.calls[2].response.text)
-        assert data["title"] == "example summary"
-        assert data["description"] == "example bug report"
+        data = json.loads(responses.calls[2].request.body)
+
+        assert data["fields"]["summary"] == event.title
+        assert event.message in data["fields"]["description"]
+        assert data["fields"]["issuetype"]["id"] == "1"
 
         external_issue = ExternalIssue.objects.get(key="APP-123")
         assert external_issue

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -32,8 +32,6 @@ class JiraCreateTicketActionTest(RuleTestCase):
         event = self.get_event()
         jira_rule = self.get_rule(
             data={
-                "title": "example summary",
-                "description": "example bug report",
                 "issuetype": "1",
                 "project": "10000",
                 "customfield_10200": "sad",
@@ -75,8 +73,9 @@ class JiraCreateTicketActionTest(RuleTestCase):
 
         # Trigger rule callback
         results[0].callback(event, futures=[])
-        data = json.loads(responses.calls[2].request.body)
 
+        # Make assertions about what would be sent.
+        data = json.loads(responses.calls[2].request.body)
         assert data["fields"]["summary"] == event.title
         assert event.message in data["fields"]["description"]
         assert data["fields"]["issuetype"]["id"] == "1"

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -33,10 +33,10 @@ class JiraCreateTicketActionTest(RuleTestCase):
         jira_rule = self.get_rule(
             data={
                 "issuetype": "1",
-                "project": "10000",
+                "labels": "bunnies",
                 "customfield_10200": "sad",
                 "customfield_10300": ["Feature 1", "Feature 2"],
-                "labels": "bunnies",
+                "project": "10000",
                 "jira_integration": self.integration.id,
                 "jira_project": "10000",
                 "issue_type": "Bug",


### PR DESCRIPTION
In the previous PR we mixed up `json.loads(responses.calls[2].response.text)` with `json.loads(responses.calls[2].request.body)`. The former is the mocked data and the latter is the data that would be sent to Jira if it were not mocked. Once we fixed the assertions, we then had to fix the tests, which were relying on a broken mock.
