### PR TITLE
build(ci): Fail job if eslint fix has changed files

### DIFF
--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -78,7 +78,6 @@ jobs:
       # Apply fixed files via pull request review comments
       - name: Apply any eslint fixed files as Pull Request review comments
         if: github.ref != 'refs/heads/master' && steps.changes.outputs.frontend == 'true'
-        continue-on-error: true
         uses: getsentry/action-git-diff-suggestions@main
         with:
           message: eslint made this change


### PR DESCRIPTION
`eslint --fix` exits with 0 (non error) when it reformats a file. There is no way to do otherwise, see eslint/eslint#10099. In this case we do not want to continue if there is an error as it should fail the job because lint failed.
