### PR TITLE
fix(ui): Fix date if event is not part of environment

### DIFF
--- a/src/sentry/static/sentry/app/components/group/seenInfo.tsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
@@ -79,12 +80,22 @@ class SeenInfo extends React.Component<Props> {
               {environment && (
                 <TimeSinceWrapper>
                   {toTitleCase(environment)}
-                  <TimeSince date={date} disabledAbsoluteTooltip />
+                  {date ? (
+                    <TimeSince date={date} disabledAbsoluteTooltip />
+                  ) : (
+                    <span>{t('N/A')}</span>
+                  )}
                 </TimeSinceWrapper>
               )}
             </div>
           }
-          body={<StyledDateTime date={date} />}
+          body={
+            date ? (
+              <StyledDateTime date={date} />
+            ) : (
+              <NoEnvironment>{t(`N/A for ${environment}`)}</NoEnvironment>
+            )
+          }
           position="top"
           tipColor={theme.gray500}
         >
@@ -99,7 +110,7 @@ class SeenInfo extends React.Component<Props> {
                 <StyledTimeSince date={dateGlobal} disabledAbsoluteTooltip />
               </React.Fragment>
             ) : (
-              <React.Fragment>{t('n/a')} </React.Fragment>
+              <NoDateTime>{t('N/A')}</NoDateTime>
             )}
           </DateWrapper>
         </StyledHovercard>
@@ -124,6 +135,13 @@ class SeenInfo extends React.Component<Props> {
   }
 }
 
+const dateTimeCss = p => css`
+  color: ${p.theme.gray300};
+  font-size: ${p.theme.fontSizeMedium};
+  display: flex;
+  justify-content: center;
+`;
+
 const HovercardWrapper = styled('div')`
   display: flex;
 `;
@@ -134,10 +152,15 @@ const DateWrapper = styled('div')`
 `;
 
 const StyledDateTime = styled(DateTime)`
-  color: ${p => p.theme.gray300};
-  font-size: ${p => p.theme.fontSizeMedium};
-  display: flex;
-  justify-content: center;
+  ${dateTimeCss};
+`;
+
+const NoEnvironment = styled('div')`
+  ${dateTimeCss};
+`;
+
+const NoDateTime = styled('span')`
+  margin-right: ${space(0.5)};
 `;
 
 const TooltipWrapper = styled('span')`


### PR DESCRIPTION
Handle the date if the environment is updated while on an Issue Details page and the event is not part of that environement. If the event is not part of the environment (single environment selected), the date returns `null`.

Fixes JAVASCRIPT-23BB

**Steps to reproduce:**

1. Go to an Issue Details page that has an `environment` set. For example:
<img width="741" alt="Screen Shot 2020-12-15 at 12 15 26 AM" src="https://user-images.githubusercontent.com/20312973/102189673-d885c400-3e6b-11eb-8b23-e2c81bea06de.png">

2. In the Global Header, update the environment to anything other than the set `environment` (for example, `staging`). 

3. Hover over the date (or "n/a") on the right-hand sidebar under Last Seen or First Seen

Either this
<img width="346" alt="Screen Shot 2020-12-15 at 12 26 03 AM" src="https://user-images.githubusercontent.com/20312973/102190166-84c7aa80-3e6c-11eb-941e-a1019f623cc9.png">

or this happens
<img width="1190" alt="Screen Shot 2020-12-15 at 12 32 06 AM" src="https://user-images.githubusercontent.com/20312973/102190582-133c2c00-3e6d-11eb-9805-11d53b573fc0.png">
with error `Cannot read property 'toISOString' of null`

### After
<img width="328" alt="Screen Shot 2020-12-15 at 12 16 04 AM" src="https://user-images.githubusercontent.com/20312973/102190824-5ac2b800-3e6d-11eb-9b0a-d0b670bc09b0.png">

