### PR TITLE
feat(grouping): Add proper inheritance support to grouping enhancements

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -67,7 +67,7 @@ def _get_project_enhancements_config(project):
         return rv
 
     try:
-        rv = Enhancements.from_config_string(enhancements, bases=[enhancements_base]).dumps()
+        rv = Enhancements.from_config_string(enhancements, base=enhancements_base).dumps()
     except InvalidEnhancerConfig:
         rv = get_default_enhancements()
     cache.set(cache_key, rv)
@@ -77,7 +77,7 @@ def _get_project_enhancements_config(project):
 def get_default_enhancements():
     from sentry.projectoptions.defaults import DEFAULT_GROUPING_ENHANCEMENTS_BASE
 
-    return Enhancements(rules=[], bases=[DEFAULT_GROUPING_ENHANCEMENTS_BASE]).dumps()
+    return Enhancements(rules=[], base=DEFAULT_GROUPING_ENHANCEMENTS_BASE).dumps()
 
 
 def get_default_grouping_config_dict(id=None):

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1666,7 +1666,7 @@ export type GroupingEnhancementBase = {
   latest: boolean;
   id: string;
   changelog: string;
-  bases: any[]; // TODO(ts): not sure what this is
+  base?: string | null;
 };
 
 type EventGroupVariantKey = 'custom-fingerprint' | 'app' | 'default' | 'system';

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -37,8 +37,7 @@ class GroupingInput(object):
         enhancement_base = grouping_info.get("enhancement_base")
         enhancements = grouping_info.get("enhancements")
         if enhancement_base or enhancements:
-            enhancement_bases = [enhancement_base] if enhancement_base else []
-            e = Enhancements.from_config_string(enhancements or "", bases=enhancement_bases)
+            e = Enhancements.from_config_string(enhancements or "", base=enhancement_base)
             grouping_config["enhancements"] = e.dumps()
 
         # Normalize the event

--- a/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing.pysnap
+++ b/tests/sentry/grouping/snapshots/test_enhancer/test_basic_parsing.pysnap
@@ -1,10 +1,9 @@
 ---
-created: '2020-09-01T22:01:36.949231Z'
+created: '2020-12-08T09:11:58.983299Z'
 creator: sentry
 source: tests/sentry/grouping/test_enhancer.py
 ---
-bases:
-- common:v1
+base: common:v1
 changelog: null
 id: null
 rules:

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -37,7 +37,7 @@ family:javascript path:*/test.js                -app
 family:javascript app:1 path:*/test.js          -app
 family:native                                   max-frames=3
 """,
-        bases=["common:v1"],
+        base="common:v1",
     )
 
     dumped = enhancement.dumps()


### PR DESCRIPTION
It's currently impossible for us to roll out actual new versions of grouping enhancements without producing a bad changelog. This now sets a single base to each grouping enhancement rule (instead of a list which was never used) and makes the UI aware of this inheritance.

This now means if you go from A->B->C the changelog will show B and C.

It also adds a `@extends` marker to the text format for grouping enhancements so that one can declare from the text file which file is the base. Currently when base rules are included they are all inherited. It might make sense to add a variation of this later which does not actually include the rules but just sets up the inheritance for the changelog in case rules have to be removed.