### PR TITLE
fix(alerts): Add default for count_unqiue metric (WOR-310)

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/metricField.tsx
@@ -8,7 +8,9 @@ import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {
+  Aggregation,
   AGGREGATIONS,
+  ColumnType,
   explodeFieldString,
   FIELDS,
   generateFieldAsString,
@@ -35,11 +37,20 @@ type Props = Omit<FormField['props'], 'children'> & {
 const getFieldOptionConfig = (dataset: Dataset) => {
   const config = dataset === Dataset.ERRORS ? errorFieldConfig : transactionFieldConfig;
 
-  const aggregations = Object.fromEntries(
-    config.aggregations.map(key => [key, AGGREGATIONS[key]])
+  const aggregations = Object.fromEntries<Aggregation>(
+    config.aggregations.map(key => {
+      // TODO(scttcper): Temporary hack for default value while we handle the translation of user
+      if (key === 'count_unique') {
+        const agg = AGGREGATIONS[key] as Aggregation;
+        agg.generateDefaultValue = () => 'tags[sentry:user]';
+        return [key, agg];
+      }
+
+      return [key, AGGREGATIONS[key]];
+    })
   );
 
-  const fields = Object.fromEntries(
+  const fields = Object.fromEntries<ColumnType>(
     config.fields.map(key => {
       // XXX(epurkhiser): Temporary hack while we handle the translation of user ->
       // tags[sentry:user].

--- a/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/metricField.spec.jsx
@@ -37,6 +37,12 @@ describe('MetricField', function () {
     openMenu(wrapper, {selector: 'QueryField', at: 1});
 
     expect(wrapper.find('SelectControl').at(1).find('Option')).toHaveLength(1);
+    expect(wrapper.find('SelectControl').at(1).find('input').at(1).props().value).toEqual(
+      {
+        kind: 'field',
+        meta: {dataType: 'string', name: 'tags[sentry:user]'},
+      }
+    );
   });
 
   it('has a select subset of transaction fields', function () {


### PR DESCRIPTION
Using `tags[sentry:user]` instead of `user` is why it doesn't have a default value. This will set up count_unique to properly start with this value.