### PR TITLE
feat(dashboards) Add a widget validation endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_widget_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_widget_details.py
@@ -1,76 +1,24 @@
 from __future__ import absolute_import
 
-from django.db import transaction
 from rest_framework.response import Response
 
-from sentry.api.bases.dashboard import OrganizationDashboardWidgetEndpoint
-from sentry.api.serializers import serialize
+from sentry.api.bases import OrganizationEndpoint
 from sentry.api.serializers.rest_framework import DashboardWidgetSerializer
-from sentry.models import DashboardWidgetQuery
 
 
-class OrganizationDashboardWidgetDetailsEndpoint(OrganizationDashboardWidgetEndpoint):
-    def delete(self, request, organization, dashboard, widget):
+class OrganizationDashboardWidgetDetailsEndpoint(OrganizationEndpoint):
+    def post(self, request, organization):
         """
-        Delete a Widget on an Organization's Dashboard
-        ``````````````````````````````````````````````
+        Validate a Widget
+        `````````````````
 
-        Delete a widget on an organization's dashboard.
-
-        :pparam string organization_slug: the slug of the organization the
-                                          dashboard belongs to.
-        :pparam int dashboard_id: the id of the dashboard.
-        :pparam int widget_id: the id of the widget.
-        :auth: required
-        """
-
-        widget.delete()
-        return self.respond(status=204)
-
-    def put(self, request, organization, dashboard, widget):
-        """
-        Edit a Widget on an Organization's Dashboard
-        ````````````````````````````````````````````
-
-        Edit a widget on an organization's dashboard.
-
-        :pparam string organization_slug: the slug of the organization the
-                                          dashboard belongs to.
-        :pparam int dashboard_id: the id of the dashboard.
-        :pparam int widget_id: the id of the widget.
-        :param string title: the title of the widget.
-        :param string displayType: the widget display type (i.e. line or table).
-        :param array displayOptions: the widget display options are special
-                                    variables necessary to displaying the widget correctly.
-        :param array dataSources: the sources of data for the widget to display.
-                                If supplied the entire set of data sources will be deleted
-                                and replaced with the input provided.
-        :auth: required
+        Ensure that a dashboard widget contains a valid queries,
+        and has a high chance of success when the dashboard is
+        saved.
         """
         serializer = DashboardWidgetSerializer(
             data=request.data, context={"organization": organization}
         )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)
-
-        data = serializer.validated_data
-
-        with transaction.atomic():
-            widget.update(
-                title=data.get("title", widget.title),
-                display_type=data.get("displayType", widget.display_type),
-            )
-
-            if "queries" in data:
-                DashboardWidgetQuery.objects.filter(widget_id=widget.id).delete()
-            for i, query in enumerate(data.get("queries", [])):
-                DashboardWidgetQuery.objects.create(
-                    name=query["name"],
-                    fields=query["fields"],
-                    conditions=query["conditions"],
-                    interval=query["interval"],
-                    order=i,
-                    widget_id=widget.id,
-                )
-
-        return Response(serialize(widget, request.user))
+        return Response({}, status=200)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -82,6 +82,9 @@ from .endpoints.organization_auth_providers import OrganizationAuthProvidersEndp
 from .endpoints.organization_avatar import OrganizationAvatarEndpoint
 from .endpoints.organization_config_integrations import OrganizationConfigIntegrationsEndpoint
 from .endpoints.organization_config_repositories import OrganizationConfigRepositoriesEndpoint
+from .endpoints.organization_dashboard_widget_details import (
+    OrganizationDashboardWidgetDetailsEndpoint,
+)
 from .endpoints.organization_dashboard_details import OrganizationDashboardDetailsEndpoint
 from .endpoints.organization_dashboards import OrganizationDashboardsEndpoint
 from .endpoints.organization_details import OrganizationDetailsEndpoint
@@ -722,6 +725,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/dashboards/$",
                     OrganizationDashboardsEndpoint.as_view(),
                     name="sentry-api-0-organization-dashboards",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/dashboards/widgets/$",
+                    OrganizationDashboardWidgetDetailsEndpoint.as_view(),
+                    name="sentry-api-0-organization-dashboard-widget-details",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/dashboards/(?P<dashboard_id>[^\/]+)/$",

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import
+
+from django.core.urlresolvers import reverse
+from sentry.testutils import OrganizationDashboardWidgetTestCase
+
+
+class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTestCase):
+    def url(self):
+        return reverse(
+            "sentry-api-0-organization-dashboard-widget-details",
+            kwargs={"organization_slug": self.organization.slug},
+        )
+
+    def test_valid_widget(self):
+        data = {
+            "name": "Errors over time",
+            "displayType": "line",
+            "queries": [
+                {"name": "errors", "conditions": "event.type:error", "fields": ["count()"]}
+            ],
+        }
+        response = self.client.post(self.url(), data=data,)
+        assert response.status_code == 200, response.data
+
+    def test_invalid_query_conditions(self):
+        data = {
+            "name": "Invalid query",
+            "displayType": "line",
+            "queries": [
+                {"name": "errors", "conditions": "event.type: tag:foo", "fields": ["count()"]}
+            ],
+        }
+        response = self.client.post(self.url(), data=data,)
+        assert response.status_code == 400, response.data
+        assert "queries" in response.data, response.data
+        assert response.data["queries"][0]["conditions"], response.data
+
+    def test_invalid_query_fields(self):
+        data = {
+            "name": "Invalid query",
+            "displayType": "line",
+            "queries": [
+                {"name": "errors", "conditions": "event.type:error", "fields": ["p95(user)"]}
+            ],
+        }
+        response = self.client.post(self.url(), data=data,)
+        assert response.status_code == 400, response.data
+        assert "queries" in response.data, response.data
+        assert response.data["queries"][0]["fields"], response.data
+
+    def test_invalid_display_type(self):
+        data = {
+            "name": "Invalid query",
+            "displayType": "cats",
+            "queries": [
+                {"name": "errors", "conditions": "event.type:error", "fields": ["count()"]}
+            ],
+        }
+        response = self.client.post(self.url(), data=data,)
+        assert response.status_code == 400, response.data
+        assert "displayType" in response.data, response.data


### PR DESCRIPTION
We currently don't have a good way to ensure success when a dashboard is
saved. If the user makes an error in a widget they don't find out until
much later and it is very hard for us to present validation errors for
multiple widgets.

The frontend could use this new endpoint to get a higher degree of
confidence that the widget is valid before the widget is added to the
dashboard. It will also enable us to show error messages in the modal
window while the user still has it open.