### PR TITLE
feat(native): Expose dif candidates to frontend

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -931,6 +931,8 @@ SENTRY_FEATURES = {
     "organizations:usage-stats-graph": False,
     # Enable inbox support in the issue stream
     "organizations:inbox": False,
+    # Enable the new images loaded design and features
+    "organizations:images-loaded-v2": False,
     # Return unhandled information on the issue level
     "organizations:unhandled-issue-flag": False,
     # Enable "owner"/"suggested assignee" features.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -837,6 +837,8 @@ SENTRY_FEATURES = {
     "organizations:custom-symbol-sources": True,
     # Enable the events stream interface.
     "organizations:events": False,
+    # Request detailed "debug logs" from Symbolicator and save them to event
+    "organizations:dif-candidates": False,
     # Enable discover 2 basic functions
     "organizations:discover-basic": True,
     # Enable discover 2 custom queries and saved queries

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -837,8 +837,6 @@ SENTRY_FEATURES = {
     "organizations:custom-symbol-sources": True,
     # Enable the events stream interface.
     "organizations:events": False,
-    # Request detailed "debug logs" from Symbolicator and save them to event
-    "organizations:dif-candidates": False,
     # Enable discover 2 basic functions
     "organizations:discover-basic": True,
     # Enable discover 2 custom queries and saved queries

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -61,7 +61,6 @@ default_manager.add("organizations:related-events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:alert-filters", OrganizationFeature)  # NOQA
 default_manager.add("organizations:custom-symbol-sources", OrganizationFeature)  # NOQA
 default_manager.add("organizations:data-forwarding", OrganizationFeature)  # NOQA
-default_manager.add("organizations:dif-candidates", ProjectFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover-query", OrganizationFeature)  # NOQA

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -84,6 +84,7 @@ default_manager.add("organizations:integrations-stacktrace-link", OrganizationFe
 default_manager.add("organizations:integrations-aws_lambda", OrganizationFeature)  # NOQA
 default_manager.add("organizations:internal-catchall", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members", OrganizationFeature)  # NOQA
+default_manager.add("organizations:images-loaded-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:large-debug-files", OrganizationFeature)  # NOQA
 default_manager.add("organizations:monitors", OrganizationFeature)  # NOQA
 default_manager.add("organizations:onboarding", OrganizationFeature)  # NOQA

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -61,6 +61,7 @@ default_manager.add("organizations:related-events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:alert-filters", OrganizationFeature)  # NOQA
 default_manager.add("organizations:custom-symbol-sources", OrganizationFeature)  # NOQA
 default_manager.add("organizations:data-forwarding", OrganizationFeature)  # NOQA
+default_manager.add("organizations:dif-candidates", ProjectFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover-query", OrganizationFeature)  # NOQA

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -261,7 +261,7 @@ def parse_sources(config):
 def get_options_for_project(project):
     return {
         # Symbolicators who do not support options will ignore this field entirely.
-        "dif_candidates": features.has("organizations:dif-candidates", project.organization)
+        "dif_candidates": features.has("organizations:images-loaded-v2", project.organization)
     }
 
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -213,7 +213,6 @@ def get_internal_source(project):
             ).replace("127.0.0.1", "host.docker.internal")
 
     assert internal_url_prefix
-    assert project._organization_cache is not None
     sentry_source_url = "%s%s" % (
         internal_url_prefix.rstrip("/"),
         reverse(
@@ -260,7 +259,6 @@ def parse_sources(config):
 
 
 def get_options_for_project(project):
-    assert project._organization_cache is not None
     return {
         # Symbolicators who do not support options will ignore this field entirely.
         "dif_candidates": features.has("organizations:dif-candidates", project.organization)
@@ -281,7 +279,6 @@ def get_sources_for_project(project):
 
     # Check that the organization still has access to symbol sources. This
     # controls both builtin and external sources.
-    assert project._organization_cache is not None
     organization = project.organization
 
     if not features.has("organizations:symbol-sources", organization):

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -448,20 +448,14 @@ class SymbolicatorSession(object):
     def upload_minidump(self, minidump):
         return self._create_task(
             path="minidump",
-            data={
-                "sources": json.dumps(self.sources),
-                "request_data": json.dumps({"options": self.options}),
-            },
+            data={"sources": json.dumps(self.sources), "options": json.dumps(self.options)},
             files={"upload_file_minidump": minidump},
         )
 
     def upload_applecrashreport(self, report):
         return self._create_task(
             path="applecrashreport",
-            data={
-                "sources": json.dumps(self.sources),
-                "request_data": json.dumps({"options": self.options}),
-            },
+            data={"sources": json.dumps(self.sources), "options": json.dumps(self.options)},
             files={"apple_crash_report": report},
         )
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -107,12 +107,20 @@ class Symbolicator(object):
         base_url = symbolicator_options["url"].rstrip("/")
         assert base_url
 
+        if not getattr(project, "_organization_cache", False):
+            # needed for efficient featureflag checks in getsentry
+            with sentry_sdk.start_span(op="lang.native.symbolicator.organization.get_from_cache"):
+                project._organization_cache = Organization.objects.get_from_cache(
+                    id=project.organization_id
+                )
+
         self.sess = SymbolicatorSession(
             url=base_url,
             project_id=six.text_type(project.id),
             event_id=six.text_type(event_id),
             timeout=settings.SYMBOLICATOR_POLL_TIMEOUT,
             sources=get_sources_for_project(project),
+            options=get_options_for_project(project),
         )
 
         self.task_id_cache_key = _task_id_cache_key_for_event(project.id, event_id)
@@ -205,6 +213,7 @@ def get_internal_source(project):
             ).replace("127.0.0.1", "host.docker.internal")
 
     assert internal_url_prefix
+    assert project._organization_cache is not None
     sentry_source_url = "%s%s" % (
         internal_url_prefix.rstrip("/"),
         reverse(
@@ -250,18 +259,20 @@ def parse_sources(config):
     return sources
 
 
+def get_options_for_project(project):
+    assert project._organization_cache is not None
+    return {
+        # Symbolicators who do not support options will ignore this field entirely.
+        "dif_candidates": features.has("organizations:dif-candidates", project.organization)
+    }
+
+
 def get_sources_for_project(project):
     """
     Returns a list of symbol sources for this project.
     """
 
     sources = []
-
-    if not getattr(project, "_organization_cache", False):
-        with sentry_sdk.start_span(op="lang.native.symbolicator.organization.get_from_cache"):
-            project._organization_cache = Organization.objects.get_from_cache(
-                id=project.organization_id
-            )
 
     # The symbolicator evaluates sources in the order they are declared. Always
     # try to download symbols from Sentry first.
@@ -270,7 +281,9 @@ def get_sources_for_project(project):
 
     # Check that the organization still has access to symbol sources. This
     # controls both builtin and external sources.
+    assert project._organization_cache is not None
     organization = project.organization
+
     if not features.has("organizations:symbol-sources", organization):
         return sources
 
@@ -319,11 +332,14 @@ def get_sources_for_project(project):
 
 
 class SymbolicatorSession(object):
-    def __init__(self, url=None, sources=None, project_id=None, event_id=None, timeout=None):
+    def __init__(
+        self, url=None, sources=None, project_id=None, event_id=None, timeout=None, options=None
+    ):
         self.url = url
         self.project_id = project_id
         self.event_id = event_id
         self.sources = sources or []
+        self.options = options or None
         self.timeout = timeout
         self.session = None
 
@@ -420,7 +436,12 @@ class SymbolicatorSession(object):
             return self._request(method="post", path=path, params=params, **kwargs)
 
     def symbolicate_stacktraces(self, stacktraces, modules, signal=None):
-        json = {"sources": self.sources, "stacktraces": stacktraces, "modules": modules}
+        json = {
+            "sources": self.sources,
+            "options": self.options,
+            "stacktraces": stacktraces,
+            "modules": modules,
+        }
 
         if signal:
             json["signal"] = signal
@@ -430,14 +451,20 @@ class SymbolicatorSession(object):
     def upload_minidump(self, minidump):
         return self._create_task(
             path="minidump",
-            data={"sources": json.dumps(self.sources)},
+            data={
+                "sources": json.dumps(self.sources),
+                "request_data": json.dumps({"options": self.options}),
+            },
             files={"upload_file_minidump": minidump},
         )
 
     def upload_applecrashreport(self, report):
         return self._create_task(
             path="applecrashreport",
-            data={"sources": json.dumps(self.sources)},
+            data={
+                "sources": json.dumps(self.sources),
+                "request_data": json.dumps({"options": self.options}),
+            },
             files={"apple_crash_report": report},
         )
 


### PR DESCRIPTION
Counterpart to https://github.com/getsentry/symbolicator/pull/309 -- sentry mostly just forwards attributes from symbolicator so very few changes needed

[JSON Download example](https://gist.github.com/untitaker/a794ef055feef6d02e998d8c145bbc2a) (send this event to get frontend data)

candidate cleanup will happen in follow-up PR