### PR TITLE
ref(dashboards): Be able to create widgets when creating a new dashboard

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.api.serializers.rest_framework import DashboardDetailsSerializer
 from sentry.models import Dashboard
 from rest_framework.response import Response
 
@@ -47,19 +48,16 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                                           dashboards belongs to.
         :param string title: the title of the dashboard.
         """
-        serializer = DashboardSerializer(data=request.data)
+        serializer = DashboardDetailsSerializer(
+            data=request.data, context={"organization_id": organization.id, "request": request}
+        )
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
 
-        result = serializer.validated_data
-
         try:
             with transaction.atomic():
-                dashboard = Dashboard.objects.create(
-                    organization_id=organization.id, title=result["title"], created_by=request.user
-                )
+                dashboard = serializer.save()
+                return Response(serialize(dashboard, request.user), status=201)
         except IntegrityError:
             return Response("Dashboard title already taken", status=409)
-
-        return Response(serialize(dashboard, request.user), status=201)

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -11,10 +11,6 @@ from sentry.models import Dashboard
 from rest_framework.response import Response
 
 
-class DashboardSerializer(serializers.Serializer):
-    title = serializers.CharField(required=True)
-
-
 class OrganizationDashboardsEndpoint(OrganizationEndpoint):
     def get(self, request, organization):
         """

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
 from django.db import IntegrityError, transaction
-from rest_framework import serializers
 
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
-from sentry.api.serializers.rest_framework import DashboardDetailsSerializer
+from sentry.api.serializers.rest_framework import DashboardSerializer
 from sentry.models import Dashboard
 from rest_framework.response import Response
 
@@ -44,7 +43,7 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
                                           dashboards belongs to.
         :param string title: the title of the dashboard.
         """
-        serializer = DashboardDetailsSerializer(
+        serializer = DashboardSerializer(
             data=request.data, context={"organization_id": organization.id, "request": request}
         )
 

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -229,7 +229,7 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
         DashboardWidgetQuery.objects.filter(widget_id=widget_id).exclude(id__in=keep_ids).delete()
 
 
-class DashboardSerializer(serializers.Serializer):
+class DashboardSerializer(DashboardDetailsSerializer):
     title = serializers.CharField(required=True)
 
     def create(self, validated_data):

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -109,23 +109,6 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
 
     validate_id = validate_id
 
-    def create(self, validated_data):
-        """
-        Create a dashboard, and create any widgets and their queries
-
-        Only call save() on this serializer from within a transaction or
-        bad things will happen
-        """
-        self.instance = Dashboard.objects.create(
-            organization_id=self.context.get("organization_id"),
-            title=validated_data["title"],
-            created_by=self.context.get("request").user,
-        )
-
-        self.update_widgets(self.instance, validated_data["widgets"])
-
-        return self.instance
-
     def update(self, instance, validated_data):
         """
         Update a dashboard, the connected widgets and queries
@@ -244,3 +227,25 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
 
     def remove_missing_queries(self, widget_id, keep_ids):
         DashboardWidgetQuery.objects.filter(widget_id=widget_id).exclude(id__in=keep_ids).delete()
+
+
+class DashboardSerializer(serializers.Serializer):
+    title = serializers.CharField(required=True)
+
+    def create(self, validated_data):
+        """
+        Create a dashboard, and create any widgets and their queries
+
+        Only call save() on this serializer from within a transaction or
+        bad things will happen
+        """
+        self.instance = Dashboard.objects.create(
+            organization_id=self.context.get("organization_id"),
+            title=validated_data["title"],
+            created_by=self.context.get("request").user,
+        )
+
+        if "widgets" in validated_data:
+            self.update_widgets(self.instance, validated_data["widgets"])
+
+        return self.instance

--- a/src/sentry/static/sentry/app/actionCreators/dashboards.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/dashboards.tsx
@@ -13,11 +13,13 @@ export function createDashboard(
   orgId: string,
   newDashboard: DashboardListItem
 ): Promise<OrgDashboardResponse> {
+  const {title, widgets} = newDashboard;
+
   const promise: Promise<OrgDashboardResponse> = api.requestPromise(
     `/organizations/${orgId}/dashboards/`,
     {
       method: 'POST',
-      data: {title: newDashboard.title},
+      data: {title, widgets},
     }
   );
 

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -234,7 +234,10 @@ class DashboardDetail extends React.Component<Props, State> {
                 <Dashboard
                   dashboard={this.state.changesDashboard || dashboard}
                   organization={organization}
-                  isEditing={this.state.dashboardState === 'edit'}
+                  isEditing={
+                    this.state.dashboardState === 'edit' ||
+                    this.state.dashboardState === 'create'
+                  }
                   onUpdate={this.onWidgetChange}
                 />
               </React.Fragment>

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -76,6 +76,8 @@ from sentry.models import (
     Organization,
     Dashboard,
     DashboardWidgetQuery,
+    DashboardWidget,
+    DashboardWidgetDisplayTypes,
 )
 from sentry.plugins.base import plugins
 from sentry.rules import EventState
@@ -1006,3 +1008,18 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
             assert data["fields"] == widget_data_source.fields
         if "conditions" in data:
             assert data["conditions"] == widget_data_source.conditions
+
+    def get_widgets(self, dashboard_id):
+        return DashboardWidget.objects.filter(dashboard_id=dashboard_id).order_by("order")
+
+    def assert_serialized_widget(self, data, expected_widget):
+        if "id" in data:
+            assert data["id"] == six.text_type(expected_widget.id)
+        if "title" in data:
+            assert data["title"] == expected_widget.title
+        if "interval" in data:
+            assert data["interval"] == expected_widget.interval
+        if "displayType" in data:
+            assert data["displayType"] == DashboardWidgetDisplayTypes.get_type_name(
+                expected_widget.display_type
+            )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -996,3 +996,13 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
             return
 
         self.assert_widget_queries(data["id"], queries)
+
+    def assert_serialized_widget_query(self, data, widget_data_source):
+        if "id" in data:
+            assert data["id"] == six.text_type(widget_data_source.id)
+        if "name" in data:
+            assert data["name"] == widget_data_source.name
+        if "fields" in data:
+            assert data["fields"] == widget_data_source.fields
+        if "conditions" in data:
+            assert data["conditions"] == widget_data_source.conditions

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -58,18 +58,6 @@ class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):
             kwargs={"organization_slug": self.organization.slug, "dashboard_id": dashboard_id},
         )
 
-    def assert_serialized_widget(self, data, expected_widget):
-        if "id" in data:
-            assert data["id"] == six.text_type(expected_widget.id)
-        if "title" in data:
-            assert data["title"] == expected_widget.title
-        if "interval" in data:
-            assert data["interval"] == expected_widget.interval
-        if "displayType" in data:
-            assert data["displayType"] == DashboardWidgetDisplayTypes.get_type_name(
-                expected_widget.display_type
-            )
-
     def assert_serialized_dashboard(self, data, dashboard):
         assert data["id"] == six.text_type(dashboard.id)
         assert data["title"] == dashboard.title
@@ -136,9 +124,6 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
         )
         self.widget_ids = [self.widget_1.id, self.widget_2.id, self.widget_3.id, self.widget_4.id]
-
-    def get_widgets(self, dashboard_id):
-        return DashboardWidget.objects.filter(dashboard_id=dashboard_id).order_by("order")
 
     def get_widget_queries(self, widget):
         return DashboardWidgetQuery.objects.filter(widget=widget).order_by("order")

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -75,16 +75,6 @@ class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):
         assert data["title"] == dashboard.title
         assert data["createdBy"] == six.text_type(dashboard.created_by.id)
 
-    def assert_serialized_widget_query(self, data, widget_data_source):
-        if "id" in data:
-            assert data["id"] == six.text_type(widget_data_source.id)
-        if "name" in data:
-            assert data["name"] == widget_data_source.name
-        if "fields" in data:
-            assert data["fields"] == widget_data_source.fields
-        if "conditions" in data:
-            assert data["conditions"] == widget_data_source.conditions
-
 
 class OrganizationDashboardDetailsGetTest(OrganizationDashboardDetailsTestCase):
     def test_get(self):

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -63,7 +63,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                     "interval": "5m",
                     "title": "Error count()",
                     "queries": [
-                        {"name": "Errors", "fields": ["count()"], "conditions": "event.type:error",}
+                        {"name": "Errors", "fields": ["count()"], "conditions": "event.type:error"}
                     ],
                 },
             ],

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -63,11 +63,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
                     "interval": "5m",
                     "title": "Error count()",
                     "queries": [
-                        {
-                            "name": "Errors",
-                            "fields": ["count()"],
-                            "conditions": "event.type:error",
-                        }
+                        {"name": "Errors", "fields": ["count()"], "conditions": "event.type:error",}
                     ],
                 },
             ],

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -97,7 +97,7 @@ class OrganizationDashboardsTest(APITestCase):
         )
         assert dashboard.created_by == self.user
 
-        widgets = self.get_widgets(self.dashboard.id)
+        widgets = self.get_widgets(dashboard.id)
         assert len(widgets) == 2
 
         for expected_widget in data["widgets"]:

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -5,7 +5,7 @@ import six
 from django.core.urlresolvers import reverse
 
 from sentry.utils.compat import zip
-from sentry.models import Dashboard, DashboardWidget, DashboardWidgetDisplayTypes
+from sentry.models import Dashboard
 from sentry.testutils import OrganizationDashboardWidgetTestCase
 
 
@@ -20,21 +20,6 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         self.dashboard_2 = Dashboard.objects.create(
             title="Dashboard 2", created_by=self.user, organization=self.organization
         )
-
-    def get_widgets(self, dashboard_id):
-        return DashboardWidget.objects.filter(dashboard_id=dashboard_id).order_by("order")
-
-    def assert_serialized_widget(self, data, expected_widget):
-        if "id" in data:
-            assert data["id"] == six.text_type(expected_widget.id)
-        if "title" in data:
-            assert data["title"] == expected_widget.title
-        if "interval" in data:
-            assert data["interval"] == expected_widget.interval
-        if "displayType" in data:
-            assert data["displayType"] == DashboardWidgetDisplayTypes.get_type_name(
-                expected_widget.display_type
-            )
 
     def assert_equal_dashboards(self, dashboard, data):
         assert data["id"] == six.text_type(dashboard.id)


### PR DESCRIPTION
Previously, only updating the dashboard was the only way to add new widgets.

This PR adds the ability to create new widgets when creating a new dashboard.