### PR TITLE
ref(stacktrace-link): Add integrations to ProjectStacktraceLink

### DIFF
--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -157,6 +157,7 @@ class ExampleIntegrationProvider(IntegrationProvider):
     metadata = metadata
 
     integration_cls = ExampleIntegration
+    has_stacktrace_linking = True
 
     features = frozenset([IntegrationFeatures.COMMITS, IntegrationFeatures.ISSUE_BASIC])
 

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -63,7 +63,11 @@ class ProjectStacktraceLinkTest(APITestCase):
 
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
-        assert not response.data["config"]
+        assert response.data == {
+            "config": None,
+            "sourceUrl": None,
+            "integrations": [self._serialized_integration()],
+        }
 
     def test_file_not_found_error(self):
         self.login_as(user=self.user)
@@ -94,6 +98,7 @@ class ProjectStacktraceLinkTest(APITestCase):
         }
         assert not response.data["sourceUrl"]
         assert response.data["error"] == "file_not_found"
+        assert response.data["integrations"] == [self._serialized_integration()]
 
     def test_stack_root_mismatch_error(self):
         self.login_as(user=self.user)
@@ -124,6 +129,7 @@ class ProjectStacktraceLinkTest(APITestCase):
         }
         assert not response.data["sourceUrl"]
         assert response.data["error"] == "stack_root_mismatch"
+        assert response.data["integrations"] == [self._serialized_integration()]
 
     def test_config_and_source_url(self):
         self.login_as(user=self.user)
@@ -155,3 +161,23 @@ class ProjectStacktraceLinkTest(APITestCase):
                 "defaultBranch": None,
             }
             assert response.data["sourceUrl"] == "https://sourceurl.com/"
+            assert response.data["integrations"] == [self._serialized_integration()]
+
+    def _serialized_integration(self):
+        return {
+            "status": "active",
+            "name": "Example",
+            "domainName": None,
+            "accountType": None,
+            "provider": {
+                "aspects": {},
+                "features": ["commits", "issue-basic"],
+                "name": "Example",
+                "canDisable": False,
+                "key": "example",
+                "slug": "example",
+                "canAdd": True,
+            },
+            "id": six.text_type(self.integration.id),
+            "icon": None,
+        }


### PR DESCRIPTION
We've added more context for why a stack trace linking configuration may not be working (https://github.com/getsentry/sentry/pull/22076) but we also want to encourage people to set it up in the first place. We want to only have a call to action if the have an integration installed that has this feature, so this PR adds `integrations` to the payload so that we have this information.