### PR TITLE
fix(ui): Fix assignee selector styles

### DIFF
--- a/src/sentry/static/sentry/app/components/assigneeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.tsx
@@ -511,6 +511,8 @@ const GroupHeader = styled('div')`
   font-weight: 600;
   margin: ${space(1)} 0;
   color: ${p => p.theme.gray500};
+  line-height: ${p => p.theme.fontSizeSmall};
+  text-align: left;
 `;
 
 const SuggestedReason = styled('span')`


### PR DESCRIPTION
Fixes right align and extra line height for the assignee selector group headings in the issue details page

**Before:**
<img src="https://user-images.githubusercontent.com/9372512/102382272-4202f100-3f98-11eb-9d55-64fb314dc17b.png" width="200"/>

**After:**
<img src="https://user-images.githubusercontent.com/9372512/102382324-52b36700-3f98-11eb-805d-d40c29ac30e0.png" width="200" />