### PR TITLE
Adding in the styles for the modal to finish setup of the jira integration

### DIFF
--- a/src/sentry/integrations/jira/ui_hook.py
+++ b/src/sentry/integrations/jira/ui_hook.py
@@ -13,6 +13,7 @@ from sentry.utils import json
 from sentry.utils.signing import sign
 from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response
+from sentry.utils.assets import get_asset_url
 
 
 class JiraUiHookView(View):
@@ -41,4 +42,6 @@ class JiraUiHookView(View):
         finish_link = u"{}.?signed_params={}".format(
             absolute_uri("/extensions/jira/configure/"), sign(**signed_data)
         )
-        return self.get_response({"finish_link": finish_link})
+
+        image_path = absolute_uri(get_asset_url("sentry", "images/sentry-glyph-black.png"))
+        return self.get_response({"finish_link": finish_link, "image_path": image_path})

--- a/src/sentry/templates/sentry/integrations/jira-config.html
+++ b/src/sentry/templates/sentry/integrations/jira-config.html
@@ -76,8 +76,8 @@
         <img src="{{image_path}}" >
       </div>
       <h3>FINISH INSTALLATION</h3>
-      <h1>Away we go!</h1>
-      <p>In order to complete the jira sentry integration we need to configure a few settings in the sentry.io application.</p>
+      <h1>Alright, here we go.</h1>
+      <p>To complete the Jira-Sentry Integration, we'll need to configure some settings in the Sentry app.</p>
       {% if error_message %}
         {{ error_message }}
       {% elif refresh_required %}

--- a/src/sentry/templates/sentry/integrations/jira-config.html
+++ b/src/sentry/templates/sentry/integrations/jira-config.html
@@ -6,17 +6,78 @@
   <script src="//aui-cdn.atlassian.com/aui-adg/6.0.9/js/aui.min.js"></script>
   <link rel="stylesheet" href="//aui-cdn.atlassian.com/aui-adg/6.0.9/css/aui.min.css" media="all">
   <style>
-  body {
-    background: transparent;
-  }
-  .container {
-    padding: 30px;
-  }
+    :root {
+      --gray500: #C6BECF;
+      --gray800: #302839;
+      --purple400: #6C5FC7;
+      --purple500: #3E2C73;
+    }
+    #wrapper{
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 90vh;
+    }
+    body {
+      background: transparent;
+    }
+    .container {
+      padding: 30px;
+      width: 30em;
+      border: 1px var(--gray500) solid;
+      border-radius: 4px;
+    }
+    .img-container{
+      width: 100%;
+    }
+    img{
+      width: 72px;
+      margin: -10px;
+    }
+    .button{
+      background-color: var(--purple400);
+      border: 1px var(--purple500) solid;
+      border-radius: 4px;
+      padding: 12px;
+      color: white;
+      float: right;
+      font-size: 14px;
+    }
+    h1,
+    h3,
+    p{
+      margin: 0;
+      padding: 0;
+      var(--purple500);
+    }
+    h1{
+      font-size: 28px;
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+    h3{
+      font-size: 12px;
+      font-weight: 800;
+      padding: 8px 0;
+      color: var(--purple400);
+      text-transform: uppercase;
+    }
+    p{
+      font-size: 18px;
+      margin-bottom: 24px;
+    }
+
   </style>
 </head>
 <body>
-  <div class="container">
-      <h2>Finish Installation</h2>
+  <div id="wrapper">
+    <div class="container">
+      <div class="img-container">
+        <img src="{{image_path}}" >
+      </div>
+      <h3>FINISH INSTALLATION</h3>
+      <h1>Away we go!</h1>
+      <p>In order to complete the jira sentry integration we need to configure a few settings in the sentry.io application.</p>
       {% if error_message %}
         {{ error_message }}
       {% elif refresh_required %}
@@ -24,10 +85,11 @@
           <p>This page has expired, please refresh to configure your Sentry integration</p>
         </div>
       {% else %}
-        <a target="_blank" href="{{ finish_link}} " class="aui-button-primary aui-button">
-          Click to Finish Installation
+        <a target="_blank" href="{{ finish_link }}" class="button">
+          Finish Installation in Sentry
         </a>
       {% endif %}
+  </div>
   </div>
 </body>
 </html>

--- a/tests/sentry/integrations/jira/test_ui_hook.py
+++ b/tests/sentry/integrations/jira/test_ui_hook.py
@@ -11,7 +11,7 @@ from sentry.utils.http import absolute_uri
 
 UNABLE_TO_VERIFY_INSTALLATION = b"Unable to verify installation"
 REFRESH_REQUIRED = b"This page has expired, please refresh to configure your Sentry integration"
-CLICK_TO_FINISH = b"Click to Finish Installation"
+CLICK_TO_FINISH = b"Finish Installation in Sentry"
 
 
 class JiraUiHookViewTestCase(APITestCase):


### PR DESCRIPTION
**Preview of the modal:**
Pretty basic and we have to use styles inline for this so I kept it pretty basic.
<img width="733" alt="jira-modal" src="https://user-images.githubusercontent.com/4982985/102135610-d85ed780-3e1d-11eb-9932-ac11743ce291.png">

Would love a review of where the button in this modal goes since i t wasn't possible for me to test this. Currently, it is set too `href="{{ finish_link }}"`