### PR TITLE
ref(ui): Refactor releaseLanding to not use withProject

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/index.tsx
@@ -220,7 +220,7 @@ class ReleasesList extends AsyncView<Props, State> {
   }
 
   renderEmptyMessage() {
-    const {location, organization} = this.props;
+    const {location, organization, selection} = this.props;
     const {statsPeriod} = location.query;
     const searchQuery = this.getQuery();
     const activeSort = this.getSort();
@@ -266,7 +266,9 @@ class ReleasesList extends AsyncView<Props, State> {
       return <EmptyStateWarning small>{t('There are no releases.')}</EmptyStateWarning>;
     }
 
-    return <ReleaseLanding organization={organization} />;
+    return (
+      <ReleaseLanding organization={organization} projectId={selection.projects[0]} />
+    );
   }
 
   renderInnerBody(activeDisplay: DisplayOption) {

--- a/src/sentry/static/sentry/app/views/releases/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/index.tsx
@@ -13,6 +13,7 @@ import PageHeading from 'app/components/pageHeading';
 import Pagination from 'app/components/pagination';
 import SearchBar from 'app/components/searchBar';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
+import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import {t} from 'app/locale';
 import {PageContent, PageHeader} from 'app/styles/organization';
 import space from 'app/styles/space';
@@ -267,7 +268,10 @@ class ReleasesList extends AsyncView<Props, State> {
     }
 
     return (
-      <ReleaseLanding organization={organization} projectId={selection.projects[0]} />
+      <ReleaseLanding
+        organization={organization}
+        projectId={selection.projects.filter(p => p !== ALL_ACCESS_PROJECTS)[0]}
+      />
     );
   }
 

--- a/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseLanding.tsx
@@ -11,9 +11,8 @@ import FeatureTourModal, {
 } from 'app/components/modals/featureTourModal';
 import OnboardingPanel from 'app/components/onboardingPanel';
 import {t} from 'app/locale';
-import {Organization, Project} from 'app/types';
+import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import withProject from 'app/utils/withProject';
 import AsyncView from 'app/views/asyncView';
 
 import emptyStateImg from '../../../../images/spot/releases-empty-state.svg';
@@ -82,7 +81,7 @@ export const RELEASES_TOUR_STEPS: TourStep[] = [
 
 type Props = {
   organization: Organization;
-  project: Project;
+  projectId?: number;
 } & AsyncView['props'];
 
 class ReleaseLanding extends AsyncView<Props> {
@@ -99,10 +98,10 @@ class ReleaseLanding extends AsyncView<Props> {
   }
 
   renderBody() {
-    const {organization, project} = this.props;
+    const {organization, projectId} = this.props;
 
     if (this.state.releases.length === 0) {
-      return <Promo organization={organization} project={project} />;
+      return <Promo organization={organization} projectId={projectId} />;
     }
 
     return <EmptyStateWarning small>{t('There are no releases.')}</EmptyStateWarning>;
@@ -111,42 +110,42 @@ class ReleaseLanding extends AsyncView<Props> {
 
 type PromoProps = {
   organization: Organization;
-  project: Project;
+  projectId?: number;
 };
 
 class Promo extends React.Component<PromoProps> {
   componentDidMount() {
-    const {organization, project} = this.props;
+    const {organization, projectId} = this.props;
 
     trackAnalyticsEvent({
       eventKey: 'releases.landing_card_viewed',
       eventName: 'Releases: Landing Card Viewed',
       organization_id: parseInt(organization.id, 10),
-      project_id: project && parseInt(project.id, 10),
+      project_id: projectId,
     });
   }
 
   handleTourAdvance = (step: number, duration: number) => {
-    const {organization, project} = this.props;
+    const {organization, projectId} = this.props;
 
     trackAnalyticsEvent({
       eventKey: 'releases.tour.advance',
       eventName: 'Releases: Tour Advance',
       organization_id: parseInt(organization.id, 10),
-      project_id: project && parseInt(project.id, 10),
+      project_id: projectId,
       step,
       duration,
     });
   };
 
   handleClose = (step: number, duration: number) => {
-    const {organization, project} = this.props;
+    const {organization, projectId} = this.props;
 
     trackAnalyticsEvent({
       eventKey: 'releases.tour.close',
       eventName: 'Releases: Tour Close',
       organization_id: parseInt(organization.id, 10),
-      project_id: project && parseInt(project.id, 10),
+      project_id: projectId,
       step,
       duration,
     });
@@ -188,4 +187,4 @@ const ButtonList = styled(ButtonBar)`
   grid-template-columns: repeat(auto-fit, minmax(130px, max-content));
 `;
 
-export default withProject(ReleaseLanding);
+export default ReleaseLanding;


### PR DESCRIPTION
Following up on this hotfix: https://github.com/getsentry/sentry/pull/22566

I'll look into changing the types of `withProject` and all its consumers next.