### PR TITLE
ref(modals): Use openModal for Confirm component

### DIFF
--- a/src/sentry/static/sentry/app/components/confirmDelete.tsx
+++ b/src/sentry/static/sentry/app/components/confirmDelete.tsx
@@ -1,55 +1,24 @@
 import React from 'react';
 
 import Alert from 'app/components/alert';
-import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import {t} from 'app/locale';
 import Input from 'app/views/settings/components/forms/controls/input';
 import Field from 'app/views/settings/components/forms/field';
 
-const defaultProps = {
-  priority: 'primary' as React.ComponentProps<typeof Button>['priority'],
-  cancelText: t('Cancel'),
-  confirmText: t('Confirm'),
-};
-
-type Props = {
-  onConfirm: () => void;
-  confirmInput: string;
-  message?: React.ReactNode;
-  renderMessage?: React.ComponentProps<typeof Confirm>['renderMessage'];
-  children?: React.ComponentProps<typeof Confirm>['children'];
-  disabled?: boolean;
-  onConfirming?: () => void;
-  onCancel?: () => void;
-} & typeof defaultProps;
-
-type State = {
-  disableConfirmButton: boolean;
+type Props = Omit<React.ComponentProps<typeof Confirm>, 'renderConfirmMessage'> & {
+  /**
+   * The string that the user must enter to confirm the deletion
+   */
   confirmInput: string;
 };
 
-class ConfirmDelete extends React.PureComponent<Props, State> {
-  static defaultProps = defaultProps;
-
-  state = {
-    disableConfirmButton: true,
-    confirmInput: '',
-  };
-
-  handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
-    const input = evt.target.value;
-    if (input === this.props.confirmInput) {
-      this.setState({disableConfirmButton: false, confirmInput: input});
-    } else {
-      this.setState({disableConfirmButton: true, confirmInput: input});
-    }
-  };
-
-  renderConfirmMessage = () => {
-    const {message, confirmInput} = this.props;
-
-    return (
+const ConfirmDelete = ({message, confirmInput, ...props}: Props) => (
+  <Confirm
+    {...props}
+    bypass={false}
+    disableConfirmButton
+    renderMessage={({disableConfirmButton}) => (
       <React.Fragment>
         <Alert type="error">{message}</Alert>
         <Field
@@ -63,26 +32,12 @@ class ConfirmDelete extends React.PureComponent<Props, State> {
           <Input
             type="text"
             placeholder={confirmInput}
-            onChange={this.handleChange}
-            value={this.state.confirmInput}
+            onChange={e => disableConfirmButton(e.target.value !== confirmInput)}
           />
         </Field>
       </React.Fragment>
-    );
-  };
-
-  render() {
-    const {disableConfirmButton} = this.state;
-
-    return (
-      <Confirm
-        {...this.props}
-        bypass={false}
-        disableConfirmButton={disableConfirmButton}
-        message={this.renderConfirmMessage()}
-      />
-    );
-  }
-}
+    )}
+  />
+);
 
 export default ConfirmDelete;

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/removeConfirm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/components/removeConfirm.tsx
@@ -18,12 +18,6 @@ const message = (
   </React.Fragment>
 );
 
-class RemoveConfirm extends React.Component<Props> {
-  static defaultProps = Confirm.defaultProps;
-
-  render() {
-    return <Confirm {...this.props} message={message} />;
-  }
-}
+const RemoveConfirm = (props: Props) => <Confirm {...props} message={message} />;
 
 export default RemoveConfirm;

--- a/src/sentry/static/sentry/app/views/settings/projectTags.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectTags.tsx
@@ -4,8 +4,8 @@ import styled from '@emotion/styled';
 
 import Access from 'app/components/acl/access';
 import Button from 'app/components/button';
+import Confirm from 'app/components/confirm';
 import ExternalLink from 'app/components/links/externalLink';
-import LinkWithConfirmation from 'app/components/links/linkWithConfirmation';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import Tooltip from 'app/components/tooltip';
 import {IconDelete} from 'app/icons';
@@ -110,19 +110,18 @@ class ProjectTags extends AsyncView<Props, State> {
                                 : t('You do not have permission to remove tags.')
                             }
                           >
-                            <LinkWithConfirmation
-                              title={t('Remove tag?')}
+                            <Confirm
                               message={t('Are you sure you want to remove this tag?')}
                               onConfirm={this.handleDelete(key, idx)}
                               disabled={!enabled}
                             >
                               <Button
                                 size="xsmall"
+                                title={t('Remove tag')}
                                 icon={<IconDelete size="xs" />}
                                 data-test-id="delete"
-                                disabled={!enabled}
                               />
-                            </LinkWithConfirmation>
+                            </Confirm>
                           </Tooltip>
                         </Actions>
                       </TagPanelItem>

--- a/tests/js/sentry-test/modal.jsx
+++ b/tests/js/sentry-test/modal.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import GlobalModal from 'app/components/globalModal';
+
+export async function mountGlobalModal(context) {
+  const modal = mountWithTheme(<GlobalModal />, context);
+  await tick();
+  modal.update();
+
+  return modal;
+}

--- a/tests/js/spec/components/actions/ignore.spec.jsx
+++ b/tests/js/spec/components/actions/ignore.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import $ from 'jquery';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import IgnoreActions from 'app/components/actions/ignore';
 
@@ -75,19 +75,20 @@ describe('IgnoreActions', function () {
 
     beforeEach(function () {
       component = mountWithTheme(
-        <IgnoreActions onUpdate={spy} shouldConfirm confirmMessage="Yoooooo" />,
+        <IgnoreActions onUpdate={spy} shouldConfirm confirmMessage="confirm me" />,
         routerContext
       );
       button = component.find('button[aria-label="Ignore"]');
     });
 
-    it('displays confirmation modal with message provided', function () {
+    it('displays confirmation modal with message provided', async function () {
       button.simulate('click');
 
-      const modal = $(document.body).find('.modal');
-      expect(modal.text()).toContain('Yoooooo');
+      const modal = await mountGlobalModal();
+
+      expect(modal.text()).toContain('confirm me');
       expect(spy).not.toHaveBeenCalled();
-      $(document.body).find('.modal button:contains("Ignore")').click();
+      modal.find('Button[priority="primary"]').simulate('click');
 
       expect(spy).toHaveBeenCalled();
     });

--- a/tests/js/spec/components/confirm.spec.jsx
+++ b/tests/js/spec/components/confirm.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme, shallow} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import Confirm from 'app/components/confirm';
 
@@ -13,10 +14,11 @@ describe('Confirm', function () {
       </Confirm>,
       TestStubs.routerContext()
     );
+
     expect(wrapper).toSnapshot();
   });
 
-  it('clicking action button opens Modal', function () {
+  it('clicking action button opens Modal', async function () {
     const mock = jest.fn();
     const wrapper = shallow(
       <Confirm message="Are you sure?" onConfirm={mock}>
@@ -27,26 +29,12 @@ describe('Confirm', function () {
 
     wrapper.find('button').simulate('click');
 
-    expect(wrapper.find('Modal').prop('show')).toBe(true);
+    const modal = await mountGlobalModal();
+
+    expect(modal.find('Modal[show=true]').exists()).toBe(true);
   });
 
-  it('clicking action button twice causes Modal to end up closed', function () {
-    const mock = jest.fn();
-    const wrapper = shallow(
-      <Confirm message="Are you sure?" onConfirm={mock}>
-        <button>Confirm?</button>
-      </Confirm>,
-      TestStubs.routerContext()
-    );
-
-    const button = wrapper.find('button');
-
-    button.simulate('click');
-    button.simulate('click');
-    expect(wrapper.find('Modal').prop('show')).toBe(false);
-  });
-
-  it('clicks Confirm in modal and calls `onConfirm` callback', function () {
+  it('clicks Confirm in modal and calls `onConfirm` callback', async function () {
     const mock = jest.fn();
     const wrapper = mountWithTheme(
       <Confirm message="Are you sure?" onConfirm={mock}>
@@ -58,12 +46,16 @@ describe('Confirm', function () {
     expect(mock).not.toHaveBeenCalled();
 
     wrapper.find('button').simulate('click');
-    wrapper.update();
+
+    const modal = await mountGlobalModal();
 
     // Click "Confirm" button, should be last button
-    wrapper.find('Button').last().simulate('click');
+    modal.find('Button').last().simulate('click');
 
-    expect(wrapper.find('Modal').first().prop('show')).toBe(false);
+    await tick();
+    modal.update();
+
+    expect(modal.find('Modal[show=true]').exists()).toBe(false);
     expect(mock).toHaveBeenCalled();
     expect(mock.mock.calls).toHaveLength(1);
   });

--- a/tests/js/spec/components/confirmDelete.spec.jsx
+++ b/tests/js/spec/components/confirmDelete.spec.jsx
@@ -1,11 +1,12 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import ConfirmDelete from 'app/components/confirmDelete';
 
 describe('ConfirmDelete', function () {
-  it('renders', function () {
+  it('renders', async function () {
     const mock = jest.fn();
     const wrapper = mountWithTheme(
       <ConfirmDelete message="Are you sure?" onConfirm={mock} confirmInput="CoolOrg">
@@ -14,11 +15,14 @@ describe('ConfirmDelete', function () {
       TestStubs.routerContext()
     );
     wrapper.find('button').simulate('click');
+
+    const modal = await mountGlobalModal();
+
     // jest had an issue rendering root component snapshot so using ModalDialog instead
-    expect(wrapper.find('ModalDialog')).toSnapshot();
+    expect(modal.find('Modal')).toSnapshot();
   });
 
-  it('confirm button is disabled and bypass prop is false when modal opens', function () {
+  it('confirm button is disabled and bypass prop is false when modal opens', async function () {
     const mock = jest.fn();
     const wrapper = mountWithTheme(
       <ConfirmDelete message="Are you sure?" onConfirm={mock} confirmInput="CoolOrg">
@@ -28,12 +32,14 @@ describe('ConfirmDelete', function () {
     );
 
     wrapper.find('button').simulate('click');
+
+    const modal = await mountGlobalModal();
 
     expect(wrapper.find('Confirm').prop('bypass')).toBe(false);
-    expect(wrapper.state('disableConfirmButton')).toBe(true);
+    expect(modal.find('Button[priority="primary"][disabled=true]').exists()).toBe(true);
   });
 
-  it('confirm button stays disabled with non-matching input', function () {
+  it('confirm button stays disabled with non-matching input', async function () {
     const mock = jest.fn();
     const wrapper = mountWithTheme(
       <ConfirmDelete message="Are you sure?" onConfirm={mock} confirmInput="CoolOrg">
@@ -42,11 +48,14 @@ describe('ConfirmDelete', function () {
       TestStubs.routerContext()
     );
     wrapper.find('button').simulate('click');
-    wrapper.find('input').simulate('change', {target: {value: 'Cool'}});
-    expect(wrapper.find('Confirm').prop('disableConfirmButton')).toBe(true);
+
+    const modal = await mountGlobalModal();
+
+    modal.find('input').simulate('change', {target: {value: 'Cool'}});
+    expect(modal.find('Button[priority="primary"][disabled=true]').exists()).toBe(true);
   });
 
-  it('confirm button is enabled when confirm input matches', function () {
+  it('confirm button is enabled when confirm input matches', async function () {
     const mock = jest.fn();
     const wrapper = mountWithTheme(
       <ConfirmDelete message="Are you sure?" onConfirm={mock} confirmInput="CoolOrg">
@@ -55,12 +64,14 @@ describe('ConfirmDelete', function () {
       TestStubs.routerContext()
     );
     wrapper.find('button').simulate('click');
-    wrapper.find('input').simulate('change', {target: {value: 'CoolOrg'}});
-    expect(wrapper.find('Confirm').prop('disableConfirmButton')).toBe(false);
 
-    wrapper.find('Button').last().simulate('click');
+    const modal = await mountGlobalModal();
 
-    expect(wrapper.find('Modal').first().prop('show')).toBe(false);
+    modal.find('input').simulate('change', {target: {value: 'CoolOrg'}});
+    expect(modal.find('Button[priority="primary"][disabled=false]').exists()).toBe(true);
+
+    modal.find('Button[priority="primary"]').simulate('click');
+
     expect(mock).toHaveBeenCalled();
     expect(mock.mock.calls).toHaveLength(1);
   });

--- a/tests/js/spec/components/forms/tableField.spec.jsx
+++ b/tests/js/spec/components/forms/tableField.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import Form from 'app/views/settings/components/forms/form';
 import FormModel from 'app/views/settings/components/forms/model';
@@ -60,7 +61,7 @@ describe('TableField', function () {
         expect(wrapper.find('HeaderLabel').at(1).text()).toBe('Column 2');
       });
 
-      it('handles removing a row', function () {
+      it('handles removing a row', async function () {
         // add a couple new rows for funsies
         wrapper.find('button[aria-label="Add Thing"]').simulate('click');
         wrapper.find('button[aria-label="Add Thing"]').simulate('click');
@@ -69,7 +70,9 @@ describe('TableField', function () {
         wrapper.find('button[aria-label="delete"]').last().simulate('click');
 
         // click through confirmation
-        wrapper.find('Button[data-test-id="confirm-button"]').simulate('click');
+        const modal = await mountGlobalModal();
+        modal.find('Button[data-test-id="confirm-button"]').simulate('click');
+        wrapper.update();
 
         expect(wrapper.find('RowContainer[data-test-id="field-row"]')).toHaveLength(1);
       });

--- a/tests/js/spec/components/repositoryRow.spec.jsx
+++ b/tests/js/spec/components/repositoryRow.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import {Client} from 'app/api';
 import RepositoryRow from 'app/components/repositoryRow';
@@ -103,10 +104,10 @@ describe('RepositoryRow', function () {
         routerContext
       );
       wrapper.find('Button[label="delete"]').simulate('click');
-      await tick();
 
       // Confirm modal
-      wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
+      const modal = await mountGlobalModal();
+      modal.find('Button[priority="primary"]').simulate('click');
       await wrapper.update();
 
       expect(deleteRepo).toHaveBeenCalled();

--- a/tests/js/spec/views/accountClose.spec.jsx
+++ b/tests/js/spec/views/accountClose.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import AccountClose from 'app/views/settings/account/accountClose';
 
@@ -32,7 +33,7 @@ describe('AccountClose', function () {
     });
   });
 
-  it('lists all orgs user is an owner of', function () {
+  it('lists all orgs user is an owner of', async function () {
     const wrapper = mountWithTheme(<AccountClose />, TestStubs.routerContext());
 
     // Input for single owner org
@@ -57,7 +58,8 @@ describe('AccountClose', function () {
     wrapper.find('Confirm Button').simulate('click');
 
     // First button is cancel, target Button at index 2
-    wrapper.find('Modal Button').at(1).simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button').at(1).simulate('click');
 
     expect(deleteMock).toHaveBeenCalledWith(
       '/users/me/',

--- a/tests/js/spec/views/accountSecurity.spec.jsx
+++ b/tests/js/spec/views/accountSecurity.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import {Client} from 'app/api';
 import AccountSecurity from 'app/views/settings/account/accountSecurity';
@@ -111,7 +112,8 @@ describe('AccountSecurity', function () {
     wrapper.find('button[aria-label="delete"]').simulate('click');
 
     // Confirm
-    wrapper.find('Modal Button').last().simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button').last().simulate('click');
 
     await tick();
     wrapper.update();
@@ -127,7 +129,7 @@ describe('AccountSecurity', function () {
     expect(wrapper.find('TwoFactorRequired')).toHaveLength(1);
   });
 
-  it('can remove one of multiple 2fa methods when org requires 2fa', function () {
+  it('can remove one of multiple 2fa methods when org requires 2fa', async function () {
     Client.addMockResponse({
       url: ENDPOINT,
       body: [
@@ -165,7 +167,9 @@ describe('AccountSecurity', function () {
     wrapper.find('button[aria-label="delete"]').first().simulate('click');
 
     // Confirm
-    wrapper.find('Modal Button').last().simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button').last().simulate('click');
+
     expect(deleteMock).toHaveBeenCalled();
   });
 

--- a/tests/js/spec/views/accountSecurityDetails.spec.jsx
+++ b/tests/js/spec/views/accountSecurityDetails.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import {Client} from 'app/api';
 import AccountSecurityDetails from 'app/views/settings/account/accountSecurity/accountSecurityDetails';
@@ -57,19 +58,21 @@ describe('AccountSecurityDetails', function () {
       expect(wrapper.find('AuthenticatorDate')).toHaveLength(2);
     });
 
-    it('can remove method', function () {
+    it('can remove method', async function () {
       const deleteMock = Client.addMockResponse({
         url: `${ENDPOINT}15/`,
         method: 'DELETE',
       });
 
       wrapper.find('RemoveConfirm Button').simulate('click');
-      wrapper.find('Modal Button').last().simulate('click');
+
+      const modal = await mountGlobalModal();
+      modal.find('Button[priority="primary"]').simulate('click');
 
       expect(deleteMock).toHaveBeenCalled();
     });
 
-    it('can remove one of multiple 2fa methods when org requires 2fa', function () {
+    it('can remove one of multiple 2fa methods when org requires 2fa', async function () {
       Client.addMockResponse({
         url: ORG_ENDPOINT,
         body: TestStubs.Organizations({require2FA: true}),
@@ -87,12 +90,13 @@ describe('AccountSecurityDetails', function () {
       );
 
       wrapper.find('RemoveConfirm Button').simulate('click');
-      wrapper.find('Modal Button').last().simulate('click');
+      const modal = await mountGlobalModal();
+      modal.find('Button[priority="primary"]').simulate('click');
 
       expect(deleteMock).toHaveBeenCalled();
     });
 
-    it('can not remove last 2fa method when org requires 2fa', function () {
+    it('can not remove last 2fa method when org requires 2fa', async function () {
       Client.addMockResponse({
         url: ORG_ENDPOINT,
         body: TestStubs.Organizations({require2FA: true}),
@@ -114,7 +118,9 @@ describe('AccountSecurityDetails', function () {
       );
 
       wrapper.find('RemoveConfirm Button').simulate('click');
-      expect(wrapper.find('Modal Button')).toHaveLength(0);
+      const modal = await mountGlobalModal();
+      expect(modal.find('Modal[show=true]').exists()).toBe(false);
+
       expect(deleteMock).not.toHaveBeenCalled();
     });
   });

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountGlobalModal} from 'sentry-test/modal';
 import {selectByLabel} from 'sentry-test/select';
 
-import GlobalModal from 'app/components/globalModal';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import {IssueListActions} from 'app/views/issueList/actions';
 
@@ -24,27 +24,24 @@ describe('IssueListActions', function () {
         SelectedGroupStore.records = {};
         SelectedGroupStore.add(['1', '2', '3']);
         wrapper = mountWithTheme(
-          <React.Fragment>
-            <GlobalModal />
-            <IssueListActions
-              api={new MockApiClient()}
-              allResultsVisible={false}
-              query=""
-              queryCount={1500}
-              organization={org}
-              projectId="project-slug"
-              selection={{
-                projects: [1],
-                environments: [],
-                datetime: {start: null, end: null, period: null, utc: true},
-              }}
-              groupIds={['1', '2', '3']}
-              onRealtimeChange={function () {}}
-              onSelectStatsPeriod={function () {}}
-              realtimeActive={false}
-              statsPeriod="24h"
-            />
-          </React.Fragment>,
+          <IssueListActions
+            api={new MockApiClient()}
+            allResultsVisible={false}
+            query=""
+            queryCount={1500}
+            organization={org}
+            projectId="project-slug"
+            selection={{
+              projects: [1],
+              environments: [],
+              datetime: {start: null, end: null, period: null, utc: true},
+            }}
+            groupIds={['1', '2', '3']}
+            onRealtimeChange={function () {}}
+            onSelectStatsPeriod={function () {}}
+            realtimeActive={false}
+            statsPeriod="24h"
+          />,
           routerContext
         );
       });
@@ -67,11 +64,11 @@ describe('IssueListActions', function () {
         });
         wrapper.find('ResolveActions button[aria-label="Resolve"]').simulate('click');
 
-        await tick();
-        wrapper.update();
+        const modal = await mountGlobalModal();
+        expect(modal.find('Modal')).toSnapshot();
 
-        expect(wrapper.find('Modal')).toSnapshot();
-        wrapper.find('Button[priority="primary"]').simulate('click');
+        modal.find('Button[priority="primary"]').simulate('click');
+
         expect(apiMock).toHaveBeenCalledWith(
           expect.anything(),
           expect.objectContaining({
@@ -92,27 +89,24 @@ describe('IssueListActions', function () {
         SelectedGroupStore.records = {};
         SelectedGroupStore.add(['1', '2', '3']);
         wrapper = mountWithTheme(
-          <React.Fragment>
-            <GlobalModal />
-            <IssueListActions
-              api={new MockApiClient()}
-              allResultsVisible={false}
-              query=""
-              queryCount={600}
-              organization={TestStubs.routerContext().context.organization}
-              projectId="1"
-              selection={{
-                projects: [1],
-                environments: [],
-                datetime: {start: null, end: null, period: null, utc: true},
-              }}
-              groupIds={['1', '2', '3']}
-              onRealtimeChange={function () {}}
-              onSelectStatsPeriod={function () {}}
-              realtimeActive={false}
-              statsPeriod="24h"
-            />
-          </React.Fragment>,
+          <IssueListActions
+            api={new MockApiClient()}
+            allResultsVisible={false}
+            query=""
+            queryCount={600}
+            organization={TestStubs.routerContext().context.organization}
+            projectId="1"
+            selection={{
+              projects: [1],
+              environments: [],
+              datetime: {start: null, end: null, period: null, utc: true},
+            }}
+            groupIds={['1', '2', '3']}
+            onRealtimeChange={function () {}}
+            onSelectStatsPeriod={function () {}}
+            realtimeActive={false}
+            statsPeriod="24h"
+          />,
           TestStubs.routerContext()
         );
       });
@@ -135,11 +129,10 @@ describe('IssueListActions', function () {
         });
         wrapper.find('ResolveActions button[aria-label="Resolve"]').simulate('click');
 
-        await tick();
-        wrapper.update();
+        const modal = await mountGlobalModal();
+        expect(modal.find('Modal')).toSnapshot();
+        modal.find('Button[priority="primary"]').simulate('click');
 
-        expect(wrapper.find('Modal')).toSnapshot();
-        wrapper.find('Button[priority="primary"]').simulate('click');
         expect(apiMock).toHaveBeenCalledWith(
           expect.anything(),
           expect.objectContaining({
@@ -160,27 +153,24 @@ describe('IssueListActions', function () {
         SelectedGroupStore.records = {};
         SelectedGroupStore.add(['1', '2', '3']);
         wrapper = mountWithTheme(
-          <React.Fragment>
-            <GlobalModal />
-            <IssueListActions
-              api={new MockApiClient()}
-              allResultsVisible
-              query=""
-              queryCount={15}
-              organization={TestStubs.routerContext().context.organization}
-              projectId="1"
-              selection={{
-                projects: [1],
-                environments: [],
-                datetime: {start: null, end: null, period: null, utc: true},
-              }}
-              groupIds={['1', '2', '3', '6', '9']}
-              onRealtimeChange={function () {}}
-              onSelectStatsPeriod={function () {}}
-              realtimeActive={false}
-              statsPeriod="24h"
-            />
-          </React.Fragment>,
+          <IssueListActions
+            api={new MockApiClient()}
+            allResultsVisible
+            query=""
+            queryCount={15}
+            organization={TestStubs.routerContext().context.organization}
+            projectId="1"
+            selection={{
+              projects: [1],
+              environments: [],
+              datetime: {start: null, end: null, period: null, utc: true},
+            }}
+            groupIds={['1', '2', '3', '6', '9']}
+            onRealtimeChange={function () {}}
+            onSelectStatsPeriod={function () {}}
+            realtimeActive={false}
+            statsPeriod="24h"
+          />,
           TestStubs.routerContext()
         );
       });
@@ -224,20 +214,17 @@ describe('IssueListActions', function () {
           .setState({allInQuerySelected: false, anySelected: true});
         wrapper.find('DropdownMenuItem ActionSubMenu a').last().simulate('click');
 
-        await tick();
-        wrapper.update();
+        const modal = await mountGlobalModal();
 
-        wrapper
+        modal
           .find('CustomIgnoreCountModal input[label="Number of users"]')
           .simulate('change', {target: {value: 300}});
 
-        selectByLabel(wrapper, 'per week', {
+        selectByLabel(modal, 'per week', {
           name: 'window',
         });
 
-        wrapper
-          .find('CustomIgnoreCountModal Button[priority="primary"]')
-          .simulate('click');
+        modal.find('Button[priority="primary"]').simulate('click');
 
         expect(apiMock).toHaveBeenCalledWith(
           expect.anything(),
@@ -363,28 +350,25 @@ describe('IssueListActions', function () {
       await tick();
       const {organization} = TestStubs.routerContext().context;
       wrapper = mountWithTheme(
-        <React.Fragment>
-          <GlobalModal />
-          <IssueListActions
-            api={new MockApiClient()}
-            query=""
-            organization={organization}
-            groupIds={['1', '2', '3']}
-            selection={{
-              projects: [],
-              environments: [],
-              datetime: {start: null, end: null, period: null, utc: true},
-            }}
-            onRealtimeChange={function () {}}
-            onSelectStatsPeriod={function () {}}
-            realtimeActive={false}
-            statsPeriod="24h"
-            queryCount={100}
-            queryMaxCount={100}
-            pageCount={3}
-            hasInbox
-          />
-        </React.Fragment>,
+        <IssueListActions
+          api={new MockApiClient()}
+          query=""
+          organization={organization}
+          groupIds={['1', '2', '3']}
+          selection={{
+            projects: [],
+            environments: [],
+            datetime: {start: null, end: null, period: null, utc: true},
+          }}
+          onRealtimeChange={function () {}}
+          onSelectStatsPeriod={function () {}}
+          realtimeActive={false}
+          statsPeriod="24h"
+          queryCount={100}
+          queryMaxCount={100}
+          pageCount={3}
+          hasInbox
+        />,
         TestStubs.routerContext()
       );
     });

--- a/tests/js/spec/views/issueList/organizationSavedSearchMenu.spec.jsx
+++ b/tests/js/spec/views/issueList/organizationSavedSearchMenu.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import IssueListSavedSearchMenu from 'app/views/issueList/savedSearchMenu';
 
@@ -71,7 +72,8 @@ describe('IssueListSavedSearchMenu', () => {
       button.simulate('click');
       await wrapper.update();
 
-      wrapper.find('Modal Button[priority="primary"] button').simulate('click');
+      const modal = await mountGlobalModal();
+      modal.find('Modal Button[priority="primary"] button').simulate('click');
       expect(onDelete).toHaveBeenCalledWith(savedSearchList[1]);
     });
   });

--- a/tests/js/spec/views/organizationGroupDetails/groupSimilarIssues.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupSimilarIssues.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import GroupSimilarIssues from 'app/views/organizationGroupDetails/groupSimilarIssues';
 
@@ -97,8 +98,11 @@ describe('Issues Similar View', function () {
 
     await tick();
     wrapper.update();
+
     wrapper.find('[data-test-id="merge"] button').simulate('click');
-    wrapper.find('Button[data-test-id="confirm-button"]').simulate('click');
+
+    const modal = await mountGlobalModal();
+    modal.find('Button[data-test-id="confirm-button"]').simulate('click');
 
     await tick();
     wrapper.update();

--- a/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 import {selectByValue} from 'sentry-test/select-new';
 
 import {Client} from 'app/api';
-import GlobalModal from 'app/components/globalModal';
 import IntegrationCodeMappings from 'app/views/organizationIntegrations/integrationCodeMappings';
 
 const mockResponse = mocks => {
@@ -76,10 +76,7 @@ describe('IntegrationCodeMappings', function () {
     ]);
 
     wrapper = mountWithTheme(
-      <React.Fragment>
-        <GlobalModal />
-        <IntegrationCodeMappings organization={org} integration={integration} />
-      </React.Fragment>
+      <IntegrationCodeMappings organization={org} integration={integration} />
     );
   });
 
@@ -90,13 +87,15 @@ describe('IntegrationCodeMappings', function () {
   });
 
   it('opens modal', async () => {
-    expect(wrapper.find('input[name="stackRoot"]')).toHaveLength(0);
+    const modal = await mountGlobalModal();
+
+    expect(modal.find('input[name="stackRoot"]')).toHaveLength(0);
     wrapper.find('button[aria-label="Add Mapping"]').first().simulate('click');
 
     await tick();
-    wrapper.update();
+    modal.update();
 
-    expect(wrapper.find('input[name="stackRoot"]')).toHaveLength(1);
+    expect(modal.find('input[name="stackRoot"]')).toHaveLength(1);
   });
 
   it('create new config', async () => {
@@ -115,22 +114,21 @@ describe('IntegrationCodeMappings', function () {
     });
     wrapper.find('button[aria-label="Add Mapping"]').first().simulate('click');
 
-    await tick();
-    wrapper.update();
+    const modal = await mountGlobalModal();
 
-    selectByValue(wrapper, projects[1].id, {control: true, name: 'projectId'});
-    selectByValue(wrapper, repos[1].id, {name: 'repositoryId'});
+    selectByValue(modal, projects[1].id, {control: true, name: 'projectId'});
+    selectByValue(modal, repos[1].id, {name: 'repositoryId'});
 
-    wrapper
+    modal
       .find('input[name="stackRoot"]')
       .simulate('change', {target: {value: stackRoot}});
-    wrapper
+    modal
       .find('input[name="sourceRoot"]')
       .simulate('change', {target: {value: sourceRoot}});
-    wrapper
+    modal
       .find('input[name="defaultBranch"]')
       .simulate('change', {target: {value: defaultBranch}});
-    wrapper.find('form').simulate('submit');
+    modal.find('form').simulate('submit');
 
     expect(createMock).toHaveBeenCalledWith(
       url,
@@ -162,13 +160,12 @@ describe('IntegrationCodeMappings', function () {
     });
     wrapper.find('button[aria-label="edit"]').first().simulate('click');
 
-    await tick();
-    wrapper.update();
+    const modal = await mountGlobalModal();
 
-    wrapper
+    modal
       .find('input[name="stackRoot"]')
       .simulate('change', {target: {value: stackRoot}});
-    wrapper.find('form').simulate('submit');
+    modal.find('form').simulate('submit');
 
     expect(editMock).toHaveBeenCalledWith(
       url,

--- a/tests/js/spec/views/projectTeams.spec.jsx
+++ b/tests/js/spec/views/projectTeams.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import * as modals from 'app/actionCreators/modal';
 import App from 'app/views/app';
@@ -111,7 +112,8 @@ describe('ProjectTeams', function () {
 
     // Modal opens because this is the last team in project
     // Click confirm
-    wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="primary"]').simulate('click');
 
     expect(mock2).toHaveBeenCalledWith(
       endpoint2,
@@ -183,7 +185,8 @@ describe('ProjectTeams', function () {
 
     // Modal opens because this is the last team in project
     // Click confirm
-    wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="primary"]').simulate('click');
 
     expect(mock2).toHaveBeenCalledWith(
       endpoint2,

--- a/tests/js/spec/views/releases/detail/releaseActions.spec.jsx
+++ b/tests/js/spec/views/releases/detail/releaseActions.spec.jsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import ReleaseActions from 'app/views/releases/detail/releaseActions';
 
@@ -42,12 +43,13 @@ describe('ReleaseActions', function () {
     expect(archiveAction.text()).toBe('Archive');
 
     archiveAction.simulate('click');
+    const modal = await mountGlobalModal();
 
-    const affectedProjects = wrapper.find('ProjectBadge');
+    const affectedProjects = modal.find('ProjectBadge');
     expect(affectedProjects.length).toBe(2);
 
     // confirm modal
-    wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
+    modal.find('ModalDialog Button[priority="primary"]').simulate('click');
 
     expect(mockUpdate).toHaveBeenCalledWith(
       expect.anything(),
@@ -89,12 +91,13 @@ describe('ReleaseActions', function () {
     expect(restoreAction.text()).toBe('Restore');
 
     restoreAction.simulate('click');
+    const modal = await mountGlobalModal();
 
-    const affectedProjects = wrapper.find('ProjectBadge');
+    const affectedProjects = modal.find('ProjectBadge');
     expect(affectedProjects.length).toBe(2);
 
     // confirm modal
-    wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
+    modal.find('Button[priority="primary"]').simulate('click');
 
     expect(mockUpdate).toHaveBeenCalledWith(
       expect.anything(),

--- a/tests/js/spec/views/settings/components/dataScrubbing/editModal.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataScrubbing/editModal.spec.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import sortBy from 'lodash/sortBy';
 
-import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import {openModal} from 'app/actionCreators/modal';
-import GlobalModal from 'app/components/globalModal';
 import convertRelayPiiConfig from 'app/views/settings/components/dataScrubbing/convertRelayPiiConfig';
 import Edit from 'app/views/settings/components/dataScrubbing/modals/edit';
 import submitRules from 'app/views/settings/components/dataScrubbing/submitRules';
@@ -31,7 +30,7 @@ const api = new MockApiClient();
 jest.mock('app/views/settings/components/dataScrubbing/submitRules');
 
 async function renderComponent() {
-  const wrapper = mountWithTheme(<GlobalModal />);
+  const modal = await mountGlobalModal();
 
   openModal(modalProps => (
     <Edit
@@ -48,9 +47,9 @@ async function renderComponent() {
 
   // @ts-expect-error
   await tick();
-  wrapper.update();
+  modal.update();
 
-  return wrapper;
+  return modal;
 }
 
 describe('Edit Modal', () => {

--- a/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationApiKeysList.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import OrganizationApiKeysList from 'app/views/settings/organizationApiKeys/organizationApiKeysList';
 
@@ -28,7 +29,7 @@ describe('OrganizationApiKeysList', function () {
     expect(wrapper).toSnapshot();
   });
 
-  it('opens a modal when trying to delete a key', function () {
+  it('opens a modal when trying to delete a key', async function () {
     const wrapper = mountWithTheme(
       <OrganizationApiKeysList
         params={{orgId: 'org-slug'}}
@@ -44,7 +45,7 @@ describe('OrganizationApiKeysList', function () {
     wrapper.update();
 
     // expect a modal
-    const modal = wrapper.find('Modal');
-    expect(modal.first().prop('show')).toBe(true);
+    const modal = await mountGlobalModal();
+    expect(modal.find('Modal[show=true]').exists()).toBe(true);
   });
 });

--- a/tests/js/spec/views/settings/organizationApiKeysView.spec.jsx
+++ b/tests/js/spec/views/settings/organizationApiKeysView.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import OrganizationApiKeys from 'app/views/settings/organizationApiKeys';
 
@@ -47,7 +48,7 @@ describe('OrganizationApiKeys', function () {
     expect(getMock).toHaveBeenCalledTimes(1);
   });
 
-  it('can delete a key', function () {
+  it('can delete a key', async function () {
     const wrapper = mountWithTheme(
       <OrganizationApiKeys
         location={TestStubs.location()}
@@ -59,7 +60,12 @@ describe('OrganizationApiKeys', function () {
 
     expect(deleteMock).toHaveBeenCalledTimes(0);
     wrapper.find('Confirm[aria-label="Remove API Key"]').simulate('click');
-    wrapper.find('button[aria-label="Confirm"]').simulate('click');
+
+    const modal = await mountGlobalModal();
+    modal.find('button[aria-label="Confirm"]').simulate('click');
+
+    wrapper.update();
+
     expect(deleteMock).toHaveBeenCalledTimes(1);
     expect(wrapper.find('AutoSelectText')).toHaveLength(0);
   });

--- a/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationDeveloperSettings/index.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import {Client} from 'app/api';
 import App from 'app/views/app';
@@ -80,8 +81,10 @@ describe('Organization Developer Settings', function () {
       expect(wrapper.find(deleteButtonSelector).prop('disabled')).toEqual(false);
       wrapper.find(deleteButtonSelector).simulate('click');
       // confirm deletion by entering in app slug
-      wrapper.find('input').simulate('change', {target: {value: 'sample-app'}});
-      wrapper.find('ConfirmDelete Button').last().simulate('click');
+      const modal = await mountGlobalModal();
+      modal.find('input').simulate('change', {target: {value: 'sample-app'}});
+      modal.find('Button[priority="danger"]').simulate('click');
+
       await tick();
       wrapper.update();
       expect(wrapper.text()).toMatch('No public integrations have been created yet');

--- a/tests/js/spec/views/settings/organizationGeneralSettings/index.spec.jsx
+++ b/tests/js/spec/views/settings/organizationGeneralSettings/index.spec.jsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import OrganizationGeneralSettings from 'app/views/settings/organizationGeneralSettings';
 
@@ -138,12 +139,14 @@ describe('OrganizationGeneralSettings', function () {
     wrapper.update();
     wrapper.find('Confirm[priority="danger"]').simulate('click');
 
+    const modal = await mountGlobalModal();
+
     // Lists projects in modal
-    expect(wrapper.find('Modal .ref-projects')).toHaveLength(1);
-    expect(wrapper.find('Modal .ref-projects li').text()).toBe('project');
+    expect(modal.find('.ref-projects')).toHaveLength(1);
+    expect(modal.find('.ref-projects li').text()).toBe('project');
 
     // Confirm delete
-    wrapper.find('Modal Portal Button[priority="danger"]').simulate('click');
+    modal.find('Button[priority="danger"]').simulate('click');
     expect(mock).toHaveBeenCalledWith(
       ENDPOINT,
       expect.objectContaining({

--- a/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 import {selectByValue} from 'sentry-test/select';
 
 import InviteRequestRow from 'app/views/settings/organizationMembers/inviteRequestRow';
@@ -75,7 +76,7 @@ describe('InviteRequestRow', function () {
     expect(wrapper.find('JoinRequestIndicator').exists()).toBe(true);
   });
 
-  it('can approve invite request', function () {
+  it('can approve invite request', async function () {
     const mockApprove = jest.fn();
     const mockDeny = jest.fn();
 
@@ -92,7 +93,10 @@ describe('InviteRequestRow', function () {
     );
 
     wrapper.find('button[aria-label="Approve"]').simulate('click');
-    wrapper.find('button[aria-label="Confirm"]').simulate('click');
+
+    const modal = await mountGlobalModal();
+    modal.find('button[aria-label="Confirm"]').simulate('click');
+
     expect(mockApprove).toHaveBeenCalledWith(inviteRequest);
     expect(mockDeny).not.toHaveBeenCalled();
   });

--- a/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMemberDetail.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import {updateMember} from 'app/actionCreators/members';
 import OrganizationMemberDetail from 'app/views/settings/organizationMembers/organizationMemberDetail';
@@ -351,7 +352,7 @@ describe('OrganizationMemberDetail', function () {
       expectButtonDisabled('Not enrolled in two-factor authentication');
     });
 
-    it('can reset member 2FA', function () {
+    it('can reset member 2FA', async function () {
       const deleteMocks = has2fa.user.authenticators.map(auth =>
         MockApiClient.addMockResponse({
           url: `/users/${has2fa.user.id}/authenticators/${auth.id}/`,
@@ -366,7 +367,10 @@ describe('OrganizationMemberDetail', function () {
 
       expectButtonEnabled();
       wrapper.find(button).simulate('click');
-      wrapper.find('Button[data-test-id="confirm-button"]').simulate('click');
+
+      const modal = await mountGlobalModal();
+      modal.find('Button[data-test-id="confirm-button"]').simulate('click');
+
       deleteMocks.map(deleteMock => {
         expect(deleteMock).toHaveBeenCalled();
       });

--- a/tests/js/spec/views/settings/organizationMembers/organizationMembersList.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationMembersList.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
@@ -121,10 +122,9 @@ describe('OrganizationMembersList', function () {
 
     wrapper.find('Button[data-test-id="remove"]').at(0).simulate('click');
 
-    await tick();
-
     // Confirm modal
-    wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="primary"]').simulate('click');
     await tick();
 
     expect(deleteMock).toHaveBeenCalled();
@@ -148,11 +148,11 @@ describe('OrganizationMembersList', function () {
 
     wrapper.find('Button[data-test-id="remove"]').at(0).simulate('click');
 
+    // Confirm modal
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="primary"]').simulate('click');
     await tick();
 
-    // Confirm modal
-    wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
-    await tick();
     expect(deleteMock).toHaveBeenCalled();
     await tick();
     expect(addErrorMessage).toHaveBeenCalled();
@@ -174,10 +174,9 @@ describe('OrganizationMembersList', function () {
 
     wrapper.find('Button[priority="danger"]').at(0).simulate('click');
 
-    await tick();
-
     // Confirm modal
-    wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="primary"]').simulate('click');
     await tick();
 
     expect(deleteMock).toHaveBeenCalled();
@@ -207,10 +206,9 @@ describe('OrganizationMembersList', function () {
 
     wrapper.find('Button[priority="danger"]').at(0).simulate('click');
 
-    await tick();
-
     // Confirm modal
-    wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="primary"]').simulate('click');
     await tick();
 
     expect(deleteMock).toHaveBeenCalled();
@@ -235,11 +233,11 @@ describe('OrganizationMembersList', function () {
 
     wrapper.find('Button[priority="danger"]').at(0).simulate('click');
 
+    // Confirm modal
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="primary"]').simulate('click');
     await tick();
 
-    // Confirm modal
-    wrapper.find('ModalDialog Button[priority="primary"]').simulate('click');
-    await tick();
     expect(deleteMock).toHaveBeenCalled();
     await tick();
     expect(addErrorMessage).toHaveBeenCalled();

--- a/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 import {selectByValue} from 'sentry-test/select';
 
 import {trackAnalyticsEvent} from 'app/utils/analytics';
@@ -248,7 +249,9 @@ describe('OrganizationRequestsView', function () {
     );
 
     wrapper.find('button[aria-label="Approve"]').simulate('click');
-    wrapper.find('button[aria-label="Confirm"]').simulate('click');
+
+    const modal = await mountGlobalModal();
+    modal.find('button[aria-label="Confirm"]').simulate('click');
 
     await tick();
     wrapper.update();
@@ -344,7 +347,8 @@ describe('OrganizationRequestsView', function () {
     selectByValue(wrapper, 'admin', {name: 'role', control: true});
 
     wrapper.find('button[aria-label="Approve"]').simulate('click');
-    wrapper.find('button[aria-label="Confirm"]').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('button[aria-label="Confirm"]').simulate('click');
 
     await tick();
     wrapper.update();

--- a/tests/js/spec/views/settings/organizationSecurityAndPrivacy.spec.jsx
+++ b/tests/js/spec/views/settings/organizationSecurityAndPrivacy.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import OrganizationSecurityAndPrivacy from 'app/views/settings/organizationSecurityAndPrivacy';
 
@@ -57,11 +58,8 @@ describe('OrganizationSecurityAndPrivacy', function () {
     // hide console.error for this test
     jest.spyOn(console, 'error').mockImplementation(() => {});
     // Confirm but has API failure
-    wrapper
-      .find(
-        'Field[name="require2FA"] ModalDialog .modal-footer Button[priority="primary"]'
-      )
-      .simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="primary"]').simulate('click');
 
     await tick();
     wrapper.update();
@@ -98,14 +96,14 @@ describe('OrganizationSecurityAndPrivacy', function () {
     wrapper.update();
     expect(wrapper.find('Switch[name="require2FA"]')).toHaveLength(1);
     wrapper.find('Switch[name="require2FA"]').simulate('click');
-    expect(wrapper.find('Field[name="require2FA"] ModalDialog')).toHaveLength(1);
 
     // Cancel
-    wrapper
-      .find('Field[name="require2FA"] ModalDialog .modal-footer Button')
-      .first()
-      .simulate('click');
-    expect(wrapper.find('Field[name="require2FA"] ModalDialog')).toHaveLength(0);
+    const modal = await mountGlobalModal();
+    modal.find('Button').first().simulate('click');
+
+    await tick();
+    wrapper.update();
+
     expect(wrapper.find('Switch[name="require2FA"]').prop('isActive')).toBe(false);
     expect(mock).not.toHaveBeenCalled();
   });
@@ -129,14 +127,14 @@ describe('OrganizationSecurityAndPrivacy', function () {
 
     expect(wrapper.find('Switch[name="require2FA"]')).toHaveLength(1);
     wrapper.find('Switch[name="require2FA"]').simulate('click');
-    expect(wrapper.find('Field[name="require2FA"] ModalDialog')).toHaveLength(1);
+
     // Confirm
-    wrapper
-      .find(
-        'Field[name="require2FA"] ModalDialog .modal-footer Button[priority="primary"]'
-      )
-      .simulate('click');
-    expect(wrapper.find('Field[name="require2FA"] ModalDialog')).toHaveLength(0);
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="primary"]').simulate('click');
+
+    await tick();
+    wrapper.update();
+
     expect(wrapper.find('Switch[name="require2FA"]').prop('isActive')).toBe(true);
     expect(mock).toHaveBeenCalledWith(
       '/organizations/org-slug/',

--- a/tests/js/spec/views/settings/projectAlerts/issueEditor.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/issueEditor.spec.jsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountGlobalModal} from 'sentry-test/modal';
 import {selectByValue} from 'sentry-test/select-new';
 
 import {updateOnboardingTask} from 'app/actionCreators/onboardingTasks';
@@ -128,8 +129,10 @@ describe('ProjectAlerts -> IssueEditor', function () {
       });
       const {wrapper} = createWrapper();
       wrapper.find('button[aria-label="Delete Rule"]').simulate('click');
-      await tick();
-      wrapper.find('Modal button[aria-label="Delete Rule"]').simulate('click');
+
+      const modal = await mountGlobalModal();
+      modal.find('button[aria-label="Delete Rule"]').simulate('click');
+
       await tick();
       expect(deleteMock).toHaveBeenCalled();
       expect(browserHistory.replace).toHaveBeenCalledWith(

--- a/tests/js/spec/views/settings/projectDebugFiles.spec.jsx
+++ b/tests/js/spec/views/settings/projectDebugFiles.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import ProjectDebugFiles from 'app/views/settings/projectDebugFiles';
 
@@ -47,7 +48,7 @@ describe('ProjectDebugFiles', function () {
     );
   });
 
-  it('deletes the file', function () {
+  it('deletes the file', async function () {
     MockApiClient.addMockResponse({
       url: endpoint,
       body: [TestStubs.DebugFile()],
@@ -65,7 +66,8 @@ describe('ProjectDebugFiles', function () {
     wrapper.find('Button[data-test-id="delete-dif"]').simulate('click');
 
     // Confirm Modal
-    wrapper.find('Modal Button[data-test-id="confirm-button"]').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Modal Button[data-test-id="confirm-button"]').simulate('click');
 
     expect(deleteMock).toHaveBeenCalled();
   });

--- a/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 import {selectByValue} from 'sentry-test/select';
 
 import ProjectsStore from 'app/stores/projectsStore';
@@ -98,7 +99,7 @@ describe('projectGeneralSettings', function () {
     expect(wrapper.find('Switch[name="scrapeJavaScript"]').prop('isActive')).toBeFalsy();
   });
 
-  it('project admins can remove project', function () {
+  it('project admins can remove project', async function () {
     const deleteMock = MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/`,
       method: 'DELETE',
@@ -117,12 +118,13 @@ describe('projectGeneralSettings', function () {
     removeBtn.simulate('click');
 
     // Confirm Modal
-    wrapper.find('Modal Button[priority="danger"]').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="danger"]').simulate('click');
 
     expect(deleteMock).toHaveBeenCalled();
   });
 
-  it('project admins can transfer project', function () {
+  it('project admins can transfer project', async function () {
     const deleteMock = MockApiClient.addMockResponse({
       url: `/projects/${org.slug}/${project.slug}/transfer/`,
       method: 'POST',
@@ -141,10 +143,11 @@ describe('projectGeneralSettings', function () {
     removeBtn.simulate('click');
 
     // Confirm Modal
-    wrapper
+    const modal = await mountGlobalModal();
+    modal
       .find('input[name="email"]')
       .simulate('change', {target: {value: 'billy@sentry.io'}});
-    wrapper.find('Modal Button[priority="danger"]').simulate('click');
+    modal.find('Modal Button[priority="danger"]').simulate('click');
 
     expect(deleteMock).toHaveBeenCalledWith(
       `/projects/${org.slug}/${project.slug}/transfer/`,

--- a/tests/js/spec/views/settings/projectKeys/details/index.spec.jsx
+++ b/tests/js/spec/views/settings/projectKeys/details/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import ProjectKeyDetails from 'app/views/settings/project/projectKeys/details';
 
@@ -136,14 +137,13 @@ describe('ProjectKeyDetails', function () {
     );
   });
 
-  it('revokes a key', function () {
+  it('revokes a key', async function () {
     wrapper
       .find('Button[priority="danger"]')
       .simulate('click', {preventDefault: () => {}});
 
-    wrapper.find('ModalDialog Button[priority="danger"]').simulate('click');
-
-    wrapper.update();
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="danger"]').simulate('click');
 
     expect(deleteMock).toHaveBeenCalled();
   });

--- a/tests/js/spec/views/settings/projectKeys/list/index.spec.jsx
+++ b/tests/js/spec/views/settings/projectKeys/list/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import ProjectKeys from 'app/views/settings/project/projectKeys/list';
 
@@ -68,12 +69,12 @@ describe('ProjectKeys', function () {
     expect(wrapper.find('ClipFade button')).toHaveLength(0);
   });
 
-  it('deletes key', function () {
+  it('deletes key', async function () {
     wrapper.find('PanelHeader Button').last().simulate('click');
 
-    wrapper.find('ModalDialog Button[priority="danger"]').simulate('click');
-
-    wrapper.update();
+    // Confirm modal
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="danger"]').simulate('click');
 
     expect(deleteMock).toHaveBeenCalled();
   });

--- a/tests/js/spec/views/settings/projectReleaseTracking.spec.jsx
+++ b/tests/js/spec/views/settings/projectReleaseTracking.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import {fetchPlugins} from 'app/actionCreators/plugins';
 import ProjectReleaseTrackingContainer, {
@@ -47,7 +48,7 @@ describe('ProjectReleaseTracking', function () {
     expect(wrapper.find('TextCopyInput').prop('children')).toBe('token token token');
   });
 
-  it('can regenerate token', function (done) {
+  it('can regenerate token', async function () {
     const wrapper = mountWithTheme(
       <ProjectReleaseTracking
         organization={org}
@@ -69,24 +70,24 @@ describe('ProjectReleaseTracking', function () {
 
     // Click Regenerate Token
     wrapper.find('Field[label="Regenerate Token"] Button').simulate('click');
-    expect(wrapper.find('ModalDialog')).toHaveLength(1);
+
+    const modal = await mountGlobalModal();
+    expect(modal.find('ModalDialog')).toHaveLength(1);
 
     expect(mock).not.toHaveBeenCalled();
 
-    wrapper.find('ModalDialog Button[priority="danger"]').simulate('click');
+    modal.find('Button[priority="danger"]').simulate('click');
 
-    setTimeout(() => {
-      expect(mock).toHaveBeenCalledWith(
-        url,
-        expect.objectContaining({
-          method: 'POST',
-          data: {
-            project: project.slug,
-          },
-        })
-      );
-      done();
-    }, 1);
+    await tick();
+    expect(mock).toHaveBeenCalledWith(
+      url,
+      expect.objectContaining({
+        method: 'POST',
+        data: {
+          project: project.slug,
+        },
+      })
+    );
   });
 
   it('fetches new plugins when project changes', function () {

--- a/tests/js/spec/views/settings/projectSourceMaps.spec.jsx
+++ b/tests/js/spec/views/settings/projectSourceMaps.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import ProjectSourceMapsDetail from 'app/views/settings/projectSourceMaps/detail';
 import ProjectSourceMaps from 'app/views/settings/projectSourceMaps/list';
@@ -47,7 +48,7 @@ describe('ProjectSourceMaps', function () {
     );
   });
 
-  it('deletes the archive', function () {
+  it('deletes the archive', async function () {
     const archive = TestStubs.SourceMapArchive();
 
     MockApiClient.addMockResponse({
@@ -65,7 +66,8 @@ describe('ProjectSourceMaps', function () {
     wrapper.find('button[aria-label="Remove All Artifacts"]').simulate('click');
 
     // Confirm Modal
-    wrapper.find('Modal Button[data-test-id="confirm-button"]').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button[data-test-id="confirm-button"]').simulate('click');
 
     expect(deleteMock).toHaveBeenCalledWith(
       endpoint,
@@ -161,7 +163,7 @@ describe('ProjectSourceMapsDetail', function () {
     );
   });
 
-  it('deletes all artifacts', function () {
+  it('deletes all artifacts', async function () {
     MockApiClient.addMockResponse({
       url: endpoint,
       body: [],
@@ -177,7 +179,8 @@ describe('ProjectSourceMapsDetail', function () {
     wrapper.find('button[aria-label="Remove All Artifacts"]').simulate('click');
 
     // Confirm Modal
-    wrapper.find('Modal Button[data-test-id="confirm-button"]').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button[data-test-id="confirm-button"]').simulate('click');
 
     expect(deleteMock).toHaveBeenCalledWith(
       archiveDeleteEndpoint,
@@ -219,7 +222,7 @@ describe('ProjectSourceMapsDetail', function () {
     });
   });
 
-  it('deletes single artifact', function () {
+  it('deletes single artifact', async function () {
     const artifact = TestStubs.SourceMapArtifact();
 
     MockApiClient.addMockResponse({
@@ -239,7 +242,8 @@ describe('ProjectSourceMapsDetail', function () {
       .simulate('click');
 
     // Confirm Modal
-    wrapper.find('Modal Button[data-test-id="confirm-button"]').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button[data-test-id="confirm-button"]').simulate('click');
 
     expect(deleteMock).toHaveBeenCalled();
   });

--- a/tests/js/spec/views/teamSettings.spec.jsx
+++ b/tests/js/spec/views/teamSettings.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {mountGlobalModal} from 'sentry-test/modal';
 
 import TeamStore from 'app/stores/teamStore';
 import TeamSettings from 'app/views/settings/organizationTeams/teamSettings';
@@ -102,7 +103,9 @@ describe('TeamSettings', function () {
     TeamStore.trigger.mockReset();
 
     // Wait for modal
-    wrapper.find('ModalDialog Button[priority="danger"] button').simulate('click');
+    const modal = await mountGlobalModal();
+    modal.find('Button[priority="danger"] button').simulate('click');
+
     expect(deleteMock).toHaveBeenCalledWith(
       `/teams/org/${team.slug}/`,
       expect.objectContaining({


### PR DESCRIPTION
- Removes the `close` prop passed to the render-prop style children.
   This was never used afaict

 - Drastically simplifies the ConfirmDelete component by introducing a
   new render-prop in the renderMessage renderer to set the disabled
   state of the primary button

 - Updates MANY tests with a new `mountGlobalModal` helper, since the
   confirm modal now is not in the component tree. (We can update more
   tests to use this helper in the future)