### PR TITLE
Tidy up tags

### DIFF
--- a/docs-ui/components/tag.stories.js
+++ b/docs-ui/components/tag.stories.js
@@ -2,10 +2,11 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {select, text} from '@storybook/addon-knobs';
 
-import theme from 'app/utils/theme';
 import Tag from 'app/components/tag';
-import {IconFire, IconWarning, IconClock, IconDelete, IconIssues} from 'app/icons';
+import Tooltip from 'app/components/tooltip';
+import {IconClock, IconDelete, IconFire, IconIssues, IconWarning} from 'app/icons';
 import {toTitleCase} from 'app/utils';
+import theme from 'app/utils/theme';
 
 export default {
   title: 'Core/Badges+Tags/Tag',
@@ -46,9 +47,9 @@ export const WithIcon = () => (
 WithIcon.story = {name: 'with icon'};
 
 export const WithTooltip = () => (
-  <Tag type={select('type', types, 'highlight')} tooltipText="lorem ipsum">
-    {text('children', 'Tooltip')}
-  </Tag>
+  <Tooltip title="This is some tooltip text" containerDisplayMode="inline">
+    <Tag type={select('type', types, 'highlight')}>{text('children', 'Tooltip')}</Tag>
+  </Tooltip>
 );
 WithTooltip.story = {name: 'with tooltip'};
 

--- a/src/sentry/static/sentry/app/components/debugFileFeature.tsx
+++ b/src/sentry/static/sentry/app/components/debugFileFeature.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import Tag from 'app/components/tag';
+import Tooltip from 'app/components/tooltip';
 import {IconCheckmark, IconClose} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
@@ -30,16 +31,20 @@ const DebugFileFeature = ({available = true, feature}: Props) => {
   const tooltipText = FEATURE_TOOLTIPS[feature];
   if (available === true) {
     return (
-      <StyledTag type="success" tooltipText={tooltipText} icon={<IconCheckmark />}>
-        {feature}
-      </StyledTag>
+      <Tooltip title={tooltipText}>
+        <StyledTag type="success" icon={<IconCheckmark />}>
+          {feature}
+        </StyledTag>
+      </Tooltip>
     );
   }
 
   return (
-    <StyledTag type="error" tooltipText={tooltipText} icon={<IconClose />}>
-      {feature}
-    </StyledTag>
+    <Tooltip title={tooltipText}>
+      <StyledTag type="error" icon={<IconClose />}>
+        {feature}
+      </StyledTag>
+    </Tooltip>
   );
 };
 export default DebugFileFeature;

--- a/src/sentry/static/sentry/app/components/featureBadge.tsx
+++ b/src/sentry/static/sentry/app/components/featureBadge.tsx
@@ -17,12 +17,6 @@ type BadgeProps = {
 
 type Props = Omit<React.HTMLAttributes<HTMLDivElement>, keyof BadgeProps> & BadgeProps;
 
-const defaultTitles = {
-  alpha: t('This feature is in alpha and may be unstable'),
-  beta: t('This feature is in beta and may change in the future'),
-  new: t('This is a new feature'),
-};
-
 const labels = {
   alpha: t('alpha'),
   beta: t('beta'),
@@ -31,7 +25,7 @@ const labels = {
 
 const FeaturedBadge = ({type, variant = 'badge', title, noTooltip, ...p}: Props) => (
   <div {...p}>
-    <Tooltip title={title ?? defaultTitles[type]} disabled={noTooltip} position="right">
+    <Tooltip title={title} disabled={noTooltip} position="right">
       <React.Fragment>
         {variant === 'badge' && <StyledTag priority={type}>{labels[type]}</StyledTag>}
         {variant === 'indicator' && (

--- a/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
+++ b/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
@@ -4,6 +4,7 @@ import moment from 'moment';
 
 import DateTime from 'app/components/dateTime';
 import Tag from 'app/components/tag';
+import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import {InboxDetails} from 'app/types';
 
@@ -57,9 +58,9 @@ const InboxReason = ({inbox}: Props) => {
   );
 
   return (
-    <Tag type={tagType} tooltipText={tooltip}>
-      {reasonBadgeText}
-    </Tag>
+    <Tooltip title={tooltip}>
+      <Tag type={tagType}>{reasonBadgeText}</Tag>
+    </Tooltip>
   );
 };
 

--- a/src/sentry/static/sentry/app/components/tag.tsx
+++ b/src/sentry/static/sentry/app/components/tag.tsx
@@ -52,7 +52,7 @@ function Tag({
   ...props
 }: Props) {
   const iconsProps = {
-    size: '11px',
+    size: '12px',
     color: theme.tag[type].iconColor as Color,
   };
 
@@ -117,7 +117,8 @@ const Background = styled('div')<{type: keyof Theme['tag']}>`
   height: ${TAG_HEIGHT};
   border-radius: ${TAG_HEIGHT};
   background-color: ${p => p.theme.tag[p.type].background};
-  padding: 0 ${space(1)};
+  color: ${p => p.theme.tag[p.type].textColor};
+  padding: 0 ${space(0.75)};
 `;
 
 const IconWrapper = styled('span')`
@@ -133,9 +134,6 @@ const Text = styled('span')<{maxWidth: number}>`
   white-space: nowrap;
   text-overflow: ellipsis;
   line-height: ${TAG_HEIGHT};
-  a:hover & {
-    color: ${p => p.theme.gray500};
-  }
 `;
 
 const DismissButton = styled(Button)`

--- a/src/sentry/static/sentry/app/components/tag.tsx
+++ b/src/sentry/static/sentry/app/components/tag.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
 import Link from 'app/components/links/link';
-import Tooltip from 'app/components/tooltip';
 import {IconClose, IconOpen} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
@@ -22,10 +21,6 @@ type Props = React.HTMLAttributes<HTMLSpanElement> & {
    * Icon on the left side.
    */
   icon?: React.ReactNode;
-  /**
-   * Text to show up on a hover.
-   */
-  tooltipText?: React.ComponentProps<typeof Tooltip>['title'];
   /**
    * Makes the tag clickable. Use for internal links handled by react router.
    * If no icon is passed, it defaults to IconOpen (can be removed by passing icon={null})
@@ -49,7 +44,6 @@ type Props = React.HTMLAttributes<HTMLSpanElement> & {
 function Tag({
   type = 'default',
   icon,
-  tooltipText,
   to,
   href,
   onDismiss,
@@ -63,7 +57,6 @@ function Tag({
   };
 
   const tag = (
-    <Tooltip title={tooltipText} containerDisplayMode="inline">
       <Background type={type}>
         {tagIcon()}
 
@@ -80,7 +73,6 @@ function Tag({
           </DismissButton>
         )}
       </Background>
-    </Tooltip>
   );
 
   function handleDismiss(event: React.MouseEvent) {

--- a/src/sentry/static/sentry/app/components/tag.tsx
+++ b/src/sentry/static/sentry/app/components/tag.tsx
@@ -117,8 +117,8 @@ const Background = styled('div')<{type: keyof Theme['tag']}>`
   height: ${TAG_HEIGHT};
   border-radius: ${TAG_HEIGHT};
   background-color: ${p => p.theme.tag[p.type].background};
-  color: ${p => p.theme.tag[p.type].textColor};
   padding: 0 ${space(1)};
+  color: ${p => p.theme.tag[p.type].textColor};
 `;
 
 const IconWrapper = styled('span')`
@@ -127,7 +127,6 @@ const IconWrapper = styled('span')`
 `;
 
 const Text = styled('span')<{maxWidth: number}>`
-  color: ${p => p.theme.gray500};
   font-size: ${p => p.theme.fontSizeSmall};
   max-width: ${p => p.maxWidth}px;
   overflow: hidden;

--- a/src/sentry/static/sentry/app/components/tag.tsx
+++ b/src/sentry/static/sentry/app/components/tag.tsx
@@ -118,7 +118,7 @@ const Background = styled('div')<{type: keyof Theme['tag']}>`
   border-radius: ${TAG_HEIGHT};
   background-color: ${p => p.theme.tag[p.type].background};
   color: ${p => p.theme.tag[p.type].textColor};
-  padding: 0 ${space(0.75)};
+  padding: 0 ${space(1)};
 `;
 
 const IconWrapper = styled('span')`

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -219,34 +219,47 @@ const tag = {
   default: {
     background: colors.gray100,
     iconColor: colors.purple300,
+    textColor: colors.gray500,
   },
   promotion: {
     background: colors.orange100,
     iconColor: colors.orange400,
+    textColor: colors.gray500,
   },
   highlight: {
     background: colors.purple100,
     iconColor: colors.purple300,
+    textColor: colors.gray500,
   },
   warning: {
     background: colors.yellow100,
     iconColor: colors.yellow300,
+    textColor: colors.gray500,
   },
   success: {
     background: colors.green100,
     iconColor: colors.green300,
+    textColor: colors.gray500,
   },
   error: {
     background: colors.red100,
     iconColor: colors.red300,
+    textColor: colors.gray500,
+  },
+  critical: {
+    background: colors.red300,
+    iconColor: colors.white,
+    textColor: colors.white,
   },
   info: {
     background: colors.blue100,
     iconColor: colors.blue300,
+    textColor: colors.gray500,
   },
   white: {
     background: colors.white,
     iconColor: colors.gray500,
+    textColor: colors.gray500,
   },
 };
 

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -163,9 +163,9 @@ class VitalCard extends React.Component<Props, State> {
         <SummaryHeading>
           <CardSectionHeading>{`${name} (${slug.toUpperCase()})`}</CardSectionHeading>
           {summary === null ? null : summary < failureThreshold ? (
-            <Tag>{t('Pass')}</Tag>
+            <StyledTag type="default">{t('Pass')}</StyledTag>
           ) : (
-            <StyledTag>{t('Fail')}</StyledTag>
+            <StyledTag type="critical">{t('Fail')}</StyledTag>
           )}
         </SummaryHeading>
         <StatNumber>{this.getFormattedStatNumber()}</StatNumber>
@@ -554,22 +554,13 @@ const Indicator = styled('div')<IndicatorProps>`
   background-color: ${p => p.color};
 `;
 
-const SummaryHeading = styled('div')`
-  display: flex;
-  justify-content: space-between;
+const StyledTag = styled(Tag)`
+  position: absolute;
+  right: ${space(3)};
 `;
 
 const Container = styled('div')`
   position: relative;
-`;
-
-const StyledTag = styled(Tag)`
-  div {
-    background-color: ${p => p.theme.red300};
-  }
-  span {
-    color: ${p => p.theme.white};
-  }
 `;
 
 function formatDuration(duration: number) {

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -544,6 +544,11 @@ type IndicatorProps = {
   color: string;
 };
 
+const SummaryHeading = styled('div')`
+  display: flex;
+  justify-content: space-between;
+`;
+
 const Indicator = styled('div')<IndicatorProps>`
   position: absolute;
   top: 20px;

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -68,11 +68,9 @@ const InviteRequestRow = ({
             </Description>
           )
         ) : (
-          <JoinRequestIndicator
-            tooltipText={t('This user has asked to join your organization.')}
-          >
-            {t('Join request')}
-          </JoinRequestIndicator>
+          <Tooltip title={t('This user has asked to join your organization.')}>
+            <Tag>{t('Join request')}</Tag>
+          </Tooltip>
         )}
       </div>
 
@@ -165,10 +163,6 @@ InviteRequestRow.propTypes = {
   allRoles: PropTypes.arrayOf(PropTypes.object),
   allTeams: PropTypes.arrayOf(PropTypes.object),
 };
-
-const JoinRequestIndicator = styled(Tag)`
-  text-transform: uppercase;
-`;
 
 const StyledPanelItem = styled(PanelItem)`
   display: grid;

--- a/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDebugFiles/debugFileRow.tsx
@@ -78,9 +78,11 @@ const DebugFileRow = ({
           {features && (
             <FeatureTags>
               {features.map(feature => (
-                <StyledTag key={feature} tooltipText={getFeatureTooltip(feature)}>
-                  {feature}
-                </StyledTag>
+                <React.Fragment key={feature}>
+                  <Tooltip title={getFeatureTooltip(feature)}>
+                    <StyledTag>{feature}</StyledTag>
+                  </Tooltip>
+                </React.Fragment>
               ))}
             </FeatureTags>
           )}

--- a/src/sentry/static/sentry/app/views/settings/projectSourceMaps/detail/sourceMapsArtifactRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSourceMaps/detail/sourceMapsArtifactRow.tsx
@@ -43,12 +43,9 @@ const SourceMapsArtifactRow = ({
             <IconClock size="sm" />
             <TimeSince date={dateCreated} />
           </TimeWrapper>
-          <StyledTag
-            type={dist ? 'info' : undefined}
-            tooltipText={dist ? undefined : t('No distribution set')}
-          >
-            {dist ?? t('none')}
-          </StyledTag>
+          <Tooltip title={dist ? undefined : t('No distribution set')}>
+            <StyledTag type={dist ? 'info' : undefined}>{dist ?? t('none')}</StyledTag>
+          </Tooltip>
         </TimeAndDistWrapper>
       </NameColumn>
       <SizeColumn>

--- a/tests/js/spec/components/tag.spec.jsx
+++ b/tests/js/spec/components/tag.spec.jsx
@@ -22,16 +22,6 @@ describe('Tag', function () {
     expect(wrapper.find('IconFire').exists()).toBeTruthy();
   });
 
-  it('with tooltip', function () {
-    const wrapper = mountWithTheme(
-      <Tag type="highlight" tooltipText="lorem ipsum">
-        Tooltip
-      </Tag>
-    );
-    expect(wrapper.text()).toEqual('Tooltip');
-    expect(wrapper.find('Tooltip').prop('title')).toEqual('lorem ipsum');
-  });
-
   it('with dismiss', function () {
     const mockCallback = jest.fn();
 

--- a/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
@@ -72,7 +72,7 @@ describe('InviteRequestRow', function () {
     );
 
     expect(wrapper.find('UserName').text()).toBe(joinRequest.email);
-    expect(wrapper.find('JoinRequestIndicator').exists()).toBe(true);
+    expect(wrapper.find('Tag').exists()).toBe(true);
   });
 
   it('can approve invite request', function () {


### PR DESCRIPTION
## Added Critical Tag type
New type of Tag added: 
<img width="135" alt="Screen Shot 2020-11-24 at 10 36 34 PM" src="https://user-images.githubusercontent.com/1900676/100191743-845b7580-2ea5-11eb-818d-97dc0f859e77.png">

## Removed tooltip from Tag component
We shouldn’t place atomic-like components in other atoms, so moving it out for now. If we want to add a tooltip to a tag then we should do this:

```
<Tooltip>
  <Tag>This is a tag</Tag>
</Tooltip>
```

## Removed default tooltip text for FeatureBadge
This creates all sorts of weirdness when we use it in different components. Like the one below: 
<img width="219" alt="Screen Shot 2020-11-24 at 4 34 29 PM" src="https://user-images.githubusercontent.com/1900676/100191600-49f1d880-2ea5-11eb-9412-583eaacb5b49.png">

From now on, if you need a FeatureBadge with a tooltip then it should be added explicitly. 

## Updated fail/pass tags on Web Vitals page
Fixed casing and updated with new tag component
