### PR TITLE
fix(discover): Educate user on redudant queries

### DIFF
--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2981,6 +2981,17 @@ class ResolveFieldListTest(unittest.TestCase):
             ],
         ]
 
+    def test_redundant_grouping_errors(self):
+        fields = [
+            ["last_seen()", "timestamp"],
+            ["avg(measurements.lcp)", "measurements.lcp"],
+            ["p95()", "transaction.duration"],
+        ]
+        with pytest.raises(InvalidSearchQuery) as error:
+            resolve_field_list(fields, eventstore.Filter())
+
+        assert "would not have stacking" in error
+
 
 def with_type(type, argument):
     argument.get_type = lambda *_: type


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4205004/101654261-5120f680-3a0e-11eb-87ba-96859372e5e6.png)
- Right now a user can add aggregates however they like, but if the
  aggregate acts directly on the column, and the column is also selected
  they'll get a bad result
- This adds an error message that should educate the user as to what
  would've happened, and stops the query.
- This was also to prevent a bug with `last_seen()` and `timestamp` not
  working, but also that not being a query that we should allow anyways
- opening as draft for now while I wait for final copy on the error message.
Fixes SENTRY-JDW