### PR TITLE
ref(dashboard): Refactor Dashboard details

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -211,7 +211,7 @@ class DashboardDetail extends React.Component<Props, State> {
           params={params}
           organization={organization}
         >
-          {({dashboard, orgDashboards, reloadData}) => {
+          {({dashboard, dashboards, reloadData}) => {
             return (
               <React.Fragment>
                 <StyledPageHeader>
@@ -221,7 +221,7 @@ class DashboardDetail extends React.Component<Props, State> {
                   />
                   <Controls
                     organization={organization}
-                    dashboards={orgDashboards}
+                    dashboards={dashboards}
                     dashboard={dashboard}
                     onEdit={this.onEdit(dashboard)}
                     onCreate={this.onCreate}

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -12,13 +12,8 @@ import {
 } from 'app/actionCreators/dashboards';
 import {addSuccessMessage} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
-import AsyncComponent from 'app/components/asyncComponent';
-import NotFound from 'app/components/errors/notFound';
-import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
-import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
-import {PageContent} from 'app/styles/organization';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import withApi from 'app/utils/withApi';
@@ -26,15 +21,10 @@ import withOrganization from 'app/utils/withOrganization';
 
 import Controls from './controls';
 import Dashboard from './dashboard';
-import {EMPTY_DASHBOARD, PREBUILT_DASHBOARDS} from './data';
+import {EMPTY_DASHBOARD} from './data';
+import OrgDashboards from './orgDashboards';
 import Title from './title';
-import {
-  DashboardListItem,
-  DashboardState,
-  OrgDashboard,
-  OrgDashboardResponse,
-  Widget,
-} from './types';
+import {DashboardListItem, DashboardState, OrgDashboardResponse, Widget} from './types';
 import {cloneDashboard} from './utils';
 
 type Props = {
@@ -45,36 +35,30 @@ type Props = {
 };
 
 type State = {
-  // local state
   dashboardState: DashboardState;
   changesDashboard: DashboardListItem | undefined;
-
-  // endpoint response
-  orgDashboards: OrgDashboardResponse[] | null;
-} & AsyncComponent['state'];
-
-class DashboardDetail extends AsyncComponent<Props, State> {
+};
+class DashboardDetail extends React.Component<Props, State> {
   state: State = {
-    // AsyncComponent state
-    loading: true,
-    reloading: false,
-    error: false,
-    errors: [],
-
-    // endpoint response
-    orgDashboards: [],
-
-    // local state
     dashboardState: 'default',
     changesDashboard: undefined,
   };
 
-  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {organization} = this.props;
+  static getDerivedStateFromProps(props: Props, state: State) {
+    if (state.changesDashboard && state.changesDashboard.type === 'org') {
+      const {params} = props;
+      const dashboardId = params.dashboardId as string | undefined;
 
-    const url = `/organizations/${organization.slug}/dashboards/`;
+      if (typeof dashboardId === 'string' && state.changesDashboard.id !== dashboardId) {
+        return {
+          ...state,
+          dashboardState: 'default',
+          changesDashboard: undefined,
+        };
+      }
+    }
 
-    return [['orgDashboards', url]];
+    return state;
   }
 
   onEdit = (dashboard: DashboardListItem) => () => {
@@ -112,7 +96,13 @@ class DashboardDetail extends AsyncComponent<Props, State> {
     }
   };
 
-  onCommit = dashboard => () => {
+  onCommit = ({
+    dashboard,
+    reloadData,
+  }: {
+    dashboard: DashboardListItem;
+    reloadData: () => void;
+  }) => () => {
     const {api, organization, location} = this.props;
     const {dashboardState, changesDashboard} = this.state;
 
@@ -162,7 +152,7 @@ class DashboardDetail extends AsyncComponent<Props, State> {
               changesDashboard: undefined,
             });
 
-            this.reloadData();
+            reloadData();
           });
 
           return;
@@ -185,21 +175,6 @@ class DashboardDetail extends AsyncComponent<Props, State> {
     }
   };
 
-  getOrgDashboards(): OrgDashboard[] {
-    const {orgDashboards} = this.state;
-
-    if (!Array.isArray(orgDashboards)) {
-      return [];
-    }
-
-    return orgDashboards.map(dashboard => {
-      return {
-        type: 'org',
-        ...dashboard,
-      };
-    });
-  }
-
   onWidgetChange = (widgets: Widget[]) => {
     const {changesDashboard} = this.state;
     if (changesDashboard === undefined) {
@@ -217,130 +192,65 @@ class DashboardDetail extends AsyncComponent<Props, State> {
     });
   };
 
-  getDashboardsList(): DashboardListItem[] {
-    const {orgDashboards} = this.state;
-
-    if (!Array.isArray(orgDashboards)) {
-      return PREBUILT_DASHBOARDS;
-    }
-
-    const normalizedOrgDashboards: OrgDashboard[] = orgDashboards.map(dashboard => {
-      return {
-        type: 'org',
-        ...dashboard,
-      };
-    });
-
-    return [...PREBUILT_DASHBOARDS, ...normalizedOrgDashboards];
-  }
-
-  getCurrentDashboard(): DashboardListItem | undefined {
-    const {params} = this.props;
-    const dashboardId = params.dashboardId as string | undefined;
-    const orgDashboards = this.getOrgDashboards();
-
-    if (typeof dashboardId === 'string') {
-      return orgDashboards.find(dashboard => {
-        return dashboard.id === dashboardId;
-      });
-    }
-
-    return PREBUILT_DASHBOARDS[0];
-  }
-
   setChangesDashboard = (dashboard: DashboardListItem) => {
     this.setState({
       changesDashboard: dashboard,
     });
   };
 
-  renderBody() {
-    const dashboard = this.getCurrentDashboard();
-
-    if (!dashboard) {
-      return <NotFound />;
-    }
-
-    return this.renderContent(dashboard);
-  }
-
-  renderError(error: Error) {
-    const notFound = Object.values(this.state.errors).find(
-      resp => resp && resp.status === 404
-    );
-
-    if (notFound) {
-      return <NotFound />;
-    }
-
-    return super.renderError(error, true, true);
-  }
-
-  renderContent(dashboard: DashboardListItem) {
-    const {organization} = this.props;
+  render() {
+    const {api, location, params, organization} = this.props;
 
     return (
       <GlobalSelectionHeader
         skipLoadLastUsed={organization.features.includes('global-views')}
       >
-        <PageContent>
-          <LightWeightNoProjectMessage organization={organization}>
-            <StyledPageHeader>
-              <Title
-                changesDashboard={this.state.changesDashboard}
-                setChangesDashboard={this.setChangesDashboard}
-              />
-              <Controls
-                organization={organization}
-                dashboards={this.getDashboardsList()}
-                dashboard={dashboard}
-                onEdit={this.onEdit(dashboard)}
-                onCreate={this.onCreate}
-                onCancel={this.onCancel}
-                onCommit={this.onCommit(dashboard)}
-                onDelete={this.onDelete(dashboard)}
-                dashboardState={this.state.dashboardState}
-              />
-            </StyledPageHeader>
-            {this.state.changesDashboard ? (
-              <Dashboard
-                dashboard={this.state.changesDashboard}
-                organization={organization}
-                isEditing={this.state.dashboardState === 'edit'}
-                onUpdate={this.onWidgetChange}
-              />
-            ) : (
-              <Dashboard
-                dashboard={dashboard}
-                organization={organization}
-                isEditing={this.state.dashboardState === 'edit'}
-                onUpdate={this.onWidgetChange}
-              />
-            )}
-          </LightWeightNoProjectMessage>
-        </PageContent>
+        <OrgDashboards
+          api={api}
+          location={location}
+          params={params}
+          organization={organization}
+        >
+          {({dashboard, orgDashboards, reloadData}) => {
+            return (
+              <React.Fragment>
+                <StyledPageHeader>
+                  <Title
+                    changesDashboard={this.state.changesDashboard}
+                    setChangesDashboard={this.setChangesDashboard}
+                  />
+                  <Controls
+                    organization={organization}
+                    dashboards={orgDashboards}
+                    dashboard={dashboard}
+                    onEdit={this.onEdit(dashboard)}
+                    onCreate={this.onCreate}
+                    onCancel={this.onCancel}
+                    onCommit={this.onCommit({dashboard, reloadData})}
+                    onDelete={this.onDelete(dashboard)}
+                    dashboardState={this.state.dashboardState}
+                  />
+                </StyledPageHeader>
+                {this.state.changesDashboard ? (
+                  <Dashboard
+                    dashboard={this.state.changesDashboard}
+                    organization={organization}
+                    isEditing={this.state.dashboardState === 'edit'}
+                    onUpdate={this.onWidgetChange}
+                  />
+                ) : (
+                  <Dashboard
+                    dashboard={dashboard}
+                    organization={organization}
+                    isEditing={this.state.dashboardState === 'edit'}
+                    onUpdate={this.onWidgetChange}
+                  />
+                )}
+              </React.Fragment>
+            );
+          }}
+        </OrgDashboards>
       </GlobalSelectionHeader>
-    );
-  }
-
-  renderComponent() {
-    const {organization, location} = this.props;
-
-    if (!organization.features.includes('dashboards-v2')) {
-      // Redirect to Dashboards v1
-      browserHistory.replace({
-        pathname: `/organizations/${organization.slug}/dashboards/`,
-        query: {
-          ...location.query,
-        },
-      });
-      return null;
-    }
-
-    return (
-      <SentryDocumentTitle title={t('Dashboards')} objSlug={organization.slug}>
-        {super.renderComponent()}
-      </SentryDocumentTitle>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -40,7 +40,7 @@ type State = {
 };
 class DashboardDetail extends React.Component<Props, State> {
   state: State = {
-    dashboardState: 'default',
+    dashboardState: 'view',
     changesDashboard: undefined,
   };
 
@@ -77,7 +77,7 @@ class DashboardDetail extends React.Component<Props, State> {
 
   onCancel = () => {
     this.setState({
-      dashboardState: 'default',
+      dashboardState: 'view',
       changesDashboard: undefined,
     });
   };
@@ -116,7 +116,7 @@ class DashboardDetail extends React.Component<Props, State> {
               // redirect to new dashboard
 
               this.setState({
-                dashboardState: 'default',
+                dashboardState: 'view',
                 changesDashboard: undefined,
               });
 
@@ -138,7 +138,7 @@ class DashboardDetail extends React.Component<Props, State> {
 
           if (isEqual(dashboard, changesDashboard)) {
             this.setState({
-              dashboardState: 'default',
+              dashboardState: 'view',
               changesDashboard: undefined,
             });
             return;
@@ -148,7 +148,7 @@ class DashboardDetail extends React.Component<Props, State> {
             addSuccessMessage(t('Dashboard updated'));
 
             this.setState({
-              dashboardState: 'default',
+              dashboardState: 'view',
               changesDashboard: undefined,
             });
 
@@ -159,15 +159,15 @@ class DashboardDetail extends React.Component<Props, State> {
         }
 
         this.setState({
-          dashboardState: 'default',
+          dashboardState: 'view',
           changesDashboard: undefined,
         });
         break;
       }
-      case 'default':
+      case 'view':
       default: {
         this.setState({
-          dashboardState: 'default',
+          dashboardState: 'view',
           changesDashboard: undefined,
         });
         break;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -44,7 +44,7 @@ class DashboardDetail extends React.Component<Props, State> {
     changesDashboard: undefined,
   };
 
-  static getDerivedStateFromProps(props: Props, state: State) {
+  static getDerivedStateFromProps(props: Props, state: State): State {
     if (state.changesDashboard && state.changesDashboard.type === 'org') {
       const {params} = props;
       const dashboardId = params.dashboardId as string | undefined;
@@ -52,7 +52,7 @@ class DashboardDetail extends React.Component<Props, State> {
       if (typeof dashboardId === 'string' && state.changesDashboard.id !== dashboardId) {
         return {
           ...state,
-          dashboardState: 'default',
+          dashboardState: 'view',
           changesDashboard: undefined,
         };
       }

--- a/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
@@ -31,7 +31,7 @@ type Props = {
 
 type State = {
   // endpoint response
-  orgDashboards: OrgDashboardResponse[] | null;
+  dashboards: OrgDashboardResponse[] | null;
 } & AsyncComponent['state'];
 
 class OrgDashboards extends AsyncComponent<Props, State> {
@@ -43,7 +43,7 @@ class OrgDashboards extends AsyncComponent<Props, State> {
     errors: [],
 
     // endpoint response
-    orgDashboards: [],
+    dashboards: [],
   };
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
@@ -51,17 +51,17 @@ class OrgDashboards extends AsyncComponent<Props, State> {
 
     const url = `/organizations/${organization.slug}/dashboards/`;
 
-    return [['orgDashboards', url]];
+    return [['dashboards', url]];
   }
 
   getOrgDashboards(): OrgDashboard[] {
-    const {orgDashboards} = this.state;
+    const {dashboards} = this.state;
 
-    if (!Array.isArray(orgDashboards)) {
+    if (!Array.isArray(dashboards)) {
       return [];
     }
 
-    return orgDashboards.map(dashboard => {
+    return dashboards.map(dashboard => {
       return {
         type: 'org',
         ...dashboard,
@@ -84,13 +84,13 @@ class OrgDashboards extends AsyncComponent<Props, State> {
   }
 
   getDashboardsList(): DashboardListItem[] {
-    const {orgDashboards} = this.state;
+    const {dashboards} = this.state;
 
-    if (!Array.isArray(orgDashboards)) {
+    if (!Array.isArray(dashboards)) {
       return PREBUILT_DASHBOARDS;
     }
 
-    const normalizedOrgDashboards: OrgDashboard[] = orgDashboards.map(dashboard => {
+    const normalizedOrgDashboards: OrgDashboard[] = dashboards.map(dashboard => {
       return {
         type: 'org',
         ...dashboard,

--- a/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
@@ -17,7 +17,7 @@ import {DashboardListItem, OrgDashboard, OrgDashboardResponse} from './types';
 
 type OrgDashboardsChildrenProps = {
   dashboard: DashboardListItem;
-  orgDashboards: DashboardListItem[];
+  dashboards: DashboardListItem[];
   reloadData: () => void;
 };
 
@@ -130,7 +130,7 @@ class OrgDashboards extends AsyncComponent<Props, State> {
         <LightWeightNoProjectMessage organization={organization}>
           {children({
             dashboard,
-            orgDashboards: this.getDashboardsList(),
+            dashboards: this.getDashboardsList(),
             reloadData: this.reloadData.bind(this),
           })}
         </LightWeightNoProjectMessage>

--- a/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
@@ -1,0 +1,163 @@
+import React from 'react';
+import {browserHistory} from 'react-router';
+import {Params} from 'react-router/lib/Router';
+import {Location} from 'history';
+
+import {Client} from 'app/api';
+import AsyncComponent from 'app/components/asyncComponent';
+import NotFound from 'app/components/errors/notFound';
+import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
+import {t} from 'app/locale';
+import {PageContent} from 'app/styles/organization';
+import {Organization} from 'app/types';
+
+import {PREBUILT_DASHBOARDS} from './data';
+import {DashboardListItem, OrgDashboard, OrgDashboardResponse} from './types';
+
+type OrgDashboardsChildrenProps = {
+  dashboard: DashboardListItem;
+  orgDashboards: DashboardListItem[];
+  reloadData: () => void;
+};
+
+type Props = {
+  api: Client;
+  location: Location;
+  params: Params;
+  organization: Organization;
+  children: (props: OrgDashboardsChildrenProps) => React.ReactNode;
+};
+
+type State = {
+  // endpoint response
+  orgDashboards: OrgDashboardResponse[] | null;
+} & AsyncComponent['state'];
+
+class OrgDashboards extends AsyncComponent<Props, State> {
+  state: State = {
+    // AsyncComponent state
+    loading: true,
+    reloading: false,
+    error: false,
+    errors: [],
+
+    // endpoint response
+    orgDashboards: [],
+  };
+
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const {organization} = this.props;
+
+    const url = `/organizations/${organization.slug}/dashboards/`;
+
+    return [['orgDashboards', url]];
+  }
+
+  getOrgDashboards(): OrgDashboard[] {
+    const {orgDashboards} = this.state;
+
+    if (!Array.isArray(orgDashboards)) {
+      return [];
+    }
+
+    return orgDashboards.map(dashboard => {
+      return {
+        type: 'org',
+        ...dashboard,
+      };
+    });
+  }
+
+  getCurrentDashboard(): DashboardListItem | undefined {
+    const {params} = this.props;
+    const dashboardId = params.dashboardId as string | undefined;
+    const orgDashboards = this.getOrgDashboards();
+
+    if (typeof dashboardId === 'string') {
+      return orgDashboards.find(dashboard => {
+        return dashboard.id === dashboardId;
+      });
+    }
+
+    return PREBUILT_DASHBOARDS[0];
+  }
+
+  getDashboardsList(): DashboardListItem[] {
+    const {orgDashboards} = this.state;
+
+    if (!Array.isArray(orgDashboards)) {
+      return PREBUILT_DASHBOARDS;
+    }
+
+    const normalizedOrgDashboards: OrgDashboard[] = orgDashboards.map(dashboard => {
+      return {
+        type: 'org',
+        ...dashboard,
+      };
+    });
+
+    return [...PREBUILT_DASHBOARDS, ...normalizedOrgDashboards];
+  }
+
+  renderBody() {
+    const dashboard = this.getCurrentDashboard();
+
+    if (!dashboard) {
+      return <NotFound />;
+    }
+
+    return this.renderContent(dashboard);
+  }
+
+  renderError(error: Error) {
+    const notFound = Object.values(this.state.errors).find(
+      resp => resp && resp.status === 404
+    );
+
+    if (notFound) {
+      return <NotFound />;
+    }
+
+    return super.renderError(error, true, true);
+  }
+
+  renderContent(dashboard: DashboardListItem) {
+    const {organization, children} = this.props;
+
+    return (
+      <PageContent>
+        <LightWeightNoProjectMessage organization={organization}>
+          {children({
+            dashboard,
+            orgDashboards: this.getDashboardsList(),
+            reloadData: this.reloadData.bind(this),
+          })}
+        </LightWeightNoProjectMessage>
+      </PageContent>
+    );
+  }
+
+  renderComponent() {
+    const {organization, location} = this.props;
+
+    if (!organization.features.includes('dashboards-v2')) {
+      // Redirect to Dashboards v1
+      browserHistory.replace({
+        pathname: `/organizations/${organization.slug}/dashboards/`,
+        query: {
+          ...location.query,
+        },
+      });
+      return null;
+    }
+
+    return (
+      <SentryDocumentTitle title={t('Dashboards')} objSlug={organization.slug}>
+        {super.renderComponent()}
+      </SentryDocumentTitle>
+    );
+  }
+}
+
+export default OrgDashboards;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/types.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/types.tsx
@@ -26,7 +26,7 @@ export type OrgDashboard = {
 
 export type DashboardListItem = PrebuiltDashboard | OrgDashboard;
 
-export type DashboardState = 'default' | 'edit' | 'create';
+export type DashboardState = 'view' | 'edit' | 'create';
 
 // POST response when creating a new dashboard
 export type OrgDashboardResponse = {


### PR DESCRIPTION
In edit mode, state such as `dashboardState` and `changesDashboard` is persisted if the user navigates through the browser session history (i.e. pressing the back button that leads to a different dashboard). This is undesirable, and these specific states should be reset. 

As a resolution, I had introduced `static getDerivedStateFromProps(props: Props, state: State)` to reset certain states whenever `changesDashboard.id` doesn't match with `params.dashboardId`. However, `static getDerivedStateFromProps(props: Props, state: State)` cannot be used with `AsyncComponent` since this component uses unsafe lifecycle methods. 

Thus, I had to split out the `DashboardDetail` component's responsibility of fetching dashboard into its own component (`OrgDashboards`). The `OrgDashboards` component is intentionally a render prop so that state can be persisted whenever the global header is changed. In other words, changing the date range shouldn't induce React to kill the entire subtree of `DashboardDetail` and the state that goes along with it.