### PR TITLE
ci(release): Fix post-release script

### DIFF
--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -eu
 
-git checkout master
-./scripts/bump-version.sh '' $(date -d "$(echo $RELEASE_VERSION | sed -e 's/^\([0-9]\{2\}\)\.\([0-9]\{1,2\}\)\.[0-9]\+$/20\1-\2-1/') 1 month" +%y.%-m.0.dev0)
+git checkout master && git pull
+./scripts/bump-version.sh '' $(date -d "$(echo $CRAFT_NEW_VERSION | sed -e 's/^\([0-9]\{2\}\)\.\([0-9]\{1,2\}\)\.[0-9]\+$/20\1-\2-1/') 1 month" +%y.%-m.0.dev0)
 git diff --quiet || git commit -anm 'meta: Bump new development version' && git pull --rebase && git push


### PR DESCRIPTION
The post-release script had 2 failures:

1. https://github.com/getsentry/publish/runs/1559745946?check_suite_focus=true#step:6:305 -- `$RELEASE_VERSION` was available inside the unified GitHub action earlier but when run stand-alone by Craft, this is not available. Luckily Craft already sets `CRAFT_NEW_VERSION` when running the script instead so we can use that.
2. https://github.com/getsentry/publish/runs/1559745946?check_suite_focus=true#step:6:293 -- This is because, even if we are already on master, the final branch merge is done on GitHub directly via the API so the local copy becomes stale. We need to run `git pull` before making any new commits.
