### PR TITLE
fix(jira): jira action dropdown to show domain name

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -40,6 +40,9 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
 
             if node.id in TICKET_ACTIONS:
                 context["actionType"] = "ticket"
+                context["ticketType"] = node.ticket_type
+                context["link"] = node.link
+
             # It is possible for a project to have no services. In that scenario we do
             # not want the front end to render the action as the action does not have
             # options.

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -22,12 +22,11 @@ INTEGRATION_KEY = "integration"
 
 
 class JiraNotifyServiceForm(forms.Form):
-    jira_integration = forms.ChoiceField(choices=(), widget=forms.Select())
+    integration = forms.ChoiceField(choices=(), widget=forms.Select())
 
     def __init__(self, *args, **kwargs):
         integrations = [(i.id, i.name) for i in kwargs.pop("integrations")]
         super(JiraNotifyServiceForm, self).__init__(*args, **kwargs)
-
         if integrations:
             self.fields[INTEGRATION_KEY].initial = integrations[0][0]
 

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -21,6 +21,11 @@ logger = logging.getLogger("sentry.rules")
 INTEGRATION_KEY = "integration"
 
 
+def get_name_for_jira(integration):
+    name = integration.metadata.get("domain_name", integration.name)
+    return name.replace(".atlassian.net", "")
+
+
 class JiraNotifyServiceForm(forms.Form):
     integration = forms.ChoiceField(choices=(), widget=forms.Select())
 
@@ -38,14 +43,14 @@ class JiraCreateTicketAction(TicketEventAction):
     form_cls = JiraNotifyServiceForm
     label = u"""Create a Jira issue in {integration} with these """
     prompt = "Create a Jira issue"
+    ticket_type = "Jira issue"
+    link = "https://docs.sentry.io/product/integrations/jira/#issue-sync"
     provider = "jira"
     integration_key = INTEGRATION_KEY
 
     def __init__(self, *args, **kwargs):
         super(JiraCreateTicketAction, self).__init__(*args, **kwargs)
-        integration_choices = [
-            (i.id, i.metadata.get("domain_name", i.name)) for i in self.get_integrations()
-        ]
+        integration_choices = [(i.id, get_name_for_jira(i)) for i in self.get_integrations()]
 
         if not self.get_integration_id() and integration_choices:
             self.data[self.integration_key] = integration_choices[0][0]

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -9,6 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 from sentry.integrations.jira.utils import (
     transform_jira_fields_to_form_fields,
     transform_jira_choices_to_strings,
+    get_name_for_jira,
 )
 from sentry.models.integration import Integration
 from sentry.rules.actions.base import TicketEventAction
@@ -16,7 +17,6 @@ from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
 
-from .utils import get_name_for_jira
 
 logger = logging.getLogger("sentry.rules")
 

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -16,14 +16,11 @@ from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
 
+from .utils import get_name_for_jira
+
 logger = logging.getLogger("sentry.rules")
 
 INTEGRATION_KEY = "integration"
-
-
-def get_name_for_jira(integration):
-    name = integration.metadata.get("domain_name", integration.name)
-    return name.replace(".atlassian.net", "")
 
 
 class JiraNotifyServiceForm(forms.Form):
@@ -42,8 +39,7 @@ class JiraNotifyServiceForm(forms.Form):
 class JiraCreateTicketAction(TicketEventAction):
     form_cls = JiraNotifyServiceForm
     label = u"""Create a Jira issue in {integration} with these """
-    prompt = "Create a Jira issue"
-    ticket_type = "Jira issue"
+    ticket_type = "a Jira issue"
     link = "https://docs.sentry.io/product/integrations/jira/#issue-sync"
     provider = "jira"
     integration_key = INTEGRATION_KEY

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -110,9 +110,9 @@ class JiraCreateTicketAction(TicketEventAction):
     def clean(self):
         cleaned_data = super(JiraCreateTicketAction, self).clean()
 
-        jira_integration = cleaned_data.get(self.integration_key)
+        integration = cleaned_data.get(self.integration_key)
         try:
-            Integration.objects.get(id=jira_integration)
+            Integration.objects.get(id=integration)
         except Integration.DoesNotExist:
             raise forms.ValidationError(
                 _("Jira integration is a required field.",), code="invalid",

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -57,3 +57,8 @@ def transform_jira_choices_to_strings(fields, data):
         else:
             choices[key] = value
     return choices
+
+
+def get_name_for_jira(integration):
+    name = integration.metadata.get("domain_name", integration.name)
+    return name.replace(".atlassian.net", "")

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -46,7 +46,7 @@ def transform_jira_fields_to_form_fields(fields_list):
 def transform_jira_choices_to_strings(fields, data):
     choices = {}
     for key, value in data.items():
-        if key in ["jira_integration", "dynamic_form_fields"] or not value:
+        if key in ["integration", "dynamic_form_fields"] or not value:
             continue
         if key in fields and fields[key]["type"] == "choice":
             temp_dict = {k: v for (k, v) in fields[key]["choices"]}

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -10,6 +10,8 @@ from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger("sentry.rules")
 
+INTEGRATION_KEY = "integration"
+
 
 class AzureDevopsNotifyServiceForm(forms.Form):
     # TODO 2.0 Add form fields.
@@ -27,7 +29,7 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
     ticket_type = "Azure DevOps work item"
     link = "https://docs.sentry.io/product/integrations/azure-devops/#issue-sync"
     provider = "vsts"
-    integration_key = "vsts_integration"
+    integration_key = INTEGRATION_KEY
 
     def __init__(self, *args, **kwargs):
         super(AzureDevopsCreateTicketAction, self).__init__(*args, **kwargs)

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -25,8 +25,7 @@ class AzureDevopsNotifyServiceForm(forms.Form):
 class AzureDevopsCreateTicketAction(TicketEventAction):
     form_cls = AzureDevopsNotifyServiceForm
     label = u"TODO Create an Azure DevOps work item in {name} with these "
-    prompt = "Create a Azure DevOps work item"
-    ticket_type = "Azure DevOps work item"
+    ticket_type = "an Azure DevOps work item"
     link = "https://docs.sentry.io/product/integrations/azure-devops/#issue-sync"
     provider = "vsts"
     integration_key = INTEGRATION_KEY

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -23,7 +23,9 @@ class AzureDevopsNotifyServiceForm(forms.Form):
 class AzureDevopsCreateTicketAction(TicketEventAction):
     form_cls = AzureDevopsNotifyServiceForm
     label = u"TODO Create an Azure DevOps work item in {name} with these "
-    prompt = "Create an Azure DevOps work item"
+    prompt = "Create a Azure DevOps work item"
+    ticket_type = "Azure DevOps work item"
+    link = "https://docs.sentry.io/product/integrations/azure-devops/#issue-sync"
     provider = "vsts"
     integration_key = "vsts_integration"
 

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -86,6 +86,10 @@ class IntegrationEventAction(EventAction):
 class TicketEventAction(IntegrationEventAction):
     """Shared ticket actions"""
 
+    @property
+    def prompt(self):
+        return u"Create {}".format(self.ticket_type)
+
     def generate_footer(self, rule_url):
         raise NotImplementedError
 

--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -29,6 +29,8 @@ export type IssueAlertRuleActionTemplate = {
   formFields?: {
     [key: string]: IssueAlertRuleFormField;
   };
+  ticketType?: string;
+  link?: string;
 };
 export type IssueAlertRuleConditionTemplate = IssueAlertRuleActionTemplate;
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -294,9 +294,11 @@ class RuleNode extends React.Component<Props> {
           <Rule>
             {data && <input type="hidden" name="id" value={data.id} />}
             {this.renderRow()}
-            {ticketRule && (
+            {ticketRule && node && (
               <TicketRuleForm
-                formFields={node?.formFields || {}}
+                formFields={node.formFields || {}}
+                link={node.link}
+                ticketType={node.ticketType}
                 instance={data}
                 index={this.props.index}
                 onSubmitAction={this.updateParent}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -18,6 +18,8 @@ import {FormField} from 'app/views/settings/projectAlerts/issueEditor/ruleNode';
 
 type Props = {
   formFields: {[key: string]: any};
+  link?: string;
+  ticketType?: string;
   instance?: IssueAlertRuleAction | IssueAlertRuleCondition;
   onSubmitAction: (data: {[key: string]: string}) => void;
   onPropertyChange: (rowIndex: number, name: string, value: string) => void;
@@ -172,10 +174,10 @@ class TicketRuleForm extends React.Component<Props, State> {
   };
 
   render() {
-    const {ticketType, link} = this.props.instance || {};
+    const {ticketType, link} = this.props;
 
     const text = t(
-      'When this alert is triggered a %s will be created with the following fields. ',
+      'When this alert is triggered %s will be created with the following fields. ',
       ticketType
     );
     const submitLabel = t('Apply Changes');

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -64,23 +64,16 @@ class TicketRuleForm extends React.Component<Props, State> {
     [key: string]: string;
   }): {
     integration?: string | number;
-    vsts_integration?: string | number; //TODO: Update
     [key: string]: any;
   } => {
     const names: string[] = this.getNames();
     const formData: {
       integration?: string | number;
-      vsts_integration?: string | number;
       [key: string]: any;
     } = {};
-    //TODO simplify
-    if (this.integrationType === 'jira') {
+    if (this.props.instance?.hasOwnProperty('integration')) {
       formData.integration = this.props.instance?.integration;
     }
-    if (this.props.instance?.hasOwnProperty('vsts_integration')) {
-      formData.vsts_integration = this.props.instance?.vsts_integration;
-    }
-
     for (const [key, value] of Object.entries(data)) {
       if (names.includes(key)) {
         formData[key] = value;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleForm.tsx
@@ -159,32 +159,6 @@ class TicketRuleForm extends React.Component<Props, State> {
         }
       : {};
 
-  get integrationType() {
-    //ex: "sentry.integrations.jira.notify_action.JiraCreateTicketAction"
-    return this.props.instance?.id.split('.')[2];
-  }
-
-  get ticketType() {
-    switch (this.integrationType) {
-      case 'jira':
-        return 'Jira issue';
-      case 'vsts':
-        return 'Azure DevOps work item';
-      default:
-        throw new Error(`Unexpected integration type ${this.integrationType}`);
-    }
-  }
-  get link() {
-    switch (this.integrationType) {
-      case 'jira':
-        return 'https://docs.sentry.io/product/integrations/jira/#issue-sync';
-      case 'vsts':
-        return 'https://docs.sentry.io/product/integrations/azure-devops/#issue-sync';
-      default:
-        throw new Error(`Unexpected integration type ${this.integrationType}`);
-    }
-  }
-
   addFields = (formFields: FormField[]): void => {
     const title = {
       name: 'title',
@@ -205,8 +179,7 @@ class TicketRuleForm extends React.Component<Props, State> {
   };
 
   render() {
-    const ticketType = this.ticketType;
-    const link = this.link;
+    const {ticketType, link} = this.props.instance || {};
 
     const text = t(
       'When this alert is triggered a %s will be created with the following fields. ',

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -36,7 +36,7 @@ class JiraCreateTicketActionTest(RuleTestCase):
                 "customfield_10200": "sad",
                 "customfield_10300": ["Feature 1", "Feature 2"],
                 "project": "10000",
-                "jira_integration": self.integration.id,
+                "integration": self.integration.id,
                 "jira_project": "10000",
                 "issue_type": "Bug",
                 "fixVersions": "[10000]",
@@ -112,7 +112,7 @@ class JiraCreateTicketActionTest(RuleTestCase):
                 "customfield_10200": "sad",
                 "customfield_10300": ["Feature 1", "Feature 2"],
                 "labels": "bunnies",
-                "jira_integration": self.integration.id,
+                "integration": self.integration.id,
                 "jira_project": "10000",
                 "issue_type": "Bug",
                 "fixVersions": "[10000]",
@@ -128,7 +128,7 @@ class JiraCreateTicketActionTest(RuleTestCase):
     def test_render_label(self):
         rule = self.get_rule(
             data={
-                "jira_integration": self.integration.id,
+                "integration": self.integration.id,
                 "issuetype": 1,
                 "project": 10000,
                 "dynamic_form_fields": {
@@ -143,20 +143,20 @@ class JiraCreateTicketActionTest(RuleTestCase):
         deleted_id = self.integration.id
         self.integration.delete()
 
-        rule = self.get_rule(data={"jira_integration": deleted_id})
+        rule = self.get_rule(data={"integration": deleted_id})
 
         assert rule.render_label() == "Create a Jira issue in [removed] with these "
 
     @responses.activate
     def test_invalid_integration(self):
-        rule = self.get_rule(data={"jira_integration": self.integration.id})
+        rule = self.get_rule(data={"integration": self.integration.id})
 
         form = rule.get_form_instance()
         assert form.is_valid()
 
     @responses.activate
     def test_invalid_project(self):
-        rule = self.get_rule(data={"jira_integration": self.integration.id})
+        rule = self.get_rule(data={"integration": self.integration.id})
 
         form = rule.get_form_instance()
         assert form.is_valid()

--- a/tests/sentry/integrations/test_ticket_rules.py
+++ b/tests/sentry/integrations/test_ticket_rules.py
@@ -82,7 +82,7 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
                         {
                             "id": "sentry.integrations.jira.notify_action.JiraCreateTicketAction",
                             "issuetype": "1",
-                            "jira_integration": self.integration.id,
+                            "integration": self.integration.id,
                             "name": "Create a Jira ticket in the Jira Cloud account",
                             "project": "10000",
                         }

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -45,7 +45,7 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase):
                 "description": "Fix this.",
                 "project": "0987654321",
                 "work_item_type": "Microsoft.VSTS.WorkItemTypes.Task",
-                "vsts_integration": self.integration.model.id,
+                "integration": self.integration.model.id,
             }
         )
         azuredevops_rule.rule = Rule.objects.create(project=self.project, label="test rule")
@@ -95,7 +95,7 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase):
                 "description": "Fix this.",
                 "project": "0987654321",
                 "work_item_type": "Microsoft.VSTS.WorkItemTypes.Task",
-                "vsts_integration": self.integration.model.id,
+                "integration": self.integration.model.id,
             }
         )
         azuredevops_rule.rule = Rule.objects.create(project=self.project, label="test rule")


### PR DESCRIPTION
This PR uses the `domain_name` for the Jira dropdown since that is unique while the `name` is not. I also did some refactoring to rename the `jira_integration` form field to `integration` so that we can have simpler code with Azure Devops.

![Screen Shot 2020-12-09 at 9 41 49 AM](https://user-images.githubusercontent.com/8533851/101666230-cb4b7e00-3a02-11eb-844c-021eb88d87ec.png)
