### PR TITLE
test(snapshots): Fix loading in Performance Summary snapshot

### DIFF
--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -66,6 +66,8 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
             self.browser.wait_until_not(
                 '[data-test-id="grid-editable"] [data-test-id="empty-state"]', timeout=2
             )
+            # We have to wait for this again because there are loaders inside of the table
+            self.page.wait_until_loaded()
             self.browser.snapshot("performance summary - with data")
 
     @patch("django.utils.timezone.now")


### PR DESCRIPTION
We need multiple wait_until_loaded here as it can be snapshotted with loading indicators in the grid.