### PR TITLE
fix(inbox): Hide actions on pages where you cannot select

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -397,16 +397,18 @@ class StreamGroup extends React.Component<Props, State> {
         <Box width={80} mx={2} className="hidden-xs hidden-sm">
           <AssigneeSelector id={data.id} memberList={memberList} />
         </Box>
-        <Feature organization={organization} features={['organizations:inbox']}>
-          <Box width={120} mx={2} className="hidden-xs hidden-sm">
-            <GroupRowActions
-              group={data}
-              orgId={organization.slug}
-              selection={selection}
-              query={query}
-            />
-          </Box>
-        </Feature>
+        {canSelect && (
+          <Feature organization={organization} features={['organizations:inbox']}>
+            <Box width={120} mx={2} className="hidden-xs hidden-sm">
+              <GroupRowActions
+                group={data}
+                orgId={organization.slug}
+                selection={selection}
+                query={query}
+              />
+            </Box>
+          </Feature>
+        )}
       </Wrapper>
     );
   }


### PR DESCRIPTION
Performance pages, etc. use this to hide the checkbox, also hide the actions.