### PR TITLE
feat(workflow): Group Owner suspect commit calculation improvements

### DIFF
--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -75,11 +75,9 @@ def process_suspect_commits(event, **kwargs):
                                     )
 
                     if unsorted_owners:
-                        sorted_owners = {
-                            author_id: unsorted_owners[author_id]
-                            for author_id in sorted(unsorted_owners, key=unsorted_owners.get)
-                        }
-                        for owner_id, score in sorted_owners[:PREFERRED_GROUP_OWNERS]:
+                        for owner_id in sorted(
+                            unsorted_owners, reverse=True, key=unsorted_owners.get
+                        )[:PREFERRED_GROUP_OWNERS]:
                             go, created = GroupOwner.objects.update_or_create(
                                 group_id=event.group_id,
                                 type=GroupOwnerType.SUSPECT_COMMIT.value,

--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -25,9 +25,8 @@ def process_suspect_commits(event, **kwargs):
     with metrics.timer("sentry.tasks.process_suspect_commits"):
         can_process = True
         cache_key = "workflow-owners-ingestion:group-{}".format(event.group_id)
-        owner_data = cache.get(cache_key)
 
-        if owner_data:
+        if cache.get(cache_key):
             # Only process once per OWNER_CACHE_LIFE seconds.
             metrics.incr(
                 "sentry.tasks.process_suspect_commits.skipped", tags={"detail": "too_many_owners"}
@@ -53,8 +52,7 @@ def process_suspect_commits(event, **kwargs):
                     )
                     can_process = False
 
-            owner_data = {"count": owner_count, "time": timezone.now()}
-            cache.set(cache_key, owner_data, OWNER_CACHE_LIFE)
+            cache.set(cache_key, True, OWNER_CACHE_LIFE)
 
         if can_process:
             with metrics.timer("sentry.tasks.process_suspect_commits.process_loop"):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -218,7 +218,9 @@ def post_process_group(
                     cache.set(has_commit_key, org_has_commit, 3600)
 
                 if org_has_commit and features.has(
-                    "projects:workflow-owners-ingestion", event.project
+                    "projects:workflow-owners-ingestion",
+                    organization=event.project.organization,
+                    project=event.project,
                 ):
                     process_suspect_commits(event=event)
             except Exception:

--- a/tests/sentry/tasks/test_groupowner.py
+++ b/tests/sentry/tasks/test_groupowner.py
@@ -22,7 +22,7 @@ class TestGroupOwners(TestCase):
             project=self.project, message="Kaboom!", first_release=self.release
         )
 
-        self.event_1 = self.store_event(
+        self.event = self.store_event(
             data={
                 "message": "Kaboom!",
                 "platform": "python",
@@ -69,50 +69,38 @@ class TestGroupOwners(TestCase):
 
     def test_simple(self):
         self.set_release_commits(self.user.email)
-        data = self.event_1.data
-        data["event_id"] = self.event_1.event_id
-        data["project"] = self.event_1.project_id
-
-        assert not GroupOwner.objects.filter(group=self.event_1.group).exists()
-        process_suspect_commits(self.event_1)
+        assert not GroupOwner.objects.filter(group=self.event.group).exists()
+        process_suspect_commits(self.event)
         assert GroupOwner.objects.get(
-            group=self.event_1.group,
-            project=self.event_1.project,
-            organization=self.event_1.project.organization,
+            group=self.event.group,
+            project=self.event.project,
+            organization=self.event.project.organization,
             type=GroupOwnerType.SUSPECT_COMMIT.value,
         )
 
     def test_no_matching_user(self):
         self.set_release_commits("not@real.user")
 
-        result = get_serialized_event_file_committers(self.project, self.event_1)
+        result = get_serialized_event_file_committers(self.project, self.event)
 
         assert len(result) == 1
         assert "commits" in result[0]
         assert len(result[0]["commits"]) == 1
         assert result[0]["commits"][0]["id"] == "a" * 40
-
-        data = self.event_1.data
-        data["event_id"] = self.event_1.event_id
-        data["project"] = self.event_1.project_id
-
-        assert not GroupOwner.objects.filter(group=self.event_1.group).exists()
-        process_suspect_commits(self.event_1)
-        assert not GroupOwner.objects.filter(group=self.event_1.group).exists()
+        assert not GroupOwner.objects.filter(group=self.event.group).exists()
+        process_suspect_commits(self.event)
+        assert not GroupOwner.objects.filter(group=self.event.group).exists()
 
     @patch("sentry.tasks.groupowner.OWNER_CACHE_LIFE", 0)
     def test_delete_old_entries(self):
         # As new events come in associated with new owners, we should delete old ones.
         self.set_release_commits(self.user.email)
-        data = self.event_1.data
-        data["event_id"] = self.event_1.event_id
-        data["project"] = self.event_1.project_id
-        process_suspect_commits(self.event_1)
-        process_suspect_commits(self.event_1)
-        process_suspect_commits(self.event_1)
+        process_suspect_commits(self.event)
+        process_suspect_commits(self.event)
+        process_suspect_commits(self.event)
 
-        assert GroupOwner.objects.filter(group=self.event_1.group).count() == 1
-        assert GroupOwner.objects.filter(group=self.event_1.group, user=self.user).exists()
+        assert GroupOwner.objects.filter(group=self.event.group).count() == 1
+        assert GroupOwner.objects.filter(group=self.event.group, user=self.user).exists()
         self.event_2 = self.store_event(
             data={
                 "message": "BANG!",
@@ -175,26 +163,19 @@ class TestGroupOwners(TestCase):
             ]
         )
 
-        assert self.event_2.group == self.event_1.group
-        assert self.event_3.group == self.event_1.group
-
-        data = self.event_2.data
-        data["event_id"] = self.event_2.event_id
-        data["project"] = self.event_2.project_id
+        assert self.event_2.group == self.event.group
+        assert self.event_3.group == self.event.group
 
         self.set_release_commits(self.user_2.email)
         process_suspect_commits(self.event_2)
-        assert GroupOwner.objects.filter(group=self.event_1.group).count() == 2
-        assert GroupOwner.objects.filter(group=self.event_1.group, user=self.user).exists()
+        assert GroupOwner.objects.filter(group=self.event.group).count() == 2
+        assert GroupOwner.objects.filter(group=self.event.group, user=self.user).exists()
         assert GroupOwner.objects.filter(group=self.event_2.group, user=self.user_2).exists()
 
-        data = self.event_3.data
-        data["event_id"] = self.event_3.event_id
-        data["project"] = self.event_3.project_id
         self.set_release_commits(self.user_3.email)
         process_suspect_commits(self.event_3)
-        assert GroupOwner.objects.filter(group=self.event_1.group).count() == 2
-        assert GroupOwner.objects.filter(group=self.event_1.group, user=self.user).exists()
+        assert GroupOwner.objects.filter(group=self.event.group).count() == 2
+        assert GroupOwner.objects.filter(group=self.event.group, user=self.user).exists()
         assert GroupOwner.objects.filter(group=self.event_2.group, user=self.user_2).exists()
         assert not GroupOwner.objects.filter(group=self.event_2.group, user=self.user_3).exists()
 
@@ -202,14 +183,11 @@ class TestGroupOwners(TestCase):
         go.date_added = timezone.now() - PREFERRED_GROUP_OWNER_AGE * 2
         go.save()
 
-        data = self.event_3.data
-        data["event_id"] = self.event_3.event_id
-        data["project"] = self.event_3.project_id
         self.set_release_commits(self.user_3.email)
         process_suspect_commits(self.event_3)
         # Won't be processed because the cache is present and this group has owners
-        assert GroupOwner.objects.filter(group=self.event_1.group).count() == 2
-        assert GroupOwner.objects.filter(group=self.event_1.group, user=self.user).exists()
+        assert GroupOwner.objects.filter(group=self.event.group).count() == 2
+        assert GroupOwner.objects.filter(group=self.event.group, user=self.user).exists()
         assert not GroupOwner.objects.filter(group=self.event_2.group, user=self.user_2).exists()
         assert GroupOwner.objects.filter(group=self.event_2.group, user=self.user_3).exists()
 
@@ -217,26 +195,107 @@ class TestGroupOwners(TestCase):
     def test_update_existing_entries(self):
         # As new events come in associated with existing owners, we should update the date_added of that owner.
         self.set_release_commits(self.user.email)
-        data = self.event_1.data
-        data["event_id"] = self.event_1.event_id
-        data["project"] = self.event_1.project_id
-
-        process_suspect_commits(self.event_1)
+        process_suspect_commits(self.event)
         go = GroupOwner.objects.get(
-            group=self.event_1.group,
-            project=self.event_1.project,
-            organization=self.event_1.project.organization,
+            group=self.event.group,
+            project=self.event.project,
+            organization=self.event.project.organization,
             type=GroupOwnerType.SUSPECT_COMMIT.value,
         )
 
         date_added_before_update = go.date_added
-        process_suspect_commits(self.event_1)
+        process_suspect_commits(self.event)
         go.refresh_from_db()
         assert go.date_added > date_added_before_update
-        assert GroupOwner.objects.filter(group=self.event_1.group).count() == 1
+        assert GroupOwner.objects.filter(group=self.event.group).count() == 1
         assert GroupOwner.objects.get(
-            group=self.event_1.group,
-            project=self.event_1.project,
-            organization=self.event_1.project.organization,
+            group=self.event.group,
+            project=self.event.project,
+            organization=self.event.project.organization,
             type=GroupOwnerType.SUSPECT_COMMIT.value,
         )
+
+    @patch("sentry.tasks.groupowner.OWNER_CACHE_LIFE", 0)
+    @patch("sentry.tasks.groupowner.get_event_file_committers")
+    def test_keep_highest_score(self, patched_committers):
+        self.user2 = self.create_user(email="user2@sentry.io")
+        self.user3 = self.create_user(email="user3@sentry.io")
+        patched_committers.return_value = [
+            {
+                "commits": [(None, 3)],
+                "author": {
+                    "username": self.user.email,
+                    "lastLogin": None,
+                    "isSuperuser": True,
+                    "isManaged": False,
+                    "experiments": {},
+                    "lastActive": timezone.now(),
+                    "isStaff": True,
+                    "id": self.user.id,
+                    "isActive": True,
+                    "has2fa": False,
+                    "name": self.user.email,
+                    "avatarUrl": "https://secure.gravatar.com/avatar/46d229b033af06a191ff2267bca9ae56?s=32&d=mm",
+                    "dateJoined": timezone.now(),
+                    "emails": [
+                        {"is _verified": True, "id": self.user.id, "email": self.user.email}
+                    ],
+                    "avatar": {"avatarUuid": None, "avatarType": "letter_avatar"},
+                    "hasPasswordAuth": True,
+                    "email": self.user.email,
+                },
+            },
+            {
+                "commits": [(None, 1)],
+                "author": {
+                    "username": self.user2.email,
+                    "lastLogin": None,
+                    "isSuperuser": True,
+                    "isManaged": False,
+                    "experiments": {},
+                    "lastActive": timezone.now(),
+                    "isStaff": True,
+                    "id": self.user2.id,
+                    "isActive": True,
+                    "has2fa": False,
+                    "name": self.user2.email,
+                    "avatarUrl": "https://secure.gravatar.com/avatar/46d229b033af06a191ff2267bca9ae56?s=32&d=mm",
+                    "dateJoined": timezone.now(),
+                    "emails": [
+                        {"is_verified": True, "id": self.user2.id, "email": self.user2.email}
+                    ],
+                    "avatar": {"avatarUuid": None, "avatarType": "letter_avatar"},
+                    "hasPasswordAuth": True,
+                    "email": self.user2.email,
+                },
+            },
+            {
+                "commits": [(None, 2)],
+                "author": {
+                    "username": self.user3.email,
+                    "lastLogin": None,
+                    "isSuperuser": True,
+                    "isManaged": False,
+                    "experiments": {},
+                    "lastActive": timezone.now(),
+                    "isStaff": True,
+                    "id": self.user3.id,
+                    "isActive": True,
+                    "has2fa": False,
+                    "name": self.user3.email,
+                    "avatarUrl": "https://secure.gravatar.com/avatar/46d229b033af06a191ff2267bca9ae56?s=32&d=mm",
+                    "dateJoined": timezone.now(),
+                    "emails": [
+                        {"is_verified": True, "id": self.user3.id, "email": self.user3.email}
+                    ],
+                    "avatar": {"avatarUuid": None, "avatarType": "letter_avatar"},
+                    "hasPasswordAuth": True,
+                    "email": self.user3.email,
+                },
+            },
+        ]
+        process_suspect_commits(self.event)
+        # Doesn't use self.user2 due to low score.
+        assert GroupOwner.objects.get(user=self.user.id)
+        assert GroupOwner.objects.get(user=self.user3.id)
+        assert not GroupOwner.objects.filter(user=self.user2.id).exists()


### PR DESCRIPTION
Limiting this to only run once per week and improving the logic for sorting owners.