### PR TITLE
chore: SENTRY_USE_SSL is not used

### DIFF
--- a/docker/sentry.conf.py
+++ b/docker/sentry.conf.py
@@ -200,12 +200,10 @@ SENTRY_DIGESTS = "sentry.digests.backends.redis.RedisBackend"
 ##############
 
 # If you're using a reverse SSL proxy, you should enable the X-Forwarded-Proto
-# header and set `SENTRY_USE_SSL=1`
-
-if Bool(env("SENTRY_USE_SSL", False)):
-    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-    SESSION_COOKIE_SECURE = True
-    CSRF_COOKIE_SECURE = True
+# header and uncomment the following settings:
+# SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+# SESSION_COOKIE_SECURE = True
+# CSRF_COOKIE_SECURE = True
 
 SENTRY_WEB_HOST = "0.0.0.0"
 SENTRY_WEB_PORT = 9000


### PR DESCRIPTION
See also https://github.com/getsentry/single-tenant/pull/295.

This is just a holdout from old docker repo - we should remove this to reduce confusion. People shoudn't be using it. 
