### PR TITLE
feat(releases): Ability to select which vital to graph on release details

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
@@ -85,7 +85,7 @@ class TransactionSummaryCharts extends React.Component<Props> {
     }
 
     const releaseQueryExtra = {
-      yAxis: display === DisplayModes.VITALS ? YAxis.COUNT_LCP : YAxis.COUNT_DURATION,
+      yAxis: display === DisplayModes.VITALS ? YAxis.COUNT_VITAL : YAxis.COUNT_DURATION,
       showTransactions:
         display === DisplayModes.VITALS
           ? TransactionsListOption.SLOW_LCP

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
@@ -10,6 +10,7 @@ import QuestionTooltip from 'app/components/questionTooltip';
 import {PlatformKey} from 'app/data/platformCategories';
 import {t} from 'app/locale';
 import {GlobalSelection, Organization, ReleaseMeta} from 'app/types';
+import {WebVital} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
 import {Theme} from 'app/utils/theme';
 import {getTermHelp} from 'app/views/performance/data';
@@ -31,8 +32,10 @@ type Props = Omit<ReleaseStatsRequestRenderProps, 'crashFreeTimeBreakdown'> & {
   platform: PlatformKey;
   yAxis: YAxis;
   eventType: EventType;
+  vitalType: WebVital;
   onYAxisChange: (yAxis: YAxis) => void;
   onEventTypeChange: (eventType: EventType) => void;
+  onVitalTypeChange: (vitalType: WebVital) => void;
   router: ReactRouter.InjectedRouter;
   organization: Organization;
   hasHealthData: boolean;
@@ -80,9 +83,9 @@ class ReleaseChartContainer extends React.Component<Props> {
           help: getTermHelp(organization, 'failureRate'),
         };
       case YAxis.COUNT_DURATION:
-        return {title: t('Slow Count (duration)')};
-      case YAxis.COUNT_LCP:
-        return {title: t('Slow Count (LCP)')};
+        return {title: t('Slow Duration Count')};
+      case YAxis.COUNT_VITAL:
+        return {title: t('Slow Vital Count')};
       case YAxis.EVENTS:
       default:
         return {title: t('Event Count')};
@@ -109,6 +112,7 @@ class ReleaseChartContainer extends React.Component<Props> {
       releaseMeta,
       yAxis,
       eventType,
+      vitalType,
       selection,
       version,
     } = this.props;
@@ -119,6 +123,7 @@ class ReleaseChartContainer extends React.Component<Props> {
       version,
       yAxis,
       eventType,
+      vitalType,
       organization
     );
     const apiPayload = eventView.getEventsAPIPayload(location);
@@ -128,6 +133,7 @@ class ReleaseChartContainer extends React.Component<Props> {
     const releaseQueryExtra = {
       showTransactions: location.query.showTransactions,
       eventType,
+      vitalType,
       yAxis,
     };
 
@@ -204,12 +210,14 @@ class ReleaseChartContainer extends React.Component<Props> {
     const {
       yAxis,
       eventType,
+      vitalType,
       hasDiscover,
       hasHealthData,
       hasPerformance,
       chartSummary,
       onYAxisChange,
       onEventTypeChange,
+      onVitalTypeChange,
       organization,
     } = this.props;
 
@@ -232,6 +240,8 @@ class ReleaseChartContainer extends React.Component<Props> {
           onYAxisChange={onYAxisChange}
           eventType={eventType}
           onEventTypeChange={onEventTypeChange}
+          vitalType={vitalType}
+          onVitalTypeChange={onVitalTypeChange}
           organization={organization}
           hasDiscover={hasDiscover}
           hasHealthData={hasHealthData}

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
@@ -23,7 +23,7 @@ export enum YAxis {
   EVENTS = 'events',
   FAILED_TRANSACTIONS = 'failedTransactions',
   COUNT_DURATION = 'countDuration',
-  COUNT_LCP = 'countLCP',
+  COUNT_VITAL = 'countVital',
 }
 
 export enum EventType {
@@ -37,7 +37,7 @@ export enum EventType {
 export const PERFORMANCE_AXIS = [
   YAxis.FAILED_TRANSACTIONS,
   YAxis.COUNT_DURATION,
-  YAxis.COUNT_LCP,
+  YAxis.COUNT_VITAL,
 ];
 
 type Props = {
@@ -46,6 +46,8 @@ type Props = {
   onYAxisChange: (value: YAxis) => void;
   eventType: EventType;
   onEventTypeChange: (value: EventType) => void;
+  vitalType: WebVital;
+  onVitalTypeChange: (value: WebVital) => void;
   organization: Organization;
   hasHealthData: boolean;
   hasDiscover: boolean;
@@ -60,8 +62,10 @@ const ReleaseChartControls = ({
   hasHealthData,
   hasDiscover,
   hasPerformance,
-  eventType,
+  eventType = EventType.ALL,
   onEventTypeChange,
+  vitalType = WebVital.LCP,
+  onVitalTypeChange,
 }: Props) => {
   const noHealthDataTooltip = !hasHealthData
     ? t('This view is only available with release health data.')
@@ -105,13 +109,13 @@ const ReleaseChartControls = ({
     },
     {
       value: YAxis.COUNT_DURATION,
-      label: t('Slow Count (duration)'),
+      label: t('Slow Duration Count'),
       disabled: !hasPerformance,
       tooltip: noPerformanceTooltip,
     },
     {
-      value: YAxis.COUNT_LCP,
-      label: t('Slow Count (LCP)'),
+      value: YAxis.COUNT_VITAL,
+      label: t('Slow Vital Count'),
       disabled: !hasPerformance,
       tooltip: noPerformanceTooltip,
     },
@@ -121,14 +125,6 @@ const ReleaseChartControls = ({
       disabled: !hasDiscover,
       tooltip: noDiscoverTooltip,
     },
-  ];
-
-  const eventTypeOptions: SelectValue<EventType>[] = [
-    {value: EventType.ALL, label: t('All')},
-    {value: EventType.CSP, label: t('CSP')},
-    {value: EventType.DEFAULT, label: t('Default')},
-    {value: EventType.ERROR, label: 'Error'},
-    {value: EventType.TRANSACTION, label: t('Transaction')},
   ];
 
   const getSummaryHeading = () => {
@@ -144,9 +140,11 @@ const ReleaseChartControls = ({
       case YAxis.FAILED_TRANSACTIONS:
         return t('Failed Transactions');
       case YAxis.COUNT_DURATION:
-        return t(`Count over ${organization.apdexThreshold}ms`);
-      case YAxis.COUNT_LCP:
-        return t(`Count over ${WEB_VITAL_DETAILS[WebVital.LCP].failureThreshold}ms`);
+        return t('Count over %sms', organization.apdexThreshold);
+      case YAxis.COUNT_VITAL:
+        return vitalType !== WebVital.CLS
+          ? t('Count over %sms', WEB_VITAL_DETAILS[vitalType].failureThreshold)
+          : t('Count over %s', WEB_VITAL_DETAILS[vitalType].failureThreshold);
       case YAxis.SESSIONS:
       default:
         return t('Total Sessions');
@@ -167,14 +165,13 @@ const ReleaseChartControls = ({
         )}
       </InlineContainer>
       <InlineContainer>
-        {yAxis === YAxis.EVENTS && (
-          <OptionSelector
-            title={t('Event Type')}
-            selected={eventType ?? EventType.ALL}
-            options={eventTypeOptions}
-            onChange={onEventTypeChange as (value: string) => void}
-          />
-        )}
+        <SecondarySelector
+          yAxis={yAxis}
+          eventType={eventType}
+          onEventTypeChange={onEventTypeChange}
+          vitalType={vitalType}
+          onVitalTypeChange={onVitalTypeChange}
+        />
         <OptionSelector
           title={t('Display')}
           selected={yAxis}
@@ -185,6 +182,61 @@ const ReleaseChartControls = ({
     </StyledChartControls>
   );
 };
+
+const eventTypeOptions: SelectValue<EventType>[] = [
+  {value: EventType.ALL, label: t('All')},
+  {value: EventType.CSP, label: t('CSP')},
+  {value: EventType.DEFAULT, label: t('Default')},
+  {value: EventType.ERROR, label: 'Error'},
+  {value: EventType.TRANSACTION, label: t('Transaction')},
+];
+
+const vitalTypeOptions: SelectValue<WebVital>[] = [
+  WebVital.FP,
+  WebVital.FCP,
+  WebVital.LCP,
+  WebVital.FID,
+  WebVital.CLS,
+].map(vital => ({value: vital, label: WEB_VITAL_DETAILS[vital].name}));
+
+type SecondarySelectorProps = {
+  yAxis: YAxis;
+  eventType: EventType;
+  onEventTypeChange: (v: EventType) => void;
+  vitalType: WebVital;
+  onVitalTypeChange: (v: WebVital) => void;
+};
+
+function SecondarySelector({
+  yAxis,
+  eventType,
+  onEventTypeChange,
+  vitalType,
+  onVitalTypeChange,
+}: SecondarySelectorProps) {
+  switch (yAxis) {
+    case YAxis.EVENTS:
+      return (
+        <OptionSelector
+          title={t('Event Type')}
+          selected={eventType}
+          options={eventTypeOptions}
+          onChange={onEventTypeChange as (value: string) => void}
+        />
+      );
+    case YAxis.COUNT_VITAL:
+      return (
+        <OptionSelector
+          title={t('Vital Type')}
+          selected={vitalType}
+          options={vitalTypeOptions}
+          onChange={onVitalTypeChange as (value: string) => void}
+        />
+      );
+    default:
+      return null;
+  }
+}
 
 const StyledChartControls = styled(ChartControls)`
   @media (max-width: ${p => p.theme.breakpoints[0]}) {

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
@@ -227,7 +227,7 @@ function SecondarySelector({
     case YAxis.COUNT_VITAL:
       return (
         <OptionSelector
-          title={t('Vital Type')}
+          title={t('Vital')}
           selected={vitalType}
           options={vitalTypeOptions}
           onChange={onVitalTypeChange as (value: string) => void}

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/utils.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/utils.tsx
@@ -68,23 +68,14 @@ export function getReleaseEventView(
           )
         ),
       });
-    case YAxis.COUNT_DURATION:
-      const durationColumn = 'transaction.duration';
-      const durationThreshold = organization?.apdexThreshold;
-      return EventView.fromSavedQuery({
-        ...baseQuery,
-        query: stringifyQueryObject(
-          new QueryResults(
-            [
-              'event.type:transaction',
-              releaseFilter,
-              durationThreshold ? `${durationColumn}:>${durationThreshold}` : '',
-            ].filter(Boolean)
-          )
-        ),
-      });
     case YAxis.COUNT_VITAL:
-      const vitalThreshold = WEB_VITAL_DETAILS[vitalType].failureThreshold;
+    case YAxis.COUNT_DURATION:
+      const column =
+        yAxis === YAxis.COUNT_DURATION ? 'transaction.duration' : vitalType;
+      const threshold =
+        yAxis === YAxis.COUNT_DURATION
+          ? organization?.apdexThreshold
+          : WEB_VITAL_DETAILS[vitalType].failureThreshold;
       return EventView.fromSavedQuery({
         ...baseQuery,
         query: stringifyQueryObject(
@@ -92,7 +83,7 @@ export function getReleaseEventView(
             [
               'event.type:transaction',
               releaseFilter,
-              vitalThreshold ? `${vitalType}:>${vitalThreshold}` : '',
+              threshold ? `${column}:>${threshold}` : '',
             ].filter(Boolean)
           )
         ),

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/utils.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/utils.tsx
@@ -70,8 +70,7 @@ export function getReleaseEventView(
       });
     case YAxis.COUNT_VITAL:
     case YAxis.COUNT_DURATION:
-      const column =
-        yAxis === YAxis.COUNT_DURATION ? 'transaction.duration' : vitalType;
+      const column = yAxis === YAxis.COUNT_DURATION ? 'transaction.duration' : vitalType;
       const threshold =
         yAxis === YAxis.COUNT_DURATION
           ? organization?.apdexThreshold

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -12,6 +12,7 @@ import {GlobalSelection, NewQuery, Organization, ReleaseProject} from 'app/types
 import {getUtcDateString} from 'app/utils/dates';
 import {TableDataRow} from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
+import {WebVital} from 'app/utils/discover/fields';
 import {formatVersion} from 'app/utils/formatters';
 import {decodeScalar} from 'app/utils/queryString';
 import routeTitleGen from 'app/utils/routeTitle';
@@ -70,7 +71,7 @@ class ReleaseOverview extends AsyncView<Props> {
 
   handleYAxisChange = (yAxis: YAxis) => {
     const {location, router} = this.props;
-    const {eventType: _eventType, ...query} = location.query;
+    const {eventType: _eventType, vitalType: _vitalType, ...query} = location.query;
 
     router.push({
       ...location,
@@ -84,6 +85,15 @@ class ReleaseOverview extends AsyncView<Props> {
     router.push({
       ...location,
       query: {...location.query, eventType},
+    });
+  };
+
+  handleVitalTypeChange = (vitalType: WebVital) => {
+    const {location, router} = this.props;
+
+    router.push({
+      ...location,
+      query: {...location.query, vitalType},
     });
   };
 
@@ -134,6 +144,20 @@ class ReleaseOverview extends AsyncView<Props> {
     }
 
     return EventType.ALL;
+  }
+
+  getVitalType(yAxis: YAxis): WebVital {
+    if (yAxis === YAxis.COUNT_VITAL) {
+      const {vitalType} = this.props.location.query;
+
+      if (typeof vitalType === 'string') {
+        if (Object.values(WebVital).includes(vitalType as WebVital)) {
+          return vitalType as WebVital;
+        }
+      }
+    }
+
+    return WebVital.LCP;
   }
 
   getReleaseEventView(
@@ -228,6 +252,7 @@ class ReleaseOverview extends AsyncView<Props> {
           const hasPerformance = organization.features.includes('performance-view');
           const yAxis = this.getYAxis(hasHealthData, hasPerformance);
           const eventType = this.getEventType(yAxis);
+          const vitalType = this.getVitalType(yAxis);
 
           const {selectedSort, sortOptions} = getTransactionsListSort(location);
           const releaseEventView = this.getReleaseEventView(
@@ -264,6 +289,7 @@ class ReleaseOverview extends AsyncView<Props> {
               location={location}
               yAxis={yAxis}
               eventType={eventType}
+              vitalType={vitalType}
               hasHealthData={hasHealthData}
               hasDiscover={hasDiscover}
               hasPerformance={hasPerformance}
@@ -286,6 +312,8 @@ class ReleaseOverview extends AsyncView<Props> {
                         onYAxisChange={this.handleYAxisChange}
                         eventType={eventType}
                         onEventTypeChange={this.handleEventTypeChange}
+                        vitalType={vitalType}
+                        onVitalTypeChange={this.handleVitalTypeChange}
                         router={router}
                         organization={organization}
                         hasHealthData={hasHealthData}

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/releaseStatsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/releaseStatsRequest.tsx
@@ -16,6 +16,7 @@ import {t, tct} from 'app/locale';
 import {CrashFreeTimeBreakdown, GlobalSelection, Organization} from 'app/types';
 import {Series} from 'app/types/echarts';
 import {defined, percent} from 'app/utils';
+import {WebVital} from 'app/utils/discover/fields';
 import {getExactDuration} from 'app/utils/formatters';
 
 import {displayCrashFreePercent, getCrashFreePercent, roundDuration} from '../../utils';
@@ -52,6 +53,7 @@ type Props = {
   location: Location;
   yAxis: YAxis;
   eventType: EventType;
+  vitalType: WebVital;
   children: (renderProps: ReleaseStatsRequestRenderProps) => React.ReactNode;
   hasHealthData: boolean;
   hasDiscover: boolean;
@@ -107,7 +109,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
         yAxis === YAxis.EVENTS ||
         yAxis === YAxis.FAILED_TRANSACTIONS ||
         yAxis === YAxis.COUNT_DURATION ||
-        yAxis === YAxis.COUNT_LCP
+        yAxis === YAxis.COUNT_VITAL
       ) {
         data = await this.fetchEventData();
       } else {
@@ -185,6 +187,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
       location,
       yAxis,
       eventType,
+      vitalType,
       selection,
       version,
       hasHealthData,
@@ -195,6 +198,7 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
       version,
       yAxis,
       eventType,
+      vitalType,
       organization,
       true
     );


### PR DESCRIPTION
The release details page only allows graphing the slow LCP but not the other
vitals. This change introduces a secondary selector for the vital type.

# Screenshot

![image](https://user-images.githubusercontent.com/10239353/102277850-db79c680-3ef6-11eb-8041-90f23508d28b.png)
