### PR TITLE
ref(stacktrace-link): Setup Code Mapping Modal

### DIFF
--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -122,10 +122,10 @@ class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
         return self.respond(
             {
                 "integrationId": integration.id,
-                "repoId": repo.id,
+                "repositoryId": repo.id,
                 "provider": integration.provider,
                 "stackRoot": stack_root,
                 "sourceRoot": source_root,
-                "branch": branch,
+                "defaultBranch": branch,
             }
         )

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -172,7 +172,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
       <CodeMappingButtonContainer columnQuantity={2}>
         {text}
         <Button onClick={() => this.onReconfigureMapping()} to={url} size="xsmall">
-          {t('Configure Code Mapping')}
+          {t('Configure Stack Trace Linking')}
         </Button>
       </CodeMappingButtonContainer>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import Modal from 'react-bootstrap/lib/Modal';
+import styled from '@emotion/styled';
+
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import AsyncComponent from 'app/components/asyncComponent';
+import Button from 'app/components/button';
+import ButtonBar from 'app/components/buttonBar';
+import {t, tct} from 'app/locale';
+import space from 'app/styles/space';
+import {Integration, Organization, Project} from 'app/types';
+import {getIntegrationIcon} from 'app/utils/integrationUtil';
+import InputField from 'app/views/settings/components/forms/inputField';
+
+import {OpenInContainer} from './openInContextLine';
+
+type Props = AsyncComponent['props'] & {
+  filename: string;
+  organization: Organization;
+  project: Project;
+  integrations: Integration[];
+  onClose: () => void;
+};
+
+type State = AsyncComponent['state'] & {
+  showModal: boolean;
+  sourceCodeInput: string;
+};
+
+class StacktraceLinkModal extends AsyncComponent<Props, State> {
+  getDefaultState(): State {
+    return {
+      ...super.getDefaultState(),
+      showModal: false,
+      sourceCodeInput: '',
+    };
+  }
+  openModal() {
+    this.setState({
+      showModal: true,
+    });
+  }
+
+  closeModal() {
+    this.setState({
+      showModal: false,
+      sourceCodeInput: '',
+    });
+  }
+
+  createConfig = async configData => {
+    const {organization, project} = this.props;
+    const endpoint = `/organizations/${organization.slug}/integrations/${configData.integrationId}/repo-project-path-configs/`;
+    try {
+      await this.api.requestPromise(endpoint, {
+        method: 'POST',
+        data: {...configData, projectId: project.id},
+      });
+      addSuccessMessage(t('Stack trace link config created.'));
+    } catch (err) {
+      const errors = err?.responseJSON
+        ? Array.isArray(err?.responseJSON)
+          ? err?.responseJSON
+          : Object.values(err?.responseJSON)
+        : [];
+      const apiErrors = errors.length > 0 ? `: ${errors.join(', ')}` : '';
+      addErrorMessage(t('Unable to save configuration%s', apiErrors));
+    }
+    this.closeModal();
+    this.props.onClose();
+  };
+
+  onHandleChange(sourceCodeInput: string) {
+    this.setState({
+      sourceCodeInput,
+    });
+  }
+
+  handleSubmit = async () => {
+    const {sourceCodeInput} = this.state;
+    const {organization, filename, project} = this.props;
+    const endpoint = `/projects/${organization.slug}/${project.slug}/repo-path-parsing/`;
+    try {
+      const configData = await this.api.requestPromise(endpoint, {
+        method: 'POST',
+        data: {
+          sourceUrl: sourceCodeInput,
+          stackPath: filename,
+        },
+      });
+      this.createConfig(configData);
+    } catch (err) {
+      const error = err?.responseJSON?.sourceUrl;
+      if (error && error.length > 0) {
+        addErrorMessage(t(`${error[0]}`));
+      } else {
+        addErrorMessage(t('An error occurred'));
+      }
+    }
+  };
+
+  renderBody() {
+    const {showModal, sourceCodeInput} = this.state;
+    const {filename, integrations, organization} = this.props;
+    const baseUrl = `/settings/${organization.slug}/integrations`;
+
+    return (
+      <CodeMappingButtonContainer columnQuantity={2}>
+        {t('Enable source code stack trace linking by setting up a code mapping.')}
+        <Button onClick={() => this.openModal()} size="xsmall">
+          {t('Setup Code Mapping')}
+        </Button>
+        <Modal
+          show={showModal}
+          onHide={() => this.closeModal()}
+          enforceFocus={false}
+          backdrop="static"
+          animation={false}
+        >
+          <Modal.Header closeButton>{t('Code Mapping Setup')}</Modal.Header>
+          <Modal.Body>
+            <ModalContainer>
+              <div>
+                <h6>{t('Quick Setup')}</h6>
+                {tct(
+                  'Enter in your source code url that corresponsds to stack trace filename [filename]. We will create a code mapping with this information.',
+                  {
+                    filename: <code>{filename}</code>,
+                  }
+                )}
+              </div>
+              <SourceCodeInput>
+                <StyledInputField
+                  inline={false}
+                  flexibleControlStateSize
+                  stacked
+                  name="source-code-input"
+                  type="text"
+                  value={sourceCodeInput}
+                  onChange={val => this.onHandleChange(val)}
+                  placeholder={t(
+                    `https://github.com/helloworld/Hello-World/blob/master/${filename}`
+                  )}
+                />
+                <ButtonBar>
+                  <Button type="button" onClick={() => this.handleSubmit()}>
+                    {t('Submit')}
+                  </Button>
+                </ButtonBar>
+              </SourceCodeInput>
+              <div>
+                <h6>{t('Manual Setup')}</h6>
+                {t(
+                  'To set up a code mapping manually, select which of your following integrations you want to set up the mapping for:'
+                )}
+              </div>
+              <ManualSetup>
+                {integrations.map(integration => (
+                  <Button
+                    key={integration.id}
+                    type="button"
+                    to={`${baseUrl}/${integration.provider.key}/${integration.id}/?tab=codeMappings`}
+                  >
+                    {getIntegrationIcon(integration.provider.key)}
+                    <IntegrationName>{integration.name}</IntegrationName>
+                  </Button>
+                ))}
+              </ManualSetup>
+            </ModalContainer>
+          </Modal.Body>
+          <Modal.Footer></Modal.Footer>
+        </Modal>
+      </CodeMappingButtonContainer>
+    );
+  }
+}
+
+export default StacktraceLinkModal;
+
+export const CodeMappingButtonContainer = styled(OpenInContainer)`
+  justify-content: space-between;
+`;
+
+const SourceCodeInput = styled('div')`
+  display: grid;
+  grid-template-columns: 5fr 1fr;
+  grid-gap: ${space(1)};
+`;
+
+const ManualSetup = styled('div')`
+  display: grid;
+  grid-gap: ${space(1)};
+  justify-items: center;
+`;
+
+const ModalContainer = styled('div')`
+  display: grid;
+  grid-gap: ${space(3)};
+`;
+
+const StyledInputField = styled(InputField)`
+  padding: 0px;
+`;
+
+const IntegrationName = styled('p')`
+  padding-left: 10px;
+`;

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -99,7 +99,7 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
       <CodeMappingButtonContainer columnQuantity={2}>
         {t('Enable source code stack trace linking by setting up a code mapping.')}
         <Button onClick={() => this.openModal()} size="xsmall">
-          {t('Setup Code Mapping')}
+          {t('Setup Stack Trace Linking')}
         </Button>
         <Modal
           show={showModal}

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -136,7 +136,11 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
                   )}
                 />
                 <ButtonBar>
-                  <Button type="button" onClick={() => this.handleSubmit()}>
+                  <Button
+                    data-test-id="quick-setup-button"
+                    type="button"
+                    onClick={() => this.handleSubmit()}
+                  >
                     {t('Submit')}
                   </Button>
                 </ButtonBar>
@@ -169,7 +173,7 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
           <Modal.Footer>
             <Alert type="info" icon={<IconInfo />}>
               {tct(
-                'Stack trace linking is still in Beta, if you have feedback, email [email:ecosystem-feedback@sentry.io].',
+                'Stack trace linking is still in Beta. If you have feedback, please email [email:ecosystem-feedback@sentry.io].',
                 {email: <a href="mailto:ecosystem-feedback@sentry.io" />}
               )}
             </Alert>

--- a/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
@@ -18,11 +18,30 @@ describe('StacktraceLink', function () {
     MockApiClient.clearMockResponses();
   });
 
+  it('renders setup CTA with integration but no configs', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      query: {file: frame.filename, commitId: 'master'},
+      body: {config: null, sourceUrl: null, integrations: [integration]},
+    });
+    const wrapper = mountWithTheme(
+      <StacktraceLink
+        frame={frame}
+        event={event}
+        projects={[project]}
+        organization={org}
+        lineNo={frame.lineNo}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.find('StacktraceLinkModal').exists()).toBe(true);
+  });
+
   it('renders source url link', async function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       query: {file: frame.filename, commitId: 'master'},
-      body: {config, sourceUrl: 'https://something.io'},
+      body: {config, sourceUrl: 'https://something.io', integrations: [integration]},
     });
     const wrapper = mountWithTheme(
       <StacktraceLink
@@ -42,7 +61,12 @@ describe('StacktraceLink', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       query: {file: frame.filename, commitId: 'master'},
-      body: {config, sourceUrl: null, error: 'file_not_found'},
+      body: {
+        config,
+        sourceUrl: null,
+        error: 'file_not_found',
+        integrations: [integration],
+      },
     });
     const wrapper = mountWithTheme(
       <StacktraceLink
@@ -64,7 +88,12 @@ describe('StacktraceLink', function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
       query: {file: frame.filename, commitId: 'master'},
-      body: {config, sourceUrl: null, error: 'stack_root_mismatch'},
+      body: {
+        config,
+        sourceUrl: null,
+        error: 'stack_root_mismatch',
+        integrations: [integration],
+      },
     });
     const wrapper = mountWithTheme(
       <StacktraceLink

--- a/tests/js/spec/components/events/interfaces/stacktraceLinkModal.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/stacktraceLinkModal.spec.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import StacktraceLinkModal from 'app/components/events/interfaces/stacktraceLinkModal';
+
+describe('StacktraceLinkModal', function () {
+  const org = TestStubs.Organization();
+  const project = TestStubs.Project();
+  const integration = TestStubs.GitHubIntegration();
+  const filename = '/sentry/app.py';
+  const repo = TestStubs.Repository({integrationId: integration.id});
+  const config = TestStubs.RepositoryProjectPathConfig(project, repo, integration);
+
+  beforeEach(function () {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders manual setup option', async function () {
+    const wrapper = mountWithTheme(
+      <StacktraceLinkModal
+        project={project}
+        organization={org}
+        integrations={[integration]}
+        filename={filename}
+        onClose={() => {}}
+      />,
+      TestStubs.routerContext()
+    );
+    wrapper.find('Button').simulate('click');
+    expect(wrapper.find('IntegrationName').text()).toEqual('Test Integration');
+  });
+
+  it('closes modal after successful quick setup', async function () {
+    const configData = {
+      stackRoot: '',
+      sourceRoot: 'src/',
+      integrationId: integration.id,
+      repositoryId: repo.id,
+      defaultBranch: 'master',
+    };
+    const sourceUrl = 'https://github.com/getsentry/sentry/blob/master/src/sentry/app.py';
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/repo-path-parsing/`,
+      method: 'POST',
+      body: {...configData},
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/integrations/${integration.id}/repo-project-path-configs/`,
+      method: 'POST',
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      query: {file: filename, commitId: 'master'},
+      body: {config, sourceUrl, integrations: [integration]},
+    });
+
+    const wrapper = mountWithTheme(
+      <StacktraceLinkModal
+        project={project}
+        organization={org}
+        integrations={[integration]}
+        filename={filename}
+        onClose={() => {}}
+      />,
+      TestStubs.routerContext()
+    );
+    // open the modal
+    wrapper.find('Button').simulate('click');
+    wrapper.find('input').simulate('change', {target: {value: sourceUrl}});
+    // submit quick setup input
+    wrapper.find('Button[data-test-id="quick-setup-button"]').simulate('click');
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.state('showModal')).toBe(false);
+  });
+
+  it('keeps modal open on unsuccessful quick setup', async function () {
+    const configData = {
+      stackRoot: '',
+      sourceRoot: 'src/',
+      integrationId: integration.id,
+      repositoryId: repo.id,
+      defaultBranch: 'master',
+    };
+    const sourceUrl = 'https://github.com/getsentry/sentry/blob/master/src/sentry/app.py';
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/repo-path-parsing/`,
+      method: 'POST',
+      body: {...configData},
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/integrations/${integration.id}/repo-project-path-configs/`,
+      method: 'POST',
+      statusCode: 400,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      query: {file: filename, commitId: 'master'},
+      body: {config, sourceUrl, integrations: [integration]},
+    });
+
+    const wrapper = mountWithTheme(
+      <StacktraceLinkModal
+        project={project}
+        organization={org}
+        integrations={[integration]}
+        filename={filename}
+        onClose={() => {}}
+      />,
+      TestStubs.routerContext()
+    );
+    // open the modal
+    wrapper.find('Button').simulate('click');
+    wrapper.find('input').simulate('change', {target: {value: sourceUrl}});
+    // submit quick setup input
+    wrapper.find('Button[data-test-id="quick-setup-button"]').simulate('click');
+
+    await tick();
+    wrapper.update();
+
+    expect(wrapper.state('showModal')).toBe(true);
+  });
+});

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -96,11 +96,11 @@ class ProjectStacktraceLinkTest(APITestCase):
 
         assert resp.data == {
             "integrationId": self.integration.id,
-            "repoId": self.repo.id,
+            "repositoryId": self.repo.id,
             "provider": "github",
             "stackRoot": "",
             "sourceRoot": "src/",
-            "branch": "master",
+            "defaultBranch": "master",
         }
 
     def test_short_path(self):
@@ -110,11 +110,11 @@ class ProjectStacktraceLinkTest(APITestCase):
         assert resp.status_code == 200, resp.content
         assert resp.data == {
             "integrationId": self.integration.id,
-            "repoId": self.repo.id,
+            "repositoryId": self.repo.id,
             "provider": "github",
             "stackRoot": "sentry/",
             "sourceRoot": "",
-            "branch": "main",
+            "defaultBranch": "main",
         }
 
     def test_long_root(self):
@@ -124,9 +124,9 @@ class ProjectStacktraceLinkTest(APITestCase):
         assert resp.status_code == 200, resp.content
         assert resp.data == {
             "integrationId": self.integration.id,
-            "repoId": self.repo.id,
+            "repositoryId": self.repo.id,
             "provider": "github",
             "stackRoot": "stuff/hey/here",
             "sourceRoot": "src",
-            "branch": "master",
+            "defaultBranch": "master",
         }


### PR DESCRIPTION
**Context:**
Going off of https://github.com/getsentry/sentry/pull/22254, we want to encourage people to set up stack trace linking if they have an integration installed (GH or GitLab) and don't have any stack trace configurations set up yet. 

**CTA Button:**
Although you do need a repository set up for the the stack trace linking to be enabled, we are not checking whether or not people have that. We will rendering the following when you have an integration installed that has the stack trace linking feature (GH or GitLab), regardless of it if you have repos set up: 

> ![Screen Shot 2020-11-30 at 10 16 51 AM](https://user-images.githubusercontent.com/15368179/100649217-f47b5880-32f6-11eb-903a-85ac6e63bff2.png)


**Setup Modal:**
There is a lot going on in this modal but there are essentially two options that we are giving users.

**Quick Setup**
We want it to be as simple as possible for people to setup up stack trace linking. When you are in the integration settings, it's not super intuitive what values you need for what (what should be saved for `stack_root` and `source_root`). The idea for the quick setup is that if you paste in your source code url, we can parse it, and compare it to the filename of the frame you are on to do the setup for you. 

We use two endpoints to do this:

1. `ProjectRepoPathParsingEndpoint`
We pass the url the user has submitted along with the filename to this endpoint. If we can parse it successfully we send back the data we need to actually create the configuration. 

    Cases where where this endpoint errors:
    * URL does not have the same filename as the stack trace frame (we need these to be the same)
    * There is no integration that maps to that domain name (i.e `github.com/getsentry`)
    * There is no repository record for the repository found in the URL


2.  `OrganizationIntegrationRepositoryProjectPathConfigEndpoint`
If parsing is successful, we use the data from the payload to post to this endpoint to create the configuration. We will catch the validation errors for missing repo/integration here as well but that shouldn't really happen given that we just did that check in the parsing endpoint. 

The validation error that may come up is when there is conflict with an existing configuration. We have a unique constraint on the `stack_root` and the `project`. If this is the case, they can then use the manual setup. 

**Manual Setup**
If we cannot automatically set up their configuration, the manual setup give users the option to go the integration settings and set it up there. We render all the possible integrations that have the feature available, and clicking the button will take them directly to the "Code Mappings" tab in that specific integration configuration settings.

> ![Screen Shot 2020-12-02 at 1 04 17 PM](https://user-images.githubusercontent.com/15368179/100932193-5aefaa80-34a0-11eb-8114-1fbf3f6ae16c.png)
