### PR TITLE
fix(workflow): Scoping rate limit to request ip

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -480,7 +480,7 @@ def rate_limit_endpoint(limit=1, window=1):
                     status=429,
                 )
             else:
-                return function(*args, **kwargs)
+                return function(self, request, *args, **kwargs)
 
         return wrapper
 

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -465,7 +465,7 @@ def track_update_groups(function):
 def rate_limit_endpoint(limit=1, window=1):
     def inner(function):
         def wrapper(self, request, *args, **kwargs):
-            ip = request.META.get("REMOTE_ADDR")
+            ip = request.META["REMOTE_ADDR"]
             if ratelimiter.is_limited(
                 u"rate_limit_endpoint:{}:{}".format(md5_text(function).hexdigest(), ip),
                 limit=limit,

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -464,10 +464,12 @@ def track_update_groups(function):
 
 def rate_limit_endpoint(limit=1, window=1):
     def inner(function):
-        def wrapper(*args, **kwargs):
+        def wrapper(self, request, *args, **kwargs):
             try:
                 if ratelimiter.is_limited(
-                    u"rate_limit_endpoint:{}".format(md5_text(function).hexdigest()),
+                    u"rate_limit_endpoint:{}:{}".format(
+                        md5_text(function).hexdigest(), request.user.id
+                    ),
                     limit=limit,
                     window=window,
                 ):


### PR DESCRIPTION
This rate limit was being applied sentry-wide, which is bad.
<img width="334" alt="Screen Shot 2020-12-03 at 3 42 30 PM" src="https://user-images.githubusercontent.com/6395250/101086021-471a7600-357e-11eb-8e86-60707d11108f.png">

This PR adds the request ip to the key, making it less bad. 

I hope. And that's where you come in.