### PR TITLE
feat(discover): Add a badge for all field types

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -5,8 +5,8 @@ import {components, OptionProps, SingleValueProps} from 'react-select';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
-import Badge from 'app/components/badge';
 import SelectControl from 'app/components/forms/selectControl';
+import Tag from 'app/components/tag';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {SelectValue} from 'app/types';
@@ -359,22 +359,29 @@ class QueryField extends React.Component<Props> {
     return inputs;
   }
 
-  renderBadge(kind) {
-    let text, priority;
+  renderTag(kind) {
+    let text, tagType;
     switch (kind) {
       case FieldValueKind.FUNCTION:
         text = 'f(x)';
-        priority = 'strong';
+        tagType = 'success';
         break;
       case FieldValueKind.MEASUREMENT:
         text = 'measure';
-        priority = 'highlight';
+        tagType = 'info';
+        break;
+      case FieldValueKind.TAG:
+        text = kind;
+        tagType = 'warning';
+        break;
+      case FieldValueKind.FIELD:
+        text = kind;
+        tagType = 'highlight';
         break;
       default:
-        priority = undefined;
         text = kind;
     }
-    return <Badge text={text} priority={priority} />;
+    return <Tag type={tagType}>{text}</Tag>;
   }
 
   render() {
@@ -436,13 +443,13 @@ class QueryField extends React.Component<Props> {
             Option: ({label, data, ...props}: OptionProps<OptionType>) => (
               <components.Option label={label} {...(props as any)}>
                 <span data-test-id="label">{label}</span>
-                {this.renderBadge(data.value.kind)}
+                {this.renderTag(data.value.kind)}
               </components.Option>
             ),
             SingleValue: ({data, ...props}: SingleValueProps<OptionType>) => (
               <components.SingleValue data={data} {...(props as any)}>
                 <span data-test-id="label">{data.label}</span>
-                {this.renderBadge(data.value.kind)}
+                {this.renderTag(data.value.kind)}
               </components.SingleValue>
             ),
           }}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -359,6 +359,24 @@ class QueryField extends React.Component<Props> {
     return inputs;
   }
 
+  renderBadge(kind) {
+    let text, priority;
+    switch (kind) {
+      case FieldValueKind.FUNCTION:
+        text = 'f(x)';
+        priority = 'strong';
+        break;
+      case FieldValueKind.MEASUREMENT:
+        text = 'measure';
+        priority = 'highlight';
+        break;
+      default:
+        priority = undefined;
+        text = kind;
+    }
+    return <Badge text={text} priority={priority} />;
+  }
+
   render() {
     const {
       className,
@@ -418,13 +436,13 @@ class QueryField extends React.Component<Props> {
             Option: ({label, data, ...props}: OptionProps<OptionType>) => (
               <components.Option label={label} {...(props as any)}>
                 <span data-test-id="label">{label}</span>
-                {data.value.kind === FieldValueKind.TAG && <Badge text="tag" />}
+                {this.renderBadge(data.value.kind)}
               </components.Option>
             ),
             SingleValue: ({data, ...props}: SingleValueProps<OptionType>) => (
               <components.SingleValue data={data} {...(props as any)}>
                 <span data-test-id="label">{data.label}</span>
-                {data.value.kind === FieldValueKind.TAG && <Badge text="tag" />}
+                {this.renderBadge(data.value.kind)}
               </components.SingleValue>
             ),
           }}

--- a/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
+++ b/tests/js/spec/views/eventsV2/table/columnEditModal.spec.js
@@ -117,7 +117,7 @@ describe('EventsV2 -> ColumnEditModal', function () {
       expect(
         fieldRow.find('SelectControl[name="field"] span[data-test-id="label"]').text()
       ).toBe('user-def');
-      expect(fieldRow.find('SelectControl[name="field"] Badge')).toHaveLength(1);
+      expect(fieldRow.find('SelectControl[name="field"] Tag')).toHaveLength(1);
       expect(fieldRow.find('BlankSpace')).toHaveLength(1);
     });
   });
@@ -140,7 +140,7 @@ describe('EventsV2 -> ColumnEditModal', function () {
       expect(
         funcRow.find('SelectControl[name="field"] span[data-test-id="label"]').text()
       ).toBe('project');
-      expect(funcRow.find('SelectControl[name="field"] Badge')).toHaveLength(1);
+      expect(funcRow.find('SelectControl[name="field"] Tag')).toHaveLength(1);
     });
 
     it('selects tag expressions that overlap functions', function () {
@@ -148,7 +148,7 @@ describe('EventsV2 -> ColumnEditModal', function () {
       expect(
         funcRow.find('SelectControl[name="field"] span[data-test-id="label"]').text()
       ).toBe('count');
-      expect(funcRow.find('SelectControl[name="field"] Badge')).toHaveLength(1);
+      expect(funcRow.find('SelectControl[name="field"] Tag')).toHaveLength(1);
     });
   });
 

--- a/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
@@ -83,7 +83,7 @@ describe('MetricField', function () {
     wrapper.find('FieldHelp button[aria-label="Failure rate"]').simulate('click');
 
     expect(wrapper.find('QueryField SingleValue SingleValue').text()).toEqual(
-      'failure_rate()'
+      'failure_rate()f(x)'
     );
   });
 });


### PR DESCRIPTION
- This adds a function, measurement and field badge to the column editor
- There was already one for tags, fields will be gray, tags yellow, functions green and measurements blue

<img width="732" alt="image" src="https://user-images.githubusercontent.com/4205004/100794251-47ced300-33eb-11eb-9197-d6e7256242dd.png">
