### PR TITLE
fix(py3): Fix jira integration field sort to not compare ints and strings.

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -626,10 +626,16 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
         # apply ordering to fields based on some known built-in Jira fields.
         # otherwise weird ordering occurs.
-        anti_gravity = {"priority": -150, "fixVersions": -125, "components": -100, "security": -50}
+        anti_gravity = {
+            "priority": (-150, ""),
+            "fixVersions": (-125, ""),
+            "components": (-100, ""),
+            "security": (-50, ""),
+        }
 
         dynamic_fields = list(issue_type_meta["fields"].keys())
-        dynamic_fields.sort(key=lambda f: anti_gravity.get(f) or f)
+        # Sort based on priority, then field name
+        dynamic_fields.sort(key=lambda f: anti_gravity.get(f, (0, f)))
 
         # build up some dynamic fields based on required shit.
         for field in dynamic_fields:


### PR DESCRIPTION
The intention here is to sort by the priority order first, and then sort alphabetically. Previously
py2 would do this magically, but in py3 we need to be more explicit.

Fixes SENTRY-JTJ