### PR TITLE
ref(workflow): Remove loading state from groupEventDetails

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/index.tsx
@@ -32,6 +32,8 @@ type Props = RouteComponentProps<
   group: Group;
   event: Event;
   loadingEvent: boolean;
+  eventError: boolean;
+  onRetry: () => void;
 };
 
 type State = typeof OrganizationEnvironmentsStore['state'];

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -87,3 +87,4 @@ class IssueDetailsPage(BasePage):
         self.browser.wait_until_test_id("loaded-device-name")
         if self.browser.element_exists("#grouping-info"):
             self.browser.wait_until_test_id("loaded-grouping-info")
+        self.browser.wait_until_not('[data-test-id="loading-placeholder"]')


### PR DESCRIPTION
We no longer need to block render in this component, all endpoints being loaded are additional details that have their own loading mock.
We also don't need to call fetchData on every event ID change.

This will start showing the event details faster by not showing a spinner while waiting for the `/releases/completion/` endpoint.

@leedongwei I moved `metric.measure` to `componentDidMount`