### PR TITLE
perf: Event details request latest event in parallel

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -22,7 +22,7 @@ import withApi from 'app/utils/withApi';
 
 import {ERROR_TYPES} from './constants';
 import GroupHeader, {TAB} from './header';
-import {fetchGroupEvent, fetchGroupEventAndMarkSeen} from './utils';
+import {fetchGroupEvent, fetchGroupEventAndMarkSeen, markEventSeen} from './utils';
 
 type Error = typeof ERROR_TYPES[keyof typeof ERROR_TYPES] | null;
 
@@ -179,6 +179,10 @@ class GroupDetails extends React.Component<Props, State> {
         },
       });
       const [data] = await Promise.all([groupPromise, eventPromise]);
+      if (this.canLoadEventEarly(this.props)) {
+        // Early loaded events are not marked as seen
+        markEventSeen(api, params.orgId, data.project.slug, params.groupId);
+      }
 
       // TODO(billy): See if this is even in use and if not, can we just rip this out?
       if (this.props.params.groupId !== data.id) {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -117,6 +117,7 @@ class GroupDetails extends React.Component<Props, State> {
     const orgSlug = params.orgId;
     const groupId = params.groupId;
     const eventId = params?.eventId || 'latest';
+    const projectId = group?.project?.slug;
     try {
       const event = await fetchGroupEvent(
         api,
@@ -124,7 +125,7 @@ class GroupDetails extends React.Component<Props, State> {
         groupId,
         eventId,
         environments,
-        group?.project?.slug
+        projectId
       );
       this.setState({
         event,

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -21,7 +21,7 @@ import {metric} from 'app/utils/analytics';
 import fetchSentryAppInstallations from 'app/utils/fetchSentryAppInstallations';
 
 import GroupEventToolbar from '../eventToolbar';
-import {fetchGroupEventAndMarkSeen, getEventEnvironment, markEventSeen} from '../utils';
+import {getEventEnvironment} from '../utils';
 
 type Props = RouteComponentProps<
   {orgId: string; groupId: string; eventId?: string},
@@ -32,14 +32,14 @@ type Props = RouteComponentProps<
   project: Project;
   organization: Organization;
   environments: Environment[];
-  eventPromise?: Promise<Event>;
+  event: Event;
+  loadingEvent: boolean;
   className?: string;
 };
 
 type State = {
   loading: boolean;
   error: boolean;
-  event: Event | null;
   eventNavLinks: string;
   releasesCompletion: any;
 };
@@ -58,7 +58,6 @@ class GroupEventDetails extends React.Component<Props, State> {
     this.state = {
       loading: true,
       error: false,
-      event: null,
       eventNavLinks: '',
       releasesCompletion: null,
     };
@@ -78,13 +77,13 @@ class GroupEventDetails extends React.Component<Props, State> {
     // current event's environment, redirect to latest
     if (
       environmentsHaveChanged &&
-      prevState.event &&
+      prevProps.event &&
       params.eventId &&
       !['latest', 'oldest'].includes(params.eventId)
     ) {
       const shouldRedirect =
         environments.length > 0 &&
-        !environments.find(env => env.name === getEventEnvironment(prevState.event));
+        !environments.find(env => env.name === getEventEnvironment(prevProps.event));
 
       if (shouldRedirect) {
         browserHistory.replace({
@@ -100,7 +99,7 @@ class GroupEventDetails extends React.Component<Props, State> {
     }
 
     // First Meaningful Paint for /organizations/:orgId/issues/:groupId/
-    if (prevState.loading && !this.state.loading && prevState.event === null) {
+    if (prevState.loading && !this.state.loading) {
       metric.measure({
         name: 'app.page.perf.issue-details',
         start: 'page-issue-details-start',
@@ -128,17 +127,7 @@ class GroupEventDetails extends React.Component<Props, State> {
   }
 
   fetchData = async () => {
-    const {
-      api,
-      group,
-      project,
-      organization,
-      params,
-      environments,
-      eventPromise,
-    } = this.props;
-    const eventId = params.eventId || 'latest';
-    const groupId = group.id;
+    const {api, project, organization} = this.props;
     const orgSlug = organization.slug;
     const projSlug = project.slug;
     const projectId = project.id;
@@ -148,22 +137,12 @@ class GroupEventDetails extends React.Component<Props, State> {
       error: false,
     });
 
-    const envNames = environments.map(e => e.name);
-
     /**
      * Perform below requests in parallel
      */
     const releasesCompletionPromise = api.requestPromise(
       `/projects/${orgSlug}/${projSlug}/releases/completion/`
     );
-    const fetchGroupEventPromise = eventPromise
-      ? eventPromise
-      : fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames);
-
-    // Eventpromise early fetch
-    if (eventPromise) {
-      markEventSeen(api, orgSlug, projSlug, groupId);
-    }
 
     fetchSentryAppInstallations(api, orgSlug);
     fetchSentryAppComponents(api, orgSlug, projectId);
@@ -174,9 +153,7 @@ class GroupEventDetails extends React.Component<Props, State> {
     });
 
     try {
-      const event = await fetchGroupEventPromise;
       this.setState({
-        event,
         error: false,
         loading: false,
       });
@@ -184,7 +161,6 @@ class GroupEventDetails extends React.Component<Props, State> {
       // This is an expected error, capture to Sentry so that it is not considered as an unhandled error
       Sentry.captureException(err);
       this.setState({
-        event: null,
         error: true,
         loading: false,
       });
@@ -202,30 +178,37 @@ class GroupEventDetails extends React.Component<Props, State> {
   }
 
   render() {
-    const {className, group, project, organization, environments, location} = this.props;
-    const evt = withMeta(this.state.event);
+    const {
+      className,
+      group,
+      project,
+      organization,
+      environments,
+      location,
+      event,
+      loadingEvent,
+    } = this.props;
+    const evt = withMeta(event);
 
     return (
       <div className={className}>
         <div className="event-details-container">
           <div className="primary">
-            {evt && (
-              <GroupEventToolbar
-                organization={organization}
-                group={group}
-                event={evt}
-                orgId={organization.slug}
-                projectId={project.slug}
-                location={location}
-              />
-            )}
+            <GroupEventToolbar
+              organization={organization}
+              group={group}
+              event={evt}
+              orgId={organization.slug}
+              projectId={project.slug}
+              location={location}
+            />
             {group.status === 'ignored' && (
               <MutedBox statusDetails={group.statusDetails} />
             )}
             {group.status === 'resolved' && (
               <ResolutionBox statusDetails={group.statusDetails} projectId={project.id} />
             )}
-            {this.state.loading ? (
+            {this.state.loading || loadingEvent ? (
               <LoadingIndicator />
             ) : this.state.error ? (
               <GroupEventDetailsLoadingError

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -32,6 +32,7 @@ type Props = RouteComponentProps<
   project: Project;
   organization: Organization;
   environments: Environment[];
+  eventPromise?: Promise<Event>;
   className?: string;
 };
 
@@ -127,7 +128,15 @@ class GroupEventDetails extends React.Component<Props, State> {
   }
 
   fetchData = async () => {
-    const {api, group, project, organization, params, environments} = this.props;
+    const {
+      api,
+      group,
+      project,
+      organization,
+      params,
+      environments,
+      eventPromise,
+    } = this.props;
     const eventId = params.eventId || 'latest';
     const groupId = group.id;
     const orgSlug = organization.slug;
@@ -147,14 +156,9 @@ class GroupEventDetails extends React.Component<Props, State> {
     const releasesCompletionPromise = api.requestPromise(
       `/projects/${orgSlug}/${projSlug}/releases/completion/`
     );
-    const fetchGroupEventPromise = fetchGroupEventAndMarkSeen(
-      api,
-      orgSlug,
-      projSlug,
-      groupId,
-      eventId,
-      envNames
-    );
+    const fetchGroupEventPromise = eventPromise
+      ? eventPromise
+      : fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames);
 
     fetchSentryAppInstallations(api, orgSlug);
     fetchSentryAppComponents(api, orgSlug, projectId);

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -21,7 +21,7 @@ import {metric} from 'app/utils/analytics';
 import fetchSentryAppInstallations from 'app/utils/fetchSentryAppInstallations';
 
 import GroupEventToolbar from '../eventToolbar';
-import {fetchGroupEventAndMarkSeen, getEventEnvironment} from '../utils';
+import {fetchGroupEventAndMarkSeen, getEventEnvironment, markEventSeen} from '../utils';
 
 type Props = RouteComponentProps<
   {orgId: string; groupId: string; eventId?: string},
@@ -159,6 +159,11 @@ class GroupEventDetails extends React.Component<Props, State> {
     const fetchGroupEventPromise = eventPromise
       ? eventPromise
       : fetchGroupEventAndMarkSeen(api, orgSlug, projSlug, groupId, eventId, envNames);
+
+    // Eventpromise early fetch
+    if (eventPromise) {
+      markEventSeen(api, orgSlug, projSlug, groupId);
+    }
 
     fetchSentryAppInstallations(api, orgSlug);
     fetchSentryAppComponents(api, orgSlug, projectId);

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/index.tsx
@@ -31,6 +31,7 @@ type Props = RouteComponentProps<
   project: Project;
   group: Group;
   event: Event;
+  loadingEvent: boolean;
 };
 
 type State = typeof OrganizationEnvironmentsStore['state'];

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as ReactRouter from 'react-router';
 
-import {Event, GlobalSelection, Organization} from 'app/types';
+import {GlobalSelection, Organization} from 'app/types';
 import {analytics, metric} from 'app/utils/analytics';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization, {isLightweightOrganization} from 'app/utils/withOrganization';
@@ -13,7 +13,6 @@ type Props = {
   isGlobalSelectionReady: boolean;
   organization: Organization;
   children: React.ReactNode;
-  eventPromise: Promise<Event>;
 } & ReactRouter.RouteComponentProps<{orgId: string; groupId: string}, {}>;
 
 class OrganizationGroupDetails extends React.Component<Props> {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as ReactRouter from 'react-router';
 
-import {GlobalSelection, Organization} from 'app/types';
+import {Event, GlobalSelection, Organization} from 'app/types';
 import {analytics, metric} from 'app/utils/analytics';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization, {isLightweightOrganization} from 'app/utils/withOrganization';
@@ -13,10 +13,11 @@ type Props = {
   isGlobalSelectionReady: boolean;
   organization: Organization;
   children: React.ReactNode;
+  eventPromise: Promise<Event>;
 } & ReactRouter.RouteComponentProps<{orgId: string; groupId: string}, {}>;
 
 class OrganizationGroupDetails extends React.Component<Props> {
-  constructor(props) {
+  constructor(props: Props) {
     super(props);
 
     // Setup in the constructor as render() may be expensive

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/utils.jsx
@@ -32,13 +32,7 @@ export async function fetchGroupEventAndMarkSeen(
 
   try {
     const data = await api.requestPromise(url, {query});
-    api.bulkUpdate({
-      orgId,
-      projectId,
-      itemIds: [groupId],
-      failSilently: true,
-      data: {hasSeen: true},
-    });
+    markEventSeen(api, orgId, projectId, groupId);
     return data;
   } catch (err) {
     throw err;
@@ -53,7 +47,7 @@ export async function fetchGroupEventAndMarkSeen(
  * @param {String} eventId "latest" or "oldest"
  * @returns {Promise<Object>}
  */
-export async function fetchLatestGroupEventAndMarkSeen(api, groupId, eventId, envNames) {
+export async function fetchGroupEvent(api, groupId, eventId, envNames) {
   const query = {};
   if (envNames.length !== 0) {
     query.environment = envNames;
@@ -63,6 +57,16 @@ export async function fetchLatestGroupEventAndMarkSeen(api, groupId, eventId, en
     query,
   });
   return data;
+}
+
+export function markEventSeen(api, orgId, projectId, groupId) {
+  api.bulkUpdate({
+    orgId,
+    projectId,
+    itemIds: [groupId],
+    failSilently: true,
+    data: {hasSeen: true},
+  });
 }
 
 export function fetchGroupUserReports(groupId, query) {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/utils.jsx
@@ -45,6 +45,26 @@ export async function fetchGroupEventAndMarkSeen(
   }
 }
 
+/**
+ * Fetches group data and mark as seen
+ * Only fetches latest or oldest event, do not pass an actual event id
+ *
+ * @param {String} groupId groupId
+ * @param {String} eventId "latest" or "oldest"
+ * @returns {Promise<Object>}
+ */
+export async function fetchLatestGroupEventAndMarkSeen(api, groupId, eventId, envNames) {
+  const query = {};
+  if (envNames.length !== 0) {
+    query.environment = envNames;
+  }
+
+  const data = await api.requestPromise(`/issues/${groupId}/events/${eventId}/`, {
+    query,
+  });
+  return data;
+}
+
 export function fetchGroupUserReports(groupId, query) {
   const api = new Client();
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/utils.jsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/utils.jsx
@@ -7,19 +7,13 @@ import {t, tct} from 'app/locale';
  * Fetches group data and mark as seen
  *
  * @param {String} orgId organization slug
- * @param {String} projectId project slug
  * @param {String} groupId groupId
  * @param {String} eventId eventId or "latest" or "oldest"
+ * @param {String[]} envNames
+ * @param {String|undefined} projectId project slug required for eventId that is not latest or oldest
  * @returns {Promise<Object>}
  */
-export async function fetchGroupEventAndMarkSeen(
-  api,
-  orgId,
-  projectId,
-  groupId,
-  eventId,
-  envNames
-) {
+export async function fetchGroupEvent(api, orgId, groupId, eventId, envNames, projectId) {
   const url =
     eventId === 'latest' || eventId === 'oldest'
       ? `/issues/${groupId}/events/${eventId}/`
@@ -30,32 +24,7 @@ export async function fetchGroupEventAndMarkSeen(
     query.environment = envNames;
   }
 
-  try {
-    const data = await api.requestPromise(url, {query});
-    markEventSeen(api, orgId, projectId, groupId);
-    return data;
-  } catch (err) {
-    throw err;
-  }
-}
-
-/**
- * Fetches group data and mark as seen
- * Only fetches latest or oldest event, do not pass an actual event id
- *
- * @param {String} groupId groupId
- * @param {String} eventId "latest" or "oldest"
- * @returns {Promise<Object>}
- */
-export async function fetchGroupEvent(api, groupId, eventId, envNames) {
-  const query = {};
-  if (envNames.length !== 0) {
-    query.environment = envNames;
-  }
-
-  const data = await api.requestPromise(`/issues/${groupId}/events/${eventId}/`, {
-    query,
-  });
+  const data = await api.requestPromise(url, {query});
   return data;
 }
 

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -145,6 +145,10 @@ describe('groupDetails', function () {
       url: `/issues/${group.id}/`,
       statusCode: 404,
     });
+    issueDetailsMock = MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/events/latest/`,
+      statusCode: 404,
+    });
 
     wrapper = createWrapper();
 
@@ -162,6 +166,10 @@ describe('groupDetails', function () {
   it('renders MissingProjectMembership when trying to access issue in project the user does not belong to', async function () {
     issueDetailsMock = MockApiClient.addMockResponse({
       url: `/issues/${group.id}/`,
+      statusCode: 403,
+    });
+    issueDetailsMock = MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/events/latest/`,
       statusCode: 403,
     });
     wrapper = createWrapper();

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -125,7 +125,7 @@ describe('groupDetails', function () {
     await tick();
 
     expect(MockComponent).toHaveBeenLastCalledWith(
-      {
+      expect.objectContaining({
         environments: [],
         group,
         project: expect.objectContaining({
@@ -133,7 +133,7 @@ describe('groupDetails', function () {
           slug: project.slug,
         }),
         event,
-      },
+      }),
       {}
     );
 
@@ -215,7 +215,7 @@ describe('groupDetails', function () {
       })
     );
     expect(MockComponent).toHaveBeenLastCalledWith(
-      {
+      expect.objectContaining({
         environments: ['staging'],
         group,
         project: expect.objectContaining({
@@ -223,7 +223,7 @@ describe('groupDetails', function () {
           slug: project.slug,
         }),
         event,
-      },
+      }),
       {}
     );
   });

--- a/tests/js/spec/views/organizationGroupDetails/groupEventDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventDetails.spec.jsx
@@ -21,16 +21,6 @@ describe('groupEventDetails', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: `/issues/${group.id}/events/latest/`,
-      body: event,
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/events/1/`,
-      body: event,
-    });
-
-    MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/issues/`,
       method: 'PUT',
     });
@@ -129,6 +119,7 @@ describe('groupEventDetails', () => {
       <GroupEventDetails
         api={new MockApiClient()}
         group={group}
+        event={event}
         project={project}
         organization={org}
         environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
@@ -150,6 +141,7 @@ describe('groupEventDetails', () => {
       <GroupEventDetails
         api={new MockApiClient()}
         group={group}
+        event={event}
         project={project}
         organization={org}
         environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
@@ -186,6 +178,7 @@ describe('groupEventDetails', () => {
       <GroupEventDetails
         api={new MockApiClient()}
         group={group}
+        event={event}
         project={project}
         organization={org}
         environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
@@ -237,6 +230,7 @@ describe('groupEventDetails', () => {
         <GroupEventDetails
           api={new MockApiClient()}
           group={group}
+          event={event}
           project={proj}
           organization={org}
           environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
@@ -267,6 +261,7 @@ describe('groupEventDetails', () => {
         <GroupEventDetails
           api={new MockApiClient()}
           group={group}
+          event={event}
           project={proj}
           organization={org}
           environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
@@ -292,6 +287,7 @@ describe('groupEventDetails', () => {
         <GroupEventDetails
           api={new MockApiClient()}
           group={group}
+          event={event}
           project={proj}
           organization={org}
           environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
@@ -318,6 +314,7 @@ describe('groupEventDetails', () => {
         <GroupEventDetails
           api={new MockApiClient()}
           group={group}
+          event={event}
           project={proj}
           organization={org}
           environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}
@@ -343,6 +340,7 @@ describe('groupEventDetails', () => {
         <GroupEventDetails
           api={new MockApiClient()}
           group={group}
+          event={event}
           project={project}
           organization={org}
           environments={[{id: '1', name: 'dev', displayName: 'Dev'}]}


### PR DESCRIPTION
On the event details page we request group details **and then** the event. If the event being viewed is latest (default) or oldest we can safely request this event on page load. 

This uses the event being loaded at the top GroupDetails level and removes loading the event from the lower GroupEventDetails component.

This is how loading looks currently, with the latest event being loaded after the group loads.
![image](https://user-images.githubusercontent.com/1400464/100656658-df57f700-3301-11eb-84f9-11860f4dff42.png)
