### PR TITLE
feat(attachments): Add mimetype abstraction for attachments

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -104,6 +104,7 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
                 "id": six.text_type(attachment.id),
                 "name": attachment.name,
                 "headers": attachment.file.headers,
+                "mimetype": attachment.mimetype,
                 "size": attachment.file.size,
                 "sha1": attachment.file.checksum,
                 "dateCreated": attachment.file.timestamp,

--- a/src/sentry/api/serializers/models/eventattachment.py
+++ b/src/sentry/api/serializers/models/eventattachment.py
@@ -13,6 +13,7 @@ class EventAttachmentSerializer(Serializer):
             "id": six.text_type(obj.id),
             "name": obj.name,
             "headers": obj.file.headers,
+            "mimetype": obj.mimetype,
             "size": obj.file.size,
             "sha1": obj.file.checksum,
             "dateCreated": obj.file.timestamp,

--- a/src/sentry/static/sentry/app/components/events/eventAttachments.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventAttachments.tsx
@@ -100,9 +100,7 @@ class EventAttachments extends React.Component<Props, State> {
   };
 
   getInlineAttachmentRenderer(attachment: EventAttachment) {
-    const contentType = attachment.headers['Content-Type'] || '';
-    const mimeType = contentType.split(';')[0].trim();
-    switch (mimeType) {
+    switch (attachment.mimetype) {
       case 'text/plain':
         return attachment.size > 0 ? LogFileViewer : undefined;
       case 'text/json':

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -306,6 +306,7 @@ export type EventAttachment = {
   id: string;
   dateCreated: string;
   headers: Object;
+  mimetype: string;
   name: string;
   sha1: string;
   size: number;

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -21,7 +21,7 @@ class CreateAttachmentMixin(object):
             project_id=self.project.id,
         )
 
-        self.file = File.objects.create(name="hello.png", type="image/png")
+        self.file = File.objects.create(name="hello.png", type="image/png; foo=bar")
         self.file.putfile(six.BytesIO(b"File contents here"))
 
         self.attachment = EventAttachment.objects.create(
@@ -31,6 +31,7 @@ class CreateAttachmentMixin(object):
             type=self.file.type,
             name="hello.png",
         )
+        assert self.attachment.mimetype == "image/png"
 
         return self.attachment
 
@@ -49,6 +50,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == six.text_type(self.attachment.id)
+        assert response.data["mimetype"] == self.attachment.mimetype
 
     def test_download(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_event_attachments.py
+++ b/tests/sentry/api/endpoints/test_event_attachments.py
@@ -44,3 +44,4 @@ class EventAttachmentsTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(attachment1.id)
+        assert response.data[0]["mimetype"] == attachment1.mimetype


### PR DESCRIPTION
This exposes a mimetype via the API for event attachments even if they don't have a header set explicitly. This means that even if customers do not say what type of event something is, it still gets detected correctly.

So if someone uploads `foo.txt` we determine `text/plain` as mimetype for the UI.