### PR TITLE
fix(spans): Zero is a falsey value and should not be filtered out

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -374,7 +374,7 @@ class SpanDetail extends React.Component<Props, State> {
 
   partitionSizes(data) {
     const sizeKeys = SIZE_DATA_KEYS.reduce((keys, key) => {
-      if (data[key]) {
+      if (data.hasOwnProperty(key)) {
         keys[key] = data[key];
       }
       return keys;


### PR DESCRIPTION
A zero size is falsey and is being filtered out. Instead, we should check with
hasOwnProperty for existence.