### PR TITLE
ref(tests) Wait for persisted events in acceptance tests

### DIFF
--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -184,7 +184,6 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             project_id=self.project.id,
             assert_no_errors=False,
         )
-
         self.store_event(
             data={
                 "event_id": "b" * 32,
@@ -202,6 +201,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             project_id=self.project.id,
             assert_no_errors=False,
         )
+        self.wait_for_event_count(self.project.id, 2)
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.result_path + "?" + all_events_query())
@@ -292,6 +292,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         event_data = generate_transaction()
 
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
+        self.wait_for_event_count(self.project.id, 1)
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.result_path + "?" + transactions_query())
@@ -344,6 +345,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             }
         )
         self.store_event(data=event_data, project_id=self.project.id)
+        self.wait_for_event_count(self.project.id, 1)
 
         with self.feature(FEATURE_NAMES):
             # Get the list page
@@ -377,6 +379,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         child_event["transaction"] = "z-child-transaction"
         child_event["spans"] = child_event["spans"][0:3]
         self.store_event(data=child_event, project_id=self.project.id, assert_no_errors=True)
+        self.wait_for_event_count(self.project.id, 2)
 
         with self.feature(FEATURE_NAMES):
             # Get the list page

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -6,7 +6,7 @@ from mock import patch
 
 from django.db.models import F
 from sentry.models import Project
-from sentry.testutils import AcceptanceTestCase
+from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
 
@@ -18,7 +18,7 @@ FEATURE_NAMES = (
 )
 
 
-class PerformanceOverviewTest(AcceptanceTestCase):
+class PerformanceOverviewTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
         super(PerformanceOverviewTest, self).setUp()
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
@@ -48,6 +48,7 @@ class PerformanceOverviewTest(AcceptanceTestCase):
         event = load_data("transaction", timestamp=before_now(minutes=1))
         self.store_event(data=event, project_id=self.project.id)
         self.project.update(flags=F("flags").bitor(Project.flags.has_transactions))
+        self.wait_for_event_count(self.project.id, 1)
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.path)


### PR DESCRIPTION
Try to reduce the amount of flaky acceptance snapshots. By waiting for events to be queryable we should avoid blank/filled snapshot states.

This could cause tests to fail more frequently, and I can address that separately if this change causes problems.

Refs #20920