### PR TITLE
ci(py3): Make py2 builds available under `-py2` suffix

### DIFF
--- a/docker/builder.dockerfile
+++ b/docker/builder.dockerfile
@@ -44,9 +44,6 @@ VOLUME ["/workspace/node_modules", "/workspace/build"]
 COPY docker/builder.sh /builder.sh
 ENTRYPOINT [ "/builder.sh" ]
 
-# TODO: Remove this once PY3 becomes stable
-ENV SENTRY_PYTHON3=1
-
 ARG SOURCE_COMMIT
 ENV SENTRY_BUILD=${SOURCE_COMMIT:-unknown}
 LABEL org.opencontainers.image.revision=$SOURCE_COMMIT

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -64,6 +64,8 @@ steps:
       - get-onpremise-repo
     entrypoint: 'bash'
     dir: onpremise
+    env:
+      - 'SENTRY_PYTHON2=1'
     args:
       - '-e'
       - '-c'
@@ -127,6 +129,12 @@ steps:
         docker push $$DOCKER_REPO:$COMMIT_SHA
         docker tag $$SENTRY_IMAGE $$DOCKER_REPO:nightly
         docker push $$DOCKER_REPO:nightly
+        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:$SHORT_SHA-py2
+        docker push $$DOCKER_REPO:$SHORT_SHA-py2
+        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:$COMMIT_SHA-py2
+        docker push $$DOCKER_REPO:$COMMIT_SHA-py2
+        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:nightly-py2
+        docker push $$DOCKER_REPO:nightly-py2
   - name: 'gcr.io/cloud-builders/docker'
     id: docker-push-py3
     waitFor:


### PR DESCRIPTION
This is in preparation to make the PY3 version the default for Docker images and self-hosted. It is part **1/5**:

1. **Add `-py2` variants for the Python 2 bulid tags and introduce the `SENTRY_PYTHON2` env variable usage**
2. Switch getsentry/onpremise to Python 3 by default, introducing the `SENTRY_PYTHON2` env var for Py2 builds via the `-py2` suffix
3. Move the unsuffixed version of the builds to Python 3
4. Remove the `SENTRY_PYTHON3` env var support and `-py3` prefix usage from getsentry/onpremise
5. Remove tagging of `-py3` builds from here
