### PR TITLE
feat(ui): Fix `<WorldMapChart>` for dark mode

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.tsx
@@ -4,7 +4,6 @@ import {withTheme} from 'emotion-theming';
 import max from 'lodash/max';
 
 import {Series, SeriesDataUnit} from 'app/types/echarts';
-import theme from 'app/utils/theme';
 
 import VisualMap from './components/visualMap';
 import MapSeries from './series/mapSeries';
@@ -67,7 +66,7 @@ class WorldMapChart extends React.Component<Props, State> {
       return null;
     }
 
-    const {series, seriesOptions, ...props} = this.props;
+    const {series, seriesOptions, theme, ...props} = this.props;
     const processedSeries = series.map(({seriesName, data, ...options}) =>
       MapSeries({
         ...seriesOptions,

--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import echarts, {EChartOption} from 'echarts';
 import {withTheme} from 'emotion-theming';
 import max from 'lodash/max';
+import {Theme} from 'app/utils/theme';
 
 import {Series, SeriesDataUnit} from 'app/types/echarts';
 
@@ -23,6 +24,7 @@ type MapChartSeries = Omit<Series, 'data'> & {
 
 type Props = Omit<ChartProps, 'series'> & {
   series: MapChartSeries[];
+  theme: Theme;
   seriesOptions?: EChartOption.SeriesMap;
 };
 

--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import echarts, {EChartOption} from 'echarts';
 import {withTheme} from 'emotion-theming';
 import max from 'lodash/max';
-import {Theme} from 'app/utils/theme';
 
 import {Series, SeriesDataUnit} from 'app/types/echarts';
+import {Theme} from 'app/utils/theme';
 
 import VisualMap from './components/visualMap';
 import MapSeries from './series/mapSeries';


### PR DESCRIPTION
This was not using theme from props, but instead the imported theme