### PR TITLE
fix(inbox): Keep buttons inline for mobile in header

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -72,6 +72,11 @@ const StyledLayoutTitle = styled(Layout.Title)`
 
 const BorderlessHeader = styled(Layout.Header)`
   border-bottom: 0;
+
+  /* Not enough buttons to change direction for mobile view */
+  @media (max-width: ${p => p.theme.breakpoints[1]}) {
+    flex-direction: row;
+  }
 `;
 
 const TabLayoutHeader = styled(Layout.Header)`


### PR DESCRIPTION
We don't have enough buttons yet to start wrapping.

before
![image](https://user-images.githubusercontent.com/1400464/101694034-58a0c980-3a27-11eb-9761-852206a2920b.png)

after
![image](https://user-images.githubusercontent.com/1400464/101694071-68b8a900-3a27-11eb-9840-eefbf63f94be.png)
