### PR TITLE
feat(releases): Link apdex in performance to Performance page

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/overview/releaseStats.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/releaseStats.tsx
@@ -6,6 +6,7 @@ import Feature from 'app/components/acl/feature';
 import {SectionHeading} from 'app/components/charts/styles';
 import Count from 'app/components/count';
 import DeployBadge from 'app/components/deployBadge';
+import GlobalSelectionLink from 'app/components/globalSelectionLink';
 import QuestionTooltip from 'app/components/questionTooltip';
 import TimeSince from 'app/components/timeSince';
 import Tooltip from 'app/components/tooltip';
@@ -103,13 +104,22 @@ function ReleaseStats({organization, release, project, location, selection}: Pro
                         return '\u2014';
                       }
                       return (
-                        <Count
-                          value={
-                            tableData.data[0][
-                              getAggregateAlias(`apdex(${organization.apdexThreshold})`)
-                            ]
-                          }
-                        />
+                        <GlobalSelectionLink
+                          to={{
+                            pathname: `/organizations/${organization.slug}/performance/`,
+                            query: {
+                              query: `release:${release?.version}`,
+                            },
+                          }}
+                        >
+                          <Count
+                            value={
+                              tableData.data[0][
+                                getAggregateAlias(`apdex(${organization.apdexThreshold})`)
+                              ]
+                            }
+                          />
+                        </GlobalSelectionLink>
                       );
                     }}
                   </DiscoverQuery>


### PR DESCRIPTION
This helps the user investigate the apdex more.

<img width="362" alt="Screen Shot 2020-12-10 at 7 16 38 AM" src="https://user-images.githubusercontent.com/155016/101771310-b977e280-3ab7-11eb-8e14-3a2c8e492473.png">

