### PR TITLE
test(symbolicator): Update snapshots

### DIFF
--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-11-17T16:59:10.116713Z'
+created: '2020-12-02T14:30:45.784827Z'
 creator: sentry
 source: tests/symbolicator/test_minidump_full.py
 ---
@@ -14,6 +14,16 @@ contexts:
 debug_meta:
   images:
   - arch: x86
+    candidates:
+    - download:
+        features:
+          has_debug_info: true
+          has_sources: false
+          has_symbols: true
+          has_unwind_info: true
+        status: ok
+      location: '1'
+      source: sentry:project
     code_file: C:\projects\breakpad-tools\windows\Release\crash.exe
     code_id: 5ab380779000
     debug_file: C:\projects\breakpad-tools\windows\Release\crash.pdb

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_reprocessed.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_reprocessed.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-11-17T17:07:25.663438Z'
+created: '2020-12-02T14:31:08.481940Z'
 creator: sentry
 source: tests/symbolicator/test_minidump_full.py
 ---
@@ -14,6 +14,16 @@ contexts:
 debug_meta:
   images:
   - arch: x86
+    candidates:
+    - download:
+        features:
+          has_debug_info: true
+          has_sources: false
+          has_symbols: true
+          has_unwind_info: true
+        status: ok
+      location: '4'
+      source: sentry:project
     code_file: C:\projects\breakpad-tools\windows\Release\crash.exe
     code_id: 5ab380779000
     debug_file: C:\projects\breakpad-tools\windows\Release\crash.pdb

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_debug_id_resolving.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T19:33:18.859595Z'
+created: '2020-12-02T14:31:13.628095Z'
 creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---
@@ -15,6 +15,16 @@ contexts:
 debug_meta:
   images:
   - arch: x86
+    candidates:
+    - download:
+        features:
+          has_debug_info: true
+          has_sources: false
+          has_symbols: true
+          has_unwind_info: true
+        status: ok
+      location: '5'
+      source: sentry:project
     code_file: C:\projects\breakpad-tools\windows\Release\crash.exe
     debug_id: 3249d99d-0c40-4931-8610-f4e4fb0b6936-1
     debug_status: found

--- a/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_real_resolving.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorResolvingIntegrationTest/test_real_resolving.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T19:33:42.975020Z'
+created: '2020-12-02T14:31:29.030371Z'
 creator: sentry
 source: tests/symbolicator/test_payload_full.py
 ---
@@ -7,6 +7,16 @@ contexts: null
 debug_meta:
   images:
   - arch: x86_64
+    candidates:
+    - download:
+        features:
+          has_debug_info: true
+          has_sources: false
+          has_symbols: true
+          has_unwind_info: false
+        status: ok
+      location: '6'
+      source: sentry:project
     code_file: Foo.app/Contents/Foo
     debug_id: 502fc0a5-1ec1-3e47-9998-684fa139dca7
     debug_status: found


### PR DESCRIPTION
Symbolicator snapshots need updating for the new download info
available from https://github.com/getsentry/symbolicator/pull/309.