### PR TITLE
feat(integrations): Create instrumented internal ApiClient and extend for Heroku

### DIFF
--- a/src/sentry_plugins/client.py
+++ b/src/sentry_plugins/client.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 
-from sentry.shared_integrations.client import BaseApiClient
+from sentry.shared_integrations.client import BaseApiClient, BaseInternalApiClient
 from sentry.shared_integrations.exceptions import ApiUnauthorized
 
 
@@ -62,3 +62,13 @@ class AuthApiClient(ApiClient):
         self.auth.refresh_token()
         kwargs = self.bind_auth(**kwargs)
         return ApiClient._request(self, method, path, **kwargs)
+
+
+class InternalApiClient(BaseInternalApiClient):
+    integration_type = "plugin"
+
+    datadog_prefix = "sentry-plugins"
+
+    log_path = "sentry.plugins.client"
+
+    plugin_name = "undefined"

--- a/src/sentry_plugins/heroku/client.py
+++ b/src/sentry_plugins/heroku/client.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import
 
-from sentry.models import ApiKey, User, ProjectOption, Repository
 from sentry_plugins.client import InternalApiClient
 
 

--- a/src/sentry_plugins/heroku/client.py
+++ b/src/sentry_plugins/heroku/client.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+
+from sentry.models import ApiKey, User, ProjectOption, Repository
+from sentry_plugins.client import InternalApiClient
+
+
+class HerokuApiClient(InternalApiClient):
+    plugin_name = "heroku"
+
+    def __init__(self):
+        super(HerokuApiClient, self).__init__()

--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 import logging
 
-from sentry.api import client
-
 from sentry.models import ApiKey, User, ProjectOption, Repository
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry_plugins.base import CorePluginMixin

--- a/src/sentry_plugins/heroku/plugin.py
+++ b/src/sentry_plugins/heroku/plugin.py
@@ -17,8 +17,7 @@ logger = logging.getLogger("sentry.plugins.heroku")
 class HerokuReleaseHook(ReleaseHook):
     def get_auth(self):
         try:
-            auth = ApiKey(organization=self.project.organization, scope_list=["project:write"])
-            return auth
+            return ApiKey(organization=self.project.organization, scope_list=["project:write"])
         except ApiKey.DoesNotExist:
             return None
 


### PR DESCRIPTION
## Objective
We want to instrument the Heroku plugin. However this plugin makes requests to Sentry and we need to create a new subclass that instruments the current ApiClient with Datadog and Sentry Performance. Then we extend it with Heroku specific values.