### PR TITLE
feat(vitals): Update vitals cards and landing with three states

### DIFF
--- a/docs-ui/components/colorBar.stories.js
+++ b/docs-ui/components/colorBar.stories.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {withInfo} from '@storybook/addon-info';
+
+import theme from 'app/utils/theme';
+import ColorBar from 'app/views/performance/vitalDetail/colorBar.tsx';
+
+export default {
+  title: 'Features/Vitals/ColorBar',
+};
+
+export const Default = withInfo(
+  'Split a group of percentages or ratios into separate colors. Will stretch to cover the entire bar if missing percents'
+)(() => (
+  <Container>
+    <ColorBar
+      colorStops={[
+        {
+          color: theme.green300,
+          percent: 0.6,
+        },
+        {
+          color: theme.yellow300,
+          percent: 0.3,
+        },
+        {
+          color: theme.red300,
+          percent: 0.1,
+        },
+      ]}
+    />
+  </Container>
+));
+
+Default.story = {
+  name: 'default',
+};
+
+const Container = styled('div')`
+  display: inline-block;
+  width: 300px;
+`;

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -7,7 +7,8 @@ import {decodeScalar} from 'app/utils/queryString';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
 
 import {
-  getVitalDetailTableStatusFunction,
+  getVitalDetailTableMehStatusFunction,
+  getVitalDetailTablePoorStatusFunction,
   vitalNameFromLocation,
 } from './vitalDetail/utils';
 
@@ -169,7 +170,8 @@ export function generatePerformanceVitalDetailView(
       `p50(${vitalName})`,
       `p75(${vitalName})`,
       `p95(${vitalName})`,
-      getVitalDetailTableStatusFunction(vitalName),
+      getVitalDetailTablePoorStatusFunction(vitalName),
+      getVitalDetailTableMehStatusFunction(vitalName),
     ],
     version: 2,
   };

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -233,6 +233,7 @@ class SummaryContent extends React.Component<Props, State> {
               location={location}
               totals={totalValues}
               transactionName={transactionName}
+              eventView={eventView}
             />
             <SidebarCharts organization={organization} eventView={eventView} />
             <StatusBreakdown

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -2,13 +2,16 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
+import Feature from 'app/components/acl/feature';
 import {SectionHeading} from 'app/components/charts/styles';
 import Link from 'app/components/links/link';
 import QuestionTooltip from 'app/components/questionTooltip';
 import UserMisery from 'app/components/userMisery';
+import {IconOpen} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 import {getAggregateAlias} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
@@ -20,14 +23,17 @@ import {
 } from 'app/views/performance/transactionVitals/constants';
 import {vitalsRouteWithQuery} from 'app/views/performance/transactionVitals/utils';
 
+import VitalsCards from '../vitalsCards';
+
 type Props = {
+  eventView: EventView;
   totals: Record<string, number>;
   location: Location;
   organization: Organization;
   transactionName: string;
 };
 
-function UserStats({totals, location, organization, transactionName}: Props) {
+function UserStats({eventView, totals, location, organization, transactionName}: Props) {
   let userMisery = <StatNumber>{'\u2014'}</StatNumber>;
   const threshold = organization.apdexThreshold;
   let apdex: React.ReactNode = <StatNumber>{'\u2014'}</StatNumber>;
@@ -99,24 +105,58 @@ function UserStats({totals, location, organization, transactionName}: Props) {
           </SectionValue>
         </Link>
       </div>
-      {vitalsPassRate !== null && (
-        <div>
-          <SectionHeading>
-            {t('Web Vitals')}
-            <QuestionTooltip
-              position="top"
-              title={t(
-                'Web Vitals with p75 better than the "poor" threshold, as defined by Google Web Vitals.'
-              )}
-              size="sm"
-            />
-          </SectionHeading>
-          <StatNumber>{vitalsPassRate}</StatNumber>
-          <Link to={webVitalsTarget}>
-            <SectionValue>{t('Passed')}</SectionValue>
-          </Link>
-        </div>
-      )}
+      <Feature features={['organizations:performance-vitals-overview']}>
+        {({hasFeature}) => {
+          if (hasFeature) {
+            return (
+              <VitalsContainer>
+                <VitalsHeading>
+                  <SectionHeading>
+                    {t('Web Vitals')}
+                    <QuestionTooltip
+                      position="top"
+                      title={t(
+                        'Web Vitals with p75 better than the "poor" threshold, as defined by Google Web Vitals.'
+                      )}
+                      size="sm"
+                    />
+                  </SectionHeading>
+                  <Link to={webVitalsTarget}>
+                    <IconOpen />
+                  </Link>
+                </VitalsHeading>
+                <VitalsCards
+                  eventView={eventView}
+                  organization={organization}
+                  location={location}
+                  hasCondensedVitals
+                />
+              </VitalsContainer>
+            );
+          } else {
+            return (
+              vitalsPassRate !== null && (
+                <div>
+                  <SectionHeading>
+                    {t('Web Vitals')}
+                    <QuestionTooltip
+                      position="top"
+                      title={t(
+                        'Web Vitals with p75 better than the "poor" threshold, as defined by Google Web Vitals.'
+                      )}
+                      size="sm"
+                    />
+                  </SectionHeading>
+                  <StatNumber>{vitalsPassRate}</StatNumber>
+                  <Link to={webVitalsTarget}>
+                    <SectionValue>{t('Passed')}</SectionValue>
+                  </Link>
+                </div>
+              )
+            );
+          }
+        }}
+      </Feature>
       <UserMiseryContainer>
         <SectionHeading>
           {t('User Misery')}
@@ -137,6 +177,16 @@ const Container = styled('div')`
   grid-template-columns: 1fr 1fr;
   grid-row-gap: ${space(2)};
   margin-bottom: ${space(4)};
+`;
+
+const VitalsContainer = styled('div')`
+  grid-column: 1/3;
+`;
+
+const VitalsHeading = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;
 
 const UserMiseryContainer = styled('div')`

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -4,6 +4,7 @@ import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 import throttle from 'lodash/throttle';
 
+import Feature from 'app/components/acl/feature';
 import BarChart from 'app/components/charts/barChart';
 import BarChartZoom from 'app/components/charts/barChartZoom';
 import MarkLine from 'app/components/charts/components/markLine';
@@ -299,17 +300,19 @@ class VitalCard extends React.Component<Props, State> {
         {zoomRenderProps => (
           <Container>
             <TransparentLoadingMask visible={isLoading} />
-            <PercentContainer>
-              <VitalInfo
-                eventView={eventView}
-                organization={organization}
-                location={location}
-                vitalName={vital}
-                hideDescription
-                hideBar
-                hideVitalPercentNames
-              />
-            </PercentContainer>
+            <Feature features={['organizations:performance-vitals-overview']}>
+              <PercentContainer>
+                <VitalInfo
+                  eventView={eventView}
+                  organization={organization}
+                  location={location}
+                  vitalName={vital}
+                  hideDescription
+                  hideBar
+                  hideVitalPercentNames
+                />
+              </PercentContainer>
+            </Feature>
             <BarChart
               series={allSeries}
               xAxis={xAxis}

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -639,6 +639,7 @@ const PercentContainer = styled('div')`
   position: absolute;
   top: ${space(1)};
   right: ${space(2)};
+  z-index: 2;
 `;
 
 const StyledTag = styled(Tag)`

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -17,7 +17,7 @@ import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
-import {getAggregateAlias} from 'app/utils/discover/fields';
+import {getAggregateAlias, WebVital} from 'app/utils/discover/fields';
 import {
   formatAbbreviatedNumber,
   formatFloat,
@@ -26,6 +26,14 @@ import {
 } from 'app/utils/formatters';
 import theme from 'app/utils/theme';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+
+import {
+  VitalState,
+  vitalStateColors,
+  webVitalMeh,
+  webVitalPoor,
+} from '../vitalDetail/utils';
+import VitalInfo from '../vitalDetail/vitalInfo';
 
 import {NUM_BUCKETS, PERCENTILE} from './constants';
 import {Card, CardSectionHeading, CardSummary, Description, StatNumber} from './styles';
@@ -37,7 +45,8 @@ type Props = {
   organization: Organization;
   isLoading: boolean;
   error: boolean;
-  vital: Vital;
+  vital: WebVital;
+  vitalDetails: Vital;
   summary: number | null;
   failureRate: number;
   chartData: HistogramData[];
@@ -102,9 +111,13 @@ class VitalCard extends React.Component<Props, State> {
     return {...prevState};
   }
 
+  showVitalColours() {
+    return this.props.organization.features.includes('performance-vitals-overview');
+  }
+
   trackOpenInDiscoverClicked = () => {
     const {organization} = this.props;
-    const {vital} = this.props;
+    const {vitalDetails: vital} = this.props;
 
     trackAnalyticsEvent({
       eventKey: 'performance_views.vitals.open_in_discover',
@@ -115,7 +128,7 @@ class VitalCard extends React.Component<Props, State> {
   };
 
   getFormattedStatNumber() {
-    const {summary, vital} = this.props;
+    const {summary, vitalDetails: vital} = this.props;
     const {type} = vital;
 
     return summary === null
@@ -126,7 +139,15 @@ class VitalCard extends React.Component<Props, State> {
   }
 
   renderSummary() {
-    const {summary, vital, colors, eventView, organization, min, max} = this.props;
+    const {
+      summary,
+      vitalDetails: vital,
+      colors,
+      eventView,
+      organization,
+      min,
+      max,
+    } = this.props;
     const {slug, name, description, failureThreshold} = vital;
 
     const column = `measurements.${slug}`;
@@ -162,7 +183,8 @@ class VitalCard extends React.Component<Props, State> {
         <Indicator color={colors[0]} />
         <SummaryHeading>
           <CardSectionHeading>{`${name} (${slug.toUpperCase()})`}</CardSectionHeading>
-          {summary === null ? null : summary < failureThreshold ? (
+          {summary === null || this.showVitalColours() ? null : summary <
+            failureThreshold ? (
             <Tag>{t('Pass')}</Tag>
           ) : (
             <StyledTag>{t('Fail')}</StyledTag>
@@ -212,8 +234,18 @@ class VitalCard extends React.Component<Props, State> {
   handleDataZoomCancelled = () => {};
 
   renderHistogram() {
-    const {location, isLoading, error, colors, vital, precision = 0} = this.props;
-    const {slug} = vital;
+    const {
+      location,
+      organization,
+      isLoading,
+      error,
+      colors,
+      vital,
+      vitalDetails,
+      eventView,
+      precision = 0,
+    } = this.props;
+    const {slug} = vitalDetails;
 
     const series = this.getSeries();
 
@@ -246,9 +278,11 @@ class VitalCard extends React.Component<Props, State> {
       if (baselineSeries !== null) {
         allSeries.push(baselineSeries);
       }
-      const failureSeries = this.getFailureSeries();
-      if (failureSeries !== null) {
-        allSeries.push(failureSeries);
+      if (!this.showVitalColours()) {
+        const failureSeries = this.getFailureSeries();
+        if (failureSeries !== null) {
+          allSeries.push(failureSeries);
+        }
       }
     }
 
@@ -265,6 +299,17 @@ class VitalCard extends React.Component<Props, State> {
         {zoomRenderProps => (
           <Container>
             <TransparentLoadingMask visible={isLoading} />
+            <PercentContainer>
+              <VitalInfo
+                eventView={eventView}
+                organization={organization}
+                location={location}
+                vitalName={vital}
+                hideDescription
+                hideBar
+                hideVitalPercentNames
+              />
+            </PercentContainer>
             <BarChart
               series={allSeries}
               xAxis={xAxis}
@@ -303,14 +348,14 @@ class VitalCard extends React.Component<Props, State> {
   }
 
   getSeries() {
-    const {chartData, vital} = this.props;
+    const {chartData, vitalDetails, vital} = this.props;
     const bucketWidth = this.bucketWidth();
 
     const seriesData = chartData.map(item => {
       const bucket = item.histogram;
       const midPoint = bucketWidth > 1 ? Math.ceil(bucket + bucketWidth / 2) : bucket;
       const name =
-        vital.type === 'duration'
+        vitalDetails.type === 'duration'
           ? formatDuration(midPoint)
           : // This is trying to avoid some of potential rounding errors that cause bins
             // have the same label, if the number of bins doesn't visually match what is
@@ -318,8 +363,18 @@ class VitalCard extends React.Component<Props, State> {
             // consider formatting the bin as a string in the response
             (Math.round((midPoint + Number.EPSILON) * 100) / 100).toLocaleString();
 
+      const value = item.count;
+
+      if (this.showVitalColours()) {
+        return {
+          value,
+          name,
+          itemStyle: {color: this.getVitalsColor(vital, midPoint)},
+        };
+      }
+
       return {
-        value: item.count,
+        value,
         name,
       };
     });
@@ -329,6 +384,20 @@ class VitalCard extends React.Component<Props, State> {
       data: seriesData,
     };
   }
+
+  getVitalsColor(vital: WebVital, value: number) {
+    const poorThreshold = webVitalPoor[vital];
+    const mehThreshold = webVitalMeh[vital];
+
+    if (value > poorThreshold) {
+      return vitalStateColors[VitalState.POOR];
+    } else if (value > mehThreshold) {
+      return vitalStateColors[VitalState.MEH];
+    } else {
+      return vitalStateColors[VitalState.GOOD];
+    }
+  }
+  d;
 
   getBaselineSeries() {
     const {chartData, summary} = this.props;
@@ -403,7 +472,7 @@ class VitalCard extends React.Component<Props, State> {
   }
 
   getFailureSeries() {
-    const {chartData, vital, failureRate} = this.props;
+    const {chartData, vitalDetails: vital, failureRate} = this.props;
     const {failureThreshold, type} = vital;
     if (this.state.refDataRect === null || this.state.refPixelRect === null) {
       return null;
@@ -561,6 +630,12 @@ const SummaryHeading = styled('div')`
 
 const Container = styled('div')`
   position: relative;
+`;
+
+const PercentContainer = styled('div')`
+  position: absolute;
+  top: ${space(1)};
+  right: ${space(2)};
 `;
 
 const StyledTag = styled(Tag)`

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalsPanel.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalsPanel.tsx
@@ -60,7 +60,8 @@ class VitalsPanel extends React.Component<Props> {
               location={location}
               isLoading={loading}
               error={errored}
-              vital={vitalDetails}
+              vital={vital}
+              vitalDetails={vitalDetails}
               summary={summary}
               failureRate={failureRate}
               chartData={chartData}

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/colorBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/colorBar.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+type ColorStop = {
+  percent: number;
+  color: string;
+};
+
+type Props = {
+  colorStops: ColorStop[];
+};
+
+const ColorBar = (props: Props) => {
+  return (
+    <Container fractions={props.colorStops.map(({percent}) => percent)}>
+      {props.colorStops.map(colorStop => {
+        return <Bar color={colorStop.color} key={colorStop.color} />;
+      })}
+    </Container>
+  );
+};
+
+type ContainerProps = {
+  fractions: number[];
+};
+
+const Container = styled('div')<ContainerProps>`
+  height: 16px;
+  width: 100%;
+  overflow: hidden;
+  position: relative;
+  background: ${p => p.theme.gray100};
+  display: grid;
+  grid-template-columns: ${p => p.fractions.map(f => `${f}fr`).join(' ')};
+`;
+
+type BarProps = {
+  color: string;
+};
+
+const Bar = styled('div')<BarProps>`
+  background-color: ${p => p.color};
+`;
+
+export default ColorBar;

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
@@ -96,7 +96,7 @@ class VitalChart extends React.Component<Props> {
     const vitalName = vitalNameFromLocation(location);
     const chartTitle = vitalChartTitleMap[vitalName];
 
-    const yAxis = [`p50(${vitalName})`, `p75(${vitalName})`];
+    const yAxis = [`p75(${vitalName})`];
 
     const legend = {
       right: 10,
@@ -229,7 +229,7 @@ class VitalChart extends React.Component<Props> {
               includePrevious={false}
               yAxis={yAxis}
             >
-              {({results: _results, errored, loading, reloading}) => {
+              {({timeseriesData: results, errored, loading, reloading}) => {
                 if (errored) {
                   return (
                     <ErrorPanel>
@@ -237,11 +237,6 @@ class VitalChart extends React.Component<Props> {
                     </ErrorPanel>
                   );
                 }
-
-                const singleSeries = _results?.find(
-                  r => r.seriesName === `p75(${vitalName})`
-                );
-                const results = _results ? (singleSeries ? [singleSeries] : []) : []; // TODO: Fix this multiseries hack
 
                 const colors =
                   (results && theme.charts.getColorPalette(results.length - 2)) || [];

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
@@ -138,7 +138,7 @@ class VitalChart extends React.Component<Props> {
           label: {
             show: true,
             position: 'insideEndBottom',
-            formatter: 'Poor',
+            formatter: t('Poor'),
           },
           data: [
             {
@@ -161,7 +161,7 @@ class VitalChart extends React.Component<Props> {
           label: {
             show: true,
             position: 'insideEndBottom',
-            formatter: 'Meh',
+            formatter: t('Meh'),
           },
           data: [
             {

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalInfo.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalInfo.tsx
@@ -60,8 +60,7 @@ export default function vitalInfo(props: Props) {
 const Container = styled('div')`
   display: grid;
   gap: ${space(3)};
-  padding-top: ${space(1)};
-  padding-bottom: ${space(4)};
+  margin-bottom: ${space(3)};
 `;
 
 const Description = styled('div')``;

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalInfo.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalInfo.tsx
@@ -17,13 +17,24 @@ type Props = {
   organization: Organization;
   location: Location;
   vitalName: WebVital;
+  hideBar?: boolean;
+  hideDescription?: boolean;
+  hideVitalPercentNames?: boolean;
 };
 
 export default function vitalInfo(props: Props) {
-  const {vitalName, eventView, organization, location} = props;
+  const {
+    vitalName,
+    eventView,
+    organization,
+    location,
+    hideVitalPercentNames,
+    hideDescription,
+  } = props;
   const description = vitalDescription[vitalName];
   return (
     <Container>
+      {!hideDescription && <Description>{description}</Description>}
       <VitalsCardDiscoverQuery
         eventView={eventView}
         orgSlug={organization.slug}
@@ -32,19 +43,23 @@ export default function vitalInfo(props: Props) {
       >
         {({isLoading, tableData}) => (
           <React.Fragment>
-            <VitalsCard tableData={tableData} isLoading={isLoading} {...props} noBorder />
+            <VitalsCard
+              tableData={tableData}
+              isLoading={isLoading}
+              {...props}
+              noBorder
+              showVitalPercentNames={!hideVitalPercentNames}
+            />
           </React.Fragment>
         )}
       </VitalsCardDiscoverQuery>
-      <Description>{description}</Description>
     </Container>
   );
 }
 
 const Container = styled('div')`
   display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: ${space(4)};
+  gap: ${space(3)};
   padding-top: ${space(1)};
   padding-bottom: ${space(4)};
 `;

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalPercents.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalPercents.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {IconCheckmark, IconFire, IconWarning} from 'app/icons';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {formatPercentage} from 'app/utils/formatters';
+import theme, {Color} from 'app/utils/theme';
+
+import {VitalState, vitalStateColors} from './utils';
+
+type Percent = {
+  vitalState: VitalState;
+  percent: number;
+};
+
+type Props = {
+  percents: Percent[];
+  showVitalPercentNames?: boolean;
+};
+
+export default function VitalPercents(props: Props) {
+  return (
+    <Container>
+      {props.percents.map(p => {
+        return (
+          <Vital key={p.vitalState}>
+            {p.vitalState === VitalState.POOR && (
+              <IconFire color={vitalStateColors[p.vitalState] as Color} />
+            )}
+            {p.vitalState === VitalState.MEH && (
+              <IconWarning color={vitalStateColors[p.vitalState] as Color} />
+            )}
+            {p.vitalState === VitalState.GOOD && (
+              <IconCheckmark color={vitalStateColors[p.vitalState] as Color} isCircled />
+            )}
+            <Percent>
+              {props.showVitalPercentNames && t(`${p.vitalState}`)}{' '}
+              {formatPercentage(p.percent, 0)}
+            </Percent>
+          </Vital>
+        );
+      })}
+    </Container>
+  );
+}
+
+const Container = styled('div')`
+  display: flex;
+  gap: ${space(2)};
+  margin-top: ${space(2)};
+`;
+
+const Vital = styled('div')`
+  display: flex;
+  align-items: center;
+  font-size: ${theme.fontSizeMedium};
+`;
+
+const Percent = styled('div')`
+  margin-left: ${space(0.5)};
+`;

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalPercents.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalPercents.tsx
@@ -48,7 +48,7 @@ export default function VitalPercents(props: Props) {
 const Container = styled('div')`
   display: flex;
   gap: ${space(2)};
-  margin-top: ${space(2)};
+  margin-top: ${space(1)};
 `;
 
 const Vital = styled('div')`

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalsCardsDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalsCardsDiscoverQuery.tsx
@@ -6,7 +6,12 @@ import GenericDiscoverQuery, {
 } from 'app/utils/discover/genericDiscoverQuery';
 import withApi from 'app/utils/withApi';
 
-import {vitalsBaseFields, vitalsThresholdFields} from './utils';
+import {
+  vitalsBaseFields,
+  vitalsMehFields,
+  vitalsP75Fields,
+  vitalsPoorFields,
+} from './utils';
 
 export type TableDataRow = {
   id: string;
@@ -25,9 +30,19 @@ function getRequestPayload(props: Props) {
   const {eventView, onlyVital} = props;
   const apiPayload = eventView?.getEventsAPIPayload(props.location);
   const vitalFields = onlyVital
-    ? [vitalsThresholdFields[onlyVital], vitalsBaseFields[onlyVital]]
-    : [...Object.values(vitalsThresholdFields), ...Object.values(vitalsBaseFields)];
-  apiPayload.field = ['count()', ...vitalFields];
+    ? [
+        vitalsPoorFields[onlyVital],
+        vitalsBaseFields[onlyVital],
+        vitalsMehFields[onlyVital],
+        vitalsP75Fields[onlyVital],
+      ]
+    : [
+        ...Object.values(vitalsPoorFields),
+        ...Object.values(vitalsMehFields),
+        ...Object.values(vitalsBaseFields),
+        ...Object.values(vitalsP75Fields),
+      ];
+  apiPayload.field = [...vitalFields];
   delete apiPayload.sort;
   return apiPayload;
 }

--- a/src/sentry/static/sentry/app/views/performance/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalsCards.tsx
@@ -6,6 +6,7 @@ import Card from 'app/components/card';
 import Link from 'app/components/links/link';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {t} from 'app/locale';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
@@ -357,8 +358,10 @@ const VitalLink = (props: VitalLinkProps) => {
 
 const CardTitle = styled('div')`
   font-size: ${p => p.theme.fontSizeLarge};
-  margin-bottom: ${space(0.5)};
+  margin-bottom: ${space(0.25)};
+  ${overflowEllipsis};
 `;
+
 const CardValue = styled('div')`
   font-size: 32px;
   margin-top: ${space(1)};

--- a/src/sentry/static/sentry/app/views/performance/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalsCards.tsx
@@ -77,9 +77,17 @@ export default function VitalsCards(props: Props) {
 
 const VitalsContainer = styled('div')`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  grid-template-columns: 1fr;
   gap: ${space(2)};
   margin-bottom: ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
 `;
 
 type CardProps = Props & {


### PR DESCRIPTION
### Summary
This modifies cards and passing/failing references to vitals to be good/meh/poor instead, with updated colors to match. Added colorBar as a feature component for now, with a storybook for it.

The x/y passed views is replaced with a query which aggregates all good/meh/poor counts across all the vitals to give an overview on transaction summary.

#### Todo
- Fix multiseries hack
- Double check feature flags
- Add/modify tests