### PR TITLE
fix(ui) Fix reading state before it is initialized

### DIFF
--- a/src/sentry/static/sentry/app/views/monitors/monitorStats.tsx
+++ b/src/sentry/static/sentry/app/views/monitors/monitorStats.tsx
@@ -20,23 +20,18 @@ type State = AsyncComponent['state'] & {
 type Stat = {name: string; value: number};
 
 export default class MonitorStats extends AsyncComponent<Props, State> {
-  getDefaultState() {
-    const until = Math.floor(new Date().getTime() / 1000);
-    const since = until - 3600 * 24 * 30;
-
-    return {...super.getDefaultState(), since, until};
-  }
-
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {monitor} = this.props;
+    const until = Math.floor(new Date().getTime() / 1000);
+    const since = until - 3600 * 24 * 30;
     return [
       [
         'stats',
         `/monitors/${monitor.id}/stats/`,
         {
           query: {
-            since: this.state.since,
-            until: this.state.until,
+            since,
+            until,
             resolution: '1d',
           },
         },


### PR DESCRIPTION
AsyncComponent doesn't initialize state until after data fetching has
started. We don't really need state for these values either.

Fixes JAVASCRIPT-23CG