### PR TITLE
ref(modals): Use openModal for CustomResolutionModal

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/resolve.tsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
+import {openModal} from 'app/actionCreators/modal';
 import ActionLink from 'app/components/actions/actionLink';
 import CustomResolutionModal from 'app/components/customResolutionModal';
 import DropdownLink from 'app/components/dropdownLink';
@@ -40,11 +41,7 @@ type Props = {
   hasInbox?: boolean;
 } & typeof defaultProps;
 
-type State = {
-  modal: boolean;
-};
-
-class ResolveActions extends React.Component<Props, State> {
+class ResolveActions extends React.Component<Props> {
   static propTypes = {
     hasRelease: PropTypes.bool.isRequired,
     latestRelease: PropTypes.object,
@@ -63,13 +60,7 @@ class ResolveActions extends React.Component<Props, State> {
 
   static defaultProps = defaultProps;
 
-  state = {modal: false};
-
   onCustomResolution(statusDetails: ResolutionStatusDetails) {
-    this.setState({
-      modal: false,
-    });
-
     this.props.onUpdate({
       status: ResolutionStatus.RESOLVED,
       statusDetails,
@@ -197,7 +188,7 @@ class ResolveActions extends React.Component<Props, State> {
             <ActionLink
               {...actionLinkProps}
               title={t('Another version')}
-              onAction={() => hasRelease && this.setState({modal: true})}
+              onAction={() => hasRelease && this.openCustomReleaseModal()}
               shouldConfirm={false}
             >
               {t('Another version\u2026')}
@@ -208,12 +199,25 @@ class ResolveActions extends React.Component<Props, State> {
     );
   }
 
+  openCustomReleaseModal() {
+    const {orgId, projectId} = this.props;
+
+    openModal(deps => (
+      <CustomResolutionModal
+        {...deps}
+        onSelected={(statusDetails: ResolutionStatusDetails) =>
+          this.onCustomResolution(statusDetails)
+        }
+        orgId={orgId}
+        projectId={projectId}
+      />
+    ));
+  }
+
   render() {
     const {
       isResolved,
       onUpdate,
-      orgId,
-      projectId,
       confirmMessage,
       shouldConfirm,
       disabled,
@@ -237,15 +241,6 @@ class ResolveActions extends React.Component<Props, State> {
 
     return (
       <Wrapper hasInbox={hasInbox}>
-        <CustomResolutionModal
-          show={this.state.modal}
-          onSelected={(statusDetails: ResolutionStatusDetails) =>
-            this.onCustomResolution(statusDetails)
-          }
-          onCanceled={() => this.setState({modal: false})}
-          orgId={orgId}
-          projectId={projectId}
-        />
         <Tooltip disabled={!projectFetchError} title={t('Error fetching project')}>
           {hasInbox ? (
             <div style={{width: '100%'}}>

--- a/src/sentry/static/sentry/app/components/customResolutionModal.tsx
+++ b/src/sentry/static/sentry/app/components/customResolutionModal.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import {Modal} from 'react-bootstrap';
 import PropTypes from 'prop-types';
 
+import {ModalRenderProps} from 'app/actionCreators/modal';
 import Button from 'app/components/button';
 import {SelectAsyncField} from 'app/components/forms';
 import TimeSince from 'app/components/timeSince';
@@ -10,12 +10,10 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Release} from 'app/types';
 
-type Props = {
+type Props = ModalRenderProps & {
   onSelected: ({inRelease: string}) => void;
-  onCanceled: () => void;
   orgId: string;
   projectId?: string;
-  show?: boolean;
 };
 
 type State = {
@@ -25,20 +23,12 @@ type State = {
 class CustomResolutionModal extends React.Component<Props, State> {
   static propTypes = {
     onSelected: PropTypes.func.isRequired,
-    onCanceled: PropTypes.func.isRequired,
     orgId: PropTypes.string.isRequired,
     projectId: PropTypes.string,
-    show: PropTypes.bool,
   };
 
   state = {
     version: '',
-  };
-
-  onSubmit = () => {
-    this.props.onSelected({
-      inRelease: this.state.version,
-    });
   };
 
   onChange = (value: string) => {
@@ -62,38 +52,42 @@ class CustomResolutionModal extends React.Component<Props, State> {
     }));
 
   render() {
-    const {orgId, projectId, show, onCanceled} = this.props;
+    const {orgId, projectId, closeModal, onSelected, Header, Body, Footer} = this.props;
     const url = projectId
       ? `/projects/${orgId}/${projectId}/releases/`
       : `/organizations/${orgId}/releases/`;
 
+    const onSubmit = (e: React.FormEvent) => {
+      e.preventDefault();
+      onSelected({inRelease: this.state.version});
+      closeModal();
+    };
+
     return (
-      <Modal show={show} animation={false} onHide={onCanceled}>
-        <form onSubmit={this.onSubmit}>
-          <Modal.Header>{t('Resolved In')}</Modal.Header>
-          <Modal.Body>
-            <SelectAsyncField
-              deprecatedSelectControl
-              label={t('Version')}
-              id="version"
-              name="version"
-              onChange={this.onChange}
-              placeholder={t('e.g. 1.0.4')}
-              url={url}
-              onResults={this.onAsyncFieldResults}
-              onQuery={query => ({query})}
-            />
-          </Modal.Body>
-          <Modal.Footer>
-            <Button type="button" css={{marginRight: space(1.5)}} onClick={onCanceled}>
-              {t('Cancel')}
-            </Button>
-            <Button type="submit" priority="primary">
-              {t('Save Changes')}
-            </Button>
-          </Modal.Footer>
-        </form>
-      </Modal>
+      <form onSubmit={onSubmit}>
+        <Header>{t('Resolved In')}</Header>
+        <Body>
+          <SelectAsyncField
+            deprecatedSelectControl
+            label={t('Version')}
+            id="version"
+            name="version"
+            onChange={this.onChange}
+            placeholder={t('e.g. 1.0.4')}
+            url={url}
+            onResults={this.onAsyncFieldResults}
+            onQuery={query => ({query})}
+          />
+        </Body>
+        <Footer>
+          <Button type="button" css={{marginRight: space(1.5)}} onClick={closeModal}>
+            {t('Cancel')}
+          </Button>
+          <Button type="submit" priority="primary">
+            {t('Save Changes')}
+          </Button>
+        </Footer>
+      </form>
     );
   }
 }

--- a/tests/js/spec/components/actions/resolve.spec.jsx
+++ b/tests/js/spec/components/actions/resolve.spec.jsx
@@ -4,6 +4,7 @@ import $ from 'jquery';
 import {mountWithTheme} from 'sentry-test/enzyme';
 
 import ResolveActions from 'app/components/actions/resolve';
+import GlobalModal from 'app/components/globalModal';
 
 describe('ResolveActions', function () {
   describe('disabled', function () {
@@ -151,14 +152,17 @@ describe('ResolveActions', function () {
 
     beforeEach(function () {
       component = mountWithTheme(
-        <ResolveActions
-          onUpdate={spy}
-          hasRelease={false}
-          orgId="org-1"
-          projectId="proj-1"
-          shouldConfirm
-          confirmMessage="Are you sure???"
-        />,
+        <React.Fragment>
+          <GlobalModal />
+          <ResolveActions
+            onUpdate={spy}
+            hasRelease={false}
+            orgId="org-1"
+            projectId="proj-1"
+            shouldConfirm
+            confirmMessage="Are you sure???"
+          />
+        </React.Fragment>,
         TestStubs.routerContext()
       );
       button = component.find('a.btn.btn-default').first();
@@ -168,10 +172,13 @@ describe('ResolveActions', function () {
       expect(component).toSnapshot();
     });
 
-    it('displays confirmation modal with message provided', function () {
+    it('displays confirmation modal with message provided', async function () {
       button.simulate('click');
 
-      const modal = $(document.body).find('.modal');
+      await tick();
+      component.update();
+
+      const modal = component.find('Modal ModalDialog');
       expect(modal.text()).toContain('Are you sure???');
       expect(spy).not.toHaveBeenCalled();
       $(document.body).find('.modal button:contains("Resolve")').click();
@@ -187,12 +194,15 @@ describe('ResolveActions', function () {
       body: [TestStubs.Release()],
     });
     const wrapper = mountWithTheme(
-      <ResolveActions
-        hasRelease
-        orgId="org-slug"
-        projectId="project-slug"
-        onUpdate={onUpdate}
-      />,
+      <React.Fragment>
+        <GlobalModal />
+        <ResolveActions
+          hasRelease
+          orgId="org-slug"
+          projectId="project-slug"
+          onUpdate={onUpdate}
+        />
+      </React.Fragment>,
       TestStubs.routerContext()
     );
 

--- a/tests/js/spec/components/customResolutionModal.spec.jsx
+++ b/tests/js/spec/components/customResolutionModal.spec.jsx
@@ -17,11 +17,13 @@ describe('CustomResolutionModal', function () {
     const onSelected = jest.fn();
     const wrapper = mountWithTheme(
       <CustomResolutionModal
+        Header={p => p.children}
+        Body={p => p.children}
+        Footer={p => p.children}
         orgId="org-slug"
         projectId="project-slug"
-        onCanceled={() => false}
         onSelected={onSelected}
-        show
+        closeModal={jest.fn()}
       />,
       TestStubs.routerContext()
     );
@@ -49,6 +51,7 @@ describe('CustomResolutionModal', function () {
       value: 'sentry-android-shop@1.2.0',
       label: expect.anything(),
     });
+
     wrapper.find('form').simulate('submit');
     expect(onSelected).toHaveBeenCalledWith({
       inRelease: 'sentry-android-shop@1.2.0',


### PR DESCRIPTION
Converts to using the `openModal` action creator, which will open the modal using the GlobalModal component.

One step closer to opening all modals from the same place, allowing easy animations / consistent styling / etc