### PR TITLE
fix(ci): Release should refer to github.event.inputs, not inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Prepare release
         uses: getsentry/action-prepare-release@main
         with:
-          version: ${{ inputs.version }}
-          force: ${{ inputs.force }}
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_SENTRY_BOT_PAT }}


### PR DESCRIPTION
Follow up to #22379, fixing https://github.com/getsentry/sentry/actions/runs/394844573
