### PR TITLE
ref(metric_alerts): Removed note from tooltip

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormWithGuiFilters.tsx
@@ -280,9 +280,7 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
               />
               <FormRowText>{t('over a')}</FormRowText>
               <Tooltip
-                title={t(
-                  'Note: Triggers are evaluated every minute regardless of this value.'
-                )}
+                title={t('Triggers are evaluated every minute regardless of this value.')}
               >
                 <SelectField
                   name="timeWindow"


### PR DESCRIPTION
Super quick text change as "Note:" doesn't offer much here.

![image](https://user-images.githubusercontent.com/9372512/100145525-75090780-2e66-11eb-8493-1a01432c85df.png)

**Becomes:**

![image](https://user-images.githubusercontent.com/9372512/100145675-abdf1d80-2e66-11eb-8408-09ca0f2cc5ea.png)
