### PR TITLE
fix(discover): Missed two aggregates for this message

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -2119,6 +2119,7 @@ FUNCTIONS = {
             aggregate=["min", ArgValue("column"), None],
             result_type_fn=reflective_result_type(),
             default_result_type="duration",
+            redundant_grouping=True,
         ),
         Function(
             "max",
@@ -2126,6 +2127,7 @@ FUNCTIONS = {
             aggregate=["max", ArgValue("column"), None],
             result_type_fn=reflective_result_type(),
             default_result_type="duration",
+            redundant_grouping=True,
         ),
         Function(
             "avg",

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -3048,8 +3048,8 @@ class ResolveFieldListTest(unittest.TestCase):
         fields = [
             ["last_seen()", "timestamp"],
             ["avg(measurements.lcp)", "measurements.lcp"],
-            ["min(timestamp)", "measurements.lcp"],
-            ["max(timestamp)", "measurements.lcp"],
+            ["min(timestamp)", "timestamp"],
+            ["max(timestamp)", "timestamp"],
             ["p95()", "transaction.duration"],
         ]
         for field in fields:

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -3048,6 +3048,8 @@ class ResolveFieldListTest(unittest.TestCase):
         fields = [
             ["last_seen()", "timestamp"],
             ["avg(measurements.lcp)", "measurements.lcp"],
+            ["min(timestamp)", "measurements.lcp"],
+            ["max(timestamp)", "measurements.lcp"],
             ["p95()", "transaction.duration"],
         ]
         for field in fields:


### PR DESCRIPTION
- We include a message about redundant aggregation, but when that change
  was made I missed the min & max aggregates