### PR TITLE
fix(discover): Don't include cursor headers when unused

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -327,7 +327,11 @@ class Endpoint(APIView):
             results = cursor_result.results
 
         response = Response(results)
-        self.add_cursor_headers(request, response, cursor_result)
+
+        # Don't include cursor headers if the client won't be using them
+        if not request.GET.get("no_cursor_headers"):
+            self.add_cursor_headers(request, response, cursor_result)
+
         return response
 
 

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -109,7 +109,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
 
         with self.handle_query_errors():
             # Don't include cursor headers if the client won't be using them
-            if request.GET.get("no_pagination"):
+            if request.GET.get("noPagination"):
                 return Response(
                     self.handle_results_with_meta(
                         request,

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -108,10 +108,21 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
             )
 
         with self.handle_query_errors():
-            return self.paginate(
-                request=request,
-                paginator=GenericOffsetPaginator(data_fn=data_fn),
-                on_results=lambda results: self.handle_results_with_meta(
-                    request, organization, params["project_id"], results
-                ),
-            )
+            # Don't include cursor headers if the client won't be using them
+            if request.GET.get("no_pagination"):
+                return Response(
+                    self.handle_results_with_meta(
+                        request,
+                        organization,
+                        params["project_id"],
+                        data_fn(0, self.get_per_page(request)),
+                    )
+                )
+            else:
+                return self.paginate(
+                    request=request,
+                    paginator=GenericOffsetPaginator(data_fn=data_fn),
+                    on_results=lambda results: self.handle_results_with_meta(
+                        request, organization, params["project_id"], results
+                    ),
+                )

--- a/src/sentry/static/sentry/app/actionCreators/events.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.tsx
@@ -97,7 +97,7 @@ export type EventQuery = {
   per_page?: number;
   referrer?: string;
   environment?: string[];
-  no_pagination?: boolean;
+  noPagination?: boolean;
 };
 
 export type TagSegment = {

--- a/src/sentry/static/sentry/app/actionCreators/events.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.tsx
@@ -97,7 +97,7 @@ export type EventQuery = {
   per_page?: number;
   referrer?: string;
   environment?: string[];
-  no_cursor_headers?: boolean;
+  no_pagination?: boolean;
 };
 
 export type TagSegment = {

--- a/src/sentry/static/sentry/app/actionCreators/events.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/events.tsx
@@ -97,6 +97,7 @@ export type EventQuery = {
   per_page?: number;
   referrer?: string;
   environment?: string[];
+  no_cursor_headers?: boolean;
 };
 
 export type TagSegment = {

--- a/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
@@ -32,6 +32,10 @@ export type DiscoverQueryProps = {
    * multiple paginated results on the page.
    */
   cursor?: string;
+  /**
+   * Include this whenever pagination won't be used
+   */
+  noCursorHeaders?: boolean;
 };
 
 type RequestProps<P> = DiscoverQueryProps & P;
@@ -136,6 +140,7 @@ class GenericDiscoverQuery<T, P> extends React.Component<Props<T, P>, State<T>> 
       limit,
       cursor,
       setError,
+      noCursorHeaders,
     } = this.props;
 
     if (!eventView.isValid()) {
@@ -152,6 +157,9 @@ class GenericDiscoverQuery<T, P> extends React.Component<Props<T, P>, State<T>> 
 
     if (limit) {
       apiPayload.per_page = limit;
+    }
+    if (noCursorHeaders) {
+      apiPayload.no_cursor_headers = noCursorHeaders;
     }
     if (cursor) {
       apiPayload.cursor = cursor;

--- a/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
@@ -160,7 +160,7 @@ class GenericDiscoverQuery<T, P> extends React.Component<Props<T, P>, State<T>> 
       apiPayload.per_page = limit;
     }
     if (noPagination) {
-      apiPayload.no_pagination = noPagination;
+      apiPayload.noPagination = noPagination;
     }
     if (cursor) {
       apiPayload.cursor = cursor;

--- a/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
@@ -33,9 +33,10 @@ export type DiscoverQueryProps = {
    */
   cursor?: string;
   /**
-   * Include this whenever pagination won't be used
+   * Include this whenever pagination won't be used. Limit can still be used when this is
+   * passed, but cursor will be ignored.
    */
-  noCursorHeaders?: boolean;
+  noPagination?: boolean;
 };
 
 type RequestProps<P> = DiscoverQueryProps & P;
@@ -140,7 +141,7 @@ class GenericDiscoverQuery<T, P> extends React.Component<Props<T, P>, State<T>> 
       limit,
       cursor,
       setError,
-      noCursorHeaders,
+      noPagination,
     } = this.props;
 
     if (!eventView.isValid()) {
@@ -158,8 +159,8 @@ class GenericDiscoverQuery<T, P> extends React.Component<Props<T, P>, State<T>> 
     if (limit) {
       apiPayload.per_page = limit;
     }
-    if (noCursorHeaders) {
-      apiPayload.no_cursor_headers = noCursorHeaders;
+    if (noPagination) {
+      apiPayload.no_pagination = noPagination;
     }
     if (cursor) {
       apiPayload.cursor = cursor;

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalsPanel.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalsPanel.tsx
@@ -169,7 +169,7 @@ class VitalsPanel extends React.Component<Props> {
           orgSlug={organization.slug}
           eventView={eventView}
           limit={1}
-          noCursorHeaders
+          noPagination
         >
           {results => (
             <React.Fragment>

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalsPanel.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalsPanel.tsx
@@ -169,6 +169,7 @@ class VitalsPanel extends React.Component<Props> {
           orgSlug={organization.slug}
           eventView={eventView}
           limit={1}
+          noCursorHeaders
         >
           {results => (
             <React.Fragment>

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2965,7 +2965,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             project_id=self.project.id,
         )
 
-        query = {"field": ["id", "project.id"], "project": [self.project.id], "no_pagination": True}
+        query = {"field": ["id", "project.id"], "project": [self.project.id], "noPagination": True}
         response = self.do_request(query)
         assert response.status_code == 200
         assert len(response.data["data"]) == 1

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2958,3 +2958,15 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(data) == 1
         assert data[0]["key_transaction"] == 0
         assert data[0]["transaction"] == "/blah_transaction/"
+
+    def test_no_pagination_param(self):
+        self.store_event(
+            data={"event_id": "a" * 32, "timestamp": self.min_ago, "fingerprint": ["group1"]},
+            project_id=self.project.id,
+        )
+
+        query = {"field": ["id", "project.id"], "project": [self.project.id], "no_pagination": True}
+        response = self.do_request(query)
+        assert response.status_code == 200
+        assert len(response.data["data"]) == 1
+        assert "Link" not in response


### PR DESCRIPTION
- This is just a small optimization to reduce the header response
  because of an issue with large headers, it's goal is just to reduce
  the headers a bit, but doesn't address the main issue yet.
  - The actual solution is going to require us to add reasonable limits
    on the query length and possibly limit our number of fields more
    along with introducing special endpoints when we require more fields
    than the limit (of 20 today)