### PR TITLE
fix(spanview): Fix horizontal scrolling bugs

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -137,6 +137,7 @@ export class Provider extends React.Component<Props, State> {
     selectRefs(this.contentSpanBar, (spanBarDOM: HTMLDivElement) => {
       spanBarDOM.style.removeProperty('width');
       spanBarDOM.style.removeProperty('max-width');
+      spanBarDOM.style.removeProperty('overflow');
     });
 
     // Find the maximum content width. We set each content spanbar to be this maximum width,
@@ -162,6 +163,7 @@ export class Provider extends React.Component<Props, State> {
     selectRefs(this.contentSpanBar, (spanBarDOM: HTMLDivElement) => {
       spanBarDOM.style.width = `${maxContentWidth}px`;
       spanBarDOM.style.maxWidth = `${maxContentWidth}px`;
+      spanBarDOM.style.overflow = 'hidden';
     });
 
     this.scrollableSpanBar.forEach(currentSpanBarRef => {

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
@@ -3,11 +3,12 @@ import React from 'react';
 import {Organization, SentryTransactionEvent} from 'app/types';
 import {TableData, TableDataRow} from 'app/utils/discover/discoverQuery';
 
+import {ScrollbarManagerChildrenProps, withScrollbarManager} from './scrollbarManager';
 import SpanBar from './spanBar';
 import {ParsedTraceType, ProcessedSpanType, TreeDepthType} from './types';
 import {getSpanID, isGapSpan, SpanBoundsType, SpanGeneratedBoundsType} from './utils';
 
-type PropType = {
+type PropType = ScrollbarManagerChildrenProps & {
   orgId: string;
   organization: Organization;
   event: Readonly<SentryTransactionEvent>;
@@ -35,6 +36,14 @@ class SpanGroup extends React.Component<PropType, State> {
   state: State = {
     showSpanTree: true,
   };
+
+  componentDidUpdate(_prevProps: PropType, prevState: State) {
+    if (prevState.showSpanTree !== this.state.showSpanTree) {
+      // Update horizontal scroll states after this subtree was either hidden or
+      // revealed.
+      this.props.updateScrollState();
+    }
+  }
 
   toggleSpanTree = () => {
     this.setState(state => ({
@@ -124,4 +133,4 @@ class SpanGroup extends React.Component<PropType, State> {
   }
 }
 
-export default SpanGroup;
+export default withScrollbarManager(SpanGroup);


### PR DESCRIPTION
**Dynamically apply overflow to the spanbar content so that its children doesn't affect the parent's scrollwidth:**

Children that is relatively positioned (outlined in blue) dynamically affects the parent's scrollwidth. This is addressed by apply `overflow: hidden` to the content container.

Before:

![Kapture 2020-12-09 at 17 57 43](https://user-images.githubusercontent.com/139499/101701531-14c0bb00-3a4d-11eb-8e99-b838483dcee9.gif)

After:

![Kapture 2020-12-09 at 18 05 51](https://user-images.githubusercontent.com/139499/101701537-18ecd880-3a4d-11eb-8123-2e75d398afea.gif)

-------

**Update scroll states whenever a span subtree is either hidden or revealed:**

Whenever a span subtree is either hidden or revealed, the spans within that sub-tree lose their applied DOM updates that is necessary for the horizontal scroll to be consistent.



Before:

![Kapture 2020-12-09 at 18 10 08-compressed](https://user-images.githubusercontent.com/139499/101702085-30789100-3a4e-11eb-8d2a-54ab995b4ea1.gif)


After:

![Kapture 2020-12-09 at 18 47 30](https://user-images.githubusercontent.com/139499/101702533-07a4cb80-3a4f-11eb-91ba-11c78a9d7657.gif)
