### PR TITLE
fix(alerts): Don't show tags for a function only dropdown

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -61,6 +61,10 @@ type Props = {
    * used for the metric alert builder.
    */
   inFieldLabels?: boolean;
+  /**
+   * Whether or not to add the tag explaining the FieldValueKind of each field
+   */
+  shouldRenderTag?: boolean;
   onChange: (fieldValue: QueryFieldValue) => void;
   disabled?: boolean;
 };
@@ -360,6 +364,10 @@ class QueryField extends React.Component<Props> {
   }
 
   renderTag(kind) {
+    const {shouldRenderTag} = this.props;
+    if (shouldRenderTag === false) {
+      return null;
+    }
     let text, tagType;
     switch (kind) {
       case FieldValueKind.FUNCTION:

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -121,6 +121,7 @@ const MetricField = ({organization, columnWidth, inFieldLabels, ...props}: Props
             columnWidth={columnWidth}
             gridColumns={numParameters}
             inFieldLabels={inFieldLabels}
+            shouldRenderTag={false}
             disabled={disabled}
           />
         </React.Fragment>

--- a/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
@@ -83,7 +83,7 @@ describe('MetricField', function () {
     wrapper.find('FieldHelp button[aria-label="Failure rate"]').simulate('click');
 
     expect(wrapper.find('QueryField SingleValue SingleValue').text()).toEqual(
-      'failure_rate()f(x)'
+      'failure_rate()'
     );
   });
 });


### PR DESCRIPTION
- This dropdown is only ever a list of functions, and we already say its
  a function, so there's no need for the tags here
Before:
<img width="290" alt="image" src="https://user-images.githubusercontent.com/4205004/100931323-60f18580-34b8-11eb-89c1-192ba576fcbc.png">

After:
<img width="250" alt="image" src="https://user-images.githubusercontent.com/4205004/100931342-6949c080-34b8-11eb-8599-9ea628c567e3.png">