### PR TITLE
fix: Restore warning about deleting events

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/reprocessingDialogForm.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/reprocessingDialogForm.tsx
@@ -88,8 +88,9 @@ function ReprocessingDialogForm({
           <NumberField
             name="maxEvents"
             label={t('Enter the number of events to be reprocessed')}
-            help={t(
-              'You can limit the number of events reprocessed in this Issue. If you set a limit, we will reprocess your most recent events.'
+            help={tct(
+              'You can limit the number of events reprocessed in this Issue. If you set a limit, we will reprocess your most recent events, [strong:and the rest will be deleted.]',
+              {strong: <strong />}
             )}
             placeholder={t('Reprocess all events')}
             min={1}


### PR DESCRIPTION
This sort of warning used to be here, I think. At a later point we may consider changing the behavior of reprocessing entirely.