### PR TITLE
feat(grouping): Remember fingerprinting rule

### DIFF
--- a/src/sentry/grouping/api.py
+++ b/src/sentry/grouping/api.py
@@ -130,15 +130,23 @@ def get_fingerprinting_config_for_project(project):
 
 
 def apply_server_fingerprinting(event, config, allow_custom_title=True):
+    client_fingerprint = event.get("fingerprint")
     rv = config.get_fingerprint_values_for_event(event)
     if rv is not None:
-        new_fingerprint, attributes = rv
+        rule, new_fingerprint, attributes = rv
 
         # A custom title attribute is stored in the event to override the
         # default title.
         if "title" in attributes and allow_custom_title:
             event["title"] = expand_title_template(attributes["title"], event)
         event["fingerprint"] = new_fingerprint
+
+        # Persist the rule that matched with the fingerprint in the event
+        # dictionary for later debugging.
+        event["_fingerprint_info"] = {
+            "client_fingerprint": client_fingerprint,
+            "matched_rule": rule.to_json(),
+        }
 
 
 def _get_calculated_grouping_variants_for_event(event, config):
@@ -199,8 +207,11 @@ def get_grouping_variants_for_event(event, config=None):
 
         return rv
 
-    # Otherwise we go to the various forms of fingerprint handling.
+    # Otherwise we go to the various forms of fingerprint handling.  If the event carries
+    # a materialized fingerprint info from server side fingerprinting we forward it to the
+    # variants which can export additional information about them.
     fingerprint = event.data.get("fingerprint") or ["{{ default }}"]
+    fingerprint_info = event.data.get("_fingerprint_info")
     defaults_referenced = sum(1 if is_default_fingerprint_var(d) else 0 for d in fingerprint)
 
     if config is None:
@@ -223,7 +234,7 @@ def get_grouping_variants_for_event(event, config=None):
             rv[key] = ComponentVariant(component, config)
 
         fingerprint = resolve_fingerprint_values(fingerprint, event.data)
-        rv["custom-fingerprint"] = CustomFingerprintVariant(fingerprint)
+        rv["custom-fingerprint"] = CustomFingerprintVariant(fingerprint, fingerprint_info)
 
     # If the fingerprints are unsalted, we can return them right away.
     elif defaults_referenced == 1 and len(fingerprint) == 1:
@@ -236,7 +247,7 @@ def get_grouping_variants_for_event(event, config=None):
         rv = {}
         fingerprint = resolve_fingerprint_values(fingerprint, event.data)
         for (key, component) in six.iteritems(components):
-            rv[key] = SaltedComponentVariant(fingerprint, component, config)
+            rv[key] = SaltedComponentVariant(fingerprint, component, config, fingerprint_info)
 
     # Ensure we have a fallback hash if nothing else works out
     if not any(x.contributes for x in six.itervalues(rv)):

--- a/src/sentry/static/sentry/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/src/sentry/static/sentry/app/components/events/groupingInfo/groupingVariant.tsx
@@ -27,6 +27,40 @@ type State = {
 
 type VariantData = [string, React.ReactNode][];
 
+function addFingerprintInfo(data: VariantData, variant: EventGroupVariant) {
+  if (variant.matched_rule) {
+    data.push([
+      t('Fingerprint rule'),
+      <TextWithQuestionTooltip key="type">
+        {variant.matched_rule}
+        <QuestionTooltip
+          size="xs"
+          position="top"
+          title={t('The server-side fingerprinting rule that produced the fingerprint.')}
+        />
+      </TextWithQuestionTooltip>,
+    ]);
+  }
+  if (variant.values) {
+    data.push([t('Fingerprint values'), variant.values]);
+  }
+  if (variant.client_values) {
+    data.push([
+      t('Client fingerprint values'),
+      <TextWithQuestionTooltip key="type">
+        {variant.client_values}
+        <QuestionTooltip
+          size="xs"
+          position="top"
+          title={t(
+            'The client sent a fingerprint that was overridden by a server-side fingerprinting rule.'
+          )}
+        />
+      </TextWithQuestionTooltip>,
+    ]);
+  }
+}
+
 class GroupVariant extends React.Component<Props, State> {
   state = {
     showNonContributing: false,
@@ -102,9 +136,7 @@ class GroupVariant extends React.Component<Props, State> {
             />
           </TextWithQuestionTooltip>,
         ]);
-        if (variant.values) {
-          data.push([t('Fingerprint values'), variant.values]);
-        }
+        addFingerprintInfo(data, variant);
         break;
       case EventGroupVariantType.SALTED_COMPONENT:
         component = variant.component;
@@ -121,9 +153,7 @@ class GroupVariant extends React.Component<Props, State> {
             />
           </TextWithQuestionTooltip>,
         ]);
-        if (variant.values) {
-          data.push([t('Fingerprint values'), variant.values]);
-        }
+        addFingerprintInfo(data, variant);
         if (showGroupingConfig && variant.config?.id) {
           data.push([t('Grouping Config'), variant.config.id]);
         }

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1683,7 +1683,9 @@ export type EventGroupVariant = {
   hashMismatch: boolean;
   key: EventGroupVariantKey;
   type: EventGroupVariantType;
-  values?: string;
+  values?: Array<string>;
+  client_values?: Array<string>;
+  matched_rule?: string;
   component?: EventGroupComponent;
   config?: EventGroupingConfig;
 };

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:31.381648Z'
+created: '2020-12-08T17:25:04.610129Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,6 +23,10 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    client_values:
+    - my-route
+    - '{{ default }}'
+    matched_rule: type:"DatabaseUnavailable" -> "database-unavailable"
     type: custom-fingerprint
     values:
     - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_type_and_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:31.951732Z'
+created: '2020-12-08T17:25:05.043711Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,6 +25,10 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    client_values:
+    - my-route
+    - '{{ default }}'
+    matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable"
     type: custom-fingerprint
     values:
     - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_exception_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-23T09:01:29.796869Z'
+created: '2020-12-08T17:25:05.016663Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,6 +23,7 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: value:"*went wrong*" -> "something-went-wrong"
     type: custom-fingerprint
     values:
     - something-went-wrong

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:30.459242Z'
+created: '2020-12-08T17:25:03.888626Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,6 +27,8 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
+      function }}"
     type: custom-fingerprint
     values:
     - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:31.856405Z'
+created: '2020-12-08T17:25:04.989714Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -17,6 +17,7 @@ fingerprint:
 title: Hello my sweet Love
 variants:
   custom-fingerprint:
+    matched_rule: message:"*love*" -> "what-is-love"
     type: custom-fingerprint
     values:
     - what-is-love

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_message_on_value.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:30.542963Z'
+created: '2020-12-08T17:25:03.946316Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,6 +23,7 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: message:"*love*" -> "what-is-love"
     type: custom-fingerprint
     values:
     - what-is-love

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:31.736959Z'
+created: '2020-12-08T17:25:04.926320Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,6 +25,8 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: type:"SymCacheError" function:"symbolicator::actors::symcaches::*"
+      -> "symcache-error"
     type: custom-fingerprint
     values:
     - symcache-error

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_native_app.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:30.966977Z'
+created: '2020-12-08T17:25:04.277740Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,6 +25,7 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: function:"symbolicator::actors::symcaches::*" app:"true" -> "symcache-error"
     type: custom-fingerprint
     values:
     - symcache-error

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_function.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:31.971253Z'
+created: '2020-12-08T17:25:05.057772Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,6 +27,8 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
+      function }}"
     type: custom-fingerprint
     values:
     - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:30.523516Z'
+created: '2020-12-08T17:25:03.931600Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,6 +23,7 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
     type: custom-fingerprint
     values:
     - <no-package>

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:30.563091Z'
+created: '2020-12-08T17:25:03.959890Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,6 +27,8 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
+      transaction }}"
     type: custom-fingerprint
     values:
     - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_no_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:30.408662Z'
+created: '2020-12-08T17:25:03.857235Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,6 +27,7 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: function:"main" -> "{{ type }}{{ module }}{{ function }}"
     type: custom-fingerprint
     values:
     - <no-type>

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_log_info.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:31.824415Z'
+created: '2020-12-08T17:25:04.978501Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -25,6 +25,7 @@ fingerprint:
 title: Love not found.
 variants:
   custom-fingerprint:
+    matched_rule: logger:"sentry.*" level:"ERROR" -> "log-{{ logger }}-{{ level }}"
     type: custom-fingerprint
     values:
     - log-

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_on_tags.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:31.802211Z'
+created: '2020-12-08T17:25:04.966299Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -19,6 +19,7 @@ fingerprint:
 title: Hello my sweet Love
 variants:
   custom-fingerprint:
+    matched_rule: tags.foobar:"*stuff*" -> "foobar-matched-stuff-{{ tags.barfoo }}"
     type: custom-fingerprint
     values:
     - foobar-matched-stuff-

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_override_client.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:30.477473Z'
+created: '2020-12-08T17:25:03.900569Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -17,6 +17,9 @@ fingerprint:
 title: Hello my sweet Love
 variants:
   custom-fingerprint:
+    client_values:
+    - client-sent
+    matched_rule: message:"*love*" -> "what-is-love"
     type: custom-fingerprint
     values:
     - what-is-love

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_package.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:31.756199Z'
+created: '2020-12-08T17:25:04.941471Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -23,6 +23,7 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: type:"DatabaseUnavailable" -> "{{ package }}"
     type: custom-fingerprint
     values:
     - foo.dylib

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_python.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:30.438865Z'
+created: '2020-12-08T17:25:03.875766Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -26,6 +26,7 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: type:"ReadTimeout" path:"**/requests/adapters.py" -> "timeout-in-requests"
     type: custom-fingerprint
     values:
     - timeout-in-requests

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_transaction.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:10:26.756360Z'
+created: '2020-12-08T17:25:05.003284Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -28,6 +28,8 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "database-unavailable{{
+      transaction }}" title="DatabaseUnavailable ({{ transaction }})"
     type: custom-fingerprint
     values:
     - database-unavailable

--- a/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
+++ b/tests/sentry/grouping/snapshots/test_fingerprinting/test_event_hash_variant/fingerprint_type_module.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-10-13T10:09:31.778916Z'
+created: '2020-12-08T17:25:04.954793Z'
 creator: sentry
 source: tests/sentry/grouping/test_fingerprinting.py
 ---
@@ -27,6 +27,8 @@ variants:
       hint: custom fingerprint takes precedence
     type: component
   custom-fingerprint:
+    matched_rule: type:"DatabaseUnavailable" module:"io.sentry.example.*" -> "{{ type
+      }}{{ module }}"
     type: custom-fingerprint
     values:
     - DatabaseUnavailable

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/combined@2019_04_07/custom_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-11T09:14:47.264741Z'
+created: '2020-12-08T17:25:16.580440Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -203,6 +203,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
+  info: null
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/custom_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-11T09:14:50.263564Z'
+created: '2020-12-08T17:25:06.286676Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -203,6 +203,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
+  info: null
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/custom_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-11T09:14:52.704725Z'
+created: '2020-12-08T17:25:12.369805Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -133,6 +133,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
+  info: null
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/custom_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-11T09:14:55.221950Z'
+created: '2020-12-08T17:25:14.288151Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -135,6 +135,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
+  info: null
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/custom_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-11T09:14:57.679199Z'
+created: '2020-12-08T17:25:08.371225Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,6 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
+  info: null
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/custom_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-11T09:15:00.149980Z'
+created: '2020-12-08T17:25:10.426520Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,6 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
+  info: null
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/custom_fingerprint.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/custom_fingerprint.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-11T11:36:29.107014Z'
+created: '2020-12-08T17:25:18.529851Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -169,6 +169,7 @@ app:
 --------------------------------------------------------------------------
 custom-fingerprint:
   hash: "f30afa00b85f5cac5ee0bce01b31f08d"
+  info: null
   values: ["celery","SoftTimeLimitExceeded","sentry.tasks.store.process_event"]
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -69,6 +69,19 @@ logger:sentry.*                                 -> logger-{{ logger }} title="Me
     )
 
 
+def test_rule_export():
+    rules = FingerprintingRules.from_config_string(
+        """
+logger:sentry.*                                 -> logger, {{ logger }}, title="Message from {{ logger }}"
+"""
+    )
+    assert rules.rules[0].to_json() == {
+        "attributes": {"title": "Message from {{ logger }}"},
+        "fingerprint": ["logger", "{{ logger }}"],
+        "matchers": [["logger", "sentry.*"]],
+    }
+
+
 def test_parsing_errors():
     with pytest.raises(InvalidFingerprintingConfig):
         FingerprintingRules.from_config_string("invalid.message:foo -> bar")


### PR DESCRIPTION
This now persists the rule that was applied for fingerprinting with the event and displays it in the grouping info UI:

![image](https://user-images.githubusercontent.com/7396/101510392-2b4a1200-397a-11eb-8270-24de4c28ab9a.png)

This should make it easier for users to understand where a fingerprint is coming from. It also can show the original value that the client sent.