### PR TITLE
feat(workflow): Support `owner:me_or_none` issue search syntax

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -15,6 +15,7 @@ from sentry.api.event_search import (
 from sentry.models.group import STATUS_QUERY_CHOICES
 from sentry.search.utils import (
     parse_actor_value,
+    parse_owner_value,
     parse_user_value,
     parse_release,
     parse_status_value,
@@ -95,6 +96,10 @@ def convert_actor_value(value, projects, user, environments):
     return parse_actor_value(projects, value, user)
 
 
+def convert_owner_value(value, projects, user, environments):
+    return parse_owner_value(projects, value, user)
+
+
 def convert_user_value(value, projects, user, environments):
     return parse_user_value(value, user)
 
@@ -111,7 +116,7 @@ def convert_status_value(value, projects, user, environments):
 
 
 value_converters = {
-    "owner": convert_actor_value,
+    "owner": convert_owner_value,
     "assigned_to": convert_actor_value,
     "bookmarked_by": convert_user_value,
     "subscribed_by": convert_user_value,

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -150,12 +150,14 @@ def owner_filter(owner, projects):
         relevant_owners = GroupOwner.objects.filter(
             project_id__in=project_ids, organization_id=organization_id
         )
+        filter_query = Q(team__in=teams) | Q(user=owner)
         return Q(
-            id__in=relevant_owners.filter(Q(team__in=teams) | Q(user=owner),)
+            id__in=relevant_owners.filter(filter_query)
             .values_list("group_id", flat=True)
             .distinct()
         )
     elif owner == "me_or_none":
+        # TODO: Tricky bit here.
         pass
 
     raise InvalidSearchQuery(u"Unsupported owner type.")

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -171,7 +171,7 @@ def owner_filter(owner, projects):
         no_owner = Q(groupowner__isnull=True)
         return Q(
             no_owner
-            | Q(
+            | (
                 Q(
                     groupowner__project_id__in=project_ids,
                     groupowner__organization_id=organization_id,

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -169,15 +169,10 @@ def owner_filter(owner, projects):
         owned_team = Q(groupowner__team__in=teams)
         owned_me = Q(groupowner__user=owner[1])
         no_owner = Q(groupowner__isnull=True)
-        return Q(
-            no_owner
-            | (
-                Q(
-                    groupowner__project_id__in=project_ids,
-                    groupowner__organization_id=organization_id,
-                )
-                & Q(owned_me | owned_team)
-            )
+        return no_owner | Q(
+            owned_me | owned_team,
+            groupowner__project_id__in=project_ids,
+            groupowner__organization_id=organization_id,
         )
 
     raise InvalidSearchQuery(u"Unsupported owner type.")

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -222,11 +222,9 @@ def parse_actor_value(projects, value, user):
 
 
 def parse_owner_value(projects, value, user):
-    if value.startswith("#"):
-        return parse_team_value(projects, value, user)
-    elif value == "me_or_none":
+    if value == "me_or_none":
         return ["me_or_none", user]
-    return parse_user_value(value, user)
+    return parse_actor_value(projects, value, user)
 
 
 def parse_user_value(value, user):

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -221,6 +221,14 @@ def parse_actor_value(projects, value, user):
     return parse_user_value(value, user)
 
 
+def parse_owner_value(projects, value, user):
+    if value.startswith("#"):
+        return parse_team_value(projects, value, user)
+    elif value == "me_or_none":
+        return "me_or_none"
+    return parse_user_value(value, user)
+
+
 def parse_user_value(value, user):
     if value == "me":
         return user
@@ -450,7 +458,7 @@ def parse_query(projects, query, user, environments):
             elif key == "assigned":
                 results["assigned_to"] = parse_actor_value(projects, value, user)
             elif key == "owner":
-                results["owner"] = parse_actor_value(projects, value, user)
+                results["owner"] = parse_owner_value(projects, value, user)
             elif key == "bookmarks":
                 results["bookmarked_by"] = parse_user_value(value, user)
             elif key == "subscribed":

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -225,7 +225,7 @@ def parse_owner_value(projects, value, user):
     if value.startswith("#"):
         return parse_team_value(projects, value, user)
     elif value == "me_or_none":
-        return "me_or_none"
+        return ["me_or_none", user]
     return parse_user_value(value, user)
 
 


### PR DESCRIPTION
Adding support for a `me_or_none` owner search that will return groups owned by you, your team, or nobody.