### PR TITLE
build(ci): Widen file filter patterns for backend tests

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -33,7 +33,7 @@ backend: &backend
   - '.github/workflows/!(js-*)'
   - 'config/**/*'
 
-plugins: &backend
+plugins:
   - *backend
   - 'src/sentry_plugins/**/*.html'
 

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -31,7 +31,6 @@ backend: &backend
   - 'migrations_lockfile.txt'
   - '.python-version'
   - '.github/workflows/!(js-*)'
-  - 'tests/!(js|apidocs)/**/*'
   - 'config/**/*'
 
 plugins: &backend

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -31,7 +31,14 @@ backend: &backend
   - 'migrations_lockfile.txt'
   - '.python-version'
   - '.github/workflows/!(js-*)'
+  - 'tests/!(js|apidocs)/**/*'
+  - 'config/**/*'
+
+plugins: &backend
+  - *backend
+  - 'src/sentry_plugins/**/*.html'
 
 api_docs:
   - *backend
   - 'api-docs/**'
+  - 'tests/apidocs/**'

--- a/.github/workflows/plugins-test.yml
+++ b/.github/workflows/plugins-test.yml
@@ -23,18 +23,18 @@ jobs:
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
-        if: steps.changes.outputs.backend == 'true'
+        if: steps.changes.outputs.plugins == 'true'
         with:
           python-version: 2.7.17
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip
         id: pip
-        if: steps.changes.outputs.backend == 'true'
+        if: steps.changes.outputs.plugins == 'true'
 
       - name: pip cache
         uses: actions/cache@v2
-        if: steps.changes.outputs.backend == 'true'
+        if: steps.changes.outputs.plugins == 'true'
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements-*.txt') }}
@@ -44,12 +44,12 @@ jobs:
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
-        if: steps.changes.outputs.backend == 'true'
+        if: steps.changes.outputs.plugins == 'true'
         with:
           snuba: true
           python: 2
 
       - name: Run test
-        if: steps.changes.outputs.backend == 'true'
+        if: steps.changes.outputs.plugins == 'true'
         run: |
           make test-plugins


### PR DESCRIPTION
This widens the file filters for our backend tests, mainly adding all of `tests/**` excluding `tests/js` and `tests/apidocs`. It also adds a new filter group called `plugins` that has an additional pattern.

This expands on https://github.com/getsentry/sentry/pull/22643

After this change these will be the remaining "unmatched" files:


```
  bin/dump-command-help,
  bin/find-good-catalogs,
  bin/lint,
  bin/load-mocks,
  bin/merge-catalogs,
  bin/mock-event,
  bin/mock-user,
  build/javascript.po,
  dist/sentry-10.0.0.dev0-py27-none-any.whl,
  dist/sentry-10.0.0.dev0.tar.gz,
  dist/sentry-10.1.0.dev0-py27-none-any.whl,
  dist/sentry-10.1.0.dev0.tar.gz,
  dist/sentry-20.9.0.dev0.tar.gz,
  dist/sentry-9.1.0.dev0.tar.gz,
  docker/builder.dockerfile,
  docker/builder.sh,
  docker/cloudbuild.yaml,
  docker/config.yml,
  docker/docker-entrypoint.sh,
  docker/Dockerfile,
  examples/oauth2_consumer_implicit/index.html,
  examples/oauth2_consumer_implicit/package.json,
  examples/oauth2_consumer_webserver/requirements.txt,
  examples/README.md,
  pip-wheel-metadata/sentry.dist-info/AUTHORS,
  pip-wheel-metadata/sentry.dist-info/entry_points.txt,
  pip-wheel-metadata/sentry.dist-info/LICENSE,
  pip-wheel-metadata/sentry.dist-info/METADATA,
  pip-wheel-metadata/sentry.dist-info/top_level.txt,
  scripts/bootstrap-py2-venv,
  scripts/bootstrap-py3-venv,
  scripts/bump-version.sh,
  scripts/ensure-venv.sh,
  src/bitfield/LICENSE,
  src/sentry_plugins/asana/README.rst,
  src/sentry_plugins/bitbucket/README.rst,
  src/sentry_plugins/github/README.rst,
  src/sentry_plugins/gitlab/README.rst,
  src/sentry_plugins/slack/README.rst,
  src/sentry_plugins/splunk/Splunk_Instructions.rst,
  src/sentry_plugins/trello/Trello_Instructions.md,
  src/sentry_plugins/twilio/Twilio_Instructions.md,
  src/sentry_plugins/vsts/LICENSE,
  src/sentry_plugins/vsts/README.rst,
  src/sentry.egg-info/dependency_links.txt,
  src/sentry.egg-info/entry_points.txt,
  src/sentry.egg-info/not-zip-safe,
  src/sentry.egg-info/PKG-INFO,
  src/sentry.egg-info/requires.txt,
  src/sentry.egg-info/SOURCES.txt,
  src/sentry.egg-info/top_level.txt,
  src/social_auth/LICENSE,
  src/social_auth/locale/de/LC_MESSAGES/django.mo,
  src/social_auth/locale/de/LC_MESSAGES/django.po,
  src/social_auth/locale/it/LC_MESSAGES/django.mo,
  src/social_auth/locale/it/LC_MESSAGES/django.po,
  src/social_auth/locale/pt_BR/LC_MESSAGES/django.mo,
  src/social_auth/locale/pt_BR/LC_MESSAGES/django.po,
  src/social_auth/locale/ru/LC_MESSAGES/django.mo,
  src/social_auth/locale/ru/LC_MESSAGES/django.po,
  src/social_auth/locale/tr/LC_MESSAGES/django.mo,
  src/social_auth/locale/tr/LC_MESSAGES/django.po,
```

Here's the script I used to generate the above (I manually removed `static/*` as thats a symlink)

```javascript
const fs = require('fs');
const assert = require('assert');
const mm = require('picomatch');
const yaml = require('js-yaml');

const Glob = require('glob').Glob;

const unmatched = new Set();

const doc = yaml.safeLoad(fs.readFileSync('./.github/file-filters.yml', 'utf8'));

const allPatterns = Object.values(doc)
  .flatMap(d => {
    if (Array.isArray(d)) {
      return d.filter(i => typeof i === 'string');
    }
  })
  .filter(Boolean);

const glob = new Glob('!(node_modules)/**/*', {nodir: true}, (err, res) => {
  if (err) {
    throw err;
  }

  res.forEach(file => {
    if (!mm.isMatch(file, allPatterns)) {
      unmatched.add(file);
    }
  });

  console.log(unmatched);
});
```