### PR TITLE
ref(modals): use openModal for stacktraceLinkModal

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import {openModal} from 'app/actionCreators/modal';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import {t} from 'app/locale';
@@ -131,7 +132,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
     }
   }
 
-  onClose() {
+  handleSubmit() {
     this.reloadData();
   }
 
@@ -151,13 +152,29 @@ class StacktraceLink extends AsyncComponent<Props, State> {
 
     if (this.project && this.integrations.length > 0 && filename) {
       return (
-        <StacktraceLinkModal
-          filename={filename}
-          project={this.project}
-          organization={organization}
-          integrations={this.integrations}
-          onClose={() => this.onClose()}
-        />
+        <CodeMappingButtonContainer columnQuantity={2}>
+          {t('Enable source code stack trace linking by setting up a code mapping.')}
+          <Button
+            onClick={() =>
+              openModal(
+                deps =>
+                  this.project && (
+                    <StacktraceLinkModal
+                      onSubmit={() => this.handleSubmit()}
+                      filename={filename}
+                      project={this.project}
+                      organization={organization}
+                      integrations={this.integrations}
+                      {...deps}
+                    />
+                  )
+              )
+            }
+            size="xsmall"
+          >
+            {t('Setup Stack Trace Linking')}
+          </Button>
+        </CodeMappingButtonContainer>
       );
     }
     return null;
@@ -193,11 +210,12 @@ class StacktraceLink extends AsyncComponent<Props, State> {
     const {config, sourceUrl} = this.match || {};
     if (config && sourceUrl) {
       return this.renderMatchWithUrl(config, sourceUrl);
-    } else if (config) {
-      return this.renderMatchNoUrl();
-    } else {
-      return this.renderNoMatch();
     }
+    if (config) {
+      return this.renderMatchNoUrl();
+    }
+
+    return this.renderNoMatch();
   }
 }
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import {Modal} from 'react-bootstrap';
 import styled from '@emotion/styled';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {ModalRenderProps} from 'app/actionCreators/modal';
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
@@ -14,18 +14,16 @@ import {Integration, Organization, Project} from 'app/types';
 import {getIntegrationIcon} from 'app/utils/integrationUtil';
 import InputField from 'app/views/settings/components/forms/inputField';
 
-import {OpenInContainer} from './openInContextLine';
-
-type Props = AsyncComponent['props'] & {
-  filename: string;
-  organization: Organization;
-  project: Project;
-  integrations: Integration[];
-  onClose: () => void;
-};
+type Props = AsyncComponent['props'] &
+  ModalRenderProps & {
+    filename: string;
+    organization: Organization;
+    project: Project;
+    integrations: Integration[];
+    onSubmit: () => void;
+  };
 
 type State = AsyncComponent['state'] & {
-  showModal: boolean;
   sourceCodeInput: string;
 };
 
@@ -33,21 +31,8 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
   getDefaultState(): State {
     return {
       ...super.getDefaultState(),
-      showModal: false,
       sourceCodeInput: '',
     };
-  }
-  openModal() {
-    this.setState({
-      showModal: true,
-    });
-  }
-
-  closeModal() {
-    this.setState({
-      showModal: false,
-      sourceCodeInput: '',
-    });
   }
 
   onHandleChange(sourceCodeInput: string) {
@@ -77,8 +62,8 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
       });
 
       addSuccessMessage(t('Stack trace configuration saved.'));
-      this.closeModal();
-      this.props.onClose();
+      this.props.closeModal();
+      this.props.onSubmit();
     } catch (err) {
       const errors = err?.responseJSON
         ? Array.isArray(err?.responseJSON)
@@ -91,104 +76,86 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
   };
 
   renderBody() {
-    const {showModal, sourceCodeInput} = this.state;
-    const {filename, integrations, organization} = this.props;
+    const {sourceCodeInput} = this.state;
+    const {Header, Body, Footer, filename, integrations, organization} = this.props;
     const baseUrl = `/settings/${organization.slug}/integrations`;
 
     return (
-      <CodeMappingButtonContainer columnQuantity={2}>
-        {t('Enable source code stack trace linking by setting up a code mapping.')}
-        <Button onClick={() => this.openModal()} size="xsmall">
-          {t('Setup Stack Trace Linking')}
-        </Button>
-        <Modal
-          show={showModal}
-          onHide={() => this.closeModal()}
-          enforceFocus={false}
-          backdrop="static"
-          animation={false}
-        >
-          <Modal.Header closeButton>
-            {t('Link Your Stack Trace To Your Source Code')}
-          </Modal.Header>
-          <Modal.Body>
-            <ModalContainer>
-              <div>
-                <h6>{t('Quick Setup')}</h6>
-                {tct(
-                  'Enter in your source code url that corresponds to stack trace filename [filename]. We will use this information to automatically set up your stack trace linking configuration.',
-                  {
-                    filename: <code>{filename}</code>,
-                  }
-                )}
-              </div>
-              <SourceCodeInput>
-                <StyledInputField
-                  inline={false}
-                  flexibleControlStateSize
-                  stacked
-                  name="source-code-input"
-                  type="text"
-                  value={sourceCodeInput}
-                  onChange={val => this.onHandleChange(val)}
-                  placeholder={t(
-                    `https://github.com/helloworld/Hello-World/blob/master/${filename}`
-                  )}
-                />
-                <ButtonBar>
-                  <Button
-                    data-test-id="quick-setup-button"
-                    type="button"
-                    onClick={() => this.handleSubmit()}
-                  >
-                    {t('Submit')}
-                  </Button>
-                </ButtonBar>
-              </SourceCodeInput>
-              <div>
-                <h6>{t('Manual Setup')}</h6>
-                <Alert type="warning">
-                  {t(
-                    'Recommended for more complicated configurations such as having multiple repositories for the same Sentry project.'
-                  )}
-                </Alert>
-                {t(
-                  'To configure stack trace linking manually, select which of your following integrations you want to set up the mapping for:'
-                )}
-              </div>
-              <ManualSetup>
-                {integrations.map(integration => (
-                  <Button
-                    key={integration.id}
-                    type="button"
-                    to={`${baseUrl}/${integration.provider.key}/${integration.id}/?tab=codeMappings`}
-                  >
-                    {getIntegrationIcon(integration.provider.key)}
-                    <IntegrationName>{integration.name}</IntegrationName>
-                  </Button>
-                ))}
-              </ManualSetup>
-            </ModalContainer>
-          </Modal.Body>
-          <Modal.Footer>
-            <Alert type="info" icon={<IconInfo />}>
+      <React.Fragment>
+        <Header closeButton>{t('Link Your Stack Trace To Your Source Code')}</Header>
+        <Body>
+          <ModalContainer>
+            <div>
+              <h6>{t('Quick Setup')}</h6>
               {tct(
-                'Stack trace linking is still in Beta. If you have feedback, please email [email:ecosystem-feedback@sentry.io].',
-                {email: <a href="mailto:ecosystem-feedback@sentry.io" />}
+                'Enter in your source code url that corresponds to stack trace filename [filename]. We will use this information to automatically set up your stack trace linking configuration.',
+                {
+                  filename: <code>{filename}</code>,
+                }
               )}
-            </Alert>
-          </Modal.Footer>
-        </Modal>
-      </CodeMappingButtonContainer>
+            </div>
+            <SourceCodeInput>
+              <StyledInputField
+                inline={false}
+                flexibleControlStateSize
+                stacked
+                name="source-code-input"
+                type="text"
+                value={sourceCodeInput}
+                onChange={val => this.onHandleChange(val)}
+                placeholder={t(
+                  `https://github.com/helloworld/Hello-World/blob/master/${filename}`
+                )}
+              />
+              <ButtonBar>
+                <Button
+                  data-test-id="quick-setup-button"
+                  type="button"
+                  onClick={() => this.handleSubmit()}
+                >
+                  {t('Submit')}
+                </Button>
+              </ButtonBar>
+            </SourceCodeInput>
+            <div>
+              <h6>{t('Manual Setup')}</h6>
+              <Alert type="warning">
+                {t(
+                  'Recommended for more complicated configurations such as having multiple repositories for the same Sentry project.'
+                )}
+              </Alert>
+              {t(
+                'To configure stack trace linking manually, select which of your following integrations you want to set up the mapping for:'
+              )}
+            </div>
+            <ManualSetup>
+              {integrations.map(integration => (
+                <Button
+                  key={integration.id}
+                  type="button"
+                  to={`${baseUrl}/${integration.provider.key}/${integration.id}/?tab=codeMappings`}
+                >
+                  {getIntegrationIcon(integration.provider.key)}
+                  <IntegrationName>{integration.name}</IntegrationName>
+                </Button>
+              ))}
+            </ManualSetup>
+          </ModalContainer>
+        </Body>
+        <Footer>
+          <Alert type="info" icon={<IconInfo />}>
+            {tct(
+              'Stack trace linking is still in Beta. If you have feedback, please email [email:ecosystem-feedback@sentry.io].',
+              {email: <a href="mailto:ecosystem-feedback@sentry.io" />}
+            )}
+          </Alert>
+        </Footer>
+      </React.Fragment>
     );
   }
 }
 
 export default StacktraceLinkModal;
-
-export const CodeMappingButtonContainer = styled(OpenInContainer)`
-  justify-content: space-between;
-`;
 
 const SourceCodeInput = styled('div')`
   display: grid;
@@ -205,6 +172,10 @@ const ManualSetup = styled('div')`
 const ModalContainer = styled('div')`
   display: grid;
   grid-gap: ${space(3)};
+
+  code {
+    word-break: break-word;
+  }
 `;
 
 const StyledInputField = styled(InputField)`

--- a/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
@@ -24,7 +24,7 @@ describe('StacktraceLink', function () {
       query: {file: frame.filename, commitId: 'master'},
       body: {config: null, sourceUrl: null, integrations: [integration]},
     });
-    const wrapper = mountWithTheme(
+    mountWithTheme(
       <StacktraceLink
         frame={frame}
         event={event}
@@ -34,7 +34,6 @@ describe('StacktraceLink', function () {
       />,
       TestStubs.routerContext()
     );
-    expect(wrapper.find('StacktraceLinkModal').exists()).toBe(true);
   });
 
   it('renders source url link', async function () {

--- a/tests/js/spec/components/events/interfaces/stacktraceLinkModal.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/stacktraceLinkModal.spec.jsx
@@ -12,22 +12,30 @@ describe('StacktraceLinkModal', function () {
   const repo = TestStubs.Repository({integrationId: integration.id});
   const config = TestStubs.RepositoryProjectPathConfig(project, repo, integration);
 
+  const closeModal = jest.fn();
+  const modalElements = {
+    Header: p => p.children,
+    Body: p => p.children,
+    Footer: p => p.children,
+  };
+
   beforeEach(function () {
+    closeModal.mockReset();
     MockApiClient.clearMockResponses();
   });
 
   it('renders manual setup option', async function () {
     const wrapper = mountWithTheme(
       <StacktraceLinkModal
+        {...modalElements}
         project={project}
         organization={org}
         integrations={[integration]}
         filename={filename}
-        onClose={() => {}}
+        closeModal={closeModal}
       />,
       TestStubs.routerContext()
     );
-    wrapper.find('Button').simulate('click');
     expect(wrapper.find('IntegrationName').text()).toEqual('Test Integration');
   });
 
@@ -60,16 +68,15 @@ describe('StacktraceLinkModal', function () {
 
     const wrapper = mountWithTheme(
       <StacktraceLinkModal
+        {...modalElements}
         project={project}
         organization={org}
         integrations={[integration]}
         filename={filename}
-        onClose={() => {}}
+        closeModal={closeModal}
       />,
       TestStubs.routerContext()
     );
-    // open the modal
-    wrapper.find('Button').simulate('click');
     wrapper.find('input').simulate('change', {target: {value: sourceUrl}});
     // submit quick setup input
     wrapper.find('Button[data-test-id="quick-setup-button"]').simulate('click');
@@ -77,7 +84,7 @@ describe('StacktraceLinkModal', function () {
     await tick();
     wrapper.update();
 
-    expect(wrapper.state('showModal')).toBe(false);
+    expect(closeModal).toHaveBeenCalled();
   });
 
   it('keeps modal open on unsuccessful quick setup', async function () {
@@ -110,16 +117,15 @@ describe('StacktraceLinkModal', function () {
 
     const wrapper = mountWithTheme(
       <StacktraceLinkModal
+        {...modalElements}
         project={project}
         organization={org}
         integrations={[integration]}
         filename={filename}
-        onClose={() => {}}
+        closeModal={closeModal}
       />,
       TestStubs.routerContext()
     );
-    // open the modal
-    wrapper.find('Button').simulate('click');
     wrapper.find('input').simulate('change', {target: {value: sourceUrl}});
     // submit quick setup input
     wrapper.find('Button[data-test-id="quick-setup-button"]').simulate('click');
@@ -127,6 +133,6 @@ describe('StacktraceLinkModal', function () {
     await tick();
     wrapper.update();
 
-    expect(wrapper.state('showModal')).toBe(true);
+    expect(closeModal).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Converts to using the `openModal` action creator, which will open the modal using the GlobalModal component.

One step closer to opening all modals from the same place, allowing easy animations / consistent styling / etc