### PR TITLE
fix(releases): Ensure transactions list options are correct

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
@@ -14,6 +14,7 @@ import {t} from 'app/locale';
 import {OrganizationSummary, SelectValue} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {decodeScalar} from 'app/utils/queryString';
+import {TransactionsListOption} from 'app/views/releases/detail/overview';
 import {YAxis} from 'app/views/releases/detail/overview/chart/releaseChartControls';
 
 import {ChartContainer} from '../styles';
@@ -87,6 +88,12 @@ class TransactionSummaryCharts extends React.Component<Props> {
     if (organization.features.includes('release-performance-views')) {
       releaseQueryExtra = {
         yAxis: display === DisplayModes.VITALS ? YAxis.COUNT_LCP : YAxis.COUNT_DURATION,
+        showTransactions:
+          display === DisplayModes.VITALS
+            ? TransactionsListOption.SLOW_LCP
+            : display === DisplayModes.DURATION
+            ? TransactionsListOption.SLOW
+            : undefined,
       };
     }
 

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
@@ -24,6 +24,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
+import {TransactionsListOption} from 'app/views/releases/detail/overview';
 
 import {HeaderTitleLegend} from '../styles';
 
@@ -207,7 +208,7 @@ class VitalsChart extends React.Component<Props> {
                     end={end}
                     queryExtra={{
                       ...queryExtra,
-                      showTransactions: 'slow_lcp',
+                      showTransactions: TransactionsListOption.SLOW_LCP,
                     }}
                     period={statsPeriod}
                     utc={utc}

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -38,6 +38,15 @@ import ReleaseArchivedNotice from './releaseArchivedNotice';
 import ReleaseStatsRequest from './releaseStatsRequest';
 import TotalCrashFreeUsers from './totalCrashFreeUsers';
 
+export enum TransactionsListOption {
+  FAILURE_COUNT = 'failure_count',
+  TPM = 'tpm',
+  SLOW = 'slow',
+  SLOW_LCP = 'slow_lcp',
+  REGRESSION = 'regression',
+  IMPROVEMENT = 'improved',
+}
+
 type RouteParams = {
   orgId: string;
   release: string;
@@ -151,19 +160,19 @@ class ReleaseOverview extends AsyncView<Props> {
     };
 
     switch (selectedSort.value) {
-      case 'p75_lcp':
+      case TransactionsListOption.SLOW_LCP:
         return EventView.fromSavedQuery({
           ...baseQuery,
           query: `event.type:transaction release:${version} epm():>0.01 has:measurements.lcp`,
           fields: ['transaction', 'failure_count()', 'epm()', 'p75(measurements.lcp)'],
           orderby: 'p75_measurements_lcp',
         });
-      case 'p50':
+      case TransactionsListOption.SLOW:
         return EventView.fromSavedQuery({
           ...baseQuery,
           query: `event.type:transaction release:${version} epm():>0.01`,
         });
-      case 'failure_count':
+      case TransactionsListOption.FAILURE_COUNT:
         return EventView.fromSavedQuery({
           ...baseQuery,
           query: `event.type:transaction release:${version} failure_count():>0`,
@@ -228,7 +237,7 @@ class ReleaseOverview extends AsyncView<Props> {
             selectedSort
           );
           const titles =
-            selectedSort.value !== 'p75_lcp'
+            selectedSort.value !== TransactionsListOption.SLOW_LCP
               ? [t('transaction'), t('failure_count()'), t('tpm()'), t('p50()')]
               : [t('transaction'), t('failure_count()'), t('tpm()'), t('p75(lcp)')];
           const releaseTrendView = this.getReleaseTrendView(
@@ -388,36 +397,36 @@ function getDropdownOptions(): DropdownOption[] {
   return [
     {
       sort: {kind: 'desc', field: 'failure_count'},
-      value: 'failure_count',
+      value: TransactionsListOption.FAILURE_COUNT,
       label: t('Failing Transactions'),
     },
     {
       sort: {kind: 'desc', field: 'epm'},
-      value: 'tpm',
+      value: TransactionsListOption.TPM,
       label: t('Frequent Transactions'),
     },
     {
       sort: {kind: 'desc', field: 'p50'},
-      value: 'slow',
+      value: TransactionsListOption.SLOW,
       label: t('Slow Transactions'),
     },
     {
       sort: {kind: 'desc', field: 'p75_measurements_lcp'},
-      value: 'slow_lcp',
+      value: TransactionsListOption.SLOW_LCP,
       label: t('Slow LCP'),
     },
     {
       sort: {kind: 'desc', field: 'trend_percentage()'},
       query: 'tpm():>0.01 trend_percentage():>0% t_test():<-6',
       trendType: TrendChangeType.REGRESSION,
-      value: 'regression',
+      value: TransactionsListOption.REGRESSION,
       label: t('Trending Regressions'),
     },
     {
       sort: {kind: 'asc', field: 'trend_percentage()'},
       query: 'tpm():>0.01 trend_percentage():>0% t_test():>6',
       trendType: TrendChangeType.IMPROVED,
-      value: 'improved',
+      value: TransactionsListOption.IMPROVEMENT,
       label: t('Trending Improvements'),
     },
   ];
@@ -427,7 +436,8 @@ function getTransactionsListSort(
   location: Location
 ): {selectedSort: DropdownOption; sortOptions: DropdownOption[]} {
   const sortOptions = getDropdownOptions();
-  const urlParam = decodeScalar(location.query.showTransactions) || 'failure_count';
+  const urlParam =
+    decodeScalar(location.query.showTransactions) || TransactionsListOption.FAILURE_COUNT;
   const selectedSort = sortOptions.find(opt => opt.value === urlParam) || sortOptions[0];
   return {selectedSort, sortOptions};
 }


### PR DESCRIPTION
This change ensures that all the dropdown options for the transactions list in
releases are working as intended and release series from other charts sets a
corresponding default in release details.