### PR TITLE
feat(ui): Use a consistent "active" and "focus" states for form inputs

### DIFF
--- a/src/sentry/static/sentry/app/components/checkboxFancy/checkboxFancy.tsx
+++ b/src/sentry/static/sentry/app/components/checkboxFancy/checkboxFancy.tsx
@@ -26,7 +26,7 @@ const hoverStyles = (p: Props & {theme: Theme}) =>
   !p.isDisabled &&
   css`
     border: 2px solid
-      ${p.isChecked || p.isIndeterminate ? p.theme.purple300 : p.theme.gray500};
+      ${p.isChecked || p.isIndeterminate ? p.theme.active : p.theme.textColor};
   `;
 
 const CheckboxFancy = styled(
@@ -50,10 +50,9 @@ const CheckboxFancy = styled(
   width: ${p => p.size};
   height: ${p => p.size};
   border-radius: 5px;
-  background: ${p =>
-    p.isChecked || p.isIndeterminate ? p.theme.purple300 : 'transparent'};
+  background: ${p => (p.isChecked || p.isIndeterminate ? p.theme.active : 'transparent')};
   border: 2px solid
-    ${p => (p.isChecked || p.isIndeterminate ? p.theme.purple300 : p.theme.gray300)};
+    ${p => (p.isChecked || p.isIndeterminate ? p.theme.active : p.theme.gray300)};
   cursor: ${p => (p.isDisabled ? 'not-allowed' : 'pointer')};
   ${p => (!p.isChecked || !p.isIndeterminate) && 'transition: 500ms border ease-out'};
 

--- a/src/sentry/static/sentry/app/components/dropdownAutoComplete/row.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownAutoComplete/row.tsx
@@ -43,7 +43,7 @@ const Row = ({
   return (
     <AutoCompleteItem
       itemSize={itemSize}
-      hasGrayBackground={index === highlightedIndex}
+      isHighlighted={index === highlightedIndex}
       {...getItemProps({item, index, style})}
     >
       {typeof item.label === 'function' ? item.label({inputValue}) : item.label}
@@ -84,7 +84,7 @@ const getItemPaddingForSize = (itemSize?: ItemSize) => {
   return space(1);
 };
 
-const AutoCompleteItem = styled('div')<{hasGrayBackground: boolean; itemSize?: ItemSize}>`
+const AutoCompleteItem = styled('div')<{isHighlighted: boolean; itemSize?: ItemSize}>`
   /* needed for virtualized lists that do not fill parent height */
   /* e.g. breadcrumbs (org height > project, but want same fixed height for both) */
   display: flex;
@@ -92,9 +92,8 @@ const AutoCompleteItem = styled('div')<{hasGrayBackground: boolean; itemSize?: I
   justify-content: center;
 
   font-size: 0.9em;
-  background-color: ${p =>
-    p.hasGrayBackground ? p.theme.backgroundSecondary : 'transparent'};
-  color: ${p => (p.hasGrayBackground ? p.theme.textColor : 'inherit')};
+  background-color: ${p => (p.isHighlighted ? p.theme.focus : 'transparent')};
+  color: ${p => (p.isHighlighted ? p.theme.textColor : 'inherit')};
   padding: ${p => getItemPaddingForSize(p.itemSize)};
   cursor: pointer;
   border-bottom: 1px solid ${p => p.theme.innerBorder};
@@ -105,6 +104,6 @@ const AutoCompleteItem = styled('div')<{hasGrayBackground: boolean; itemSize?: I
 
   :hover {
     color: ${p => p.theme.textColor};
-    background-color: ${p => p.theme.backgroundSecondary};
+    background-color: ${p => p.theme.focus};
   }
 `;

--- a/src/sentry/static/sentry/app/components/dropdownControl.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownControl.tsx
@@ -5,7 +5,6 @@ import DropdownBubble from 'app/components/dropdownBubble';
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownMenu, {GetActorPropsFn} from 'app/components/dropdownMenu';
 import MenuItem from 'app/components/menuItem';
-import theme from 'app/utils/theme';
 
 type DefaultProps = {
   /**
@@ -93,7 +92,6 @@ class DropdownControl extends React.Component<Props> {
                 width={menuWidth}
                 isOpen={isOpen}
                 blendWithActor={blendWithActor}
-                theme={theme}
                 blendCorner
               >
                 {children}
@@ -124,7 +122,6 @@ const Content = styled(DropdownBubble)<{isOpen: boolean}>`
 
 const DropdownItem = styled(MenuItem)`
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.gray300};
 `;
 
 export default DropdownControl;

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -48,7 +48,7 @@ const combineStyles = (newStyles, baseStyles) => {
   }, baseStyles);
 };
 
-const SelectControlComponent = props => {
+const SelectControl = props => {
   // TODO(epurkhiser): We should remove all SelectControls (and SelectFields,
   // SelectAsyncFields, etc) that are using this prop, before we can remove the
   // v1 react-select component.
@@ -288,10 +288,9 @@ const SelectControlComponent = props => {
     />
   );
 };
-SelectControlComponent.propTypes = SelectControlLegacy.propTypes;
+SelectControl.propTypes = SelectControlLegacy.propTypes;
 
-const SelectControl = withTheme(SelectControlComponent);
-SelectControl.propTypes = SelectControlComponent.propTypes;
+const SelectControlWithTheme = withTheme(SelectControl);
 
 const SelectPicker = ({async, creatable, forwardedRef, ...props}) => {
   // Pick the right component to use
@@ -311,7 +310,9 @@ const SelectPicker = ({async, creatable, forwardedRef, ...props}) => {
 
 SelectPicker.propTypes = SelectControl.propTypes;
 
-const forwardRef = (props, ref) => <SelectControl forwardedRef={ref} {...props} />;
+const forwardRef = (props, ref) => (
+  <SelectControlWithTheme forwardedRef={ref} {...props} />
+);
 forwardRef.displayName = 'RefForwardedSelectControl';
 
 const RefForwardedSelectControl = React.forwardRef(forwardRef);

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -3,11 +3,11 @@ import ReactSelect, {components as selectComponents} from 'react-select';
 import Async from 'react-select/async';
 import AsyncCreatable from 'react-select/async-creatable';
 import Creatable from 'react-select/creatable';
+import {withTheme} from 'emotion-theming';
 
 import {IconChevron, IconClose} from 'app/icons';
 import space from 'app/styles/space';
 import convertFromSelect2Choices from 'app/utils/convertFromSelect2Choices';
-import theme from 'app/utils/theme';
 
 import SelectControlLegacy from './selectControlLegacy';
 
@@ -29,149 +29,6 @@ const MultiValueRemove = props => (
   </selectComponents.MultiValueRemove>
 );
 
-// TODO(epurkhiser): The loading indicator should probably also be our loading
-// indicator.
-
-// Unfortunately we cannot use emotions `css` helper here, since react-select
-// *requires* object styles, which the css helper cannot produce.
-
-const indicatorStyles = ({padding: _padding, ...provided}) => ({
-  ...provided,
-  padding: '4px',
-  alignItems: 'center',
-  cursor: 'pointer',
-});
-
-const defaultStyles = {
-  control: (_, state) => ({
-    height: '100%',
-    fontSize: '15px',
-    color: theme.formText,
-    display: 'flex',
-    background: theme.background,
-    border: `1px solid ${theme.border}`,
-    borderRadius: theme.borderRadius,
-    boxShadow: `inset ${theme.dropShadowLight}`,
-    transition: 'border 0.1s linear',
-    alignItems: 'center',
-    minHeight: '40px',
-    '&:hover': {
-      borderColor: theme.border,
-    },
-    ...(state.isFocused && {
-      border: `1px solid ${theme.border}`,
-      boxShadow: 'rgba(209, 202, 216, 0.5) 0 0 0 3px',
-    }),
-    ...(state.menuIsOpen && {
-      borderBottomLeftRadius: '0',
-      borderBottomRightRadius: '0',
-      boxShadow: 'none',
-    }),
-    ...(state.isDisabled && {
-      borderColor: theme.border,
-      background: theme.backgroundSecondary,
-      color: theme.disabled,
-      cursor: 'not-allowed',
-    }),
-    ...(!state.isSearchable && {
-      cursor: 'pointer',
-    }),
-  }),
-
-  menu: provided => ({
-    ...provided,
-    zIndex: theme.zIndex.dropdown,
-    marginTop: '-1px',
-    background: theme.background,
-    border: `1px solid ${theme.border}`,
-    borderRadius: `0 0 ${theme.borderRadius} ${theme.borderRadius}`,
-    borderTop: `1px solid ${theme.border}`,
-    boxShadow: theme.dropShadowLight,
-  }),
-  option: (provided, state) => ({
-    ...provided,
-    lineHeight: '1.5',
-    fontSize: theme.fontSizeMedium,
-    cursor: 'pointer',
-    color: state.isFocused
-      ? theme.textColor
-      : state.isSelected
-      ? theme.background
-      : theme.textColor,
-    backgroundColor: state.isFocused
-      ? theme.backgroundSecondary
-      : state.isSelected
-      ? theme.purple300
-      : 'transparent',
-    '&:active': {
-      backgroundColor: theme.backgroundSecondary,
-    },
-  }),
-  valueContainer: provided => ({
-    ...provided,
-    alignItems: 'center',
-  }),
-  multiValue: () => ({
-    color: '#007eff',
-    backgroundColor: '#ebf5ff',
-    borderRadius: '2px',
-    border: '1px solid #c2e0ff',
-    display: 'flex',
-    marginRight: '4px',
-  }),
-  multiValueLabel: provided => ({
-    ...provided,
-    color: '#007eff',
-    padding: '0',
-    paddingLeft: '6px',
-    lineHeight: '1.8',
-  }),
-  multiValueRemove: () => ({
-    cursor: 'pointer',
-    alignItems: 'center',
-    borderLeft: '1px solid #c2e0ff',
-    borderRadius: '0 2px 2px 0',
-    display: 'flex',
-    padding: '0 4px',
-    marginLeft: '4px',
-
-    '&:hover': {
-      color: '#6284b9',
-      background: '#cce5ff',
-    },
-  }),
-  indicatorsContainer: () => ({
-    display: 'grid',
-    gridAutoFlow: 'column',
-    gridGap: '2px',
-    marginRight: '6px',
-  }),
-  clearIndicator: indicatorStyles,
-  dropdownIndicator: indicatorStyles,
-  loadingIndicator: indicatorStyles,
-  groupHeading: provided => ({
-    ...provided,
-    lineHeight: '1.5',
-    fontWeight: '600',
-    backgroundColor: theme.backgroundSecondary,
-    color: theme.textColor,
-    marginBottom: 0,
-    padding: `${space(1)} ${space(1.5)}`,
-  }),
-  group: provided => ({
-    ...provided,
-    padding: 0,
-  }),
-};
-
-const getFieldLabelStyle = label => ({
-  ':before': {
-    content: `"${label}"`,
-    color: theme.gray300,
-    fontWeight: 600,
-  },
-});
-
 /**
  * Applies one set of styles onto the other while maintaining the same function
  * interface that is used by react-styled.
@@ -191,7 +48,7 @@ const combineStyles = (newStyles, baseStyles) => {
   }, baseStyles);
 };
 
-const SelectControl = props => {
+const SelectControlComponent = props => {
   // TODO(epurkhiser): We should remove all SelectControls (and SelectFields,
   // SelectAsyncFields, etc) that are using this prop, before we can remove the
   // v1 react-select component.
@@ -199,6 +56,159 @@ const SelectControl = props => {
     const {deprecatedSelectControl: _, ...legacyProps} = props;
     return <SelectControlLegacy {...legacyProps} />;
   }
+
+  const {theme} = props;
+
+  // TODO(epurkhiser): The loading indicator should probably also be our loading
+  // indicator.
+
+  // Unfortunately we cannot use emotions `css` helper here, since react-select
+  // *requires* object styles, which the css helper cannot produce.
+
+  const indicatorStyles = ({padding: _padding, ...provided}) => ({
+    ...provided,
+    padding: '4px',
+    alignItems: 'center',
+    cursor: 'pointer',
+  });
+
+  const defaultStyles = {
+    control: (_, state) => ({
+      height: '100%',
+      fontSize: '15px',
+      color: theme.formText,
+      display: 'flex',
+      background: theme.background,
+      border: `1px solid ${theme.border}`,
+      borderRadius: theme.borderRadius,
+      boxShadow: `inset ${theme.dropShadowLight}`,
+      transition: 'border 0.1s linear',
+      alignItems: 'center',
+      minHeight: '40px',
+      '&:hover': {
+        borderColor: theme.border,
+      },
+      ...(state.isFocused && {
+        border: `1px solid ${theme.border}`,
+        boxShadow: 'rgba(209, 202, 216, 0.5) 0 0 0 3px',
+      }),
+      ...(state.menuIsOpen && {
+        borderBottomLeftRadius: '0',
+        borderBottomRightRadius: '0',
+        boxShadow: 'none',
+      }),
+      ...(state.isDisabled && {
+        borderColor: theme.border,
+        background: theme.backgroundSecondary,
+        color: theme.disabled,
+        cursor: 'not-allowed',
+      }),
+      ...(!state.isSearchable && {
+        cursor: 'pointer',
+      }),
+    }),
+
+    menu: provided => ({
+      ...provided,
+      zIndex: theme.zIndex.dropdown,
+      marginTop: '-1px',
+      background: theme.background,
+      border: `1px solid ${theme.border}`,
+      borderRadius: `0 0 ${theme.borderRadius} ${theme.borderRadius}`,
+      borderTop: `1px solid ${theme.border}`,
+      boxShadow: theme.dropShadowLight,
+    }),
+    option: (provided, state) => ({
+      ...provided,
+      lineHeight: '1.5',
+      fontSize: theme.fontSizeMedium,
+      cursor: 'pointer',
+      color: state.isFocused
+        ? theme.textColor
+        : state.isSelected
+        ? theme.background
+        : theme.textColor,
+      backgroundColor: state.isFocused
+        ? theme.focus
+        : state.isSelected
+        ? theme.active
+        : 'transparent',
+      '&:active': {
+        backgroundColor: theme.active,
+      },
+    }),
+    valueContainer: provided => ({
+      ...provided,
+      alignItems: 'center',
+    }),
+    singleValue: provided => ({
+      ...provided,
+      color: theme.formText,
+    }),
+    placeholder: provided => ({
+      ...provided,
+      color: theme.formPlaceholder,
+    }),
+    multiValue: () => ({
+      color: '#007eff',
+      backgroundColor: '#ebf5ff',
+      borderRadius: '2px',
+      border: '1px solid #c2e0ff',
+      display: 'flex',
+      marginRight: '4px',
+    }),
+    multiValueLabel: provided => ({
+      ...provided,
+      color: '#007eff',
+      padding: '0',
+      paddingLeft: '6px',
+      lineHeight: '1.8',
+    }),
+    multiValueRemove: () => ({
+      cursor: 'pointer',
+      alignItems: 'center',
+      borderLeft: '1px solid #c2e0ff',
+      borderRadius: '0 2px 2px 0',
+      display: 'flex',
+      padding: '0 4px',
+      marginLeft: '4px',
+
+      '&:hover': {
+        color: '#6284b9',
+        background: '#cce5ff',
+      },
+    }),
+    indicatorsContainer: () => ({
+      display: 'grid',
+      gridAutoFlow: 'column',
+      gridGap: '2px',
+      marginRight: '6px',
+    }),
+    clearIndicator: indicatorStyles,
+    dropdownIndicator: indicatorStyles,
+    loadingIndicator: indicatorStyles,
+    groupHeading: provided => ({
+      ...provided,
+      lineHeight: '1.5',
+      fontWeight: '600',
+      backgroundColor: theme.backgroundSecondary,
+      color: theme.textColor,
+      marginBottom: 0,
+      padding: `${space(1)} ${space(1.5)}`,
+    }),
+    group: provided => ({
+      ...provided,
+      padding: 0,
+    }),
+  };
+
+  const getFieldLabelStyle = label => ({
+    ':before': {
+      content: `"${label}"`,
+      color: theme.gray300,
+      fontWeight: 600,
+    },
+  });
 
   const {
     async,
@@ -278,8 +288,10 @@ const SelectControl = props => {
     />
   );
 };
+SelectControlComponent.propTypes = SelectControlLegacy.propTypes;
 
-SelectControl.propTypes = SelectControlLegacy.propTypes;
+const SelectControl = withTheme(SelectControlComponent);
+SelectControl.propTypes = SelectControlComponent.propTypes;
 
 const SelectPicker = ({async, creatable, forwardedRef, ...props}) => {
   // Pick the right component to use

--- a/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
@@ -193,10 +193,11 @@ const StyledSelect = styled(SelectPicker)`
     color: ${p => p.theme.textColor};
 
     &.is-focused.is-selected {
-      color: ${p => p.theme.white};
+      color: ${p => p.theme.textColor};
     }
     &.is-selected {
       background-color: ${p => p.theme.active};
+      color: ${p => p.theme.black};
     }
     &.is-focused {
       background-color: ${p => p.theme.focus};

--- a/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
@@ -150,15 +150,34 @@ const StyledSelect = styled(SelectPicker)`
     overflow: visible;
   }
 
-  &.Select.is-focused > .Select-control {
-    border: 1px solid ${p => p.theme.border};
-    border-color: ${p => p.theme.textColor};
-    box-shadow: rgba(209, 202, 216, 0.5) 0 0 0 3px;
-  }
+  &.Select {
+    &.has-value {
+      &.is-pseudo-focused.Select--single,
+      &.Select--single {
+        > .Select-control {
+          .Select-value {
+            .Select-value-label {
+              color: ${p => p.theme.formText};
+            }
+          }
+        }
+      }
+    }
 
-  &.Select.is-focused:not(.is-open) > .Select-control {
-    height: ${p => p.height}px;
-    overflow: visible;
+    &.is-focused {
+      > .Select-control {
+        background: ${p => p.theme.background};
+        border: 1px solid ${p => p.theme.border};
+        box-shadow: rgba(209, 202, 216, 0.5) 0 0 0 3px;
+      }
+
+      &:not(.is-open) {
+        > .Select-control {
+          height: ${p => p.height}px;
+          overflow: visible;
+        }
+      }
+    }
   }
 
   .Select-input {
@@ -166,6 +185,21 @@ const StyledSelect = styled(SelectPicker)`
     input {
       line-height: ${p => p.height}px;
       padding: 0 0;
+    }
+  }
+
+  .Select-option {
+    background: ${p => p.theme.background};
+    color: ${p => p.theme.textColor};
+
+    &.is-focused.is-selected {
+      color: ${p => p.theme.white};
+    }
+    &.is-selected {
+      background-color: ${p => p.theme.active};
+    }
+    &.is-focused {
+      background-color: ${p => p.theme.focus};
     }
   }
 
@@ -186,10 +220,6 @@ const StyledSelect = styled(SelectPicker)`
     color: ${p => p.theme.disabled};
   }
 
-  .Select-option.is-focused {
-    color: ${p => p.theme.white};
-    background-color: ${p => p.theme.purple300};
-  }
   .Select-multi-value-wrapper {
     > a {
       margin-left: 4px;

--- a/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
@@ -145,6 +145,8 @@ SelectPicker.propTypes = {
 
 const StyledSelect = styled(SelectPicker)`
   .Select-control {
+    background-color: ${p => p.theme.background};
+    color: ${p => p.theme.formText};
     border: 1px solid ${p => p.theme.border};
     height: ${p => p.height}px;
     overflow: visible;
@@ -158,6 +160,17 @@ const StyledSelect = styled(SelectPicker)`
           .Select-value {
             .Select-value-label {
               color: ${p => p.theme.formText};
+            }
+          }
+        }
+        &.is-disabled {
+          .Select-control {
+            cursor: not-allowed;
+            background-color: ${p => p.theme.backgroundSecondary};
+            .Select-value {
+              .Select-value-label {
+                color: ${p => p.theme.disabled};
+              }
             }
           }
         }
@@ -192,15 +205,16 @@ const StyledSelect = styled(SelectPicker)`
     background: ${p => p.theme.background};
     color: ${p => p.theme.textColor};
 
-    &.is-focused.is-selected {
-      color: ${p => p.theme.textColor};
+    &.is-focused {
+      color: ${p => p.theme.black};
+      background-color: ${p => p.theme.focus};
     }
     &.is-selected {
       background-color: ${p => p.theme.active};
-      color: ${p => p.theme.black};
+      color: ${p => p.theme.white};
     }
-    &.is-focused {
-      background-color: ${p => p.theme.focus};
+    &.is-focused.is-selected {
+      color: ${p => p.theme.black};
     }
   }
 

--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -208,6 +208,7 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
 
     &:hover {
       background: ${props.theme.focus};
+      color: ${props.theme.black};
     }
   `;
 }

--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -193,17 +193,21 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
     return `
       ${common}
       color: ${props.theme.white};
-      background: ${props.theme.purple300};
+      background: ${props.theme.active};
+
+      &:hover {
+        color: ${props.theme.black};
+      }
     `;
   }
 
   return `
     ${common}
     color: ${props.theme.gray500};
-    background-color: ${props.theme.white};
+    background-color: ${props.theme.background};
 
     &:hover {
-      background: ${props.theme.gray100};
+      background: ${props.theme.focus};
     }
   `;
 }

--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -203,12 +203,9 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
 
   return `
     ${common}
-    color: ${props.theme.textColor};
-    background-color: ${props.theme.background};
 
     &:hover {
       background: ${props.theme.focus};
-      color: ${props.theme.black};
     }
   `;
 }

--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -203,7 +203,7 @@ function getListItemStyles(props: MenuListItemProps & {theme: Theme}) {
 
   return `
     ${common}
-    color: ${props.theme.gray500};
+    color: ${props.theme.textColor};
     background-color: ${props.theme.background};
 
     &:hover {

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/selectorItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/selectorItem.tsx
@@ -42,12 +42,14 @@ const StyledSelectorItem = styled(SelectorItem)`
   padding: ${space(1)};
   align-items: center;
   flex: 1;
-  background-color: ${p => (p.selected ? p.theme.backgroundSecondary : 'transparent')};
+  background-color: ${p => (p.selected ? p.theme.active : 'transparent')};
+  color: ${p => (p.selected ? p.theme.white : 'inherit')};
   font-weight: ${p => (p.selected ? 'bold' : 'normal')};
   border-bottom: 1px solid ${p => (p.last ? 'transparent' : p.theme.innerBorder)};
 
   &:hover {
-    background: ${p => p.theme.backgroundSecondary};
+    color: ${p => p.theme.black};
+    background: ${p => p.theme.focus};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/radio.tsx
+++ b/src/sentry/static/sentry/app/components/radio.tsx
@@ -12,7 +12,7 @@ const checkedCss = (p: CheckedProps) => css`
   width: 1rem;
   height: 1rem;
   border-radius: 50%;
-  background-color: ${p.theme.green300};
+  background-color: ${p.theme.active};
   animation: 0.2s ${growIn} ease;
   opacity: ${p.disabled ? 0.4 : null};
 `;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
@@ -150,7 +150,7 @@ const getActiveStyle = ({active, theme}: {active?: string; theme?: Theme}) => {
     }
 
     &:before {
-      background-color: ${theme?.purple300};
+      background-color: ${theme?.active};
     }
   `;
 };

--- a/src/sentry/static/sentry/app/components/smartSearchBar/searchDropdown.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/searchDropdown.tsx
@@ -177,7 +177,7 @@ const SearchListItem = styled(ListItem)`
 
   &:hover,
   &.active {
-    background: ${p => p.theme.backgroundSecondary};
+    background: ${p => p.theme.focus};
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/switch.tsx
+++ b/src/sentry/static/sentry/app/components/switch.tsx
@@ -98,7 +98,7 @@ const Toggle = styled('span')<StyleProps>`
   transform: translateX(${getTranslateX}px);
   width: ${getToggleSize}px;
   height: ${getToggleSize}px;
-  background: ${p => (p.isActive ? p.theme.green300 : p.theme.gray200)};
+  background: ${p => (p.isActive ? p.theme.active : p.theme.border)};
   opacity: ${p => (p.isDisabled ? 0.4 : null)};
 `;
 

--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -161,9 +161,7 @@ const styles = (theme: Theme, isDark: boolean) => css`
           background-color: ${theme.backgroundSecondary};
           color: ${theme.textColor};
         }
-        .search .search-input,
-        .Select-control,
-        .Select-menu-outer {
+        .search .search-input {
           background: ${theme.background};
           color: ${theme.formText};
         }

--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -65,18 +65,24 @@ const styles = (theme: Theme, isDark: boolean) => css`
         .modal .modal-footer {
           border-top-color: ${theme.border};
         }
-        .nav-tabs > li > a:hover,
-        .nav-tabs > li > a:active,
-        .nav-tabs > li > a:focus {
-          border-bottom-color: ${theme.purple300} !important; /* TODO(dark): active */
-          color: ${theme.textColor} !important;
+
+        .nav-tabs {
+          & > li {
+            &.active {
+              a {
+                color: ${theme.textColor} !important;
+                border-bottom-color: ${theme.active} !important;
+              }
+            }
+
+            a:hover {
+              color: ${theme.textColor} !important;
+            }
+          }
         }
+
         ul.crumbs li .table.key-value pre {
           color: ${theme.subText};
-        }
-        .nav-tabs > li.active a,
-        .nav-tabs > li.active a:hover {
-          color: ${theme.textColor};
         }
 
         .exception {

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -111,6 +111,12 @@ const aliases = {
   active: colors.pink300,
 
   /**
+   * Indicates that something has "focus", which is different than "active" state as it is more temporal
+   * and should be a bit subtler than active
+   */
+  focus: 'rgba(240, 87, 129, 0.2)',
+
+  /**
    * Inactive
    */
   inactive: colors.gray200,
@@ -468,6 +474,7 @@ const commonTheme = {
 } as const;
 
 const darkAliases = {
+  ...aliases,
   bodyBackground: colors.black,
   headerBackground: colors.gray500,
   background: colors.black,
@@ -478,7 +485,6 @@ const darkAliases = {
   subText: colors.gray200,
   linkColor: colors.purple200,
   disabled: colors.gray200,
-  active: colors.pink300,
   inactive: colors.gray200,
   error: colors.red300,
   success: colors.green300,

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -114,7 +114,7 @@ const aliases = {
    * Indicates that something has "focus", which is different than "active" state as it is more temporal
    * and should be a bit subtler than active
    */
-  focus: 'rgba(240, 87, 129, 0.2)',
+  focus: color(colors.pink300).alpha(0.2).string(),
 
   /**
    * Inactive

--- a/src/sentry/static/sentry/app/views/issueList/savedSearchSelector.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchSelector.tsx
@@ -7,6 +7,7 @@ import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownControl from 'app/components/dropdownControl';
+import MenuItem from 'app/components/menuItem';
 import Tooltip from 'app/components/tooltip';
 import {IconDelete} from 'app/icons';
 import {t} from 'app/locale';
@@ -53,6 +54,8 @@ export default class SavedSearchSelector extends React.Component<Props> {
       onSavedSearchDelete,
       onSavedSearchSelect,
       organization,
+      query,
+      searchId,
     } = this.props;
 
     if (savedSearchList.length === 0) {
@@ -71,7 +74,10 @@ export default class SavedSearchSelector extends React.Component<Props> {
         delay={1000}
         key={search.id}
       >
-        <MenuItem last={index === savedSearchList.length - 1}>
+        <StyledMenuItem
+          isActive={search.id === searchId || search.query === query}
+          last={index === savedSearchList.length - 1}
+        >
           <MenuItemLink tabIndex={-1} onClick={() => onSavedSearchSelect(search)}>
             <SearchTitle>{search.name}</SearchTitle>
             <SearchQuery>{search.query}</SearchQuery>
@@ -97,7 +103,7 @@ export default class SavedSearchSelector extends React.Component<Props> {
               </Confirm>
             </Access>
           )}
-        </MenuItem>
+        </StyledMenuItem>
       </Tooltip>
     ));
   }
@@ -176,24 +182,24 @@ const DeleteButton = styled(Button)`
   }
 `;
 
-const MenuItem = styled('li')<{last: boolean}>`
-  display: flex;
-  background-color: ${p => p.theme.background};
-
-  position: relative;
+const StyledMenuItem = styled(MenuItem)<{isActive: boolean; last: boolean}>`
   border-bottom: ${p => (!p.last ? `1px solid ${p.theme.innerBorder}` : null)};
   font-size: ${p => p.theme.fontSizeMedium};
   padding: 0;
 
-  & :hover {
-    background: ${p => p.theme.backgroundSecondary};
+  ${p =>
+    p.isActive &&
+    `
+  ${SearchTitle}, ${SearchQuery} {
+    color: ${p.theme.white};
   }
+  `}
 `;
 
 const MenuItemLink = styled('a')`
   display: block;
   flex-grow: 1;
-  padding: ${space(1)} ${space(1.5)};
+  padding: ${space(0.5)} 0;
 
   ${overflowEllipsis}
 `;

--- a/src/sentry/static/sentry/app/views/issueList/savedSearchSelector.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchSelector.tsx
@@ -187,11 +187,22 @@ const StyledMenuItem = styled(MenuItem)<{isActive: boolean; last: boolean}>`
   font-size: ${p => p.theme.fontSizeMedium};
   padding: 0;
 
+  &:hover {
+    ${SearchTitle}, ${SearchQuery} {
+      color: ${p => p.theme.black};
+    }
+  }
+
   ${p =>
     p.isActive &&
     `
   ${SearchTitle}, ${SearchQuery} {
     color: ${p.theme.white};
+  }
+  &:hover {
+    ${SearchTitle}, ${SearchQuery} {
+      color: ${p.theme.black};
+    }
   }
   `}
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/rangeSlider.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/rangeSlider.tsx
@@ -260,7 +260,7 @@ const Slider = styled('input')<{hasLabel: boolean}>`
     width: 100%;
     height: 3px;
     cursor: pointer;
-    background: ${p => p.theme.gray200};
+    background: ${p => p.theme.border};
     border-radius: 3px;
     border: 0;
   }
@@ -269,7 +269,7 @@ const Slider = styled('input')<{hasLabel: boolean}>`
     width: 100%;
     height: 3px;
     cursor: pointer;
-    background: ${p => p.theme.gray200};
+    background: ${p => p.theme.border};
     border-radius: 3px;
     border: 0;
   }
@@ -278,17 +278,17 @@ const Slider = styled('input')<{hasLabel: boolean}>`
     width: 100%;
     height: 3px;
     cursor: pointer;
-    background: ${p => p.theme.gray200};
+    background: ${p => p.theme.border};
     border-radius: 3px;
     border: 0;
   }
 
   &::-webkit-slider-thumb {
-    box-shadow: 0 0 0 3px #fff;
+    box-shadow: 0 0 0 3px ${p => p.theme.background};
     height: 17px;
     width: 17px;
     border-radius: 50%;
-    background: ${p => p.theme.purple300};
+    background: ${p => p.theme.active};
     cursor: pointer;
     /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-appearance: none;
@@ -297,11 +297,11 @@ const Slider = styled('input')<{hasLabel: boolean}>`
   }
 
   &::-moz-range-thumb {
-    box-shadow: 0 0 0 3px #fff;
+    box-shadow: 0 0 0 3px ${p => p.theme.background};
     height: 17px;
     width: 17px;
     border-radius: 50%;
-    background: ${p => p.theme.purple300};
+    background: ${p => p.theme.active};
     cursor: pointer;
     /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-appearance: none;
@@ -310,11 +310,11 @@ const Slider = styled('input')<{hasLabel: boolean}>`
   }
 
   &::-ms-thumb {
-    box-shadow: 0 0 0 3px #fff;
+    box-shadow: 0 0 0 3px ${p => p.theme.background};
     height: 17px;
     width: 17px;
     border-radius: 50%;
-    background: ${p => p.theme.purple300};
+    background: ${p => p.theme.active};
     cursor: pointer;
     /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-appearance: none;
@@ -323,13 +323,13 @@ const Slider = styled('input')<{hasLabel: boolean}>`
   }
 
   &::-ms-fill-lower {
-    background: ${p => p.theme.gray200};
+    background: ${p => p.theme.border};
     border: 0;
     border-radius: 50%;
   }
 
   &::-ms-fill-upper {
-    background: ${p => p.theme.gray200};
+    background: ${p => p.theme.border};
     border: 0;
     border-radius: 50%;
   }
@@ -338,31 +338,31 @@ const Slider = styled('input')<{hasLabel: boolean}>`
     outline: none;
 
     &::-webkit-slider-runnable-track {
-      background: ${p => p.theme.gray200};
+      background: ${p => p.theme.border};
     }
 
     &::-ms-fill-upper {
-      background: ${p => p.theme.gray200};
+      background: ${p => p.theme.border};
     }
 
     &::-ms-fill-lower {
-      background: ${p => p.theme.gray200};
+      background: ${p => p.theme.border};
     }
   }
 
   &[disabled] {
     &::-webkit-slider-thumb {
-      background: ${p => p.theme.gray200};
+      background: ${p => p.theme.border};
       cursor: default;
     }
 
     &::-moz-range-thumb {
-      background: ${p => p.theme.gray200};
+      background: ${p => p.theme.border};
       cursor: default;
     }
 
     &::-ms-thumb {
-      background: ${p => p.theme.gray200};
+      background: ${p => p.theme.border};
       cursor: default;
     }
 

--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavItem.tsx
@@ -44,7 +44,7 @@ const StyledNavItem = styled(Link)`
     color: ${p => p.theme.textColor};
 
     &:before {
-      background: ${p => p.theme.purple300};
+      background: ${p => p.theme.active};
     }
   }
 

--- a/tests/js/spec/components/forms/sentryProjectSelectorField.spec.jsx
+++ b/tests/js/spec/components/forms/sentryProjectSelectorField.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {mount} from 'sentry-test/enzyme';
+import {mountWithTheme} from 'sentry-test/enzyme';
 import {selectByValue} from 'sentry-test/select-new';
 
 import SentryProjectSelectorField from 'app/views/settings/components/forms/sentryProjectSelectorField';
@@ -16,7 +16,7 @@ describe('SentryProjectSelectorField', () => {
         name: 'My Proj',
       }),
     ];
-    const wrapper = mount(
+    const wrapper = mountWithTheme(
       <SentryProjectSelectorField onChange={mock} name="project" projects={projects} />
     );
 


### PR DESCRIPTION
This change will make `theme.active` and `theme.focus` the aliases to represent an active/selected state and the focus state respectively.

The motivations behind this change are:

- Dark mode
- Consistent design for an "active" or "selected" state
- Consistent design for a "focused" state which differs from an "active" state in that "focus" is temporal.
- To make our designers happy