### PR TITLE
feat(relay): Always send numericId as part of project config

### DIFF
--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -36,6 +36,7 @@ def get_public_key_configs(project, full_config, project_keys=None):
     for project_key in project_keys or ():
         key = {
             "publicKey": project_key.public_key,
+            "numericId": project_key.id,
             "isEnabled": project_key.status == ProjectKeyStatus.ACTIVE,
         }
 
@@ -43,7 +44,6 @@ def get_public_key_configs(project, full_config, project_keys=None):
             key["quotas"] = [
                 q.to_json_legacy() for q in quotas.get_quotas(project, key=project_key)
             ]
-            key["numericId"] = project_key.id
 
         public_keys.append(key)
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -221,6 +221,7 @@ def test_trusted_external_relays_should_receive_minimal_configs(
     assert safe.get_path(cfg, "disabled") is False
     (public_key,) = cfg["publicKeys"]
     assert public_key["publicKey"] == default_projectkey.public_key
+    assert public_key["numericId"] == default_projectkey.id
     assert public_key["isEnabled"]
     assert "quotas" not in public_key
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -137,6 +137,7 @@ def test_internal_relays_should_receive_full_configs(
 
     (public_key,) = cfg["publicKeys"]
     assert public_key["publicKey"] == default_projectkey.public_key
+    assert public_key["numericId"] == default_projectkey.id
     assert public_key["isEnabled"]
     assert "quotas" in public_key
 
@@ -221,6 +222,7 @@ def test_trusted_external_relays_should_receive_minimal_configs(
     assert safe.get_path(cfg, "disabled") is False
     (public_key,) = cfg["publicKeys"]
     assert public_key["publicKey"] == default_projectkey.public_key
+    assert public_key["numericId"] == default_projectkey.id
     assert public_key["isEnabled"]
     assert "quotas" not in public_key
 


### PR DESCRIPTION
External relays have to know about key IDs so they can produce proper outcomes.

Related to https://github.com/getsentry/relay/pull/854