### PR TITLE
feat(issues): Decompose request for issue data

### DIFF
--- a/src/sentry/static/sentry/app/actions/groupActions.tsx
+++ b/src/sentry/static/sentry/app/actions/groupActions.tsx
@@ -18,6 +18,7 @@ const GroupActions = Reflux.createActions([
   'merge',
   'mergeError',
   'mergeSuccess',
+  'populateStats',
 ]);
 
 export default GroupActions;

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -18,6 +18,7 @@ import Link from 'app/components/links/link';
 import MenuItem from 'app/components/menuItem';
 import {getRelativeSummary} from 'app/components/organizations/timeRangeSelector/utils';
 import {PanelItem} from 'app/components/panels';
+import Placeholder from 'app/components/placeholder';
 import GroupChart from 'app/components/stream/groupChart';
 import GroupCheckBox from 'app/components/stream/groupCheckBox';
 import GroupRowActions from 'app/components/stream/groupRowActions';
@@ -265,33 +266,104 @@ class StreamGroup extends React.Component<Props, State> {
               </InboxReasonWrapper>
             )}
             <div>
-              <TimesTag
-                lastSeen={data.lifetime?.lastSeen || data.lastSeen}
-                firstSeen={data.lifetime?.firstSeen || data.firstSeen}
-              />
+              {!data.lifetime && !data.lastSeen ? (
+                <Placeholder height="14px" />
+              ) : (
+                <TimesTag
+                  lastSeen={data.lifetime?.lastSeen || data.lastSeen}
+                  firstSeen={data.lifetime?.firstSeen || data.firstSeen}
+                />
+              )}
             </div>
           </ReasonAndTimesContainer>
         )}
         {hasGuideAnchor && <GuideAnchor target="issue_stream" />}
         {withChart && (
           <Box width={160} mx={2} className="hidden-xs hidden-sm">
-            <GroupChart
-              statsPeriod={statsPeriod!}
-              data={data}
-              showSecondaryPoints={showSecondaryPoints}
-            />
+            {!data.filtered?.stats && !data.stats ? (
+              <Placeholder height="24px" />
+            ) : (
+              <GroupChart
+                statsPeriod={statsPeriod!}
+                data={data}
+                showSecondaryPoints={showSecondaryPoints}
+              />
+            )}
           </Box>
         )}
         <Flex width={[40, 60, 80, 80]} mx={2} justifyContent="flex-end">
-          <DropdownMenu isNestedDropdown>
-            {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
-              const topLevelCx = classNames('dropdown', {
-                'anchor-middle': true,
-                open: isOpen,
-              });
+          {primaryCount === undefined ? (
+            <Placeholder height="18px" />
+          ) : (
+            <DropdownMenu isNestedDropdown>
+              {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
+                const topLevelCx = classNames('dropdown', {
+                  'anchor-middle': true,
+                  open: isOpen,
+                });
 
-              return (
-                <GuideAnchor target="dynamic_counts" disabled={!hasGuideAnchor}>
+                return (
+                  <GuideAnchor target="dynamic_counts" disabled={!hasGuideAnchor}>
+                    <span
+                      {...getRootProps({
+                        className: topLevelCx,
+                      })}
+                    >
+                      <span {...getActorProps({})}>
+                        <div className="dropdown-actor-title">
+                          <PrimaryCount value={primaryCount} />
+                          {secondaryCount !== undefined && (
+                            <SecondaryCount value={secondaryCount} />
+                          )}
+                        </div>
+                      </span>
+                      <StyledDropdownList
+                        {...getMenuProps({className: 'dropdown-menu inverted'})}
+                      >
+                        {data.filtered && (
+                          <React.Fragment>
+                            <StyledMenuItem to={this.getDiscoverUrl(true)}>
+                              <MenuItemText>{t('Matching search filters')}</MenuItemText>
+                              <MenuItemCount value={data.filtered.count} />
+                            </StyledMenuItem>
+                            <MenuItem divider />
+                          </React.Fragment>
+                        )}
+
+                        <StyledMenuItem to={this.getDiscoverUrl()}>
+                          <MenuItemText>{t(`Total in ${summary}`)}</MenuItemText>
+                          <MenuItemCount value={data.count} />
+                        </StyledMenuItem>
+
+                        {data.lifetime && (
+                          <React.Fragment>
+                            <MenuItem divider />
+                            <StyledMenuItem>
+                              <MenuItemText>{t('Since issue began')}</MenuItemText>
+                              <MenuItemCount value={data.lifetime.count} />
+                            </StyledMenuItem>
+                          </React.Fragment>
+                        )}
+                      </StyledDropdownList>
+                    </span>
+                  </GuideAnchor>
+                );
+              }}
+            </DropdownMenu>
+          )}
+        </Flex>
+        <Flex width={[40, 60, 80, 80]} mx={2} justifyContent="flex-end">
+          {primaryUserCount === undefined ? (
+            <Placeholder height="18px" />
+          ) : (
+            <DropdownMenu isNestedDropdown>
+              {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
+                const topLevelCx = classNames('dropdown', {
+                  'anchor-middle': true,
+                  open: isOpen,
+                });
+
+                return (
                   <span
                     {...getRootProps({
                       className: topLevelCx,
@@ -299,9 +371,9 @@ class StreamGroup extends React.Component<Props, State> {
                   >
                     <span {...getActorProps({})}>
                       <div className="dropdown-actor-title">
-                        <PrimaryCount value={primaryCount} />
-                        {secondaryCount !== undefined && (
-                          <SecondaryCount value={secondaryCount} />
+                        <PrimaryCount value={primaryUserCount} />
+                        {secondaryUserCount !== undefined && (
+                          <SecondaryCount dark value={secondaryUserCount} />
                         )}
                       </div>
                     </span>
@@ -312,7 +384,7 @@ class StreamGroup extends React.Component<Props, State> {
                         <React.Fragment>
                           <StyledMenuItem to={this.getDiscoverUrl(true)}>
                             <MenuItemText>{t('Matching search filters')}</MenuItemText>
-                            <MenuItemCount value={data.filtered.count} />
+                            <MenuItemCount value={data.filtered.userCount} />
                           </StyledMenuItem>
                           <MenuItem divider />
                         </React.Fragment>
@@ -320,7 +392,7 @@ class StreamGroup extends React.Component<Props, State> {
 
                       <StyledMenuItem to={this.getDiscoverUrl()}>
                         <MenuItemText>{t(`Total in ${summary}`)}</MenuItemText>
-                        <MenuItemCount value={data.count} />
+                        <MenuItemCount value={data.userCount} />
                       </StyledMenuItem>
 
                       {data.lifetime && (
@@ -328,71 +400,16 @@ class StreamGroup extends React.Component<Props, State> {
                           <MenuItem divider />
                           <StyledMenuItem>
                             <MenuItemText>{t('Since issue began')}</MenuItemText>
-                            <MenuItemCount value={data.lifetime.count} />
+                            <MenuItemCount value={data.lifetime.userCount} />
                           </StyledMenuItem>
                         </React.Fragment>
                       )}
                     </StyledDropdownList>
                   </span>
-                </GuideAnchor>
-              );
-            }}
-          </DropdownMenu>
-        </Flex>
-        <Flex width={[40, 60, 80, 80]} mx={2} justifyContent="flex-end">
-          <DropdownMenu isNestedDropdown>
-            {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
-              const topLevelCx = classNames('dropdown', {
-                'anchor-middle': true,
-                open: isOpen,
-              });
-
-              return (
-                <span
-                  {...getRootProps({
-                    className: topLevelCx,
-                  })}
-                >
-                  <span {...getActorProps({})}>
-                    <div className="dropdown-actor-title">
-                      <PrimaryCount value={primaryUserCount} />
-                      {secondaryUserCount !== undefined && (
-                        <SecondaryCount dark value={secondaryUserCount} />
-                      )}
-                    </div>
-                  </span>
-                  <StyledDropdownList
-                    {...getMenuProps({className: 'dropdown-menu inverted'})}
-                  >
-                    {data.filtered && (
-                      <React.Fragment>
-                        <StyledMenuItem to={this.getDiscoverUrl(true)}>
-                          <MenuItemText>{t('Matching search filters')}</MenuItemText>
-                          <MenuItemCount value={data.filtered.userCount} />
-                        </StyledMenuItem>
-                        <MenuItem divider />
-                      </React.Fragment>
-                    )}
-
-                    <StyledMenuItem to={this.getDiscoverUrl()}>
-                      <MenuItemText>{t(`Total in ${summary}`)}</MenuItemText>
-                      <MenuItemCount value={data.userCount} />
-                    </StyledMenuItem>
-
-                    {data.lifetime && (
-                      <React.Fragment>
-                        <MenuItem divider />
-                        <StyledMenuItem>
-                          <MenuItemText>{t('Since issue began')}</MenuItemText>
-                          <MenuItemCount value={data.lifetime.userCount} />
-                        </StyledMenuItem>
-                      </React.Fragment>
-                    )}
-                  </StyledDropdownList>
-                </span>
-              );
-            }}
-          </DropdownMenu>
+                );
+              }}
+            </DropdownMenu>
+          )}
         </Flex>
         <Box width={80} mx={2} className="hidden-xs hidden-sm">
           <AssigneeSelector id={data.id} memberList={memberList} />

--- a/src/sentry/static/sentry/app/stores/groupStore.tsx
+++ b/src/sentry/static/sentry/app/stores/groupStore.tsx
@@ -5,7 +5,7 @@ import Reflux from 'reflux';
 import GroupActions from 'app/actions/groupActions';
 import {t} from 'app/locale';
 import IndicatorStore from 'app/stores/indicatorStore';
-import {Activity, Group} from 'app/types';
+import {Activity, BaseGroup, Group, GroupStats} from 'app/types';
 
 function showAlert(msg, type) {
   IndicatorStore.addMessage(msg, type, {
@@ -52,15 +52,15 @@ type Internals = {
 type GroupStoreInterface = Reflux.StoreDefinition & {
   init: () => void;
   reset: () => void;
-  loadInitialData: (items: Group[]) => void;
-  add: (items: Group[]) => void;
+  loadInitialData: (items: BaseGroup[] | Group[]) => void;
+  add: (items: BaseGroup[] | Group[]) => void;
   remove: (itemId: string) => void;
   addStatus: (id: string, status: string) => void;
   clearStatus: (id: string, status: string) => void;
   hasStatus: (id: string, status: string) => boolean;
-  get: (id: string) => Group | undefined;
+  get: (id: string) => BaseGroup | Group | undefined;
   getAllItemIds: () => string[];
-  getAllItems: () => Group[];
+  getAllItems: () => BaseGroup[] | Group[];
   onAssignTo: (changeId: string, itemId: string, data: any) => void;
   onAssignToError: (changeId: string, itemId: string, error: Error) => void;
   onAssignToSuccess: (changeId: string, itemId: string, response: any) => void;
@@ -85,6 +85,7 @@ type GroupStoreInterface = Reflux.StoreDefinition & {
     error: Error,
     silent: boolean
   ) => void;
+  onPopulateStats: (itemIds: string[], response: GroupStats[]) => void;
 };
 
 type GroupStore = Reflux.Store & GroupStoreInterface;
@@ -474,6 +475,24 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupStoreInterface = {
       }
     });
     this.pendingChanges.remove(changeId);
+    this.trigger(new Set(itemIds));
+  },
+
+  onPopulateStats(itemIds: string[], response: GroupStats[]) {
+    // Organize stats by id
+    const groupStatsMap = response.reduce((map, stats) => {
+      map[stats.id] = stats;
+      return map;
+    }, {});
+
+    this.items.forEach((item, idx) => {
+      if (itemIds.indexOf(item.id) !== -1) {
+        this.items[idx] = {
+          ...item,
+          ...groupStatsMap[item.id],
+        };
+      }
+    });
     this.trigger(new Set(itemIds));
   },
 };

--- a/src/sentry/static/sentry/app/stores/groupStore.tsx
+++ b/src/sentry/static/sentry/app/stores/groupStore.tsx
@@ -486,7 +486,7 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupStoreInterface = {
     }, {});
 
     this.items.forEach((item, idx) => {
-      if (itemIds.indexOf(item.id) !== -1) {
+      if (itemIds.includes(item.id)) {
         this.items[idx] = {
           ...item,
           ...groupStatsMap[item.id],

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -819,14 +819,6 @@ export type SuggestedOwner = {
   date_added: string;
 };
 
-type GroupFiltered = {
-  count: string;
-  stats: Record<string, TimeseriesValue[]>;
-  lastSeen: string;
-  firstSeen: string;
-  userCount: number;
-};
-
 type GroupActivityData = {
   eventCount?: number;
   newGroupId?: number;
@@ -842,8 +834,22 @@ type GroupActivity = {
   user?: null | User;
 };
 
+type GroupFiltered = {
+  count: string;
+  stats: Record<string, TimeseriesValue[]>;
+  lastSeen: string;
+  firstSeen: string;
+  userCount: number;
+};
+
+export type GroupStats = GroupFiltered & {
+  lifetime?: GroupFiltered;
+  filtered: GroupFiltered | null;
+  id: string;
+};
+
 // TODO(ts): incomplete
-export type Group = GroupFiltered & {
+export type BaseGroup = {
   id: string;
   latestEvent: Event;
   activity: GroupActivity[];
@@ -879,11 +885,11 @@ export type Group = GroupFiltered & {
   type: EventOrGroupType;
   userReportCount: number;
   subscriptionDetails: {disabled?: boolean; reason?: string} | null;
-  filtered: GroupFiltered | null;
-  lifetime?: any; // TODO(ts)
   inbox?: InboxDetails | null;
   owners?: SuggestedOwner[] | null;
 };
+
+export type Group = BaseGroup & GroupStats;
 
 export type GroupTombstone = {
   id: string;

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -341,6 +341,10 @@ class IssueListOverview extends React.Component<Props, State> {
   }
 
   fetchStats = async (groups: string[]) => {
+    // If we have no groups to fetch, just skip stats
+    if (!groups.length) {
+      return;
+    }
     const requestParams: StatEndpointParams = {
       ...this.getEndpointParams(),
       groups,

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -488,9 +488,9 @@ class IssueListOverview extends React.Component<Props, State> {
   }
 
   getGroupStatsEndpoint(): string {
-    const params = this.props.params;
+    const {orgId} = this.props.params;
 
-    return `/organizations/${params.orgId}/issues-stats/`;
+    return `/organizations/${orgId}/issues-stats/`;
   }
 
   onRealtimeChange = (realtime: boolean) => {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -226,7 +226,7 @@ class GroupDetails extends React.Component<Props, State> {
   onGroupChange(itemIds: Set<string>) {
     const id = this.props.params.groupId;
     if (itemIds.has(id)) {
-      const group = GroupStore.get(id);
+      const group = GroupStore.get(id) as Group;
       if (group) {
         // TODO(ts) This needs a better approach. issueActions is splicing attributes onto
         // group objects to cheat here.

--- a/tests/js/sentry-test/fixtures/groupStats.js
+++ b/tests/js/sentry-test/fixtures/groupStats.js
@@ -1,0 +1,20 @@
+export function GroupStats(params = {}) {
+  return {
+    count: '327482',
+    firstSeen: '2019-04-05T19:44:05.963Z',
+    id: '1',
+    lastSeen: '2019-04-11T01:08:59Z',
+    stats: {
+      '24h': [
+        [1517281200, 2],
+        [1517310000, 1],
+      ],
+      '30d': [
+        [1514764800, 1],
+        [1515024000, 122],
+      ],
+    },
+    userCount: 35097,
+    ...params,
+  };
+}

--- a/tests/js/spec/views/issueList/overview.polling.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.polling.spec.jsx
@@ -126,6 +126,11 @@ describe('IssueList -> Polling', function () {
         Link: DEFAULT_LINKS_HEADER,
       },
     });
+    const groupStats = TestStubs.GroupStats();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues-stats/',
+      body: [groupStats],
+    });
     pollRequest = MockApiClient.addMockResponse({
       url: `http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=${PREVIOUS_PAGE_CURSOR}:0:1`,
       body: [],

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -30,6 +30,7 @@ describe('IssueList', function () {
   let organization;
   let project;
   let group;
+  let groupStats;
   let savedSearch;
 
   let fetchTagsRequest;
@@ -66,6 +67,11 @@ describe('IssueList', function () {
       headers: {
         Link: DEFAULT_LINKS_HEADER,
       },
+    });
+    groupStats = TestStubs.GroupStats();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues-stats/',
+      body: [groupStats],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/searches/',
@@ -1263,7 +1269,7 @@ describe('IssueList', function () {
         '/organizations/org-slug/issues/',
         expect.objectContaining({
           data:
-            'limit=25&project=99&query=is%3Aunresolved&shortIdLookup=1&statsPeriod=14d',
+            'collapse=stats&limit=25&project=99&query=is%3Aunresolved&shortIdLookup=1&statsPeriod=14d',
         })
       );
     });


### PR DESCRIPTION
Following up on Chris's work with decomposing the GroupSerializer: https://github.com/getsentry/sentry/pull/21986, this PR introduces the frontend changes making use of `collapse=stats` on the initial issue data request and then requesting stats separately from `/issue-stats/`

This should theoretically bring immediate group data to the user faster with little effect on the time it takes for the page to load with all issue data. 

**Gif with an artificial 2 second delay on loading issue stats:**
![Kapture 2020-12-04 at 12 46 12](https://user-images.githubusercontent.com/9372512/101204668-93c38700-363a-11eb-801e-78f390d09e55.gif)

If it takes too long for all the data to come in we can experiment with trying to parallelize the requests for base group data and group stats
