### PR TITLE
fix(release-details): Clicking a release preserve event-type

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
@@ -121,6 +121,7 @@ class ReleaseChartContainer extends React.Component<Props> {
 
     const releaseQueryExtra = {
       showTransactions: location.query.showTransactions,
+      eventType,
       yAxis,
     };
 


### PR DESCRIPTION
- This fixes a bug where clicking a release on the chart, if the y-axis
  was event count, the event type wouldn't be preserved.