### PR TITLE
feat(avatar): Added suggested avatar style to storybook

### DIFF
--- a/docs-ui/components/avatar.stories.js
+++ b/docs-ui/components/avatar.stories.js
@@ -16,12 +16,14 @@ export default {
 
 export const Letters = withInfo('This is the default avatar')(() => {
   const hasTooltip = boolean('Display a tooltip', false);
+  const showAsSuggested = boolean('Show as suggested avatar', false);
   const user = Object.assign({}, USER);
-  return <Avatar user={user} hasTooltip={hasTooltip} />;
+  return <Avatar user={user} hasTooltip={hasTooltip} suggested={showAsSuggested} />;
 });
 
 export const Gravatar = withInfo('Avatar source from gravatar')(() => {
   const hasTooltip = boolean('Display a tooltip', false);
+  const showAsSuggested = boolean('Show as suggested avatar', false);
   const user = {
     id: 2,
     name: 'Ben Vinegar',
@@ -31,25 +33,27 @@ export const Gravatar = withInfo('Avatar source from gravatar')(() => {
       avatarUuid: '2d641b5d-8c74-44de-9cb6-fbd54701b35e',
     },
   };
-  return <Avatar user={user} hasTooltip={hasTooltip} />;
+  return <Avatar user={user} hasTooltip={hasTooltip} suggested={showAsSuggested} />;
 });
 
 export const UploadedImage = withInfo('Uploaded image')(() => {
   const hasTooltip = boolean('Display a tooltip', false);
+  const showAsSuggested = boolean('Show as suggested avatar', false);
   const user = Object.assign({}, USER, {
     avatar: {
       avatarType: 'upload',
       avatarUuid: '51e63edabf31412aa2a955e9cf2c1ca0',
     },
   });
-  return <Avatar user={user} hasTooltip={hasTooltip} />;
+  return <Avatar user={user} hasTooltip={hasTooltip} suggested={showAsSuggested} />;
 });
 
 export const TeamAvatar = withInfo('Avatar for teams')(() => {
   const hasTooltip = boolean('Display a tooltip', false);
+  const showAsSuggested = boolean('Display as suggested avatar', false);
   const team = {
     name: 'Captain Planet',
     slug: 'captain-planet',
   };
-  return <Avatar team={team} hasTooltip={hasTooltip} />;
+  return <Avatar team={team} hasTooltip={hasTooltip} suggested={showAsSuggested} />;
 });

--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
@@ -8,7 +8,7 @@ import LetterAvatar from 'app/components/letterAvatar';
 import Tooltip from 'app/components/tooltip';
 
 import Gravatar from './gravatar';
-import {imageStyle} from './styles';
+import {imageStyle, ImageStyleProps} from './styles';
 
 const DEFAULT_GRAVATAR_SIZE = 64;
 const ALLOWED_SIZES = [20, 32, 36, 48, 52, 64, 80, 96, 120];
@@ -67,6 +67,8 @@ type Props = {
   forwardedRef?: React.Ref<HTMLSpanElement>;
 
   style?: React.CSSProperties;
+
+  suggested?: boolean;
 } & Partial<DefaultProps> &
   React.HTMLAttributes<HTMLSpanElement>;
 
@@ -167,7 +169,7 @@ class BaseAvatar extends React.Component<Props, State> {
       return null;
     }
 
-    const {type, round, gravatarId} = this.props;
+    const {type, round, gravatarId, suggested} = this.props;
 
     const eventProps = {
       onError: this.handleError,
@@ -181,21 +183,38 @@ class BaseAvatar extends React.Component<Props, State> {
           gravatarId={gravatarId}
           round={round}
           remoteSize={DEFAULT_REMOTE_SIZE}
+          suggested={suggested}
+          grayscale={suggested}
           {...eventProps}
         />
       );
     }
 
     if (type === 'upload') {
-      return <Image round={round} src={this.buildUploadUrl()} {...eventProps} />;
+      return (
+        <Image
+          round={round}
+          src={this.buildUploadUrl()}
+          {...eventProps}
+          suggested={suggested}
+          grayscale={suggested}
+        />
+      );
     }
 
     return this.renderLetterAvatar();
   };
 
   renderLetterAvatar() {
-    const {title, letterId, round} = this.props;
-    return <LetterAvatar round={round} displayName={title} identifier={letterId} />;
+    const {title, letterId, round, suggested} = this.props;
+    return (
+      <LetterAvatar
+        round={round}
+        displayName={title}
+        identifier={letterId}
+        suggested={suggested}
+      />
+    );
   }
 
   render() {
@@ -250,6 +269,6 @@ const StyledBaseAvatar = styled('span')<{round: boolean; loaded: boolean}>`
   ${p => p.round && 'border-radius: 100%;'};
 `;
 
-const Image = styled('img')<Pick<Props, 'round'>>`
+const Image = styled('img')<ImageStyleProps>`
   ${imageStyle};
 `;

--- a/src/sentry/static/sentry/app/components/avatar/gravatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/gravatar.tsx
@@ -96,6 +96,6 @@ class Gravatar extends React.Component<Props, State> {
 
 export default Gravatar;
 
-const Image = styled('img')<{round?: boolean; suggested?: boolean; grayscale?: boolean}>`
+const Image = styled('img')<ImageStyleProps>`
   ${imageStyle};
 `;

--- a/src/sentry/static/sentry/app/components/avatar/gravatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/gravatar.tsx
@@ -6,19 +6,15 @@ import * as qs from 'query-string';
 import ConfigStore from 'app/stores/configStore';
 import {callIfFunction} from 'app/utils/callIfFunction';
 
-import {imageStyle} from './styles';
+import {imageStyle, ImageStyleProps} from './styles';
 
 type Props = {
   remoteSize: number;
   gravatarId?: string;
   placeholder?: string;
-  /**
-   * Should avatar be round instead of a square
-   */
-  round?: boolean;
   onLoad?: () => void;
   onError?: () => void;
-};
+} & ImageStyleProps;
 
 type State = {
   MD5?: any;
@@ -83,7 +79,7 @@ class Gravatar extends React.Component<Props, State> {
       return null;
     }
 
-    const {round, onError, onLoad} = this.props;
+    const {round, onError, onLoad, suggested, grayscale} = this.props;
 
     return (
       <Image
@@ -91,6 +87,8 @@ class Gravatar extends React.Component<Props, State> {
         src={this.buildGravatarUrl()}
         onLoad={onLoad}
         onError={onError}
+        suggested={suggested}
+        grayscale={grayscale}
       />
     );
   }
@@ -98,6 +96,6 @@ class Gravatar extends React.Component<Props, State> {
 
 export default Gravatar;
 
-const Image = styled('img')<{round?: boolean}>`
+const Image = styled('img')<{round?: boolean; suggested?: boolean; grayscale?: boolean}>`
   ${imageStyle};
 `;

--- a/src/sentry/static/sentry/app/components/avatar/styles.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/styles.tsx
@@ -1,8 +1,22 @@
 import {css} from '@emotion/core';
 
-export const imageStyle = (props: {round?: boolean}) => css`
+import theme from 'app/utils/theme';
+
+export type ImageStyleProps = {
+  round?: boolean;
+  suggested?: boolean;
+  grayscale?: boolean;
+};
+
+export const imageStyle = (props: ImageStyleProps) => css`
   position: absolute;
   top: 0px;
   left: 0px;
   border-radius: ${props.round ? '50%' : '3px'};
+  border: ${props.suggested ? `1px dashed ${theme.gray400}` : 'none'};
+  ${props.grayscale &&
+  css`
+    padding: 1px;
+    filter: grayscale(100%);
+  `}
 `;

--- a/src/sentry/static/sentry/app/components/letterAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/letterAvatar.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
 import {imageStyle} from 'app/components/avatar/styles';
+import theme from 'app/utils/theme';
 
 const COLORS = [
   '#4674ca', // blue
@@ -56,6 +57,7 @@ type Props = {
   displayName?: string;
   round?: boolean;
   forwardedRef?: React.Ref<SVGSVGElement>;
+  suggested?: boolean;
 };
 
 type LetterAvatarProps = React.ComponentProps<'svg'> & Props;
@@ -70,6 +72,7 @@ const LetterAvatar = styled(
     displayName,
     round: _round,
     forwardedRef,
+    suggested,
     ...props
   }: LetterAvatarProps) => (
     <svg ref={forwardedRef} viewBox="0 0 120 120" {...props}>
@@ -80,7 +83,7 @@ const LetterAvatar = styled(
         height="120"
         rx="15"
         ry="15"
-        fill={getColor(identifier)}
+        fill={suggested ? '#FFFFFF' : getColor(identifier)}
       />
       <text
         x="50%"
@@ -88,7 +91,7 @@ const LetterAvatar = styled(
         fontSize="65"
         style={{dominantBaseline: 'central'}}
         textAnchor="middle"
-        fill="#FFFFFF"
+        fill={suggested ? theme.gray400 : '#FFFFFF'}
       >
         {getInitials(displayName)}
       </text>


### PR DESCRIPTION
Soon the issues stream will surface suggested owners based on ownership rules and suspect commits. This PR adds the style of avatar that will be shown when there is a suggested assignee present on an issue.

![image](https://user-images.githubusercontent.com/9372512/100278510-fcbc4800-2f32-11eb-8b77-f8b99ab3fa39.png)

New styles are visible via knobs in the avatar story.