### PR TITLE
feat(api): Add `theme` as a user option

### DIFF
--- a/src/sentry/api/endpoints/user_details.py
+++ b/src/sentry/api/endpoints/user_details.py
@@ -53,6 +53,10 @@ class UserOptionsSerializer(serializers.Serializer):
     )
     timezone = serializers.ChoiceField(choices=TIMEZONE_CHOICES, required=False)
     clock24Hours = serializers.BooleanField(required=False)
+    theme = serializers.ChoiceField(
+        choices=(("light", _("Light")), ("dark", _("Dark")), ("system", _("Default to system")),),
+        required=False,
+    )
 
 
 class BaseUserSerializer(serializers.ModelSerializer):
@@ -131,6 +135,7 @@ class UserDetailsEndpoint(UserEndpoint):
         :param string stacktrace_order: One of -1 (default), 1 (most recent call last), 2 (most recent call first).
         :param string timezone: timezone option
         :param clock_24_hours boolean: use 24 hour clock
+        :param string theme: UI theme, either "light", "dark", or "system"
         :auth: required
         """
 
@@ -150,6 +155,7 @@ class UserDetailsEndpoint(UserEndpoint):
 
         # map API keys to keys in model
         key_map = {
+            "theme": "theme",
             "language": "language",
             "timezone": "timezone",
             "stacktraceOrder": "stacktrace_order",

--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -92,6 +92,7 @@ class UserSerializer(Serializer):
             stacktrace_order = int(options.get("stacktrace_order", -1) or -1)
 
             d["options"] = {
+                "theme": options.get("theme") or "light",
                 "language": options.get("language") or "en",
                 "stacktraceOrder": stacktrace_order,
                 "timezone": options.get("timezone") or settings.SENTRY_DEFAULT_TIME_ZONE,

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -35,6 +35,7 @@ class UserDetailsTest(APITestCase):
 
         assert resp.status_code == 200, resp.content
         assert resp.data["id"] == six.text_type(user.id)
+        assert resp.data["options"]["theme"] == "light"
         assert resp.data["options"]["timezone"] == "UTC"
         assert resp.data["options"]["language"] == "en"
         assert resp.data["options"]["stacktraceOrder"] == -1
@@ -67,6 +68,7 @@ class UserUpdateTest(APITestCase):
             data={
                 "name": "hello world",
                 "options": {
+                    "theme": "system",
                     "timezone": "UTC",
                     "stacktraceOrder": "2",
                     "language": "fr",
@@ -83,6 +85,7 @@ class UserUpdateTest(APITestCase):
         # note: email should not change, removed support for email changing from this endpoint
         assert user.email == "a@example.com"
         assert user.username == "a@example.com"
+        assert UserOption.objects.get_value(user=self.user, key="theme") == "system"
         assert UserOption.objects.get_value(user=self.user, key="timezone") == "UTC"
         assert UserOption.objects.get_value(user=self.user, key="stacktrace_order") == "2"
         assert UserOption.objects.get_value(user=self.user, key="language") == "fr"
@@ -90,8 +93,7 @@ class UserUpdateTest(APITestCase):
         assert not UserOption.objects.get_value(user=self.user, key="extra")
 
     def test_saving_changes_value(self):
-        """ Even when saving on an option directly, we should still be able to use get_value to retrieve updated options
-        """
+        """Even when saving on an option directly, we should still be able to use get_value to retrieve updated options"""
         UserOption.objects.set_value(user=self.user, key="language", value="fr")
 
         uo = UserOption.objects.get(user=self.user, key="language")


### PR DESCRIPTION
This adds a new user option named `theme` which will be used for dark mode in the future.