### PR TITLE
feat(auth): Prevent redirect when OAuth errors

### DIFF
--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -65,6 +65,7 @@ class OAuthAuthorizeView(AuthLoginView):
                         "Missing or invalid <em>{}</em> parameter.".format(err_response)
                     )
                 },
+                status=400,
             )
 
         return self.redirect_response(response_type, redirect_uri, {"error": name, "state": state})

--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -38,7 +38,16 @@ class OAuthAuthorizeView(AuthLoginView):
         parts[4] = urlencode(query)
         return self.redirect(urlunparse(parts))
 
-    def error(self, request, response_type, redirect_uri, name, state=None, client_id=None):
+    def error(
+        self,
+        request,
+        response_type,
+        redirect_uri,
+        name,
+        state=None,
+        client_id=None,
+        err_redirect=False,
+    ):
         logging.error(
             "oauth.authorize-error",
             extra={
@@ -48,6 +57,12 @@ class OAuthAuthorizeView(AuthLoginView):
                 "redirect_uri": redirect_uri,
             },
         )
+        if err_redirect:
+            return self.respond(
+                "sentry/oauth-error.html",
+                {"error": mark_safe("Missing or invalid <em>client_id</em> parameter.")},
+            )
+
         return self.redirect_response(response_type, redirect_uri, {"error": name, "state": state})
 
     def respond_login(self, request, context, application, **kwargs):
@@ -63,18 +78,13 @@ class OAuthAuthorizeView(AuthLoginView):
         force_prompt = request.GET.get("force_prompt")
 
         if not client_id:
-            logging.error(
-                "oauth.authorize-error",
-                extra={
-                    "error_name": "unauthorized_client",
-                    "response_type": response_type,
-                    "client_id": client_id,
-                    "redirect_uri": redirect_uri,
-                },
-            )
-            return self.respond(
-                "sentry/oauth-error.html",
-                {"error": mark_safe("Missing or invalid <em>client_id</em> parameter.")},
+            return self.error(
+                request=request,
+                client_id=client_id,
+                response_type=response_type,
+                redirect_uri=redirect_uri,
+                name="unauthorized_client",
+                err_redirect=True,
             )
 
         try:
@@ -82,35 +92,25 @@ class OAuthAuthorizeView(AuthLoginView):
                 client_id=client_id, status=ApiApplicationStatus.active
             )
         except ApiApplication.DoesNotExist:
-            logging.error(
-                "oauth.authorize-error",
-                extra={
-                    "error_name": "unauthorized_client",
-                    "response_type": response_type,
-                    "client_id": client_id,
-                    "redirect_uri": redirect_uri,
-                },
-            )
-            return self.respond(
-                "sentry/oauth-error.html",
-                {"error": mark_safe("Missing or invalid <em>client_id</em> parameter.")},
+            return self.error(
+                request=request,
+                client_id=client_id,
+                response_type=response_type,
+                redirect_uri=redirect_uri,
+                name="unauthorized_client",
+                err_redirect=True,
             )
 
         if not redirect_uri:
             redirect_uri = application.get_default_redirect_uri()
         elif not application.is_valid_redirect_uri(redirect_uri):
-            logging.error(
-                "oauth.authorize-error",
-                extra={
-                    "error_name": "invalid_request",
-                    "response_type": response_type,
-                    "client_id": client_id,
-                    "redirect_uri": redirect_uri,
-                },
-            )
-            return self.respond(
-                "sentry/oauth-error.html",
-                {"error": mark_safe("Missing or invalid <em>redirect_uri</em> parameter.")},
+            return self.error(
+                request=request,
+                client_id=client_id,
+                response_type=response_type,
+                redirect_uri=redirect_uri,
+                name="invalid_request",
+                err_redirect=True,
             )
 
         if not application.is_allowed_response_type(response_type):
@@ -120,7 +120,7 @@ class OAuthAuthorizeView(AuthLoginView):
                 response_type=response_type,
                 redirect_uri=redirect_uri,
                 name="unsupported_response_type",
-                state=state,
+                err_redirect=True,
             )
 
         if scopes:

--- a/src/sentry/web/frontend/oauth_authorize.py
+++ b/src/sentry/web/frontend/oauth_authorize.py
@@ -46,7 +46,7 @@ class OAuthAuthorizeView(AuthLoginView):
         name,
         state=None,
         client_id=None,
-        err_redirect=False,
+        err_response=None,
     ):
         logging.error(
             "oauth.authorize-error",
@@ -57,10 +57,14 @@ class OAuthAuthorizeView(AuthLoginView):
                 "redirect_uri": redirect_uri,
             },
         )
-        if err_redirect:
+        if err_response:
             return self.respond(
                 "sentry/oauth-error.html",
-                {"error": mark_safe("Missing or invalid <em>client_id</em> parameter.")},
+                {
+                    "error": mark_safe(
+                        "Missing or invalid <em>{}</em> parameter.".format(err_response)
+                    )
+                },
             )
 
         return self.redirect_response(response_type, redirect_uri, {"error": name, "state": state})
@@ -84,7 +88,7 @@ class OAuthAuthorizeView(AuthLoginView):
                 response_type=response_type,
                 redirect_uri=redirect_uri,
                 name="unauthorized_client",
-                err_redirect=True,
+                err_response="client_id",
             )
 
         try:
@@ -98,7 +102,7 @@ class OAuthAuthorizeView(AuthLoginView):
                 response_type=response_type,
                 redirect_uri=redirect_uri,
                 name="unauthorized_client",
-                err_redirect=True,
+                err_response="client_id",
             )
 
         if not redirect_uri:
@@ -110,7 +114,7 @@ class OAuthAuthorizeView(AuthLoginView):
                 response_type=response_type,
                 redirect_uri=redirect_uri,
                 name="invalid_request",
-                err_redirect=True,
+                err_response="redirect_uri",
             )
 
         if not application.is_allowed_response_type(response_type):
@@ -120,7 +124,7 @@ class OAuthAuthorizeView(AuthLoginView):
                 response_type=response_type,
                 redirect_uri=redirect_uri,
                 name="unsupported_response_type",
-                err_redirect=True,
+                err_response="client_id",
             )
 
         if scopes:

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -27,7 +27,7 @@ class OAuthAuthorizeCodeTest(TestCase):
             )
         )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 400
         self.assertTemplateUsed("sentry/oauth-error.html")
         assert resp.context["error"] == "Missing or invalid <em>client_id</em> parameter."
 
@@ -40,7 +40,7 @@ class OAuthAuthorizeCodeTest(TestCase):
             )
         )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 400
         self.assertTemplateUsed("sentry/oauth-error.html")
         assert resp.context["error"] == "Missing or invalid <em>client_id</em> parameter."
 
@@ -51,7 +51,7 @@ class OAuthAuthorizeCodeTest(TestCase):
             u"{}?response_type=code&redirect_uri={}".format(self.path, "https://example.com")
         )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 400
         self.assertTemplateUsed("sentry/oauth-error.html")
         assert resp.context["error"] == "Missing or invalid <em>client_id</em> parameter."
 
@@ -76,7 +76,7 @@ class OAuthAuthorizeCodeTest(TestCase):
             )
         )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 400
         self.assertTemplateUsed("sentry/oauth-error.html")
         assert resp.context["error"] == "Missing or invalid <em>redirect_uri</em> parameter."
 
@@ -280,7 +280,7 @@ class OAuthAuthorizeTokenTest(TestCase):
             )
         )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 400
         self.assertTemplateUsed("sentry/oauth-error.html")
         assert resp.context["error"] == "Missing or invalid <em>client_id</em> parameter."
 
@@ -293,7 +293,7 @@ class OAuthAuthorizeTokenTest(TestCase):
             )
         )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 400
         self.assertTemplateUsed("sentry/oauth-error.html")
         assert resp.context["error"] == "Missing or invalid <em>client_id</em> parameter."
 
@@ -304,7 +304,7 @@ class OAuthAuthorizeTokenTest(TestCase):
             u"{}?response_type=token&redirect_uri={}".format(self.path, "https://example.com")
         )
 
-        assert resp.status_code == 200
+        assert resp.status_code == 400
         self.assertTemplateUsed("sentry/oauth-error.html")
         assert resp.context["error"] == "Missing or invalid <em>client_id</em> parameter."
 

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -27,8 +27,9 @@ class OAuthAuthorizeCodeTest(TestCase):
             )
         )
 
-        assert resp.status_code == 302
-        assert resp["Location"] == "https://example.com?error=unsupported_response_type"
+        assert resp.status_code == 200
+        self.assertTemplateUsed("sentry/oauth-error.html")
+        assert resp.context["error"] == "Missing or invalid <em>client_id</em> parameter."
 
     def test_invalid_response_type(self):
         self.login_as(self.user)
@@ -39,8 +40,9 @@ class OAuthAuthorizeCodeTest(TestCase):
             )
         )
 
-        assert resp.status_code == 302
-        assert resp["Location"] == "https://example.com?error=unsupported_response_type"
+        assert resp.status_code == 200
+        self.assertTemplateUsed("sentry/oauth-error.html")
+        assert resp.context["error"] == "Missing or invalid <em>client_id</em> parameter."
 
     def test_missing_client_id(self):
         self.login_as(self.user)
@@ -278,8 +280,9 @@ class OAuthAuthorizeTokenTest(TestCase):
             )
         )
 
-        assert resp.status_code == 302
-        assert resp["Location"] == "https://example.com?error=unsupported_response_type"
+        assert resp.status_code == 200
+        self.assertTemplateUsed("sentry/oauth-error.html")
+        assert resp.context["error"] == "Missing or invalid <em>client_id</em> parameter."
 
     def test_invalid_response_type(self):
         self.login_as(self.user)
@@ -290,8 +293,9 @@ class OAuthAuthorizeTokenTest(TestCase):
             )
         )
 
-        assert resp.status_code == 302
-        assert resp["Location"] == "https://example.com?error=unsupported_response_type"
+        assert resp.status_code == 200
+        self.assertTemplateUsed("sentry/oauth-error.html")
+        assert resp.context["error"] == "Missing or invalid <em>client_id</em> parameter."
 
     def test_missing_client_id(self):
         self.login_as(self.user)


### PR DESCRIPTION
## Objective:
It was discovered that the open redirect vulnerability exists in the “API Applications” feature, effectively opening the possibilities for an attacker to conduct Phishing attacks, or chain it with other bugs to elevate impact. The issue lies in the OAuth endpoint created by the “API Applications” feature. When an error occurs during the OAuth processing, the application redirects to the user-specified URL without any confirmation.

### Steps to reproduce:
1. Log-in
2. Navigate to https://sentry.io/settings/account/api/applications/
3. Click on the “Create New Application” button
4. Enter “https://example.com/” to the “Authorized Redirect URIs” field
5. Copy the “Client ID”
6. Concatenate the copied ID with “https://sentry.io/oauth/authorize/?client_id=”
7. Navigate to https://sentry.io/oauth/authorize/?client_id=[CLIENT_ID]. It will
redirect to https://example.com/ directly

While the issue itself has a low severity, open redirects in many cases operate as very useful gadgets for forming chains with other issues.

It is recommended to return a 400 error page rather than redirect to the URL specified in the “Authorized Redirect URIs” when an error happens in the OAuth processing.

So in this PR, I made Sentry redirect to the 400 error page. I also refactored to remove duplicated logic.