### PR TITLE
feat(integrations): Save dynamic field choices to the rule data

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -285,13 +285,12 @@ class RuleNode extends React.Component<Props> {
     // element is changed to match the spec
     for (const [name, value] of Object.entries(data)) {
       this.props.onPropertyChange(this.props.index, name, value);
-    }
-    // We only know the choices after the form loads.
-    for (const fieldName of ['assignee', 'reporter']) {
-      if (fieldName in data) {
+
+      // We only know the choices after the form loads.
+      if (name in ['assignee', 'reporter'] && dynamicFieldChoices[name]) {
         const dynamicFormFieldsCopy: any = this.props.node?.formFields || {};
         // Overwrite the choices because the user's pick is in this list.
-        dynamicFormFieldsCopy[fieldName].choices = dynamicFieldChoices[fieldName];
+        dynamicFormFieldsCopy[name].choices = dynamicFieldChoices[name];
         this.props.onPropertyChange(
           this.props.index,
           'dynamic_form_fields',

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -277,11 +277,27 @@ class RuleNode extends React.Component<Props> {
     }
   }
 
-  updateParent = (data: {[key: string]: string}): void => {
+  updateParent = (
+    data: {[key: string]: string},
+    dynamicFieldChoices: {[key: string]: string[]}
+  ): void => {
     // iterating through these upon save instead of when each
     // element is changed to match the spec
     for (const [name, value] of Object.entries(data)) {
       this.props.onPropertyChange(this.props.index, name, value);
+    }
+    // We only know the choices after the form loads.
+    for (const fieldName of ['assignee', 'reporter']) {
+      if (fieldName in data) {
+        const dynamicFormFieldsCopy: any = this.props.node?.formFields || {};
+        // Overwrite the choices because the user's pick is in this list.
+        dynamicFormFieldsCopy[fieldName].choices = dynamicFieldChoices[fieldName];
+        this.props.onPropertyChange(
+          this.props.index,
+          'dynamic_form_fields',
+          dynamicFormFieldsCopy
+        );
+      }
     }
   };
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -287,7 +287,7 @@ class RuleNode extends React.Component<Props> {
       this.props.onPropertyChange(this.props.index, name, value);
 
       // We only know the choices after the form loads.
-      if (name in ['assignee', 'reporter'] && dynamicFieldChoices[name]) {
+      if (['assignee', 'reporter'].includes(name) && dynamicFieldChoices[name]) {
         const dynamicFormFieldsCopy: any = this.props.node?.formFields || {};
         // Overwrite the choices because the user's pick is in this list.
         dynamicFormFieldsCopy[name].choices = dynamicFieldChoices[name];

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -29,7 +29,7 @@ type Props = {
 
 type State = {
   showModal: boolean;
-  dynamicFieldChoices: any;
+  dynamicFieldChoices: {[key: string]: string[]};
 };
 
 class TicketRuleForm extends React.Component<Props, State> {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {Modal} from 'react-bootstrap';
 import styled from '@emotion/styled';
+import cloneDeep from 'lodash/cloneDeep';
 import debounce from 'lodash/debounce';
+import set from 'lodash/set';
 import * as queryString from 'query-string';
 
 import {addSuccessMessage} from 'app/actionCreators/indicator';
@@ -118,13 +120,10 @@ class TicketRuleForm extends React.Component<Props, State> {
           reject(err);
         } else {
           const dynamicFieldChoices = result.options.map(obj => [obj.value, obj.label]);
-          this.setState(state => {
-            return {
-              dynamicFieldChoices: {
-                ...state.dynamicFieldChoices,
-                [field.name]: dynamicFieldChoices,
-              },
-            };
+          this.setState(prevState => {
+            const newState = cloneDeep(prevState);
+            set(newState, `dynamicFieldChoices[${field.name}]`, dynamicFieldChoices);
+            return newState;
           });
           resolve(result);
         }

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -19,18 +19,23 @@ import {FormField} from 'app/views/settings/projectAlerts/issueEditor/ruleNode';
 type Props = {
   formFields: {[key: string]: any};
   instance?: IssueAlertRuleAction | IssueAlertRuleCondition;
-  onSubmitAction: (data: {[key: string]: string}) => void;
+  onSubmitAction: (
+    data: {[key: string]: string},
+    dynamicFieldChoices: {[key: string]: string[]}
+  ) => void;
   onPropertyChange: (rowIndex: number, name: string, value: string) => void;
   index: number;
 };
 
 type State = {
   showModal: boolean;
+  dynamicFieldChoices: any;
 };
 
 class TicketRuleForm extends React.Component<Props, State> {
   state = {
     showModal: false,
+    dynamicFieldChoices: {},
   };
 
   openModal = (event: React.MouseEvent) => {
@@ -94,7 +99,7 @@ class TicketRuleForm extends React.Component<Props, State> {
     e.stopPropagation();
 
     const formData = this.cleanData(data);
-    this.props.onSubmitAction(formData);
+    this.props.onSubmitAction(formData, this.state.dynamicFieldChoices);
     addSuccessMessage(t('Changes applied.'));
     this.closeModal();
   };
@@ -107,10 +112,20 @@ class TicketRuleForm extends React.Component<Props, State> {
         const options = choices.map(([value, label]) => ({value, label}));
         return resolve({options});
       }
+
       return this.debouncedOptionLoad(field, input, (err, result) => {
         if (err) {
           reject(err);
         } else {
+          const dynamicFieldChoices = result.options.map(obj => [obj.value, obj.label]);
+          this.setState(state => {
+            return {
+              dynamicFieldChoices: {
+                ...state.dynamicFieldChoices,
+                [field.name]: dynamicFieldChoices,
+              },
+            };
+          });
           resolve(result);
         }
       });


### PR DESCRIPTION
The Ticket Rule form gets its fields from Jira's "createmeta" API. Every non-user field has its choices included but `assignee` and `reporter` need to get users in a separate API call.
This PR captures those user choices and saves them to the form's choices.