### PR TITLE
feat(reprocessing2): Start eventdata backup for all projects now

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -276,3 +276,8 @@ register("store.use-relay-dsn-sample-rate", default=1)
 
 # Mock out integrations and services for tests
 register("mocks.jira", default=False)
+
+# Sample rate for saving pre-event-processing backups of event payload to be
+# used for reprocessing.  Once the rollout is complete this option will become
+# defunct.
+register("reprocessing2.sample-dataset-building", default=0.0)


### PR DESCRIPTION
Note: This PR is mostly intended as DACI-like basis for discussion
on future architecture of reprocessing.

Reprocessing currently copies the event payload as it is before
processing into a secondary nodestore key, such that every event is
saved twice into nodestore: Once in its saved state, and once in its
raw, unprocessed state that is then used for reprocessing.

When rolling out reprocessing as GA, we will likely inflict severe
additional cost to nodestore because of this. Assuming we are fine with
storing events-eligible-for-processing twice in general, we can use this
PR to preempt any surprises before reprocessing goes GA, and measure the
performance impact of doing that now.

If we're not fine with that because we think the cost is too high in
principle, we can likely find workarounds such as making the relevant
parts of the processing pipeline idempotent. This is already necessary
because we let the user reprocess issues that never made it through
process- or symbolicate_event. And while it does appear to work fine, it
is very fragile in nature (each pipeline component needs to be able to
deal with data produced by a later component) and still needs to be
tested with all kinds of input data.