### PR TITLE
ref(modals): Use openModal for ignore modals

### DIFF
--- a/src/sentry/static/sentry/app/components/customIgnoreCountModal.tsx
+++ b/src/sentry/static/sentry/app/components/customIgnoreCountModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {Modal} from 'react-bootstrap';
-import PropTypes from 'prop-types';
 
+import {ModalRenderProps} from 'app/actionCreators/modal';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import {t} from 'app/locale';
@@ -12,10 +11,8 @@ import SelectField from 'app/views/settings/components/forms/selectField';
 type CountNames = 'ignoreCount' | 'ignoreUserCount';
 type WindowNames = 'ignoreWindow' | 'ignoreUserWindow';
 
-type Props = {
+type Props = ModalRenderProps & {
   onSelected: (statusDetails: ResolutionStatusDetails) => void;
-  onCanceled: () => void;
-  show: boolean;
   label: string;
   countLabel: string;
   countName: CountNames;
@@ -28,18 +25,7 @@ type State = {
   window: number | null;
 };
 
-export default class CustomIgnoreCountModal extends React.Component<Props, State> {
-  static propTypes = {
-    onSelected: PropTypes.func,
-    onCanceled: PropTypes.func,
-    show: PropTypes.bool,
-    label: PropTypes.string.isRequired,
-    countLabel: PropTypes.string.isRequired,
-    countName: PropTypes.string.isRequired,
-    windowName: PropTypes.string.isRequired,
-    windowChoices: PropTypes.array.isRequired,
-  };
-
+class CustomIgnoreCountModal extends React.Component<Props, State> {
   state: State = {
     count: 100,
     window: null,
@@ -54,6 +40,7 @@ export default class CustomIgnoreCountModal extends React.Component<Props, State
       statusDetails[windowName] = window;
     }
     this.props.onSelected(statusDetails);
+    this.props.closeModal();
   };
 
   handleChange = (name: keyof State, value: number) => {
@@ -61,14 +48,22 @@ export default class CustomIgnoreCountModal extends React.Component<Props, State
   };
 
   render() {
-    const {countLabel, label, show, windowChoices, onCanceled} = this.props;
+    const {
+      Header,
+      Footer,
+      Body,
+      countLabel,
+      label,
+      closeModal,
+      windowChoices,
+    } = this.props;
     const {count, window} = this.state;
     return (
-      <Modal show={show} animation={false} onHide={onCanceled}>
-        <Modal.Header>
+      <React.Fragment>
+        <Header>
           <h4>{label}</h4>
-        </Modal.Header>
-        <Modal.Body>
+        </Header>
+        <Body>
           <InputField
             inline={false}
             flexibleControlStateSize
@@ -95,18 +90,20 @@ export default class CustomIgnoreCountModal extends React.Component<Props, State
             allowClear
             help={t('(Optional) If supplied, this rule will apply as a rate of change.')}
           />
-        </Modal.Body>
-        <Modal.Footer>
+        </Body>
+        <Footer>
           <ButtonBar gap={1}>
-            <Button type="button" onClick={onCanceled}>
+            <Button type="button" onClick={closeModal}>
               {t('Cancel')}
             </Button>
             <Button type="button" priority="primary" onClick={this.handleSubmit}>
               {t('Ignore')}
             </Button>
           </ButtonBar>
-        </Modal.Footer>
-      </Modal>
+        </Footer>
+      </React.Fragment>
     );
   }
 }
+
+export default CustomIgnoreCountModal;

--- a/src/sentry/static/sentry/app/components/customIgnoreDurationModal.tsx
+++ b/src/sentry/static/sentry/app/components/customIgnoreDurationModal.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import {Modal} from 'react-bootstrap';
 import moment from 'moment';
 import {sprintf} from 'sprintf-js';
 
+import {ModalRenderProps} from 'app/actionCreators/modal';
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
@@ -14,10 +14,8 @@ const defaultProps = {
   label: t('Ignore this issue until \u2026'),
 };
 
-type Props = {
-  show: boolean;
+type Props = ModalRenderProps & {
   onSelected: (details: ResolutionStatusDetails) => void;
-  onCanceled: () => void;
 } & typeof defaultProps;
 
 type State = {
@@ -27,9 +25,10 @@ type State = {
 export default class CustomIgnoreDurationModal extends React.Component<Props, State> {
   static defaultProps = defaultProps;
 
-  state = {
+  state: State = {
     dateWarning: false,
   };
+
   snoozeDateInputRef = React.createRef<HTMLInputElement>();
 
   snoozeTimeInputRef = React.createRef<HTMLInputElement>();
@@ -57,6 +56,7 @@ export default class CustomIgnoreDurationModal extends React.Component<Props, St
     if (minutes > 0) {
       this.props.onSelected({ignoreDuration: minutes});
     }
+    this.props.closeModal();
   };
 
   render() {
@@ -75,14 +75,12 @@ export default class CustomIgnoreDurationModal extends React.Component<Props, St
     );
 
     const defaultTimeVal = sprintf('%02d:00', defaultDate.getUTCHours());
-    const {show, onCanceled, label} = this.props;
+    const {Header, Body, Footer, label} = this.props;
 
     return (
-      <Modal show={show} animation={false} onHide={onCanceled}>
-        <Modal.Header>
-          <h4>{label}</h4>
-        </Modal.Header>
-        <Modal.Body>
+      <React.Fragment>
+        <Header>{label}</Header>
+        <Body>
           <form className="form-horizontal">
             <div className="control-group">
               <h6 className="nav-header">{t('Date')}</h6>
@@ -109,23 +107,23 @@ export default class CustomIgnoreDurationModal extends React.Component<Props, St
               />
             </div>
           </form>
-        </Modal.Body>
+        </Body>
         {this.state.dateWarning && (
           <Alert icon={<IconWarning size="md" />} type="error">
             {t('Please enter a valid date in the future')}
           </Alert>
         )}
-        <Modal.Footer>
+        <Footer>
           <ButtonBar gap={1}>
-            <Button type="button" priority="default" onClick={this.props.onCanceled}>
+            <Button type="button" priority="default" onClick={this.props.closeModal}>
               {t('Cancel')}
             </Button>
             <Button type="button" priority="primary" onClick={this.snoozeClicked}>
               {t('Ignore')}
             </Button>
           </ButtonBar>
-        </Modal.Footer>
-      </Modal>
+        </Footer>
+      </React.Fragment>
     );
   }
 }

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -4,6 +4,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {selectByLabel} from 'sentry-test/select';
 
+import GlobalModal from 'app/components/globalModal';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import {IssueListActions} from 'app/views/issueList/actions';
 
@@ -23,25 +24,28 @@ describe('IssueListActions', function () {
         SelectedGroupStore.records = {};
         SelectedGroupStore.add([1, 2, 3]);
         wrapper = mountWithTheme(
-          <IssueListActions
-            api={new MockApiClient()}
-            allResultsVisible={false}
-            query=""
-            queryCount={1500}
-            orgId="1337"
-            organization={org}
-            projectId="project-slug"
-            selection={{
-              projects: [1],
-              environments: [],
-              datetime: {start: null, end: null, period: null, utc: true},
-            }}
-            groupIds={[1, 2, 3]}
-            onRealtimeChange={function () {}}
-            onSelectStatsPeriod={function () {}}
-            realtimeActive={false}
-            statsPeriod="24h"
-          />,
+          <React.Fragment>
+            <GlobalModal />
+            <IssueListActions
+              api={new MockApiClient()}
+              allResultsVisible={false}
+              query=""
+              queryCount={1500}
+              orgId="1337"
+              organization={org}
+              projectId="project-slug"
+              selection={{
+                projects: [1],
+                environments: [],
+                datetime: {start: null, end: null, period: null, utc: true},
+              }}
+              groupIds={[1, 2, 3]}
+              onRealtimeChange={function () {}}
+              onSelectStatsPeriod={function () {}}
+              realtimeActive={false}
+              statsPeriod="24h"
+            />
+          </React.Fragment>,
           routerContext
         );
       });
@@ -64,7 +68,10 @@ describe('IssueListActions', function () {
         });
         wrapper.find('ResolveActions ActionLink').first().simulate('click');
 
-        expect(wrapper.find('ModalDialog')).toSnapshot();
+        await tick();
+        wrapper.update();
+
+        expect(wrapper.find('Modal')).toSnapshot();
         wrapper.find('Button[priority="primary"]').simulate('click');
         expect(apiMock).toHaveBeenCalledWith(
           expect.anything(),
@@ -86,25 +93,28 @@ describe('IssueListActions', function () {
         SelectedGroupStore.records = {};
         SelectedGroupStore.add([1, 2, 3]);
         wrapper = mountWithTheme(
-          <IssueListActions
-            api={new MockApiClient()}
-            allResultsVisible={false}
-            query=""
-            queryCount={600}
-            orgId="1337"
-            organization={TestStubs.routerContext().context.organization}
-            projectId="1"
-            selection={{
-              projects: [1],
-              environments: [],
-              datetime: {start: null, end: null, period: null, utc: true},
-            }}
-            groupIds={[1, 2, 3]}
-            onRealtimeChange={function () {}}
-            onSelectStatsPeriod={function () {}}
-            realtimeActive={false}
-            statsPeriod="24h"
-          />,
+          <React.Fragment>
+            <GlobalModal />
+            <IssueListActions
+              api={new MockApiClient()}
+              allResultsVisible={false}
+              query=""
+              queryCount={600}
+              orgId="1337"
+              organization={TestStubs.routerContext().context.organization}
+              projectId="1"
+              selection={{
+                projects: [1],
+                environments: [],
+                datetime: {start: null, end: null, period: null, utc: true},
+              }}
+              groupIds={[1, 2, 3]}
+              onRealtimeChange={function () {}}
+              onSelectStatsPeriod={function () {}}
+              realtimeActive={false}
+              statsPeriod="24h"
+            />
+          </React.Fragment>,
           TestStubs.routerContext()
         );
       });
@@ -127,7 +137,10 @@ describe('IssueListActions', function () {
         });
         wrapper.find('ResolveActions ActionLink').first().simulate('click');
 
-        expect(wrapper.find('ModalDialog')).toSnapshot();
+        await tick();
+        wrapper.update();
+
+        expect(wrapper.find('Modal')).toSnapshot();
         wrapper.find('Button[priority="primary"]').simulate('click');
         expect(apiMock).toHaveBeenCalledWith(
           expect.anything(),
@@ -149,25 +162,28 @@ describe('IssueListActions', function () {
         SelectedGroupStore.records = {};
         SelectedGroupStore.add([1, 2, 3]);
         wrapper = mountWithTheme(
-          <IssueListActions
-            api={new MockApiClient()}
-            allResultsVisible
-            query=""
-            queryCount={15}
-            orgId="1337"
-            organization={TestStubs.routerContext().context.organization}
-            projectId="1"
-            selection={{
-              projects: [1],
-              environments: [],
-              datetime: {start: null, end: null, period: null, utc: true},
-            }}
-            groupIds={[1, 2, 3, 6, 9]}
-            onRealtimeChange={function () {}}
-            onSelectStatsPeriod={function () {}}
-            realtimeActive={false}
-            statsPeriod="24h"
-          />,
+          <React.Fragment>
+            <GlobalModal />
+            <IssueListActions
+              api={new MockApiClient()}
+              allResultsVisible
+              query=""
+              queryCount={15}
+              orgId="1337"
+              organization={TestStubs.routerContext().context.organization}
+              projectId="1"
+              selection={{
+                projects: [1],
+                environments: [],
+                datetime: {start: null, end: null, period: null, utc: true},
+              }}
+              groupIds={[1, 2, 3, 6, 9]}
+              onRealtimeChange={function () {}}
+              onSelectStatsPeriod={function () {}}
+              realtimeActive={false}
+              statsPeriod="24h"
+            />
+          </React.Fragment>,
           TestStubs.routerContext()
         );
       });
@@ -181,7 +197,9 @@ describe('IssueListActions', function () {
           .spyOn(SelectedGroupStore, 'getSelectedIds')
           .mockImplementation(() => new Set([3, 6, 9]));
 
-        wrapper.setState({allInQuerySelected: false, anySelected: true});
+        wrapper
+          .find('IssueListActions')
+          .setState({allInQuerySelected: false, anySelected: true});
         wrapper.find('ResolveActions ActionLink').first().simulate('click');
         expect(apiMock).toHaveBeenCalledWith(
           expect.anything(),
@@ -195,7 +213,7 @@ describe('IssueListActions', function () {
         );
       });
 
-      it('ignores selected items', function () {
+      it('ignores selected items', async function () {
         const apiMock = MockApiClient.addMockResponse({
           url: '/organizations/1337/issues/',
           method: 'PUT',
@@ -204,8 +222,13 @@ describe('IssueListActions', function () {
           .spyOn(SelectedGroupStore, 'getSelectedIds')
           .mockImplementation(() => new Set([3, 6, 9]));
 
-        wrapper.setState({allInQuerySelected: false, anySelected: true});
+        wrapper
+          .find('IssueListActions')
+          .setState({allInQuerySelected: false, anySelected: true});
         wrapper.find('IgnoreActions MenuItem a').last().simulate('click');
+
+        await tick();
+        wrapper.update();
 
         wrapper
           .find('CustomIgnoreCountModal input[label="Number of users"]')
@@ -341,26 +364,29 @@ describe('IssueListActions', function () {
       SelectedGroupStore.records = {};
       const {organization} = TestStubs.routerContext().context;
       wrapper = mountWithTheme(
-        <IssueListActions
-          api={new MockApiClient()}
-          query=""
-          orgId="1337"
-          organization={organization}
-          groupIds={[1, 2, 3]}
-          selection={{
-            projects: [],
-            environments: [],
-            datetime: {start: null, end: null, period: null, utc: true},
-          }}
-          onRealtimeChange={function () {}}
-          onSelectStatsPeriod={function () {}}
-          realtimeActive={false}
-          statsPeriod="24h"
-          queryCount={100}
-          queryMaxCount={100}
-          pageCount={3}
-          hasInbox
-        />,
+        <React.Fragment>
+          <GlobalModal />
+          <IssueListActions
+            api={new MockApiClient()}
+            query=""
+            orgId="1337"
+            organization={organization}
+            groupIds={[1, 2, 3]}
+            selection={{
+              projects: [],
+              environments: [],
+              datetime: {start: null, end: null, period: null, utc: true},
+            }}
+            onRealtimeChange={function () {}}
+            onSelectStatsPeriod={function () {}}
+            realtimeActive={false}
+            statsPeriod="24h"
+            queryCount={100}
+            queryMaxCount={100}
+            pageCount={3}
+            hasInbox
+          />
+        </React.Fragment>,
         TestStubs.routerContext()
       );
     });
@@ -370,12 +396,12 @@ describe('IssueListActions', function () {
     });
 
     it('displays actions on issue selection', async function () {
-      wrapper.setState({anySelected: true});
+      wrapper.find('IssueListActions').setState({anySelected: true});
       expect(wrapper.find('[data-test-id="button-acknowledge"]').exists()).toBe(true);
     });
 
     it('acknowledges group', async function () {
-      wrapper.setState({anySelected: true});
+      wrapper.find('IssueListActions').setState({anySelected: true});
       SelectedGroupStore.add([1, 2, 3]);
       SelectedGroupStore.toggleSelectAll();
       const apiMock = MockApiClient.addMockResponse({
@@ -384,7 +410,7 @@ describe('IssueListActions', function () {
       });
       wrapper.find('[data-test-id="button-acknowledge"]').first().simulate('click');
 
-      expect(wrapper.find('ModalDialog')).toSnapshot();
+      expect(wrapper.find('Modal')).toSnapshot();
       wrapper.find('Button[priority="primary"]').simulate('click');
       expect(apiMock).toHaveBeenCalledWith(
         expect.anything(),


### PR DESCRIPTION
Converts to using the openModal action creator, which will open the modal using the GlobalModal component.

One step closer to opening all modals from the same place, allowing easy animations / consistent styling / etc