### PR TITLE
fix(processing): Fix broken feature check

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -218,9 +218,7 @@ def post_process_group(
                     cache.set(has_commit_key, org_has_commit, 3600)
 
                 if org_has_commit and features.has(
-                    "projects:workflow-owners-ingestion",
-                    organization=event.project.organization,
-                    project=event.project,
+                    "projects:workflow-owners-ingestion", event.project,
                 ):
                     process_suspect_commits(event=event)
             except Exception:


### PR DESCRIPTION
This fixes a broken feature check introduced by 5c9420a1ab55d46054787d32a7d03c66de7790a2

The feature handler does not accept organization which caused the feature check to fail and with it all suspect commit code.

Fixes SENTRY-K2B