### PR TITLE
fix(inbox): Fix `GroupSerializer` to handle new collapsed params.

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -582,6 +582,7 @@ class GroupSerializerBase(Serializer):
 @register(Group)
 class GroupSerializer(GroupSerializerBase):
     def __init__(self, environment_func=None):
+        GroupSerializerBase.__init__(self)
         self.environment_func = environment_func if environment_func is not None else lambda: None
 
     def _get_seen_stats(self, item_list, user):


### PR DESCRIPTION
Missed this in https://github.com/getsentry/sentry/pull/22612. Just need to make sure the base class
has super called so that we default some instance variables.

Fixes SENTRY-K3P