### PR TITLE
fix(issues): GroupSerializer collapses snooze stats along with group stats

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -934,6 +934,8 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert "count" not in response.data[0]
         assert "lifetime" not in response.data[0]
         assert "filtered" not in response.data[0]
+        assert "status" not in response.data[0]
+        assert "statusDetails" not in response.data[0]
 
     def test_collapse_lifetime(self):
         event = self.store_event(

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -54,6 +54,8 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert "count" in response.data[0]
         assert "lifetime" in response.data[0]
         assert "filtered" in response.data[0]
+        assert "status" in response.data[0]
+        assert "statusDetails" in response.data[0]
 
     def test_no_matching_groups(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
Unfortunately ignored issues can break the GroupSerializer because of _get_status which relies on having user_count when checking for snoozed status (SENTRY-JZZ). Therefore when we use `collapse=stats` we should also collapse the snooze stats and resolution details.

I chose to check for the existence of stats to conditionally fetch these resolution details. Therefore when collapsing stats, `_get_status()` shouldn't be called. 