### PR TITLE
fix(ui): Tooltip hover hide delay issues in issue stream

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/tooltip.tsx
@@ -207,6 +207,7 @@ export default function Tooltip({
   formatAxisLabel,
   valueFormatter,
   nameFormatter,
+  hideDelay,
   ...props
 }: Props = {}): EChartOption.Tooltip {
   formatter =
@@ -229,6 +230,8 @@ export default function Tooltip({
     backgroundColor: 'transparent',
     transitionDuration: 0,
     padding: 0,
+    // Default hideDelay in echarts docs is 100ms
+    hideDelay: hideDelay || 100,
     position(pos, _params, dom, _rec, _size) {
       // Center the tooltip slightly above the cursor.
       const tipWidth = dom.clientWidth;

--- a/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/miniBarChart.tsx
@@ -59,6 +59,11 @@ type Props = Omit<ChartProps, 'series'> &
      */
     emphasisColors?: string[];
 
+    /**
+     * Delay time for hiding tooltip, in ms.
+     */
+    hideDelay?: number;
+
     series?: BarChartProps['series'];
   };
 
@@ -74,6 +79,7 @@ class MiniBarChart extends React.Component<Props> {
       labelYAxisExtents,
       stacked,
       series,
+      hideDelay,
       ...props
     } = this.props;
 
@@ -161,6 +167,7 @@ class MiniBarChart extends React.Component<Props> {
     const chartOptions = {
       tooltip: {
         trigger: 'axis' as const,
+        hideDelay,
       },
       yAxis: {
         max(value) {

--- a/src/sentry/static/sentry/app/components/stream/groupChart.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupChart.tsx
@@ -66,6 +66,7 @@ function GroupChart({
         series={series}
         colors={colors}
         emphasisColors={emphasisColors}
+        hideDelay={50}
       />
     </LazyLoad>
   );


### PR DESCRIPTION
This pr fixes an issue with the tooltip of the barchart in the issue stream where the hide delay was causing them to leave a trail. Users regularly scroll in the issue stream so this is a noticeable issue.

Reported
[JIRA Card](https://getsentry.atlassian.net/browse/WOR-444)

Issue:
with default 100ms hide delay
![issue](https://user-images.githubusercontent.com/15015880/100626906-38606480-32db-11eb-9794-60ed506875e2.gif)

Fixed:
with 50ms hide delay
![fixed](https://user-images.githubusercontent.com/15015880/100626937-3e564580-32db-11eb-9228-621acb404760.gif)
