### PR TITLE
fix(releases): Add missing performance-view feature flags

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -305,7 +305,7 @@ class ReleaseOverview extends AsyncView<Props> {
                       version={version}
                       location={location}
                     />
-                    <Feature features={['release-performance-views']}>
+                    <Feature features={['performance-view', 'release-performance-views']}>
                       <TransactionsList
                         location={location}
                         organization={organization}

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
@@ -126,7 +126,7 @@ const ReleaseHeader = ({
               <Count value={sessionsCrashed} />
             </ReleaseStat>
           )}
-          <Feature features={['release-performance-views']}>
+          <Feature features={['performance-view', 'release-performance-views']}>
             <ReleaseStat label={t('Apdex')} help={getTermHelp(organization, 'apdex')}>
               <DiscoverQuery
                 eventView={releaseEventView}


### PR DESCRIPTION
These features needs to be gated behind the `performance-view` feature flags as
the org may not have access to the performance features if they are not on an am
plan.