### PR TITLE
feat(ui): Add user preference for dark mode

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/account.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/account.tsx
@@ -17,6 +17,17 @@ export async function disconnectIdentity(identity: Identity) {
 }
 
 export function updateUser(user: User) {
+  const previousUser = ConfigStore.get('user');
+
+  // If the user changed their theme preferences, we should also update
+  // the config store
+  if (
+    previousUser.options.theme !== user.options.theme &&
+    user.options.theme !== 'system'
+  ) {
+    ConfigStore.set('theme', user.options.theme);
+  }
+
   // Ideally we'd fire an action but this is gonna get refactored soon anyway
   ConfigStore.set('user', user);
 }

--- a/src/sentry/static/sentry/app/data/forms/accountPreferences.tsx
+++ b/src/sentry/static/sentry/app/data/forms/accountPreferences.tsx
@@ -16,6 +16,21 @@ const formGroups: JsonFormObject[] = [
     title: 'Preferences',
     fields: [
       {
+        name: 'theme',
+        type: 'choice',
+        label: t('Theme'),
+        visible: ({user}) => user.isStaff,
+        help: t(
+          "Select your theme preference. It can be synced to your system's theme, always Light mode, or always Dark mode."
+        ),
+        choices: [
+          ['light', t('Light')],
+          ['dark', t('Dark')],
+          ['system', t('Default to system')],
+        ],
+        getData: transformOptions,
+      },
+      {
         name: 'stacktraceOrder',
         type: 'choice',
         required: false,

--- a/src/sentry/static/sentry/app/stores/configStore.tsx
+++ b/src/sentry/static/sentry/app/stores/configStore.tsx
@@ -4,7 +4,6 @@ import Reflux from 'reflux';
 
 import {setLocale} from 'app/locale';
 import {Config} from 'app/types';
-import {prefersDark} from 'app/utils/matchMedia';
 
 type ConfigStoreInterface = {
   config: Config;
@@ -42,14 +41,7 @@ const configStoreConfig: Reflux.StoreDefinition & ConfigStoreInterface = {
    * the auto switching of color schemes without affecting manual toggle
    */
   updateTheme(theme) {
-    // TODO(dark): Dark mode is currently staff only
-    if (!this.config.user?.isStaff) {
-      return;
-    }
-
-    // TODO(dark): Add this as a user preference
-    // @ts-ignore
-    if (!this.config.user?.options.enableDarkMode) {
+    if (this.config.user?.options.theme !== 'system') {
       return;
     }
 
@@ -64,7 +56,7 @@ const configStoreConfig: Reflux.StoreDefinition & ConfigStoreInterface = {
     // TODO(dark): Remove staff requirement and add dark mode user preference
     const shouldUseDarkMode =
       // @ts-ignore
-      config.user?.isStaff && config.user?.options.enableDarkMode && prefersDark();
+      config.user?.isStaff && config.user?.options.theme === 'dark';
 
     this.config = {
       ...config,

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -562,6 +562,7 @@ export type User = Omit<AvatarUser, 'options'> & {
   authenticators: UserEnrolledAuthenticator[];
   dateJoined: string;
   options: {
+    theme: 'system' | 'light' | 'dark';
     timezone: string;
     stacktraceOrder: number;
     language: string;

--- a/src/sentry/static/sentry/app/utils/matchMedia.tsx
+++ b/src/sentry/static/sentry/app/utils/matchMedia.tsx
@@ -23,7 +23,7 @@ function handleColorSchemeChange(e: MediaQueryListEvent): void {
   ConfigStore.updateTheme(type);
 }
 
-export function prefersDark(): boolean {
+function prefersDark(): boolean {
   return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
 

--- a/src/sentry/static/sentry/app/views/settings/account/accountDetails.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountDetails.tsx
@@ -40,23 +40,20 @@ class AccountDetails extends AsyncView {
       apiMethod: 'PUT' as APIRequestMethod,
       allowUndo: true,
       saveOnBlur: true,
+      onSubmitSuccess: this.handleSubmitSuccess,
     };
 
     return (
       <div>
         <SettingsPageHeader title={t('Account Details')} />
-        <Form
-          initialData={user}
-          {...formCommonProps}
-          onSubmitSuccess={this.handleSubmitSuccess}
-        >
+        <Form initialData={user} {...formCommonProps}>
           <JsonForm
             location={location}
             forms={accountDetailsFields}
             additionalFieldProps={{user}}
           />
         </Form>
-        <Form initialData={user.options} {...formCommonProps} allowUndo>
+        <Form initialData={user.options} {...formCommonProps}>
           <JsonForm
             location={location}
             forms={accountPreferencesFields}

--- a/src/sentry/static/sentry/app/views/settings/account/accountDetails.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountDetails.tsx
@@ -57,7 +57,11 @@ class AccountDetails extends AsyncView {
           />
         </Form>
         <Form initialData={user.options} {...formCommonProps} allowUndo>
-          <JsonForm location={location} forms={accountPreferencesFields} />
+          <JsonForm
+            location={location}
+            forms={accountPreferencesFields}
+            additionalFieldProps={{user}}
+          />
         </Form>
         <AvatarChooser
           endpoint="/users/me/avatar/"

--- a/tests/js/spec/views/accountDetail.spec.jsx
+++ b/tests/js/spec/views/accountDetail.spec.jsx
@@ -31,7 +31,7 @@ describe('AccountDetails', function () {
     expect(wrapper.find('input[name="name"]')).toHaveLength(1);
 
     // Stacktrace order, language, timezone
-    expect(wrapper.find('SelectControl')).toHaveLength(3);
+    expect(wrapper.find('SelectControl')).toHaveLength(4);
 
     expect(wrapper.find('BooleanField')).toHaveLength(1);
     expect(wrapper.find('RadioGroup')).toHaveLength(1);

--- a/tests/js/spec/views/accountDetail.spec.jsx
+++ b/tests/js/spec/views/accountDetail.spec.jsx
@@ -30,7 +30,7 @@ describe('AccountDetails', function () {
 
     expect(wrapper.find('input[name="name"]')).toHaveLength(1);
 
-    // Stacktrace order, language, timezone
+    // Stacktrace order, language, timezone, theme
     expect(wrapper.find('SelectControl')).toHaveLength(4);
 
     expect(wrapper.find('BooleanField')).toHaveLength(1);


### PR DESCRIPTION
This allows staff to set their user preference for dark mode. The available options are: 1) sync w/ system settings, 2) always light, or 3) always dark.

The user preference is currently gated to staff only.

Requires https://github.com/getsentry/sentry/pull/22665