### PR TITLE
build(dev): Prevent using Python 3.9 and greater

### DIFF
--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -40,6 +40,10 @@ EOF
         # If .venv is less than Python 3.6 fail
         [[ "$minor" -lt 6 ]] &&
             die "Remove $VIRTUAL_ENV and try again since the Python version installed should be at least 3.6."
+        # If .venv is created with Python 3.9 or higher you might encounter problems and we want to ask you to downgrade
+        # At the moment, Pillow does not install with Python 3.9 and requires adding more build dependencies.
+        [[ "$minor" -ge 9 ]] &&
+            die "We recommend you create this virtualenv with a Python version between 3.6 and 3.8. Remove $VIRTUAL_ENV and start again."
     fi
 else
     if [[ ! -f "${venv_name}/bin/activate" ]]; then


### PR DESCRIPTION
Currently Pillow requires being bumped to a higher version that would support Python 3.6 to Python 3.9.
Perhaps there are more issues than Pillow.

This prevents using the make targets to use a Python versions of 3.9 or greater.
The developer could still use Python 3.9 or greater by solving any build issues and avoiding the
make targets we maintain.

```
sentry on  master [$!?] via ⬢ v12.19.0 via 🐍 v3.9.1 (.venv)
❯ make install-py-dev
We recommend you create this virtualenv with a Python version between 3.6 and 3.8. Remove /Users/armenzg/code/sentry/.venv and start again.
make: *** [ensure-venv] Error 1

sentry on  master [$!?] via ⬢ v12.19.0 via 🐍 v3.9.1 (.venv)
❯ direnv allow
direnv: loading ~/code/sentry/.envrc
direnv: Configuring git...
direnv: Activating virtualenv...
direnv: Ensuring proper virtualenv...
We recommend you create this virtualenv with a Python version between 3.6 and 3.8. Remove /Users/armenzg/code/sentry/.venv and start again.
direnv wasn't able to complete execution.
You may have been given some recommendations in the error message.
Follow them, and then you'll need to redo direnv by running "direnv allow".

direnv tooling is in an ALPHA state!
If you're having trouble, or have questions, please ask in #discuss-dev-tooling
and/or reach out to @josh.
```