### PR TITLE
fix(ui): Show error toast for invalid team

### DIFF
--- a/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
+++ b/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
@@ -117,13 +117,9 @@ class MissingProjectMembership extends React.Component<Props, State> {
     teams.forEach(({slug}) => {
       const team = TeamStore.getBySlug(slug);
       if (!team) {
-        addErrorMessage(
-          t(
-            'There was an error while trying to request a team associated with this project.'
-          )
-        );
+        return;
       } else {
-        team?.isPending ? pending.push(team!.slug) : request.push(team!.slug);
+        team.isPending ? pending.push(team.slug) : request.push(team.slug);
       }
     });
 

--- a/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
+++ b/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
@@ -116,7 +116,15 @@ class MissingProjectMembership extends React.Component<Props, State> {
     const teams = this.state.project?.teams ?? [];
     teams.forEach(({slug}) => {
       const team = TeamStore.getBySlug(slug);
-      team?.isPending ? pending.push(team!.slug) : request.push(team!.slug);
+      if (!team) {
+        addErrorMessage(
+          t(
+            'There was an error while trying to request a team associated with this project.'
+          )
+        );
+      } else {
+        team?.isPending ? pending.push(team!.slug) : request.push(team!.slug);
+      }
     });
 
     return [request, pending];

--- a/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
+++ b/src/sentry/static/sentry/app/components/projects/missingProjectMembership.tsx
@@ -118,9 +118,8 @@ class MissingProjectMembership extends React.Component<Props, State> {
       const team = TeamStore.getBySlug(slug);
       if (!team) {
         return;
-      } else {
-        team.isPending ? pending.push(team.slug) : request.push(team.slug);
       }
+      team.isPending ? pending.push(team.slug) : request.push(team.slug);
     });
 
     return [request, pending];


### PR DESCRIPTION
Handle `Cannot read property 'slug' of null` error. Show an error toast if a team is null. Valid teams are still returned and displayed in the list to request access to join the project.

FIXES JAVASCRIPT-23BT
FIXES JAVASCRIPT-23B0

### Before
<img width="1205" alt="Screen Shot 2020-12-08 at 1 15 09 AM 1" src="https://user-images.githubusercontent.com/20312973/101464174-2a21d200-38f3-11eb-8d03-29533da25f1c.png">

### After
<img width="1204" alt="Screen Shot 2020-12-08 at 1 06 44 AM" src="https://user-images.githubusercontent.com/20312973/101464311-53426280-38f3-11eb-895c-a08f0b15482b.png">
<img width="1182" alt="Screen Shot 2020-12-08 at 1 06 59 AM" src="https://user-images.githubusercontent.com/20312973/101464329-58071680-38f3-11eb-8978-eded8ae324b2.png">
