### PR TITLE
feat(discover): Expand failure_count() into transaction.status

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -169,6 +169,7 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
 
 const ALIASED_AGGREGATES_COLUMN = {
   last_seen: 'timestamp',
+  failure_count: 'transaction.status',
 };
 
 /**

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -298,6 +298,7 @@ describe('getExpandedResults()', function () {
         {field: 'unique_count(id)'},
         {field: 'apdex(300)'}, // should be dropped
         {field: 'user_misery(300)'}, // should be dropped
+        {field: 'failure_count()'}, // expect this to be transformed to transaction.status
       ],
     });
 
@@ -307,6 +308,7 @@ describe('getExpandedResults()', function () {
       {field: 'title'},
       {field: 'transaction.duration', width: -1},
       {field: 'custom_tag'},
+      {field: 'transaction.status', width: -1},
     ]);
 
     // transforms pXX functions with optional arguments properly


### PR DESCRIPTION
When drilling down with a `failure_count()` column, it should be expanded into
`transaction.status` for a cohesive workflow.

Closes VIS-421