### PR TITLE
ref(stacktrace-link): Transaction tags to stacktrace linking 

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -39,6 +39,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
             return Response({"detail": "Filepath is required"}, status=400)
 
         commitId = request.GET.get("commitId")
+        platform = request.GET.get("platform")
         result = {"config": None, "sourceUrl": None}
 
         integrations = Integration.objects.filter(organizations=project.organization_id)
@@ -60,7 +61,8 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                 # use the provider key to be able to spilt up stacktrace
                 # link metrics by integration type
                 provider = result["config"]["provider"]["key"]
-                scope.set_tag("integration", provider)
+                scope.set_tag("integration_provider", provider)
+                scope.set_tag("stacktrace_link.platform", platform)
 
                 if not filepath.startswith(config.stack_root):
                     scope.set_tag("stacktrace_link.error", "stack_root_mismatch")

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -6,7 +6,8 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.models import Integration, RepositoryProjectPathConfig
 from sentry.api.serializers import serialize
 from sentry.utils.compat import filter
-from sentry.web.decorators import transaction_start
+
+from sentry_sdk import configure_scope
 
 
 def get_link(config, filepath, default, version=None):
@@ -21,17 +22,16 @@ def get_link(config, filepath, default, version=None):
 
 class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
     """
-        Returns valid links for source code providers so that
-        users can go from the file in the stack trace to the
-        provider of their choice.
+    Returns valid links for source code providers so that
+    users can go from the file in the stack trace to the
+    provider of their choice.
 
-        `filepath`: The file path from the strack trace
-        `commitId` (optional): The commit_id for the last commit of the
-                               release associated to the stack trace's event
+    `filepath`: The file path from the strack trace
+    `commitId` (optional): The commit_id for the last commit of the
+                           release associated to the stack trace's event
 
     """
 
-    @transaction_start("ProjectStacktraceLinkEndpoint")
     def get(self, request, project):
         # should probably feature gate
         filepath = request.GET.get("file")
@@ -53,24 +53,33 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         # sure that we are still ordering by `id` because we want to make sure
         # the ordering is deterministic
         configs = RepositoryProjectPathConfig.objects.filter(project=project)
+        with configure_scope() as scope:
+            for config in configs:
 
-        for config in configs:
-            result["config"] = serialize(config, request.user)
+                result["config"] = serialize(config, request.user)
+                # use the provider key to be able to spilt up stacktrace
+                # link metrics by integration type
+                provider = result["config"]["provider"]["key"]
+                scope.set_tag("integration", provider)
 
-            if not filepath.startswith(config.stack_root):
-                result["error"] = "stack_root_mismatch"
-                continue
+                if not filepath.startswith(config.stack_root):
+                    scope.set_tag("stacktrace_link.error", "stack_root_mismatch")
+                    result["error"] = "stack_root_mismatch"
+                    continue
 
-            link = get_link(config, filepath, config.default_branch, commitId)
+                link = get_link(config, filepath, config.default_branch, commitId)
 
-            # it's possible for the link to be None, and in that
-            # case it means we could not find a match for the
-            # configuration
-            result["sourceUrl"] = link
-            if not link:
-                result["error"] = "file_not_found"
-
-            # if we found a match, we can break
-            break
+                # it's possible for the link to be None, and in that
+                # case it means we could not find a match for the
+                # configuration
+                result["sourceUrl"] = link
+                if not link:
+                    scope.set_tag("stacktrace_link.found", False)
+                    scope.set_tag("stacktrace_link.error", "file_not_found")
+                    result["error"] = "file_not_found"
+                else:
+                    scope.set_tag("stacktrace_link.found", True)
+                    # if we found a match, we can break
+                    break
 
         return Response(result)

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 from sentry.integrations.github.utils import get_jwt
 from sentry.integrations.client import ApiClient
-from sentry.web.decorators import transaction_start
 
 
 class GitHubClientMixin(ApiClient):
@@ -113,7 +112,6 @@ class GitHubClientMixin(ApiClient):
             },
         )
 
-    @transaction_start("GitHubClientMixin.check_file")
     def check_file(self, repo, path, version):
         repo_name = repo.name
         return self.head_cached(

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -115,6 +115,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
       );
     }
   }
+
   onReconfigureMapping() {
     const provider = this.config?.provider;
     const error = this.match.error;
@@ -150,13 +151,24 @@ class StacktraceLink extends AsyncComponent<Props, State> {
   renderNoMatch() {
     const {organization} = this.props;
     const filename = this.props.frame.filename;
+    const platform = this.props.event.platform;
 
     if (this.project && this.integrations.length > 0 && filename) {
       return (
         <CodeMappingButtonContainer columnQuantity={2}>
           {t('Enable source code stack trace linking by setting up a code mapping.')}
           <Button
-            onClick={() =>
+            onClick={() => {
+              trackIntegrationEvent(
+                {
+                  eventKey: 'integrations.stacktrace_start_setup',
+                  eventName: 'Integrations: Stacktrace Start Setup',
+                  view: 'stacktrace_issue_details',
+                  platform,
+                },
+                this.props.organization,
+                {startSession: true}
+              );
               openModal(
                 deps =>
                   this.project && (
@@ -169,8 +181,8 @@ class StacktraceLink extends AsyncComponent<Props, State> {
                       {...deps}
                     />
                   )
-              )
-            }
+              );
+            }}
             size="xsmall"
           >
             {t('Setup Stack Trace Linking')}

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -81,11 +81,12 @@ class StacktraceLink extends AsyncComponent<Props, State> {
       throw new Error('Unable to find project');
     }
     const commitId = event.release?.lastCommit?.id;
+    const platform = event.platform;
     return [
       [
         'match',
         `/projects/${organization.slug}/${project.slug}/stacktrace-link/`,
-        {query: {file: frame.filename, commitId}},
+        {query: {file: frame.filename, platform, commitId}},
       ],
     ];
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -11,7 +11,7 @@ import {IconInfo} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {Integration, Organization, Project} from 'app/types';
-import {getIntegrationIcon} from 'app/utils/integrationUtil';
+import {getIntegrationIcon, trackIntegrationEvent} from 'app/utils/integrationUtil';
 import InputField from 'app/views/settings/components/forms/inputField';
 
 type Props = AsyncComponent['props'] &
@@ -41,9 +41,31 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
     });
   }
 
+  onManualSetup(provider: string) {
+    trackIntegrationEvent(
+      {
+        eventKey: 'integrations.stacktrace_manual_setup',
+        eventName: 'Integrations: Stacktrace Manual Setup',
+        view: 'stacktrace_issue_details',
+        provider,
+      },
+      this.props.organization,
+      {startSession: true}
+    );
+  }
+
   handleSubmit = async () => {
     const {sourceCodeInput} = this.state;
     const {organization, filename, project} = this.props;
+    trackIntegrationEvent(
+      {
+        eventKey: 'integrations.stacktrace_automatic_setup',
+        eventName: 'Integrations: Stacktrace Automatic Setup',
+        view: 'stacktrace_issue_details',
+      },
+      this.props.organization,
+      {startSession: true}
+    );
 
     const parsingEndpoint = `/projects/${organization.slug}/${project.slug}/repo-path-parsing/`;
     try {
@@ -133,6 +155,7 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
                 <Button
                   key={integration.id}
                   type="button"
+                  onClick={() => this.onManualSetup(integration.provider.key)}
                   to={`${baseUrl}/${integration.provider.key}/${integration.id}/?tab=codeMappings`}
                 >
                   {getIntegrationIcon(integration.provider.key)}

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -113,12 +113,18 @@ type IntegrationCategorySelectEvent = {
 
 type IntegrationStacktraceLinkEvent = {
   eventKey:
+    | 'integrations.stacktrace_start_setup'
+    | 'integrations.stacktrace_automatic_setup'
+    | 'integrations.stacktrace_manual_setup'
     | 'integrations.stacktrace_link_clicked'
     | 'integrations.reconfigure_stacktrace_setup';
   eventName:
+    | 'Integrations: Stacktrace Start Setup'
+    | 'Integrations: Stacktrace Automatic Setup'
+    | 'Integrations: Stacktrace Manual Setup'
     | 'Integrations: Stacktrace Link Clicked'
     | 'Integrations: Reconfigure Stacktrace Setup';
-  provider: string;
+  provider?: string;
   error_reason?: 'file_not_found' | 'stack_root_mismatch';
 };
 

--- a/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
@@ -12,6 +12,7 @@ describe('StacktraceLink', function () {
   const repo = TestStubs.Repository({integrationId: integration.id});
 
   const frame = {filename: '/sentry/app.py', lineNo: 233};
+  const platform = 'python';
   const config = TestStubs.RepositoryProjectPathConfig(project, repo, integration);
 
   beforeEach(function () {
@@ -21,7 +22,7 @@ describe('StacktraceLink', function () {
   it('renders setup CTA with integration but no configs', async function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-      query: {file: frame.filename, commitId: 'master'},
+      query: {file: frame.filename, commitId: 'master', platform},
       body: {config: null, sourceUrl: null, integrations: [integration]},
     });
     mountWithTheme(
@@ -39,7 +40,7 @@ describe('StacktraceLink', function () {
   it('renders source url link', async function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-      query: {file: frame.filename, commitId: 'master'},
+      query: {file: frame.filename, commitId: 'master', platform},
       body: {config, sourceUrl: 'https://something.io', integrations: [integration]},
     });
     const wrapper = mountWithTheme(
@@ -59,7 +60,7 @@ describe('StacktraceLink', function () {
   it('renders file_not_found message', async function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-      query: {file: frame.filename, commitId: 'master'},
+      query: {file: frame.filename, commitId: 'master', platform},
       body: {
         config,
         sourceUrl: null,
@@ -86,7 +87,7 @@ describe('StacktraceLink', function () {
   it('renders stack_root_mismatch message', async function () {
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-      query: {file: frame.filename, commitId: 'master'},
+      query: {file: frame.filename, commitId: 'master', platform},
       body: {
         config,
         sourceUrl: null,

--- a/tests/js/spec/components/events/interfaces/stacktraceLinkModal.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/stacktraceLinkModal.spec.jsx
@@ -62,7 +62,7 @@ describe('StacktraceLinkModal', function () {
 
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-      query: {file: filename, commitId: 'master'},
+      query: {file: filename, commitId: 'master', platform: 'python'},
       body: {config, sourceUrl, integrations: [integration]},
     });
 
@@ -111,7 +111,7 @@ describe('StacktraceLinkModal', function () {
 
     MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-      query: {file: filename, commitId: 'master'},
+      query: {file: filename, commitId: 'master', platform: 'python'},
       body: {config, sourceUrl, integrations: [integration]},
     });
 


### PR DESCRIPTION
**Sentry Transactions:**
I've added a handful of tags to the transaction for the `project_stacktrace_link` endpoint:

`stacktrace_link.found`
`stacktrace_link.error`
`stacktrace_link.platform`
`stacktrace_link.tried_version`
`stacktrace_link.used_version`
`integration_provider` (this could be used across features)

Here is what an example search might look like: 

![Screen Shot 2020-12-04 at 12 19 56 PM](https://user-images.githubusercontent.com/15368179/101219497-fae03c00-3638-11eb-84b2-f7e2fd77a552.png)

**Amplitude Analytics**
I also added a few more amplitude analytics, so that we can track when they start the setup, and whether or not they chose the automatic or manual routes. If the automatic route worked, we should be able to see the `'integrations.stacktrace_link_clicked'` next, and if it didn't I would expect `'integrations.reconfigure_stacktrace_setup'`.

```python 
'integrations.stacktrace_start_setup'
'integrations.stacktrace_automatic_setup'
'integrations.stacktrace_manual_setup'
```