### PR TITLE
ref(py3): Add default cache key prefix for PY3

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -10,6 +10,7 @@ import os.path
 import re
 import socket
 import sys
+import six
 import tempfile
 
 import sentry
@@ -1127,7 +1128,7 @@ CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 # The cache version affects both Django's internal cache (at runtime) as well
 # as Sentry's cache. This automatically overrides VERSION on the default
 # CACHES backend.
-CACHE_VERSION = 1
+CACHE_VERSION = 2 if six.PY3 else 1
 
 # Digests backend
 SENTRY_DIGESTS = "sentry.digests.backends.dummy.DummyBackend"

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -313,7 +313,9 @@ def initialize_app(config, skip_service_validation=False):
     if not hasattr(settings, "CSRF_COOKIE_PATH"):
         settings.CSRF_COOKIE_PATH = getattr(settings, "SESSION_COOKIE_PATH", "/")
 
-    settings.CACHES["default"]["VERSION"] = settings.CACHE_VERSION
+    for key in settings.CACHES:
+        if not hasattr(settings.CACHES[key], "VERSION"):
+            settings.CACHES[key]["VERSION"] = settings.CACHE_VERSION
 
     settings.ASSET_VERSION = get_asset_version(settings)
     settings.STATIC_URL = settings.STATIC_URL.format(version=settings.ASSET_VERSION)

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -5,9 +5,13 @@ from __future__ import absolute_import
 from sentry.utils.compat import mock
 import zlib
 import pytest
+import six
 
 from sentry.cache.redis import RedisClusterCache, RbCache
 from sentry.utils.imports import import_string
+
+
+KEY_FMT = "c:2:%s" if six.PY3 else "c:1:%s"
 
 
 class FakeClient(object):
@@ -55,8 +59,8 @@ def mocked_attachment_cache(request, mock_client):
 
 
 def test_process_pending_one_batch(mocked_attachment_cache, mock_client):
-    mock_client.data["c:1:foo:a"] = '[{"name":"foo.txt","content_type":"text/plain"}]'
-    mock_client.data["c:1:foo:a:0"] = zlib.compress(b"Hello World!")
+    mock_client.data[KEY_FMT % "foo:a"] = '[{"name":"foo.txt","content_type":"text/plain"}]'
+    mock_client.data[KEY_FMT % "foo:a:0"] = zlib.compress(b"Hello World!")
 
     (attachment,) = mocked_attachment_cache.get("foo")
     assert attachment.meta() == {
@@ -69,10 +73,12 @@ def test_process_pending_one_batch(mocked_attachment_cache, mock_client):
 
 
 def test_chunked(mocked_attachment_cache, mock_client):
-    mock_client.data["c:1:foo:a"] = '[{"name":"foo.txt","content_type":"text/plain","chunks":3}]'
-    mock_client.data["c:1:foo:a:0:0"] = zlib.compress(b"Hello World!")
-    mock_client.data["c:1:foo:a:0:1"] = zlib.compress(b" This attachment is ")
-    mock_client.data["c:1:foo:a:0:2"] = zlib.compress(b"chunked up.")
+    mock_client.data[
+        KEY_FMT % "foo:a"
+    ] = '[{"name":"foo.txt","content_type":"text/plain","chunks":3}]'
+    mock_client.data[KEY_FMT % "foo:a:0:0"] = zlib.compress(b"Hello World!")
+    mock_client.data[KEY_FMT % "foo:a:0:1"] = zlib.compress(b" This attachment is ")
+    mock_client.data[KEY_FMT % "foo:a:0:2"] = zlib.compress(b"chunked up.")
 
     (attachment,) = mocked_attachment_cache.get("foo")
     assert attachment.meta() == {

--- a/tests/sentry/integrations/test_client.py
+++ b/tests/sentry/integrations/test_client.py
@@ -48,18 +48,17 @@ class ApiClientTest(TestCase):
         resp = ApiClient().patch("http://example.com")
         assert resp.status_code == 200
 
-    @mock.patch("django.core.cache.cache.set")
-    @mock.patch("django.core.cache.cache.get")
+    @mock.patch("sentry.shared_integrations.client.cache")
     @responses.activate
-    def test_cache_mocked(self, cache_get, cache_set):
-        cache_get.return_value = None
+    def test_cache_mocked(self, cache):
+        cache.get.return_value = None
         responses.add(responses.GET, "http://example.com", json={"key": "value1"})
         resp = ApiClient().get_cached("http://example.com")
         assert resp == {"key": "value1"}
 
         key = "integration.undefined.client:a9b9f04336ce0181a08e774e01113b31"
-        cache_get.assert_called_with(key)
-        cache_set.assert_called_with(key, {"key": "value1"}, 900)
+        cache.get.assert_called_with(key)
+        cache.set.assert_called_with(key, {"key": "value1"}, 900)
 
     @responses.activate
     def test_get_cached_basic(self):

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -7,6 +7,7 @@ from uuid import uuid1
 import pytest
 from exam import before, fixture
 from sentry.utils.compat.mock import patch
+from django.conf import settings
 from django.core.cache.backends.locmem import LocMemCache
 
 from sentry.models import Option
@@ -17,7 +18,7 @@ from sentry.testutils import TestCase
 class OptionsStoreTest(TestCase):
     @fixture
     def store(self):
-        c = LocMemCache("test", {})
+        c = LocMemCache("test", settings.CACHES["default"])
         c.clear()
         return OptionsStore(cache=c)
 


### PR DESCRIPTION
Supercedes getsentry/getsentry#4711, depends on #22322.
getsentry/getsentry#4711 needs to be reverted after this lands.