### PR TITLE
feat(workflow): GroupOwner frontend search

### DIFF
--- a/src/sentry/static/sentry/app/stores/tagStore.tsx
+++ b/src/sentry/static/sentry/app/stores/tagStore.tsx
@@ -138,6 +138,13 @@ const tagStoreConfig: Reflux.StoreDefinition & TagStoreInterface = {
         values: [],
         predefined: true,
       },
+      owner: {
+        key: 'owner',
+        name: 'Owner',
+        isInput: true,
+        values: [],
+        predefined: true,
+      },
     };
   },
 

--- a/src/sentry/static/sentry/app/utils/withIssueTags.tsx
+++ b/src/sentry/static/sentry/app/utils/withIssueTags.tsx
@@ -87,6 +87,7 @@ const withIssueTags = <P extends InjectedTagsProps>(
         .filter(team => team.isMember)
         .map(team => `#${team.name}`);
       const allAssigned = usernames.concat(teamnames);
+      allAssigned.unshift('me_or_none');
       allAssigned.unshift('me');
       usernames.unshift('me');
 
@@ -100,6 +101,10 @@ const withIssueTags = <P extends InjectedTagsProps>(
           bookmarks: {
             ...tags.bookmarks,
             values: usernames,
+          },
+          owner: {
+            ...tags.owner,
+            values: allAssigned,
           },
         },
       });

--- a/src/sentry/static/sentry/app/utils/withIssueTags.tsx
+++ b/src/sentry/static/sentry/app/utils/withIssueTags.tsx
@@ -87,7 +87,6 @@ const withIssueTags = <P extends InjectedTagsProps>(
         .filter(team => team.isMember)
         .map(team => `#${team.name}`);
       const allAssigned = usernames.concat(teamnames);
-      allAssigned.unshift('me_or_none');
       allAssigned.unshift('me');
       usernames.unshift('me');
 

--- a/tests/js/spec/utils/withIssueTags.spec.jsx
+++ b/tests/js/spec/utils/withIssueTags.spec.jsx
@@ -51,7 +51,7 @@ describe('withIssueTags HoC', function () {
 
     let tagsProp = wrapper.find('MyComponent').prop('tags');
     expect(tagsProp.assigned).toBeTruthy();
-    expect(tagsProp.assigned.values).toEqual(['me', 'me_or_none']);
+    expect(tagsProp.assigned.values).toEqual(['me']);
 
     const users = [TestStubs.User(), TestStubs.User({username: 'joe@example.com'})];
     TeamStore.loadInitialData([
@@ -63,14 +63,12 @@ describe('withIssueTags HoC', function () {
     tagsProp = wrapper.find('MyComponent').prop('tags');
     expect(tagsProp.assigned.values).toEqual([
       'me',
-      'me_or_none',
       'foo@example.com',
       'joe@example.com',
       '#best-team-na',
     ]);
     expect(tagsProp.owner.values).toEqual([
       'me',
-      'me_or_none',
       'foo@example.com',
       'joe@example.com',
       '#best-team-na',

--- a/tests/js/spec/utils/withIssueTags.spec.jsx
+++ b/tests/js/spec/utils/withIssueTags.spec.jsx
@@ -51,7 +51,7 @@ describe('withIssueTags HoC', function () {
 
     let tagsProp = wrapper.find('MyComponent').prop('tags');
     expect(tagsProp.assigned).toBeTruthy();
-    expect(tagsProp.assigned.values).toEqual(['me']);
+    expect(tagsProp.assigned.values).toEqual(['me', 'me_or_none']);
 
     const users = [TestStubs.User(), TestStubs.User({username: 'joe@example.com'})];
     TeamStore.loadInitialData([
@@ -63,6 +63,14 @@ describe('withIssueTags HoC', function () {
     tagsProp = wrapper.find('MyComponent').prop('tags');
     expect(tagsProp.assigned.values).toEqual([
       'me',
+      'me_or_none',
+      'foo@example.com',
+      'joe@example.com',
+      '#best-team-na',
+    ]);
+    expect(tagsProp.owner.values).toEqual([
+      'me',
+      'me_or_none',
       'foo@example.com',
       'joe@example.com',
       '#best-team-na',


### PR DESCRIPTION
Adding in autocomplete for the frontend portion of group owner search. Utilizes https://github.com/getsentry/sentry/pull/22304 for the backend search logic.

![image](https://user-images.githubusercontent.com/9372512/100906436-2f1bf700-3497-11eb-802a-e447e9aeec02.png)
