### PR TITLE
fix(py3): Make sure we only bump the cache version for memcache (and not redis)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -10,7 +10,6 @@ import os.path
 import re
 import socket
 import sys
-import six
 import tempfile
 
 import sentry
@@ -1134,7 +1133,7 @@ CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 # The cache version affects both Django's internal cache (at runtime) as well
 # as Sentry's cache. This automatically overrides VERSION on the default
 # CACHES backend.
-CACHE_VERSION = 2 if six.PY3 else 1
+CACHE_VERSION = 1
 
 # Digests backend
 SENTRY_DIGESTS = "sentry.digests.backends.dummy.DummyBackend"

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -317,7 +317,7 @@ def initialize_app(config, skip_service_validation=False):
 
     for key in settings.CACHES:
         if not hasattr(settings.CACHES[key], "VERSION"):
-            settings.CACHES[key]["VERSION"] = settings.CACHE_VERSION
+            settings.CACHES[key]["VERSION"] = 2 if six.PY3 else 1
 
     settings.ASSET_VERSION = get_asset_version(settings)
     settings.STATIC_URL = settings.STATIC_URL.format(version=settings.ASSET_VERSION)

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -5,13 +5,12 @@ from __future__ import absolute_import
 from sentry.utils.compat import mock
 import zlib
 import pytest
-import six
 
 from sentry.cache.redis import RedisClusterCache, RbCache
 from sentry.utils.imports import import_string
 
 
-KEY_FMT = "c:2:%s" if six.PY3 else "c:1:%s"
+KEY_FMT = "c:1:%s"
 
 
 class FakeClient(object):

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import
 
 from django.core.urlresolvers import reverse
-from django.core.cache import cache
 
+from sentry.cache import default_cache
 from sentry.testutils import PermissionTestCase
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY
 
@@ -24,7 +24,7 @@ class SetupWizard(PermissionTestCase):
         self.login_as(self.user)
 
         key = "%s%s" % (SETUP_WIZARD_CACHE_KEY, "abc")
-        cache.set(key, "test")
+        default_cache.set(key, "test", 600)
 
         url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "abc"})
         resp = self.client.get(url)
@@ -49,14 +49,14 @@ class SetupWizard(PermissionTestCase):
         self.login_as(self.user)
 
         key = "%s%s" % (SETUP_WIZARD_CACHE_KEY, "abc")
-        cache.set(key, "test")
+        default_cache.set(key, "test", 600)
 
         url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "abc"})
         resp = self.client.get(url)
 
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/setup-wizard.html")
-        cached = cache.get(key)
+        cached = default_cache.get(key)
         assert cached.get("apiKeys").get("scopes")[0] == "project:releases"
         assert cached.get("projects")[0].get("status") == "active"
         assert cached.get("projects")[0].get("keys")[0].get("isActive")


### PR DESCRIPTION
We dropped a bunch of events while testing the py3 deploy. Turns out that our changes in https://github.com/getsentry/sentry/pull/22283
caused us to bump the redis cache version, which causes event failures.