### PR TITLE
fix(perf-views): Adding rollup to the tp* columns

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -253,6 +253,8 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                     "event_count": "count()",
                     "epm()": "epm(%d)" % rollup,
                     "eps()": "eps(%d)" % rollup,
+                    "tpm()": "tpm(%d)" % rollup,
+                    "tps()": "tps(%d)" % rollup,
                 }
                 query_columns = [column_map.get(column, column) for column in columns]
             with sentry_sdk.start_span(op="discover.endpoint", description="base.stats_query"):

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -248,6 +248,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                 # column aliases as it straddles both versions of events/discover.
                 # We will need these aliases until discover2 flags are enabled for all
                 # users.
+                # We need these rollup columns to generate correct events-stats results
                 column_map = {
                     "user_count": "count_unique(user)",
                     "event_count": "count()",


### PR DESCRIPTION
- This fixes a bug that without this rollup, we were defaulting this
  value, resulting in inaccurate TPM in the perf views.