### PR TITLE
feat(Ticket Rules): Django forms for Azure DevOps Ticket Actions

### DIFF
--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -131,10 +131,18 @@ class JiraCreateTicketAction(TicketEventAction):
             self.rule.label, absolute_uri(rule_url),
         )
 
+    def fix_data_for_issue(self):
+        # HACK to get fixVersion in the correct format
+        if self.data.get("fixVersions"):
+            if not isinstance(self.data["fixVersions"], list):
+                self.data["fixVersions"] = [self.data["fixVersions"]]
+        return self.data
+
     def translate_integration(self, integration):
         name = integration.metadata.get("domain_name", integration.name)
         return name.replace(".atlassian.net", "")
 
     @transaction_start("JiraCreateTicketAction.after")
     def after(self, event, state):
+        self.fix_data_for_issue()
         yield super(JiraCreateTicketAction, self).after(event, state)

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -11,7 +11,7 @@ from sentry.integrations.jira.utils import (
     transform_jira_choices_to_strings,
 )
 from sentry.models.integration import Integration
-from sentry.rules.actions.base import TicketEventAction
+from sentry.rules.actions.base import TicketEventAction, NotifyServiceForm, INTEGRATION_KEY
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
@@ -19,20 +19,12 @@ from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger("sentry.rules")
 
-INTEGRATION_KEY = "integration"
 
-
-class JiraNotifyServiceForm(forms.Form):
+class JiraNotifyServiceForm(NotifyServiceForm):
     integration = forms.ChoiceField(choices=(), widget=forms.Select())
 
     def __init__(self, *args, **kwargs):
-        integrations = [(i.id, i.name) for i in kwargs.pop("integrations")]
         super(JiraNotifyServiceForm, self).__init__(*args, **kwargs)
-        if integrations:
-            self.fields[INTEGRATION_KEY].initial = integrations[0][0]
-
-        self.fields[INTEGRATION_KEY].choices = integrations
-        self.fields[INTEGRATION_KEY].widget.choices = self.fields[INTEGRATION_KEY].choices
 
 
 class JiraCreateTicketAction(TicketEventAction):

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -93,4 +93,4 @@ class JiraCreateTicketAction(TicketEventAction):
 
     @transaction_start("JiraCreateTicketAction.after")
     def after(self, event, state):
-        super(JiraCreateTicketAction, self).after(event, state)
+        yield super(JiraCreateTicketAction, self).after(event, state)

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -70,6 +70,28 @@ class JiraCreateTicketAction(TicketEventAction):
             if "name" in field:
                 fields[field["name"]] = field
         return fields
+        # if "dynamic_form_fields" in self.data:
+        #     return self.data["dynamic_form_fields"]
+
+        # try:
+        #     integration = self.get_integration()
+        # except Integration.DoesNotExist:
+        #     pass
+        # else:
+        #     installation = integration.get_installation(self.project.organization.id)
+        #     if installation:
+        #         try:
+        #             fields = installation.get_create_issue_config_no_params()
+        #         except IntegrationError as e:
+        #             # TODO log when the API call fails.
+        #             logger.info(e)
+        #         else:
+        #             dynamic_form_fields = transform_jira_fields_to_form_fields(fields)
+        #             print("jira form fields: ", dynamic_form_fields)
+        #             self.data["dynamic_form_fields"] = dynamic_form_fields
+        #             # TODO should I wipe out the rest of the data?
+        #             return dynamic_form_fields
+        # return None
 
     def clean(self):
         cleaned_data = super(JiraCreateTicketAction, self).clean()

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -5,18 +5,13 @@ import logging
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 
-from sentry.integrations.jira.utils import (
-    get_name_for_jira,
-    transform_jira_fields_to_form_fields,
-    transform_jira_choices_to_strings,
-)
+from sentry.integrations.jira.utils import transform_jira_choices_to_strings
 from sentry.models.integration import Integration
 from sentry.rules.actions.base import (
     TicketEventAction,
     IntegrationNotifyServiceForm,
     INTEGRATION_KEY,
 )
-from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
 
@@ -42,67 +37,6 @@ class JiraCreateTicketAction(TicketEventAction):
 
         # Only add values when they exist.
         return self.label.format(**kwargs)
-
-    def get_dynamic_form_fields(self):
-        """
-        Either get the dynamic form fields cached on the DB return `None`.
-
-        :return: (Option) Django form fields dictionary
-        """
-        fields_list = self.data.get("dynamic_form_fields")
-        if not fields_list:
-            return None
-
-        # Although this can be done with dict comprehension, looping for clarity.
-        fields = {}
-        for field in fields_list:
-            if "name" in field:
-                fields[field["name"]] = field
-        return fields
-        # if "dynamic_form_fields" in self.data:
-        #     return self.data["dynamic_form_fields"]
-
-        # try:
-        #     integration = self.get_integration()
-        # except Integration.DoesNotExist:
-        #     pass
-        # else:
-        #     installation = integration.get_installation(self.project.organization.id)
-        #     if installation:
-        #         try:
-        #             fields = installation.get_create_issue_config_no_params()
-        #         except IntegrationError as e:
-        #             # TODO log when the API call fails.
-        #             logger.info(e)
-        #         else:
-        #             dynamic_form_fields = transform_jira_fields_to_form_fields(fields)
-        #             print("jira form fields: ", dynamic_form_fields)
-        #             self.data["dynamic_form_fields"] = dynamic_form_fields
-        #             # TODO should I wipe out the rest of the data?
-        #             return dynamic_form_fields
-        # return None
-        if "dynamic_form_fields" in self.data:
-            return self.data["dynamic_form_fields"]
-
-        try:
-            integration = self.get_integration()
-        except Integration.DoesNotExist:
-            pass
-        else:
-            installation = integration.get_installation(self.project.organization.id)
-            if installation:
-                try:
-                    fields = installation.get_create_issue_config_no_params()
-                except IntegrationError as e:
-                    # TODO log when the API call fails.
-                    logger.info(e)
-                else:
-                    dynamic_form_fields = transform_jira_fields_to_form_fields(fields)
-                    self.data["dynamic_form_fields"] = dynamic_form_fields
-                    # TODO should I wipe out the rest of the data?
-                    return dynamic_form_fields
-        return None
->>>>>>> okay it works again
 
     def clean(self):
         cleaned_data = super(JiraCreateTicketAction, self).clean()

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -92,6 +92,28 @@ class JiraCreateTicketAction(TicketEventAction):
         #             # TODO should I wipe out the rest of the data?
         #             return dynamic_form_fields
         # return None
+        if "dynamic_form_fields" in self.data:
+            return self.data["dynamic_form_fields"]
+
+        try:
+            integration = self.get_integration()
+        except Integration.DoesNotExist:
+            pass
+        else:
+            installation = integration.get_installation(self.project.organization.id)
+            if installation:
+                try:
+                    fields = installation.get_create_issue_config_no_params()
+                except IntegrationError as e:
+                    # TODO log when the API call fails.
+                    logger.info(e)
+                else:
+                    dynamic_form_fields = transform_jira_fields_to_form_fields(fields)
+                    self.data["dynamic_form_fields"] = dynamic_form_fields
+                    # TODO should I wipe out the rest of the data?
+                    return dynamic_form_fields
+        return None
+>>>>>>> okay it works again
 
     def clean(self):
         cleaned_data = super(JiraCreateTicketAction, self).clean()

--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -11,7 +11,11 @@ from sentry.integrations.jira.utils import (
     transform_jira_choices_to_strings,
 )
 from sentry.models.integration import Integration
-from sentry.rules.actions.base import TicketEventAction, NotifyServiceForm, INTEGRATION_KEY
+from sentry.rules.actions.base import (
+    TicketEventAction,
+    IntegrationNotifyServiceForm,
+    INTEGRATION_KEY,
+)
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
@@ -20,15 +24,8 @@ from sentry.web.decorators import transaction_start
 logger = logging.getLogger("sentry.rules")
 
 
-class JiraNotifyServiceForm(NotifyServiceForm):
-    integration = forms.ChoiceField(choices=(), widget=forms.Select())
-
-    def __init__(self, *args, **kwargs):
-        super(JiraNotifyServiceForm, self).__init__(*args, **kwargs)
-
-
 class JiraCreateTicketAction(TicketEventAction):
-    form_cls = JiraNotifyServiceForm
+    form_cls = IntegrationNotifyServiceForm
     label = u"""Create a Jira issue in {integration} with these """
     ticket_type = "a Jira issue"
     link = "https://docs.sentry.io/product/integrations/jira/#issue-sync"

--- a/src/sentry/integrations/jira/utils.py
+++ b/src/sentry/integrations/jira/utils.py
@@ -64,8 +64,3 @@ def transform_jira_choices_to_strings(fields, data):
         else:
             choices[key] = value
     return choices
-
-
-def get_name_for_jira(integration):
-    name = integration.metadata.get("domain_name", integration.name)
-    return name.replace(".atlassian.net", "")

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -28,7 +28,7 @@ class VstsIssueSync(IssueSyncMixin):
         project = self.get_client().get_project(self.instance, default_repo)
         return (project["id"], project["name"])
 
-    def get_project_choices(self, group, **kwargs):
+    def get_project_choices(self, group=None, **kwargs):
         client = self.get_client()
         try:
             projects = client.get_projects(self.instance)
@@ -38,28 +38,31 @@ class VstsIssueSync(IssueSyncMixin):
         project_choices = [(project["id"], project["name"]) for project in projects]
 
         params = kwargs.get("params", {})
-        defaults = self.get_project_defaults(group.project_id)
-        try:
-            default_project = params.get(
-                "project", defaults.get("project") or project_choices[0][0]
-            )
-        except IndexError:
-            return None, project_choices
-
-        # If a project has been selected outside of the default list of
-        # projects, stick it onto the front of the list so that it can be
-        # selected.
-        try:
-            next(True for r in project_choices if r[0] == default_project)
-        except StopIteration:
+        if group:
+            defaults = self.get_project_defaults(group.project_id)
             try:
-                project_choices.insert(0, self.create_default_repo_choice(default_project))
-            except (ApiError, ApiUnauthorized):
+                default_project = params.get(
+                    "project", defaults.get("project") or project_choices[0][0]
+                )
+            except IndexError:
                 return None, project_choices
+
+            # If a project has been selected outside of the default list of
+            # projects, stick it onto the front of the list so that it can be
+            # selected.
+            try:
+                next(True for r in project_choices if r[0] == default_project)
+            except StopIteration:
+                try:
+                    project_choices.insert(0, self.create_default_repo_choice(default_project))
+                except (ApiError, ApiUnauthorized):
+                    return None, project_choices
+        else:
+            default_project = project_choices[0][0]
 
         return default_project, project_choices
 
-    def get_work_item_choices(self, project, group):
+    def get_work_item_choices(self, project, group=None):
         client = self.get_client()
         try:
             item_categories = client.get_work_item_categories(self.instance, project)["value"]
@@ -79,7 +82,9 @@ class VstsIssueSync(IssueSyncMixin):
         item_tuples = list(item_type_map.items())
 
         # try to get the default from either the last value used or from the first item on the list
-        defaults = self.get_project_defaults(group.project_id)
+        defaults = {}
+        if group:
+            defaults = self.get_project_defaults(group.project_id)
         try:
             default_item_type = defaults.get("work_item_type") or item_tuples[0][0]
         except IndexError:
@@ -87,19 +92,29 @@ class VstsIssueSync(IssueSyncMixin):
 
         return default_item_type, item_tuples
 
+    def get_create_issue_config_no_params(self):
+        return self.get_create_issue_config(None, None, params={})
+
     def get_create_issue_config(self, group, user, **kwargs):
         kwargs["link_referrer"] = "vsts_integration"
-        fields = super(VstsIssueSync, self).get_create_issue_config(group, user, **kwargs)
-        # Azure/VSTS has BOTH projects and repositories. A project can have many repositories.
-        # Workitems (issues) are associated with the project not the repository.
-        default_project, project_choices = self.get_project_choices(group, **kwargs)
+        fields = []
+        if group:
+            fields = super(VstsIssueSync, self).get_create_issue_config(group, user, **kwargs)
+            # Azure/VSTS has BOTH projects and repositories. A project can have many repositories.
+            # Workitems (issues) are associated with the project not the repository.
+            default_project, project_choices = self.get_project_choices(group, **kwargs)
+        else:
+            default_project, project_choices = self.get_project_choices(**kwargs)
 
         work_item_choices = []
         default_work_item = None
         if default_project:
-            default_work_item, work_item_choices = self.get_work_item_choices(
-                default_project, group
-            )
+            if group:
+                default_work_item, work_item_choices = self.get_work_item_choices(
+                    default_project, group
+                )
+            else:
+                default_work_item, work_item_choices = self.get_work_item_choices(default_project)
 
         return [
             {

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -92,8 +92,8 @@ class VstsIssueSync(IssueSyncMixin):
 
         return default_item_type, item_tuples
 
-    def get_create_issue_config_no_params(self):
-        return self.get_create_issue_config(None, None, params={})
+    def get_create_issue_config_no_args(self):
+        return self.get_create_issue_config(None, None)
 
     def get_create_issue_config(self, group, user, **kwargs):
         kwargs["link_referrer"] = "vsts_integration"

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -39,7 +39,7 @@ class VstsIssueSync(IssueSyncMixin):
 
         params = kwargs.get("params", {})
         if group:
-            default_project_id = group.project.id
+            default_project_id = group.project_id
         else:
             project = kwargs.get("project")
             default_project_id = project.id

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -40,9 +40,11 @@ class VstsIssueSync(IssueSyncMixin):
         params = kwargs.get("params", {})
         if group:
             default_project_id = group.project_id
-        else:
+        elif kwargs.get("project"):
             project = kwargs.get("project")
             default_project_id = project.id
+        else:
+            default_project_id = projects[0]["id"]
         defaults = self.get_project_defaults(default_project_id)
         try:
             default_project = params.get(

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -28,7 +28,7 @@ class VstsIssueSync(IssueSyncMixin):
         project = self.get_client().get_project(self.instance, default_repo)
         return (project["id"], project["name"])
 
-    def get_project_choices(self, group=None, **kwargs):
+    def get_project_choices(self, group=None, project=None, **kwargs):
         client = self.get_client()
         try:
             projects = client.get_projects(self.instance)
@@ -41,8 +41,7 @@ class VstsIssueSync(IssueSyncMixin):
         if group:
             default_project_id = group.project.id
         else:
-            rule_project = kwargs.get("project", None)
-            default_project_id = rule_project.id
+            default_project_id = project.id
         defaults = self.get_project_defaults(default_project_id)
         try:
             default_project = params.get(
@@ -104,19 +103,14 @@ class VstsIssueSync(IssueSyncMixin):
             fields = super(VstsIssueSync, self).get_create_issue_config(group, user, **kwargs)
             # Azure/VSTS has BOTH projects and repositories. A project can have many repositories.
             # Workitems (issues) are associated with the project not the repository.
-            default_project, project_choices = self.get_project_choices(group, **kwargs)
-        else:
-            default_project, project_choices = self.get_project_choices(**kwargs)
+        default_project, project_choices = self.get_project_choices(group, **kwargs)
 
         work_item_choices = []
         default_work_item = None
         if default_project:
-            if group:
-                default_work_item, work_item_choices = self.get_work_item_choices(
-                    default_project, group
-                )
-            else:
-                default_work_item, work_item_choices = self.get_work_item_choices(default_project)
+            default_work_item, work_item_choices = self.get_work_item_choices(
+                default_project, group
+            )
 
         return [
             {

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -28,7 +28,7 @@ class VstsIssueSync(IssueSyncMixin):
         project = self.get_client().get_project(self.instance, default_repo)
         return (project["id"], project["name"])
 
-    def get_project_choices(self, group=None, project_id=None, **kwargs):
+    def get_project_choices(self, group=None, **kwargs):
         client = self.get_client()
         try:
             projects = client.get_projects(self.instance)
@@ -41,7 +41,8 @@ class VstsIssueSync(IssueSyncMixin):
         if group:
             default_project_id = group.project.id
         else:
-            default_project_id = project_id
+            project = kwargs.get("project")
+            default_project_id = project.id
         defaults = self.get_project_defaults(default_project_id)
         try:
             default_project = params.get(
@@ -103,8 +104,7 @@ class VstsIssueSync(IssueSyncMixin):
             fields = super(VstsIssueSync, self).get_create_issue_config(group, user, **kwargs)
             # Azure/VSTS has BOTH projects and repositories. A project can have many repositories.
             # Workitems (issues) are associated with the project not the repository.
-        project = kwargs.get("project")
-        default_project, project_choices = self.get_project_choices(group, project.id, **kwargs)
+        default_project, project_choices = self.get_project_choices(group, **kwargs)
 
         work_item_choices = []
         default_work_item = None

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -28,7 +28,7 @@ class VstsIssueSync(IssueSyncMixin):
         project = self.get_client().get_project(self.instance, default_repo)
         return (project["id"], project["name"])
 
-    def get_project_choices(self, group=None, project=None, **kwargs):
+    def get_project_choices(self, group=None, project_id=None, **kwargs):
         client = self.get_client()
         try:
             projects = client.get_projects(self.instance)
@@ -41,7 +41,7 @@ class VstsIssueSync(IssueSyncMixin):
         if group:
             default_project_id = group.project.id
         else:
-            default_project_id = project.id
+            default_project_id = project_id
         defaults = self.get_project_defaults(default_project_id)
         try:
             default_project = params.get(
@@ -103,7 +103,8 @@ class VstsIssueSync(IssueSyncMixin):
             fields = super(VstsIssueSync, self).get_create_issue_config(group, user, **kwargs)
             # Azure/VSTS has BOTH projects and repositories. A project can have many repositories.
             # Workitems (issues) are associated with the project not the repository.
-        default_project, project_choices = self.get_project_choices(group, **kwargs)
+        project = kwargs.get("project")
+        default_project, project_choices = self.get_project_choices(group, project.id, **kwargs)
 
         work_item_choices = []
         default_work_item = None

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -1,19 +1,15 @@
 from __future__ import absolute_import
 
 import logging
-import six
 
-from sentry.models.integration import Integration
 from sentry.rules.actions.base import (
     TicketEventAction,
     IntegrationNotifyServiceForm,
     INTEGRATION_KEY,
 )
-from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
 
-from sentry.integrations.vsts.integration import VstsIntegration
 
 logger = logging.getLogger("sentry.rules")
 
@@ -29,36 +25,6 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
 
     def render_label(self):
         return self.label.format(integration=self.get_integration_name())
-
-    def get_dynamic_form_fields(self):
-        """
-        Either get the dynamic form fields cached on the DB or make an API call
-        to VSTS to get them for the selected integration. If both fail, return `None`.
-
-        :return: Django form fields dictionary
-        """
-        if "dynamic_form_fields" in self.data:
-            return self.data["dynamic_form_fields"]
-
-        try:
-            integration = self.get_integration()
-        except Integration.DoesNotExist:
-            return None
-        vsts_integration = VstsIntegration(integration, self.project.organization.id)
-        try:
-            fields = vsts_integration.get_create_issue_config_no_group(self.project)
-        except IntegrationError as e:
-            # TODO log when the API call fails.
-            logger.info(e)
-            return self.error(six.text_type(e))
-        else:
-            form_fields = {}
-            for field in fields:
-                if "name" in field:
-                    form_fields[field["name"]] = field
-            self.data["dynamic_form_fields"] = form_fields
-            return form_fields
-        return None
 
     def generate_footer(self, rule_url):
         return u"\nThis work item was automatically created by Sentry via [{}]({})".format(

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -19,17 +19,16 @@ INTEGRATION_KEY = "integration"
 
 
 class AzureDevopsNotifyServiceForm(forms.Form):
-    vsts_integration = forms.ChoiceField(choices=(), widget=forms.Select())
+    integration = forms.ChoiceField(choices=(), widget=forms.Select())
 
     def __init__(self, *args, **kwargs):
         integrations = [(i.id, i.name) for i in kwargs.pop("integrations")]
         super(AzureDevopsNotifyServiceForm, self).__init__(*args, **kwargs)
-
         if integrations:
-            self.fields["vsts_integration"].initial = integrations[0][0]
+            self.fields[INTEGRATION_KEY].initial = integrations[0][0]
 
-        self.fields["vsts_integration"].choices = integrations
-        self.fields["vsts_integration"].widget.choices = self.fields["vsts_integration"].choices
+        self.fields[INTEGRATION_KEY].choices = integrations
+        self.fields[INTEGRATION_KEY].widget.choices = self.fields[INTEGRATION_KEY].choices
 
     def clean(self):
         return super(AzureDevopsNotifyServiceForm, self).clean()
@@ -37,11 +36,9 @@ class AzureDevopsNotifyServiceForm(forms.Form):
 
 class AzureDevopsCreateTicketAction(TicketEventAction):
     form_cls = AzureDevopsNotifyServiceForm
-
+    label = u"Create an Azure DevOps work item in {integration} with these "
     ticket_type = "an Azure DevOps work item"
     link = "https://docs.sentry.io/product/integrations/azure-devops/#issue-sync"
-    label = u"Create an Azure DevOps work item in {vsts_integration} with these "
-    prompt = "Create an Azure DevOps work item"
     provider = "vsts"
     integration_key = INTEGRATION_KEY
 
@@ -53,7 +50,7 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
             self.data[self.integration_key] = integration_choices[0][0]
 
         self.form_fields = {
-            "vsts_integration": {
+            self.integration_key: {
                 "choices": integration_choices,
                 "initial": six.text_type(self.get_integration_id()),
                 "type": "choice",
@@ -67,7 +64,7 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
                 self.form_fields[field["name"]] = field
 
     def render_label(self):
-        return self.label.format(vsts_integration=self.get_integration_name())
+        return self.label.format(integration=self.get_integration_name())
 
     def get_dynamic_form_fields(self):
         """

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -6,7 +6,7 @@ import six
 from django import forms
 
 from sentry.models.integration import Integration
-from sentry.rules.actions.base import TicketEventAction
+from sentry.rules.actions.base import TicketEventAction, NotifyServiceForm, INTEGRATION_KEY
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
@@ -15,20 +15,12 @@ from sentry.integrations.vsts.integration import VstsIntegration
 
 logger = logging.getLogger("sentry.rules")
 
-INTEGRATION_KEY = "integration"
 
-
-class AzureDevopsNotifyServiceForm(forms.Form):
+class AzureDevopsNotifyServiceForm(NotifyServiceForm):
     integration = forms.ChoiceField(choices=(), widget=forms.Select())
 
     def __init__(self, *args, **kwargs):
-        integrations = [(i.id, i.name) for i in kwargs.pop("integrations")]
         super(AzureDevopsNotifyServiceForm, self).__init__(*args, **kwargs)
-        if integrations:
-            self.fields[INTEGRATION_KEY].initial = integrations[0][0]
-
-        self.fields[INTEGRATION_KEY].choices = integrations
-        self.fields[INTEGRATION_KEY].widget.choices = self.fields[INTEGRATION_KEY].choices
 
     def clean(self):
         return super(AzureDevopsNotifyServiceForm, self).clean()

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -54,7 +54,7 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
             return None
         vsts_integration = VstsIntegration(integration, self.project.organization.id)
         try:
-            fields = vsts_integration.get_create_issue_config_no_group(project=self.project)
+            fields = vsts_integration.get_create_issue_config_no_group(self.project)
         except IntegrationError as e:
             # TODO log when the API call fails.
             logger.info(e)

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -69,7 +69,7 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
                 logger.info(e)
                 return self.error(six.text_type(e))
             else:
-                self.data["dynamic_form_fields"] = fields
+                self.data["dynamic_form_fields"] = fields[0]
                 return fields
         return None
 
@@ -80,4 +80,4 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
 
     @transaction_start("AzureDevopsCreateTicketAction.after")
     def after(self, event, state):
-        super(AzureDevopsCreateTicketAction, self).after(event, state)
+        yield super(AzureDevopsCreateTicketAction, self).after(event, state)

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -86,7 +86,7 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
         else:
             vsts_integration = VstsIntegration(integration, self.project.organization.id)
             try:
-                fields = vsts_integration.get_create_issue_config_no_params()
+                fields = vsts_integration.get_create_issue_config_no_args()
             except IntegrationError as e:
                 # TODO log when the API call fails.
                 logger.info(e)

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -42,27 +42,6 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
     provider = "vsts"
     integration_key = INTEGRATION_KEY
 
-    def __init__(self, *args, **kwargs):
-        super(AzureDevopsCreateTicketAction, self).__init__(*args, **kwargs)
-        integration_choices = [(i.id, i.name) for i in self.get_integrations()]
-
-        if not self.get_integration_id() and integration_choices:
-            self.data[self.integration_key] = integration_choices[0][0]
-
-        self.form_fields = {
-            self.integration_key: {
-                "choices": integration_choices,
-                "initial": six.text_type(self.get_integration_id()),
-                "type": "choice",
-                "updatesForm": True,
-            },
-        }
-
-        dynamic_fields = self.get_dynamic_form_fields()
-        if dynamic_fields:
-            for field in dynamic_fields:
-                self.form_fields[field["name"]] = field
-
     def render_label(self):
         return self.label.format(integration=self.get_integration_name())
 

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -54,8 +54,6 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
         :return: Django form fields dictionary
         """
         if "dynamic_form_fields" in self.data:
-            print("already have this")
-            print(self.data["dynamic_form_fields"])
             return self.data["dynamic_form_fields"]
 
         try:
@@ -66,17 +64,14 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
         try:
             fields = vsts_integration.get_create_issue_config_no_group(self.project)
         except IntegrationError as e:
-            print("error ", e)
             # TODO log when the API call fails.
             logger.info(e)
             return self.error(six.text_type(e))
         else:
-            print("vsts fields: ", fields)
             form_fields = {}
             for field in fields:
                 if "name" in field:
                     form_fields[field["name"]] = field
-            print("form fields: ", form_fields)
             self.data["dynamic_form_fields"] = form_fields
             return form_fields
         return None

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -62,7 +62,7 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
             return None
         vsts_integration = VstsIntegration(integration, self.project.organization.id)
         try:
-            fields = vsts_integration.get_create_issue_config_no_group(self.project)
+            fields = vsts_integration.get_create_issue_config_no_group(project=self.project)
         except IntegrationError as e:
             # TODO log when the API call fails.
             logger.info(e)

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -1,12 +1,17 @@
 from __future__ import absolute_import
 
 import logging
+import six
 
 from django import forms
 
+from sentry.models.integration import Integration
 from sentry.rules.actions.base import TicketEventAction
+from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
+
+from sentry.integrations.vsts.integration import VstsIntegration
 
 logger = logging.getLogger("sentry.rules")
 
@@ -14,9 +19,17 @@ INTEGRATION_KEY = "integration"
 
 
 class AzureDevopsNotifyServiceForm(forms.Form):
-    # TODO 2.0 Add form fields.
+    vsts_integration = forms.ChoiceField(choices=(), widget=forms.Select())
+
     def __init__(self, *args, **kwargs):
+        integrations = [(i.id, i.name) for i in kwargs.pop("integrations")]
         super(AzureDevopsNotifyServiceForm, self).__init__(*args, **kwargs)
+
+        if integrations:
+            self.fields["vsts_integration"].initial = integrations[0][0]
+
+        self.fields["vsts_integration"].choices = integrations
+        self.fields["vsts_integration"].widget.choices = self.fields["vsts_integration"].choices
 
     def clean(self):
         return super(AzureDevopsNotifyServiceForm, self).clean()
@@ -24,19 +37,63 @@ class AzureDevopsNotifyServiceForm(forms.Form):
 
 class AzureDevopsCreateTicketAction(TicketEventAction):
     form_cls = AzureDevopsNotifyServiceForm
-    label = u"TODO Create an Azure DevOps work item in {name} with these "
+
     ticket_type = "an Azure DevOps work item"
     link = "https://docs.sentry.io/product/integrations/azure-devops/#issue-sync"
+    label = u"Create an Azure DevOps work item in {vsts_integration} with these "
+    prompt = "Create an Azure DevOps work item"
     provider = "vsts"
     integration_key = INTEGRATION_KEY
 
     def __init__(self, *args, **kwargs):
         super(AzureDevopsCreateTicketAction, self).__init__(*args, **kwargs)
-        # TODO 2.1 Add form_fields
-        self.form_fields = {}
+        integration_choices = [(i.id, i.name) for i in self.get_integrations()]
+
+        if not self.get_integration_id() and integration_choices:
+            self.data[self.integration_key] = integration_choices[0][0]
+
+        self.form_fields = {
+            "vsts_integration": {
+                "choices": integration_choices,
+                "initial": six.text_type(self.get_integration_id()),
+                "type": "choice",
+                "updatesForm": True,
+            },
+        }
+
+        dynamic_fields = self.get_dynamic_form_fields()
+        if dynamic_fields:
+            for field in dynamic_fields:
+                self.form_fields[field["name"]] = field
 
     def render_label(self):
-        return self.label.format(name=self.get_integration_name())
+        return self.label.format(vsts_integration=self.get_integration_name())
+
+    def get_dynamic_form_fields(self):
+        """
+        Either get the dynamic form fields cached on the DB or make an API call
+        to VSTS to get them for the selected integration. If both fail, return `None`.
+
+        :return: Django form fields dictionary
+        """
+        if "dynamic_form_fields" in self.data:
+            return self.data["dynamic_form_fields"]
+
+        try:
+            integration = self.get_integration()
+        except Integration.DoesNotExist:
+            pass
+        else:
+            vsts_integration = VstsIntegration(integration, self.project.organization.id)
+            try:
+                fields = vsts_integration.get_create_issue_config_no_params()
+            except IntegrationError as e:
+                # TODO log when the API call fails.
+                logger.info(e)
+            else:
+                self.data["dynamic_form_fields"] = fields
+                return fields
+        return None
 
     def generate_footer(self, rule_url):
         return u"\nThis work item was automatically created by Sentry via [{}]({})".format(
@@ -46,12 +103,22 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
     @transaction_start("AzureDevopsCreateTicketAction.after")
     def after(self, event, state):
         organization = self.project.organization
-        integration = self.get_integration()
+        try:
+            integration = self.get_integration()
+        except Integration.DoesNotExist:
+            # Integration removed, rule still active.
+            return
+
         installation = integration.get_installation(organization.id)
+
+        self.data["title"] = event.title
         self.data["description"] = self.build_description(event, installation)
 
         def create_issue(event, futures):
             """Create an Azure DevOps work item for a given event"""
+
+            if self.data.get("dynamic_form_fields"):
+                del self.data["dynamic_form_fields"]
 
             if not self.has_linked_issue(event, integration):
                 resp = installation.create_issue(self.data)

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -3,10 +3,12 @@ from __future__ import absolute_import
 import logging
 import six
 
-from django import forms
-
 from sentry.models.integration import Integration
-from sentry.rules.actions.base import TicketEventAction, NotifyServiceForm, INTEGRATION_KEY
+from sentry.rules.actions.base import (
+    TicketEventAction,
+    IntegrationNotifyServiceForm,
+    INTEGRATION_KEY,
+)
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.web.decorators import transaction_start
@@ -16,18 +18,8 @@ from sentry.integrations.vsts.integration import VstsIntegration
 logger = logging.getLogger("sentry.rules")
 
 
-class AzureDevopsNotifyServiceForm(NotifyServiceForm):
-    integration = forms.ChoiceField(choices=(), widget=forms.Select())
-
-    def __init__(self, *args, **kwargs):
-        super(AzureDevopsNotifyServiceForm, self).__init__(*args, **kwargs)
-
-    def clean(self):
-        return super(AzureDevopsNotifyServiceForm, self).clean()
-
-
 class AzureDevopsCreateTicketAction(TicketEventAction):
-    form_cls = AzureDevopsNotifyServiceForm
+    form_cls = IntegrationNotifyServiceForm
     label = u"Create an Azure DevOps work item in {integration} with these "
     ticket_type = "an Azure DevOps work item"
     link = "https://docs.sentry.io/product/integrations/azure-devops/#issue-sync"

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -251,9 +251,6 @@ class TicketEventAction(IntegrationEventAction):
     def translate_integration(self, integration):
         return integration.name
 
-    def fix_data_for_issue(self):
-        raise NotImplementedError
-
     @property
     def prompt(self):
         return u"Create {}".format(self.ticket_type)

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -212,13 +212,15 @@ class TicketEventAction(IntegrationEventAction):
 
         dynamic_fields = self.get_dynamic_form_fields()
         if dynamic_fields:
-            if isinstance(dynamic_fields, list):
-                self.form_fields.update(dynamic_fields[0])
-            else:
-                self.form_fields.update(dynamic_fields)
+            print("dynamic_fields: ", dynamic_fields)
+            fields = {}
+            for field in dynamic_fields:
+                if "name" in field:
+                    fields[field["name"]] = field
+            self.form_fields.update(fields)
 
     def translate_integration(self, integration):
-        return integration
+        return integration.name
 
     @property
     def prompt(self):

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -229,6 +229,25 @@ class TicketEventAction(IntegrationEventAction):
         if dynamic_fields:
             self.form_fields.update(dynamic_fields)
 
+    def get_dynamic_form_fields(self):
+        """
+        Either get the dynamic form fields cached on the DB return `None`.
+
+        :return: (Option) Django form fields dictionary
+        """
+        form_fields = self.data.get("dynamic_form_fields")
+        if not form_fields:
+            return None
+
+        # Although this can be done with dict comprehension, looping for clarity.
+        if isinstance(form_fields, list):
+            fields = {}
+            for field in form_fields:
+                if "name" in field:
+                    fields[field["name"]] = field
+            return fields
+        return form_fields
+
     def translate_integration(self, integration):
         return integration.name
 

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -17,7 +17,9 @@ logger = logging.getLogger("sentry.rules")
 INTEGRATION_KEY = "integration"
 
 
-class NotifyServiceForm(forms.Form):
+class IntegrationNotifyServiceForm(forms.Form):
+    integration = forms.ChoiceField(choices=(), widget=forms.Select())
+
     def __init__(self, *args, **kwargs):
         integrations = [(i.id, i.name) for i in kwargs.pop("integrations")]
         super(forms.Form, self).__init__(*args, **kwargs)
@@ -26,6 +28,9 @@ class NotifyServiceForm(forms.Form):
 
         self.fields[INTEGRATION_KEY].choices = integrations
         self.fields[INTEGRATION_KEY].widget.choices = self.fields[INTEGRATION_KEY].choices
+
+    def clean(self):
+        return super(IntegrationNotifyServiceForm, self).clean()
 
 
 class EventAction(RuleBase):
@@ -108,7 +113,7 @@ class IntegrationEventAction(EventAction):
 def _linked_issues(event, integration):
     return ExternalIssue.objects.filter(
         id__in=GroupLink.objects.filter(
-            project_id=event.group.project.id,
+            project_id=event.group.project_id,
             group_id=event.group.id,
             linked_type=GroupLink.LinkedType.issue,
         ).values_list("linked_id", flat=True),

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -29,9 +29,6 @@ class IntegrationNotifyServiceForm(forms.Form):
         self.fields[INTEGRATION_KEY].choices = integrations
         self.fields[INTEGRATION_KEY].widget.choices = self.fields[INTEGRATION_KEY].choices
 
-    def clean(self):
-        return super(IntegrationNotifyServiceForm, self).clean()
-
 
 class EventAction(RuleBase):
     rule_type = "action/event"

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -5,12 +5,27 @@ import logging
 import operator
 import six
 
+from django import forms
+
 from sentry.constants import ObjectStatus
 from sentry.models.integration import Integration
 from sentry.models import ExternalIssue, GroupLink
 from sentry.rules.base import RuleBase
 
 logger = logging.getLogger("sentry.rules")
+
+INTEGRATION_KEY = "integration"
+
+
+class NotifyServiceForm(forms.Form):
+    def __init__(self, *args, **kwargs):
+        integrations = [(i.id, i.name) for i in kwargs.pop("integrations")]
+        super(forms.Form, self).__init__(*args, **kwargs)
+        if integrations:
+            self.fields[INTEGRATION_KEY].initial = integrations[0][0]
+
+        self.fields[INTEGRATION_KEY].choices = integrations
+        self.fields[INTEGRATION_KEY].widget.choices = self.fields[INTEGRATION_KEY].choices
 
 
 class EventAction(RuleBase):

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -212,12 +212,7 @@ class TicketEventAction(IntegrationEventAction):
 
         dynamic_fields = self.get_dynamic_form_fields()
         if dynamic_fields:
-            print("dynamic_fields: ", dynamic_fields)
-            fields = {}
-            for field in dynamic_fields:
-                if "name" in field:
-                    fields[field["name"]] = field
-            self.form_fields.update(fields)
+            self.form_fields.update(dynamic_fields)
 
     def translate_integration(self, integration):
         return integration.name

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -75,7 +75,6 @@ class BaseApiResponse(object):
                 )
         else:
             data = json.loads(response.text, object_pairs_hook=OrderedDict)
-
         if isinstance(data, dict):
             return MappingApiResponse(data, response.headers, response.status_code)
         elif isinstance(data, (list, tuple)):

--- a/src/sentry/shared_integrations/client.py
+++ b/src/sentry/shared_integrations/client.py
@@ -75,6 +75,7 @@ class BaseApiResponse(object):
                 )
         else:
             data = json.loads(response.text, object_pairs_hook=OrderedDict)
+
         if isinstance(data, dict):
             return MappingApiResponse(data, response.headers, response.status_code)
         elif isinstance(data, (list, tuple)):

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -88,7 +88,7 @@ class JiraCreateTicketActionTest(RuleTestCase):
         results[0].callback(event, futures=[rule_future])
 
         # Make assertions about what would be POSTed to api/2/issue.
-        data = json.loads(responses.calls[2].request.body)
+        data = json.loads(responses.calls[1].request.body)
         assert data["fields"]["summary"] == event.title
         assert event.message in data["fields"]["description"]
         assert data["fields"]["issuetype"]["id"] == "1"

--- a/tests/sentry/integrations/jira/test_notify_action.py
+++ b/tests/sentry/integrations/jira/test_notify_action.py
@@ -1,12 +1,15 @@
 from __future__ import absolute_import
 
 import responses
+from collections import namedtuple
 
 from sentry.integrations.jira.notify_action import JiraCreateTicketAction
 from sentry.models import Integration, ExternalIssue, GroupLink, Rule
 from sentry.testutils.cases import RuleTestCase
 from sentry.utils import json
 from tests.fixtures.integrations.mock_service import StubService
+
+RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])
 
 
 class JiraCreateTicketActionTest(RuleTestCase):
@@ -29,6 +32,21 @@ class JiraCreateTicketActionTest(RuleTestCase):
     @responses.activate
     def test_creates_issue(self):
         event = self.get_event()
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/project",
+            body=StubService.get_stub_json("jira", "project_list_response.json"),
+            content_type="application/json",
+            match_querystring=False,
+        )
+
+        responses.add(
+            responses.GET,
+            "https://example.atlassian.net/rest/api/2/issue/createmeta",
+            body=StubService.get_stub_json("jira", "createmeta_response.json"),
+            content_type="json",
+            match_querystring=False,
+        )
         jira_rule = self.get_rule(
             data={
                 "issuetype": "1",
@@ -44,14 +62,6 @@ class JiraCreateTicketActionTest(RuleTestCase):
         )
         jira_rule.rule = Rule.objects.create(project=self.project, label="test rule",)
 
-        responses.add(
-            responses.GET,
-            "https://example.atlassian.net/rest/api/2/issue/createmeta",
-            body=StubService.get_stub_json("jira", "createmeta_response.json"),
-            content_type="json",
-            match_querystring=False,
-        )
-
         jira_rule.data["key"] = "APP-123"
 
         # Add two mocks: one for POSTing the issue and a GET to confirm it's there.
@@ -66,7 +76,7 @@ class JiraCreateTicketActionTest(RuleTestCase):
             responses.GET,
             "https://example.atlassian.net/rest/api/2/issue/APP-123",
             body=StubService.get_stub_json("jira", "get_issue_response.json"),
-            content_type="json",
+            content_type="application/json",
             match_querystring=False,
         )
 
@@ -74,10 +84,11 @@ class JiraCreateTicketActionTest(RuleTestCase):
         assert len(results) == 1
 
         # Trigger rule callback
-        results[0].callback(event, futures=[])
+        rule_future = RuleFuture(rule=jira_rule, kwargs=results[0].kwargs)
+        results[0].callback(event, futures=[rule_future])
 
-        # Make assertions about what would be sent.
-        data = json.loads(responses.calls[1].request.body)
+        # Make assertions about what would be POSTed to api/2/issue.
+        data = json.loads(responses.calls[2].request.body)
         assert data["fields"]["summary"] == event.title
         assert event.message in data["fields"]["description"]
         assert data["fields"]["issuetype"]["id"] == "1"

--- a/tests/sentry/integrations/test_ticket_rules.py
+++ b/tests/sentry/integrations/test_ticket_rules.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from collections import namedtuple
+
 from django.core.urlresolvers import reverse
 from rest_framework.test import APITestCase as BaseAPITestCase
 
@@ -12,6 +14,8 @@ from sentry.testutils import RuleTestCase
 from sentry.utils.compat import mock
 
 from tests.fixtures.integrations.jira import MockJira
+
+RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])
 
 
 class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
@@ -47,7 +51,9 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
         results = list(action_inst.after(event=event, state=self.get_state()))
         assert len(results) == 1
 
-        return results[0].callback(event, futures=[])
+        rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)
+        return results[0].callback(event, futures=[rule_future])
+        # return results[0].callback(event, futures=[])
 
     def get_key(self, event):
         return ExternalIssue.objects.filter(

--- a/tests/sentry/integrations/test_ticket_rules.py
+++ b/tests/sentry/integrations/test_ticket_rules.py
@@ -53,7 +53,6 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
 
         rule_future = RuleFuture(rule=rule_object, kwargs=results[0].kwargs)
         return results[0].callback(event, futures=[rule_future])
-        # return results[0].callback(event, futures=[])
 
     def get_key(self, event):
         return ExternalIssue.objects.filter(

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -69,6 +69,64 @@ class VstsIssueBase(TestCase):
         )
         self.project_id_with_states = "c0bf429a-c03c-4a99-9336-d45be74db5a6"
 
+    def mock_categories(self, project):
+        responses.add(
+            responses.GET,
+            u"https://fabrikam-fiber-inc.visualstudio.com/{}/_apis/wit/workitemtypecategories".format(
+                project
+            ),
+            json={
+                "value": [
+                    {
+                        "workItemTypes": [
+                            {
+                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Bug".format(
+                                    project
+                                ),
+                                "name": "Bug",
+                            }
+                        ],
+                    },
+                    {
+                        "workItemTypes": [
+                            {
+                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Bug".format(
+                                    project
+                                ),
+                                "name": "Issue Bug",
+                            },
+                            {
+                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Some-Thing.GIssue".format(
+                                    project
+                                ),
+                                "name": "G Issue",
+                            },
+                        ],
+                    },
+                    {
+                        "workItemTypes": [
+                            {
+                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Task".format(
+                                    project
+                                ),
+                                "name": "Task",
+                            }
+                        ],
+                    },
+                    {
+                        "workItemTypes": [
+                            {
+                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.UserStory".format(
+                                    project
+                                ),
+                                "name": "User Story",
+                            }
+                        ],
+                    },
+                ]
+            },
+        )
+
 
 class VstsIssueSyncTest(VstsIssueBase):
     def tearDown(self):
@@ -373,64 +431,6 @@ class VstsIssueFormTest(VstsIssueBase):
             data={"fingerprint": ["group1"], "timestamp": min_ago}, project_id=self.project.id
         )
         self.group = event.group
-
-    def mock_categories(self, project):
-        responses.add(
-            responses.GET,
-            u"https://fabrikam-fiber-inc.visualstudio.com/{}/_apis/wit/workitemtypecategories".format(
-                project
-            ),
-            json={
-                "value": [
-                    {
-                        "workItemTypes": [
-                            {
-                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Bug".format(
-                                    project
-                                ),
-                                "name": "Bug",
-                            }
-                        ],
-                    },
-                    {
-                        "workItemTypes": [
-                            {
-                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Bug".format(
-                                    project
-                                ),
-                                "name": "Issue Bug",
-                            },
-                            {
-                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Some-Thing.GIssue".format(
-                                    project
-                                ),
-                                "name": "G Issue",
-                            },
-                        ],
-                    },
-                    {
-                        "workItemTypes": [
-                            {
-                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Task".format(
-                                    project
-                                ),
-                                "name": "Task",
-                            }
-                        ],
-                    },
-                    {
-                        "workItemTypes": [
-                            {
-                                "url": u"https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.UserStory".format(
-                                    project
-                                ),
-                                "name": "User Story",
-                            }
-                        ],
-                    },
-                ]
-            },
-        )
 
     def tearDown(self):
         responses.reset()

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import responses
+from collections import namedtuple
 
 from time import time
 
@@ -13,6 +14,8 @@ from sentry.models import ExternalIssue, GroupLink, Identity, IdentityProvider, 
 
 from .test_issues import VstsIssueBase
 from .testutils import WORK_ITEM_RESPONSE, GET_PROJECTS_RESPONSE
+
+RuleFuture = namedtuple("RuleFuture", ["rule", "kwargs"])
 
 
 class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
@@ -68,7 +71,8 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
         assert len(results) == 1
 
         # Trigger rule callback
-        results[0].callback(event, futures=[])
+        rule_future = RuleFuture(rule=azuredevops_rule, kwargs=results[0].kwargs)
+        results[0].callback(event, futures=[rule_future])
         data = json.loads(responses.calls[2].response.text)
 
         assert data["fields"]["System.Title"] == "Hello"

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -104,3 +104,19 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase):
         assert len(results) == 1
         results[0].callback(event, futures=[])
         assert len(responses.calls) == 0
+
+    def test_render_label(self):
+        azuredevops_rule = self.get_rule(
+            data={
+                "title": "Hello",
+                "description": "Fix this.",
+                "project": "0987654321",
+                "work_item_type": "Microsoft.VSTS.WorkItemTypes.Task",
+                "vsts_integration": self.integration.model.id,
+            }
+        )
+
+        assert (
+            azuredevops_rule.rule.render_label()
+            == """Create an Azure DevOps work item in fabrikam-fiber-inc with these """
+        )

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -44,12 +44,6 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
     def test_create_issue(self):
         self.mock_categories("ac7c05bb-7f8e-4880-85a6-e08f37fd4a10")
         event = self.get_event()
-        responses.add(
-            responses.GET,
-            "https://fabrikam-fiber-inc.visualstudio.com/_apis/projects?stateFilter=WellFormed&%24skip=0&%24top=100",
-            body=GET_PROJECTS_RESPONSE,
-            content_type="application/json",
-        )
         azuredevops_rule = self.get_rule(
             data={
                 "title": "Hello",
@@ -73,7 +67,7 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
         # Trigger rule callback
         rule_future = RuleFuture(rule=azuredevops_rule, kwargs=results[0].kwargs)
         results[0].callback(event, futures=[rule_future])
-        data = json.loads(responses.calls[2].response.text)
+        data = json.loads(responses.calls[0].response.text)
 
         assert data["fields"]["System.Title"] == "Hello"
         assert data["fields"]["System.Description"] == "Fix this."
@@ -122,7 +116,7 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
         results = list(azuredevops_rule.after(event=event, state=self.get_state()))
         assert len(results) == 1
         results[0].callback(event, futures=[])
-        assert len(responses.calls) == 2
+        assert len(responses.calls) == 0
 
     def test_render_label(self):
         azuredevops_rule = self.get_rule(

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -130,8 +130,8 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
                 "integration": self.integration.model.id,
                 "work_item_type": "Microsoft.VSTS.WorkItemTypes.Task",
                 "project": "0987654321",
-                "dynamic_form_fields": [
-                    {
+                "dynamic_form_fields": {
+                    "project": {
                         "name": "project",
                         "required": True,
                         "type": "choice",
@@ -141,21 +141,35 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
                         "placeholder": "ac7c05bb-7f8e-4880-85a6-e08f37fd4a10",
                         "updatesForm": True,
                     },
-                    {
+                    "work_item_type": {
                         "name": "work_item_type",
                         "required": True,
                         "type": "choice",
                         "choices": [
-                            ("Microsoft.VSTS.WorkItemTypes.Bug", "Bug"),
-                            ("Some-Thing.GIssue", "G Issue"),
+                            ("Microsoft.VSTS.WorkItemTypes.Issue", "Issue"),
+                            ("Microsoft.VSTS.WorkItemTypes.Epic", "Epic"),
+                            ("Microsoft.VSTS.WorkItemTypes.TestCase", "Test Case"),
+                            ("Microsoft.VSTS.WorkItemTypes.SharedStep", "Shared Steps"),
+                            ("Microsoft.VSTS.WorkItemTypes.SharedParameter", "Shared Parameter"),
+                            (
+                                "Microsoft.VSTS.WorkItemTypes.CodeReviewRequest",
+                                "Code Review Request",
+                            ),
+                            (
+                                "Microsoft.VSTS.WorkItemTypes.CodeReviewResponse",
+                                "Code Review Response",
+                            ),
+                            ("Microsoft.VSTS.WorkItemTypes.FeedbackRequest", "Feedback Request"),
+                            ("Microsoft.VSTS.WorkItemTypes.FeedbackResponse", "Feedback Response"),
+                            ("Microsoft.VSTS.WorkItemTypes.TestPlan", "Test Plan"),
+                            ("Microsoft.VSTS.WorkItemTypes.TestSuite", "Test Suite"),
                             ("Microsoft.VSTS.WorkItemTypes.Task", "Task"),
-                            ("Microsoft.VSTS.WorkItemTypes.UserStory", "User Story"),
                         ],
-                        "defaultValue": "Microsoft.VSTS.WorkItemTypes.Bug",
+                        "defaultValue": "Microsoft.VSTS.WorkItemTypes.Issue",
                         "label": "Work Item Type",
                         "placeholder": "Bug",
                     },
-                ],
+                },
             }
         )
 


### PR DESCRIPTION
This PR adds in the Django forms for Azure DevOps ticket actions, which essentially populates the modal shown in the screenshot. It's the Azure counterpart to https://github.com/getsentry/sentry/pull/21833

![Screen Shot 2020-12-09 at 3 15 12 PM](https://user-images.githubusercontent.com/29959063/101700130-5f343e80-3a31-11eb-91e4-f8b01c70c6cf.png)
