### PR TITLE
meta: Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,6 +30,15 @@
 /src/sentry/auth/                   @getsentry/security
 /src/sentry/api/permissions.py      @getsentry/security
 
+# Dev
+/.github/                   @getsentry/owners-sentry-dev
+/config/hooks/              @getsentry/owners-sentry-dev
+/scripts/                   @getsentry/owners-sentry-dev
+Makefile                    @getsentry/owners-sentry-dev
+.envrc                      @getsentry/owners-sentry-dev
+.pre-commit-config.yaml     @getsentry/owners-sentry-dev
+.git-blame-ignore-revs      @getsentry/owners-sentry-dev
+
 # Build & Releases
 /.github/workflows/release.yml  @getsentry/releases
 /scripts/bump-version.sh        @getsentry/releases
@@ -45,18 +54,7 @@ package.json        @getsentry/owners-js-build
 babel.config.*      @getsentry/owners-js-build
 build-utils/        @getsentry/owners-js-build
 
-# Dev
-/.github/                   @getsentry/owners-sentry-dev
-/config/hooks/              @getsentry/owners-sentry-dev
-/scripts/                   @getsentry/owners-sentry-dev
-Makefile                    @getsentry/owners-sentry-dev
-.envrc                      @getsentry/owners-sentry-dev
-.pre-commit-config.yaml     @getsentry/owners-sentry-dev
-.git-blame-ignore-revs      @getsentry/owners-sentry-dev
-
-
 # Owners by product feature
-
 
 ### Issue/Metric Alerts ###
 /src/sentry/static/sentry/app/views/settings/projectAlerts/     @getsentry/workflow


### PR DESCRIPTION
Based on https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file, the order matters and **the last line that matches** takes precedense. That makes all definitions above the wider `# Dev` section useless (for releases). This PR fixes that.
