### PR TITLE
ui(perf): Swap position of throughput and failure rate charts

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
@@ -99,23 +99,23 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
         ...axisLineConfig,
       },
       {
-        // throughput
-        gridIndex: 1,
-        splitNumber: 4,
-        axisLabel: {
-          formatter: formatAbbreviatedNumber,
-          color: theme.chartLabel,
-        },
-        ...axisLineConfig,
-      },
-      {
         // failure rate
-        gridIndex: 2,
+        gridIndex: 1,
         splitNumber: 4,
         interval: 0.5,
         max: 1.0,
         axisLabel: {
           formatter: (value: number) => formatPercentage(value, 0),
+          color: theme.chartLabel,
+        },
+        ...axisLineConfig,
+      },
+      {
+        // throughput
+        gridIndex: 2,
+        splitNumber: 4,
+        axisLabel: {
+          formatter: formatAbbreviatedNumber,
           color: theme.chartLabel,
         },
         ...axisLineConfig,
@@ -154,20 +154,20 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
         />
       </ChartTitle>
 
-      <ChartTitle top="190px" key="throughput">
-        {t('TPM')}
-        <QuestionTooltip
-          position="top"
-          title={getTermHelp(organization, 'tpm')}
-          size="sm"
-        />
-      </ChartTitle>
-
-      <ChartTitle top="410px" key="failure-rate">
+      <ChartTitle top="190px" key="failure-rate">
         {t('Failure Rate')}
         <QuestionTooltip
           position="top"
           title={getTermHelp(organization, 'failureRate')}
+          size="sm"
+        />
+      </ChartTitle>
+
+      <ChartTitle top="410px" key="throughput">
+        {t('TPM')}
+        <QuestionTooltip
+          position="top"
+          title={getTermHelp(organization, 'tpm')}
           size="sm"
         />
       </ChartTitle>
@@ -192,7 +192,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
             showLoading={false}
             query={eventView.query}
             includePrevious={false}
-            yAxis={[`apdex(${organization.apdexThreshold})`, 'epm()', 'failure_rate()']}
+            yAxis={[`apdex(${organization.apdexThreshold})`, 'failure_rate()', 'epm()']}
           >
             {({results, errored, loading, reloading}) => {
               if (errored) {


### PR DESCRIPTION
Failure rate is more important than throughput, so bring the failure rate chart
above the throughput chart.

Closes VIS-426