### PR TITLE
feat(ui): Show only selected projects in release card

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/list/releaseCard.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseCard.tsx
@@ -57,6 +57,7 @@ const ReleaseCard = ({
           activeDisplay={activeDisplay}
           location={location}
           showPlaceholders={showHealthPlaceholders}
+          reloading={reloading}
           selection={selection}
         />
       </ReleaseProjects>

--- a/tests/js/spec/views/releases/list/index.spec.jsx
+++ b/tests/js/spec/views/releases/list/index.spec.jsx
@@ -13,7 +13,7 @@ describe('ReleasesList', function () {
   const props = {
     router,
     organization,
-    selection: {projects: [2]},
+    selection: {projects: []},
     params: {orgId: organization.slug},
     location: {
       query: {
@@ -278,5 +278,46 @@ describe('ReleasesList', function () {
         healthStatsPeriod: '14d',
       }),
     });
+  });
+
+  it('shows health rows only for selected projects in global header', function () {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/',
+      body: [
+        {
+          ...TestStubs.Release({version: '2.0.0'}),
+          projects: [
+            {
+              id: 1,
+              name: 'Test',
+              slug: 'test',
+            },
+            {
+              id: 2,
+              name: 'Test2',
+              slug: 'test2',
+            },
+            {
+              id: 3,
+              name: 'Test3',
+              slug: 'test3',
+            },
+          ],
+        },
+      ],
+    });
+    const healthSection = mountWithTheme(
+      <ReleasesList {...props} selection={{projects: [2]}} />,
+      routerContext
+    ).find('ReleaseHealth');
+    const hiddenProjectsMessage = healthSection.find('HiddenProjectsMessage');
+
+    expect(hiddenProjectsMessage.text()).toBe('2 hidden projects');
+
+    expect(hiddenProjectsMessage.find('Tooltip').prop('title')).toBe('test, test3');
+
+    expect(healthSection.find('ProjectRow').length).toBe(1);
+
+    expect(healthSection.find('ProjectName').text()).toBe('test2');
   });
 });


### PR DESCRIPTION
We used to always show all projects, no we only display the ones that are selected in the global header.

<img width="1440" alt="Screenshot 2020-12-04 at 16 19 40" src="https://user-images.githubusercontent.com/9060071/101322710-c7cfbf80-3867-11eb-8b84-01a500ed24ab.png">