### PR TITLE
test: Align test init with normal app init

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -15,32 +15,4 @@ def pytest_configure(config):
     # being used
     warnings.filterwarnings("error", "", Warning, r"^(?!(|kombu|raven|sentry))")
 
-    # always install plugins for the tests
-    install_sentry_plugins()
-
     config.addinivalue_line("markers", "obsolete: mark test as obsolete and soon to be removed")
-
-
-def install_sentry_plugins():
-    # Sentry's pytest plugin explicitly doesn't load plugins, so let's load all of them
-    # and ignore the fact that we're not *just* testing our own
-    # Note: We could manually register/configure INSTALLED_APPS by traversing our entry points
-    # or package directories, but this is easier assuming Sentry doesn't change APIs.
-    # Note: Order of operations matters here.
-    from sentry.runner.importer import install_plugin_apps
-    from django.conf import settings
-
-    install_plugin_apps("sentry.apps", settings)
-
-    from sentry.runner.initializer import register_plugins
-
-    register_plugins(settings, raise_on_plugin_load_failure=True)
-
-    settings.ASANA_CLIENT_ID = "abc"
-    settings.ASANA_CLIENT_SECRET = "123"
-    settings.BITBUCKET_CONSUMER_KEY = "abc"
-    settings.BITBUCKET_CONSUMER_SECRET = "123"
-    settings.GITHUB_APP_ID = "abc"
-    settings.GITHUB_API_SECRET = "123"
-    # this isn't the real secret
-    settings.SENTRY_OPTIONS["github.integration-hook-secret"] = "b3002c3e321d4b7880360d397db2ccfd"


### PR DESCRIPTION
Instead of doing custom and repeated initialization code that creates
unexpected divergence w/ normal app init, just use the regular
initializer. Needed for #22283.
