### PR TITLE
feat(avatar): Suggested owner avatar stack

### DIFF
--- a/docs-ui/components/avatar.stories.js
+++ b/docs-ui/components/avatar.stories.js
@@ -1,8 +1,11 @@
 import React from 'react';
+import styled from '@emotion/styled';
 import {withInfo} from '@storybook/addon-info';
-import {boolean} from '@storybook/addon-knobs';
+import {boolean, select} from '@storybook/addon-knobs';
 
 import Avatar from 'app/components/avatar';
+import SuggestedAvatarStack from 'app/components/avatar/suggestedAvatarStack';
+import TeamStore from 'app/stores/teamStore';
 
 const USER = {
   id: 1,
@@ -57,3 +60,47 @@ export const TeamAvatar = withInfo('Avatar for teams')(() => {
   };
   return <Avatar team={team} hasTooltip={hasTooltip} suggested={showAsSuggested} />;
 });
+
+export const SuggestedAvatars = withInfo('Suggested avatar stack')(() => {
+  // Setup mock data
+  const exampleUserActor = {
+    type: 'user',
+    id: '1',
+    name: 'Jane Bloggs',
+  };
+  const exampleTeam = {
+    id: '2',
+    name: 'Captain Planet',
+    slug: 'captain-planet',
+    isMember: true,
+    hasAccess: true,
+    isPending: false,
+    memberCount: 1,
+    avatar: 'letter_avatar',
+  };
+  const exampleTeamActor = {
+    type: 'team',
+    id: exampleTeam.id,
+    name: exampleTeam.name,
+  };
+  TeamStore.loadInitialData([exampleTeam]);
+
+  // Provide knob options
+  const suggestionsWithUser = [exampleUserActor, exampleTeamActor, exampleTeamActor];
+  const suggestionsWithTeam = [exampleTeamActor, exampleUserActor, exampleTeamActor];
+  const options = {
+    User: suggestionsWithUser,
+    Team: suggestionsWithTeam,
+  };
+  const suggestedOwners = select('Suggested Owner Type', options, suggestionsWithTeam);
+
+  return (
+    <SuggestedAvatarContainer>
+      <SuggestedAvatarStack owners={suggestedOwners} />
+    </SuggestedAvatarContainer>
+  );
+});
+
+const SuggestedAvatarContainer = styled('div')`
+  width: 40px;
+`;

--- a/src/sentry/static/sentry/app/components/avatar/actorAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/actorAvatar.tsx
@@ -21,6 +21,7 @@ type Props = DefaultProps & {
   gravatar?: boolean;
   className?: string;
   onClick?: () => void;
+  suggested?: boolean;
 };
 
 class ActorAvatar extends React.Component<Props> {
@@ -31,6 +32,7 @@ class ActorAvatar extends React.Component<Props> {
     title: PropTypes.string,
     gravatar: PropTypes.bool,
     hasTooltip: PropTypes.bool,
+    suggested: PropTypes.bool,
   };
 
   static defaultProps: DefaultProps = {

--- a/src/sentry/static/sentry/app/components/avatar/backgroundAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/backgroundAvatar.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+
+import {imageStyle} from 'app/components/avatar/styles';
+import theme from 'app/utils/theme';
+
+type Props = {
+  round?: boolean;
+  suggested?: boolean;
+  forwardedRef?: React.Ref<SVGSVGElement>;
+};
+
+type BackgroundAvatarProps = React.ComponentProps<'svg'> & Props;
+
+/**
+ * Creates an avatar placeholder that is used when showing multiple
+ * suggested assignees
+ */
+const BackgroundAvatar = styled(
+  ({round: _round, forwardedRef, ...props}: BackgroundAvatarProps) => (
+    <svg ref={forwardedRef} viewBox="0 0 120 120" {...props}>
+      <rect x="0" y="0" width="120" height="120" rx="15" ry="15" fill={theme.purple100} />
+    </svg>
+  )
+)<Props>`
+  ${imageStyle};
+`;
+
+BackgroundAvatar.propTypes = {
+  round: PropTypes.bool,
+};
+
+BackgroundAvatar.defaultProps = {
+  round: false,
+  suggested: true,
+};
+
+export default React.forwardRef<SVGSVGElement, Props>((props, ref) => (
+  <BackgroundAvatar forwardedRef={ref} {...props} />
+));

--- a/src/sentry/static/sentry/app/components/avatar/backgroundAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/backgroundAvatar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {imageStyle} from 'app/components/avatar/styles';
 import theme from 'app/utils/theme';
@@ -26,10 +25,6 @@ const BackgroundAvatar = styled(
 )<Props>`
   ${imageStyle};
 `;
-
-BackgroundAvatar.propTypes = {
-  round: PropTypes.bool,
-};
 
 BackgroundAvatar.defaultProps = {
   round: false,

--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import * as qs from 'query-string';
 
+import BackgroundAvatar from 'app/components/avatar/backgroundAvatar';
 import LetterAvatar from 'app/components/letterAvatar';
 import Tooltip from 'app/components/tooltip';
 
@@ -202,6 +203,10 @@ class BaseAvatar extends React.Component<Props, State> {
       );
     }
 
+    if (type === 'background') {
+      return this.renderBackgroundAvatar();
+    }
+
     return this.renderLetterAvatar();
   };
 
@@ -215,6 +220,11 @@ class BaseAvatar extends React.Component<Props, State> {
         suggested={suggested}
       />
     );
+  }
+
+  renderBackgroundAvatar() {
+    const {round, suggested} = this.props;
+    return <BackgroundAvatar round={round} suggested={suggested} />;
   }
 
   render() {

--- a/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import {css} from '@emotion/core';
+import styled from '@emotion/styled';
+
+import ActorAvatar from 'app/components/avatar/actorAvatar';
+import BaseAvatar from 'app/components/avatar/baseAvatar';
+import {Actor} from 'app/types';
+
+type Props = {
+  owners: Actor[];
+};
+
+// Constrain the number of visible suggestions
+const MAX_SUGGESTIONS = 5;
+
+const SuggestedAvatarStack = ({owners, ...props}: Props) => {
+  const backgroundAvatarProps = {
+    round: owners[0].type === 'user',
+    suggested: true,
+    ...props,
+  };
+  const reversedOwners = owners.slice(0, MAX_SUGGESTIONS).reverse();
+  return (
+    <AvatarStack>
+      {reversedOwners.map((owner, id) => {
+        if (id === reversedOwners.length - 1) {
+          return (
+            <StyledAvatar
+              key={owner.id}
+              actor={owner}
+              suggested
+              {...props}
+              index={id}
+              hasTooltip={false}
+            />
+          );
+        } else {
+          return (
+            <StyledBackgroundAvatar
+              key={owner.id}
+              {...backgroundAvatarProps}
+              type="background"
+              index={id}
+            />
+          );
+        }
+      })}
+    </AvatarStack>
+  );
+};
+
+const AvatarStack = styled('div')`
+  display: flex;
+  align-content: center;
+  flex-direction: row-reverse;
+`;
+
+const translateStyles = (props: {index: number}) => css`
+  transform: translateX(${60 * props.index}%);
+`;
+
+const StyledAvatar = styled(ActorAvatar)<{index: number}>`
+  ${translateStyles}
+`;
+
+const StyledBackgroundAvatar = styled(BaseAvatar)<{index: number}>`
+  ${translateStyles}
+`;
+
+export default SuggestedAvatarStack;

--- a/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
@@ -8,7 +8,8 @@ import {Actor} from 'app/types';
 
 type Props = {
   owners: Actor[];
-};
+} & BaseAvatar['props'] &
+  ActorAvatar['props'];
 
 // Constrain the number of visible suggestions
 const MAX_SUGGESTIONS = 5;
@@ -19,32 +20,29 @@ const SuggestedAvatarStack = ({owners, ...props}: Props) => {
     suggested: true,
     ...props,
   };
-  const reversedOwners = owners.slice(0, MAX_SUGGESTIONS).reverse();
+  const numAvatars = Math.min(owners.length, MAX_SUGGESTIONS);
+  const backgroundAvatars: React.ReactElement[] = [];
+  // Generate N - 1 background avatars
+  for (let i = 0; i < numAvatars - 1; i++) {
+    backgroundAvatars.push(
+      <StyledBackgroundAvatar
+        key={i}
+        {...backgroundAvatarProps}
+        type="background"
+        index={i}
+      />
+    );
+  }
   return (
     <AvatarStack>
-      {reversedOwners.map((owner, id) => {
-        if (id === reversedOwners.length - 1) {
-          return (
-            <StyledAvatar
-              key={owner.id}
-              actor={owner}
-              suggested
-              {...props}
-              index={id}
-              hasTooltip={false}
-            />
-          );
-        } else {
-          return (
-            <StyledBackgroundAvatar
-              key={owner.id}
-              {...backgroundAvatarProps}
-              type="background"
-              index={id}
-            />
-          );
-        }
-      })}
+      {backgroundAvatars}
+      <StyledAvatar
+        suggested
+        {...props}
+        actor={owners[0]}
+        index={numAvatars - 1}
+        hasTooltip={false}
+      />
     </AvatarStack>
   );
 };

--- a/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
@@ -21,22 +21,17 @@ const SuggestedAvatarStack = ({owners, ...props}: Props) => {
     suggested: true,
   };
   const numAvatars = Math.min(owners.length, MAX_SUGGESTIONS);
-  const backgroundAvatars: React.ReactElement[] = [];
-  // Generate N - 1 background avatars
-  for (let i = 0; i < numAvatars - 1; i++) {
-    backgroundAvatars.push(
-      <StyledBackgroundAvatar
-        {...backgroundAvatarProps}
-        key={i}
-        type="background"
-        index={i}
-      />
-    );
-  }
   return (
     <AvatarStack>
-      {backgroundAvatars}
-      <StyledAvatar
+      {[...Array(numAvatars - 1)].map((_, i) => (
+        <BackgroundAvatar
+          {...backgroundAvatarProps}
+          key={i}
+          type="background"
+          index={i}
+        />
+      ))}
+      <Avatar
         {...props}
         suggested
         actor={owners[0]}
@@ -57,11 +52,11 @@ const translateStyles = (props: {index: number}) => css`
   transform: translateX(${60 * props.index}%);
 `;
 
-const StyledAvatar = styled(ActorAvatar)<{index: number}>`
+const Avatar = styled(ActorAvatar)<{index: number}>`
   ${translateStyles}
 `;
 
-const StyledBackgroundAvatar = styled(BaseAvatar)<{index: number}>`
+const BackgroundAvatar = styled(BaseAvatar)<{index: number}>`
   ${translateStyles}
 `;
 

--- a/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
@@ -9,7 +9,7 @@ import {Actor} from 'app/types';
 type Props = {
   owners: Actor[];
 } & BaseAvatar['props'] &
-  ActorAvatar['props'];
+  Omit<ActorAvatar['props'], 'actor' | 'hasTooltip'>;
 
 // Constrain the number of visible suggestions
 const MAX_SUGGESTIONS = 5;

--- a/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
@@ -16,9 +16,9 @@ const MAX_SUGGESTIONS = 5;
 
 const SuggestedAvatarStack = ({owners, ...props}: Props) => {
   const backgroundAvatarProps = {
+    ...props,
     round: owners[0].type === 'user',
     suggested: true,
-    ...props,
   };
   const numAvatars = Math.min(owners.length, MAX_SUGGESTIONS);
   const backgroundAvatars: React.ReactElement[] = [];
@@ -26,8 +26,8 @@ const SuggestedAvatarStack = ({owners, ...props}: Props) => {
   for (let i = 0; i < numAvatars - 1; i++) {
     backgroundAvatars.push(
       <StyledBackgroundAvatar
-        key={i}
         {...backgroundAvatarProps}
+        key={i}
         type="background"
         index={i}
       />
@@ -37,8 +37,8 @@ const SuggestedAvatarStack = ({owners, ...props}: Props) => {
     <AvatarStack>
       {backgroundAvatars}
       <StyledAvatar
-        suggested
         {...props}
+        suggested
         actor={owners[0]}
         index={numAvatars - 1}
         hasTooltip={false}


### PR DESCRIPTION
Continuing off the work from https://github.com/getsentry/sentry/pull/22280, this PR uses the "suggested" version of the avatar and adds a new background avatar that will be shown when there are multiple suggested assignees. 

**Current examples viewable in storybook:**
![image](https://user-images.githubusercontent.com/9372512/100301930-3eff7c80-2f67-11eb-8140-1bde6d9ba096.png)
![image](https://user-images.githubusercontent.com/9372512/100301963-4d4d9880-2f67-11eb-899a-d9ce7efd1af7.png)

**What it would like in the issue stream**
<img width="314" alt="Screen Shot 2020-11-25 at 9 05 28 PM" src="https://user-images.githubusercontent.com/9372512/100302009-622a2c00-2f67-11eb-9f33-3316f167adb5.png">
