### PR TITLE
fix(ui): Correct bad default sizing of boolean fields

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/booleanField.tsx
@@ -52,6 +52,7 @@ export default class BooleanField extends React.Component<Props> {
 
           const switchProps = {
             ...props,
+            size: 'lg' as React.ComponentProps<typeof Switch>['size'],
             isActive: !!value,
             isDisabled: disabled,
             toggle: handleChange,
@@ -66,7 +67,6 @@ export default class BooleanField extends React.Component<Props> {
                 {({open}) => (
                   <Switch
                     {...switchProps}
-                    size="lg"
                     toggle={(e: React.MouseEvent) => {
                       // If we have a `confirm` prop and enabling switch
                       // Then show confirm dialog, otherwise propagate change as normal


### PR DESCRIPTION
Regressed here: https://github.com/getsentry/sentry/commit/d924458667a7e3c206e6633f8d942d1996f4fc61#diff-fc1bfdbec8ed959e64e5676f0290cb2cd8500187aa137804bf6e49a10b6b8bbdL39