### PR TITLE
build(ci): Fix getsentry javascript dispatch

### DIFF
--- a/.github/workflows/js-getsentry-dispatch.yml
+++ b/.github/workflows/js-getsentry-dispatch.yml
@@ -42,7 +42,7 @@ jobs:
             github.actions.createWorkflowDispatch({
               owner: 'getsentry',
               repo: 'getsentry',
-              workflow_id: 'javascript.yml',
+              workflow_id: 'js-build-and-lint.yml',
               ref: 'master',
               inputs: {
                 'skip': "${{ steps.changes.outputs.frontend != 'true' }}",


### PR DESCRIPTION
This broke due to https://github.com/getsentry/getsentry/pull/4787 when I changed the workflow filename, because of `pull_request_target`, this PR is going to fail, but you can see it working here https://github.com/getsentry/sentry/pull/22427 