### PR TITLE
feat(stacktrace-linking): creates endpoint for parsing repo paths and finding the roots

### DIFF
--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -29,7 +29,7 @@ def find_roots(stack_path, source_path):
         overlap_to_check = overlap_to_check[1:]
     # validate_source_url should have ensured the file names match
     # so if we get here something went wrong and there is a bug
-    raise Exception("Could not common root from paths")
+    raise Exception("Could not find common root from paths")
 
 
 class PathMappingSerializer(CamelSnakeSerializer):

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -1,0 +1,131 @@
+from __future__ import absolute_import
+
+from rest_framework import status, serializers
+
+from sentry import integrations
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
+from sentry.models import Integration, Repository
+from sentry.utils.compat import filter, map
+from sentry.web.decorators import transaction_start
+
+
+def find_roots(stack_path, source_path):
+    """
+        Returns a tuple containing the stack_root, and the source_root.
+        If there is no overlap, raise an exception since this should not happen
+    """
+    overlap_to_check = stack_path
+    stack_root = ""
+    while overlap_to_check:
+        # see if our path ends with the overlap we want
+        if source_path.endswith(overlap_to_check):
+            # determine the source root by removing the overlap
+            source_root = source_path.rpartition(overlap_to_check)[0]
+            return (stack_root, source_root)
+        # increase the stack root specificity
+        # while decreasing the overlap
+        stack_root += overlap_to_check[0]
+        overlap_to_check = overlap_to_check[1:]
+    # validate_source_url should have ensured the file names match
+    # so if we get here something went wrong and there is a bug
+    raise Exception("Could not common root from paths")
+
+
+class PathMappingSerializer(CamelSnakeSerializer):
+    stack_path = serializers.CharField()
+    source_url = serializers.URLField()
+
+    def __init__(self, *args, **kwargs):
+        super(PathMappingSerializer, self).__init__(*args, **kwargs)
+        self.integration = None
+        self.repo = None
+
+    @property
+    def providers(self):
+        # TODO: use feature flag in the future
+        providers = filter(lambda x: x.has_stacktrace_linking, list(integrations.all()))
+        return map(lambda x: x.key, providers)
+
+    @property
+    def org_id(self):
+        return self.context["organization_id"]
+
+    def validate_source_url(self, source_url):
+        # first check to see if we are even looking at the same file
+        stack_path = self.initial_data["stack_path"]
+        stack_file = stack_path.split("/")[-1]
+        source_file = source_url.split("/")[-1]
+
+        if stack_file != source_file:
+            raise serializers.ValidationError(
+                "Source code URL points to a different file than the stack trace"
+            )
+
+        def integration_match(integration):
+            return source_url.startswith(u"https://{}".format(integration.metadata["domain_name"]))
+
+        def repo_match(repo):
+            return source_url.startswith(repo.url)
+
+        # now find the matching integration
+        integrations = Integration.objects.filter(
+            organizations=self.org_id, provider__in=self.providers
+        )
+
+        matching_integrations = filter(integration_match, integrations)
+        if not matching_integrations:
+            raise serializers.ValidationError("Could not find integration")
+
+        self.integration = matching_integrations[0]
+
+        # now find the matching repo
+        repos = Repository.objects.filter(integration_id=self.integration.id)
+        matching_repos = filter(repo_match, repos)
+        if not matching_repos:
+            raise serializers.ValidationError("Could not find repo")
+
+        # store the repo we found
+        self.repo = matching_repos[0]
+        return source_url
+
+
+class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
+    """
+        Returns the parameters associated with the RepositoryProjectPathConfig
+        we would create based on a particular stack trace and source code URL.
+        Does validation to make sure we have an integration and repo
+        depending on the source code URL
+    """
+
+    @transaction_start("ProjectRepoPathParsingEndpoint")
+    def post(self, request, project):
+        serializer = PathMappingSerializer(
+            context={"organization_id": project.organization_id}, data=request.data,
+        )
+        if not serializer.is_valid():
+            return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        data = serializer.validated_data
+        source_url = data["source_url"]
+        stack_path = data["stack_path"]
+
+        repo = serializer.repo
+        integration = serializer.integration
+
+        # strip off the base URL
+        rest_url = source_url.replace(u"{}/blob/".format(repo.url), "")
+        branch, _, source_path = rest_url.partition("/")
+
+        stack_root, source_root = find_roots(stack_path, source_path)
+
+        return self.respond(
+            {
+                "integrationId": integration.id,
+                "repoId": repo.id,
+                "provider": integration.provider,
+                "stackRoot": stack_root,
+                "sourceRoot": source_root,
+                "branch": branch,
+            }
+        )

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -239,6 +239,7 @@ from .endpoints.project_user_reports import ProjectUserReportsEndpoint
 from .endpoints.project_user_stats import ProjectUserStatsEndpoint
 from .endpoints.project_users import ProjectUsersEndpoint
 from .endpoints.project_stacktrace_link import ProjectStacktraceLinkEndpoint
+from .endpoints.project_repo_path_parsing import ProjectRepoPathParsingEndpoint
 from .endpoints.prompts_activity import PromptsActivityEndpoint
 from .endpoints.relay_details import RelayDetailsEndpoint
 from .endpoints.relay_healthcheck import RelayHealthCheck
@@ -1603,6 +1604,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/stacktrace-link/$",
                     ProjectStacktraceLinkEndpoint.as_view(),
                     name="sentry-api-0-project-stacktrace-link",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/repo-path-parsing/$",
+                    ProjectRepoPathParsingEndpoint.as_view(),
+                    name="sentry-api-0-project-repo-path-parsing",
                 ),
             ]
         ),

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -256,6 +256,7 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
     name = "GitHub Enterprise"
     metadata = metadata
     integration_cls = GitHubEnterpriseIntegration
+    has_stacktrace_linking = False
 
     def _make_identity_pipeline_view(self):
         """

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -433,11 +433,14 @@ class Factories(object):
         return bundle.getvalue()
 
     @staticmethod
-    def create_repo(project, name=None):
+    def create_repo(project, name=None, provider=None, integration_id=None, url=None):
         repo = Repository.objects.create(
             organization_id=project.organization_id,
             name=name
             or "{}-{}".format(petname.Generate(2, "", letters=10), random.randint(1000, 9999)),
+            provider=provider,
+            integration_id=integration_id,
+            url=url,
         )
         return repo
 

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -1,0 +1,132 @@
+from __future__ import absolute_import
+
+
+from django.core.urlresolvers import reverse
+
+from sentry.models import Integration
+from sentry.testutils import APITestCase
+
+
+class ProjectStacktraceLinkTest(APITestCase):
+    def setUp(self):
+        self.org = self.create_organization(owner=self.user, name="blap")
+        self.project = self.create_project(
+            name="foo", organization=self.org, teams=[self.create_team(organization=self.org)]
+        )
+
+        self.integration = Integration.objects.create(
+            provider="github",
+            name="getsentry",
+            external_id="1234",
+            metadata={"domain_name": "github.com/getsentry"},
+        )
+
+        self.oi = self.integration.add_organization(self.org, self.user)
+
+        self.repo = self.create_repo(
+            project=self.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            integration_id=self.integration.id,
+            url="https://github.com/getsentry/sentry",
+        )
+
+        self.create_repo(
+            project=self.project,
+            name="getsentry/getsentry",
+            provider="integrations:github",
+            integration_id=self.integration.id,
+            url="https://github.com/getsentry/getsentry",
+        )
+
+    def make_post(self, source_url, stack_path, project=None):
+        self.login_as(user=self.user)
+        if not project:
+            project = self.project
+
+        url = reverse(
+            "sentry-api-0-project-repo-path-parsing",
+            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        )
+
+        return self.client.post(url, data={"sourceUrl": source_url, "stackPath": stack_path})
+
+    def test_bad_source_url(self):
+        source_url = "github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/project_stacktrace_link.py"
+        stack_path = "sentry/api/endpoints/project_stacktrace_link.py"
+        resp = self.make_post(source_url, stack_path)
+        assert resp.status_code == 400, resp.content
+        assert resp.data == {"sourceUrl": ["Enter a valid URL."]}
+
+    def test_wrong_file(self):
+        source_url = "https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/project_releases.py"
+        stack_path = "sentry/api/endpoints/project_stacktrace_link.py"
+        resp = self.make_post(source_url, stack_path)
+        assert resp.status_code == 400, resp.content
+        assert resp.data == {
+            "sourceUrl": ["Source code URL points to a different file than the stack trace"]
+        }
+
+    def test_no_integration(self):
+        # create the integration but don't install it
+        Integration.objects.create(
+            provider="github",
+            name="steve",
+            external_id="345",
+            metadata={"domain_name": "github.com/steve"},
+        )
+        source_url = "https://github.com/steve/sentry/blob/master/src/sentry/api/endpoints/project_stacktrace_link.py"
+        stack_path = "sentry/api/endpoints/project_stacktrace_link.py"
+        resp = self.make_post(source_url, stack_path)
+        assert resp.status_code == 400, resp.content
+        assert resp.data == {"sourceUrl": ["Could not find integration"]}
+
+    def test_no_repo(self):
+        source_url = "https://github.com/getsentry/snuba/blob/master/src/sentry/api/endpoints/project_stacktrace_link.py"
+        stack_path = "sentry/api/endpoints/project_stacktrace_link.py"
+        resp = self.make_post(source_url, stack_path)
+        assert resp.status_code == 400, resp.content
+        assert resp.data == {"sourceUrl": ["Could not find repo"]}
+
+    def test_basic(self):
+        source_url = "https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/project_stacktrace_link.py"
+        stack_path = "sentry/api/endpoints/project_stacktrace_link.py"
+        resp = self.make_post(source_url, stack_path)
+        assert resp.status_code == 200, resp.content
+
+        assert resp.data == {
+            "integrationId": self.integration.id,
+            "repoId": self.repo.id,
+            "provider": "github",
+            "stackRoot": "",
+            "sourceRoot": "src/",
+            "branch": "master",
+        }
+
+    def test_short_path(self):
+        source_url = "https://github.com/getsentry/sentry/blob/main/project_stacktrace_link.py"
+        stack_path = "sentry/project_stacktrace_link.py"
+        resp = self.make_post(source_url, stack_path)
+        assert resp.status_code == 200, resp.content
+        assert resp.data == {
+            "integrationId": self.integration.id,
+            "repoId": self.repo.id,
+            "provider": "github",
+            "stackRoot": "sentry/",
+            "sourceRoot": "",
+            "branch": "main",
+        }
+
+    def test_long_root(self):
+        source_url = "https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/project_stacktrace_link.py"
+        stack_path = "stuff/hey/here/sentry/api/endpoints/project_stacktrace_link.py"
+        resp = self.make_post(source_url, stack_path)
+        assert resp.status_code == 200, resp.content
+        assert resp.data == {
+            "integrationId": self.integration.id,
+            "repoId": self.repo.id,
+            "provider": "github",
+            "stackRoot": "stuff/hey/here",
+            "sourceRoot": "src",
+            "branch": "master",
+        }


### PR DESCRIPTION
This PR creates a new endpoint that takes in a stack trace and the matching source code URL and determines the parameters needed to create a `RepositoryProjectPathConfig`. This will be used on the issues page so people can set up rules without really understanding how to set up a config; they just have to find the file in their source code provider that matches the stack trace they are looking at. The parameters of the endpoint are:

- sourceUrl (the full URL of the file in the source code )
- stackPath (the path of the file in the stack trace)

The endpoint returns the following:

- integrationId
- repoId
- provider
- stackRoot
- sourceRoot
- branch

The endpoint works by looping through all the integrations that support stacktrace linking (just Github and Gitlab for now) then finding the integration that has a matching `domain_name`. If no integration is found, we raise an error. We then loop through the repos for one that has a matching `url`. If none is found, we raise an error.

From there we pull apart the rest of the URL to determine the branch given in the path and the path to the file within that branch (`source_path`). We then figure out what the longest possible ending substring is between the `sourcePath` and the `stackPath`. Everything that is not part of that common substring are the roots (`stackRoot` and `sourceRoot`).