### PR TITLE
feat(ui): Add charts to project detail

### DIFF
--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -17,7 +17,7 @@ type Props = Omit<
   keyof Omit<GlobalSelection, 'datetime'> | keyof GlobalSelection['datetime']
 > & {
   title: string;
-  help: string;
+  help?: string;
   selection: GlobalSelection;
   onTotalValuesChange: (value: number | null) => void;
 };
@@ -91,7 +91,7 @@ class ProjectBaseEventsChart extends React.Component<Props> {
           chartHeader={
             <HeaderTitleLegend>
               {title}
-              <QuestionTooltip size="sm" position="top" title={help} />
+              {help && <QuestionTooltip size="sm" position="top" title={help} />}
             </HeaderTitleLegend>
           }
           legendOptions={{right: 10, top: 0}}

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -17,9 +17,9 @@ type Props = Omit<
   keyof Omit<GlobalSelection, 'datetime'> | keyof GlobalSelection['datetime']
 > & {
   title: string;
-  help?: string;
   selection: GlobalSelection;
   onTotalValuesChange: (value: number | null) => void;
+  help?: string;
 };
 
 class ProjectBaseEventsChart extends React.Component<Props> {

--- a/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
@@ -16,6 +16,7 @@ import {Panel} from 'app/components/panels';
 import CHART_PALETTE from 'app/constants/chartPalette';
 import {t} from 'app/locale';
 import {Organization, SelectValue} from 'app/types';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {decodeScalar} from 'app/utils/queryString';
 import {Theme} from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
@@ -146,7 +147,14 @@ class ProjectCharts extends React.Component<Props, State> {
   }
 
   handleDisplayModeChange = (value: string) => {
-    const {location, index} = this.props;
+    const {location, index, organization} = this.props;
+
+    trackAnalyticsEvent({
+      eventKey: `project_detail.change_chart${index + 1}`,
+      eventName: `Project Detail: Change Chart #${index + 1}`,
+      organization_id: parseInt(organization.id, 10),
+      metric: value,
+    });
 
     browserHistory.push({
       pathname: location.pathname,

--- a/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import * as ReactRouter from 'react-router';
 import {browserHistory} from 'react-router';
+import {withTheme} from 'emotion-theming';
 import {Location} from 'history';
 
 import {Client} from 'app/api';
@@ -16,7 +17,7 @@ import CHART_PALETTE from 'app/constants/chartPalette';
 import {t} from 'app/locale';
 import {Organization, SelectValue} from 'app/types';
 import {decodeScalar} from 'app/utils/queryString';
-import theme from 'app/utils/theme';
+import {Theme} from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 
 import {getTermHelp} from '../performance/data';
@@ -41,6 +42,7 @@ type Props = {
   organization: Organization;
   router: ReactRouter.InjectedRouter;
   index: number;
+  theme: Theme;
 };
 
 type State = {
@@ -83,7 +85,7 @@ class ProjectCharts extends React.Component<Props, State> {
     const noPerformanceTooltip = t(
       'This view is only available with Performance Monitoring.'
     );
-    const noDiscoverTooltip = t('This view is only available with Discover feature.');
+    const noDiscoverTooltip = t('This view is only available with Discover.');
 
     return [
       {
@@ -157,7 +159,7 @@ class ProjectCharts extends React.Component<Props, State> {
   };
 
   render() {
-    const {api, router, organization} = this.props;
+    const {api, router, organization, theme} = this.props;
     const {totalValues} = this.state;
     const displayMode = this.displayMode;
 
@@ -256,4 +258,4 @@ class ProjectCharts extends React.Component<Props, State> {
   }
 }
 
-export default withApi(ProjectCharts);
+export default withApi(withTheme(ProjectCharts));

--- a/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
@@ -115,11 +115,15 @@ class ProjectDetail extends AsyncView<Props, State> {
             <Layout.Body>
               <Layout.Main>
                 <ProjectScoreCards />
-                <ProjectCharts
-                  location={location}
-                  organization={organization}
-                  router={router}
-                />
+                {[1, 2].map((id, index) => (
+                  <ProjectCharts
+                    location={location}
+                    organization={organization}
+                    router={router}
+                    key={`project-charts-${id}`}
+                    index={index}
+                  />
+                ))}
               </Layout.Main>
               <Layout.Side>
                 <ProjectTeamAccess organization={organization} project={project} />

--- a/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
@@ -115,13 +115,13 @@ class ProjectDetail extends AsyncView<Props, State> {
             <Layout.Body>
               <Layout.Main>
                 <ProjectScoreCards />
-                {[1, 2].map((id, index) => (
+                {[0, 1].map(id => (
                   <ProjectCharts
                     location={location}
                     organization={organization}
                     router={router}
                     key={`project-charts-${id}`}
-                    index={index}
+                    index={id}
                   />
                 ))}
               </Layout.Main>

--- a/src/sentry/static/sentry/app/views/projectDetail/projectLatestAlerts.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectLatestAlerts.tsx
@@ -41,7 +41,7 @@ type State = {
 class ProjectLatestAlerts extends AsyncComponent<Props, State> {
   shouldComponentUpdate(nextProps: Props, nextState: State) {
     if (
-      !isEqual(this.state, nextState) ||
+      this.state !== nextState ||
       !isEqual(
         pick(this.props.location.query, Object.values(URL_PARAM)),
         pick(nextProps.location.query, Object.values(URL_PARAM))

--- a/src/sentry/static/sentry/app/views/projectDetail/projectLatestAlerts.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectLatestAlerts.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {withTheme} from 'emotion-theming';
 import {Location} from 'history';
+import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 
 import AsyncComponent from 'app/components/asyncComponent';
@@ -38,11 +39,25 @@ type State = {
 } & AsyncComponent['state'];
 
 class ProjectLatestAlerts extends AsyncComponent<Props, State> {
+  shouldComponentUpdate(nextProps: Props, nextState: State) {
+    if (
+      !isEqual(this.state, nextState) ||
+      !isEqual(
+        pick(this.props.location.query, Object.values(URL_PARAM)),
+        pick(nextProps.location.query, Object.values(URL_PARAM))
+      )
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {location, organization} = this.props;
 
     const query = {
-      ...pick(location.query, [...Object.values(URL_PARAM)]),
+      ...pick(location.query, Object.values(URL_PARAM)),
       per_page: 3,
     };
 

--- a/src/sentry/static/sentry/app/views/projectDetail/projectLatestReleases.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectLatestReleases.tsx
@@ -38,7 +38,7 @@ type State = {
 class ProjectLatestReleases extends AsyncComponent<Props, State> {
   shouldComponentUpdate(nextProps: Props, nextState: State) {
     if (
-      !isEqual(this.state, nextState) ||
+      this.state !== nextState ||
       !isEqual(
         pick(this.props.location.query, Object.values(URL_PARAM)),
         pick(nextProps.location.query, Object.values(URL_PARAM))

--- a/src/sentry/static/sentry/app/views/projectDetail/projectLatestReleases.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectLatestReleases.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Location} from 'history';
+import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 
 import AsyncComponent from 'app/components/asyncComponent';
@@ -35,11 +36,25 @@ type State = {
 } & AsyncComponent['state'];
 
 class ProjectLatestReleases extends AsyncComponent<Props, State> {
+  shouldComponentUpdate(nextProps: Props, nextState: State) {
+    if (
+      !isEqual(this.state, nextState) ||
+      !isEqual(
+        pick(this.props.location.query, Object.values(URL_PARAM)),
+        pick(nextProps.location.query, Object.values(URL_PARAM))
+      )
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {location, organization, projectSlug} = this.props;
 
     const query = {
-      ...pick(location.query, [...Object.values(URL_PARAM)]),
+      ...pick(location.query, Object.values(URL_PARAM)),
       per_page: 5,
     };
 

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
@@ -68,7 +68,7 @@ const ReleaseChartControls = ({
     ? t('This view is only available with release health data.')
     : undefined;
   const noDiscoverTooltip = !hasDiscover
-    ? t('This view is only available with Discover feature.')
+    ? t('This view is only available with Discover.')
     : undefined;
   const noPerformanceTooltip = !hasPerformance
     ? t('This view is only available with Performance Monitoring.')


### PR DESCRIPTION
![Screenshot 2020-11-30 at 17 08 54](https://user-images.githubusercontent.com/9060071/100634002-0547c080-332f-11eb-8fef-ebb03c85f724.png)

These charts were added:
- Failure Rate
- Transactions Per Minute
- Daily Errors
- Daily Transactions


This is feature flagged (`organizations:project-detail`) work in progress.

