### PR TITLE
fix(setup-wizard): Revert to using class button

### DIFF
--- a/src/sentry/static/sentry/app/components/setupWizard.tsx
+++ b/src/sentry/static/sentry/app/components/setupWizard.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {Client} from 'app/api';
-import Button from 'app/components/button';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {t} from 'app/locale';
 import withApi from 'app/utils/withApi';
@@ -54,7 +53,9 @@ class SetupWizard extends React.Component<Props, State> {
       <div className="row">
         <h5>{t('Return to your terminal to complete your setup')}</h5>
         <h5>{t('(This window will close in 10 seconds)')}</h5>
-        <Button onClick={() => window.close()}>{t('Close browser tab')}</Button>
+        <button className="btn btn-default" onClick={() => window.close()}>
+          Close browser tab
+        </button>
       </div>
     );
   }


### PR DESCRIPTION
The setupWizard right now is not correctly provided the Theme via
emotions ThemeProvider. We'll have to come back to this, but right now
this...

Fixes: JAVASCRIPT-23BY