### PR TITLE
fix(issue-details): Render meta errors without payloads

### DIFF
--- a/src/sentry/static/sentry/app/components/events/meta/annotatedText/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/meta/annotatedText/index.tsx
@@ -35,15 +35,23 @@ const AnnotatedText = ({value, meta, ...props}: Props) => {
     return element;
   };
 
+  const formatErrorKind = (kind: string) => {
+    return capitalize(kind.replace('_', ' '));
+  };
+
   const getErrorMessage = (error: MetaError) => {
     const errorMessage: string[] = [];
 
-    if (error[0]) {
-      errorMessage.push(capitalize(error[0].replace('_', ' ')));
-    }
+    if (Array.isArray(error)) {
+      if (error[0]) {
+        errorMessage.push(formatErrorKind(error[0]));
+      }
 
-    if (error[1]?.reason) {
-      errorMessage.push(`(${error[1].reason})`);
+      if (error[1]?.reason) {
+        errorMessage.push(`(${error[1].reason})`);
+      }
+    } else {
+      errorMessage.push(formatErrorKind(error));
     }
 
     return errorMessage.join(' ');

--- a/src/sentry/static/sentry/app/components/events/meta/annotatedText/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/meta/annotatedText/index.tsx
@@ -36,7 +36,7 @@ const AnnotatedText = ({value, meta, ...props}: Props) => {
   };
 
   const formatErrorKind = (kind: string) => {
-    return capitalize(kind.replace('_', ' '));
+    return capitalize(kind.replace(/_/g, ' '));
   };
 
   const getErrorMessage = (error: MetaError) => {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1498,7 +1498,7 @@ export type Meta = {
   err: Array<MetaError>;
 };
 
-export type MetaError = [string, any];
+export type MetaError = string | [string, any];
 export type MetaRemark = Array<string | number>;
 
 export type ChunkType = {


### PR DESCRIPTION
Supports meta data errors that come without a payload. Relay serializes those as a plain string, as opposed to a `["string", null]` tuple. Also introduces a helper method that correctly converts the `ErrorKind` constants by replacing all underscores with spaces.

Before: 
![Screen Shot 2020-12-01 at 20 49 36](https://user-images.githubusercontent.com/1433023/100789624-03f1c300-3417-11eb-8a71-caeef8bb9826.png)

After:
![image](https://user-images.githubusercontent.com/1433023/100789863-516e3000-3417-11eb-8e9b-b9ed082ffc10.png)

