### PR TITLE
feat(dashboards) Warn on route navigation and beforeunload in dashboards

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboards/overviewDashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/overviewDashboard.tsx
@@ -63,15 +63,16 @@ type DashboardLandingProps = {
 } & RouteComponentProps<{orgId: string}, {}>;
 
 function DashboardLanding(props: DashboardLandingProps) {
-  const {organization, ...restProps} = props;
+  const {organization, params, ...restProps} = props;
 
   const showDashboardV2 = organization.features.includes('dashboards-v2');
 
   if (showDashboardV2) {
-    return <DashboardDetail {...restProps} />;
+    const updatedParams = {...params, dashboardId: ''};
+    return <DashboardDetail {...restProps} params={updatedParams} />;
   }
 
-  return <OverviewDashboard {...restProps} />;
+  return <OverviewDashboard {...restProps} params={params} />;
 }
 
 export default withOrganization(DashboardLanding);


### PR DESCRIPTION
Dashboards can store a significant amount of unsaved state and we should warn users when they might end up losing that state.