### PR TITLE
ref(stacktrace-link): Add has_stacktrace_linking

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -249,6 +249,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
     integration_cls = GitlabIntegration
 
     needs_default_identity = True
+    has_stacktrace_linking = True
 
     features = frozenset([IntegrationFeatures.ISSUE_BASIC, IntegrationFeatures.COMMITS])
 


### PR DESCRIPTION
Gitlab needs this on the integration just like GitHub