### PR TITLE
Require developers to explicitly request using a different Python 3 v…

### DIFF
--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -40,10 +40,25 @@ EOF
         # If .venv is less than Python 3.6 fail
         [[ "$minor" -lt 6 ]] &&
             die "Remove $VIRTUAL_ENV and try again since the Python version installed should be at least 3.6."
-        # If .venv is created with Python 3.9 or higher you might encounter problems and we want to ask you to downgrade
-        # At the moment, Pillow does not install with Python 3.9 and requires adding more build dependencies.
-        [[ "$minor" -ge 9 ]] &&
-            die "We recommend you create this virtualenv with a Python version between 3.6 and 3.8. Remove $VIRTUAL_ENV and start again."
+        # If .venv is created with Python greater than 3.6 you might encounter problems and we want to ask you to downgrade
+        # unless you explicitely set an environment variable
+        if [[ "$minor" -gt 6 ]]; then
+            if [[ -n "$PYTHON_VERSION" ]]; then
+                cat << EOF
+${yellow}${bold}
+You have explicitely set a non-recommend Python version (${PYTHON_VERSION}). You're on your own.
+${reset}
+EOF
+            else
+                cat << EOF
+${yellow}${bold}
+WARNING! You are running a virtualenv with a Python version different than 3.6
+We recommend you start with a fresh virtualenv or to set the variable PYTHON_VERSION
+to the Python version you want to use (e.g. 3.7).
+${reset}
+EOF
+            fi
+        fi
     fi
 else
     if [[ ! -f "${venv_name}/bin/activate" ]]; then

--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -6,6 +6,7 @@ if [[ "$SENTRY_NO_VIRTUALENV_CREATION" == "1" ]]; then
     exit 0
 fi
 
+red="$(tput setaf 1)"
 yellow="$(tput setaf 3)"
 bold="$(tput bold)"
 reset="$(tput sgr0)"
@@ -51,12 +52,13 @@ ${reset}
 EOF
             else
                 cat << EOF
-${yellow}${bold}
+${red}${bold}
 WARNING! You are running a virtualenv with a Python version different than 3.6
 We recommend you start with a fresh virtualenv or to set the variable PYTHON_VERSION
 to the Python version you want to use (e.g. 3.7).
 ${reset}
 EOF
+                exit 1
             fi
         fi
     fi

--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -47,7 +47,7 @@ EOF
             if [[ -n "$PYTHON_VERSION" ]]; then
                 cat << EOF
 ${yellow}${bold}
-You have explicitely set a non-recommend Python version (${PYTHON_VERSION}). You're on your own.
+You have explicitly set a non-recommended Python version (${PYTHON_VERSION}). You're on your own.
 ${reset}
 EOF
             else

--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -44,17 +44,17 @@ EOF
         # If .venv is created with Python greater than 3.6 you might encounter problems and we want to ask you to downgrade
         # unless you explicitely set an environment variable
         if [[ "$minor" -gt 6 ]]; then
-            if [[ -n "$PYTHON_VERSION" ]]; then
+            if [[ -n "$SENTRY_PYTHON_VERSION" ]]; then
                 cat << EOF
 ${yellow}${bold}
-You have explicitly set a non-recommended Python version (${PYTHON_VERSION}). You're on your own.
+You have explicitly set a non-recommended Python version (${SENTRY_PYTHON_VERSION}). You're on your own.
 ${reset}
 EOF
             else
                 cat << EOF
 ${red}${bold}
 WARNING! You are running a virtualenv with a Python version different than 3.6
-We recommend you start with a fresh virtualenv or to set the variable PYTHON_VERSION
+We recommend you start with a fresh virtualenv or to set the variable SENTRY_PYTHON_VERSION
 to the Python version you want to use (e.g. 3.7).
 ${reset}
 EOF

--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -53,7 +53,7 @@ EOF
             else
                 cat << EOF
 ${red}${bold}
-WARNING! You are running a virtualenv with a Python version different than 3.6
+ERROR! You are running a virtualenv with a Python version different than 3.6
 We recommend you start with a fresh virtualenv or to set the variable SENTRY_PYTHON_VERSION
 to the Python version you want to use (e.g. 3.7).
 ${reset}


### PR DESCRIPTION
…ersion

The developer is now warned if they are using a Python version different than 3.6.
The developer will need to explicitely set `PYTHON_VERSION` if they wish to use a different
Python version.

Fixes #22724