### PR TITLE
feat(ui): Fix text color for "select all" notice on issues stream

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
@@ -375,6 +375,7 @@ const SelectAllNotice = styled('div')`
   background-color: ${p => p.theme.yellow100};
   border-top: 1px solid ${p => p.theme.yellow300};
   border-bottom: 1px solid ${p => p.theme.yellow300};
+  color: ${p => p.theme.black};
   font-size: ${p => p.theme.fontSizeMedium};
   text-align: center;
   padding: ${space(0.5)} ${space(1.5)};


### PR DESCRIPTION
This was using the dark mode text color (white)... it should always be black

![image](https://user-images.githubusercontent.com/79684/102395554-2693e800-3f90-11eb-959b-20ca8154b4c2.png)
