### PR TITLE
ui(perf-view): Move x axis labels to default position

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
@@ -158,9 +158,6 @@ class LatencyChart extends AsyncComponent<Props, State> {
     const xAxis = {
       type: 'category' as const,
       truncate: true,
-      axisLabel: {
-        margin: 20,
-      },
       axisTick: {
         interval: 0,
         alignWithLabel: true,

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -253,9 +253,6 @@ class VitalCard extends React.Component<Props, State> {
     const xAxis = {
       type: 'category' as const,
       truncate: true,
-      axisLabel: {
-        margin: 20,
-      },
       axisTick: {
         alignWithLabel: true,
       },


### PR DESCRIPTION
The two bar charts had a custom margin on the x axis labels making them further
away from the axis. This removes the custom margin and uses the default to be
aligned with other charts.

# Screenshots

## Vitals Histogram

### Before

![image](https://user-images.githubusercontent.com/10239353/102121541-2241c080-3e12-11eb-8be4-52952945af91.png)

### After

![image](https://user-images.githubusercontent.com/10239353/102121515-1524d180-3e12-11eb-8500-f7f1630d95f6.png)

## Duration Histogram

### Before

![image](https://user-images.githubusercontent.com/10239353/102121605-3ab1db00-3e12-11eb-9a69-1e26a15753c6.png)

### After

![image](https://user-images.githubusercontent.com/10239353/102121646-48676080-3e12-11eb-81c4-2b1e38a35d8f.png)
