### PR TITLE
feat(security) Add script template tag to assist with CSP nonces

### DIFF
--- a/src/sentry/templates/sentry/partial/interfaces/user_email.html
+++ b/src/sentry/templates/sentry/partial/interfaces/user_email.html
@@ -36,7 +36,7 @@
           {% if user_data %}
             {% for key, value in user_data.items %}
               <tr>
-                <th>{{ key|titlize }}</th>
+                <th>{{ key|titleize }}</th>
                 <td class="code">{{ value }}</td>
               </tr>
             {% endfor %}

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -104,7 +104,7 @@ class ScriptNode(template.Node):
     def render(self, context):
         request = context.get("request")
         if hasattr(request, "csp_nonce"):
-            self.attrs.update({"nonce": request.csp_nonce})
+            self.attrs["nonce"] = request.csp_nonce
 
         content = ""
         attrs = self._render_attrs(context)

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -1,14 +1,17 @@
 from __future__ import absolute_import
 
+import six
+import re
 from django.conf import settings
-from django.template import Library
+from django import template
+from django.template.base import token_kwargs
 from django.utils.safestring import mark_safe
 
 from sentry import options
 from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri
 
-register = Library()
+register = template.Library()
 
 register.simple_tag(get_asset_url, name="asset_url")
 
@@ -56,5 +59,75 @@ def locale_js_include(context):
     if lang_code == "en" or lang_code not in settings.SUPPORTED_LANGUAGES:
         return ""
 
+    nonce = ""
+    if hasattr(request, "csp_nonce"):
+        nonce = ' nonce="{}"'.format(request.csp_nonce)
+
     href = get_asset_url("sentry", "dist/locale/" + lang_code + ".js")
-    return mark_safe('<script src="{0}"{1}></script>'.format(href, crossorigin()))
+    return mark_safe('<script src="{0}"{1}{2}></script>'.format(href, crossorigin(), nonce))
+
+
+@register.tag
+def script(parser, token):
+    """
+    A custom script tag wrapper that applies
+    CSP nonce attribute if found in the request.
+
+    In Saas sentry middleware sets the csp_nonce
+    attribute on the request and we strict CSP rules
+    to prevent XSS
+    """
+    try:
+        args = token.split_contents()
+        kwargs = token_kwargs(args[1:], parser)
+
+        nodelist = parser.parse(("endscript",))
+        parser.delete_first_token()
+
+        return ScriptNode(nodelist, **kwargs)
+    except ValueError as err:
+        raise template.TemplateSyntaxError("`script` tag failed to compile. : {}".format(err))
+
+
+class ScriptNode(template.Node):
+    def __init__(self, nodelist, **kwargs):
+        self.nodelist = nodelist
+        self.attrs = kwargs
+
+    def _get_value(self, token, context):
+        if isinstance(token, six.string_types):
+            return token
+        if isinstance(token, template.base.FilterExpression):
+            return token.resolve(context)
+        return None
+
+    def render(self, context):
+        request = context.get("request")
+        if hasattr(request, "csp_nonce"):
+            self.attrs.update({"nonce": request.csp_nonce})
+
+        content = ""
+        attrs = self._render_attrs(context)
+        if "src" not in self.attrs:
+            content = self.nodelist.render(context).strip()
+            content = self._unwrap_content(content)
+        return "<script{}>{}</script>".format(attrs, content)
+
+    def _render_attrs(self, context):
+        output = []
+        for k, v in self.attrs.items():
+            value = self._get_value(v, context)
+            if value in (True, "True"):
+                output.append(" {}".format(k))
+            elif value in (None, False, "False"):
+                continue
+            else:
+                output.append(' {}="{}"'.format(k, value))
+        output = sorted(output)
+        return "".join(output)
+
+    def _unwrap_content(self, text):
+        matches = re.search(r"<script[^\>]*>([\s\S]*?)</script>", text)
+        if matches:
+            return matches.group(1).strip()
+        return text

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -124,7 +124,7 @@ def script(parser, token):
 
         return ScriptNode(nodelist, **kwargs)
     except ValueError as err:
-        raise template.TemplateSyntaxError("`script` tag failed to compile. : %s".format(err))
+        raise template.TemplateSyntaxError("`script` tag failed to compile. : {}".format(err))
 
 
 class ScriptNode(template.Node):

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -135,10 +135,8 @@ class ScriptNode(template.Node):
     def _get_value(self, token, context):
         if isinstance(token, six.string_types):
             return token
-        if isinstance(token.var, template.Variable):
-            return token.var.resolve(context)
-        if hasattr(token, "var"):
-            return token.var
+        if isinstance(token, template.base.FilterExpression):
+            return token.resolve(context)
         return None
 
     def render(self, context):

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import functools
 import os.path
 import re
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from datetime import timedelta
 from random import randint
 
@@ -130,7 +130,7 @@ def script(parser, token):
 class ScriptNode(template.Node):
     def __init__(self, nodelist, **kwargs):
         self.nodelist = nodelist
-        self.attrs = OrderedDict()
+        self.attrs = {}
         for k, v in kwargs.items():
             self.attrs[k] = self._get_value(v)
 
@@ -162,6 +162,7 @@ class ScriptNode(template.Node):
             else:
                 value = v.strip('"')
                 output.append(' {}="{}"'.format(k, value))
+        output = sorted(output)
         return "".join(output)
 
     def _unwrap_content(self, text):

--- a/tests/sentry/templatetags/test_sentry_assets.py
+++ b/tests/sentry/templatetags/test_sentry_assets.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
+import pytest
+
+from django.test import RequestFactory
 from django.template import engines
-from sentry.utils.compat.mock import MagicMock
 
 from sentry.testutils import TestCase
 
@@ -15,25 +17,121 @@ class AssetsTest(TestCase):
     )
 
     def test_supported_foreign_lang(self):
-        result = self.TEMPLATE.render(
-            request=MagicMock(LANGUAGE_CODE="fr")  # French, in locale/catalogs.json
-        )
+        request = RequestFactory().get("/")
+        request.LANGUAGE_CODE = "fr"  # French, in locale/catalogs.json
+        result = self.TEMPLATE.render(request=request)
 
         assert '<script src="/_static/{version}/sentry/dist/locale/fr.js"></script>' in result
 
-    def test_unsupported_foreign_lang(self):
-        result = self.TEMPLATE.render(
-            request=MagicMock(LANGUAGE_CODE="ro")  # Romanian, not in locale/catalogs.json
+    def test_supported_foreign_lang_csp_nonce(self):
+        request = RequestFactory().get("/")
+        request.LANGUAGE_CODE = "fr"  # French, in locale/catalogs.json
+        request.csp_nonce = "r@nD0m"
+        result = self.TEMPLATE.render(request=request)
+
+        assert (
+            '<script src="/_static/{version}/sentry/dist/locale/fr.js" nonce="r@nD0m"></script>'
+            in result
         )
+
+    def test_unsupported_foreign_lang(self):
+        request = RequestFactory().get("/")
+        request.LANGUAGE_CODE = "ro"  # Romanian, not in locale/catalogs.json
+
+        result = self.TEMPLATE.render(request=request)
 
         assert result.strip() == ""
 
     def test_english(self):
-        result = self.TEMPLATE.render(request=MagicMock(LANGUAGE_CODE="en"))
+        request = RequestFactory().get("/")
+        request.LANGUAGE_CODE = "en"
+        result = self.TEMPLATE.render(request=request)
 
         assert result.strip() == ""
 
     def test_no_lang(self):
-        result = self.TEMPLATE.render(request=MagicMock())
+        request = RequestFactory().get("/")
+        result = self.TEMPLATE.render(request=request)
 
         assert result.strip() == ""
+
+
+@pytest.mark.parametrize(
+    "input, output",
+    (
+        # Basic nothing fancy
+        ('{% script %}alert("hi"){% endscript %}', '<script>alert("hi")</script>'),
+        # Whitespace should be stripped.
+        ('{% script %}  alert("hi")  {% endscript %}', '<script>alert("hi")</script>'),
+        # Attributes can be set.
+        ('{% script async=True %}alert("hi"){% endscript %}', '<script async>alert("hi")</script>'),
+        # Script tags can still be used for syntax highlighting
+        (
+            '{% script async=True %}<script>alert("hi")</script>{% endscript %}',
+            '<script async>alert("hi")</script>',
+        ),
+    ),
+)
+def test_script_no_context(input, output):
+    prefix = "{% load sentry_assets %}"
+    result = engines["django"].from_string(prefix + input).render(context={}).strip()
+    assert result == output
+
+
+@pytest.mark.parametrize(
+    "input, output",
+    (
+        # Basic nothing fancy
+        ('{% script %}alert("hi"){% endscript %}', '<script nonce="r@nD0m">alert("hi")</script>'),
+        # Basic with attributes
+        (
+            '{% script async=True defer=True type="text/javascript" %}alert("hi"){% endscript %}',
+            '<script async defer nonce="r@nD0m" type="text/javascript">alert("hi")</script>',
+        ),
+        # Wrap script tag used for highlighting
+        (
+            """
+        {% script async=True defer=True type="text/javascript" %}
+        <script>alert("hi")</script>
+        {% endscript %}""",
+            '<script async defer nonce="r@nD0m" type="text/javascript">alert("hi")</script>',
+        ),
+        # Content with newlines and whitespace.
+        (
+            """
+        {% script %}
+        <script>
+        alert("hi")
+        </script>
+        {% endscript %}""",
+            '<script nonce="r@nD0m">alert("hi")</script>',
+        ),
+        # src with static string
+        (
+            '{% script src="/app.js" %}{% endscript %}',
+            '<script nonce="r@nD0m" src="/app.js"></script>',
+        ),
+        # src with variable string name
+        (
+            "{% script src=url_path %}{% endscript %}",
+            '<script nonce="r@nD0m" src="/asset.js"></script>',
+        ),
+        # src with variable string name
+        (
+            "{% script src=url_path|upper %}{% endscript %}",
+            '<script nonce="r@nD0m" src="/ASSET.JS"></script>',
+        ),
+    ),
+)
+def test_script_context(input, output):
+    request = RequestFactory().get("/")
+    request.csp_nonce = "r@nD0m"
+
+    prefix = "{% load sentry_assets %}"
+    result = (
+        engines["django"]
+        .from_string(prefix + input)
+        .render(context={"request": request, "url_path": "/asset.js"})
+        .strip()
+    )
+    assert result == output

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -115,6 +115,11 @@ def test_script_no_context(input, output):
             "{% script src=url_path %}{% endscript %}",
             '<script nonce="r@nD0m" src="/asset.js"></script>',
         ),
+        # src with variable string name
+        (
+            "{% script src=url_path|upper %}{% endscript %}",
+            '<script nonce="r@nD0m" src="/ASSET.JS"></script>',
+        ),
     ),
 )
 def test_script_context(input, output):

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -105,6 +105,16 @@ def test_script_no_context(input, output):
         {% endscript %}""",
             '<script async defer nonce="r@nD0m" type="text/javascript">alert("hi")</script>',
         ),
+        # src with static string
+        (
+            '{% script src="/app.js" %}{% endscript %}',
+            '<script nonce="r@nD0m" src="/app.js"></script>',
+        ),
+        # src with variable string name
+        (
+            "{% script src=url_path %}{% endscript %}",
+            '<script nonce="r@nD0m" src="/asset.js"></script>',
+        ),
     ),
 )
 def test_script_context(input, output):
@@ -113,6 +123,9 @@ def test_script_context(input, output):
 
     prefix = "{% load sentry_helpers %}"
     result = (
-        engines["django"].from_string(prefix + input).render(context={"request": request}).strip()
+        engines["django"]
+        .from_string(prefix + input)
+        .render(context={"request": request, "url_path": "/asset.js"})
+        .strip()
     )
     assert result == output

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import pytest
-from django.test import RequestFactory
 from django.template import engines
 
 
@@ -60,77 +59,6 @@ def test_absolute_uri(input, output):
         engines["django"]
         .from_string(prefix + input)
         .render(context={"who": "matt", "desc": "awesome"})
-        .strip()
-    )
-    assert result == output
-
-
-@pytest.mark.parametrize(
-    "input, output",
-    (
-        # Basic nothing fancy
-        ('{% script %}alert("hi"){% endscript %}', '<script>alert("hi")</script>'),
-        # Whitespace should be stripped.
-        ('{% script %}  alert("hi")  {% endscript %}', '<script>alert("hi")</script>'),
-        # Attributes can be set.
-        ('{% script async=True %}alert("hi"){% endscript %}', '<script async>alert("hi")</script>'),
-        # Script tags can still be used for syntax highlighting
-        (
-            '{% script async=True %}<script>alert("hi")</script>{% endscript %}',
-            '<script async>alert("hi")</script>',
-        ),
-    ),
-)
-def test_script_no_context(input, output):
-    prefix = "{% load sentry_helpers %}"
-    result = engines["django"].from_string(prefix + input).render(context={}).strip()
-    assert result == output
-
-
-@pytest.mark.parametrize(
-    "input, output",
-    (
-        # Basic nothing fancy
-        ('{% script %}alert("hi"){% endscript %}', '<script nonce="r@nD0m">alert("hi")</script>'),
-        # Basic with attributes
-        (
-            '{% script async=True defer=True type="text/javascript" %}alert("hi"){% endscript %}',
-            '<script async defer nonce="r@nD0m" type="text/javascript">alert("hi")</script>',
-        ),
-        # Wrap script tag used for highlighting
-        (
-            """
-        {% script async=True defer=True type="text/javascript" %}
-        <script>alert("hi")</script>
-        {% endscript %}""",
-            '<script async defer nonce="r@nD0m" type="text/javascript">alert("hi")</script>',
-        ),
-        # src with static string
-        (
-            '{% script src="/app.js" %}{% endscript %}',
-            '<script nonce="r@nD0m" src="/app.js"></script>',
-        ),
-        # src with variable string name
-        (
-            "{% script src=url_path %}{% endscript %}",
-            '<script nonce="r@nD0m" src="/asset.js"></script>',
-        ),
-        # src with variable string name
-        (
-            "{% script src=url_path|upper %}{% endscript %}",
-            '<script nonce="r@nD0m" src="/ASSET.JS"></script>',
-        ),
-    ),
-)
-def test_script_context(input, output):
-    request = RequestFactory().get("/")
-    request.csp_nonce = "r@nD0m"
-
-    prefix = "{% load sentry_helpers %}"
-    result = (
-        engines["django"]
-        .from_string(prefix + input)
-        .render(context={"request": request, "url_path": "/asset.js"})
         .strip()
     )
     assert result == output

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -95,7 +95,7 @@ def test_script_no_context(input, output):
         # Basic with attributes
         (
             '{% script async=True defer=True type="text/javascript" %}alert("hi"){% endscript %}',
-            '<script async defer type="text/javascript" nonce="r@nD0m">alert("hi")</script>',
+            '<script async defer nonce="r@nD0m" type="text/javascript">alert("hi")</script>',
         ),
         # Wrap script tag used for highlighting
         (
@@ -103,7 +103,7 @@ def test_script_no_context(input, output):
         {% script async=True defer=True type="text/javascript" %}
         <script>alert("hi")</script>
         {% endscript %}""",
-            '<script async defer type="text/javascript" nonce="r@nD0m">alert("hi")</script>',
+            '<script async defer nonce="r@nD0m" type="text/javascript">alert("hi")</script>',
         ),
     ),
 )

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import pytest
+from django.test import RequestFactory
 from django.template import engines
 
 
@@ -60,5 +61,58 @@ def test_absolute_uri(input, output):
         .from_string(prefix + input)
         .render(context={"who": "matt", "desc": "awesome"})
         .strip()
+    )
+    assert result == output
+
+
+@pytest.mark.parametrize(
+    "input, output",
+    (
+        # Basic nothing fancy
+        ('{% script %}alert("hi"){% endscript %}', '<script>alert("hi")</script>'),
+        # Whitespace should be stripped.
+        ('{% script %}  alert("hi")  {% endscript %}', '<script>alert("hi")</script>'),
+        # Attributes can be set.
+        ('{% script async=True %}alert("hi"){% endscript %}', '<script async>alert("hi")</script>'),
+        # Script tags can still be used for syntax highlighting
+        (
+            '{% script async=True %}<script>alert("hi")</script>{% endscript %}',
+            '<script async>alert("hi")</script>',
+        ),
+    ),
+)
+def test_script_no_context(input, output):
+    prefix = "{% load sentry_helpers %}"
+    result = engines["django"].from_string(prefix + input).render(context={}).strip()
+    assert result == output
+
+
+@pytest.mark.parametrize(
+    "input, output",
+    (
+        # Basic nothing fancy
+        ('{% script %}alert("hi"){% endscript %}', '<script nonce="r@nD0m">alert("hi")</script>'),
+        # Basic with attributes
+        (
+            '{% script async=True defer=True type="text/javascript" %}alert("hi"){% endscript %}',
+            '<script async defer type="text/javascript" nonce="r@nD0m">alert("hi")</script>',
+        ),
+        # Wrap script tag used for highlighting
+        (
+            """
+        {% script async=True defer=True type="text/javascript" %}
+        <script>alert("hi")</script>
+        {% endscript %}""",
+            '<script async defer type="text/javascript" nonce="r@nD0m">alert("hi")</script>',
+        ),
+    ),
+)
+def test_script_context(input, output):
+    request = RequestFactory().get("/")
+    request.csp_nonce = "r@nD0m"
+
+    prefix = "{% load sentry_helpers %}"
+    result = (
+        engines["django"].from_string(prefix + input).render(context={"request": request}).strip()
     )
     assert result == output


### PR DESCRIPTION
Adopting nonces will enable us to use a more strict CSP implementation. Nonces will be generated automatically by middleware added separately by sentry saas.

I've also fixed the name of the `titleize` template tag and removed some unused ones.
