### PR TITLE
Revert "build(pip): Enable the new 2020 resolver (#21507)"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,6 @@ RUN set -x \
   " \
   && apt-get update \
   && apt-get install -y --no-install-recommends $buildDeps \
-  && python -m pip install --upgrade 'pip>=20.3.0' \
   && pip install -r /tmp/dist/requirements.txt \
   && mkdir /tmp/uwsgi-dogstatsd \
   && wget -O - https://github.com/eventbrite/uwsgi-dogstatsd/archive/filters-and-tags.tar.gz | \


### PR DESCRIPTION
This reverts commit e3cf80529940be834502f78d466f961cfca818f1. The new resolver seems to be breaking still. Will investigate.
