### PR TITLE
Revert "chore(release): Remove release-performance-views feature flag"

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
@@ -83,9 +83,12 @@ class TransactionSummaryCharts extends React.Component<Props> {
       trendDisplay = TrendFunctionField.P50;
     }
 
-    const releaseQueryExtra = {
-      yAxis: display === DisplayModes.VITALS ? YAxis.COUNT_LCP : YAxis.COUNT_DURATION,
-    };
+    let releaseQueryExtra = {};
+    if (organization.features.includes('release-performance-views')) {
+      releaseQueryExtra = {
+        yAxis: display === DisplayModes.VITALS ? YAxis.COUNT_LCP : YAxis.COUNT_DURATION,
+      };
+    }
 
     return (
       <Panel>

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -236,6 +236,7 @@ class Chart extends React.Component<Props> {
       isLoading,
       location,
       projects,
+      organization,
     } = props;
     const lineColor = trendToColor[trendChangeType || ''];
 
@@ -290,10 +291,13 @@ class Chart extends React.Component<Props> {
     const yDiff = yMax - yMin;
     const yMargin = yDiff * 0.1;
 
-    const queryExtra = {
-      showTransactions: trendChangeType,
-      yAxis: YAxis.COUNT_DURATION,
-    };
+    let queryExtra = {};
+    if (organization.features.includes('release-performance-views')) {
+      queryExtra = {
+        showTransactions: trendChangeType,
+        yAxis: YAxis.COUNT_DURATION,
+      };
+    }
 
     const chartOptions = {
       tooltip: {

--- a/src/sentry/static/sentry/app/views/releases/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.tsx
@@ -242,16 +242,18 @@ class ReleasesDetailContainer extends AsyncComponent<Omit<Props, 'releaseMeta'>>
       );
     }
 
-    const releaseDate = new Date(releaseMeta.released);
-    // Center the release in a 24h time period
-    const defaultSelection = {
-      datetime: {
-        start: new Date(releaseDate.getTime() - 12 * 3600 * 1000),
-        end: new Date(releaseDate.getTime() + 12 * 3600 * 1000),
-        period: '',
-        utc: false,
-      },
-    };
+    let defaultSelection = {};
+    if (organization.features.includes('release-performance-views')) {
+      const releaseDate = new Date(releaseMeta.released);
+      // Center the release in a 24h time period
+      defaultSelection = {
+        datetime: {
+          start: new Date(releaseDate.getTime() - 12 * 3600 * 1000),
+          end: new Date(releaseDate.getTime() + 12 * 3600 * 1000),
+          utc: false,
+        },
+      };
+    }
 
     return (
       <GlobalSelectionHeader

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
@@ -38,6 +38,41 @@ type Props = Omit<ReleaseStatsRequestRenderProps, 'crashFreeTimeBreakdown'> & {
 };
 
 class ReleaseChartContainer extends React.Component<Props> {
+  // TODO(tonyx): Delete this else once the feature flags are removed
+  renderEventsChart() {
+    const {location, router, organization, api, yAxis, selection, version} = this.props;
+    const {projects, environments, datetime} = selection;
+    const {start, end, period, utc} = datetime;
+    const eventView = getReleaseEventView(
+      selection,
+      version,
+      yAxis,
+      undefined,
+      organization
+    );
+    const apiPayload = eventView.getEventsAPIPayload(location);
+
+    return (
+      <EventsChart
+        router={router}
+        organization={organization}
+        showLegend
+        yAxis={eventView.getYAxis()}
+        query={apiPayload.query}
+        api={api}
+        projects={projects}
+        environments={environments}
+        start={start}
+        end={end}
+        period={period}
+        utc={utc}
+        disablePrevious
+        disableReleases
+        currentSeriesName={t('Events')}
+      />
+    );
+  }
+
   getTransactionsChartColors(): [string, string] {
     const {yAxis} = this.props;
 
@@ -143,6 +178,12 @@ class ReleaseChartContainer extends React.Component<Props> {
 
     let chart: React.ReactNode = null;
     if (
+      hasDiscover &&
+      yAxis === YAxis.EVENTS &&
+      !organization.features.includes('release-performance-views')
+    ) {
+      chart = this.renderEventsChart();
+    } else if (
       (hasDiscover && yAxis === YAxis.EVENTS) ||
       (hasPerformance && PERFORMANCE_AXIS.includes(yAxis))
     ) {

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import Feature from 'app/components/acl/feature';
 import OptionSelector from 'app/components/charts/optionSelector';
 import {
   ChartControls,
@@ -67,7 +68,7 @@ const ReleaseChartControls = ({
     ? t('This view is only available with release health data.')
     : undefined;
   const noDiscoverTooltip = !hasDiscover
-    ? t('This view is only available with Discover.')
+    ? t('This view is only available with Discover feature.')
     : undefined;
   const noPerformanceTooltip = !hasPerformance
     ? t('This view is only available with Performance Monitoring.')
@@ -101,18 +102,21 @@ const ReleaseChartControls = ({
       value: YAxis.FAILED_TRANSACTIONS,
       label: t('Failure Count'),
       disabled: !hasPerformance,
+      hidden: !hasPerformance,
       tooltip: noPerformanceTooltip,
     },
     {
       value: YAxis.COUNT_DURATION,
       label: t('Slow Count (duration)'),
       disabled: !hasPerformance,
+      hidden: !hasPerformance,
       tooltip: noPerformanceTooltip,
     },
     {
       value: YAxis.COUNT_LCP,
       label: t('Slow Count (LCP)'),
       disabled: !hasPerformance,
+      hidden: !hasPerformance,
       tooltip: noPerformanceTooltip,
     },
     {
@@ -121,7 +125,9 @@ const ReleaseChartControls = ({
       disabled: !hasDiscover,
       tooltip: noDiscoverTooltip,
     },
-  ];
+  ]
+    .filter(opt => !opt.hidden)
+    .map(({hidden: _hidden, ...rest}) => rest);
 
   const eventTypeOptions: SelectValue<EventType>[] = [
     {value: EventType.ALL, label: t('All')},
@@ -158,23 +164,27 @@ const ReleaseChartControls = ({
       <InlineContainer>
         <SectionHeading key="total-label">{getSummaryHeading()}</SectionHeading>
         <SectionValue key="total-value">{summary}</SectionValue>
-        {(yAxis === YAxis.EVENTS || PERFORMANCE_AXIS.includes(yAxis)) && (
-          <QuestionTooltip
-            position="top"
-            size="sm"
-            title="This count includes only the current release."
-          />
-        )}
+        <Feature features={['release-performance-views']}>
+          {(yAxis === YAxis.EVENTS || PERFORMANCE_AXIS.includes(yAxis)) && (
+            <QuestionTooltip
+              position="top"
+              size="sm"
+              title="This count includes only the current release."
+            />
+          )}
+        </Feature>
       </InlineContainer>
       <InlineContainer>
-        {yAxis === YAxis.EVENTS && (
-          <OptionSelector
-            title={t('Event Type')}
-            selected={eventType ?? EventType.ALL}
-            options={eventTypeOptions}
-            onChange={onEventTypeChange as (value: string) => void}
-          />
-        )}
+        <Feature features={['release-performance-views']}>
+          {yAxis === YAxis.EVENTS && (
+            <OptionSelector
+              title={t('Event Type')}
+              selected={eventType ?? EventType.ALL}
+              options={eventTypeOptions}
+              onChange={onEventTypeChange as (value: string) => void}
+            />
+          )}
+        </Feature>
         <OptionSelector
           title={t('Y-Axis')}
           selected={yAxis}

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -5,6 +5,7 @@ import {Location, LocationDescriptor, Query} from 'history';
 
 import {restoreRelease} from 'app/actionCreators/release';
 import {Client} from 'app/api';
+import Feature from 'app/components/acl/feature';
 import TransactionsList, {DropdownOption} from 'app/components/discover/transactionsList';
 import {Body, Main, Side} from 'app/components/layouts/thirds';
 import {t} from 'app/locale';
@@ -214,7 +215,9 @@ class ReleaseOverview extends AsyncView<Props> {
           const {commitCount, version} = release;
           const {hasHealthData} = project.healthData || {};
           const hasDiscover = organization.features.includes('discover-basic');
-          const hasPerformance = organization.features.includes('performance-view');
+          const hasPerformance =
+            organization.features.includes('performance-view') &&
+            organization.features.includes('release-performance-views');
           const yAxis = this.getYAxis(hasHealthData, hasPerformance);
           const eventType = this.getEventType(yAxis);
 
@@ -282,23 +285,25 @@ class ReleaseOverview extends AsyncView<Props> {
                       version={version}
                       location={location}
                     />
-                    <TransactionsList
-                      api={api}
-                      location={location}
-                      organization={organization}
-                      eventView={releaseEventView}
-                      trendView={releaseTrendView}
-                      selected={selectedSort}
-                      options={sortOptions}
-                      handleDropdownChange={this.handleTransactionsListSortChange}
-                      titles={titles}
-                      generateFirstLink={generateTransactionLinkFn(
-                        version,
-                        project.id,
-                        selection,
-                        location.query.showTransactions
-                      )}
-                    />
+                    <Feature features={['release-performance-views']}>
+                      <TransactionsList
+                        api={api}
+                        location={location}
+                        organization={organization}
+                        eventView={releaseEventView}
+                        trendView={releaseTrendView}
+                        selected={selectedSort}
+                        options={sortOptions}
+                        handleDropdownChange={this.handleTransactionsListSortChange}
+                        titles={titles}
+                        generateFirstLink={generateTransactionLinkFn(
+                          version,
+                          project.id,
+                          selection,
+                          location.query.showTransactions
+                        )}
+                      />
+                    </Feature>
                   </Main>
                   <Side>
                     <ProjectReleaseDetails

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 import pick from 'lodash/pick';
 
+import Feature from 'app/components/acl/feature';
 import Badge from 'app/components/badge';
 import Breadcrumbs from 'app/components/breadcrumbs';
 import Clipboard from 'app/components/clipboard';
@@ -124,28 +125,30 @@ const ReleaseHeader = ({
               <Count value={sessionsCrashed} />
             </ReleaseStat>
           )}
-          <ReleaseStat label={t('Apdex')} help={getTermHelp(organization, 'apdex')}>
-            <DiscoverQuery
-              eventView={releaseEventView}
-              location={location}
-              orgSlug={organization.slug}
-            >
-              {({isLoading, error, tableData}) => {
-                if (isLoading || error || !tableData || tableData.data.length === 0) {
-                  return '\u2014';
-                }
-                return (
-                  <Count
-                    value={
-                      tableData.data[0][
-                        getAggregateAlias(`apdex(${organization.apdexThreshold})`)
-                      ]
-                    }
-                  />
-                );
-              }}
-            </DiscoverQuery>
-          </ReleaseStat>
+          <Feature features={['release-performance-views']}>
+            <ReleaseStat label={t('Apdex')} help={getTermHelp(organization, 'apdex')}>
+              <DiscoverQuery
+                eventView={releaseEventView}
+                location={location}
+                orgSlug={organization.slug}
+              >
+                {({isLoading, error, tableData}) => {
+                  if (isLoading || error || !tableData || tableData.data.length === 0) {
+                    return '\u2014';
+                  }
+                  return (
+                    <Count
+                      value={
+                        tableData.data[0][
+                          getAggregateAlias(`apdex(${organization.apdexThreshold})`)
+                        ]
+                      }
+                    />
+                  );
+                }}
+              </DiscoverQuery>
+            </ReleaseStat>
+          </Feature>
           <ReleaseStat label={t('New Issues')}>
             <Count value={newGroups} />
           </ReleaseStat>


### PR DESCRIPTION
Reverts getsentry/sentry#22259

The `to_other` function doesn't place nice when there are symbols in the release name. Rolling this back for now until we resolve this.