### PR TITLE
fix(api-keys): Consistent capitalization

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/organizationApiKeys/organizationApiKeyDetails.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationApiKeys/organizationApiKeyDetails.tsx
@@ -68,7 +68,7 @@ class OrganizationApiKeyDetails extends AsyncView<Props, State> {
   renderBody() {
     return (
       <div>
-        <SettingsPageHeader title={t('Edit Api Key')} />
+        <SettingsPageHeader title={t('Edit API Key')} />
 
         <Panel>
           <PanelHeader>{t('API Key')}</PanelHeader>


### PR DESCRIPTION
## Objective
We want to maintain a consistent UI/UX and that means consistent capitalization.

**Before:**
![Screen Shot 2020-12-15 at 6 04 41 PM](https://user-images.githubusercontent.com/10491193/102295654-ae321600-3f00-11eb-9fb9-272d927b103b.png)

**After:**
![Screen Shot 2020-12-15 at 6 10 13 PM](https://user-images.githubusercontent.com/10491193/102295701-cdc93e80-3f00-11eb-84a9-85393a6eea5f.png)
