### PR TITLE
fix(py3): Fix bug in `BigtableNodeStorage.get_multi`

### DIFF
--- a/src/sentry/nodestore/bigtable/backend.py
+++ b/src/sentry/nodestore/bigtable/backend.py
@@ -126,7 +126,7 @@ class BigtableNodeStorage(NodeStorage):
             rv[id] = None
 
         for row in self.connection.read_rows(row_set=rows):
-            rv[row.row_key] = self.decode_row(row)
+            rv[row.row_key.decode("utf-8")] = self.decode_row(row)
         self._set_cache_items(rv)
         rv.update(cache_items)
         return rv


### PR DESCRIPTION
This fixes a bug where we pass in a list of ids as unicode, then attempt to compare those ids to the
bytestrings that are returned as row keys from Bigtable. This was causing cache misses whenever we
attempted to fetch events in bulk, as well as causing `None` values to be returned for each event
and showing no data for the events in the ui.