### PR TITLE
ref(js-processor): Avoid compression and caching of large files

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1246,6 +1246,13 @@ SENTRY_SOURCE_FETCH_SOCKET_TIMEOUT = 2
 # Maximum content length for source files before we abort fetching
 SENTRY_SOURCE_FETCH_MAX_SIZE = 40 * 1024 * 1024
 
+# Maximum content length for cache value.  Currently used only to avoid
+# pointless compression of sourcemaps and other release files because we
+# silently fail to cache the compressed result anyway.  Defaults to None which
+# disables the check and allows different backends for unlimited payload.
+# e.g. memcached defaults to 1MB  = 1024 * 1024
+SENTRY_CACHE_MAX_VALUE_SIZE = None
+
 # Fields which managed users cannot change via Sentry UI. Username and password
 # cannot be changed by managed users. Optionally include 'email' and
 # 'name' in SENTRY_MANAGED_USER_FIELDS.


### PR DESCRIPTION
For release files that even compressed exceed the payload limit of the caching
backend we repeat the compression and caching attempt every time the file is
being retrieved.

This PR introduces cache key to save metadata with the size of compressed
payload cached next retrieval can avoid the pointless compression and caching.