### PR TITLE
fix(py3): Fix `glob_match` to work when value is `None`.

### DIFF
--- a/src/sentry/utils/glob.py
+++ b/src/sentry/utils/glob.py
@@ -8,7 +8,7 @@ def glob_match(
 ):
     """A beefed up version of fnmatch.fnmatch"""
     return sentry_relay.is_glob_match(
-        value,
+        value if value is not None else "",
         pat,
         double_star=doublestar,
         case_insensitive=ignorecase,

--- a/tests/sentry/utils/test_glob.py
+++ b/tests/sentry/utils/test_glob.py
@@ -23,6 +23,8 @@ class GlobInput(object):
     [
         [GlobInput("hello.py", "*.py"), True],
         [GlobInput("hello.py", "*.js"), False],
+        [GlobInput(None, "*.js"), False],
+        [GlobInput(None, "*"), True],
         [GlobInput("foo/hello.py", "*.py"), True],
         [GlobInput("foo/hello.py", "*.py", doublestar=True), False],
         [GlobInput("foo/hello.py", "**/*.py", doublestar=True), True],


### PR DESCRIPTION
This also matches the behaviour in py2 - a pattern of `*` will still match a `None` value.

Fixes SENTRY-JTB