### PR TITLE
feat(releases): Clicking on release lines should preserve params

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {InjectedRouter} from 'react-router/lib/Router';
+import {Query} from 'history';
 import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 
@@ -304,6 +305,8 @@ type Props = {
    * Override the default color palette.
    */
   colors?: string[];
+  releaseQueryExtra?: Query;
+  preserveReleaseQueryParams?: boolean;
 } & Pick<
   ChartProps,
   | 'currentSeriesName'
@@ -350,6 +353,8 @@ class EventsChart extends React.Component<Props> {
     orderby: PropTypes.string,
     confirmedQuery: PropTypes.bool,
     colors: PropTypes.array,
+    preserveReleaseQueryParams: PropTypes.bool,
+    releaseQueryExtras: PropTypes.object,
     disableableSeries: PropTypes.array,
   };
 
@@ -379,6 +384,8 @@ class EventsChart extends React.Component<Props> {
       orderby,
       confirmedQuery,
       colors,
+      preserveReleaseQueryParams,
+      releaseQueryExtra,
       ...props
     } = this.props;
     // Include previous only on relative dates (defaults to relative if no start and end)
@@ -444,6 +451,8 @@ class EventsChart extends React.Component<Props> {
           projects={projects}
           environments={environments}
           emphasizeReleases={emphasizeReleases}
+          preserveQueryParams={preserveReleaseQueryParams}
+          queryExtra={releaseQueryExtra}
         >
           {({releaseSeries}) => previousChart({...chartProps, releaseSeries})}
         </ReleaseSeries>

--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.jsx
@@ -56,6 +56,7 @@ class ReleaseSeries extends React.Component {
     queryExtra: PropTypes.object,
 
     memoized: PropTypes.bool,
+    preserveQueryParams: PropTypes.bool,
     emphasizeReleases: PropTypes.arrayOf(PropTypes.string),
   };
 
@@ -86,6 +87,8 @@ class ReleaseSeries extends React.Component {
       !isEqual(prevProps.period, this.props.period)
     ) {
       this.fetchData();
+    } else if (!isEqual(prevProps.emphasizeReleases, this.props.emphasizeReleases)) {
+      this.setReleasesWithSeries(this.state.releases);
     }
   }
 
@@ -167,11 +170,27 @@ class ReleaseSeries extends React.Component {
   }
 
   getReleaseSeries = (releases, opacity = 0.3) => {
-    const {organization, router, tooltip, queryExtra} = this.props;
+    const {
+      organization,
+      router,
+      tooltip,
+      environments,
+      start,
+      end,
+      period,
+      preserveQueryParams,
+      queryExtra,
+    } = this.props;
 
     const query = {...queryExtra};
     if (organization.features.includes('global-views')) {
       query.project = router.location.query.project;
+    }
+    if (preserveQueryParams) {
+      query.environment = environments;
+      query.start = start ? getUtcDateString(start) : undefined;
+      query.end = start ? getUtcDateString(end) : undefined;
+      query.statsPeriod = period || undefined;
     }
 
     return {

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
@@ -119,6 +119,11 @@ class ReleaseChartContainer extends React.Component<Props> {
     const apiPayload = eventView.getEventsAPIPayload(location);
     const colors = this.getTransactionsChartColors();
 
+    const releaseQueryExtra = {
+      showTransactions: location.query.showTransactions,
+      yAxis,
+    };
+
     return (
       <EventsChart
         router={router}
@@ -145,6 +150,8 @@ class ReleaseChartContainer extends React.Component<Props> {
         seriesNameTransformer={this.seriesNameTransformer}
         disableableSeries={[t('This Release'), t('Other Releases')]}
         colors={colors}
+        preserveReleaseQueryParams
+        releaseQueryExtra={releaseQueryExtra}
       />
     );
   }

--- a/tests/js/spec/components/charts/releaseSeries.spec.jsx
+++ b/tests/js/spec/components/charts/releaseSeries.spec.jsx
@@ -8,15 +8,16 @@ import ReleaseSeries from 'app/components/charts/releaseSeries';
 describe('ReleaseSeries', function () {
   const renderFunc = jest.fn(() => null);
   const {routerContext, organization} = initializeOrg();
-  const releases = [
-    {
-      version: 'sentry-android-shop@1.2.0',
-      date: '2020-03-23T00:00:00Z',
-    },
-  ];
+  let releases;
   let releasesMock;
 
   beforeEach(function () {
+    releases = [
+      {
+        version: 'sentry-android-shop@1.2.0',
+        date: '2020-03-23T00:00:00Z',
+      },
+    ];
     MockApiClient.clearMockResponses();
     releasesMock = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/releases/stats/`,
@@ -165,7 +166,7 @@ describe('ReleaseSeries', function () {
     }
   });
 
-  it('doest not refetch releases with memoize enabled', async function () {
+  it('doesnt not refetch releases with memoize enabled', async function () {
     const originalPeriod = '14d';
     const updatedPeriod = '7d';
     const wrapper = mount(
@@ -205,6 +206,106 @@ describe('ReleaseSeries', function () {
           expect.objectContaining({
             // we don't care about the other properties for now
             markLine: expect.objectContaining({
+              data: [
+                expect.objectContaining({
+                  name: '1.2.0, sentry-android-shop',
+                  value: '1.2.0, sentry-android-shop',
+                  xAxis: 1584921600000,
+                }),
+              ],
+            }),
+          }),
+        ],
+      })
+    );
+  });
+
+  it('allows updating the emphasized release', async function () {
+    releases.push({
+      version: 'sentry-android-shop@1.2.1',
+      date: '2020-03-24T00:00:00Z',
+    });
+    const wrapper = mount(
+      <ReleaseSeries emphasizeReleases={['sentry-android-shop@1.2.0']}>
+        {renderFunc}
+      </ReleaseSeries>,
+      routerContext
+    );
+
+    await tick();
+    wrapper.update();
+
+    expect(renderFunc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        releaseSeries: [
+          expect.objectContaining({
+            // we don't care about the other properties for now
+            markLine: expect.objectContaining({
+              // the unemphasized releases have opacity 0.3
+              lineStyle: {
+                normal: expect.objectContaining({opacity: 0.3}),
+              },
+              data: [
+                expect.objectContaining({
+                  name: '1.2.1, sentry-android-shop',
+                  value: '1.2.1, sentry-android-shop',
+                  xAxis: 1585008000000,
+                }),
+              ],
+            }),
+          }),
+          expect.objectContaining({
+            // we don't care about the other properties for now
+            markLine: expect.objectContaining({
+              // the emphasized releases have opacity 0.8
+              lineStyle: {
+                normal: expect.objectContaining({opacity: 0.8}),
+              },
+              data: [
+                expect.objectContaining({
+                  name: '1.2.0, sentry-android-shop',
+                  value: '1.2.0, sentry-android-shop',
+                  xAxis: 1584921600000,
+                }),
+              ],
+            }),
+          }),
+        ],
+      })
+    );
+
+    wrapper.setProps({
+      emphasizedReleases: ['sentry-android-shop@1.2.1'],
+    });
+    await tick();
+    wrapper.update();
+
+    expect(renderFunc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        releaseSeries: [
+          expect.objectContaining({
+            // we don't care about the other properties for now
+            markLine: expect.objectContaining({
+              // the unemphasized releases have opacity 0.3
+              lineStyle: {
+                normal: expect.objectContaining({opacity: 0.3}),
+              },
+              data: [
+                expect.objectContaining({
+                  name: '1.2.1, sentry-android-shop',
+                  value: '1.2.1, sentry-android-shop',
+                  xAxis: 1585008000000,
+                }),
+              ],
+            }),
+          }),
+          expect.objectContaining({
+            // we don't care about the other properties for now
+            markLine: expect.objectContaining({
+              // the emphasized releases have opacity 0.8
+              lineStyle: {
+                normal: expect.objectContaining({opacity: 0.8}),
+              },
               data: [
                 expect.objectContaining({
                   name: '1.2.0, sentry-android-shop',


### PR DESCRIPTION
Clicking on the release lines on the release details page currently resets all
the parameters and takes you to the corresponding release. This change preserves
the parameters from the current view including the stats period, environment,
project, y-axis and transaction filter while taking you to the target release.