### PR TITLE
fix(py3): Use text_type for internal_warnings message sort

### DIFF
--- a/src/sentry/api/endpoints/internal_warnings.py
+++ b/src/sentry/api/endpoints/internal_warnings.py
@@ -29,7 +29,7 @@ class InternalWarningsEndpoint(Endpoint):
             else:
                 warnings.append(six.text_type(warning))
 
-        sort_by_message = functools.partial(sorted, key=six.binary_type)
+        sort_by_message = functools.partial(sorted, key=six.text_type)
 
         data = {
             "groups": sorted(


### PR DESCRIPTION
Fixes SENTRY-K3R