### PR TITLE
fix(workflow): Disable inline mark review if reviewed (WOR-479)

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
@@ -73,11 +73,12 @@ class GroupRowActions extends React.Component<Props> {
 
     return (
       <Wrapper>
-        <Tooltip title={t('Mark Reviewed')}>
+        <Tooltip title={group.inbox ? t('Mark Reviewed') : null}>
           <ActionLink
             className="btn btn-default btn-sm"
             onAction={() => this.handleUpdate({inbox: false})}
             shouldConfirm={false}
+            disabled={!group.inbox}
             title={t('Mark Reviewed')}
           >
             <IconIssues size="sm" color="gray300" />


### PR DESCRIPTION
Disable row mark reviewed button when item is not in inbox or after it has been reviewed. Also disables the tooltip.
![image](https://user-images.githubusercontent.com/1400464/102289782-5a213480-3ef4-11eb-987c-00f0f6be0bfa.png)
