### PR TITLE
ref(dashboards) Add title and fix padding

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -242,8 +242,9 @@ class DashboardDetail extends React.Component<Props, State> {
               <React.Fragment>
                 <StyledPageHeader>
                   <DashboardTitle
-                    dashboard={modifiedDashboard}
+                    dashboard={modifiedDashboard || dashboard}
                     onUpdate={this.setModifiedDashboard}
+                    isEditing={dashboardState !== 'view'}
                   />
                   <Controls
                     organization={organization}

--- a/src/sentry/static/sentry/app/views/dashboardsV2/title.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/title.tsx
@@ -10,6 +10,7 @@ import {DashboardDetails} from './types';
 
 type Props = {
   dashboard: DashboardDetails | null;
+  isEditing: boolean;
   onUpdate: (dashboard: DashboardDetails) => void;
 };
 
@@ -30,12 +31,11 @@ class DashboardTitle extends React.Component<Props> {
       return;
     }
     const {dashboard, onUpdate} = this.props;
-
-    event.target.innerText = nextDashboardTitle;
-
     if (!dashboard) {
       return;
     }
+
+    event.target.innerText = nextDashboardTitle;
 
     onUpdate({
       ...dashboard,
@@ -44,10 +44,14 @@ class DashboardTitle extends React.Component<Props> {
   };
 
   render() {
-    const {dashboard} = this.props;
+    const {dashboard, isEditing} = this.props;
 
     if (!dashboard) {
       return <Container>{t('Dashboards')}</Container>;
+    }
+
+    if (!isEditing) {
+      return <Container>{dashboard.title}</Container>;
     }
 
     return (

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -272,7 +272,7 @@ const WidgetHeader = styled('div')`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: ${space(2)} ${space(3)};
+  padding: 0 ${space(1)};
 
   position: absolute;
   z-index: 2;
@@ -282,7 +282,7 @@ const StyledPanel = styled(Panel)`
   margin-bottom: 0;
   width: 100%;
   position: relative;
-  overflow: hidden;
+  padding: ${space(1)};
 `;
 
 const EditPanel = styled('div')`

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -26,6 +26,8 @@ import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 
+import {ChartContainer, HeaderTitleLegend} from '../performance/styles';
+
 import {Widget} from './types';
 import WidgetQueries from './widgetQueries';
 
@@ -108,10 +110,10 @@ class WidgetCard extends React.Component<Props, State> {
     const axisField = widget.queries[0]?.fields?.[0] ?? 'count()';
     const chartOptions = {
       grid: {
-        left: '10px',
-        right: '10px',
+        left: '0px',
+        right: '0px',
         top: '40px',
-        bottom: '0px',
+        bottom: '10px',
       },
       seriesOptions: {
         showSymbol: false,
@@ -244,9 +246,11 @@ class WidgetCard extends React.Component<Props, State> {
             }
           }}
         >
-          <WidgetHeader>{widget.title}</WidgetHeader>
-          {this.renderVisual()}
-          {this.renderEditPanel()}
+          <ChartContainer>
+            <HeaderTitleLegend>{widget.title}</HeaderTitleLegend>
+            {this.renderVisual()}
+            {this.renderEditPanel()}
+          </ChartContainer>
         </StyledPanel>
       </ErrorBoundary>
     );
@@ -268,21 +272,8 @@ const ErrorCard = styled(Placeholder)`
   margin-bottom: ${space(2)};
 `;
 
-const WidgetHeader = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0 ${space(1)};
-
-  position: absolute;
-  z-index: 2;
-`;
-
 const StyledPanel = styled(Panel)`
-  margin-bottom: 0;
-  width: 100%;
-  position: relative;
-  padding: ${space(1)};
+  margin: 0;
 `;
 
 const EditPanel = styled('div')`


### PR DESCRIPTION
Display the dashboard's title at all times, and add some padding to the widget cards as they were a bit cramped.


### Before
![Screen Shot 2020-12-14 at 12 35 19 PM](https://user-images.githubusercontent.com/24086/102116775-709f9100-3e0b-11eb-911f-add8e039a23a.png)

### After

![Screen Shot 2020-12-14 at 12 44 06 PM](https://user-images.githubusercontent.com/24086/102116788-772e0880-3e0b-11eb-961a-ec86316fc641.png)
