### PR TITLE
fix(test): Fix trends test timeout

### DIFF
--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -369,11 +369,14 @@ describe('Performance > Trends', function () {
       data.routerContext
     );
 
+    await tick();
+    wrapper.update();
+
     for (const trendFunction of TRENDS_FUNCTIONS) {
+      selectTrendFunction(wrapper, trendFunction.field);
+
       await tick();
       wrapper.update();
-
-      selectTrendFunction(wrapper, trendFunction.field);
 
       expect(browserHistory.push).toHaveBeenCalledWith({
         query: expect.objectContaining({
@@ -396,11 +399,14 @@ describe('Performance > Trends', function () {
       data.routerContext
     );
 
+    await tick();
+    wrapper.update();
+
     for (const confidenceLevel of CONFIDENCE_LEVELS) {
+      selectConfidenceLevel(wrapper, confidenceLevel.label);
+
       await tick();
       wrapper.update();
-
-      selectConfidenceLevel(wrapper, confidenceLevel.label);
 
       expect(browserHistory.push).toHaveBeenCalledWith({
         query: expect.objectContaining({

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -370,8 +370,10 @@ describe('Performance > Trends', function () {
     );
 
     for (const trendFunction of TRENDS_FUNCTIONS) {
-      selectTrendFunction(wrapper, trendFunction.field);
       await tick();
+      wrapper.update();
+
+      selectTrendFunction(wrapper, trendFunction.field);
 
       expect(browserHistory.push).toHaveBeenCalledWith({
         query: expect.objectContaining({
@@ -395,8 +397,10 @@ describe('Performance > Trends', function () {
     );
 
     for (const confidenceLevel of CONFIDENCE_LEVELS) {
-      selectConfidenceLevel(wrapper, confidenceLevel.label);
       await tick();
+      wrapper.update();
+
+      selectConfidenceLevel(wrapper, confidenceLevel.label);
 
       expect(browserHistory.push).toHaveBeenCalledWith({
         query: expect.objectContaining({


### PR DESCRIPTION
### Summary
Occasionally during pre-commit the trends test will timeout, going to fix tick/update for these tests to see if it happens, will open up another ticket later if it is still not fixed