### PR TITLE
build(py3): Make PY3 images default (w/o suffix)

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -25,13 +25,13 @@ steps:
         '--cache=true',
         '--build-arg',
         'SOURCE_COMMIT=$COMMIT_SHA',
-        '--destination=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA',
+        '--destination=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA-py2',
         '-f',
         './docker/Dockerfile',
       ]
     timeout: 300s
   - name: 'gcr.io/kaniko-project/executor:v0.22.0'
-    id: runtime-image-py3
+    id: runtime-image
     waitFor:
       - builder-run
     args:
@@ -41,7 +41,7 @@ steps:
         'SOURCE_COMMIT=$COMMIT_SHA',
         '--build-arg',
         'PY_VER=3.6.10',
-        '--destination=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA-py3',
+        '--destination=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA',
         '-f',
         './docker/Dockerfile',
       ]
@@ -62,6 +62,7 @@ steps:
     waitFor:
       - runtime-image-py2
       - get-onpremise-repo
+      - e2e-test
     entrypoint: 'bash'
     dir: onpremise
     env:
@@ -83,15 +84,12 @@ steps:
         fi
     timeout: 450s
   - name: 'gcr.io/$PROJECT_ID/docker-compose'
-    id: e2e-test-py3
+    id: e2e-test
     waitFor:
-      - runtime-image-py3
+      - runtime-image
       - get-onpremise-repo
-      - e2e-test-py2
     entrypoint: 'bash'
     dir: onpremise
-    env:
-      - 'SENTRY_PYTHON3=1'
     args:
       - '-e'
       - '-c'
@@ -109,9 +107,30 @@ steps:
         fi
     timeout: 450s
   - name: 'gcr.io/cloud-builders/docker'
-    id: docker-push
+    id: docker-push-py2
     waitFor:
       - e2e-test-py2
+    secretEnv: ['DOCKER_PASSWORD']
+    entrypoint: 'bash'
+    args:
+      - '-e'
+      - '-c'
+      - |
+        # Only push to Docker Hub from master
+        [ "$BRANCH_NAME" != "master" ] && exit 0
+        # Need to pull the image first due to Kaniko
+        docker pull $$SENTRY_IMAGE
+        echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
+        docker tag $$SENTRY_IMAGE-py2 $$DOCKER_REPO:$SHORT_SHA-py2
+        docker push $$DOCKER_REPO:$SHORT_SHA-py2
+        docker tag $$SENTRY_IMAGE-py2 $$DOCKER_REPO:$COMMIT_SHA-py2
+        docker push $$DOCKER_REPO:$COMMIT_SHA-py2
+        docker tag $$SENTRY_IMAGE-py2 $$DOCKER_REPO:nightly-py2
+        docker push $$DOCKER_REPO:nightly-py2
+  - name: 'gcr.io/cloud-builders/docker'
+    id: docker-push
+    waitFor:
+      - e2e-test
     secretEnv: ['DOCKER_PASSWORD']
     entrypoint: 'bash'
     args:
@@ -129,32 +148,11 @@ steps:
         docker push $$DOCKER_REPO:$COMMIT_SHA
         docker tag $$SENTRY_IMAGE $$DOCKER_REPO:nightly
         docker push $$DOCKER_REPO:nightly
-        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:$SHORT_SHA-py2
-        docker push $$DOCKER_REPO:$SHORT_SHA-py2
-        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:$COMMIT_SHA-py2
-        docker push $$DOCKER_REPO:$COMMIT_SHA-py2
-        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:nightly-py2
-        docker push $$DOCKER_REPO:nightly-py2
-  - name: 'gcr.io/cloud-builders/docker'
-    id: docker-push-py3
-    waitFor:
-      - e2e-test-py3
-    secretEnv: ['DOCKER_PASSWORD']
-    entrypoint: 'bash'
-    args:
-      - '-e'
-      - '-c'
-      - |
-        # Only push to Docker Hub from master
-        [ "$BRANCH_NAME" != "master" ] && exit 0
-        # Need to pull the image first due to Kaniko
-        docker pull $$SENTRY_IMAGE-py3
-        echo "$$DOCKER_PASSWORD" | docker login --username=sentrybuilder --password-stdin
-        docker tag $$SENTRY_IMAGE-py3 $$DOCKER_REPO:$SHORT_SHA-py3
+        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:$SHORT_SHA-py3
         docker push $$DOCKER_REPO:$SHORT_SHA-py3
-        docker tag $$SENTRY_IMAGE-py3 $$DOCKER_REPO:$COMMIT_SHA-py3
+        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:$COMMIT_SHA-py3
         docker push $$DOCKER_REPO:$COMMIT_SHA-py3
-        docker tag $$SENTRY_IMAGE-py3 $$DOCKER_REPO:nightly-py3
+        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:nightly-py3
         docker push $$DOCKER_REPO:nightly-py3
   - name: 'node:12'
     id: zeus-upload

--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -17,20 +17,6 @@ steps:
       - 'SOURCE_COMMIT=$COMMIT_SHA'
     timeout: 360s
   - name: 'gcr.io/kaniko-project/executor:v0.22.0'
-    id: runtime-image-py2
-    waitFor:
-      - builder-run
-    args:
-      [
-        '--cache=true',
-        '--build-arg',
-        'SOURCE_COMMIT=$COMMIT_SHA',
-        '--destination=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA-py2',
-        '-f',
-        './docker/Dockerfile',
-      ]
-    timeout: 300s
-  - name: 'gcr.io/kaniko-project/executor:v0.22.0'
     id: runtime-image
     waitFor:
       - builder-run
@@ -42,6 +28,20 @@ steps:
         '--build-arg',
         'PY_VER=3.6.10',
         '--destination=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA',
+        '-f',
+        './docker/Dockerfile',
+      ]
+    timeout: 300s
+  - name: 'gcr.io/kaniko-project/executor:v0.22.0'
+    id: runtime-image-py2
+    waitFor:
+      - builder-run
+    args:
+      [
+        '--cache=true',
+        '--build-arg',
+        'SOURCE_COMMIT=$COMMIT_SHA',
+        '--destination=us.gcr.io/$PROJECT_ID/sentry:$COMMIT_SHA-py2',
         '-f',
         './docker/Dockerfile',
       ]
@@ -58,15 +58,12 @@ steps:
         curl -L "https://github.com/getsentry/onpremise/archive/master.tar.gz" | tar xzf - --strip-components=1
         echo '{"version": "3.4", "networks":{"default":{"external":{"name":"cloudbuild"}}}}' > docker-compose.override.yml
   - name: 'gcr.io/$PROJECT_ID/docker-compose'
-    id: e2e-test-py2
+    id: e2e-test
     waitFor:
-      - runtime-image-py2
+      - runtime-image
       - get-onpremise-repo
-      - e2e-test
     entrypoint: 'bash'
     dir: onpremise
-    env:
-      - 'SENTRY_PYTHON2=1'
     args:
       - '-e'
       - '-c'
@@ -84,12 +81,15 @@ steps:
         fi
     timeout: 450s
   - name: 'gcr.io/$PROJECT_ID/docker-compose'
-    id: e2e-test
+    id: e2e-test-py2
     waitFor:
-      - runtime-image
+      - runtime-image-py2
       - get-onpremise-repo
+      - e2e-test
     entrypoint: 'bash'
     dir: onpremise
+    env:
+      - 'SENTRY_PYTHON2=1'
     args:
       - '-e'
       - '-c'


### PR DESCRIPTION
This is in preparation to make the PY3 version the default for Docker images and self-hosted. It is part **3/5**:

1. ~~Add `-py2` variants for the Python 2 build tags and introduce the `SENTRY_PYTHON2` env variable usage~~ (getsentry/sentry#22460)
2. ~~Switch getsentry/onpremise to Python 3 by default*, introducing the `SENTRY_PYTHON2` env var for Py2 builds via the `-py2` suffix~~ (getsentry/onpremise#763)
3. **Move the unsuffixed version of the builds to Python 3**
4. Remove the `SENTRY_PYTHON3` env var support and `-py3` prefix usage from getsentry/onpremise
5. Remove tagging of `-py3` builds from here

We should still have the `-py3` images, whcih will be the same with the images w/o the suffix.
