### PR TITLE
ref(reprocessing-v2): Expose group status and add more data to activity

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -56,6 +56,7 @@ from sentry.utils.db import attach_foreignkey
 from sentry.utils.safe import safe_execute
 from sentry.utils.compat import map, zip
 from sentry.utils.snuba import Dataset, raw_query
+from sentry.reprocessing2 import get_num_pending_events
 
 SUBSCRIPTION_REASON_MAP = {
     GroupSubscriptionReason.comment: "commented",
@@ -383,6 +384,7 @@ class GroupSerializerBase(Serializer):
                 ignore_actor = None
 
             result[item] = {
+                "id": item.id,
                 "assigned_to": resolved_assignees.get(item.id),
                 "is_bookmarked": item.id in bookmarks,
                 "subscription": subscriptions[item.id],
@@ -450,6 +452,9 @@ class GroupSerializerBase(Serializer):
             status_label = "pending_deletion"
         elif status == GroupStatus.PENDING_MERGE:
             status_label = "pending_merge"
+        elif status == GroupStatus.REPROCESSING:
+            status_label = "reprocessing"
+            status_details["pendingEvents"] = get_num_pending_events(attrs["id"])
         else:
             status_label = "unresolved"
         return status_details, status_label

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -56,7 +56,7 @@ internally:
 
   After that the Redis set can be cleared out.
 
-As such, reusing the group model will not work as the Redis set will prevent
+As such, reusing the group ID will not work as the Redis set will prevent
 any events in that group from being searchable. We can also not skip the Redis
 part specifically for reprocessing: When the user chooses to process `x` out of
 `n` events, the other `n - x` events would randomly appear within search

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -1,3 +1,81 @@
+"""
+Reprocessing allows a user to re-enqueue all events of a group at the start of
+preprocess-event, for example to reattempt symbolication of stacktraces or
+reattempt grouping.
+
+How reprocessing works
+======================
+
+1. In `start_group_reprocessing`, the group is put into REPROCESSING state. In
+   this state it must not be modified or receive events. Much like with group
+   merging, all its hashes are detached, they are moved to a new, empty group.
+
+   The group gets a new activity entry that contains metadata about who
+   triggered reprocessing with how many events. This is purely to serve UI.
+
+   If a user at this point navigates to the group, they will not be able to
+   interact with it at all, but only watch the progress of reprocessing.
+
+2. All events from the group are iterated through and enqueued into
+   preprocess_event. The event payload is taken from a backup that was made on
+   first ingestion in preprocess_event.
+
+3. wait_group_reprocessed in sentry.tasks.reprocessing2 polls a counter in
+   Redis to see if reprocessing is done. When it reaches zero, all associated
+   models like assignee and activity are moved into the new group.
+
+   A group redirect is installed. The old group is deleted, while the new group
+   is unresolved. This effectively unsets the REPROCESSING status.
+
+   A user looking at the progressbar on the old group's URL is supposed to be
+   redirected at this point. The new group can either:
+
+   a. Have events by itself, but also show a success message based on the data in activity.
+   b. Be totally empty but suggest a search for original_group_id based on data in activity.
+
+   However, there's no special flag for whether that new group has been a
+   result of reprocessing.
+
+Why not mutate the group in-place? (and how reprocessing actually works)
+========================================================================
+
+Snuba is only able to delete entire groups at once. How group deletion works
+internally:
+
+* A new row is inserted into the events table with the same event_id, but a
+  `deleted=1` property. This row by itself would naturally appear as a new
+  event with the same event ID, however Snuba adds `and not deleted` to every query.
+
+* The group ID is added to a Redis set of "temporarily excluded group IDs".
+  This set is now appended to every query: `and group_id not in (<long list of
+  deleted group IDs>)`
+
+* Every n hours, ClickHouse folds rows with duplicate primary keys into one
+  row. Now only the `deleted=1` row of the deleted event remains. This process
+  is basically rewriting the table, and as such itself takes a couple of hours.
+
+  After that the Redis set can be cleared out.
+
+As such, reusing the group model will not work as the Redis set will prevent
+any events in that group from being searchable. We can also not skip the Redis
+part specifically for reprocessing: When the user chooses to process `x` out of
+`n` events, the other `n - x` events would randomly appear within search
+results until the next table rewrite is done.
+
+One could in theory store individual event IDs in Redis that should be excluded
+from all queries. However, this blows up the size of all queries within a
+project until the next table rewrite is done, and slows down all searches. In
+theory this slowdown can also happen if one chose to delete a lot of groups
+within a project.
+
+There is the additional complication that the `deleted=1` row "wins" over any
+other row one may insert at a later point. So what reprocessing actually does
+instead of group deletion is:
+
+* Insert `deleted=1` for all events that are *not* supposed to be reprocessed.
+* Mark the group as deleted in Redis.
+* All reprocessed events are "just" inserted over the old ones.
+"""
 from __future__ import absolute_import
 
 import hashlib
@@ -18,7 +96,7 @@ from sentry.deletions.defaults.group import DIRECT_GROUP_RELATED_MODELS
 
 logger = logging.getLogger("sentry.reprocessing")
 
-_REDIS_SYNC_TTL = 3600
+_REDIS_SYNC_TTL = 3600 * 24
 
 
 # Note: Event attachments and group reports are migrated in save_event.
@@ -215,6 +293,13 @@ def start_group_reprocessing(project_id, group_id, max_events=None, acting_user_
     with transaction.atomic():
         group = models.Group.objects.get(id=group_id)
         original_status = group.status
+        if original_status == models.GroupStatus.REPROCESSING:
+            # This is supposed to be a rather unlikely UI race when two people
+            # click reprocessing in the UI at the same time.
+            #
+            # During reprocessing the button is greyed out.
+            raise RuntimeError("Cannot reprocess group that is currently being reprocessed")
+
         original_short_id = group.short_id
         group.status = models.GroupStatus.REPROCESSING
         # satisfy unique constraint of (project_id, short_id)
@@ -241,20 +326,6 @@ def start_group_reprocessing(project_id, group_id, max_events=None, acting_user_
         for model in GROUP_MODELS_TO_MIGRATE:
             model.objects.filter(group_id=group_id).update(group_id=new_group.id)
 
-    models.GroupRedirect.objects.create(
-        organization_id=new_group.project.organization_id,
-        group_id=new_group.id,
-        previous_group_id=group_id,
-    )
-
-    models.Activity.objects.create(
-        type=models.Activity.REPROCESS,
-        project=new_group.project,
-        ident=six.text_type(group_id),
-        group=new_group,
-        user_id=acting_user_id,
-    )
-
     # Get event counts of issue (for all environments etc). This was copypasted
     # and simplified from groupserializer.
     event_count = snuba.aliased_query(
@@ -267,8 +338,24 @@ def start_group_reprocessing(project_id, group_id, max_events=None, acting_user_
     if max_events is not None:
         event_count = min(event_count, max_events)
 
-    key = _get_sync_counter_key(group_id)
-    _get_sync_redis_client().setex(key, _REDIS_SYNC_TTL, event_count)
+    # Create activity on *old* group as that will serve the landing page for our
+    # reprocessing status
+    #
+    # Later the activity is migrated to the new group where it is used to serve
+    # the success message.
+    models.Activity.objects.create(
+        type=models.Activity.REPROCESS,
+        project=new_group.project,
+        ident=six.text_type(group_id),
+        group_id=group_id,
+        user_id=acting_user_id,
+        data={"eventCount": event_count, "oldGroupId": group_id, "newGroupId": new_group.id},
+    )
+
+    client = _get_sync_redis_client()
+    client.setex(_get_sync_counter_key(group_id), _REDIS_SYNC_TTL, event_count)
+
+    return new_group.id
 
 
 def is_group_finished(group_id):
@@ -276,5 +363,9 @@ def is_group_finished(group_id):
     Checks whether a group has finished reprocessing.
     """
 
-    pending = int(_get_sync_redis_client().get(_get_sync_counter_key(group_id)))
+    pending = get_num_pending_events(group_id)
     return pending <= 0
+
+
+def get_num_pending_events(group_id):
+    return int(_get_sync_redis_client().get(_get_sync_counter_key(group_id)))


### PR DESCRIPTION
* Expose "reprocessing" group status in group serializer and also add progress of reprocessing as group status details. This appears to not break the UI at all (I did thorough testing) but we're kind of treading on thin ice.

  @priscilawebdev To test this new status when developing UI, I recommend doing in sentry shell:

  ```python
  from sentry.reprocessing2 import start_group_reprocessing
  start_group_reprocessing(project_id=1, group_id=123)
  ```

  This will start reprocessing but actually never finish it. You can then no longer find the group in `is:unresolved`, you need to clear the search to be able to see it. You can also delete the group safely.

* Add more data about reprocessed event count to activity feed, + old/new group IDs to be able to link to search.
* Add documentation to reprocessing module
* bump ttl of redis counter such that we will have an easier time debugging hanging reprocessing jobs if it comes to that