### PR TITLE
ref(ui): Better sizing on copy to clipboard icon

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/featureDisabled.tsx
+++ b/src/sentry/static/sentry/app/components/acl/featureDisabled.tsx
@@ -123,7 +123,7 @@ class FeatureDisabled extends React.Component<Props, State> {
                   e.stopPropagation();
                   e.preventDefault();
                 }}
-                icon={<IconCopy />}
+                icon={<IconCopy size="xs" />}
               >
                 {t('Copy to Clipboard')}
               </Button>


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1421724/101419431-d7212e00-38a4-11eb-964b-a7dffd88720a.png)


After
![image](https://user-images.githubusercontent.com/1421724/101419392-c1136d80-38a4-11eb-8f96-882a03e79983.png)
