### PR TITLE
feat(metric_alerts): Disable creating metric alerts with unsupported queries

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -67,6 +67,8 @@ dataset_valid_event_types = {
     ),
     QueryDatasets.TRANSACTIONS: set([SnubaQueryEventType.EventType.TRANSACTION]),
 }
+
+# TODO(davidenwang): eventually we should pass some form of these to the event_search parser to raise an error
 unsupported_queries = {"release:latest"}
 
 

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -67,6 +67,7 @@ dataset_valid_event_types = {
     ),
     QueryDatasets.TRANSACTIONS: set([SnubaQueryEventType.EventType.TRANSACTION]),
 }
+unsupported_queries = {"release:latest"}
 
 
 class AlertRuleTriggerActionSerializer(CamelSnakeModelSerializer):
@@ -324,6 +325,15 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             "threshold_type": {"required": True},
             "resolve_threshold": {"required": False},
         }
+
+    def validate_query(self, query):
+        query_terms = query.split()
+        for query_term in query_terms:
+            if query_term in unsupported_queries:
+                raise serializers.ValidationError(
+                    "Unsupported Query: We do not currently support the {} query".format(query_term)
+                )
+        return query
 
     def validate_aggregate(self, aggregate):
         try:

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -485,6 +485,12 @@ class TestAlertRuleSerializer(TestCase):
         alert_rule = serializer.save()
         assert set(alert_rule.snuba_query.event_types) == set([SnubaQueryEventType.EventType.ERROR])
 
+    def test_unsupported_query(self):
+        self.run_fail_validation_test(
+            {"name": "Aun1qu3n4m3", "query": "release:latest1"},
+            {"query": ["Unsupported Query: We do not currently support the release:latest query"]},
+        )
+
 
 class TestAlertRuleTriggerSerializer(TestCase):
     @fixture

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -487,7 +487,7 @@ class TestAlertRuleSerializer(TestCase):
 
     def test_unsupported_query(self):
         self.run_fail_validation_test(
-            {"name": "Aun1qu3n4m3", "query": "release:latest1"},
+            {"name": "Aun1qu3n4m3", "query": "release:latest"},
             {"query": ["Unsupported Query: We do not currently support the release:latest query"]},
         )
 


### PR DESCRIPTION
Certain terms in a metric alert query don't work such as `release:latest` as that will be translated to a discrete release id and not determine the latest release every time the query is evaluated. In the future if we find additional queries like `release:latest` we can add them to the set of unsupported queries.