### PR TITLE
build(fix): Include librdkafka in order to support Big Sur

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -12,6 +12,9 @@ brew 'pkgconfig'
 brew 'libxmlsec1'
 brew 'geoip'
 
+# Currently needed because on Big Sur there's no wheel for it
+brew install librdkafka
+
 # direnv isn't defined here, because we have it configured to check for a bootstrapped environment.
 # If it's installed in the early steps of the setup process, it just leads to confusion.
 # brew 'direnv'

--- a/Brewfile
+++ b/Brewfile
@@ -13,7 +13,7 @@ brew 'libxmlsec1'
 brew 'geoip'
 
 # Currently needed because on Big Sur there's no wheel for it
-brew install librdkafka
+brew 'librdkafka'
 
 # direnv isn't defined here, because we have it configured to check for a bootstrapped environment.
 # If it's installed in the early steps of the setup process, it just leads to confusion.


### PR DESCRIPTION
There's currently no wheel for confluent-kafka, thus, we need librdkafka
to build it.

This can be removed once there's a wheel for it.

Fixes #22497