### PR TITLE
fix: Fix ordering bug in similarity-v2

### DIFF
--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -47,7 +47,7 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
                 group_scores.append(scores)
 
         serialized_groups = {
-            g["id"]: g
+            int(g["id"]): g
             for g in serialize(
                 list(Group.objects.get_many_from_cache(group_ids)), user=request.user
             )
@@ -65,6 +65,6 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
                 # unexpected behavior, but still possible.)
                 continue
 
-            results.append((group, scores))
+            results.append((group, {_fix_label(k): v for k, v in scores.items()}))
 
         return Response(results)

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -38,22 +38,33 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
         if limit is not None:
             limit = int(limit) + 1  # the target group will always be included
 
-        raw_results = {
-            group_id: {_fix_label(label): features for label, features in scores.items()}
-            for group_id, scores in features.compare(group, limit=limit)
-            if group_id != group.id
+        group_ids = []
+        group_scores = []
+
+        for group_id, scores in features.compare(group, limit=limit):
+            if group_id != group.id:
+                group_ids.append(group_id)
+                group_scores.append(scores)
+
+        serialized_groups = {
+            g["id"]: g
+            for g in serialize(
+                list(Group.objects.get_many_from_cache(group_ids)), user=request.user
+            )
         }
 
-        fetched_groups = Group.objects.get_many_from_cache(list(raw_results))
-        serialized_groups = serialize(fetched_groups, user=request.user)
-        group_scores = list(raw_results.pop(group.id) for group in fetched_groups)
+        results = []
 
-        results = list(zip(serialized_groups, group_scores))
+        # We need to preserve the ordering of the Redis results, as that
+        # ordering is directly shown in the UI
+        for group_id, scores in zip(group_ids, group_scores):
+            group = serialized_groups.get(group_id)
+            if group is None:
+                # TODO(tkaemming): This should log when we filter out a group that is
+                # unable to be retrieved from the database. (This will soon be
+                # unexpected behavior, but still possible.)
+                continue
 
-        if raw_results:
-            # Similarity has returned non-existent group IDs. This can indicate
-            # that group deletion is not triggering deletion in similarity, and
-            # that we are leaking resources
-            logger.error("similarity.api.unknown_group", extra={"group_ids": list(raw_results)})
+            results.append((group, scores))
 
         return Response(results)

--- a/src/sentry/static/sentry/app/components/similarScoreCard.tsx
+++ b/src/sentry/static/sentry/app/components/similarScoreCard.tsx
@@ -17,11 +17,13 @@ const scoreComponents = {
   'similarity:*:message:character-5-shingle': t('Log Message'),
 };
 
-type Key = keyof typeof scoreComponents;
 type Score = number | null;
 
 type Props = {
-  scoreList?: [Key, Score][];
+  // we treat the score list keys as opaque as we wish to be able to extend the
+  // backend without having to fix UI. Keys not in scoreComponents are grouped
+  // into Other anyway
+  scoreList?: [string, Score][];
 };
 
 const SimilarScoreCard = ({scoreList = []}: Props) => {

--- a/src/sentry/static/sentry/app/components/similarScoreCard.tsx
+++ b/src/sentry/static/sentry/app/components/similarScoreCard.tsx
@@ -35,7 +35,8 @@ const SimilarScoreCard = ({scoreList = []}: Props) => {
   return (
     <React.Fragment>
       {scoreList.map(([key, score]) => {
-        const title = scoreComponents[key.replace(/similarity:\d\d\d\d-\d\d-\d\d/, 'similarity:*')];
+        const title =
+          scoreComponents[key.replace(/similarity:\d\d\d\d-\d\d-\d\d/, 'similarity:*')];
 
         if (!title) {
           if (score !== null) {
@@ -55,8 +56,8 @@ const SimilarScoreCard = ({scoreList = []}: Props) => {
 
       {numOtherScores > 0 && sumOtherScores > 0 && (
         <Wrapper key="other">
-          <div>{t("Other")}</div>
-          <Score score={Math.round(sumOtherScores * 4 / numOtherScores)} />
+          <div>{t('Other')}</div>
+          <Score score={Math.round((sumOtherScores * 4) / numOtherScores)} />
         </Wrapper>
       )}
     </React.Fragment>

--- a/src/sentry/static/sentry/app/components/similarScoreCard.tsx
+++ b/src/sentry/static/sentry/app/components/similarScoreCard.tsx
@@ -7,7 +7,14 @@ import space from 'app/styles/space';
 const scoreComponents = {
   'exception:message:character-shingles': t('Exception Message'),
   'exception:stacktrace:pairs': t('Stack Trace Frames'),
+  'exception:stacktrace:application-chunks': t('In-App Frames'),
   'message:message:character-shingles': t('Log Message'),
+
+  // v2
+  'similarity:*:value:character-5-shingle': t('Exception Type'),
+  'similarity:*:value:character-5-shingle': t('Exception Message'),
+  'similarity:*:stacktrace:frames-pairs': t('Stack Trace Frames'),
+  'similarity:*:message:character-5-shingle': t('Log Message'),
 };
 
 type Key = keyof typeof scoreComponents;
@@ -22,15 +29,36 @@ const SimilarScoreCard = ({scoreList = []}: Props) => {
     return null;
   }
 
+  let sumOtherScores = 0;
+  let numOtherScores = 0;
+
   return (
     <React.Fragment>
-      {scoreList.map(([key, score]) => (
-        <Wrapper key={key}>
-          <div>{scoreComponents[key]}</div>
+      {scoreList.map(([key, score]) => {
+        const title = scoreComponents[key.replace(/similarity:\d\d\d\d-\d\d-\d\d/, 'similarity:*')];
 
-          <Score score={score === null ? score : Math.round(score * 5)} />
+        if (!title) {
+          if (score !== null) {
+            sumOtherScores += score;
+            numOtherScores += 1;
+          }
+          return null;
+        }
+
+        return (
+          <Wrapper key={key}>
+            <div>{title}</div>
+            <Score score={score === null ? score : Math.round(score * 4)} />
+          </Wrapper>
+        );
+      })}
+
+      {numOtherScores > 0 && sumOtherScores > 0 && (
+        <Wrapper key="other">
+          <div>{t("Other")}</div>
+          <Score score={Math.round(sumOtherScores * 4 / numOtherScores)} />
         </Wrapper>
-      ))}
+      )}
     </React.Fragment>
   );
 };

--- a/src/sentry/static/sentry/app/components/similarScoreCard.tsx
+++ b/src/sentry/static/sentry/app/components/similarScoreCard.tsx
@@ -55,7 +55,7 @@ const SimilarScoreCard = ({scoreList = []}: Props) => {
       })}
 
       {numOtherScores > 0 && sumOtherScores > 0 && (
-        <Wrapper key="other">
+        <Wrapper>
           <div>{t('Other')}</div>
           <Score score={Math.round((sumOtherScores * 4) / numOtherScores)} />
         </Wrapper>

--- a/src/sentry/static/sentry/app/components/similarScoreCard.tsx
+++ b/src/sentry/static/sentry/app/components/similarScoreCard.tsx
@@ -11,7 +11,7 @@ const scoreComponents = {
   'message:message:character-shingles': t('Log Message'),
 
   // v2
-  'similarity:*:value:character-5-shingle': t('Exception Type'),
+  'similarity:*:type:character-5-shingle': t('Exception Type'),
   'similarity:*:value:character-5-shingle': t('Exception Message'),
   'similarity:*:stacktrace:frames-pairs': t('Stack Trace Frames'),
   'similarity:*:message:character-5-shingle': t('Log Message'),

--- a/src/sentry/static/sentry/app/stores/groupingStore.tsx
+++ b/src/sentry/static/sentry/app/stores/groupingStore.tsx
@@ -97,7 +97,6 @@ type GroupingStoreInterface = Reflux.StoreDefinition & {
     toFetchArray?: Array<{
       dataKey: DataKey;
       endpoint: string;
-      version?: Version;
       queryParams?: Record<string, any>;
     }>
   ) => Promise<any>;
@@ -213,7 +212,6 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
   // Fetches data
   onFetch(toFetchArray) {
     const requests = toFetchArray || this.toFetchArray;
-    const version = toFetchArray?.[0]?.version;
 
     // Reset state and trigger update
     this.init();

--- a/src/sentry/static/sentry/app/stores/groupingStore.tsx
+++ b/src/sentry/static/sentry/app/stores/groupingStore.tsx
@@ -66,8 +66,6 @@ type ResponseProcessors = {
 
 type DataKey = keyof ResponseProcessors;
 
-type Version = '1' | '2';
-
 type ResultsAsArrayDataMerged = Array<Parameters<ResponseProcessors['merged']>[0]>;
 
 type ResultsAsArrayDataSimilar = Array<Parameters<ResponseProcessors['similar']>[0]>;

--- a/src/sentry/static/sentry/app/stores/groupingStore.tsx
+++ b/src/sentry/static/sentry/app/stores/groupingStore.tsx
@@ -93,7 +93,6 @@ type GroupingStoreInterface = Reflux.StoreDefinition & {
     newState: IdState
   ) => Array<IdState>;
   isAllUnmergedSelected: () => boolean;
-  convertScoreStructure: (scoreMap: ScoreMap, version?: Version) => ScoreMap;
   onFetch: (
     toFetchArray?: Array<{
       dataKey: DataKey;
@@ -211,38 +210,6 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
     );
   },
 
-  convertScoreStructure(scoreMap, version) {
-    if (scoreMap.hasOwnProperty('exception:stacktrace:application-chunks')) {
-      delete scoreMap['exception:stacktrace:application-chunks'];
-    }
-
-    if (!version || version === '1') {
-      return scoreMap;
-    }
-
-    const newScoreMap = {};
-
-    const scoreMapKeys = Object.keys(scoreMap);
-
-    for (const key in scoreMapKeys) {
-      const scoreMapKey = scoreMapKeys[key];
-      if (scoreMapKey.includes('message:character-5-shingle')) {
-        newScoreMap['message:message:character-shingles'] = scoreMap[scoreMapKey];
-        continue;
-      }
-      if (scoreMapKey.includes('value:character-5-shingle')) {
-        newScoreMap['exception:message:character-shingles'] = scoreMap[scoreMapKey];
-        continue;
-      }
-      if (scoreMapKey.includes('stacktrace:frames-pairs')) {
-        newScoreMap['exception:stacktrace:pairs'] = scoreMap[scoreMapKey];
-        continue;
-      }
-    }
-
-    return newScoreMap;
-  },
-
   // Fetches data
   onFetch(toFetchArray) {
     const requests = toFetchArray || this.toFetchArray;
@@ -282,15 +249,16 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
         return item;
       },
       similar: ([issue, scoreMap]) => {
-        const convertedScore = this.convertScoreStructure(scoreMap, version);
         // Hide items with a low scores
-        const isBelowThreshold = checkBelowThreshold(convertedScore);
+        const isBelowThreshold = checkBelowThreshold(scoreMap);
 
         // List of scores indexed by interface (i.e., exception and message)
-        const scoresByInterface = Object.keys(convertedScore)
-          .map(scoreKey => [scoreKey, convertedScore[scoreKey]])
+        // Note: for v2, the interface is always "similarity". When v2 is
+        // rolled out we can get rid of this grouping entirely.
+        const scoresByInterface = Object.keys(scoreMap)
+          .map(scoreKey => [scoreKey, scoreMap[scoreKey]])
           .reduce((acc, [scoreKey, score]) => {
-            // tokenize scorekey, first token is the interface name
+            // v1 layout: '<interface>:...'
             const [interfaceName] = String(scoreKey).split(':');
 
             if (!acc[interfaceName]) {
@@ -317,7 +285,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupingStoreInterface =
 
         return {
           issue,
-          score: convertedScore,
+          score: scoreMap,
           scoresByInterface,
           aggregate,
           isBelowThreshold,

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -123,7 +123,6 @@ class SimilarStackTrace extends React.Component<Props, State> {
           version,
         })}`,
         dataKey: 'similar',
-        version,
       });
     }
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -224,6 +224,7 @@ class SimilarStackTrace extends React.Component<Props, State> {
             project={project}
             groupId={groupId}
             pageLinks={similarLinks}
+            v2={v2}
           />
         )}
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/item.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/item.tsx
@@ -21,14 +21,13 @@ import space from 'app/styles/space';
 import {Group, Organization, Project} from 'app/types';
 import {callIfFunction} from 'app/utils/callIfFunction';
 
-const similarInterfaces = ['exception', 'message'];
-
 type Props = {
   issue: Group;
   project: Project;
   orgId: Organization['id'];
   groupId: Group['id'];
   score?: Record<string, any>;
+  v2: boolean;
   scoresByInterface?: {
     exception: Array<[string, number | null]>;
     message: Array<[string, any | null]>;
@@ -99,8 +98,9 @@ class Item extends React.Component<Props, State> {
   };
 
   render() {
-    const {aggregate, scoresByInterface, issue} = this.props;
+    const {aggregate, scoresByInterface, issue, v2} = this.props;
     const {visible, busy} = this.state;
+    const similarInterfaces = v2 ? ['similarity'] : ['exception', 'message'];
 
     if (!visible) {
       return null;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/item.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/item.tsx
@@ -26,8 +26,8 @@ type Props = {
   project: Project;
   orgId: Organization['id'];
   groupId: Group['id'];
-  score?: Record<string, any>;
   v2: boolean;
+  score?: Record<string, any>;
   scoresByInterface?: {
     exception: Array<[string, number | null]>;
     message: Array<[string, any | null]>;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/list.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/list.tsx
@@ -35,6 +35,7 @@ type Props = {
   orgId: Organization['id'];
   project: Project;
   onMerge: () => void;
+  v2: boolean;
   groupId: string;
   pageLinks: string | null;
   items: Array<SimilarItem>;
@@ -75,6 +76,7 @@ class List extends React.Component<Props, State> {
       filteredItems,
       pageLinks,
       onMerge,
+      v2,
     } = this.props;
 
     const {showAllItems} = this.state;
@@ -92,12 +94,13 @@ class List extends React.Component<Props, State> {
         <Header>
           <SimilarSpectrum />
         </Header>
-        <Toolbar onMerge={onMerge} />
+        <Toolbar v2={v2} onMerge={onMerge} />
         <div className="similar-list">
           {itemsWithFiltered.map(item => (
             <Item
               key={item.issue.id}
               orgId={orgId}
+              v2={v2}
               groupId={groupId}
               project={project}
               {...item}

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
@@ -71,18 +71,20 @@ class SimilarToolbar extends React.Component<Props, State> {
               {t('Events')}
             </StyledToolbarHeader>
 
-            {v2 && (
+            {(v2 && (
               <StyledToolbarHeader className="event-similar-header">
                 {t('Score')}
               </StyledToolbarHeader>
-            ) || (<React.Fragment>
-              <StyledToolbarHeader className="event-similar-header">
-                {t('Exception')}
-              </StyledToolbarHeader>
-              <StyledToolbarHeader className="event-similar-header">
-                {t('Message')}
-              </StyledToolbarHeader>
-            </React.Fragment>)}
+            )) || (
+              <React.Fragment>
+                <StyledToolbarHeader className="event-similar-header">
+                  {t('Exception')}
+                </StyledToolbarHeader>
+                <StyledToolbarHeader className="event-similar-header">
+                  {t('Message')}
+                </StyledToolbarHeader>
+              </React.Fragment>
+            )}
           </Columns>
         </SpreadLayout>
       </Toolbar>

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
@@ -71,11 +71,11 @@ class SimilarToolbar extends React.Component<Props, State> {
               {t('Events')}
             </StyledToolbarHeader>
 
-            {(v2 && (
+            {v2 ? (
               <StyledToolbarHeader className="event-similar-header">
                 {t('Score')}
               </StyledToolbarHeader>
-            )) || (
+            ) : (
               <React.Fragment>
                 <StyledToolbarHeader className="event-similar-header">
                   {t('Exception')}

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
@@ -14,6 +14,7 @@ import {callIfFunction} from 'app/utils/callIfFunction';
 
 type Props = {
   onMerge: () => void;
+  v2: boolean;
 };
 
 const inititalState = {
@@ -42,7 +43,7 @@ class SimilarToolbar extends React.Component<Props, State> {
   listener = GroupingStore.listen(this.onGroupChange, undefined);
 
   render() {
-    const {onMerge} = this.props;
+    const {onMerge, v2} = this.props;
     const {mergeCount} = this.state;
 
     return (
@@ -69,12 +70,19 @@ class SimilarToolbar extends React.Component<Props, State> {
             <StyledToolbarHeader className="event-count-header">
               {t('Events')}
             </StyledToolbarHeader>
-            <StyledToolbarHeader className="event-similar-header">
-              {t('Exception')}
-            </StyledToolbarHeader>
-            <StyledToolbarHeader className="event-similar-header">
-              {t('Message')}
-            </StyledToolbarHeader>
+
+            {v2 && (
+              <StyledToolbarHeader className="event-similar-header">
+                {t('Score')}
+              </StyledToolbarHeader>
+            ) || (<React.Fragment>
+              <StyledToolbarHeader className="event-similar-header">
+                {t('Exception')}
+              </StyledToolbarHeader>
+              <StyledToolbarHeader className="event-similar-header">
+                {t('Message')}
+              </StyledToolbarHeader>
+            </React.Fragment>)}
           </Columns>
         </SpreadLayout>
       </Toolbar>

--- a/tests/js/spec/components/similarScoreCard.spec.jsx
+++ b/tests/js/spec/components/similarScoreCard.spec.jsx
@@ -18,10 +18,11 @@ describe('SimilarScoreCard', function () {
     const wrapper = mountWithTheme(
       <SimilarScoreCard
         scoreList={[
-          ['exception,message,character-shingles', null],
-          ['exception,stacktrace,application-chunks', 0.8],
-          ['exception,stacktrace,pairs', 1],
-          ['message,message,character-shingles', 0.5],
+          ['exception:message:character-shingles', null],
+          ['exception:stacktrace:application-chunks', 0.8],
+          ['exception:stacktrace:pairs', 1],
+          ['message:message:character-shingles', 0.5],
+          ['unknown:foo:bar', 0.5],
         ]}
       />
     );


### PR DESCRIPTION
Fix a couple of bugs:

* preserve ordering in endpoint, we accidentally broke the order when refactoring. UI order of rows is directly taken from Redis/backend.
* For v2 we preprocess scores and throw away the ones that the UI can't handle. Discarding scores in the UI leads to a discrepancy where the ordering of scores (from the server) does not match the avg (color) score of each row (calculated in JS)

Add features:

* We now extend score-hover-cards to expose all non-null features in some way (as Other if necessary) too. I think this will help with debugging similarity-v2 issues as the alpha starts.
* Remove noisy logging call.

Fix SENTRY-HHB

#sync-getsentry