### PR TITLE
feat(ticket rules): Ticket Rule Settings Modal

### DIFF
--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -30,6 +30,7 @@ def transform_jira_fields_to_form_fields(fields_list):
     :param fields_list: Create ticket fields from Jira as an array.
     :return: The "create ticket" fields from Jira as a dict.
     """
+    # print("fields", fields_list)
     return {
         field["name"]: {
             key: ({"select": "choice", "text": "string"}.get(value, value))
@@ -44,9 +45,15 @@ def transform_jira_fields_to_form_fields(fields_list):
 
 
 def transform_jira_choices_to_strings(fields, data):
-    return {
-        key: ({k: v for k, v in fields[key]["choices"]}.get(value, value))
-        if key in fields and fields[key]["type"] == "choice"
-        else value
-        for key, value in data.items()
-    }
+    choices = {}
+    for key, value in data.items():
+        if key in fields and fields[key]["type"] == "choice":
+            temp_dict = {k: v for (k, v) in fields[key]["choices"]}
+            if type(value) == list:
+                temp_value = [v for v in value]
+            else:
+                temp_value = temp_dict.get(value, value)
+            choices[key] = temp_value
+        else:
+            choices[key] = value
+    return choices

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -30,7 +30,6 @@ def transform_jira_fields_to_form_fields(fields_list):
     :param fields_list: Create ticket fields from Jira as an array.
     :return: The "create ticket" fields from Jira as a dict.
     """
-    # print("fields", fields_list)
     return {
         field["name"]: {
             key: ({"select": "choice", "text": "string"}.get(value, value))

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -47,13 +47,14 @@ def transform_jira_fields_to_form_fields(fields_list):
 def transform_jira_choices_to_strings(fields, data):
     choices = {}
     for key, value in data.items():
+        if key in ["jira_integration", "dynamic_form_fields"] or not value:
+            continue
         if key in fields and fields[key]["type"] == "choice":
             temp_dict = {k: v for (k, v) in fields[key]["choices"]}
-            if type(value) == list:
-                temp_value = [v for v in value]
+            if fields[key].get("multiple") and type(value) == list:
+                choices[key] = [temp_dict[v] for v in value]
             else:
-                temp_value = temp_dict.get(value, value)
-            choices[key] = temp_value
+                choices[key] = temp_dict.get(value)
         else:
             choices[key] = value
     return choices

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -21,7 +21,7 @@ import Input from 'app/views/settings/components/forms/controls/input';
 import MemberTeamFields from 'app/views/settings/projectAlerts/issueEditor/memberTeamFields';
 import TicketRuleForm from 'app/views/settings/projectAlerts/issueEditor/ticketRuleForm';
 
-type FormField = {
+export type FormField = {
   // Type of form fields
   type: string;
   // The rest is configuration for the form field
@@ -277,7 +277,7 @@ class RuleNode extends React.Component<Props> {
     }
   }
 
-  updateParent = data => {
+  updateParent = (data: {[key: string]: string}): void => {
     // iterating through these upon save instead of when each
     // element is changed to match the spec
     for (const [name, value] of Object.entries(data)) {
@@ -296,7 +296,7 @@ class RuleNode extends React.Component<Props> {
             {this.renderRow()}
             {ticketRule && (
               <TicketRuleForm
-                data={node}
+                formFields={node?.formFields || {}}
                 instance={data}
                 index={this.props.index}
                 onSubmitAction={this.updateParent}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -304,7 +304,10 @@ class RuleNode extends React.Component<Props, State> {
               <TicketRuleForm
                 data={node}
                 instance={data}
+                index={this.props.index}
+                formData={this.state.formData}
                 onSubmitAction={this.updateParent}
+                onPropertyChange={this.props.onPropertyChange}
               />
             )}
           </Rule>

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -39,7 +39,15 @@ type Props = {
   onPropertyChange: (rowIndex: number, name: string, value: string) => void;
 };
 
-class RuleNode extends React.Component<Props> {
+type State = {
+  formData?: any;
+};
+
+class RuleNode extends React.Component<Props, State> {
+  state = {
+    formData: {},
+  };
+
   handleDelete = () => {
     const {index, onDelete} = this.props;
     onDelete(index);
@@ -277,18 +285,42 @@ class RuleNode extends React.Component<Props> {
     }
   }
 
+  updateParent = data => {
+    this.setState({
+      formData: data,
+    });
+  };
+
+  updateFormFields = () => {
+    if (this.props.data.hasOwnProperty('jira_integration')) {
+      const stateCopy = {...this.state.formData};
+      stateCopy.jira_integration = this.props.data.jira_integration;
+      this.setState({
+        formData: stateCopy,
+      });
+    }
+    if (this.props.data.hasOwnProperty('vsts_integration')) {
+      const stateCopy = {...this.state.formData};
+      stateCopy.vsts_integration = this.props.data.vsts_integration;
+      this.setState({
+        formData: stateCopy,
+      });
+    }
+  };
+
   render() {
     const {data, disabled, node} = this.props;
     const ticketRule = node?.hasOwnProperty('actionType');
-    console.log({node});
-    console.log({data})
+    this.updateFormFields();
     return (
       <RuleRowContainer>
         <RuleRow>
           <Rule>
             {data && <input type="hidden" name="id" value={data.id} />}
             {this.renderRow()}
-            {ticketRule && <TicketRuleForm data={node}/>} 
+            {ticketRule && (
+              <TicketRuleForm data={node} onSubmitAction={this.updateParent} />
+            )}
           </Rule>
           <DeleteButton
             disabled={disabled}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -291,27 +291,9 @@ class RuleNode extends React.Component<Props, State> {
     });
   };
 
-  updateFormFields = () => {
-    if (this.props.data.hasOwnProperty('jira_integration')) {
-      const stateCopy = {...this.state.formData};
-      stateCopy.jira_integration = this.props.data.jira_integration;
-      this.setState({
-        formData: stateCopy,
-      });
-    }
-    if (this.props.data.hasOwnProperty('vsts_integration')) {
-      const stateCopy = {...this.state.formData};
-      stateCopy.vsts_integration = this.props.data.vsts_integration;
-      this.setState({
-        formData: stateCopy,
-      });
-    }
-  };
-
   render() {
     const {data, disabled, node} = this.props;
     const ticketRule = node?.hasOwnProperty('actionType');
-    this.updateFormFields();
     return (
       <RuleRowContainer>
         <RuleRow>
@@ -319,7 +301,11 @@ class RuleNode extends React.Component<Props, State> {
             {data && <input type="hidden" name="id" value={data.id} />}
             {this.renderRow()}
             {ticketRule && (
-              <TicketRuleForm data={node} onSubmitAction={this.updateParent} />
+              <TicketRuleForm
+                data={node}
+                instance={data}
+                onSubmitAction={this.updateParent}
+              />
             )}
           </Rule>
           <DeleteButton

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -39,15 +39,7 @@ type Props = {
   onPropertyChange: (rowIndex: number, name: string, value: string) => void;
 };
 
-type State = {
-  formData?: any;
-};
-
-class RuleNode extends React.Component<Props, State> {
-  state = {
-    formData: {},
-  };
-
+class RuleNode extends React.Component<Props> {
   handleDelete = () => {
     const {index, onDelete} = this.props;
     onDelete(index);
@@ -286,9 +278,11 @@ class RuleNode extends React.Component<Props, State> {
   }
 
   updateParent = data => {
-    this.setState({
-      formData: data,
-    });
+    // iterating through these upon save instead of when each
+    // element is changed to match the spec
+    for (const [name, value] of Object.entries(data)) {
+      this.props.onPropertyChange(this.props.index, name, value);
+    }
   };
 
   render() {
@@ -305,7 +299,6 @@ class RuleNode extends React.Component<Props, State> {
                 data={node}
                 instance={data}
                 index={this.props.index}
-                formData={this.state.formData}
                 onSubmitAction={this.updateParent}
                 onPropertyChange={this.props.onPropertyChange}
               />

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -280,14 +280,15 @@ class RuleNode extends React.Component<Props> {
   render() {
     const {data, disabled, node} = this.props;
     const ticketRule = node?.hasOwnProperty('actionType');
-
+    console.log({node});
+    console.log({data})
     return (
       <RuleRowContainer>
         <RuleRow>
           <Rule>
             {data && <input type="hidden" name="id" value={data.id} />}
             {this.renderRow()}
-            {ticketRule && <TicketRuleForm />}
+            {ticketRule && <TicketRuleForm data={node}/>} 
           </Rule>
           <DeleteButton
             disabled={disabled}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 
 import Button from 'app/components/button';
+import {IconSettings} from 'app/icons';
+import {t} from 'app/locale';
 import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
 import Form from 'app/views/settings/components/forms/form';
-import {IconSettings} from 'app/icons';
 
 type Props = {
   data: any;
@@ -12,6 +13,7 @@ type Props = {
 
 type State = {
   showModal: boolean;
+  formData: any;
 };
 
 class TicketRuleForm extends React.Component<Props, State> {
@@ -31,33 +33,64 @@ class TicketRuleForm extends React.Component<Props, State> {
     });
   };
 
-  linkIssueSuccess = (onSuccess: () => void) => {
-    // this.props.onChange(() => onSuccess());
+  getNames = () => {
+    const names = [];
+    for (const name in this.props.data.formFields) {
+      if (this.props.data.formFields[name].hasOwnProperty('name')) {
+        names.push(this.props.data.formFields[name].name);
+      }
+    }
+    return names;
+  };
+
+  cleanData = data => {
+    const names = this.getNames();
+    const formData = {};
+
+    for (const [key, value] of Object.entries(data)) {
+      if (names.includes(key)) {
+        formData[key] = value;
+      }
+    }
+    return formData;
+  };
+
+  onFormSubmit = (data: any) => {
+    const formData = this.cleanData(data);
+    this.props.onSubmitAction(formData);
     this.closeModal();
   };
 
   renderFields = () => {
-    let fields = [];
+    const fields = [];
+    this.props.data.formFields.reporter.required = false; // this is a hack for now until I figure out how to populate it with loadOptions!!
     const formFields = Object.values(this.props.data.formFields);
-    delete formFields.jira_integration; // this doesn't have a name field and doesn't render anyway
-    
+
     for (const key in formFields) {
-      fields.push(
-        <FieldFromConfig
-          key={formFields[key].name}
-          field={formFields[key]}
-          inline={false}
-          stacked
-          flexibleControlStateSize
-        />
-        )
+      if (formFields[key].hasOwnProperty('name')) {
+        fields.push(
+          <FieldFromConfig
+            key={formFields[key].name}
+            field={formFields[key]}
+            inline={false}
+            stacked
+            flexibleControlStateSize
+            // loadOptions={() => {console.log("helloooo")}}
+            // async={true}
+            // cache={false}
+            // onSelectResetsInput={false}
+            // onCloseResetsInput={false}
+            // onBlurResetsInput={false}
+            // autoload={true}
+          />
+        );
+      }
     }
     return fields;
-  }
+  };
 
   render() {
-    console.log("the props data: ")
-    console.log(this.props.data);
+    const submitLabel = t('Apply Changes');
     return (
       <React.Fragment>
         <Button
@@ -81,34 +114,18 @@ class TicketRuleForm extends React.Component<Props, State> {
             <Form
               // apiEndpoint={`/groups/${group.id}/integrations/${integration.id}/`}
               // apiMethod={action === 'create' ? 'POST' : 'PUT'}
-              // onSubmitSuccess={this.onSubmitSuccess}
+              onSubmit={this.onFormSubmit}
+              // onSubmitSuccess={this.formSubmitSuccess}
               initialData={this.props.data}
               // onFieldChange={this.onFieldChange}
-              // submitLabel={SUBMIT_LABEL_BY_ACTION[action]}
+              submitLabel={submitLabel}
               // submitDisabled={this.state.reloading}
               // footerClass="modal-footer"
               // onPreSubmit={this.handlePreSubmit}
               // onSubmitError={this.handleSubmitError}
             >
-            {this.renderFields}
+              {this.renderFields}
             </Form>
-
-
-            {/* 
-              okay maybe fuck ExternalIssueForm and just do our own
-
-            */}
-            {/* 
-                <ExternalIssueForm
-                  // need the key here so React will re-render
-                  // with a new action prop
-                  key={this.props.data.actionType}
-                  group={this.props.group} // don't have access to group
-                  integration={integration}
-                  action='create'
-                  onSubmitSuccess={(_, onSuccess) => this.linkIssueSuccess(onSuccess)}
-                />
-            */}
           </Modal.Body>
         </Modal>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -145,6 +145,25 @@ class TicketRuleForm extends React.Component<Props, State> {
     return bodyText;
   };
 
+  addFields = formFields => {
+    const title = {
+      name: 'title',
+      label: 'Title',
+      type: 'string',
+      default: 'This will be the same as the Sentry Issue.',
+      disabled: true,
+    };
+    const description = {
+      name: 'description',
+      label: 'Description',
+      type: 'string',
+      default: 'This will be generated from the Sentry Issue details.',
+      disabled: true,
+    };
+    formFields.unshift(description);
+    formFields.unshift(title);
+  };
+
   render() {
     const {ticketType, link} = this.buildText();
     const text = t(
@@ -153,6 +172,7 @@ class TicketRuleForm extends React.Component<Props, State> {
     );
     const submitLabel = t('Apply Changes');
     const formFields = Object.values(this.props.data.formFields);
+    this.addFields(formFields);
     const initialData = {};
     formFields.forEach(field => {
       // passing an empty array breaks multi select

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
+import styled from '@emotion/styled';
+import debounce from 'lodash/debounce';
+import * as queryString from 'query-string';
 
 import Button from 'app/components/button';
+import ExternalLink from 'app/components/links/externalLink';
 import {IconSettings} from 'app/icons';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
+import space from 'app/styles/space';
+import {IssueConfigField} from 'app/types';
 import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
 import Form from 'app/views/settings/components/forms/form';
 
 type Props = {
   data: any;
   instance: any;
+  onSubmitAction: any;
 };
 
 type State = {
@@ -48,10 +55,10 @@ class TicketRuleForm extends React.Component<Props, State> {
     const names = this.getNames();
     const formData = {};
     if (this.props.instance.hasOwnProperty('jira_integration')) {
-      formData.jira_integration = this.props.instance.jira_integration;
+      formData.jira_integration = this.props.instance?.jira_integration;
     }
     if (this.props.instance.hasOwnProperty('vsts_integration')) {
-      formData.vsts_integration = this.props.instance.vsts_integration;
+      formData.vsts_integration = this.props.instance?.vsts_integration;
     }
 
     for (const [key, value] of Object.entries(data)) {
@@ -68,36 +75,90 @@ class TicketRuleForm extends React.Component<Props, State> {
     this.closeModal();
   };
 
-  renderFields = () => {
-    const fields = [];
-    this.props.data.formFields.reporter.required = false; // this is a hack for now until I figure out how to populate it with loadOptions!!
-    const formFields = Object.values(this.props.data.formFields);
-
-    for (const key in formFields) {
-      if (formFields[key].hasOwnProperty('name')) {
-        fields.push(
-          <FieldFromConfig
-            key={formFields[key].name}
-            field={formFields[key]}
-            inline={false}
-            stacked
-            flexibleControlStateSize
-            // loadOptions={() => {console.log("helloooo")}}
-            // async={true}
-            // cache={false}
-            // onSelectResetsInput={false}
-            // onCloseResetsInput={false}
-            // onBlurResetsInput={false}
-            // autoload={true}
-          />
-        );
+  getOptions = (field: IssueConfigField, input: string) =>
+    new Promise((resolve, reject) => {
+      if (!input) {
+        const choices =
+          (field.choices as Array<[number | string, number | string]>) || [];
+        const options = choices.map(([value, label]) => ({value, label}));
+        return resolve({options});
       }
-    }
-    return fields;
+      return this.debouncedOptionLoad(field, input, (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+
+  debouncedOptionLoad = debounce(
+    async (
+      field: IssueConfigField,
+      input: string,
+      cb: (err: Error | null, result?) => void
+    ) => {
+      const options = this.props.instance;
+      const query = queryString.stringify({
+        project: options.project,
+        issuetype: options.issuetype,
+        field: field.name,
+        query: input,
+      });
+
+      const url = field.url || '';
+      const separator = url.includes('?') ? '&' : '?';
+      // We can't use the API client here since the URL is not scoped under the
+      // API endpoints (which the client prefixes)
+      try {
+        const response = await fetch(url + separator + query);
+        cb(null, {options: response.ok ? await response.json() : []});
+      } catch (err) {
+        cb(err);
+      }
+    },
+    200,
+    {trailing: true}
+  );
+
+  getFieldProps = (field: IssueConfigField) =>
+    field.url
+      ? {
+          loadOptions: (input: string) => this.getOptions(field, input),
+          async: true,
+          cache: false,
+          onSelectResetsInput: false,
+          onCloseResetsInput: false,
+          onBlurResetsInput: false,
+          autoload: true,
+        }
+      : {};
+
+  buildText = () => {
+    const bodyText = {};
+    bodyText.ticketType = this.props.instance.hasOwnProperty('jira_integration')
+      ? 'Jira issue'
+      : 'Azure DevOps work item';
+    bodyText.link = this.props.instance.hasOwnProperty('jira_integration')
+      ? 'https://docs.sentry.io/product/integrations/jira/#issue-sync'
+      : 'https://docs.sentry.io/product/integrations/azure-devops/#issue-sync';
+    return bodyText;
   };
 
   render() {
+    const {ticketType, link} = this.buildText();
+    const text = t(
+      'When this alert is triggered a %s will be created with the following fields. ',
+      ticketType
+    );
     const submitLabel = t('Apply Changes');
+    const formFields = Object.values(this.props.data.formFields);
+    const initialData = {};
+    formFields.forEach(field => {
+      // passing an empty array breaks multi select
+      // TODO(jess): figure out why this is breaking and fix
+      initialData[field.name] = field.multiple ? '' : field.default;
+    });
     return (
       <React.Fragment>
         <Button
@@ -118,20 +179,35 @@ class TicketRuleForm extends React.Component<Props, State> {
             <Modal.Title>Issue Link Settings</Modal.Title>
           </Modal.Header>
           <Modal.Body>
+            <BodyText>
+              {text}
+              {tct("It'll also [linkToDocs] with the new Sentry Issue.", {
+                linkToDocs: <ExternalLink href={link}>{t('stay in sync')}</ExternalLink>,
+              })}
+            </BodyText>
             <Form
-              // apiEndpoint={`/groups/${group.id}/integrations/${integration.id}/`}
-              // apiMethod={action === 'create' ? 'POST' : 'PUT'}
               onSubmit={this.onFormSubmit}
               // onSubmitSuccess={this.formSubmitSuccess}
-              initialData={this.props.data}
+              initialData={initialData}
               // onFieldChange={this.onFieldChange}
               submitLabel={submitLabel}
               // submitDisabled={this.state.reloading}
-              // footerClass="modal-footer"
+              footerClass="modal-footer"
               // onPreSubmit={this.handlePreSubmit}
               // onSubmitError={this.handleSubmitError}
             >
-              {this.renderFields}
+              {formFields
+                .filter(field => field.hasOwnProperty('name'))
+                .map(field => (
+                  <FieldFromConfig
+                    key={`${field.name}-${field.default}-${field.required}`}
+                    field={field}
+                    inline={false}
+                    stacked
+                    flexibleControlStateSize
+                    {...this.getFieldProps(field)}
+                  />
+                ))}
             </Form>
           </Modal.Body>
         </Modal>
@@ -139,5 +215,9 @@ class TicketRuleForm extends React.Component<Props, State> {
     );
   }
 }
+
+const BodyText = styled('div')`
+  margin-bottom: ${space(3)};
+`;
 
 export default TicketRuleForm;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -2,9 +2,13 @@ import React from 'react';
 import Modal from 'react-bootstrap/lib/Modal';
 
 import Button from 'app/components/button';
+import FieldFromConfig from 'app/views/settings/components/forms/fieldFromConfig';
+import Form from 'app/views/settings/components/forms/form';
 import {IconSettings} from 'app/icons';
 
-type Props = {};
+type Props = {
+  data: any;
+};
 
 type State = {
   showModal: boolean;
@@ -27,7 +31,33 @@ class TicketRuleForm extends React.Component<Props, State> {
     });
   };
 
+  linkIssueSuccess = (onSuccess: () => void) => {
+    // this.props.onChange(() => onSuccess());
+    this.closeModal();
+  };
+
+  renderFields = () => {
+    let fields = [];
+    const formFields = Object.values(this.props.data.formFields);
+    delete formFields.jira_integration; // this doesn't have a name field and doesn't render anyway
+    
+    for (const key in formFields) {
+      fields.push(
+        <FieldFromConfig
+          key={formFields[key].name}
+          field={formFields[key]}
+          inline={false}
+          stacked
+          flexibleControlStateSize
+        />
+        )
+    }
+    return fields;
+  }
+
   render() {
+    console.log("the props data: ")
+    console.log(this.props.data);
     return (
       <React.Fragment>
         <Button
@@ -47,7 +77,39 @@ class TicketRuleForm extends React.Component<Props, State> {
           <Modal.Header closeButton>
             <Modal.Title>Issue Link Settings</Modal.Title>
           </Modal.Header>
-          <Modal.Body>replace me with an ExternalIssueForm in API-1448</Modal.Body>
+          <Modal.Body>
+            <Form
+              // apiEndpoint={`/groups/${group.id}/integrations/${integration.id}/`}
+              // apiMethod={action === 'create' ? 'POST' : 'PUT'}
+              // onSubmitSuccess={this.onSubmitSuccess}
+              initialData={this.props.data}
+              // onFieldChange={this.onFieldChange}
+              // submitLabel={SUBMIT_LABEL_BY_ACTION[action]}
+              // submitDisabled={this.state.reloading}
+              // footerClass="modal-footer"
+              // onPreSubmit={this.handlePreSubmit}
+              // onSubmitError={this.handleSubmitError}
+            >
+            {this.renderFields}
+            </Form>
+
+
+            {/* 
+              okay maybe fuck ExternalIssueForm and just do our own
+
+            */}
+            {/* 
+                <ExternalIssueForm
+                  // need the key here so React will re-render
+                  // with a new action prop
+                  key={this.props.data.actionType}
+                  group={this.props.group} // don't have access to group
+                  integration={integration}
+                  action='create'
+                  onSubmitSuccess={(_, onSuccess) => this.linkIssueSuccess(onSuccess)}
+                />
+            */}
+          </Modal.Body>
         </Modal>
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 import * as queryString from 'query-string';
 
+import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
 import {IconSettings} from 'app/icons';
@@ -22,14 +23,17 @@ type Props = {
 type State = {
   showModal: boolean;
   formData: any;
+  disabled: boolean;
 };
 
 class TicketRuleForm extends React.Component<Props, State> {
   state = {
     showModal: false,
+    disabled: false,
   };
 
-  openModal = () => {
+  openModal = (event: React.MouseEvent) => {
+    event.preventDefault();
     this.setState({
       showModal: true,
     });
@@ -69,11 +73,29 @@ class TicketRuleForm extends React.Component<Props, State> {
     return formData;
   };
 
-  onFormSubmit = (data: any) => {
+  onFieldChange = (data: any) => {
+    // check if required fields have been filled out
+    console.log({data})
+    // and if so, set disabled state to false
+
+  }
+
+  handleSubmitError = () => {
+    addErrorMessage(t('Fill out required fields.'))
+  }
+
+  onFormSubmit = (data, success, error, e, model) => {
+    e.preventDefault(); 
+    e.stopPropagation(); 
+    
     const formData = this.cleanData(data);
     this.props.onSubmitAction(formData);
-    this.closeModal();
+    this.closeModal( );
   };
+
+  formSubmitSuccess = () => {
+    addSuccessMessage(t('Saved choices.'))
+  }
 
   getOptions = (field: IssueConfigField, input: string) =>
     new Promise((resolve, reject) => {
@@ -184,7 +206,7 @@ class TicketRuleForm extends React.Component<Props, State> {
         <Button
           size="small"
           icon={<IconSettings size="xs" />}
-          onClick={() => this.openModal()}
+          onClick={() => this.openModal(event)}
         >
           Issue Link Settings
         </Button>
@@ -207,14 +229,14 @@ class TicketRuleForm extends React.Component<Props, State> {
             </BodyText>
             <Form
               onSubmit={this.onFormSubmit}
-              // onSubmitSuccess={this.formSubmitSuccess}
+              onSubmitSuccess={this.formSubmitSuccess}
               initialData={initialData}
-              // onFieldChange={this.onFieldChange}
+              onFieldChange={this.onFieldChange}
               submitLabel={submitLabel}
-              // submitDisabled={this.state.reloading}
+              submitDisabled={this.state.disabled}
               footerClass="modal-footer"
               // onPreSubmit={this.handlePreSubmit}
-              // onSubmitError={this.handleSubmitError}
+              onSubmitError={this.handleSubmitError}
             >
               {formFields
                 .filter(field => field.hasOwnProperty('name'))

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 import * as queryString from 'query-string';
 
-import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {addSuccessMessage} from 'app/actionCreators/indicator';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
 import {IconSettings} from 'app/icons';
@@ -47,7 +47,7 @@ class TicketRuleForm extends React.Component<Props, State> {
 
   onCancel = () => {
     this.closeModal();
-  }
+  };
 
   getNames = () => {
     const names = [];
@@ -77,32 +77,23 @@ class TicketRuleForm extends React.Component<Props, State> {
     return formData;
   };
 
-  onFieldChange = (data: any) => {
-    console.log({data})
-  }
-
   // @ts-ignore success and error are not used
   onFormSubmit = (data, _success, _error, e) => {
     e.preventDefault();
     e.stopPropagation();
-    
+
     const formData = this.cleanData(data);
     this.props.onSubmitAction(formData);
-    addSuccessMessage(t('Changes applied.'))
+    addSuccessMessage(t('Changes applied.'));
     this.closeModal();
   };
 
   getOptions = (field: IssueConfigField, input: string) =>
     new Promise((resolve, reject) => {
       if (!input) {
-        console.log("no input");
-        console.log({field})
-        // field["choices"] = ["5ab0069933719f2a50168cab", "it me"]
         const choices =
           (field.choices as Array<[number | string, number | string]>) || [];
         const options = choices.map(([value, label]) => ({value, label}));
-        console.log({choices})
-        console.log({options})
         return resolve({options});
       }
       return this.debouncedOptionLoad(field, input, (err, result) => {
@@ -195,10 +186,8 @@ class TicketRuleForm extends React.Component<Props, State> {
     const submitLabel = t('Apply Changes');
     const cancelLabel = t('Close');
     const formFields = Object.values(this.props.data.formFields);
-    console.log({formFields})
     this.addFields(formFields);
-    console.log("form data: ", this.props.formData)
-    const initialData = this.props.formData || {};
+    const initialData = this.props.instance || {};
     formFields.forEach(field => {
       // passing an empty array breaks multi select
       // TODO(jess): figure out why this is breaking and fix
@@ -206,7 +195,6 @@ class TicketRuleForm extends React.Component<Props, State> {
         initialData[field.name] = field.multiple ? '' : field.default;
       }
     });
-    console.log({initialData})
     return (
       <React.Fragment>
         <Button
@@ -242,7 +230,6 @@ class TicketRuleForm extends React.Component<Props, State> {
               submitDisabled={this.state.disabled}
               footerClass="modal-footer"
               onCancel={this.onCancel}
-              // onPreSubmit={this.handlePreSubmit}
             >
               {formFields
                 .filter(field => field.hasOwnProperty('name'))
@@ -253,7 +240,6 @@ class TicketRuleForm extends React.Component<Props, State> {
                     inline={false}
                     stacked
                     flexibleControlStateSize
-                    onChange={(value) => this.props.onPropertyChange(this.props.index, field, value)}
                     {...this.getFieldProps(field)}
                   />
                 ))}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -9,6 +9,7 @@ import Form from 'app/views/settings/components/forms/form';
 
 type Props = {
   data: any;
+  instance: any;
 };
 
 type State = {
@@ -46,6 +47,12 @@ class TicketRuleForm extends React.Component<Props, State> {
   cleanData = data => {
     const names = this.getNames();
     const formData = {};
+    if (this.props.instance.hasOwnProperty('jira_integration')) {
+      formData.jira_integration = this.props.instance.jira_integration;
+    }
+    if (this.props.instance.hasOwnProperty('vsts_integration')) {
+      formData.vsts_integration = this.props.instance.vsts_integration;
+    }
 
     for (const [key, value] of Object.entries(data)) {
       if (names.includes(key)) {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -227,7 +227,6 @@ class TicketRuleForm extends React.Component<Props, State> {
               onFieldChange={this.onFieldChange}
               submitLabel={submitLabel}
               cancelLabel={cancelLabel}
-              submitDisabled={this.state.disabled}
               footerClass="modal-footer"
               onCancel={this.onCancel}
             >


### PR DESCRIPTION
This PR builds out a modal that will open when the user clicks the "Issue Link Settings" button introduced in https://github.com/getsentry/sentry/pull/22113. As of now it can only be tested on Jira as the backend of Azure DevOps hasn't been built. This form allows the user to choose what the automatically created Jira ticket will look like when the rule fires.

![Screen Shot 2020-12-01 at 1 03 38 PM](https://user-images.githubusercontent.com/29959063/100807511-51eed280-33e7-11eb-9da2-c8db85645250.png)

**Known issues**
(These will be fixed in separate PRs since this is beefy)
    * Reporter and Assignee human readable names don't populate on edit (though id data is saved)
    * Form  does not validate on “Apply Changes”
        * form can be submitted w/o required fields filled out