### PR TITLE
feat(ui): Tidy up design of first/last seen

### DIFF
--- a/src/sentry/static/sentry/app/components/group/releaseStats.tsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.tsx
@@ -87,7 +87,7 @@ const GroupReleaseStats = ({
                       title={t('When the most recent event in this issue was captured.')}
                       disableForVisualTest
                     >
-                      <IconQuestion size="xs" color="gray300" />
+                      <IconQuestion size="xs" color="gray200" />
                     </Tooltip>
                   </TooltipWrapper>
                 </span>
@@ -121,7 +121,7 @@ const GroupReleaseStats = ({
                       title={t('When the first event in this issue was captured.')}
                       disableForVisualTest
                     >
-                      <IconQuestion size="xs" color="gray300" />
+                      <IconQuestion size="xs" color="gray200" />
                     </Tooltip>
                   </TooltipWrapper>
                 </span>

--- a/src/sentry/static/sentry/app/components/group/releaseStats.tsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.tsx
@@ -79,19 +79,17 @@ const GroupReleaseStats = ({
           <SidebarSection
             secondary
             title={
-              <React.Fragment>
-                <span>
-                  {t('Last seen')}
-                  <TooltipWrapper>
-                    <Tooltip
-                      title={t('When the most recent event in this issue was captured.')}
-                      disableForVisualTest
-                    >
-                      <StyledIconQuest size="xs" color="gray200" />
-                    </Tooltip>
-                  </TooltipWrapper>
-                </span>
-              </React.Fragment>
+              <span>
+                {t('Last seen')}
+                <TooltipWrapper>
+                  <Tooltip
+                    title={t('When the most recent event in this issue was captured.')}
+                    disableForVisualTest
+                  >
+                    <StyledIconQuest size="xs" color="gray200" />
+                  </Tooltip>
+                </TooltipWrapper>
+              </span>
             }
           >
             <SeenInfo
@@ -113,19 +111,17 @@ const GroupReleaseStats = ({
           <SidebarSection
             secondary
             title={
-              <React.Fragment>
-                <span>
-                  {t('First seen')}
-                  <TooltipWrapper>
-                    <Tooltip
-                      title={t('When the first event in this issue was captured.')}
-                      disableForVisualTest
-                    >
-                      <StyledIconQuest size="xs" color="gray200" />
-                    </Tooltip>
-                  </TooltipWrapper>
-                </span>
-              </React.Fragment>
+              <span>
+                {t('First seen')}
+                <TooltipWrapper>
+                  <Tooltip
+                    title={t('When the first event in this issue was captured.')}
+                    disableForVisualTest
+                  >
+                    <StyledIconQuest size="xs" color="gray200" />
+                  </Tooltip>
+                </TooltipWrapper>
+              </span>
             }
           >
             <SeenInfo
@@ -144,11 +140,9 @@ const GroupReleaseStats = ({
             />
           </SidebarSection>
           {!hasRelease ? (
-            <SidebarSection secondary title={<span>{t('Releases not configured')}</span>}>
-              <span>
-                <a href={releaseTrackingUrl}>{t('Setup Releases')}</a>{' '}
-                {t(' to make issues easier to fix.')}
-              </span>
+            <SidebarSection secondary title={t('Releases not configured')}>
+              <a href={releaseTrackingUrl}>{t('Setup Releases')}</a>{' '}
+              {t(' to make issues easier to fix.')}
             </SidebarSection>
           ) : null}
         </React.Fragment>

--- a/src/sentry/static/sentry/app/components/group/releaseStats.tsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.tsx
@@ -87,7 +87,7 @@ const GroupReleaseStats = ({
                       title={t('When the most recent event in this issue was captured.')}
                       disableForVisualTest
                     >
-                      <IconQuestion size="xs" color="gray200" />
+                      <StyledIconQuest size="xs" color="gray200" />
                     </Tooltip>
                   </TooltipWrapper>
                 </span>
@@ -121,7 +121,7 @@ const GroupReleaseStats = ({
                       title={t('When the first event in this issue was captured.')}
                       disableForVisualTest
                     >
-                      <IconQuestion size="xs" color="gray200" />
+                      <StyledIconQuest size="xs" color="gray200" />
                     </Tooltip>
                   </TooltipWrapper>
                 </span>
@@ -144,20 +144,11 @@ const GroupReleaseStats = ({
             />
           </SidebarSection>
           {!hasRelease ? (
-            <SidebarSection
-              secondary
-              title={
-                <React.Fragment>
-                  <span>{t('Releases not configured')}</span>
-                </React.Fragment>
-              }
-            >
-              <React.Fragment>
-                <NotConfigured>
-                  <a href={releaseTrackingUrl}>{t('Setup Releases')}</a>{' '}
-                  {t(' to make issues easier to fix.')}
-                </NotConfigured>
-              </React.Fragment>
+            <SidebarSection secondary title={<span>{t('Releases not configured')}</span>}>
+              <span>
+                <a href={releaseTrackingUrl}>{t('Setup Releases')}</a>{' '}
+                {t(' to make issues easier to fix.')}
+              </span>
             </SidebarSection>
           ) : null}
         </React.Fragment>
@@ -168,16 +159,11 @@ const GroupReleaseStats = ({
 
 export default React.memo(GroupReleaseStats);
 
-const NotConfigured = styled('span')``;
-
 const TooltipWrapper = styled('span')`
-  svg {
-    margin-left: ${space(0.5)};
-    position: relative;
-    top: 1px;
-  }
+  margin-left: ${space(0.5)};
+`;
 
-  a {
-    display: inline;
-  }
+const StyledIconQuest = styled(IconQuestion)`
+  position: relative;
+  top: 2px;
 `;

--- a/src/sentry/static/sentry/app/components/group/releaseStats.tsx
+++ b/src/sentry/static/sentry/app/components/group/releaseStats.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
+import styled from '@emotion/styled';
 
 import GroupReleaseChart from 'app/components/group/releaseChart';
 import SeenInfo from 'app/components/group/seenInfo';
 import Placeholder from 'app/components/placeholder';
+import Tooltip from 'app/components/tooltip';
+import {IconQuestion} from 'app/icons';
 import {t} from 'app/locale';
+import space from 'app/styles/space';
 import {Environment, Group, Organization, Project} from 'app/types';
 import getDynamicText from 'app/utils/getDynamicText';
 
@@ -40,6 +44,7 @@ const GroupReleaseStats = ({
   const projectSlug = project.slug;
   const orgSlug = organization.slug;
   const hasRelease = new Set(project.features).has('releases');
+  const releaseTrackingUrl = `/settings/${organization.slug}/projects/${project.slug}/release-tracking/`;
 
   return (
     <SidebarSection title={<span data-test-id="env-label">{environmentLabel}</span>}>
@@ -75,8 +80,17 @@ const GroupReleaseStats = ({
             secondary
             title={
               <React.Fragment>
-                <span>{t('Last seen')}</span>
-                {environments.length > 0 && <small>({environmentLabel})</small>}
+                <span>
+                  {t('Last seen')}
+                  <TooltipWrapper>
+                    <Tooltip
+                      title={t('When the most recent event in this issue was captured.')}
+                      disableForVisualTest
+                    >
+                      <IconQuestion size="xs" color="gray300" />
+                    </Tooltip>
+                  </TooltipWrapper>
+                </span>
               </React.Fragment>
             }
           >
@@ -100,8 +114,17 @@ const GroupReleaseStats = ({
             secondary
             title={
               <React.Fragment>
-                <span>{t('First seen')}</span>
-                {environments.length > 0 && <small>({environmentLabel})</small>}
+                <span>
+                  {t('First seen')}
+                  <TooltipWrapper>
+                    <Tooltip
+                      title={t('When the first event in this issue was captured.')}
+                      disableForVisualTest
+                    >
+                      <IconQuestion size="xs" color="gray300" />
+                    </Tooltip>
+                  </TooltipWrapper>
+                </span>
               </React.Fragment>
             }
           >
@@ -120,6 +143,23 @@ const GroupReleaseStats = ({
               title={t('First seen')}
             />
           </SidebarSection>
+          {!hasRelease ? (
+            <SidebarSection
+              secondary
+              title={
+                <React.Fragment>
+                  <span>{t('Releases not configured')}</span>
+                </React.Fragment>
+              }
+            >
+              <React.Fragment>
+                <NotConfigured>
+                  <a href={releaseTrackingUrl}>{t('Setup Releases')}</a>{' '}
+                  {t(' to make issues easier to fix.')}
+                </NotConfigured>
+              </React.Fragment>
+            </SidebarSection>
+          ) : null}
         </React.Fragment>
       )}
     </SidebarSection>
@@ -127,3 +167,17 @@ const GroupReleaseStats = ({
 };
 
 export default React.memo(GroupReleaseStats);
+
+const NotConfigured = styled('span')``;
+
+const TooltipWrapper = styled('span')`
+  svg {
+    margin-left: ${space(0.5)};
+    position: relative;
+    top: 1px;
+  }
+
+  a {
+    display: inline;
+  }
+`;

--- a/src/sentry/static/sentry/app/components/group/seenInfo.tsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.tsx
@@ -147,10 +147,6 @@ const TooltipWrapper = styled('span')`
     position: relative;
     top: 1px;
   }
-
-  a {
-    display: inline;
-  }
 `;
 
 const TimeSinceWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/components/group/seenInfo.tsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.tsx
@@ -70,21 +70,21 @@ class SeenInfo extends React.Component<Props> {
     return (
       <HovercardWrapper>
         <StyledHovercard
-          header={<DateTime date={date} />}
-          body={
+          header={
             <div>
+              <TimeSinceWrapper>
+                {t('Any Environment')}
+                <TimeSince date={dateGlobal} disabledAbsoluteTooltip />
+              </TimeSinceWrapper>
               {environment && (
                 <TimeSinceWrapper>
                   {toTitleCase(environment)}
                   <TimeSince date={date} disabledAbsoluteTooltip />
                 </TimeSinceWrapper>
               )}
-              <TimeSinceWrapper>
-                {t('Any Environment')}
-                <TimeSince date={dateGlobal} disabledAbsoluteTooltip />
-              </TimeSinceWrapper>
             </div>
           }
+          body={<StyledDateTime date={date} />}
           position="top"
           tipColor={theme.gray500}
         >
@@ -133,6 +133,13 @@ const DateWrapper = styled('div')`
   ${overflowEllipsis};
 `;
 
+const StyledDateTime = styled(DateTime)`
+  color: ${theme.gray300};
+  font-size: ${theme.fontSizeMedium};
+  display: flex;
+  justify-content: center;
+`;
+
 const TooltipWrapper = styled('span')`
   margin-right: ${space(0.25)};
   svg {
@@ -158,15 +165,18 @@ const StyledTimeSince = styled(TimeSince)`
 `;
 
 const StyledHovercard = styled(Hovercard)`
-  background: ${theme.gray500};
+  width: 250px;
+  font-weight: normal;
   border: 1px solid ${theme.gray500};
+  background: ${theme.gray500};
   ${Header} {
+    font-weight: normal;
+    color: ${theme.white};
     background: ${theme.gray500};
-    color: ${theme.gray300};
     border-bottom: 1px solid ${theme.gray400};
   }
   ${Body} {
-    color: ${theme.white};
+    padding: ${space(1.5)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/group/seenInfo.tsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.tsx
@@ -134,8 +134,8 @@ const DateWrapper = styled('div')`
 `;
 
 const StyledDateTime = styled(DateTime)`
-  color: ${theme.gray300};
-  font-size: ${theme.fontSizeMedium};
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeMedium};
   display: flex;
   justify-content: center;
 `;
@@ -167,13 +167,13 @@ const StyledTimeSince = styled(TimeSince)`
 const StyledHovercard = styled(Hovercard)`
   width: 250px;
   font-weight: normal;
-  border: 1px solid ${theme.gray500};
-  background: ${theme.gray500};
+  border: 1px solid ${p => p.theme.gray500};
+  background: ${p => p.theme.gray500};
   ${Header} {
     font-weight: normal;
-    color: ${theme.white};
-    background: ${theme.gray500};
-    border-bottom: 1px solid ${theme.gray400};
+    color: ${p => p.theme.white};
+    background: ${p => p.theme.gray500};
+    border-bottom: 1px solid ${p => p.theme.gray400};
   }
   ${Body} {
     padding: ${space(1.5)};

--- a/src/sentry/static/sentry/app/components/hovercard.tsx
+++ b/src/sentry/static/sentry/app/components/hovercard.tsx
@@ -312,5 +312,5 @@ const HovercardArrow = styled('span')<HovercardArrowProps>`
   }
 `;
 
-export {Body, Hovercard};
+export {Body, Header, Hovercard, HovercardArrow};
 export default Hovercard;

--- a/src/sentry/static/sentry/app/components/hovercard.tsx
+++ b/src/sentry/static/sentry/app/components/hovercard.tsx
@@ -312,5 +312,5 @@ const HovercardArrow = styled('span')<HovercardArrowProps>`
   }
 `;
 
-export {Body, Header, Hovercard, HovercardArrow};
+export {Body, Header, Hovercard};
 export default Hovercard;


### PR DESCRIPTION
Tidy up the design of First/Last Seen in Issue Details page.

- [Design Ref](https://www.figma.com/file/XKUzlE69BMMCX6ufTykly2/Fist%2FLast-Seen-Tidy-up?node-id=37%3A163)

**Releases Not Configured**
<img width="323" alt="Screen Shot 2020-11-24 at 1 34 28 AM" src="https://user-images.githubusercontent.com/20312973/100079839-00987f00-2dfa-11eb-89a3-9db2c0d92103.png">

**Issue Not in Release**
<img width="326" alt="Screen Shot 2020-11-24 at 1 45 53 AM" src="https://user-images.githubusercontent.com/20312973/100079907-1443e580-2dfa-11eb-8b46-b8fd630193a7.png">

**Release Specified**
<img width="337" alt="Screen Shot 2020-11-24 at 1 36 27 AM" src="https://user-images.githubusercontent.com/20312973/100079967-26258880-2dfa-11eb-9442-419cbf50c734.png">

## Tooltips

**Last Seen**
<img width="294" alt="Screen Shot 2020-11-24 at 1 42 14 AM" src="https://user-images.githubusercontent.com/20312973/100080110-49503800-2dfa-11eb-8711-5b800ea4a703.png">

**First Seen**
<img width="314" alt="Screen Shot 2020-11-24 at 1 42 20 AM" src="https://user-images.githubusercontent.com/20312973/100080133-50774600-2dfa-11eb-8808-754ce5c4d956.png">

**Date/Time/Environment**
<img width="300" alt="Screen Shot 2020-11-25 at 10 28 09 PM" src="https://user-images.githubusercontent.com/20312973/100315478-90126f00-2f6d-11eb-9a93-213d68304858.png">
<img width="295" alt="Screen Shot 2020-11-25 at 10 27 38 PM" src="https://user-images.githubusercontent.com/20312973/100315490-93a5f600-2f6d-11eb-9075-40d01e3e8d59.png">





