### PR TITLE
fix(performance) Improve sidebar charts

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/utils.tsx
+++ b/src/sentry/static/sentry/app/components/charts/utils.tsx
@@ -11,6 +11,7 @@ import {decodeList} from 'app/utils/queryString';
 const DEFAULT_TRUNCATE_LENGTH = 80;
 
 // In minutes
+export const SIXTY_DAYS = 86400;
 export const THIRTY_DAYS = 43200;
 export const TWO_WEEKS = 20160;
 export const ONE_WEEK = 10080;
@@ -45,12 +46,21 @@ export function useShortInterval(datetimeObj: DateTimeObject): boolean {
 export function getInterval(datetimeObj: DateTimeObject, highFidelity = false) {
   const diffInMinutes = getDiffInMinutes(datetimeObj);
 
+  if (diffInMinutes >= SIXTY_DAYS) {
+    // Greater than or equal to 30 days
+    if (highFidelity) {
+      return '4h';
+    } else {
+      return '1d';
+    }
+  }
+
   if (diffInMinutes >= THIRTY_DAYS) {
     // Greater than or equal to 30 days
     if (highFidelity) {
       return '1h';
     } else {
-      return '24h';
+      return '4h';
     }
   }
 
@@ -59,7 +69,7 @@ export function getInterval(datetimeObj: DateTimeObject, highFidelity = false) {
     if (highFidelity) {
       return '30m';
     } else {
-      return '24h';
+      return '1h';
     }
   }
 

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
@@ -91,6 +91,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
       {
         // apdex
         gridIndex: 0,
+        interval: 0.2,
         axisLabel: {
           formatter: (value: number) => formatFloat(value, 1),
           color: theme.chartLabel,
@@ -100,6 +101,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
       {
         // throughput
         gridIndex: 1,
+        splitNumber: 4,
         axisLabel: {
           formatter: formatAbbreviatedNumber,
           color: theme.chartLabel,
@@ -109,6 +111,8 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
       {
         // failure rate
         gridIndex: 2,
+        splitNumber: 4,
+        interval: 0.5,
         axisLabel: {
           formatter: (value: number) => formatPercentage(value, 0),
           color: theme.chartLabel,
@@ -183,7 +187,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
             environment={[...environment]}
             start={start}
             end={end}
-            interval={getInterval(datetimeSelection, true)}
+            interval={getInterval(datetimeSelection)}
             showLoading={false}
             query={eventView.query}
             includePrevious={false}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
@@ -113,6 +113,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
         gridIndex: 2,
         splitNumber: 4,
         interval: 0.5,
+        max: 1.0,
         axisLabel: {
           formatter: (value: number) => formatPercentage(value, 0),
           color: theme.chartLabel,

--- a/tests/js/spec/components/charts/utils.spec.jsx
+++ b/tests/js/spec/components/charts/utils.spec.jsx
@@ -17,11 +17,17 @@ describe('Chart Utils', function () {
       it('between 30 minutes and 24 hours', function () {
         expect(getInterval({period: '12h'}, true)).toBe('5m');
       });
+      it('more than 30 days', function () {
+        expect(getInterval({period: '30d'}, true)).toBe('1h');
+      });
+      it('more than 60 days', function () {
+        expect(getInterval({period: '90d'}, true)).toBe('4h');
+      });
     });
 
     describe('with low fidelity', function () {
       it('greater than 24 hours', function () {
-        expect(getInterval({period: '25h'})).toBe('24h');
+        expect(getInterval({period: '25h'})).toBe('1h');
       });
 
       it('less than 30 minutes', function () {
@@ -29,6 +35,12 @@ describe('Chart Utils', function () {
       });
       it('between 30 minutes and 24 hours', function () {
         expect(getInterval({period: '12h'})).toBe('15m');
+      });
+      it('more than 30 days', function () {
+        expect(getInterval({period: '30d'})).toBe('4h');
+      });
+      it('more than 90 days', function () {
+        expect(getInterval({period: '90d'})).toBe('1d');
       });
     });
   });

--- a/tests/js/spec/views/dashboards/dashboard.spec.jsx
+++ b/tests/js/spec/views/dashboards/dashboard.spec.jsx
@@ -109,7 +109,7 @@ describe('OrganizationDashboard', function () {
           limit: 1000,
           orderby: '-time',
           groupby: ['time'],
-          rollup: 86400,
+          rollup: 3600,
         }),
       })
     );

--- a/tests/js/spec/views/dashboards/dashboard.spec.jsx
+++ b/tests/js/spec/views/dashboards/dashboard.spec.jsx
@@ -91,7 +91,7 @@ describe('OrganizationDashboard', function () {
           limit: 1000,
           orderby: '-time',
           groupby: ['time'],
-          rollup: 86400,
+          rollup: 3600,
         }),
       })
     );

--- a/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
+++ b/tests/js/spec/views/dashboards/overviewDashboard.spec.jsx
@@ -91,7 +91,7 @@ describe('OverviewDashboard', function () {
 
           orderby: '-time',
           groupby: ['time', 'release'],
-          rollup: 86400,
+          rollup: 3600,
         },
       ],
     });
@@ -122,7 +122,7 @@ describe('OverviewDashboard', function () {
           limit: 1000,
           orderby: '-time',
           groupby: ['time'],
-          rollup: 86400,
+          rollup: 3600,
         }),
       })
     );
@@ -142,7 +142,7 @@ describe('OverviewDashboard', function () {
           limit: 1000,
           orderby: '-time',
           groupby: ['time'],
-          rollup: 86400,
+          rollup: 3600,
         }),
       })
     );
@@ -174,7 +174,7 @@ describe('OverviewDashboard', function () {
           orderby: '-time',
           groupby: ['time', 'release'],
           name: 'Events by Release',
-          rollup: 86400,
+          rollup: 3600,
         }),
       })
     );
@@ -229,7 +229,7 @@ describe('OverviewDashboard', function () {
           orderby: '-time',
           groupby: ['time', 'release'],
           name: 'Events by Release',
-          rollup: 86400,
+          rollup: 3600,
         }),
       })
     );

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -108,7 +108,7 @@ describe('Dashboards > WidgetQueries', function () {
     expect(errorMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
-        query: expect.objectContaining({interval: '1h'}),
+        query: expect.objectContaining({interval: '4h'}),
       })
     );
   });


### PR DESCRIPTION
1. Increase the resolution in 'low fidelity' mode so that there is   a less drastic change between intervals. This will impact charts    across the application but in a good way.
2. Reduce y-axis label noise in sidebar charts. There were often too    many labels that contained duplicate values because of how we format    y-axis values. Reducing the number of elements makes the charts    easier to read.