### PR TITLE
fix(py3): Fix `EventSerializer` to handle sorting tags with `None` keys

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -112,7 +112,7 @@ class EventSerializer(Serializer):
                 for i, kv in enumerate(raw_tags)
                 if kv is not None
             ],
-            key=lambda x: x["key"],
+            key=lambda x: x["key"] if x["key"] is not None else "",
         )
 
         # Add 'query' for each tag to tell the UI what to use as query


### PR DESCRIPTION
We can't compare `None` to `str`, but for the sake of comparison using an empty string will work
fine.