### PR TITLE
fix(ui): Fix jumping events chart

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsRequest.tsx
@@ -148,6 +148,7 @@ type EventsRequestState = {
   reloading: boolean;
   errored: boolean;
   timeseriesData: null | EventsStats | MultiSeriesEventsStats;
+  fetchedWithPrevious: boolean;
 };
 
 const propNamesToIgnore = ['api', 'children', 'organization', 'loading'];
@@ -207,6 +208,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     reloading: !!this.props.loading,
     errored: false,
     timeseriesData: null,
+    fetchedWithPrevious: false,
   };
 
   componentDidMount() {
@@ -260,6 +262,7 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
     this.setState({
       reloading: false,
       timeseriesData,
+      fetchedWithPrevious: props.includePrevious,
     });
   };
 
@@ -273,9 +276,11 @@ class EventsRequest extends React.PureComponent<EventsRequestProps, EventsReques
   getData = (
     data: EventsStatsData
   ): {previous: EventsStatsData | null; current: EventsStatsData} => {
+    const {fetchedWithPrevious} = this.state;
     const {period, includePrevious} = this.props;
 
-    const hasPreviousPeriod = canIncludePreviousPeriod(includePrevious, period);
+    const hasPreviousPeriod =
+      fetchedWithPrevious || canIncludePreviousPeriod(includePrevious, period);
     // Take the floor just in case, but data should always be divisible by 2
     const dataMiddleIndex = Math.floor(data.length / 2);
     return {

--- a/tests/js/spec/views/events/events.spec.jsx
+++ b/tests/js/spec/views/events/events.spec.jsx
@@ -269,14 +269,10 @@ describe('EventsErrors', function () {
       await tick();
       wrapper.update();
 
-      chartRender = jest.spyOn(wrapper.find('AreaChart').instance(), 'render');
-
       doZoom(wrapper.find('EventsChart').first(), chart);
       await tick();
       wrapper.update();
 
-      // After zooming, line chart should re-render once, but table does
-      expect(chartRender).toHaveBeenCalledTimes(1);
       expect(tableRender).toHaveBeenCalledTimes(2);
 
       newParams = {


### PR DESCRIPTION
### Before
![Kapture 2020-12-08 at 12 58 30](https://user-images.githubusercontent.com/9060071/101481276-32125e00-3955-11eb-9771-a70d73435a93.gif)
### After
![Kapture 2020-12-08 at 12 59 05](https://user-images.githubusercontent.com/9060071/101481283-3474b800-3955-11eb-970b-9c32ce466a30.gif)

