### PR TITLE
feat(releases): Collect release analytics after successful commits upload

### DIFF
--- a/src/sentry/analytics/events/release_set_commits.py
+++ b/src/sentry/analytics/events/release_set_commits.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, print_function
 from sentry import analytics
 
 
-class ReleaseSetCommitsEvent(analytics.Event):
-    type = "release.set_commits"
+class ReleaseSetCommitsLocalEvent(analytics.Event):
+    type = "release.set_commits_local"
 
     attributes = (
         analytics.Attribute("user_id", required=False),
@@ -14,4 +14,4 @@ class ReleaseSetCommitsEvent(analytics.Event):
     )
 
 
-analytics.register(ReleaseSetCommitsEvent)
+analytics.register(ReleaseSetCommitsLocalEvent)

--- a/src/sentry/analytics/events/release_set_commits.py
+++ b/src/sentry/analytics/events/release_set_commits.py
@@ -1,0 +1,17 @@
+from __future__ import absolute_import, print_function
+
+from sentry import analytics
+
+
+class ReleaseSetCommitsEvent(analytics.Event):
+    type = "release.set_commits"
+
+    attributes = (
+        analytics.Attribute("user_id", required=False),
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_ids"),
+        analytics.Attribute("user_agent", required=False),
+    )
+
+
+analytics.register(ReleaseSetCommitsEvent)

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -17,7 +17,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from sentry import tsdb
+from sentry import tsdb, analytics
 from sentry.auth import access
 from sentry.models import Environment
 from sentry.utils.cursors import Cursor
@@ -414,3 +414,14 @@ class StatsMixin(object):
             return int(value[:-1])
         else:
             raise ValueError(value)
+
+
+class ReleaseAnalyticsMixin(object):
+    def track_set_commits_local(self, request, organization_id=None, project_ids=None):
+        analytics.record(
+            "release.set_commits_local",
+            user_id=request.user.id if request.user and request.user.id else None,
+            organization_id=organization_id,
+            project_ids=project_ids,
+            user_agent=request.META.get("HTTP_USER_AGENT", ""),
+        )

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -374,7 +374,7 @@ class OrganizationReleasesEndpoint(
                     try:
                         release.set_commits(commit_list)
                         self.track_set_commits_local(
-                            release,
+                            request,
                             organization_id=organization.id,
                             project_ids=[project.id for project in projects],
                         )

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -372,10 +372,10 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
                     try:
                         release.set_commits(commit_list)
                         analytics.record(
-                            "release.set_commits",
+                            "release.set_commits_local",
                             user_id=request.user.id if request.user and request.user.id else None,
                             organization_id=organization.id,
-                            project_ids=[project.id for project in release.projects.all()],
+                            project_ids=[project.id for project in projects],
                             user_agent=request.META.get("HTTP_USER_AGENT", ""),
                         )
                     except ReleaseCommitError:
@@ -402,13 +402,6 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, Environment
                     fetch_commits = not commit_list
                     try:
                         release.set_refs(refs, request.user, fetch=fetch_commits)
-                        analytics.record(
-                            "release.set_commits",
-                            user_id=request.user.id if request.user and request.user.id else None,
-                            organization_id=organization.id,
-                            project_ids=[project.id for project in release.projects.all()],
-                            user_agent=request.META.get("HTTP_USER_AGENT", ""),
-                        )
                     except InvalidRepository as e:
                         scope.set_tag("failure_reason", "InvalidRepository")
                         return Response({"refs": [six.text_type(e)]}, status=400)

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -5,8 +5,7 @@ import six
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
-from sentry import analytics
-
+from sentry.api.base import ReleaseAnalyticsMixin
 from sentry.api.bases.project import ProjectEndpoint, ProjectReleasePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
@@ -23,7 +22,7 @@ from sentry.utils.sdk import configure_scope, bind_organization_context
 from sentry.web.decorators import transaction_start
 
 
-class ProjectReleaseDetailsEndpoint(ProjectEndpoint):
+class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
     permission_classes = (ProjectReleasePermission,)
 
     @transaction_start("ProjectReleaseDetailsEndpoint.get")
@@ -133,12 +132,8 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint):
                 hook = ReleaseHook(project)
                 # TODO(dcramer): handle errors with release payloads
                 hook.set_commits(release.version, commit_list)
-                analytics.record(
-                    "release.set_commits_local",
-                    user_id=request.user.id if request.user and request.user.id else None,
-                    organization_id=project.organization_id,
-                    project_ids=[project.id],
-                    user_agent=request.META.get("HTTP_USER_AGENT", ""),
+                self.track_set_commits_local(
+                    request, organization_id=project.organization_id, project_ids=[project.id]
                 )
 
             if not was_released and release.date_released:


### PR DESCRIPTION
## Objective
Currently, we collect analytics when we get the commit of the most recent release. https://github.com/getsentry/sentry/blob/a7e3d2199b78b8f83550b413ca451b17442978b2/src/sentry/api/endpoints/organization_release_previous_commits.py#L49 This happens before we update the release with the commits. We should be collecting the analytics after the release we successfully associate commits.