### PR TITLE
fix(integrations): Overflow styling in Publish Request Modal

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/sentryAppPublishRequestModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppPublishRequestModal.tsx
@@ -80,15 +80,15 @@ export default class SentryAppPublishRequestModal extends React.Component<Props>
     )}.`;
 
     const permissionLabel = (
-      <ListPermissions>
-        {permissionQuestionBaseText}
+      <React.Fragment>
+        <PermissionLabel>{permissionQuestionBaseText}</PermissionLabel>
         {permissions.map((permission, i) => (
           <React.Fragment key={permission}>
-            {i > 0 && ', '} <code>{permission}</code>
+            {i > 0 && ', '} <Permission>{permission}</Permission>
           </React.Fragment>
         ))}
         .
-      </ListPermissions>
+      </React.Fragment>
     );
 
     //No translations since we need to be able to read this email :)
@@ -190,6 +190,10 @@ const Explanation = styled('div')`
   font-size: 18px;
 `;
 
-const ListPermissions = styled('span')`
+const PermissionLabel = styled('span')`
+  line-height: 24px;
+`;
+
+const Permission = styled('code')`
   line-height: 24px;
 `;

--- a/src/sentry/static/sentry/app/components/modals/sentryAppPublishRequestModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppPublishRequestModal.tsx
@@ -80,7 +80,7 @@ export default class SentryAppPublishRequestModal extends React.Component<Props>
     )}.`;
 
     const permissionLabel = (
-      <React.Fragment>
+      <ListPermissions>
         {permissionQuestionBaseText}
         {permissions.map((permission, i) => (
           <React.Fragment key={permission}>
@@ -88,7 +88,7 @@ export default class SentryAppPublishRequestModal extends React.Component<Props>
           </React.Fragment>
         ))}
         .
-      </React.Fragment>
+      </ListPermissions>
     );
 
     //No translations since we need to be able to read this email :)
@@ -188,4 +188,8 @@ export default class SentryAppPublishRequestModal extends React.Component<Props>
 const Explanation = styled('div')`
   margin: ${space(1.5)} 0px;
   font-size: 18px;
+`;
+
+const ListPermissions = styled('span')`
+  line-height: 24px;
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldLabel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldLabel.tsx
@@ -9,7 +9,7 @@ const FieldLabel = styled('div', {shouldForwardProp})<{disabled?: boolean}>`
   color: ${p => (!p.disabled ? p.theme.textColor : p.theme.disabled)};
   display: grid;
   grid-gap: ${space(0.5)};
-  grid-template-columns: repeat(2, max-content);
+  grid-template-columns: repeat(2, auto);
   line-height: 16px;
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldLabel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/fieldLabel.tsx
@@ -7,9 +7,8 @@ const shouldForwardProp = p => p !== 'disabled' && isPropValid(p);
 
 const FieldLabel = styled('div', {shouldForwardProp})<{disabled?: boolean}>`
   color: ${p => (!p.disabled ? p.theme.textColor : p.theme.disabled)};
-  display: grid;
-  grid-gap: ${space(0.5)};
-  grid-template-columns: repeat(2, auto);
+  display: flex;
+  gap: ${space(0.5)};
   line-height: 16px;
 `;
 


### PR DESCRIPTION
## Objective:
We want to fix the overflow in the form when there is a list of permissions.

## UI:

_Before_
![Screen Shot 2020-11-25 at 11 03 36 AM](https://user-images.githubusercontent.com/10491193/100659703-d5d08e00-3305-11eb-805e-7d3eb5228a65.png)

_After_
![Screen Shot 2020-11-30 at 12 09 03 PM](https://user-images.githubusercontent.com/10491193/100659723-dc5f0580-3305-11eb-8789-12de3bfcebd0.png)


