### PR TITLE
build: Support normalized paths used for WSL shared folders

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -106,7 +106,8 @@ for pkg in \
     docker \
     chromedriver \
     pkg-config \
-    openssl; do
+    openssl \
+    coreutils; do
     if ! require "$pkg"; then
         die "You seem to be missing the system dependency: ${pkg}
 Please install homebrew, and run brew bundle."
@@ -151,7 +152,7 @@ source ${venv_name}/bin/activate
 unset PS1
 
 # We're explicitly disallowing symlinked venvs (python would resolve to the canonical location)
-if [ "$(command -v python)" != "${PWD}/${venv_name}/bin/python" ]; then
+if [ "$(command -v python)" != $(realpath "${PWD}/${venv_name}/bin/python") ]; then
     info "Failed to activate virtualenv. Your virtualenv's probably symlinked." \
         "We want everyone to be on the same page here, so you'll have to recreate your virtualenv."
     advice_init_venv "$python_version" "$venv_name"
@@ -165,7 +166,7 @@ else
         die "For some reason, the virtualenv isn't Python 2.7."
 fi
 
-if [ "$(command -v sentry)" != "${PWD}/${venv_name}/bin/sentry" ]; then
+if [ "$(command -v sentry)" != $(realpath "${PWD}/${venv_name}/bin/sentry") ]; then
     info "Your virtual env is activated, but sentry doesn't seem to be installed."
     # XXX: if direnv fails, the venv won't be activated outside of direnv execution...
     # So, it is critical that make install-py-dev is guarded by scripts/ensure-venv.

--- a/Brewfile
+++ b/Brewfile
@@ -8,6 +8,8 @@ brew 'readline'
 brew 'watchman'
 
 # required to build some of sentry's dependencies
+# XXX: we need realpath here for macOS to be uniform with Linux
+brew 'coreutils'
 brew 'pkgconfig'
 brew 'libxmlsec1'
 brew 'geoip'

--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -21,7 +21,7 @@ die() {
 
 if [ -n "$VIRTUAL_ENV" ]; then
     # we're enforcing that virtualenv be in .venv, since future tooling e.g. venv-update will rely on this.
-    if [ "$VIRTUAL_ENV" != "${PWD}/${venv_name}" ]; then
+    if [ "$VIRTUAL_ENV" != $(realpath "${PWD}/${venv_name}") ]; then
         die "You're in a virtualenv, but it's not in the expected location (${PWD}/${venv_name})"
     fi
 


### PR DESCRIPTION
Generically we need to use realpath when referencing `$PWD` (and likely others) in order to resolve symlinks fully.