### PR TITLE
ref(features): Enable Relay for development and onpremise

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -900,7 +900,7 @@ SENTRY_FEATURES = {
     "organizations:related-events": False,
     # Enable usage of external relays, for use with Relay. See
     # https://github.com/getsentry/relay.
-    "organizations:relay": False,
+    "organizations:relay": True,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -340,7 +340,9 @@ class OrganizationUpdateTest(APITestCase):
             ]
         }
 
-        response = self.client.put(url, data=data)
+        with self.feature({"organizations:relay": False}):
+            response = self.client.put(url, data=data)
+
         assert response.status_code == 400
         assert b"feature" in response.content
 

--- a/tests/sentry/api/endpoints/test_organization_relay_usage.py
+++ b/tests/sentry/api/endpoints/test_organization_relay_usage.py
@@ -87,6 +87,7 @@ class OrganizationRelayHistoryTest(APITestCase):
         response = self.get_valid_response(self.organization.slug)
         assert response.data == []
 
+    @with_feature({"organizations:relay": False})
     def test_endpoint_checks_feature_present(self):
         self.login_as(user=self.user)
         resp = self.get_response(self.organization.slug)

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -43,6 +43,7 @@ class OrganizationSerializerTest(TestCase):
                 "custom-symbol-sources",
                 "discover-basic",
                 "discover-query",
+                "relay",
             ]
         )
 


### PR DESCRIPTION
This has been enabled on sentry.io before and should now be available to onpremise and local development. On Sentry, managed Relays require a business subscription.