### PR TITLE
feat(aws): bump boto3 version

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,6 +1,6 @@
 beautifulsoup4>=4.7.1,<4.8
-boto3>=1.4.1,<1.4.6
-botocore<1.5.71
+boto3>=1.10.1,<1.11
+botocore>1.13.0,<1.14.0
 celery==4.4.7
 click>=7.0,<8.0
 confluent-kafka==1.5.0


### PR DESCRIPTION
This PR increases the boto3 version of the AWS SDK to a higher version that supports providing the `Layer` argument for [update_function_configuration](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/lambda.html#Lambda.Client.update_function_configuration). This is going to be used for the future AWS Lambda integration. We can't use the latest version because we'd need to bump `urllib3` to `1.26`. I picked an older version arbitrarily (1.10.x version) which I confirmed supports the new `Layer` argument but doesn't require us to update the `urllib3` library.