### PR TITLE
fix(email): Sendgrid categories

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -87,7 +87,7 @@ class EmailActionHandler(ActionHandler):
             html_template=u"sentry/emails/incidents/trigger.html",
             type="incident.alert_rule_{}".format(display.lower()),
             context=context,
-            headers={"category": "metric_alert_email"},
+            headers={"X-SMTPAPI": {"category": "metric_alert_email"}},
         )
 
 

--- a/src/sentry/mail/activity/base.py
+++ b/src/sentry/mail/activity/base.py
@@ -133,7 +133,10 @@ class ActivityEmail(object):
         project = self.project
         group = self.group
 
-        headers = {"X-Sentry-Project": project.slug}
+        headers = {
+            "X-Sentry-Project": project.slug,
+            "X-SMTPAPI": {"category": self.get_category()},
+        }
 
         if group:
             headers.update(
@@ -141,7 +144,6 @@ class ActivityEmail(object):
                     "X-Sentry-Logger": group.logger,
                     "X-Sentry-Logger-Level": group.get_level_display(),
                     "X-Sentry-Reply-To": group_id_to_email(group.id),
-                    "category": self.get_category(),
                 }
             )
 

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -444,7 +444,7 @@ class MailAdapter(object):
 
             headers = {
                 "X-Sentry-Project": project.slug,
-                "category": "digest_email",
+                "X-SMTPAPI": {"category": "digest_email"},
             }
 
             group = six.next(iter(counts))
@@ -520,7 +520,7 @@ class MailAdapter(object):
 
         headers = {
             "X-Sentry-Project": project.slug,
-            "category": "user_report_email",
+            "X-SMTPAPI": {"category": "user_report_email"},
         }
 
         # TODO(dcramer): this is copypasta'd from activity notifications

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -545,7 +545,7 @@ def build_message(timestamp, duration, organization, user, reports):
             "report": to_context(organization, interval, reports),
             "user": user,
         },
-        headers={"category": "organization_report_email"},
+        headers={"X-SMTPAPI": {"category": "organization_report_email"}},
     )
 
     message.add_users((user.id,))


### PR DESCRIPTION
Previously tried to implement categorization in sendgrid with this PR: https://github.com/getsentry/sentry/pull/20887. However after deploying it seems like no categories are available for selection/filtering in sendgrid. Upon further investigation I may have supplied the wrong headers when building the categories.

https://sendgrid.com/docs/API_Reference/SMTP_API/categories.html
The docs say to use the `X-SMTPAPI` header and add a `category` object inside of that. So I switched to that approach. Hopefully this should enable the categories for us.