### PR TITLE
fix(integrations): Refresh form fields

### DIFF
--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -7,6 +7,7 @@ import six
 from sentry.api.bases.organization import OrganizationIntegrationsPermission
 from sentry.api.bases.organization_integrations import OrganizationIntegrationBaseEndpoint
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.integration import OrganizationIntegrationSerializer
 from sentry.models import AuditLogEntryEvent, ObjectStatus, OrganizationIntegration
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.tasks.deletion import delete_organization_integration
@@ -19,7 +20,11 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
     def get(self, request, organization, integration_id):
         org_integration = self.get_organization_integration(organization, integration_id)
 
-        return self.respond(serialize(org_integration, request.user))
+        return self.respond(
+            serialize(
+                org_integration, request.user, OrganizationIntegrationSerializer(params=request.GET)
+            )
+        )
 
     def delete(self, request, organization, integration_id):
         # Removing the integration removes the organization

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -38,8 +38,9 @@ class IntegrationSerializer(Serializer):
 
 
 class IntegrationConfigSerializer(IntegrationSerializer):
-    def __init__(self, organization_id=None):
+    def __init__(self, organization_id=None, params=None):
         self.organization_id = organization_id
+        self.params = params or {}
 
     def serialize(self, obj, attrs, user, include_config=True):
         data = super(IntegrationConfigSerializer, self).serialize(obj, attrs, user)
@@ -63,6 +64,9 @@ class IntegrationConfigSerializer(IntegrationSerializer):
 
 @register(OrganizationIntegration)
 class OrganizationIntegrationSerializer(Serializer):
+    def __init__(self, params=None):
+        self.params = params
+
     def serialize(self, obj, attrs, user, include_config=True):
         # XXX(epurkhiser): This is O(n) for integrations, especially since
         # we're using the IntegrationConfigSerializer which pulls in the
@@ -71,7 +75,7 @@ class OrganizationIntegrationSerializer(Serializer):
         integration = serialize(
             objects=obj.integration,
             user=user,
-            serializer=IntegrationConfigSerializer(obj.organization.id),
+            serializer=IntegrationConfigSerializer(obj.organization.id, params=self.params),
             include_config=include_config,
         )
 

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -61,7 +61,9 @@ class IntegrationConfigSerializer(IntegrationSerializer):
 
             # Query param "action" only attached in TicketRuleForm modal.
             if self.params.get("action") == "create":
-                data["createIssueConfig"] = install.get_create_issue_config_no_params()
+                data["createIssueConfig"] = install.get_create_issue_config(
+                    None, user, params=self.params
+                )
 
         return data
 

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -59,6 +59,10 @@ class IntegrationConfigSerializer(IntegrationSerializer):
         else:
             data.update({"configOrganization": install.get_organization_config()})
 
+            # Query param "action" only attached in TicketRuleForm modal.
+            if self.params.get("action") == "create":
+                data["createIssueConfig"] = install.get_create_issue_config_no_params()
+
         return data
 
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -562,17 +562,11 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         params = kwargs.get("params", {})
         fields = []
         defaults = {}
-
-        project_param_option = params.get("project")
-        project_option = None
         if group:
             fields = super(JiraIntegration, self).get_create_issue_config(group, user, **kwargs)
-            project_option = group.project
-        project_option = project_param_option or project_option
-        if project_option:
-            defaults = self.get_defaults(project_option, user)
+            defaults = self.get_defaults(group.project, user)
 
-        project_id = project_param_option or defaults.get("project")
+        project_id = params.get("project", defaults.get("project"))
         client = self.get_client()
         try:
             jira_projects = client.get_projects_list()

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -541,19 +541,21 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             )
         return meta
 
-    def get_create_issue_config_no_params(self):
-        return self.get_create_issue_config(None, None, params={})
-
     def get_create_issue_config(self, group, user, **kwargs):
         kwargs["link_referrer"] = "jira_integration"
         params = kwargs.get("params", {})
         fields = []
         defaults = {}
+        project_param_option = params.get("project")
+        project_option = None
         if group:
             fields = super(JiraIntegration, self).get_create_issue_config(group, user, **kwargs)
-            defaults = self.get_defaults(group.project, user)
+            project_option = group.project
+        project_option = project_param_option or project_option
+        if project_option:
+            defaults = self.get_defaults(project_option, user)
 
-        project_id = params.get("project", defaults.get("project"))
+        project_id = project_param_option or defaults.get("project")
         client = self.get_client()
         try:
             jira_projects = client.get_projects_list()

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -552,7 +552,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         :param user: User model. TODO Make this the first parameter.
         :param kwargs: (Optional) Object
             * params: (Optional) Object
-            * params.project: (Optional) String. The Jira project ID.
+            * params.project: (Optional) Sentry Project object
             * params.issuetype: (Optional) String. The Jira issue type. For
                 example: "Bug", "Epic", "Story".
         :return:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -542,10 +542,27 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         return meta
 
     def get_create_issue_config(self, group, user, **kwargs):
+        """
+        We use the `group` to get three things: organization_slug, project
+        defaults, and default title and description. In the case where we're
+        getting `createIssueConfig` from Jira for Ticket Rules, we don't know
+        the issue group beforehand.
+
+        :param group: (Optional) Group model.
+        :param user: User model. TODO Make this the first parameter.
+        :param kwargs: (Optional) Object
+            * params: (Optional) Object
+            * params.project: (Optional) String. The Jira project ID.
+            * params.issuetype: (Optional) String. The Jira issue type. For
+                example: "Bug", "Epic", "Story".
+        :return:
+        """
+        kwargs = kwargs or {}
         kwargs["link_referrer"] = "jira_integration"
         params = kwargs.get("params", {})
         fields = []
         defaults = {}
+
         project_param_option = params.get("project")
         project_option = None
         if group:

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -79,8 +79,16 @@ class JiraCreateTicketAction(TicketEventAction):
 
         :return: (Option) Django form fields dictionary
         """
-        fields = self.data.get("dynamic_form_fields")
-        return {field["name"]: field for field in fields if "name" in field} if fields else None
+        fields_list = self.data.get("dynamic_form_fields")
+        if not fields_list:
+            return None
+
+        # Although this can be done with dict comprehension, looping for clarity.
+        fields = {}
+        for field in fields_list:
+            if "name" in field:
+                fields[field["name"]] = field
+        return fields
 
     def clean(self):
         cleaned_data = super(JiraCreateTicketAction, self).clean()

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -80,12 +80,7 @@ class JiraCreateTicketAction(TicketEventAction):
         :return: (Option) Django form fields dictionary
         """
         fields = self.data.get("dynamic_form_fields")
-        print("fields", fields)
-        return {
-            field['name']: field
-            for field in fields
-            if 'name' in field
-        } if fields else None
+        return {field["name"]: field for field in fields if "name" in field} if fields else None
 
     def clean(self):
         cleaned_data = super(JiraCreateTicketAction, self).clean()

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -55,6 +55,7 @@ class JiraCreateTicketAction(TicketEventAction):
                 "initial": six.text_type(self.get_integration_id()),
                 "type": "choice",
                 "updatesForm": True,
+                "name": "integration",
             }
         }
 
@@ -78,7 +79,13 @@ class JiraCreateTicketAction(TicketEventAction):
 
         :return: (Option) Django form fields dictionary
         """
-        return self.data.get("dynamic_form_fields")
+        fields = self.data.get("dynamic_form_fields")
+        print("fields", fields)
+        return {
+            field['name']: field
+            for field in fields
+            if 'name' in field
+        } if fields else None
 
     def clean(self):
         cleaned_data = super(JiraCreateTicketAction, self).clean()

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -7,13 +7,11 @@ from django import forms
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.integrations.jira.utils import (
-    transform_jira_fields_to_form_fields,
-    transform_jira_choices_to_strings,
     get_name_for_jira,
+    transform_jira_choices_to_strings,
 )
 from sentry.models.integration import Integration
 from sentry.rules.actions.base import TicketEventAction
-from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
 
@@ -76,32 +74,11 @@ class JiraCreateTicketAction(TicketEventAction):
 
     def get_dynamic_form_fields(self):
         """
-        Either get the dynamic form fields cached on the DB or make an API call
-        to Jira to get them for the selected integration. If both fail, return `None`.
+        Either get the dynamic form fields cached on the DB return `None`.
 
-        :return: Django form fields dictionary
+        :return: (Option) Django form fields dictionary
         """
-        if "dynamic_form_fields" in self.data:
-            return self.data["dynamic_form_fields"]
-
-        try:
-            integration = self.get_integration()
-        except Integration.DoesNotExist:
-            pass
-        else:
-            installation = integration.get_installation(self.project.organization.id)
-            if installation:
-                try:
-                    fields = installation.get_create_issue_config_no_params()
-                except IntegrationError as e:
-                    # TODO log when the API call fails.
-                    logger.info(e)
-                else:
-                    dynamic_form_fields = transform_jira_fields_to_form_fields(fields)
-                    self.data["dynamic_form_fields"] = dynamic_form_fields
-                    # TODO should I wipe out the rest of the data?
-                    return dynamic_form_fields
-        return None
+        return self.data.get("dynamic_form_fields")
 
     def clean(self):
         cleaned_data = super(JiraCreateTicketAction, self).clean()

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -54,7 +54,12 @@ def transform_jira_choices_to_strings(fields, data):
     for key, value in data.items():
         if key in ["integration", "dynamic_form_fields"] or not value:
             continue
-        if key in fields and fields[key]["type"] == "choice":
+
+        if (
+            key in fields
+            and "type" in fields[key]
+            and fields[key]["type"] == "choice"
+        ):
             temp_dict = {k: v for (k, v) in fields[key]["choices"]}
             if fields[key].get("multiple") and type(value) == list:
                 choices[key] = [temp_dict[v] for v in value]

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -44,6 +44,12 @@ def transform_jira_fields_to_form_fields(fields_list):
 
 
 def transform_jira_choices_to_strings(fields, data):
+    """
+    Transform to strings so that an AlertRule can be serialized.
+    :param fields: Object
+    :param data: Object
+    :return:
+    """
     choices = {}
     for key, value in data.items():
         if key in ["integration", "dynamic_form_fields"] or not value:

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -55,11 +55,7 @@ def transform_jira_choices_to_strings(fields, data):
         if key in ["integration", "dynamic_form_fields"] or not value:
             continue
 
-        if (
-            key in fields
-            and "type" in fields[key]
-            and fields[key]["type"] == "choice"
-        ):
+        if key in fields and "type" in fields[key] and fields[key]["type"] == "choice":
             temp_dict = {k: v for (k, v) in fields[key]["choices"]}
             if fields[key].get("multiple") and type(value) == list:
                 choices[key] = [temp_dict[v] for v in value]

--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -42,7 +42,6 @@ export default class AbstractExternalIssueForm<
     return {
       ...super.getDefaultState(),
       action: 'create',
-      // This is derived from integrationDetails when it loads.
       dynamicFieldValues: null,
       // This is fetched by AsyncComponent.getEndpoints.
       integrationDetails: null,
@@ -94,12 +93,18 @@ export default class AbstractExternalIssueForm<
 
   onRequestSuccess = ({stateKey, data}) => {
     if (stateKey === 'integrationDetails') {
+      this.handleReceiveIntegrationDetails(data);
       this.setState({
         dynamicFieldValues: this.getDynamicFields(data),
       });
     }
   };
 
+  /**
+   * If this field should updateFrom, updateForm. Otherwise, do nothing.
+   * @param label
+   * @param value
+   */
   onFieldChange = (label: string, value: FieldValue) => {
     const {dynamicFieldValues} = this.state;
     const dynamicFields = this.getDynamicFields();
@@ -117,7 +122,7 @@ export default class AbstractExternalIssueForm<
     }
   };
 
-  updateDynamicFieldChoices = (
+  updateFetchedFieldOptionsCache = (
     _field: IssueConfigField,
     _result: {options: {value: string; label: string}[]}
   ): void => {
@@ -136,7 +141,7 @@ export default class AbstractExternalIssueForm<
         if (err) {
           reject(err);
         } else {
-          this.updateDynamicFieldChoices(field, result);
+          this.updateFetchedFieldOptionsCache(field, result);
           resolve(result);
         }
       });
@@ -184,6 +189,9 @@ export default class AbstractExternalIssueForm<
       : {};
 
   // Abstract methods.
+  handleReceiveIntegrationDetails = (_data: any) => {
+    // Do nothing.
+  };
   getEndPointString = (): string => {
     throw new Error("Method 'getEndPointString()' must be implemented.");
   };

--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -43,7 +43,6 @@ export default class AbstractExternalIssueForm<
       ...super.getDefaultState(),
       action: 'create',
       dynamicFieldValues: null,
-      // This is fetched by AsyncComponent.getEndpoints.
       integrationDetails: null,
     };
   }

--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -101,8 +101,6 @@ export default class AbstractExternalIssueForm<
 
   /**
    * If this field should updateFrom, updateForm. Otherwise, do nothing.
-   * @param label
-   * @param value
    */
   onFieldChange = (label: string, value: FieldValue) => {
     const {dynamicFieldValues} = this.state;

--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -59,7 +59,7 @@ export default class AbstractExternalIssueForm<
     });
   };
 
-  getConfigName = (): string => {
+  getConfigName = (): 'createIssueConfig' | 'linkIssueConfig' => {
     // Explicitly returning a non-interpolated string for clarity.
     const {action} = this.state;
     switch (action) {
@@ -110,7 +110,10 @@ export default class AbstractExternalIssueForm<
     }
   };
 
-  updateDynamicFieldChoices = (_field: IssueConfigField, _result: any): void => {
+  updateDynamicFieldChoices = (
+    _field: IssueConfigField,
+    _result: {options: {value: string; label: string}[]}
+  ): void => {
     // Do nothing.
   };
 
@@ -174,7 +177,9 @@ export default class AbstractExternalIssueForm<
       : {};
 
   // Abstract methods.
-  getEndPointString = () => '';
+  getEndPointString = (): string => {
+    throw new Error("Method 'getEndPointString()' must be implemented.");
+  };
   renderNavTabs = (): React.ReactNode => null;
   renderBodyText = (): React.ReactNode => null;
   getTitle = () => tct('Issue Link Settings', {});

--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -17,7 +17,14 @@ type Props = AsyncComponent['props'];
 
 type State = {
   action: ExternalIssueAction;
+  /**
+   * Fetched via endpoint, null until set.
+   */
   integrationDetails: IntegrationIssueConfig | null;
+  /**
+   * Object of fields where `updatesFrom` is true, by field name. Derived from
+   * `integrationDetails` when it loads. Null until set.
+   */
   dynamicFieldValues: {[key: string]: FieldValue | null} | null;
 } & AsyncComponent['state'];
 

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -129,7 +129,8 @@ export default class ExternalIssueForm extends AbstractExternalIssueForm<Props, 
 
   renderBody() {
     const {integrationDetails} = this.state;
-    const config: IssueConfigField[] = (integrationDetails || {})[this.getConfigName()];
+    const config: IssueConfigField[] =
+      (integrationDetails || {})[this.getConfigName()] || [];
     return this.renderForm(config);
   }
 }

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1632,7 +1632,7 @@ export type SelectValue<T> = {
  */
 export type IssueConfigField = Field & {
   name: string;
-  default?: string;
+  default?: string | number;
   choices?: [number | string, number | string][];
   url?: string;
   multiple?: boolean;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -33,7 +33,7 @@ export type FormField = {
 type Props = {
   index: number;
   node?: IssueAlertRuleActionTemplate | IssueAlertRuleConditionTemplate | null;
-  data?: IssueAlertRuleAction | IssueAlertRuleCondition;
+  data: IssueAlertRuleAction | IssueAlertRuleCondition;
   project: Project;
   organization: Organization;
   disabled: boolean;
@@ -303,7 +303,7 @@ class RuleNode extends React.Component<Props> {
   };
 
   render() {
-    const {data, disabled, index, node, onPropertyChange} = this.props;
+    const {data, disabled, index, node, onPropertyChange, organization} = this.props;
     const ticketRule = node?.hasOwnProperty('actionType');
     return (
       <RuleRowContainer>
@@ -327,6 +327,7 @@ class RuleNode extends React.Component<Props> {
                       index={index}
                       onSubmitAction={this.updateParent}
                       onPropertyChange={onPropertyChange}
+                      organization={organization}
                     />
                   ))
                 }

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -286,27 +286,30 @@ class RuleNode extends React.Component<Props> {
    * @param fetchedFieldOptionsCache Object
    */
   updateParent = (
-    data: {[key: string]: string},
-    dynamicFieldChoices: {[key: string]: string[]}
+    formData: {[key: string]: string},
+    fetchedFieldOptionsCache: {[key: string]: [string, string][]}
   ): void => {
-    const {index, node, onPropertyChange} = this.props;
-    // Iterating through these upon save instead of when each element is changed
-    // to match the spec.
-    for (const [name, value] of Object.entries(data)) {
+    const {data, index, onPropertyChange} = this.props;
+    for (const [name, value] of Object.entries(formData)) {
       onPropertyChange(index, name, value);
+    }
 
-      // We only know the choices after the form loads.
-      if (['assignee', 'reporter'].includes(name) && dynamicFieldChoices[name]) {
-        const dynamicFormFieldsCopy: any = node?.formFields || {};
+    // We only know the choices after the form loads.
+    for (const [name, choices] of Object.entries(fetchedFieldOptionsCache)) {
+      // If a value was actually selected.
+      if (name in formData) {
+        const dynamicFormFieldsCopy = data.dynamic_form_fields as any;
         // Overwrite the choices because the user's pick is in this list.
-        dynamicFormFieldsCopy[name].choices = dynamicFieldChoices[name];
-        onPropertyChange(index, 'dynamic_form_fields', dynamicFormFieldsCopy);
+        if (dynamicFormFieldsCopy?.hasOwnProperty(name)) {
+          dynamicFormFieldsCopy[name].choices = choices;
+          onPropertyChange(index, 'dynamic_form_fields', dynamicFormFieldsCopy);
+        }
       }
     }
   };
 
   render() {
-    const {data, disabled, index, node, onPropertyChange, organization} = this.props;
+    const {data, disabled, index, node, organization} = this.props;
     const ticketRule = node?.hasOwnProperty('actionType');
     return (
       <RuleRowContainer>
@@ -329,7 +332,6 @@ class RuleNode extends React.Component<Props> {
                       instance={data}
                       index={index}
                       onSubmitAction={this.updateParent}
-                      onPropertyChange={onPropertyChange}
                       organization={organization}
                     />
                   ))

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -279,6 +279,12 @@ class RuleNode extends React.Component<Props> {
     }
   }
 
+  /**
+   * Update all the AlertRuleAction's fields from the TicketRuleModal together
+   * only after the user clicks "Apply Changes".
+   * @param formData Form data
+   * @param fetchedFieldOptionsCache Object
+   */
   updateParent = (
     data: {[key: string]: string},
     dynamicFieldChoices: {[key: string]: string[]}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -283,21 +283,18 @@ class RuleNode extends React.Component<Props> {
     data: {[key: string]: string},
     dynamicFieldChoices: {[key: string]: string[]}
   ): void => {
-    // iterating through these upon save instead of when each
-    // element is changed to match the spec
+    const {index, node, onPropertyChange} = this.props;
+    // Iterating through these upon save instead of when each element is changed
+    // to match the spec.
     for (const [name, value] of Object.entries(data)) {
-      this.props.onPropertyChange(this.props.index, name, value);
+      onPropertyChange(index, name, value);
 
       // We only know the choices after the form loads.
       if (['assignee', 'reporter'].includes(name) && dynamicFieldChoices[name]) {
-        const dynamicFormFieldsCopy: any = this.props.node?.formFields || {};
+        const dynamicFormFieldsCopy: any = node?.formFields || {};
         // Overwrite the choices because the user's pick is in this list.
         dynamicFormFieldsCopy[name].choices = dynamicFieldChoices[name];
-        this.props.onPropertyChange(
-          this.props.index,
-          'dynamic_form_fields',
-          dynamicFormFieldsCopy
-        );
+        onPropertyChange(index, 'dynamic_form_fields', dynamicFormFieldsCopy);
       }
     }
   };

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -57,8 +57,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
   getNames = (): string[] => {
     const {formFields} = this.props;
 
-    return formFields
-      .values()
+    return Object.values(formFields)
       .filter(field => field.hasOwnProperty('name'))
       .map(field => field.name);
   };
@@ -154,7 +153,11 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
           if (instance.hasOwnProperty(field.name)) {
             field.default = instance[field.name];
           }
-          if (['assignee', 'reporter'].includes(field.name)) {
+          if (
+            ['assignee', 'reporter'].includes(field.name) &&
+            instance.dynamic_form_fields &&
+            instance.dynamic_form_fields[field.name]
+          ) {
             field.choices = instance.dynamic_form_fields[field.name].choices;
           }
           return field;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -196,7 +196,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     return (
       <BodyText>
         {tct(
-          'When this alert is triggered a {ticketType} will be ' +
+          'When this alert is triggered a [ticketType] will be ' +
             'created with the following fields. It will also [linkToDocs] ' +
             'with the new Sentry Issue.',
           {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -33,10 +33,6 @@ type State = {
 } & AbstractExternalIssueForm['state'];
 
 class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
-  constructor(props: Props, context: any) {
-    super(props, context);
-  }
-
   getDefaultState(): State {
     return {
       ...super.getDefaultState(),

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -58,7 +58,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
       .map(field => field.name);
   };
 
-  getEndPointString = () => {
+  getEndPointString = (): string => {
     const {instance, organization} = this.props;
     return `/organizations/${organization.slug}/integrations/${instance.integration}/`;
   };
@@ -101,7 +101,10 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     }
   };
 
-  updateDynamicFieldChoices = (field: IssueConfigField, result: any): void => {
+  updateDynamicFieldChoices = (
+    field: IssueConfigField,
+    result: {options: {value: string; label: string}[]}
+  ): void => {
     const dynamicFieldChoices = result.options.map(obj => [obj.value, obj.label]);
     this.setState(prevState => {
       const newState = cloneDeep(prevState);

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -13,7 +13,6 @@ import {IssueConfigField, Organization} from 'app/types';
 import {IssueAlertRuleAction, IssueAlertRuleCondition} from 'app/types/alerts';
 import AsyncView from 'app/views/asyncView';
 import Form from 'app/views/settings/components/forms/form';
-import {FormField} from 'app/views/settings/projectAlerts/issueEditor/ruleNode';
 
 type Props = ModalRenderProps & {
   formFields: {[key: string]: any};
@@ -59,13 +58,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
   getNames = (): string[] => {
     const {formFields} = this.props;
 
-    const names: string[] = [];
-    for (const name in formFields) {
-      if (formFields[name].hasOwnProperty('name')) {
-        names.push(formFields[name].name);
-      }
-    }
-    return names;
+    return formFields.values().filter(field => field.hasOwnProperty('name')).map(field => field.name);
   };
 
   getEndPointString = () => {
@@ -100,11 +93,11 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     const {onSubmitAction, closeModal} = this.props;
     const {dynamicFieldChoices} = this.state;
 
+    // This is a "fake form", so don't actually POST to an endpoint.
     e.preventDefault();
     e.stopPropagation();
 
-    const formData = this.cleanData(data);
-    onSubmitAction(formData, dynamicFieldChoices);
+    onSubmitAction(this.cleanData(data), dynamicFieldChoices);
     addSuccessMessage(t('Changes applied.'));
     closeModal();
   };

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -80,7 +80,6 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
 
   /**
    * Clean up the form data before saving it to state.
-   * @param data
    */
   cleanData = (data: {
     [key: string]: string;
@@ -196,13 +195,15 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     const {ticketType, link} = this.props;
     return (
       <BodyText>
-        {t(
-          'When this alert is triggered a %s will be created with the following fields. ',
-          ticketType
+        {tct(
+          'When this alert is triggered a {ticketType} will be ' +
+            'created with the following fields. It will also [linkToDocs] ' +
+            'with the new Sentry Issue.',
+          {
+            linkToDocs: <ExternalLink href={link}>{t('stay in sync')}</ExternalLink>,
+            ticketType,
+          }
         )}
-        {tct("It'll also [linkToDocs] with the new Sentry Issue.", {
-          linkToDocs: <ExternalLink href={link}>{t('stay in sync')}</ExternalLink>,
-        })}
       </BodyText>
     );
   };

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -18,9 +18,9 @@ import {FormField} from 'app/views/settings/projectAlerts/issueEditor/ruleNode';
 
 type Props = ModalRenderProps & {
   formFields: {[key: string]: any};
+  instance: IssueAlertRuleAction | IssueAlertRuleCondition;
   link?: string;
   ticketType?: string;
-  instance?: IssueAlertRuleAction | IssueAlertRuleCondition;
   onSubmitAction: (
     data: {[key: string]: string},
     dynamicFieldChoices: {[key: string]: string[]}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -90,7 +90,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     return formData;
   };
 
-  onFormSubmit: Form['props']['onSubmit'] = (data, _success, _error, e) => {
+  onFormSubmit: Form['props']['onSubmit'] = (data, _success, _error, e, model) => {
     const {onSubmitAction, closeModal} = this.props;
     const {dynamicFieldChoices} = this.state;
 
@@ -98,9 +98,11 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     e.preventDefault();
     e.stopPropagation();
 
-    onSubmitAction(this.cleanData(data), dynamicFieldChoices);
-    addSuccessMessage(t('Changes applied.'));
-    closeModal();
+    if (model.validateForm()) {
+      onSubmitAction(this.cleanData(data), dynamicFieldChoices);
+      addSuccessMessage(t('Changes applied.'));
+      closeModal();
+    }
   };
 
   updateDynamicFieldChoices = (field: IssueConfigField, result: any): void => {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -130,36 +130,29 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     };
   };
 
-  getFieldProps = (field: IssueConfigField) =>
-    field.url
-      ? {
-          loadOptions: (input: string) => this.getOptions(field, input),
-          async: true,
-          cache: false,
-          onSelectResetsInput: false,
-          onCloseResetsInput: false,
-          onBlurResetsInput: false,
-          autoload: true,
-        }
-      : {};
-
-  addFields = (fields: FormField[]): void => {
-    const title = {
-      name: 'title',
-      label: 'Title',
-      type: 'string',
-      default: 'This will be the same as the Sentry Issue.',
-      disabled: true,
-    };
-    const description = {
-      name: 'description',
-      label: 'Description',
-      type: 'string',
-      default: 'This will be generated from the Sentry Issue details.',
-      disabled: true,
-    };
-    fields.unshift(description);
-    fields.unshift(title);
+  /**
+   * Set the order of the fields for the modal and replace `title` and `description`.
+   */
+  cleanFields = (): FormField[] => {
+    const {formFields} = this.props;
+    return [
+      {
+        name: 'title',
+        label: 'Title',
+        type: 'string',
+        default: 'This will be the same as the Sentry Issue.',
+        disabled: true,
+      },
+      {
+        name: 'description',
+        label: 'Description',
+        type: 'string',
+        default: 'This will be generated from the Sentry Issue details.',
+        disabled: true,
+      },
+    ].concat(
+      Object.values(formFields).filter(f => !['title', 'description'].includes(f.name))
+    );
   };
 
   renderBodyText = () => {
@@ -178,19 +171,8 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
   };
 
   render() {
-    const {formFields, instance} = this.props;
-    const fields = Object.values(formFields);
-    this.addFields(fields);
-    const initialData = instance || {};
-    fields.forEach((field: FormField) => {
-      // passing an empty array breaks multi select
-      // TODO(jess): figure out why this is breaking and fix
-      if (!initialData.hasOwnProperty(field.name)) {
-        initialData[field.name] = field.multiple ? '' : field.default;
-      }
-    });
-
-    return this.renderForm(fields, instance);
+    const {instance} = this.props;
+    return this.renderForm(this.cleanFields(), instance);
   }
 }
 

--- a/tests/fixtures/integrations/jira/mock.py
+++ b/tests/fixtures/integrations/jira/mock.py
@@ -1,6 +1,8 @@
 from tests.fixtures.integrations.jira.stub_client import StubJiraApiClient
 from tests.fixtures.integrations import MockService
 
+DEFAULT_PROJECT_ID = '10000'
+
 
 class MockJira(StubJiraApiClient, MockService):
     def get_projects_list(self):
@@ -21,7 +23,7 @@ class MockJira(StubJiraApiClient, MockService):
                 "description": project_name
             },
             "simplified": False
-        } for project_name in self._get_project_names()]
+        } for project_name in self._get_project_names() + [DEFAULT_PROJECT_ID]]
 
     def set_createmeta(self, project, createmeta):
         """

--- a/tests/fixtures/integrations/jira/stub_client.py
+++ b/tests/fixtures/integrations/jira/stub_client.py
@@ -40,3 +40,9 @@ class StubJiraApiClient(StubService):
         if user["accountId"] == user_id:
             return user
         raise ApiError("no user found")
+
+    def get_valid_statuses(self):
+        return self._get_stub_data("status_response.json")
+
+    def search_users_for_project(self, project, username):
+        return [self._get_stub_data("user.json")]

--- a/tests/fixtures/integrations/jira/stubs/status_response.json
+++ b/tests/fixtures/integrations/jira/stubs/status_response.json
@@ -1,0 +1,62 @@
+[
+  {
+    "statusCategory": {
+      "name": "In Progress",
+      "self": "https://getsentry-dev.atlassian.net/rest/api/2/statuscategory/4",
+      "id": 4,
+      "key": "indeterminate",
+      "colorName": "yellow"
+    },
+    "untranslatedName": "In Progress",
+    "description": "This issue is being actively worked on at the moment by the assignee.",
+    "self": "https://getsentry-dev.atlassian.net/rest/api/2/status/3",
+    "iconUrl": "https://getsentry-dev.atlassian.net/images/icons/statuses/inprogress.png",
+    "id": "3",
+    "name": "In Progress"
+  },
+  {
+    "statusCategory": {
+      "name": "To Do",
+      "self": "https://getsentry-dev.atlassian.net/rest/api/2/statuscategory/2",
+      "id": 2,
+      "key": "new",
+      "colorName": "blue-gray"
+    },
+    "untranslatedName": "To Do",
+    "description": "",
+    "self": "https://getsentry-dev.atlassian.net/rest/api/2/status/10000",
+    "iconUrl": "https://getsentry-dev.atlassian.net/",
+    "id": "10000",
+    "name": "To Do"
+  },
+  {
+    "statusCategory": {
+      "name": "In Progress",
+      "self": "https://getsentry-dev.atlassian.net/rest/api/2/statuscategory/4",
+      "id": 4,
+      "key": "indeterminate",
+      "colorName": "yellow"
+    },
+    "untranslatedName": "In Review",
+    "description": "",
+    "self": "https://getsentry-dev.atlassian.net/rest/api/2/status/10001",
+    "iconUrl": "https://getsentry-dev.atlassian.net/",
+    "id": "10001",
+    "name": "In Review"
+  },
+  {
+    "statusCategory": {
+      "name": "Done",
+      "self": "https://getsentry-dev.atlassian.net/rest/api/2/statuscategory/3",
+      "id": 3,
+      "key": "done",
+      "colorName": "green"
+    },
+    "untranslatedName": "Done",
+    "description": "",
+    "self": "https://getsentry-dev.atlassian.net/rest/api/2/status/10002",
+    "iconUrl": "https://getsentry-dev.atlassian.net/",
+    "id": "10002",
+    "name": "Done"
+  }
+]

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -53,6 +53,8 @@ class JiraCreateTicketActionTest(RuleTestCase):
         )
 
         jira_rule.data["key"] = "APP-123"
+
+        # Add two mocks: one for POSTing the issue and a GET to confirm it's there.
         responses.add(
             method=responses.POST,
             url="https://example.atlassian.net/rest/api/2/issue",
@@ -75,7 +77,7 @@ class JiraCreateTicketActionTest(RuleTestCase):
         results[0].callback(event, futures=[])
 
         # Make assertions about what would be sent.
-        data = json.loads(responses.calls[2].request.body)
+        data = json.loads(responses.calls[1].request.body)
         assert data["fields"]["summary"] == event.title
         assert event.message in data["fields"]["description"]
         assert data["fields"]["issuetype"]["id"] == "1"
@@ -123,7 +125,9 @@ class JiraCreateTicketActionTest(RuleTestCase):
         results = list(jira_rule.after(event=event, state=self.get_state()))
         assert len(results) == 1
         results[0].callback(event, futures=[])
-        assert len(responses.calls) == 1
+
+        # Assert that we don't POST to create the issue.
+        assert len(responses.calls) == 0
 
     def test_render_label(self):
         rule = self.get_rule(


### PR DESCRIPTION
This PR builds on the refactor work in https://github.com/getsentry/sentry/pull/22621. By making the `TicketRulesModal` inherit from the abstract base class, it automatically understands how to refresh itself when form fields change.
I also needed to modify some backend code to get this working. The "Issues Page" modal get its configs from `GroupIntegrationDetailsEndpoint` which uses the `IntegrationIssueConfigSerializer` to get `createIssueConfig`. The "Ticket Rule" modal doesn't have a **`group`** so it has to get configs from `OrganizationIntegrationDetailsEndpoint`, which uses `IntegrationConfigSerializer`. I had to add an API call to Jira to the serializer but hid it behind a query parameter so that it wouldn't change behavior for existing APIs.