### PR TITLE
fix(stacktrace-linking): handle Gitlab urls

### DIFF
--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -113,8 +113,9 @@ class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
         repo = serializer.repo
         integration = serializer.integration
 
-        # strip off the base URL
-        rest_url = source_url.replace(u"{}/blob/".format(repo.url), "")
+        # strip off the base URL (could be in different formats)
+        rest_url = source_url.replace(u"{}/-/blob/".format(repo.url), "")
+        rest_url = rest_url.replace(u"{}/blob/".format(repo.url), "")
         branch, _, source_path = rest_url.partition("/")
 
         stack_root, source_root = find_roots(stack_path, source_path)


### PR DESCRIPTION
This PR fixes a bug where we couldn't parse Gitlab URLs that had `/-/blob/` instead of `/blob`/ in the path. Example: `https://gitlab.com/test-sentry1/hello/-/blob/master/src/components/App.js`