### PR TITLE
feat(dashboards) Attach widget validation endpoint up.

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -45,7 +45,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
     id = serializers.CharField(required=False)
     fields = serializers.ListField(child=serializers.CharField(), required=False)
     name = serializers.CharField(required=False, allow_blank=True)
-    conditions = serializers.CharField(required=False)
+    conditions = serializers.CharField(required=False, allow_blank=True)
 
     required_for_create = {"fields", "conditions"}
 

--- a/src/sentry/static/sentry/app/actionCreators/dashboards.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/dashboards.tsx
@@ -6,6 +6,7 @@ import {
   OrgDashboard,
   OrgDashboardResponse,
   OrgDashboardUpdate,
+  Widget,
 } from 'app/views/dashboardsV2/types';
 
 export function createDashboard(
@@ -87,5 +88,20 @@ export function deleteDashboard(
     }
   });
 
+  return promise;
+}
+
+export function validateWidget(
+  api: Client,
+  orgId: string,
+  widget: Widget
+): Promise<undefined> {
+  const promise: Promise<undefined> = api.requestPromise(
+    `/organizations/${orgId}/dashboards/widgets/`,
+    {
+      method: 'POST',
+      data: widget,
+    }
+  );
   return promise;
 }

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
@@ -23,6 +23,7 @@ import SearchBar from 'app/views/events/searchBar';
 import {QueryField} from 'app/views/eventsV2/table/queryField';
 import {generateFieldOptions} from 'app/views/eventsV2/utils';
 import Input from 'app/views/settings/components/forms/controls/input';
+import FieldErrorReason from 'app/views/settings/components/forms/field/fieldErrorReason';
 import FieldHelp from 'app/views/settings/components/forms/field/fieldHelp';
 
 type Props = {
@@ -34,6 +35,7 @@ type Props = {
   onChange: (widgetQuery: WidgetQuery) => void;
   canRemove: boolean;
   onRemove: () => void;
+  errors?: Record<string, any>;
 };
 
 type SavedQueryOption = SelectValue<SavedQuery>;
@@ -45,6 +47,7 @@ type SavedQueryOption = SelectValue<SavedQuery>;
 function WidgetQueryForm({
   api,
   canRemove,
+  errors,
   fieldOptions,
   onChange,
   onRemove,
@@ -156,20 +159,24 @@ function WidgetQueryForm({
             value={widgetQuery.name}
             onChange={event => handleFieldChange('name')(event.target.value)}
           />
+          {errors?.name && <FieldErrorReason>{errors.name}</FieldErrorReason>}
           <FieldHelp>{t('Used to disambiguate results from multiple queries')}</FieldHelp>
         </VerticalPanelItem>
       )}
       <VerticalPanelItem>
         <Heading>{t('Conditions')}</Heading>
-        <SearchBar
-          organization={organization}
-          projectIds={selection.projects}
-          query={widgetQuery.conditions}
-          fields={[]}
-          onSearch={handleFieldChange('conditions')}
-          onBlur={handleFieldChange('conditions')}
-          useFormWrapper={false}
-        />
+        <ConditionContainer>
+          <SearchBar
+            organization={organization}
+            projectIds={selection.projects}
+            query={widgetQuery.conditions}
+            fields={[]}
+            onSearch={handleFieldChange('conditions')}
+            onBlur={handleFieldChange('conditions')}
+            useFormWrapper={false}
+          />
+          {errors?.conditions && <FieldErrorReason>{errors.conditions}</FieldErrorReason>}
+        </ConditionContainer>
       </VerticalPanelItem>
       <VerticalPanelItem>
         <Heading>{t('Fields')}</Heading>
@@ -192,6 +199,7 @@ function WidgetQueryForm({
             )}
           </QueryFieldWrapper>
         ))}
+        {errors?.fields && <FieldErrorReason>{errors.fields}</FieldErrorReason>}
         <div>
           <Button
             data-test-id="add-field"
@@ -211,6 +219,10 @@ function WidgetQueryForm({
 const StyledPanelBody = styled(PanelBody)`
   position: relative;
   border-bottom: 1px solid ${p => p.theme.innerBorder};
+`;
+
+const ConditionContainer = styled('div')`
+  position: relative;
 `;
 
 const Heading = styled('h3')`

--- a/src/sentry/static/sentry/app/views/dashboardsV2/types.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/types.tsx
@@ -7,7 +7,7 @@ export type WidgetQuery = {
 };
 
 export type Widget = {
-  id: string;
+  id?: string;
   title: string;
   displayType: DisplayType;
   interval: string;
@@ -41,5 +41,5 @@ export type OrgDashboardResponse = {
 // PUT body for updating a dashboard
 export type OrgDashboardUpdate = {
   title: string;
-  widgets: Array<{id: string}>;
+  widgets: Widget[];
 };

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -23,6 +23,15 @@ function mountModal({onAddWidget, initialData}) {
   );
 }
 
+async function clickSubmit(wrapper) {
+  // Click on submit.
+  const button = wrapper.find('Button[data-test-id="add-widget"] button');
+  button.simulate('click');
+
+  // Wait for xhr to complete.
+  return tick();
+}
+
 describe('Modals -> AddDashboardWidgetModal', function () {
   const initialData = initializeOrg({
     organization: {
@@ -47,13 +56,19 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       url: '/organizations/org-slug/discover/saved/',
       body: [discoverQuery],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/widgets/',
+      method: 'POST',
+      statusCode: 200,
+      body: [],
+    });
   });
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
   });
 
-  it('can update the title', function () {
+  it('can update the title', async function () {
     let widget = undefined;
     const wrapper = mountModal({
       initialData,
@@ -62,16 +77,13 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     const input = wrapper.find('Input[name="title"] input');
     input.simulate('change', {target: {value: 'Unique Users'}});
 
-    // Click on submit.
-    const button = wrapper.find('Button[data-test-id="add-widget"] button');
-    button.simulate('click');
+    await clickSubmit(wrapper);
 
     expect(widget.title).toEqual('Unique Users');
   });
 
-  it('can add conditions', function () {
+  it('can add conditions', async function () {
     jest.useFakeTimers();
-
     let widget = undefined;
     const wrapper = mountModal({
       initialData,
@@ -80,17 +92,17 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     // Change the search text on the first query.
     const input = wrapper.find('#smart-search-input').first();
     input.simulate('change', {target: {value: 'color:blue'}}).simulate('blur');
-    jest.runAllTimers();
 
-    // Click on submit.
-    const button = wrapper.find('Button[data-test-id="add-widget"] button');
-    button.simulate('click');
+    jest.runAllTimers();
+    jest.useRealTimers();
+
+    await clickSubmit(wrapper);
 
     expect(widget.queries).toHaveLength(1);
     expect(widget.queries[0].conditions).toEqual('color:blue');
   });
 
-  it('can choose a field', function () {
+  it('can choose a field', async function () {
     let widget = undefined;
     const wrapper = mountModal({
       initialData,
@@ -101,15 +113,13 @@ describe('Modals -> AddDashboardWidgetModal', function () {
 
     selectByLabel(wrapper, 'p95(\u2026)', {name: 'field', at: 0, control: true});
 
-    // Click on submit.
-    const button = wrapper.find('Button[data-test-id="add-widget"] button');
-    button.simulate('click');
+    await clickSubmit(wrapper);
 
     expect(widget.queries).toHaveLength(1);
     expect(widget.queries[0].fields).toEqual(['p95(transaction.duration)']);
   });
 
-  it('can add additional fields', function () {
+  it('can add additional fields', async function () {
     let widget = undefined;
     const wrapper = mountModal({
       initialData,
@@ -126,15 +136,13 @@ describe('Modals -> AddDashboardWidgetModal', function () {
 
     selectByLabel(wrapper, 'p95(\u2026)', {name: 'field', at: 1, control: true});
 
-    // Click on submit.
-    const button = wrapper.find('Button[data-test-id="add-widget"] button');
-    button.simulate('click');
+    await clickSubmit(wrapper);
 
     expect(widget.queries).toHaveLength(1);
     expect(widget.queries[0].fields).toEqual(['count()', 'p95(transaction.duration)']);
   });
 
-  it('can add widget queries', function () {
+  it('can add widget queries', async function () {
     let widget = undefined;
     const wrapper = mountModal({
       initialData,
@@ -147,14 +155,47 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     // Click the add button
     const add = wrapper.find('Button[data-test-id="add-query"] button');
     add.simulate('click');
-    wrapper.update();
 
     // Second query section should display.
     expect(wrapper.find('WidgetQueryForm')).toHaveLength(2);
 
     // Updated widget should have two queries.
     wrapper.find('Button[data-test-id="add-widget"] button').simulate('click');
+    // Wait for xhr to complete.
+    await tick();
+
     expect(widget.queries).toHaveLength(2);
+  });
+
+  it('can respond to validation feedback', async function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/widgets/',
+      method: 'POST',
+      statusCode: 400,
+      body: {
+        title: ['This field is required'],
+        queries: [{conditions: ['Invalid value']}],
+      },
+    });
+
+    let widget = undefined;
+    const wrapper = mountModal({
+      initialData,
+      onAddWidget: data => (widget = data),
+    });
+
+    await clickSubmit(wrapper);
+    await wrapper.update();
+
+    // API request should fail and not add widget.
+    expect(widget).toBeUndefined();
+
+    const errors = wrapper.find('FieldErrorReason');
+    expect(errors).toHaveLength(2);
+
+    // Nested object error should display
+    const conditionError = wrapper.find('WidgetQueryForm FieldErrorReason');
+    expect(conditionError).toHaveLength(1);
   });
 
   it('can remove widget queries', function () {
@@ -204,8 +245,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       .at(0)
       .simulate('click');
 
-    // Add widget to get update.
-    wrapper.find('Button[data-test-id="add-widget"] button').simulate('click');
+    await clickSubmit(wrapper);
 
     expect(widget.queries[0].conditions).toEqual(discoverQuery.query);
     expect(widget.queries[0].fields).toEqual([discoverQuery.yAxis]);


### PR DESCRIPTION
Use the widget validation endpoint when adding widgets from the modal. If the request fails propagate errors to relevant inputs.

![Screen Shot 2020-11-30 at 4 54 37 PM](https://user-images.githubusercontent.com/24086/100754972-abd8a380-33b9-11eb-8ed6-4137fe9b35e7.png)
