### PR TITLE
fix(ci): Cover pysnap files in backend filter

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -25,6 +25,7 @@ backend_lintable: &backend_lintable
 
 backend: &backend
   - *backend_lintable
+  - '**/*.pysnap'
   - 'src/sentry/!(static)/**'
   - 'requirements-*.txt'
   - 'migrations_lockfile.txt'


### PR DESCRIPTION
The backend file filter introduced in #21621 is missing python snapshot files,
which means symbolicator and relay tests don't run on snapshot updates and
suggest the job completes successfully.

Note that we may need to change this again for builds on master, where
integration tests should run **always**, and not just when the backend changes.

cc @billyvg @joshuarli 