### PR TITLE
feat(platformicons): update to 3.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "papaparse": "^5.2.0",
     "parseurl": "^1.3.2",
-    "platformicons": "^3.2.2",
+    "platformicons": "^3.3.0",
     "po-catalog-loader": "2.0.0",
     "prism-sentry": "^1.0.0",
     "prop-types": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11947,10 +11947,10 @@ pkg-up@2.0.0:
   dependencies:
     find-up "^2.1.0"
 
-platformicons@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-3.2.2.tgz#d244c8b76852c050032411091f5179fd8350376e"
-  integrity sha512-wAc0rFM6N22Mb24+stnQyjZaMAp3kTBzjzujs9gvnPHDwB4SWUvA+BQ9VRRcvJ7S8jBSpLASD/ZZHtRFedDNZQ==
+platformicons@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/platformicons/-/platformicons-3.3.0.tgz#36c7dc72e7fef023fa9c8d75110fc8a3fd8152bb"
+  integrity sha512-o9K2zhvas5iWkbfBkvywhlGYGVebpoTek7I8xP1gbvotMZIpltgthmtIbdsyAlvQFUxT64lsIBlsukXwYxuFJg==
   dependencies:
     "@types/node" "*"
     "@types/react" "^16 || ^17"


### PR DESCRIPTION
Linked to https://github.com/getsentry/platformicons/pull/21 and includes
- Quill
- Zepel
- Sinatra
- Scala