### PR TITLE
feat(workflow): Create alert from event.type error/default

### DIFF
--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -73,7 +73,7 @@ function IncompatibleQueryAlert({
   const eventTypeDefault = eventView.clone();
   eventTypeDefault.query += ' event.type:default';
   const eventTypeErrorDefault = eventView.clone();
-  eventTypeErrorDefault.query += ' event.type:error or event.type:transaction';
+  eventTypeErrorDefault.query += ' event.type:error or event.type:default';
   const pathname = `/organizations/${orgId}/discover/results/`;
 
   const eventTypeLinks = {

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -12,7 +12,7 @@ import {t, tct} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {Aggregation, AGGREGATIONS, explodeFieldString} from 'app/utils/discover/fields';
-import {getQuerySource} from 'app/views/alerts/utils';
+import {getQueryDatasource} from 'app/views/alerts/utils';
 import {
   errorFieldConfig,
   transactionFieldConfig,
@@ -253,7 +253,7 @@ function CreateAlertFromViewButton({
   // Must have one or zero environments
   const hasEnvironmentError = eventView.environment.length > 1;
   // Must have event.type of error or transaction
-  const hasEventTypeError = getQuerySource(eventView.query) === null;
+  const hasEventTypeError = getQueryDatasource(eventView.query) === null;
   // yAxis must be a function and enabled on alerts
   const hasYAxisError = incompatibleYAxis(eventView);
   const errors: IncompatibleQueryProperties = {

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -12,6 +12,7 @@ import {t, tct} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {Aggregation, AGGREGATIONS, explodeFieldString} from 'app/utils/discover/fields';
+import {getQuerySource} from 'app/views/alerts/utils';
 import {
   errorFieldConfig,
   transactionFieldConfig,
@@ -69,7 +70,46 @@ function IncompatibleQueryAlert({
   eventTypeError.query += ' event.type:error';
   const eventTypeTransaction = eventView.clone();
   eventTypeTransaction.query += ' event.type:transaction';
+  const eventTypeDefault = eventView.clone();
+  eventTypeDefault.query += ' event.type:default';
+  const eventTypeErrorDefault = eventView.clone();
+  eventTypeErrorDefault.query += ' event.type:error or event.type:transaction';
   const pathname = `/organizations/${orgId}/discover/results/`;
+
+  const eventTypeLinks = {
+    error: (
+      <Link
+        to={{
+          pathname,
+          query: eventTypeError.generateQueryStringObject(),
+        }}
+      />
+    ),
+    default: (
+      <Link
+        to={{
+          pathname,
+          query: eventTypeError.generateQueryStringObject(),
+        }}
+      />
+    ),
+    transaction: (
+      <Link
+        to={{
+          pathname,
+          query: eventTypeDefault.generateQueryStringObject(),
+        }}
+      />
+    ),
+    errorDefault: (
+      <Link
+        to={{
+          pathname,
+          query: eventTypeErrorDefault.generateQueryStringObject(),
+        }}
+      />
+    ),
+  };
 
   return (
     <StyledAlert type="warning" icon={<IconInfo color="yellow300" size="sm" />}>
@@ -83,25 +123,8 @@ function IncompatibleQueryAlert({
             )}
           {hasEventTypeError &&
             tct(
-              'An alert needs a filter of [error:event.type:error] or [transaction:event.type:transaction]. Use one of these and try again.',
-              {
-                error: (
-                  <Link
-                    to={{
-                      pathname,
-                      query: eventTypeError.generateQueryStringObject(),
-                    }}
-                  />
-                ),
-                transaction: (
-                  <Link
-                    to={{
-                      pathname,
-                      query: eventTypeTransaction.generateQueryStringObject(),
-                    }}
-                  />
-                ),
-              }
+              'An alert needs a filter of [error:event.type:error], [default:event.type:default], [transaction:event.type:transaction], [errorDefault:(event.type:error OR event.type:default)]. Use one of these and try again.',
+              eventTypeLinks
             )}
           {hasYAxisError &&
             tct(
@@ -123,25 +146,8 @@ function IncompatibleQueryAlert({
             {hasEventTypeError && (
               <li>
                 {tct(
-                  'Use the filter [error:event.type:error] or [transaction:event.type:transaction].',
-                  {
-                    error: (
-                      <Link
-                        to={{
-                          pathname,
-                          query: eventTypeError.generateQueryStringObject(),
-                        }}
-                      />
-                    ),
-                    transaction: (
-                      <Link
-                        to={{
-                          pathname,
-                          query: eventTypeTransaction.generateQueryStringObject(),
-                        }}
-                      />
-                    ),
-                  }
+                  'Use the filter [error:event.type:error], [default:event.type:default], [transaction:event.type:transaction], [errorDefault:(event.type:error OR event.type:default)].',
+                  eventTypeLinks
                 )}
               </li>
             )}
@@ -247,9 +253,7 @@ function CreateAlertFromViewButton({
   // Must have one or zero environments
   const hasEnvironmentError = eventView.environment.length > 1;
   // Must have event.type of error or transaction
-  const hasEventTypeError =
-    !eventView.query.includes('event.type:error') &&
-    !eventView.query.includes('event.type:transaction');
+  const hasEventTypeError = getQuerySource(eventView.query) === null;
   // yAxis must be a function and enabled on alerts
   const hasYAxisError = incompatibleYAxis(eventView);
   const errors: IncompatibleQueryProperties = {

--- a/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
@@ -219,7 +219,7 @@ export function getQueryDatasource(
   query: string
 ): {source: Datasource; query: string} | null {
   let match = query.match(
-    /\(?event.type:(error|default|transaction)\)?\WOR\W\(?\!?event.type:(error|default|transaction)\)?/i
+    /\(?\bevent\.type:(error|default|transaction)\)?\WOR\W\(?event\.type:(error|default|transaction)\)?/i
   );
   if (match) {
     // should be [error, default] or [default, error]
@@ -231,10 +231,10 @@ export function getQueryDatasource(
     return {source: Datasource.ERROR_DEFAULT, query: query.replace(match[0], '').trim()};
   }
 
-  match = query.match(/event.type:(error|default|transaction)/i);
-  if (match && Datasource[match[1].toUpperCase()]) {
+  match = query.match(/(^|\s)event\.type:(error|default|transaction)/i);
+  if (match && Datasource[match[2].toUpperCase()]) {
     return {
-      source: Datasource[match[1].toUpperCase()],
+      source: Datasource[match[2].toUpperCase()],
       query: query.replace(match[0], '').trim(),
     };
   }

--- a/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
@@ -213,9 +213,9 @@ export function convertDatasetEventTypesToSource(
 /**
  * Attempt to guess the data source of a discover query
  *
- * @returns A new query without the datasource or null on no result
+ * @returns A new query without the datasource. null on no datasource
  */
-export function getQuerySource(
+export function getQueryDatasource(
   query: string
 ): {source: Datasource; query: string} | null {
   let match = query.match(

--- a/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
@@ -213,7 +213,8 @@ export function convertDatasetEventTypesToSource(
 /**
  * Attempt to guess the data source of a discover query
  *
- * @returns A new query without the datasource. null on no datasource
+ * @returns An object containing the datasource and new query without the datasource.
+ * Returns null on no datasource.
  */
 export function getQueryDatasource(
   query: string

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -336,10 +336,12 @@ class Results extends React.Component<Props, State> {
     typeof CreateAlertFromViewButton
   >['onIncompatibleQuery'] = (incompatibleAlertNoticeFn, errors) => {
     const {organization} = this.props;
+    const {eventView} = this.state;
     trackAnalyticsEvent({
       eventKey: 'discover_v2.create_alert_clicked',
       eventName: 'Discoverv2: Create alert clicked',
       status: 'error',
+      query: eventView.query,
       errors,
       organization_id: organization.id,
       url: window.location.href,

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -1,5 +1,9 @@
 import EventView from 'app/utils/discover/eventView';
 import {AggregationKey, LooseFieldKey} from 'app/utils/discover/fields';
+import {
+  DATA_SOURCE_TO_SET_AND_EVENT_TYPES,
+  getQueryDatasource,
+} from 'app/views/alerts/utils';
 import {WEB_VITAL_DETAILS} from 'app/views/performance/transactionVitals/constants';
 import {
   AlertRuleThresholdType,
@@ -85,15 +89,14 @@ export function createDefaultRule(): UnsavedIncidentRule {
  * Create an unsaved alert from a discover EventView object
  */
 export function createRuleFromEventView(eventView: EventView): UnsavedIncidentRule {
+  const parsedQuery = getQueryDatasource(eventView.query);
+  const datasetAndEventtypes = parsedQuery
+    ? DATA_SOURCE_TO_SET_AND_EVENT_TYPES[parsedQuery.source]
+    : DATA_SOURCE_TO_SET_AND_EVENT_TYPES.error;
   return {
     ...createDefaultRule(),
-    dataset: eventView.query.includes(DATASET_EVENT_TYPE_FILTERS[Dataset.TRANSACTIONS])
-      ? Dataset.TRANSACTIONS
-      : Dataset.ERRORS,
-    query: eventView.query
-      .slice()
-      .replace(/event\.type:(transaction|error)/, '')
-      .trim(),
+    ...datasetAndEventtypes,
+    query: parsedQuery?.query ?? eventView.query,
     aggregate: eventView.getYAxis(),
     environment: eventView.environment.length ? eventView.environment[0] : null,
   };

--- a/tests/js/spec/components/createAlertButton.spec.jsx
+++ b/tests/js/spec/components/createAlertButton.spec.jsx
@@ -82,9 +82,7 @@ describe('CreateAlertFromViewButton', () => {
     const errorsAlert = mountWithTheme(
       onIncompatibleQueryMock.mock.calls[0][0](onCloseMock)
     );
-    expect(errorsAlert.text()).toBe(
-      'An alert needs a filter of event.type:error or event.type:transaction. Use one of these and try again.'
-    );
+    expect(errorsAlert.text()).toContain('An alert needs a filter of event.type:error');
   });
 
   it('should warn when yAxis is not allowed', () => {

--- a/tests/js/spec/views/alerts/utils.spec.jsx
+++ b/tests/js/spec/views/alerts/utils.spec.jsx
@@ -103,6 +103,12 @@ describe('Alert utils', function () {
         source: Datasource.ERROR_DEFAULT,
         query: 'event.level:fatal)',
       });
+      expect(
+        getQueryDatasource('(event.type:error OR event.type:default) event.level:fatal')
+      ).toEqual({
+        source: Datasource.ERROR_DEFAULT,
+        query: 'event.level:fatal',
+      });
     });
 
     it('should not allow event type transaction with anything else', () => {
@@ -110,6 +116,12 @@ describe('Alert utils', function () {
       expect(
         getQueryDatasource('event.type:transaction OR event.type:default')
       ).toBeNull();
+    });
+
+    it('should not allow boolean event types', () => {
+      expect(getQueryDatasource('!event.type:error')).toBeNull();
+      expect(getQueryDatasource('!event.type:transaction something')).toBeNull();
+      expect(getQueryDatasource('!event.type:default')).toBeNull();
     });
 
     it('should allow error, transaction, default alone', () => {

--- a/tests/js/spec/views/alerts/utils.spec.jsx
+++ b/tests/js/spec/views/alerts/utils.spec.jsx
@@ -1,6 +1,6 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
-import {getQuerySource} from 'app/views/alerts/utils';
+import {getQueryDatasource} from 'app/views/alerts/utils';
 import {getIncidentDiscoverUrl} from 'app/views/alerts/utils/getIncidentDiscoverUrl';
 import {Dataset, Datasource} from 'app/views/settings/incidentRules/types';
 
@@ -85,42 +85,48 @@ describe('Alert utils', function () {
 
   describe('getQuerySource', () => {
     it('should parse event type error or default', () => {
-      expect(getQuerySource('event.type:default OR event.type:error')).toEqual({
+      expect(getQueryDatasource('event.type:default OR event.type:error')).toEqual({
         source: Datasource.ERROR_DEFAULT,
         query: '',
       });
       expect(
-        getQuerySource('event.type:error OR event.type:default transaction.duration:<30s')
+        getQueryDatasource(
+          'event.type:error OR event.type:default transaction.duration:<30s'
+        )
       ).toEqual({
         source: Datasource.ERROR_DEFAULT,
         query: 'transaction.duration:<30s',
       });
       expect(
-        getQuerySource('event.type:error OR (event.type:default event.level:fatal)')
+        getQueryDatasource('event.type:error OR (event.type:default event.level:fatal)')
       ).toEqual({
         source: Datasource.ERROR_DEFAULT,
         query: 'event.level:fatal)',
       });
     });
+
     it('should not allow event type transaction with anything else', () => {
-      expect(getQuerySource('event.type:error OR event.type:transaction')).toBeNull();
-      expect(getQuerySource('event.type:transaction OR event.type:default')).toBeNull();
+      expect(getQueryDatasource('event.type:error OR event.type:transaction')).toBeNull();
+      expect(
+        getQueryDatasource('event.type:transaction OR event.type:default')
+      ).toBeNull();
     });
+
     it('should allow error, transaction, default alone', () => {
-      expect(getQuerySource('event.type:error test')).toEqual({
+      expect(getQueryDatasource('event.type:error test')).toEqual({
         source: Datasource.ERROR,
         query: 'test',
       });
-      expect(getQuerySource('event.type:default test')).toEqual({
+      expect(getQueryDatasource('event.type:default test')).toEqual({
         source: Datasource.DEFAULT,
         query: 'test',
       });
-      expect(getQuerySource('event.type:transaction test')).toEqual({
+      expect(getQueryDatasource('event.type:transaction test')).toEqual({
         source: Datasource.TRANSACTION,
         query: 'test',
       });
       expect(
-        getQuerySource(
+        getQueryDatasource(
           'event.type:error explode OR (event.type:default event.level:fatal)'
         )
       ).toEqual({

--- a/tests/js/spec/views/alerts/utils.spec.jsx
+++ b/tests/js/spec/views/alerts/utils.spec.jsx
@@ -1,7 +1,8 @@
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
+import {getQuerySource} from 'app/views/alerts/utils';
 import {getIncidentDiscoverUrl} from 'app/views/alerts/utils/getIncidentDiscoverUrl';
-import {Dataset} from 'app/views/settings/incidentRules/types';
+import {Dataset, Datasource} from 'app/views/settings/incidentRules/types';
 
 describe('Alert utils', function () {
   const {org, projects} = initializeOrg();
@@ -78,6 +79,53 @@ describe('Alert utils', function () {
           yAxis: 'p90()',
         }),
         pathname: '/organizations/org-slug/discover/results/',
+      });
+    });
+  });
+
+  describe('getQuerySource', () => {
+    it('should parse event type error or default', () => {
+      expect(getQuerySource('event.type:default OR event.type:error')).toEqual({
+        source: Datasource.ERROR_DEFAULT,
+        query: '',
+      });
+      expect(
+        getQuerySource('event.type:error OR event.type:default transaction.duration:<30s')
+      ).toEqual({
+        source: Datasource.ERROR_DEFAULT,
+        query: 'transaction.duration:<30s',
+      });
+      expect(
+        getQuerySource('event.type:error OR (event.type:default event.level:fatal)')
+      ).toEqual({
+        source: Datasource.ERROR_DEFAULT,
+        query: 'event.level:fatal)',
+      });
+    });
+    it('should not allow event type transaction with anything else', () => {
+      expect(getQuerySource('event.type:error OR event.type:transaction')).toBeNull();
+      expect(getQuerySource('event.type:transaction OR event.type:default')).toBeNull();
+    });
+    it('should allow error, transaction, default alone', () => {
+      expect(getQuerySource('event.type:error test')).toEqual({
+        source: Datasource.ERROR,
+        query: 'test',
+      });
+      expect(getQuerySource('event.type:default test')).toEqual({
+        source: Datasource.DEFAULT,
+        query: 'test',
+      });
+      expect(getQuerySource('event.type:transaction test')).toEqual({
+        source: Datasource.TRANSACTION,
+        query: 'test',
+      });
+      expect(
+        getQuerySource(
+          'event.type:error explode OR (event.type:default event.level:fatal)'
+        )
+      ).toEqual({
+        source: Datasource.ERROR,
+        query: 'explode OR (event.type:default event.level:fatal)',
       });
     });
   });

--- a/tests/js/spec/views/settings/incidentRules/constants.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/constants.spec.jsx
@@ -1,6 +1,6 @@
 import EventView from 'app/utils/discover/eventView';
 import {createRuleFromEventView} from 'app/views/settings/incidentRules/constants';
-import {Dataset} from 'app/views/settings/incidentRules/types';
+import {Dataset, EventTypes} from 'app/views/settings/incidentRules/types';
 
 describe('createRuleFromEventView()', () => {
   it('sets transaction dataset from event.type:transaction', () => {
@@ -18,6 +18,7 @@ describe('createRuleFromEventView()', () => {
 
     const rule = createRuleFromEventView(eventView);
     expect(rule.dataset).toBe(Dataset.ERRORS);
+    expect(rule.eventTypes).toEqual([EventTypes.ERROR]);
   });
   it('removes event.type from query', () => {
     const eventView = new EventView({
@@ -42,5 +43,14 @@ describe('createRuleFromEventView()', () => {
 
     const rule = createRuleFromEventView(eventView);
     expect(rule.aggregate).toBe(eventView.yAxis);
+  });
+  it('gets dataset and eventtypes from query', () => {
+    const eventView = new EventView({
+      query: 'event.type:error or event.type:default something',
+    });
+
+    const rule = createRuleFromEventView(eventView);
+    expect(rule.dataset).toBe(Dataset.ERRORS);
+    expect(rule.eventTypes).toEqual([EventTypes.ERROR, EventTypes.DEFAULT]);
   });
 });


### PR DESCRIPTION
Handle creating alerts with `event.type:default OR event.type:error` and removing that piece from the query when creating from alerts. Should fill in the event source dropdown.

Should not allow `event.type:transaction or event.type:error`. 