### PR TITLE
feat(vitals): Remove color indicator in vital cards for new views

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -181,7 +181,7 @@ class VitalCard extends React.Component<Props, State> {
 
     return (
       <CardSummary>
-        <Indicator color={colors[0]} />
+        {!this.showVitalColours() && <Indicator color={colors[0]} />}
         <SummaryHeading>
           <CardSectionHeading>{`${name} (${slug.toUpperCase()})`}</CardSectionHeading>
           {summary === null || this.showVitalColours() ? null : summary <


### PR DESCRIPTION
The colour indicator in the vital cards should only exist in the original vitals
tab. The new vitals tab should not have these indicators.

# Screenshot

## Before

![image](https://user-images.githubusercontent.com/10239353/102134291-4f976a00-3e24-11eb-8a47-731d5febf3d3.png)

## After

![image](https://user-images.githubusercontent.com/10239353/102134253-460e0200-3e24-11eb-9417-0de01d680231.png)