### PR TITLE
build(feat): Support pyenv/Python installation on Big Sur

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ WEBPACK := yarn build-acceptance
 # Currently, this is only required to install black via pre-commit.
 REQUIRED_PY3_VERSION := $(shell grep "3.6" .python-version)
 
+BIG_SUR := $(shell sw_vers -productVersion | egrep "11\.0\.")
+
 bootstrap: develop init-config run-dependent-services create-db apply-migrations build-platform-assets
 
 develop: ensure-pinned-pip setup-git install-js-dev install-py-dev
@@ -49,7 +51,19 @@ apply-migrations: ensure-venv
 reset-db: drop-db create-db apply-migrations
 
 setup-pyenv:
+ifdef BIG_SUR
+	# NOTE: Once we have a new release of pyenv and once a newer Python version we can remove these
+	# https://github.com/pyenv/pyenv/pull/1711
+	# cat is used since pyenv would finish to soon when the Python version is already installed
+	curl -sSL https://github.com/python/cpython/commit/8ea6353.patch | cat | \
+		LDFLAGS="-L$(shell xcrun --show-sdk-path)/usr/lib ${LDFLAGS}" \
+		pyenv install --skip-existing --patch 3.6.10
+	curl -sSL https://github.com/python/cpython/commit/8ea6353.patch | cat | \
+		LDFLAGS="-L$(shell xcrun --show-sdk-path)/usr/lib ${LDFLAGS}" \
+		pyenv install --skip-existing --patch 2.7.16
+else
 	@cat .python-version | xargs -n1 pyenv install --skip-existing
+endif
 
 ensure-venv:
 	@./scripts/ensure-venv.sh


### PR DESCRIPTION
Installing Python via pyenv on Big Sur for older Python versions requires:
* Setting LDFLAGS for zlib (pyenv/pyenv#1711)
* Patching the source code

Once a new release of pyenv is released and we use a newer Python 3 version
we will not need all these hacks and all Mac versions will be able to use
the same code paths.

Fixes #22497