### PR TITLE
build: Remove hard path assertions for venv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -146,17 +146,10 @@ source "${venv_name}/bin/activate"
 #      but we'd have to patch direnv, and ".venv" isn't descriptive anyways
 unset PS1
 
-# We're explicitly disallowing symlinked venvs (python would resolve to the canonical location)
-if [ "$(command -v python)" != "${PWD}/${venv_name}/bin/python" ]; then
-    info "Failed to activate virtualenv. Your virtualenv's probably symlinked." \
-        "We want everyone to be on the same page here, so you'll have to recreate your virtualenv."
-    advice_init_venv "$python_version" "$venv_name"
-fi
-
 info "Ensuring proper virtualenv..."
 ${PWD}/scripts/ensure-venv.sh
 
-if [ "$(command -v sentry)" != "${PWD}/${venv_name}/bin/sentry" ]; then
+if [ ! "$(command -v sentry)" ]; then
     info "Your virtualenv is activated, but sentry doesn't seem to be installed."
     # XXX: if direnv fails, the venv won't be activated outside of direnv execution...
     # So, it is critical that make install-py-dev is guarded by scripts/ensure-venv.


### PR DESCRIPTION
Ensures we can operate with $PWD being symlinked on environments like WSL2.