### PR TITLE
fix: Bump sentry-sdk to git sha

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,6 @@ RUN set -x \
   dirmngr \
   gnupg \
   wget \
-  git \
   " \
   && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
   && rm -rf /var/lib/apt/lists/* \
@@ -63,6 +62,10 @@ ENV PIP_NO_CACHE_DIR=off \
 COPY /dist/requirements.txt /tmp/dist/requirements.txt
 RUN set -x \
   && buildDeps="" \
+  # ability to install git dependencies
+  && buildDeps="$buildDeps \
+  git \
+  " \
   # uwsgi
   && buildDeps="$buildDeps \
   gcc \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,7 @@ RUN set -x \
   dirmngr \
   gnupg \
   wget \
+  git \
   " \
   && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
   && rm -rf /var/lib/apt/lists/* \

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -52,7 +52,7 @@ rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
 sentry-relay>=0.8.1,<0.9.0
-git+https://github.com/getsentry/sentry-python@c277ed5#egg=sentry-sdk
+sentry-sdk @ git+https://github.com/getsentry/sentry-python@c277ed5#egg=sentry-sdk
 simplejson>=3.11.0,<3.12.0
 six>=1.11.0,<1.12.0
 sqlparse>=0.2.0,<0.3.0

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -52,7 +52,7 @@ rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
 sentry-relay>=0.8.1,<0.9.0
-sentry-sdk>=0.17.7,<0.18.0
+git+https://github.com/getsentry/sentry-python@c277ed5#egg=sentry-sdk
 simplejson>=3.11.0,<3.12.0
 six>=1.11.0,<1.12.0
 sqlparse>=0.2.0,<0.3.0

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -179,6 +179,7 @@ def configure_sdk():
 
     sentry_sdk.init(
         transport=MultiplexingTransport(),
+        auto_enabling_integrations=False,
         integrations=[
             DjangoIntegration(),
             CeleryIntegration(),


### PR DESCRIPTION
wanna get https://github.com/getsentry/sentry-python/pull/942 in

#sync-getsentry