### PR TITLE
fix(discover) Fix column dragging in small/touch viewports

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -49,8 +49,13 @@ enum PlaceholderPosition {
   BOTTOM,
 }
 
+/**
+ * Handle getting position out of both React and Raw DOM events
+ * as both are handled here due to mousedown/mousemove events
+ * working differently.
+ */
 function getPointerPosition<T>(
-  event: MouseEvent | React.MouseEvent<T> | TouchEvent,
+  event: MouseEvent | TouchEvent | React.MouseEvent<T> | React.TouchEvent<T>,
   property: 'pageX' | 'pageY'
 ): number {
   if (event instanceof TouchEvent) {
@@ -150,7 +155,10 @@ class ColumnEditCollection extends React.Component<Props, State> {
     this.props.onChange(newColumns);
   }
 
-  startDrag(event: React.MouseEvent<HTMLButtonElement> | TouchEvent, index: number) {
+  startDrag(
+    event: React.MouseEvent<HTMLButtonElement> | React.TouchEvent<HTMLButtonElement>,
+    index: number
+  ) {
     const isDragging = this.state.isDragging;
     if (isDragging || !['mousedown', 'touchstart'].includes(event.type)) {
       return;


### PR DESCRIPTION
In small viewports where the modal needs to scroll dragging items was not working correctly as getBoundingClientRect() returns values relative to the viewport size. We need to add the scrollY offset in order to get a value that shares coordinates with an event y property.

Adding touch handlers improves the ability to move columns around in a touch device.