### PR TITLE
feat(workflow): Disable confirmation on mark reviewed (WOR-478)

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
@@ -69,7 +69,7 @@ function ActionSet({
             disabled={!anySelected}
             onAction={() => onUpdate({inbox: false})}
             shouldConfirm={onShouldConfirm(ConfirmAction.ACKNOWLEDGE)}
-            message={confirm(ConfirmAction.MARK, false, ' as reviewed')}
+            message={confirm('mark', false, ' as reviewed')}
             confirmLabel={label('Mark', ' as reviewed')}
             title={t('Mark Reviewed')}
           >
@@ -203,7 +203,7 @@ function ActionSet({
               disabled={!anySelected}
               onAction={() => onUpdate({isBookmarked: false})}
               shouldConfirm={onShouldConfirm(ConfirmAction.UNBOOKMARK)}
-              message={confirm(ConfirmAction.REMOVE, false, ' from your bookmarks')}
+              message={confirm('remove', false, ' from your bookmarks')}
               confirmLabel={label('remove', ' from your bookmarks')}
               title={t('Remove from Bookmarks')}
             >

--- a/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
@@ -215,11 +215,11 @@ class IssueListActions extends React.Component<Props, State> {
       case ConfirmAction.RESOLVE:
       case ConfirmAction.UNRESOLVE:
       case ConfirmAction.IGNORE:
+      case ConfirmAction.ACKNOWLEDGE:
       case ConfirmAction.UNBOOKMARK: {
         const {pageSelected} = this.state;
         return pageSelected && selectedItems.size > 1;
       }
-      case ConfirmAction.ACKNOWLEDGE:
       case ConfirmAction.BOOKMARK:
         return selectedItems.size > 1;
       case ConfirmAction.MERGE:

--- a/src/sentry/static/sentry/app/views/issueList/actions/utils.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/utils.tsx
@@ -16,10 +16,8 @@ export enum ConfirmAction {
   IGNORE = 'ignore',
   BOOKMARK = 'bookmark',
   UNBOOKMARK = 'unbookmark',
-  MARK = 'mark',
   MERGE = 'merge',
   DELETE = 'delete',
-  REMOVE = 'remove',
 }
 
 function getBulkConfirmMessage(action: string, queryCount: number) {
@@ -48,7 +46,7 @@ export function getConfirm(
   query: string,
   queryCount: number
 ) {
-  return function (action: ConfirmAction, canBeUndone: boolean, append = '') {
+  return function (action: ConfirmAction | string, canBeUndone: boolean, append = '') {
     const question = allInQuerySelected
       ? getBulkConfirmMessage(`${action}${append}`, queryCount)
       : tn(


### PR DESCRIPTION
Disable confirmation when the selection is not >= the entire page.
Remove some enums that are only for wordsmithing the confirmation message.