### PR TITLE
ref(modals): Improve integrationCodeMappings modal

### DIFF
--- a/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
+++ b/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
 import {t} from 'app/locale';
@@ -10,16 +9,17 @@ import {
   Repository,
   RepositoryProjectPathConfig,
 } from 'app/types';
+import {FieldFromConfig} from 'app/views/settings/components/forms';
 import Form from 'app/views/settings/components/forms/form';
-import JsonForm from 'app/views/settings/components/forms/jsonForm';
-import {JsonFormObject} from 'app/views/settings/components/forms/type';
+import {Field} from 'app/views/settings/components/forms/type';
 
 type Props = {
   organization: Organization;
   integration: Integration;
   projects: Project[];
   repos: Repository[];
-  onSubmitSuccess: Form['onSubmitSuccess'];
+  onSubmitSuccess: Form['props']['onSubmitSuccess'];
+  onCancel: Form['props']['onCancel'];
   existingConfig?: RepositoryProjectPathConfig;
 };
 
@@ -35,72 +35,70 @@ export default class RepositoryProjectPathConfigForm extends React.Component<Pro
     };
   }
 
-  get formFields(): JsonFormObject {
+  get formFields(): Field[] {
     const {projects, repos} = this.props;
     const repoChoices = repos.map(({name, id}) => ({value: id, label: name}));
-    return {
-      title: t('Create Code Path'),
-      fields: [
-        {
-          name: 'projectId',
-          type: 'sentry_project_selector',
-          required: true,
-          label: t('Project'),
-          inline: false,
-          projects,
-        },
-        {
-          name: 'repositoryId',
-          type: 'select',
-          required: true,
-          label: t('Repo'),
-          inline: false,
-          placeholder: t('Choose repo'),
-          options: repoChoices,
-          deprecatedSelectControl: false,
-        },
-        {
-          name: 'defaultBranch',
-          type: 'string',
-          required: true,
-          label: t('Branch'),
-          placeholder: t('Type your branch'),
-          inline: false,
-          showHelpInTooltip: true,
-          help: t(
-            'If an event does not have a release tied to a commit, we will use this branch when linking to your source code.'
-          ),
-        },
-        {
-          name: 'stackRoot',
-          type: 'string',
-          required: false,
-          label: t('Stack Trace Root'),
-          placeholder: t('Type root path of your stack traces'),
-          inline: false,
-          showHelpInTooltip: true,
-          help: t(
-            'Any stack trace starting with this path will be mapped with this rule. An empty string will match all paths.'
-          ),
-        },
-        {
-          name: 'sourceRoot',
-          type: 'string',
-          required: false,
-          label: t('Source Code Root'),
-          placeholder: t('Type root path of your source code'),
-          inline: false,
-          showHelpInTooltip: true,
-          help: t(
-            'When a rule matches, the stack trace root is replaced with this path to get the path in your repository. Leaving this empty means replacing the stack trace root with an empty string.'
-          ),
-        },
-      ],
-    };
+    return [
+      {
+        name: 'projectId',
+        type: 'sentry_project_selector',
+        required: true,
+        label: t('Project'),
+        projects,
+      },
+      {
+        name: 'repositoryId',
+        type: 'select',
+        required: true,
+        label: t('Repo'),
+        placeholder: t('Choose repo'),
+        options: repoChoices,
+        deprecatedSelectControl: false,
+      },
+      {
+        name: 'defaultBranch',
+        type: 'string',
+        required: true,
+        label: t('Branch'),
+        placeholder: t('Type your branch'),
+        showHelpInTooltip: true,
+        help: t(
+          'If an event does not have a release tied to a commit, we will use this branch when linking to your source code.'
+        ),
+      },
+      {
+        name: 'stackRoot',
+        type: 'string',
+        required: false,
+        label: t('Stack Trace Root'),
+        placeholder: t('Type root path of your stack traces'),
+        showHelpInTooltip: true,
+        help: t(
+          'Any stack trace starting with this path will be mapped with this rule. An empty string will match all paths.'
+        ),
+      },
+      {
+        name: 'sourceRoot',
+        type: 'string',
+        required: false,
+        label: t('Source Code Root'),
+        placeholder: t('Type root path of your source code'),
+        showHelpInTooltip: true,
+        help: t(
+          'When a rule matches, the stack trace root is replaced with this path to get the path in your repository. Leaving this empty means replacing the stack trace root with an empty string.'
+        ),
+      },
+    ];
   }
 
   render() {
-    const {organization, integration, onSubmitSuccess, existingConfig} = this.props;
+    const {
+      organization,
+      integration,
+      onSubmitSuccess,
+      onCancel,
+      existingConfig,
+    } = this.props;
 
     // endpoint changes if we are making a new row or updating an existing one
     const baseEndpoint = `/organizations/${organization.slug}/integrations/${integration.id}/repo-project-path-configs/`;
@@ -110,24 +108,23 @@ export default class RepositoryProjectPathConfigForm extends React.Component<Pro
     const apiMethod = existingConfig ? 'PUT' : 'POST';
 
     return (
-      <StyledForm
+      <Form
         onSubmitSuccess={onSubmitSuccess}
         initialData={this.initialData}
         apiEndpoint={endpoint}
         apiMethod={apiMethod}
+        onCancel={onCancel}
       >
-        <JsonForm forms={[this.formFields]} />
-      </StyledForm>
+        {this.formFields.map(field => (
+          <FieldFromConfig
+            key={field.name}
+            field={field}
+            inline={false}
+            stacked
+            flexibleControlStateSize
+          />
+        ))}
+      </Form>
     );
   }
 }
-
-const StyledForm = styled(Form)`
-  label {
-    color: ${p => p.theme.subText};
-    font-family: Rubik;
-    font-size: 12px;
-    font-weight: 500;
-    text-transform: uppercase;
-  }
-`;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import {Modal} from 'react-bootstrap';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import {openModal} from 'app/actionCreators/modal';
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
@@ -36,8 +36,6 @@ type Props = AsyncComponent['props'] & {
 type State = AsyncComponent['state'] & {
   pathConfigs: RepositoryProjectPathConfig[];
   repos: Repository[];
-  showModal: boolean;
-  configInEdit?: RepositoryProjectPathConfig;
 };
 
 class IntegrationCodeMappings extends AsyncComponent<Props, State> {
@@ -46,7 +44,6 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
       ...super.getDefaultState(),
       pathConfigs: [],
       repos: [],
-      showModal: false,
     };
   }
 
@@ -88,24 +85,6 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
     return this.projects.find(project => project.id === pathConfig.projectId);
   }
 
-  openModal = (pathConfig?: RepositoryProjectPathConfig) => {
-    this.setState({
-      showModal: true,
-      configInEdit: pathConfig,
-    });
-  };
-
-  closeModal = () => {
-    this.setState({
-      showModal: false,
-      pathConfig: undefined,
-    });
-  };
-
-  handleEdit = (pathConfig: RepositoryProjectPathConfig) => {
-    this.openModal(pathConfig);
-  };
-
   handleDelete = async (pathConfig: RepositoryProjectPathConfig) => {
     const {organization, integration} = this.props;
     const endpoint = `/organizations/${organization.slug}/integrations/${integration.id}/repo-project-path-configs/${pathConfig.id}/`;
@@ -130,13 +109,36 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
     // our getter handles the order of the configs
     pathConfigs = pathConfigs.concat([pathConfig]);
     this.setState({pathConfigs});
-    this.closeModal();
+    this.setState({pathConfig: undefined});
+  };
+
+  openModal = (pathConfig?: RepositoryProjectPathConfig) => {
+    const {organization, integration} = this.props;
+
+    openModal(({Body, Header, closeModal}) => (
+      <React.Fragment>
+        <Header closeButton>{t('Configure code path mapping')}</Header>
+        <Body>
+          <RepositoryProjectPathConfigForm
+            organization={organization}
+            integration={integration}
+            projects={this.projects}
+            repos={this.repos}
+            onSubmitSuccess={config => {
+              this.handleSubmitSuccess(config);
+              closeModal();
+            }}
+            existingConfig={pathConfig}
+            onCancel={closeModal}
+          />
+        </Body>
+      </React.Fragment>
+    ));
   };
 
   renderBody() {
-    const {organization, integration} = this.props;
-    const {showModal, configInEdit} = this.state;
     const pathConfigs = this.pathConfigs;
+    const {integration} = this.props;
 
     return (
       <React.Fragment>
@@ -193,7 +195,7 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
                       <RepositoryProjectPathConfigRow
                         pathConfig={pathConfig}
                         project={project}
-                        onEdit={this.handleEdit}
+                        onEdit={this.openModal}
                         onDelete={this.handleDelete}
                       />
                     </Layout>
@@ -203,26 +205,6 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
               .filter(item => !!item)}
           </PanelBody>
         </Panel>
-
-        <Modal
-          show={showModal}
-          onHide={this.closeModal}
-          enforceFocus={false}
-          backdrop="static"
-          animation={false}
-        >
-          <Modal.Header closeButton />
-          <Modal.Body>
-            <RepositoryProjectPathConfigForm
-              organization={organization}
-              integration={integration}
-              projects={this.projects}
-              repos={this.repos}
-              onSubmitSuccess={this.handleSubmitSuccess}
-              existingConfig={configInEdit}
-            />
-          </Modal.Body>
-        </Modal>
       </React.Fragment>
     );
   }
@@ -242,8 +224,9 @@ const Layout = styled('div')`
 `;
 
 const HeaderLayout = styled(Layout)`
-  align-items: flex-end;
-  margin: ${space(1)};
+  align-items: center;
+  margin: 0;
+  margin-left: ${space(2)};
 `;
 
 const ConfigPanelItem = styled(PanelItem)``;

--- a/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -4,6 +4,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select-new';
 
 import {Client} from 'app/api';
+import GlobalModal from 'app/components/globalModal';
 import IntegrationCodeMappings from 'app/views/organizationIntegrations/integrationCodeMappings';
 
 const mockResponse = mocks => {
@@ -75,7 +76,10 @@ describe('IntegrationCodeMappings', function () {
     ]);
 
     wrapper = mountWithTheme(
-      <IntegrationCodeMappings organization={org} integration={integration} />
+      <React.Fragment>
+        <GlobalModal />
+        <IntegrationCodeMappings organization={org} integration={integration} />
+      </React.Fragment>
     );
   });
 
@@ -88,11 +92,14 @@ describe('IntegrationCodeMappings', function () {
   it('opens modal', async () => {
     expect(wrapper.find('input[name="stackRoot"]')).toHaveLength(0);
     wrapper.find('button[aria-label="Add Mapping"]').first().simulate('click');
+
     await tick();
+    wrapper.update();
+
     expect(wrapper.find('input[name="stackRoot"]')).toHaveLength(1);
   });
 
-  it('create new config', () => {
+  it('create new config', async () => {
     const stackRoot = 'my/root';
     const sourceRoot = 'hey/dude';
     const defaultBranch = 'release';
@@ -107,6 +114,9 @@ describe('IntegrationCodeMappings', function () {
       }),
     });
     wrapper.find('button[aria-label="Add Mapping"]').first().simulate('click');
+
+    await tick();
+    wrapper.update();
 
     selectByValue(wrapper, projects[1].id, {control: true, name: 'projectId'});
     selectByValue(wrapper, repos[1].id, {name: 'repositoryId'});
@@ -136,7 +146,7 @@ describe('IntegrationCodeMappings', function () {
     );
   });
 
-  it('edit existing config', () => {
+  it('edit existing config', async () => {
     const stackRoot = 'new/root';
     const sourceRoot = 'source/root';
     const defaultBranch = 'master';
@@ -151,10 +161,15 @@ describe('IntegrationCodeMappings', function () {
       }),
     });
     wrapper.find('button[aria-label="edit"]').first().simulate('click');
+
+    await tick();
+    wrapper.update();
+
     wrapper
       .find('input[name="stackRoot"]')
       .simulate('change', {target: {value: stackRoot}});
     wrapper.find('form').simulate('submit');
+
     expect(editMock).toHaveBeenCalledWith(
       url,
       expect.objectContaining({


### PR DESCRIPTION
- Use openModal instead of maintaining 'modal is opened' state
 - Improve aesthetics of the modal
 - Improve aesthetics of the IntegrationCodeMappings panel header

Old:
![image](https://user-images.githubusercontent.com/1421724/101739459-63397e00-3a7c-11eb-9c89-a4add922bd7c.png)
![image](https://user-images.githubusercontent.com/1421724/101739467-66cd0500-3a7c-11eb-8385-39dc64a22d15.png)


New:
![image](https://user-images.githubusercontent.com/1421724/101739388-4d2bbd80-3a7c-11eb-9517-39002d6045ae.png)
![image](https://user-images.githubusercontent.com/1421724/101739397-5157db00-3a7c-11eb-89d9-4bc68e142c1f.png)

I switched out the JsonForm for individual `FieldFromConfig`s, and then set the `stacked` and `inline={false}` properties for the improved modal form style. I also added `flexibleControlStateSize` to avoid extra space on the right unless there is an error.

