### PR TITLE
fix(metric_alerts): Make tasks that fire to snuba happen on transaction commit.

### DIFF
--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -95,7 +95,7 @@ class HandleMessageTest(BaseQuerySubscriptionTest, TestCase):
         registration_key = "registered_test"
         mock_callback = Mock()
         register_subscriber(registration_key)(mock_callback)
-        with self.tasks():
+        with self.tasks(), self.capture_on_commit_callbacks(execute=True):
             snuba_query = create_snuba_query(
                 QueryDatasets.EVENTS,
                 "hello",

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -87,7 +87,7 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
         return "registered_keyboard_interrupt"
 
     def create_subscription(self):
-        with self.tasks():
+        with self.tasks(), self.capture_on_commit_callbacks(execute=True):
             snuba_query = create_snuba_query(
                 QueryDatasets.EVENTS,
                 "hello",
@@ -97,9 +97,8 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
                 None,
             )
             sub = create_snuba_subscription(self.project, self.registration_key, snuba_query)
-            sub.subscription_id = self.subscription_id
-            sub.status = 0
-            sub.save()
+        sub.refresh_from_db()
+        sub.update(subscription_id=self.subscription_id, status=0)
         return sub
 
     def test_old(self):


### PR DESCRIPTION
Relying on the delay of 5 seconds is unstable, and although it's reasonably unlikely that we'll take
longer than 5 seconds, it's possible that it could happen. Switch to using on_commit instead.