### PR TITLE
build(dev): Correctly match Big Sur version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ WEBPACK := yarn build-acceptance
 # Currently, this is only required to install black via pre-commit.
 REQUIRED_PY3_VERSION := $(shell grep "3.6" .python-version)
 
-BIG_SUR := $(shell sw_vers -productVersion | egrep "11\.0\.")
+BIG_SUR := $(shell sw_vers -productVersion | egrep "11\.")
 
 bootstrap: develop init-config run-dependent-services create-db apply-migrations build-platform-assets
 


### PR DESCRIPTION
There was an OS update this week and the version is now `11.1` rather than `11.0`.
This fixes pyenv failing to install Python versions.

Fixes #22732