### PR TITLE
ref: Consolidate reprocessing2 featureflags again

### DIFF
--- a/src/sentry/api/endpoints/group_reprocessing.py
+++ b/src/sentry/api/endpoints/group_reprocessing.py
@@ -20,7 +20,7 @@ class GroupReprocessingEndpoint(GroupEndpoint):
         :auth: required
         """
 
-        if not features.has("projects:reprocessing-v2", group.project, actor=request.user):
+        if not features.has("organizations:reprocessing-v2", group.project, actor=request.user):
             return self.respond(
                 {"error": "This project does not have the reprocessing v2 feature"}, status=404,
             )

--- a/src/sentry/api/endpoints/group_reprocessing.py
+++ b/src/sentry/api/endpoints/group_reprocessing.py
@@ -20,7 +20,9 @@ class GroupReprocessingEndpoint(GroupEndpoint):
         :auth: required
         """
 
-        if not features.has("organizations:reprocessing-v2", group.project, actor=request.user):
+        if not features.has(
+            "organizations:reprocessing-v2", group.project.organization, actor=request.user
+        ):
             return self.respond(
                 {"error": "This project does not have the reprocessing v2 feature"}, status=404,
             )

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -911,6 +911,8 @@ SENTRY_FEATURES = {
     # Enable usage of external relays, for use with Relay. See
     # https://github.com/getsentry/relay.
     "organizations:relay": True,
+    # Enable version 2 of reprocessing (completely distinct from v1)
+    "organizations:reprocessing-v2": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.
@@ -935,8 +937,6 @@ SENTRY_FEATURES = {
     "organizations:unhandled-issue-flag": False,
     # Enable "owner"/"suggested assignee" features.
     "organizations:workflow-owners": False,
-    # Enable Issues List Reprocessing Tab.
-    "organizations:reprocessing-ui": False,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.
@@ -956,8 +956,6 @@ SENTRY_FEATURES = {
     "projects:plugins": True,
     # Enable functionality for rate-limiting events on projects.
     "projects:rate-limits": True,
-    # Enable version 2 of reprocessing (completely distinct from v1)
-    "projects:reprocessing-v2": False,
     # Enable functionality for sampling of events on projects.
     "projects:sample-events": False,
     # Enable functionality to trigger service hooks upon event ingestion.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -93,8 +93,8 @@ default_manager.add("organizations:performance-view", OrganizationFeature)  # NO
 default_manager.add("organizations:project-detail", OrganizationFeature)  # NOQA
 default_manager.add("organizations:relay", OrganizationFeature)  # NOQA
 default_manager.add("organizations:release-performance-views", OrganizationFeature)  # NOQA
+default_manager.add("organizations:reprocessing-v2", ProjectFeature)  # NOQA
 default_manager.add("organizations:rule-page", OrganizationFeature)  # NOQA
-default_manager.add("organizations:reprocessing-ui", OrganizationFeature)  # NOQA
 default_manager.add("organizations:set-grouping-config", OrganizationFeature)  # NOQA
 default_manager.add("organizations:custom-event-title", OrganizationFeature)  # NOQA
 default_manager.add("organizations:slack-migration", OrganizationFeature)  # NOQA
@@ -114,7 +114,6 @@ default_manager.add("organizations:performance-landing-v2", OrganizationFeature)
 default_manager.add("organizations:performance-vitals-overview", OrganizationFeature)  # NOQA
 default_manager.add("organizations:workflow-owners", OrganizationFeature)  # NOQA
 
-
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.
 
@@ -132,7 +131,6 @@ default_manager.add("projects:similarity-view", ProjectFeature)  # NOQA
 default_manager.add("projects:similarity-indexing", ProjectFeature)  # NOQA
 default_manager.add("projects:similarity-view-v2", ProjectFeature)  # NOQA
 default_manager.add("projects:similarity-indexing-v2", ProjectFeature)  # NOQA
-default_manager.add("projects:reprocessing-v2", ProjectFeature)  # NOQA
 default_manager.add("projects:workflow-owners-ingestion", ProjectFeature)  # NOQA
 
 # Project plugin features

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -93,7 +93,7 @@ default_manager.add("organizations:performance-view", OrganizationFeature)  # NO
 default_manager.add("organizations:project-detail", OrganizationFeature)  # NOQA
 default_manager.add("organizations:relay", OrganizationFeature)  # NOQA
 default_manager.add("organizations:release-performance-views", OrganizationFeature)  # NOQA
-default_manager.add("organizations:reprocessing-v2", ProjectFeature)  # NOQA
+default_manager.add("organizations:reprocessing-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:rule-page", OrganizationFeature)  # NOQA
 default_manager.add("organizations:set-grouping-config", OrganizationFeature)  # NOQA
 default_manager.add("organizations:custom-event-title", OrganizationFeature)  # NOQA

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -116,7 +116,7 @@ def save_unprocessed_event(project, event_id):
     Move event from event_processing_store into nodestore. Only call if event
     has outcome=accepted.
     """
-    if not features.has("projects:reprocessing-v2", project, actor=None):
+    if not features.has("organizations:reprocessing-v2", project, actor=None):
         return
 
     with sentry_sdk.start_span(
@@ -139,7 +139,7 @@ def backup_unprocessed_event(project, data):
     able to be reprocessed.
     """
 
-    if not features.has("projects:reprocessing-v2", project, actor=None):
+    if not features.has("organizations:reprocessing-v2", project, actor=None):
         return
 
     event_processing_store.store(data, unprocessed=True)

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -116,7 +116,7 @@ def save_unprocessed_event(project, event_id):
     Move event from event_processing_store into nodestore. Only call if event
     has outcome=accepted.
     """
-    if not features.has("organizations:reprocessing-v2", project, actor=None):
+    if not features.has("organizations:reprocessing-v2", project.organization, actor=None):
         return
 
     with sentry_sdk.start_span(
@@ -139,7 +139,7 @@ def backup_unprocessed_event(project, data):
     able to be reprocessed.
     """
 
-    if not features.has("organizations:reprocessing-v2", project, actor=None):
+    if not features.has("organizations:reprocessing-v2", project.organization, actor=None):
         return
 
     event_processing_store.store(data, unprocessed=True)

--- a/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
@@ -256,7 +256,7 @@ class IssueListActions extends React.Component<Props, State> {
 
     const numIssues = issues.size;
     const isReprocessingQuery =
-      query === Query.REPROCESSING && organization.features.includes('reprocessing-ui');
+      query === Query.REPROCESSING && organization.features.includes('reprocessing-v2');
 
     return (
       <Sticky>

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -636,7 +636,7 @@ class IssueListOverview extends React.Component<Props, State> {
     const {organization} = this.props;
     const query = this.getQuery();
     const isReprocessingQuery =
-      query === Query.REPROCESSING && organization.features.includes('reprocessing-ui');
+      query === Query.REPROCESSING && organization.features.includes('reprocessing-v2');
 
     return ids.map(id => {
       const hasGuideAnchor = id === topIssue;
@@ -778,7 +778,7 @@ class IssueListOverview extends React.Component<Props, State> {
 
     const projectIds = selection?.projects?.map(p => p.toString());
     const orgSlug = organization.slug;
-    const hasReprocessingV2Feature = organization.features.includes('reprocessing-ui');
+    const hasReprocessingV2Feature = organization.features.includes('reprocessing-v2');
 
     return (
       <Feature organization={organization} features={['organizations:inbox']}>

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -26,7 +26,7 @@ from sentry.utils.cache import cache_key_for_event
 def reprocessing_feature(monkeypatch):
     monkeypatch.setattr("sentry.tasks.reprocessing2.GROUP_REPROCESSING_CHUNK_SIZE", 1)
 
-    with Feature({"projects:reprocessing-v2": True}):
+    with Feature({"organizations:reprocessing-v2": True}):
         yield
 
 

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -140,7 +140,7 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
         self.project.update_option("sentry:store_crash_reports", STORE_CRASH_REPORTS_ALL)
 
         with self.feature(
-            {"organizations:event-attachments": True, "projects:reprocessing-v2": True}
+            {"organizations:event-attachments": True, "organizations:reprocessing-v2": True}
         ):
             with open(get_fixture_path("windows.dmp"), "rb") as f:
                 event = self.post_and_retrieve_minidump(


### PR DESCRIPTION
When building UI for reprocessing we discovered it would be nicer to use
an organization-wide feature. However, backend in theory benefits from
having per-project granularity due to performance constraints.

I asked for having two featureflags then but after thinking about it,
it makes user enrollment just more complicating.