### PR TITLE
fix(py3): Don't pass invalid http status codes to `span.set_http_status`

### DIFF
--- a/src/sentry/integrations/slack/client.py
+++ b/src/sentry/integrations/slack/client.py
@@ -16,7 +16,11 @@ class SlackClient(ApiClient):
     datadog_prefix = "integrations.slack"
 
     def track_response_data(self, code, span, error=None, resp=None):
-        span.set_http_status(code)
+        try:
+            span.set_http_status(int(code))
+        except ValueError:
+            span.set_status(code)
+
         span.set_tag("integration", "slack")
 
         is_ok = False


### PR DESCRIPTION
We already fixed this elsewhere in https://github.com/getsentry/sentry/pull/20201. Unfortunately
that code  was duplicated, so fixing it here too.

Fixes SENTRY-JTQ