### PR TITLE
fix(alerts): Default to empty array when no conditions provided

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -72,7 +72,7 @@ class ProjectRuleDetailsEndpoint(ProjectEndpoint):
             data = serializer.validated_data
 
             # combine filters and conditions into one conditions criteria for the rule object
-            conditions = data["conditions"]
+            conditions = data.get("conditions", [])
             if "filters" in data:
                 conditions.extend(data["filters"])
 


### PR DESCRIPTION
When conditions are not supplied to the api endpoint, default to an empty array of conditions. 

This should usually not happen as the frontend always gives an empty array, but there is a case that if people manually call the api with no conditions such as in [SENTRY-JRT](https://sentry.io/organizations/sentry/issues/2065879707/?project=1&query=is%3Ainbox+is%3Aunresolved+is%3Aunassigned&sort=freq&statsPeriod=14d), then we will get a server error.