### PR TITLE
build(py3): Stop tagging the `-py3` images

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -148,12 +148,6 @@ steps:
         docker push $$DOCKER_REPO:$COMMIT_SHA
         docker tag $$SENTRY_IMAGE $$DOCKER_REPO:nightly
         docker push $$DOCKER_REPO:nightly
-        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:$SHORT_SHA-py3
-        docker push $$DOCKER_REPO:$SHORT_SHA-py3
-        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:$COMMIT_SHA-py3
-        docker push $$DOCKER_REPO:$COMMIT_SHA-py3
-        docker tag $$SENTRY_IMAGE $$DOCKER_REPO:nightly-py3
-        docker push $$DOCKER_REPO:nightly-py3
   - name: 'node:12'
     id: zeus-upload
     waitFor:


### PR DESCRIPTION
This is the final step in making the PY3 version the default for Docker images and self-hosted. It is part **5/5**:

1. ~~Add `-py2` variants for the Python 2 build tags and introduce the `SENTRY_PYTHON2` env variable usage~~ (getsentry/sentry#22460)
2. ~~Switch getsentry/onpremise to Python 3 by default*, introducing the `SENTRY_PYTHON2` env var for Py2 builds via the `-py2` suffix~~ (getsentry/onpremise#763)
3. ~~Move the unsuffixed version of the builds to Python 3~~ (getsentry/sentry#22466)
4. ~~Remove the `SENTRY_PYTHON3` env var support and `-py3` prefix usage from getsentry/onpremise~~ (getsentry/onpremise#764)
5. **Remove tagging of `-py3` builds from getsentry/sentry**
