### PR TITLE
fix(workflow): Revert width change to users/events column

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -561,22 +561,12 @@ const ChartWrapper = styled('div')`
 const EventUserWrapper = styled('div')`
   display: flex;
   justify-content: flex-end;
-  margin: 0 ${space(2)};
   align-self: center;
-  margin-left: ${space(1.5)};
-  margin-right: ${space(1.5)};
-  width: 40px;
+  width: 60px;
+  margin: 0 ${space(2)};
 
-  @media (min-width: ${p => p.theme.breakpoints[0]}) {
-    width: 60px;
-  }
-  @media (min-width: ${p => p.theme.breakpoints[1]}) {
-    width: 60px;
-  }
-  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+  @media (min-width: ${p => p.theme.breakpoints[3]}) {
     width: 80px;
-    margin-left: ${space(2)};
-    margin-right: ${space(2)};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/issueList/actions.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions.tsx
@@ -867,19 +867,11 @@ const EventsOrUsersLabel = styled(IssueToolbarHeader)`
   align-items: center;
   justify-content: flex-end;
   text-align: right;
+  width: 60px;
+  margin: 0 ${space(2)};
 
-  margin-left: ${space(1.5)};
-  margin-right: ${space(1.5)};
-  @media (min-width: ${theme.breakpoints[0]}) {
-    width: 60px;
-  }
-  @media (min-width: ${theme.breakpoints[1]}) {
-    width: 60px;
-  }
-  @media (min-width: ${theme.breakpoints[2]}) {
+  @media (min-width: ${theme.breakpoints[3]}) {
     width: 80px;
-    margin-left: ${space(2)};
-    margin-right: ${space(2)};
   }
 `;
 


### PR DESCRIPTION
Had removed the reflexbox use and i think something got lost, it's a little too small when on mobile.
Fixes the size and simplifies the css

![image](https://user-images.githubusercontent.com/1400464/101698305-1f1f8c80-3a2e-11eb-9cb2-47e6da7fe490.png)
