### PR TITLE
feat(alert-rules): Add grouped select options to alert rules

### DIFF
--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -25,6 +25,7 @@ export type IssueAlertRuleActionTemplate = {
   label: string;
   prompt: string;
   enabled: boolean;
+  actionType?: 'ticket';
   formFields?: {
     [key: string]: IssueAlertRuleFormField;
   };

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -678,6 +678,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
                       <RuleNodeList
                         nodes={this.state.configs?.actions ?? null}
+                        selectType="grouped"
                         items={actions ?? []}
                         placeholder={t('Add action...')}
                         onPropertyChange={this.handleChangeActionProperty}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -10,6 +10,7 @@ import {
   IssueAlertRuleCondition,
   IssueAlertRuleConditionTemplate,
 } from 'app/types/alerts';
+import {t} from 'app/locale';
 
 import RuleNode from './ruleNode';
 
@@ -90,7 +91,8 @@ class RuleNodeList extends React.Component<Props> {
       );
 
       options = Object.entries(grouped).map(([key, values]) => {
-        let label = key === 'ticket' ? t('Create new...') : t('Send notifcation to...');
+        let label =
+          key === 'ticket' ? t('Create new\u{2026}') : t('Send notification to\u{2026}');
 
         return {label, options: createSelectOptions(values)};
       });

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -66,16 +66,16 @@ class RuleNodeList extends React.Component<Props> {
     const shouldUsePrompt = project.features?.includes?.('issue-alerts-targeting');
     let enabledNodes = nodes ? nodes.filter(({enabled}) => enabled) : [];
 
-    const createSelectOptions = nodes =>
+    const createSelectOptions = (nodes: IssueAlertRuleActionTemplate[]) =>
       nodes.map(node => ({
         value: node.id,
         label: shouldUsePrompt && node.prompt?.length > 0 ? node.prompt : node.label,
       }));
 
-    let options = !selectType ? createSelectOptions(enabledNodes) : [];
+    let options: any = !selectType ? createSelectOptions(enabledNodes) : [];
 
     if (selectType === 'grouped') {
-      let grouped = enabledNodes.reduce(
+      const grouped = enabledNodes.reduce(
         (acc, curr) => {
           if (curr.actionType === 'ticket') {
             acc['ticket'] ? acc['ticket'].push(curr) : (acc['ticket'] = [curr]);
@@ -91,8 +91,7 @@ class RuleNodeList extends React.Component<Props> {
 
       options = Object.entries(grouped).map(([key, values]) => {
         let label = key === 'ticket' ? t('Create new...') : t('Send notifcation to...');
-        let options = createSelectOptions(values);
-        return {label, options};
+        return {label, options: createSelectOptions(values)};
       });
     }
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -67,8 +67,8 @@ class RuleNodeList extends React.Component<Props> {
     const shouldUsePrompt = project.features?.includes?.('issue-alerts-targeting');
     let enabledNodes = nodes ? nodes.filter(({enabled}) => enabled) : [];
 
-    const createSelectOptions = (nodes: IssueAlertRuleActionTemplate[]) =>
-      nodes.map(node => ({
+    const createSelectOptions = (actions: IssueAlertRuleActionTemplate[]) =>
+      actions.map(node => ({
         value: node.id,
         label: shouldUsePrompt && node.prompt?.length > 0 ? node.prompt : node.label,
       }));

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -79,23 +79,28 @@ class RuleNodeList extends React.Component<Props> {
       const grouped = enabledNodes.reduce(
         (acc, curr) => {
           if (curr.actionType === 'ticket') {
-            acc['ticket'] ? acc['ticket'].push(curr) : (acc['ticket'] = [curr]);
+            acc.ticket.push(curr);
           } else {
-            acc['notify'].push(curr);
+            acc.notify.push(curr);
           }
           return acc;
         },
         {
           notify: [] as IssueAlertRuleActionTemplate[],
+          ticket: [] as IssueAlertRuleActionTemplate[],
         }
       );
 
-      options = Object.entries(grouped).map(([key, values]) => {
-        let label =
-          key === 'ticket' ? t('Create new\u{2026}') : t('Send notification to\u{2026}');
+      options = Object.entries(grouped)
+        .filter(([_, values]) => values.length)
+        .map(([key, values]) => {
+          const label =
+            key === 'ticket'
+              ? t('Create new\u{2026}')
+              : t('Send notification to\u{2026}');
 
-        return {label, options: createSelectOptions(values)};
-      });
+          return {label, options: createSelectOptions(values)};
+        });
     }
 
     return (

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -90,7 +90,7 @@ class RuleNodeList extends React.Component<Props> {
       );
 
       options = Object.entries(grouped).map(([key, values]) => {
-        let label = key === 'ticket' ? 'Create new...' : 'Send notifcation to...';
+        let label = key === 'ticket' ? t('Create new...') : t('Send notifcation to...');
         let options = createSelectOptions(values);
         return {label, options};
       });

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -91,6 +91,7 @@ class RuleNodeList extends React.Component<Props> {
 
       options = Object.entries(grouped).map(([key, values]) => {
         let label = key === 'ticket' ? t('Create new...') : t('Send notifcation to...');
+
         return {label, options: createSelectOptions(values)};
       });
     }

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNodeList.tsx
@@ -65,7 +65,7 @@ class RuleNodeList extends React.Component<Props> {
     } = this.props;
 
     const shouldUsePrompt = project.features?.includes?.('issue-alerts-targeting');
-    let enabledNodes = nodes ? nodes.filter(({enabled}) => enabled) : [];
+    const enabledNodes = nodes ? nodes.filter(({enabled}) => enabled) : [];
 
     const createSelectOptions = (actions: IssueAlertRuleActionTemplate[]) =>
       actions.map(node => ({


### PR DESCRIPTION
## Objective
We want a select that has grouped options.

## UI
![Screen Shot 2020-11-30 at 3 40 42 PM](https://user-images.githubusercontent.com/10491193/100678849-f78c3e00-3322-11eb-825e-ed772a553c2a.png)
