### PR TITLE
feat(ui): Fix `<ClippedBox>` to support theme aliases for dark mode

### DIFF
--- a/src/sentry/static/sentry/app/components/clippedBox.tsx
+++ b/src/sentry/static/sentry/app/components/clippedBox.tsx
@@ -1,7 +1,7 @@
-import color from 'color';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import styled from '@emotion/styled';
+import color from 'color';
 
 import Button from 'app/components/button';
 import {t} from 'app/locale';

--- a/src/sentry/static/sentry/app/components/clippedBox.tsx
+++ b/src/sentry/static/sentry/app/components/clippedBox.tsx
@@ -1,3 +1,4 @@
+import color from 'color';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import styled from '@emotion/styled';
@@ -173,8 +174,8 @@ const ClipFade = styled('div')`
   padding: 40px 0 0;
   background-image: linear-gradient(
     180deg,
-    rgba(255, 255, 255, 0.15),
-    rgba(255, 255, 255, 1)
+    ${p => color(p.theme.background).alpha(0.15).string()},
+    ${p => p.theme.background}
   );
   text-align: center;
   border-bottom: ${space(1.5)} solid ${p => p.theme.background};


### PR DESCRIPTION
<details><summary>old</summary>

![image](https://user-images.githubusercontent.com/79684/102282924-440c7780-3ee6-11eb-9335-ceac22c2c429.png)

</details>

<details><summary>new</summary>

![image](https://user-images.githubusercontent.com/79684/102282950-52f32a00-3ee6-11eb-8ba7-28f9f8eb793a.png)

</details>