### PR TITLE
fix: Fix flaky reprocessing test

### DIFF
--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -266,7 +266,7 @@ def test_attachments_and_userfeedback(
 
         return data
 
-    event_id_to_delete = process_and_save({"message": "hello world"})
+    event_id_to_delete = process_and_save({"message": "hello world"}, seconds_ago=5)
     event_to_delete = eventstore.get_event_by_id(default_project.id, event_id_to_delete)
 
     event_id = process_and_save({"message": "hello world"})


### PR DESCRIPTION
We create two events here, so we need to make sure the timestamps are sufficiently far apart to get ordering guarantees when using max_events.

This flake happens when CI machines are too fast.