### PR TITLE
ref(stacktrace-link): Link to docs in empty state 

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -86,9 +86,9 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
         <Body>
           <ModalContainer>
             <div>
-              <h6>{t('Quick Setup')}</h6>
+              <h6>{t('Automatic Setup')}</h6>
               {tct(
-                'Enter in your source code url that corresponds to stack trace filename [filename]. We will use this information to automatically set up your stack trace linking configuration.',
+                'Enter the source code url corresponding to stack trace filename [filename] so we can automatically set up the configuration for your stack trace linking.',
                 {
                   filename: <code>{filename}</code>,
                 }
@@ -121,11 +121,11 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
               <h6>{t('Manual Setup')}</h6>
               <Alert type="warning">
                 {t(
-                  'Recommended for more complicated configurations such as having multiple repositories for the same Sentry project.'
+                  'We recommend this for more complicated configurations, like projects with multiple repositories.'
                 )}
               </Alert>
               {t(
-                'To configure stack trace linking manually, select which of your following integrations you want to set up the mapping for:'
+                "To manually configure stack trace linking, select the integration you'd like to use for mapping:"
               )}
             </div>
             <ManualSetup>
@@ -145,7 +145,7 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
         <Footer>
           <Alert type="info" icon={<IconInfo />}>
             {tct(
-              'Stack trace linking is still in Beta. If you have feedback, please email [email:ecosystem-feedback@sentry.io].',
+              "Stack trace linking is in Beta. We'd welcome your feedback emailed to [email:ecosystem-feedback@sentry.io].",
               {email: <a href="mailto:ecosystem-feedback@sentry.io" />}
             )}
           </Alert>

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -82,13 +82,13 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
 
     return (
       <React.Fragment>
-        <Header closeButton>{t('Link Your Stack Trace To Your Source Code')}</Header>
+        <Header closeButton>{t('Link Stack Trace To Source Code')}</Header>
         <Body>
           <ModalContainer>
             <div>
               <h6>{t('Automatic Setup')}</h6>
               {tct(
-                'Enter the source code url corresponding to stack trace filename [filename] so we can automatically set up the configuration for your stack trace linking.',
+                'Enter the source code URL corresponding to stack trace filename [filename] so we can automatically set up stack trace linking for this project.',
                 {
                   filename: <code>{filename}</code>,
                 }
@@ -145,7 +145,7 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
         <Footer>
           <Alert type="info" icon={<IconInfo />}>
             {tct(
-              "Stack trace linking is in Beta. We'd welcome your feedback emailed to [email:ecosystem-feedback@sentry.io].",
+              'Stack trace linking is in Beta. Got feedback? Email [email:ecosystem-feedback@sentry.io].',
               {email: <a href="mailto:ecosystem-feedback@sentry.io" />}
             )}
           </Alert>

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -356,21 +356,22 @@ export const safeGetQsParam = (param: string) => {
   }
 };
 
-export const getIntegrationIcon = (integrationType?: string) => {
+export const getIntegrationIcon = (integrationType?: string, size?: string) => {
+  const iconSize = size || 'md';
   switch (integrationType) {
     case 'bitbucket':
-      return <IconBitbucket size="md" />;
+      return <IconBitbucket size={iconSize} />;
     case 'gitlab':
-      return <IconGitlab size="md" />;
+      return <IconGitlab size={iconSize} />;
     case 'github':
     case 'github_enterprise':
-      return <IconGithub size="md" />;
+      return <IconGithub size={iconSize} />;
     case 'jira':
     case 'jira_server':
-      return <IconJira size="md" />;
+      return <IconJira size={iconSize} />;
     case 'vsts':
-      return <IconVsts size="md" />;
+      return <IconVsts size={iconSize} />;
     default:
-      return <IconGeneric size="md" />;
+      return <IconGeneric size={iconSize} />;
   }
 };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -23,6 +23,7 @@ import {
   Organization,
   Repository,
   RepositoryProjectPathConfig,
+} from 'app/types';
 import {getIntegrationIcon} from 'app/utils/integrationUtil';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -14,8 +14,8 @@ import RepositoryProjectPathConfigRow, {
   NameRepoColumn,
   OutputPathColumn,
 } from 'app/components/repositoryProjectPathConfigRow';
-import {IconAdd, IconGithub} from 'app/icons';
-import {t} from 'app/locale';
+import {IconAdd, IconInfo} from 'app/icons';
+import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {
   Integration,
@@ -26,6 +26,7 @@ import {
 import withOrganization from 'app/utils/withOrganization';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import {getIntegrationIcon} from 'app/utils/integrationUtil';
+import Alert from 'app/components/alert';
 
 type Props = AsyncComponent['props'] & {
   integration: Integration;
@@ -139,6 +140,12 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
 
     return (
       <React.Fragment>
+        <Alert type="info" icon={<IconInfo />}>
+          {tct(
+            'Stack trace linking is still in Beta. If you have feedback, please email [email:ecosystem-feedback@sentry.io].',
+            {email: <a href="mailto:ecosystem-feedback@sentry.io" />}
+          )}
+        </Alert>
         <Panel>
           <PanelHeader disablePadding hasButtons>
             <HeaderLayout>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -4,8 +4,10 @@ import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
+import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import RepositoryProjectPathConfigForm from 'app/components/repositoryProjectPathConfigForm';
 import RepositoryProjectPathConfigRow, {
@@ -15,6 +17,7 @@ import RepositoryProjectPathConfigRow, {
   OutputPathColumn,
 } from 'app/components/repositoryProjectPathConfigRow';
 import {IconAdd, IconInfo} from 'app/icons';
+import {getIntegrationIcon} from 'app/utils/integrationUtil';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {
@@ -24,9 +27,6 @@ import {
   RepositoryProjectPathConfig,
 } from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
-import EmptyMessage from 'app/views/settings/components/emptyMessage';
-import {getIntegrationIcon} from 'app/utils/integrationUtil';
-import Alert from 'app/components/alert';
 
 type Props = AsyncComponent['props'] & {
   integration: Integration;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -142,7 +142,7 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
       <React.Fragment>
         <Alert type="info" icon={<IconInfo />}>
           {tct(
-            'Stack trace linking is still in Beta. If you have feedback, please email [email:ecosystem-feedback@sentry.io].',
+            "Stack trace linking is in Beta. We'd welcome your feedback emailed to [email:ecosystem-feedback@sentry.io].",
             {email: <a href="mailto:ecosystem-feedback@sentry.io" />}
           )}
         </Alert>
@@ -169,7 +169,7 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
                 icon={getIntegrationIcon(integration.provider.key, 'lg')}
                 action={
                   <Button
-                    href={`https://docs.sentry.io/product/integrations/${integration.provider.key}/#stacktrace-linking`}
+                    href={`https://docs.sentry.io/product/integrations/${integration.provider.key}/#stack-trace-linking`}
                     size="small"
                   >
                     View Documentation

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -25,6 +25,7 @@ import {
   RepositoryProjectPathConfig,
 } from 'app/types';
 import {getIntegrationIcon} from 'app/utils/integrationUtil';
+import withOrganization from 'app/utils/withOrganization';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
 type Props = AsyncComponent['props'] & {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -7,7 +7,6 @@ import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
-import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import RepositoryProjectPathConfigForm from 'app/components/repositoryProjectPathConfigForm';
 import RepositoryProjectPathConfigRow, {
@@ -17,7 +16,6 @@ import RepositoryProjectPathConfigRow, {
   OutputPathColumn,
 } from 'app/components/repositoryProjectPathConfigRow';
 import {IconAdd, IconInfo} from 'app/icons';
-import {getIntegrationIcon} from 'app/utils/integrationUtil';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {
@@ -25,8 +23,8 @@ import {
   Organization,
   Repository,
   RepositoryProjectPathConfig,
-} from 'app/types';
-import withOrganization from 'app/utils/withOrganization';
+import {getIntegrationIcon} from 'app/utils/integrationUtil';
+import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
 type Props = AsyncComponent['props'] & {
   integration: Integration;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -142,7 +142,7 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
       <React.Fragment>
         <Alert type="info" icon={<IconInfo />}>
           {tct(
-            "Stack trace linking is in Beta. We'd welcome your feedback emailed to [email:ecosystem-feedback@sentry.io].",
+            'Stack trace linking is in Beta. Got feedback? Email [email:ecosystem-feedback@sentry.io].',
             {email: <a href="mailto:ecosystem-feedback@sentry.io" />}
           )}
         </Alert>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -14,7 +14,7 @@ import RepositoryProjectPathConfigRow, {
   NameRepoColumn,
   OutputPathColumn,
 } from 'app/components/repositoryProjectPathConfigRow';
-import {IconAdd} from 'app/icons';
+import {IconAdd, IconGithub} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {
@@ -25,6 +25,7 @@ import {
 } from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
+import {getIntegrationIcon} from 'app/utils/integrationUtil';
 
 type Props = AsyncComponent['props'] & {
   integration: Integration;
@@ -135,6 +136,7 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
     const {organization, integration} = this.props;
     const {showModal, configInEdit} = this.state;
     const pathConfigs = this.pathConfigs;
+
     return (
       <React.Fragment>
         <Panel>
@@ -156,7 +158,19 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
           </PanelHeader>
           <PanelBody>
             {pathConfigs.length === 0 && (
-              <EmptyMessage description={t('No code path mappings')} />
+              <EmptyMessage
+                icon={getIntegrationIcon(integration.provider.key, 'lg')}
+                action={
+                  <Button
+                    href={`https://docs.sentry.io/product/integrations/${integration.provider.key}/#stacktrace-linking`}
+                    size="small"
+                  >
+                    View Documentation
+                  </Button>
+                }
+              >
+                Set up stack trace linking by adding a code mapping.
+              </EmptyMessage>
             )}
             {pathConfigs
               .map(pathConfig => {


### PR DESCRIPTION
**Context:**
Our empty state simply says "No code path mappings". Instead we want to link to the docs that will be added in https://github.com/getsentry/sentry-docs/pull/2762.

We also want to add the Beta alert messaging that we've added in for the Setup Modal (added in https://github.com/getsentry/sentry/pull/22329).

![Screen Shot 2020-12-10 at 11 58 53 AM](https://user-images.githubusercontent.com/15368179/101823079-1cc93b00-3adf-11eb-8c19-252d42acb4db.png)


**Other Changes:**
* I changed `getIntegrationIcon` to take a size as another argument, and it defaults to `'md'` which is what it was before.