### PR TITLE
feat(ui): Update issue details context data colors

### DIFF
--- a/src/sentry/static/sentry/app/components/contextData.tsx
+++ b/src/sentry/static/sentry/app/components/contextData.tsx
@@ -277,10 +277,10 @@ class ContextData extends React.Component<Props, State> {
     } = this.props;
 
     return (
-      <ContextValues {...other}>
+      <pre {...other}>
         {this.renderValue(data)}
         {children}
-      </ContextValues>
+      </pre>
     );
   }
 }
@@ -305,11 +305,6 @@ const ToggleIcon = styled('a')<{isOpen?: boolean}>`
   &:hover {
     background: ${p => (p.isOpen ? p.theme.gray400 : p.theme.blue200)};
   }
-`;
-
-const ContextValues = styled('pre')`
-  /* Not using theme to be consistent with less files */
-  color: #4e3fb4;
 `;
 
 export default ContextData;

--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -128,7 +128,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
         pre,
         code {
           background-color: ${theme.backgroundSecondary};
-          color: ${theme.subText};
+          color: ${theme.textColor};
         }
         .search .search-input,
         .Select-control,

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -1064,7 +1064,6 @@ span.val {
 }
 
 .val-string {
-  color: darken(@purple, 10);
   border-radius: 3px;
   padding: 2px 4px;
 }

--- a/src/sentry/static/sentry/less/includes/bootstrap/variables.less
+++ b/src/sentry/static/sentry/less/includes/bootstrap/variables.less
@@ -742,7 +742,7 @@
 @kbd-bg: #333;
 
 @pre-bg: #f7f8f9;
-@pre-color: @gray-dark;
+@pre-color: #1d1127;
 @pre-border-color: #ccc;
 
 //== Type


### PR DESCRIPTION
This updates the colors to be consistent with other places where we use `pre`. Also makes the color more dark mode compatible.

Old:
![image](https://user-images.githubusercontent.com/79684/102149885-5cb45900-3e24-11eb-8691-569af61a34c4.png)
![image](https://user-images.githubusercontent.com/79684/102149971-88cfda00-3e24-11eb-8642-da95d935a950.png)


New:
![image](https://user-images.githubusercontent.com/79684/102149830-3abad680-3e24-11eb-9a88-369e58b4d6ba.png)

![image](https://user-images.githubusercontent.com/79684/102149816-2e367e00-3e24-11eb-916b-f3b6f078ebb6.png)
