### PR TITLE
feat(dashboard) Add more queries to the default dashboard

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -39,7 +39,9 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             serialized = []
             for item in results:
                 if isinstance(item, dict):
-                    serialized.append(item)
+                    cloned = item.copy()
+                    del cloned["widgets"]
+                    serialized.append(cloned)
                 else:
                     serialized.append(serialize(item, request.user, serializer=list_serializer))
             return serialized

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -90,7 +90,41 @@ PREBUILT_DASHBOARDS = {
                             "fields": ["count()"],
                         }
                     ],
-                }
+                },
+                {
+                    "title": "Affected Users",
+                    "displayType": "line",
+                    "interval": "5m",
+                    "queries": [
+                        {
+                            "name": "Known Users",
+                            "conditions": "has:user.email",
+                            "fields": ["count_unique(user.email)"],
+                        },
+                        {
+                            "name": "Anonymous Users",
+                            "conditions": "!has:user.email",
+                            "fields": ["count()"],
+                        },
+                    ],
+                },
+                {
+                    "title": "Handled vs. Unhandled",
+                    "displayType": "line",
+                    "interval": "5m",
+                    "queries": [
+                        {
+                            "name": "Handled",
+                            "conditions": "error.handled:true",
+                            "fields": ["count()"],
+                        },
+                        {
+                            "name": "Unhandled",
+                            "conditions": "error.handled:false",
+                            "fields": ["count()"],
+                        },
+                    ],
+                },
             ],
         }
     ]

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -78,6 +78,8 @@ PREBUILT_DASHBOARDS = {
         {
             "id": "default-overview",
             "title": "Dashboard",
+            "dateCreated": "",
+            "createdBy": "",
             "widgets": [
                 {
                     "title": "Events",

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -25,6 +25,7 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert data["id"] == six.text_type(dashboard.id)
         assert data["title"] == dashboard.title
         assert data["createdBy"] == six.text_type(dashboard.created_by.id)
+        assert "widgets" not in data
 
     def test_get(self):
         response = self.client.get(self.url)


### PR DESCRIPTION
Add a few more widgets and queries to the default dashboard that let us replicate the existing default dashboard.

![Screen Shot 2020-12-15 at 2 28 48 PM](https://user-images.githubusercontent.com/24086/102263081-e1b17800-3ee1-11eb-8ddf-a09c8d79cf0b.png)
