### PR TITLE
fix(ui): Fix MissingProjectMembership Error

### DIFF
--- a/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
+++ b/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
@@ -11,7 +11,7 @@ import {IconFlag} from 'app/icons';
 import {t} from 'app/locale';
 import TeamStore from 'app/stores/teamStore';
 import space from 'app/styles/space';
-import {Organization, Project, Team} from 'app/types';
+import {Organization, Project} from 'app/types';
 import withApi from 'app/utils/withApi';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import Form from 'app/views/settings/components/forms/form';
@@ -22,7 +22,6 @@ type Props = {
   organization: Organization;
   projectId?: string;
   groupId: string;
-  team: Team;
 };
 
 type State = {
@@ -133,8 +132,11 @@ class MissingProjectMembership extends React.Component<Props, State> {
 
   render() {
     const {organization, groupId} = this.props;
+    const team = this.state.team;
     const teams = this.state.project?.teams ?? [];
     const features = new Set(organization.features);
+
+    const endpoint = `/organizations/${organization.slug}/members/me/`;
 
     const teamAccess = [
       {
@@ -167,7 +169,12 @@ class MissingProjectMembership extends React.Component<Props, State> {
                 `You'll need to join a team with access to Issue ID ${groupId} before you can view it.`
               )}
               action={
-                <StyledForm submitLabel={t('Request Access')} hideFooter>
+                <StyledForm
+                  apiEndpoint={endpoint}
+                  apiMethod="GET"
+                  submitLabel={t('Request Access')}
+                  hideFooter
+                >
                   <StyledSelectField
                     name="select"
                     placeholder={t('Select a Team')}
@@ -175,8 +182,8 @@ class MissingProjectMembership extends React.Component<Props, State> {
                     onChange={this.handleChange}
                     flexibleControlStateSize
                   />
-                  {this.state.team ? (
-                    this.renderJoinTeam(this.state.team, features)
+                  {team ? (
+                    this.renderJoinTeam(team, features)
                   ) : (
                     <StyledButton disabled>Select a Team</StyledButton>
                   )}

--- a/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
+++ b/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
@@ -5,6 +5,7 @@ import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {joinTeam} from 'app/actionCreators/teams';
 import {Client} from 'app/api';
 import Button from 'app/components/button';
+import SelectControl from 'app/components/forms/selectControl';
 import {Panel} from 'app/components/panels';
 import {IconFlag} from 'app/icons';
 import {t} from 'app/locale';
@@ -13,7 +14,6 @@ import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import withApi from 'app/utils/withApi';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
-import SelectField from 'app/views/settings/components/forms/selectField';
 
 type Props = {
   api: Client;
@@ -44,7 +44,7 @@ class MissingProjectMembership extends React.Component<Props, State> {
     };
   }
 
-  joinTeam(team: string) {
+  joinTeam(team: {value: string; label: string}) {
     this.setState({
       loading: true,
     });
@@ -53,7 +53,7 @@ class MissingProjectMembership extends React.Component<Props, State> {
       this.props.api,
       {
         orgId: this.props.organization.slug,
-        teamId: team,
+        teamId: team.value,
       },
       {
         success: () => {
@@ -118,12 +118,11 @@ class MissingProjectMembership extends React.Component<Props, State> {
     return [request, pending];
   }
 
-  handleChange = (evt: string) => {
-    const input = evt;
-    this.setState({team: input});
+  handleChangeTeam = (team: string) => {
+    this.setState({team});
   };
 
-  renderPendingTeam = (team: string) => {
+  getPendingTeamOption = (team: string) => {
     return {
       value: team,
       label: <DisabledLabel>{`#${team}`}</DisabledLabel>,
@@ -147,58 +146,59 @@ class MissingProjectMembership extends React.Component<Props, State> {
       {
         label: t('Pending Requests'),
         options: this.getTeamsForAccess()[1].map(pending =>
-          this.renderPendingTeam(pending)
+          this.getPendingTeamOption(pending)
         ),
       },
     ];
 
     return (
-      <div className="container">
-        <Panel>
-          {!teams.length ? (
-            <EmptyMessage icon={<StyledIconFlag size="xl" color="gray300" />}>
-              {t(
-                'No teams have access to this project yet. Ask an admin to add your team to this project.'
-              )}
-            </EmptyMessage>
-          ) : (
-            <EmptyMessage
-              icon={<StyledIconFlag size="xl" color="gray300" />}
-              title={t("You're not a member of this project.")}
-              description={t(
-                `You'll need to join a team with access to Issue ID ${groupId} before you can view it.`
-              )}
-              action={
-                <StyledField>
-                  <StyledSelectField
-                    name="select"
-                    placeholder={t('Select a Team')}
-                    options={teamAccess}
-                    onChange={this.handleChange}
-                    flexibleControlStateSize
-                  />
-                  {team ? (
-                    this.renderJoinTeam(team, features)
-                  ) : (
-                    <StyledButton disabled>{t('Select a Team')}</StyledButton>
-                  )}
-                </StyledField>
-              }
-            />
-          )}
-        </Panel>
-      </div>
+      <StyledPanel>
+        {!teams.length ? (
+          <EmptyMessage icon={<IconFlag size="xl" />}>
+            {t(
+              'No teams have access to this project yet. Ask an admin to add your team to this project.'
+            )}
+          </EmptyMessage>
+        ) : (
+          <EmptyMessage
+            icon={<IconFlag size="xl" />}
+            title={t("You're not a member of this project.")}
+            description={t(
+              `You'll need to join a team with access to Issue ID ${groupId} before you can view it.`
+            )}
+            action={
+              <StyledField>
+                <StyledSelectControl
+                  name="select"
+                  placeholder={t('Select a Team')}
+                  options={teamAccess}
+                  onChange={this.handleChangeTeam}
+                />
+                {team ? (
+                  this.renderJoinTeam(team, features)
+                ) : (
+                  <StyledButton disabled>{t('Select a Team')}</StyledButton>
+                )}
+              </StyledField>
+            }
+          />
+        )}
+      </StyledPanel>
     );
   }
 }
+
+const StyledPanel = styled(Panel)`
+  margin: 15px 0 15px 0;
+`;
 
 const StyledField = styled('div')`
   display: inline-block;
   text-align: left;
 `;
 
-const StyledSelectField = styled(SelectField)`
-  width: 350px;
+const StyledSelectControl = styled(SelectControl)`
+  width: 250px;
   border-bottom: 0;
   display: inline-block;
   & > div {
@@ -207,16 +207,10 @@ const StyledSelectField = styled(SelectField)`
   }
 `;
 
-const StyledIconFlag = styled(IconFlag)`
-  display: flex;
-  justify-content: center;
-  margin: auto;
-`;
-
 const StyledButton = styled(Button)`
   display: inline-block;
   justify-content: center;
-  margin-right: ${space(2)};
+  margin-left: ${space(2)};
 `;
 
 const DisabledLabel = styled('div')`

--- a/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
+++ b/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
@@ -19,7 +19,6 @@ type Props = {
   api: Client;
   organization: Organization;
   projectId?: string;
-  groupId: string;
 };
 
 type State = {
@@ -130,7 +129,7 @@ class MissingProjectMembership extends React.Component<Props, State> {
   };
 
   render() {
-    const {organization, groupId} = this.props;
+    const {organization} = this.props;
     const team = this.state.team;
     const teams = this.state.project?.teams ?? [];
     const features = new Set(organization.features);
@@ -164,7 +163,7 @@ class MissingProjectMembership extends React.Component<Props, State> {
             icon={<IconFlag size="xl" />}
             title={t("You're not a member of this project.")}
             description={t(
-              `You'll need to join a team with access to Issue ID ${groupId} before you can view it.`
+              `You'll need to join a team with access before you can view this data.`
             )}
             action={
               <StyledField>

--- a/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
+++ b/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
@@ -27,7 +27,7 @@ type State = {
   loading: boolean;
   error: boolean;
   project?: Project;
-  value: string | null;
+  team: string | null;
 };
 
 class MissingProjectMembership extends React.Component<Props, State> {
@@ -41,7 +41,7 @@ class MissingProjectMembership extends React.Component<Props, State> {
       loading: false,
       error: false,
       project,
-      value: '',
+      team: '',
     };
   }
 
@@ -114,19 +114,18 @@ class MissingProjectMembership extends React.Component<Props, State> {
     const request: string[] = [];
     const pending: string[] = [];
     const teams = this.state.project?.teams ?? [];
-    const team = teams.map(tm => TeamStore.getBySlug(tm.slug));
-    team.map(tm => (tm?.isPending ? pending.push(tm!.slug) : request.push(tm!.slug)));
+    teams.forEach(({slug}) => {
+      const team = TeamStore.getBySlug(slug);
+      team?.isPending ? pending.push(team!.slug) : request.push(team!.slug);
+    });
+
     return [request, pending];
   }
 
   handleChangeTeam = (teamObj: SelectOption | null) => {
-    const value = teamObj ? teamObj.value : null;
-    this.handleChange(value);
+    const team = teamObj ? teamObj.value : null;
+    this.setState({team});
   };
-
-  handleChange(value: string | null) {
-    this.setState({value});
-  }
 
   getPendingTeamOption = (team: string) => {
     return {
@@ -137,7 +136,7 @@ class MissingProjectMembership extends React.Component<Props, State> {
 
   render() {
     const {organization} = this.props;
-    const teamSlug = this.state.value;
+    const teamSlug = this.state.team;
     const teams = this.state.project?.teams ?? [];
     const features = new Set(organization.features);
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -238,7 +238,7 @@ class GroupDetails extends React.Component<Props, State> {
   }
 
   renderError() {
-    const {organization, location} = this.props;
+    const {organization, location, params} = this.props;
     const projects = organization.projects;
     const projectId = location.query.project;
 
@@ -259,6 +259,7 @@ class GroupDetails extends React.Component<Props, State> {
           <MissingProjectMembership
             organization={this.props.organization}
             projectId={projectSlug}
+            groupId={params.groupId}
           />
         );
       default:

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -238,7 +238,7 @@ class GroupDetails extends React.Component<Props, State> {
   }
 
   renderError() {
-    const {organization, location, params} = this.props;
+    const {organization, location} = this.props;
     const projects = organization.projects;
     const projectId = location.query.project;
 
@@ -259,7 +259,6 @@ class GroupDetails extends React.Component<Props, State> {
           <MissingProjectMembership
             organization={this.props.organization}
             projectId={projectSlug}
-            groupId={params.groupId}
           />
         );
       default:

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -247,10 +247,12 @@ const ProjectContext = createReactClass({
           // TODO(dcramer): add various controls to improve this flow and break it
           // out into a reusable missing access error component
           return (
-            <MissingProjectMembership
-              organization={this.props.organization}
-              projectId={this.state.project.slug}
-            />
+            <ErrorWrapper>
+              <MissingProjectMembership
+                organization={this.props.organization}
+                projectId={this.state.project.slug}
+              />
+            </ErrorWrapper>
           );
         default:
           return <LoadingError onRetry={this.remountComponent} />;
@@ -263,7 +265,7 @@ const ProjectContext = createReactClass({
   render() {
     return (
       <DocumentTitle ref={ref => (this.docTitleRef = ref)} title={this.getTitle()}>
-        <ErrorWrapper>{this.renderBody()}</ErrorWrapper>
+        {this.renderBody()}
       </DocumentTitle>
     );
   },

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import DocumentTitle from 'react-document-title';
 import {withRouter} from 'react-router';
+import styled from '@emotion/styled';
 import createReactClass from 'create-react-class';
 import PropTypes from 'prop-types';
 import Reflux from 'reflux';
@@ -261,7 +262,7 @@ const ProjectContext = createReactClass({
   render() {
     return (
       <DocumentTitle ref={ref => (this.docTitleRef = ref)} title={this.getTitle()}>
-        {this.renderBody()}
+        <ErrorWrapper>{this.renderBody()}</ErrorWrapper>
       </DocumentTitle>
     );
   },
@@ -270,3 +271,8 @@ const ProjectContext = createReactClass({
 export {ProjectContext};
 
 export default withApi(withOrganization(withProjects(withRouter(ProjectContext))));
+
+const ErrorWrapper = styled('div')`
+  width: 100%;
+  margin: 15px 30px;
+`;

--- a/src/sentry/static/sentry/app/views/projects/projectContext.jsx
+++ b/src/sentry/static/sentry/app/views/projects/projectContext.jsx
@@ -15,6 +15,7 @@ import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 import MemberListStore from 'app/stores/memberListStore';
 import ProjectsStore from 'app/stores/projectsStore';
+import space from 'app/styles/space';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
@@ -274,5 +275,5 @@ export default withApi(withOrganization(withProjects(withRouter(ProjectContext))
 
 const ErrorWrapper = styled('div')`
   width: 100%;
-  margin: 15px 30px;
+  margin: ${space(2)} ${space(4)};
 `;


### PR DESCRIPTION
Fix MissingProjectMembership error page when trying to access an issue belonging to a team you're not a member of.

(re: https://github.com/getsentry/sentry/pull/22149, [Design](https://getsentry.atlassian.net/browse/WOR-448))

### Before
<img width="1129" alt="99714161-1bfe3580-2a5a-11eb-9295-ef65cbcea3e3" src="https://user-images.githubusercontent.com/20312973/100581118-054ab080-329c-11eb-98a2-934ba5bda067.png">

### After

**Landing Page** _see note at bottom_
<img width="1139" alt="Screen Shot 2020-11-29 at 11 18 35 PM" src="https://user-images.githubusercontent.com/20312973/100581186-24e1d900-329c-11eb-9c24-e6674e646230.png">

**Dropdown Selections** _see note at bottom_
<img width="1131" alt="Screen Shot 2020-11-29 at 11 18 44 PM" src="https://user-images.githubusercontent.com/20312973/100581217-3a570300-329c-11eb-8969-afa5125a2934.png">

**With Pending Requests + Tooltip**
<img width="1144" alt="Screen Shot 2020-11-29 at 11 19 52 PM" src="https://user-images.githubusercontent.com/20312973/100581303-5f4b7600-329c-11eb-9041-06af4c43bcae.png">

**Selecting Team**
<img width="1133" alt="Screen Shot 2020-11-29 at 11 18 52 PM" src="https://user-images.githubusercontent.com/20312973/100581314-65d9ed80-329c-11eb-9854-bfca2a5db57c.png">

**Successful Request**
<img width="1166" alt="Screen Shot 2020-11-29 at 11 19 08 PM" src="https://user-images.githubusercontent.com/20312973/100581339-71c5af80-329c-11eb-97ca-e722a491371c.png">


**Notes**
- Original design had multiselect - do we want to open this up to a multiselect?
- Original design had the short ID in the subtext, but the short ID isn't available to the user here, so I put the Issue ID instead. Let me know if I should adjust this.