### PR TITLE
fix(onboarding) Fix feature name in project setup

### DIFF
--- a/src/sentry/static/sentry/app/views/projectInstall/platform.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.tsx
@@ -166,7 +166,7 @@ class ProjectInstallPlatform extends React.Component<Props, State> {
                   <React.Fragment>
                     {showPerformancePrompt && (
                       <Feature
-                        features={['organization:performance-view']}
+                        features={['performance-view']}
                         hookName="feature-disabled:performance-new-project"
                       >
                         {({hasFeature}) => {


### PR DESCRIPTION
Use the correct feature name so that an info alert doesn't show to all accounts.