### PR TITLE
feat(integration): allow form to be used for integration extension endpoints

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -41,6 +41,8 @@ type Props = {
   // Save field on control blur
   saveOnBlur?: boolean;
   model?: FormModel;
+  // if set to true, preventDefault is not called
+  allowDefault?: boolean;
   'data-test-id'?: string;
 
   onCancel?: (e: React.MouseEvent) => void;
@@ -145,7 +147,7 @@ export default class Form extends React.Component<Props> {
   model: FormModel = this.props.model || new FormModel();
 
   onSubmit = e => {
-    e.preventDefault();
+    !this.props.allowDefault && e.preventDefault();
     if (this.model.isSaving) {
       return;
     }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -42,7 +42,7 @@ type Props = {
   saveOnBlur?: boolean;
   model?: FormModel;
   // if set to true, preventDefault is not called
-  allowDefault?: boolean;
+  skipPreventDefault?: boolean;
   'data-test-id'?: string;
 
   onCancel?: (e: React.MouseEvent) => void;
@@ -147,7 +147,7 @@ export default class Form extends React.Component<Props> {
   model: FormModel = this.props.model || new FormModel();
 
   onSubmit = e => {
-    !this.props.allowDefault && e.preventDefault();
+    !this.props.skipPreventDefault && e.preventDefault();
     if (this.model.isSaving) {
       return;
     }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.tsx
@@ -28,7 +28,9 @@ export type FormOptions = {
   onSubmitError?: (error: any, instance: FormModel, id?: string) => void;
 };
 
-type OptionsWithInitial = FormOptions & {initialData?: object};
+type ClientOptions = ConstructorParameters<typeof Client>[0];
+
+type OptionsWithInitial = FormOptions & ClientOptions & {initialData?: object};
 
 class FormModel {
   /**
@@ -84,7 +86,7 @@ class FormModel {
       this.setInitialData(initialData);
     }
 
-    this.api = new Client();
+    this.api = new Client(options);
   }
 
   /**

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.tsx
@@ -80,13 +80,13 @@ class FormModel {
 
   options: FormOptions;
 
-  constructor({initialData, ...options}: OptionsWithInitial = {}) {
+  constructor({initialData, baseUrl, ...options}: OptionsWithInitial = {}) {
     this.options = options || {};
     if (initialData) {
       this.setInitialData(initialData);
     }
 
-    this.api = new Client(options);
+    this.api = new Client({baseUrl});
   }
 
   /**

--- a/src/sentry/static/sentry/app/views/settings/components/forms/model.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/model.tsx
@@ -30,7 +30,10 @@ export type FormOptions = {
 
 type ClientOptions = ConstructorParameters<typeof Client>[0];
 
-type OptionsWithInitial = FormOptions & ClientOptions & {initialData?: object};
+type OptionsWithInitial = FormOptions & {
+  initialData?: object;
+  apiOptions?: ClientOptions;
+};
 
 class FormModel {
   /**
@@ -80,13 +83,13 @@ class FormModel {
 
   options: FormOptions;
 
-  constructor({initialData, baseUrl, ...options}: OptionsWithInitial = {}) {
+  constructor({initialData, apiOptions, ...options}: OptionsWithInitial = {}) {
     this.options = options || {};
     if (initialData) {
       this.setInitialData(initialData);
     }
 
-    this.api = new Client({baseUrl});
+    this.api = new Client(apiOptions);
   }
 
   /**


### PR DESCRIPTION
This PR adds the ability to let our forms post to integration extension endpoints (e.g. `/extensions/aws_lambda/setup/`) with the new React pipeline views added in https://github.com/getsentry/sentry/pull/22611. These endpoints are not the`/api/0/` endpoints so we need a way to pass in the `baseUrl` to the `Client` when creating a form model. We also want these to act like old-fashioned HTML views so that we render the HTML in the post response on a refresh which is why we have to prevent  `preventDefault` from being called.