### PR TITLE
ref(ui): Remove `btn-group` from issue list/details actions

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/ignore.tsx
+++ b/src/sentry/static/sentry/app/components/actions/ignore.tsx
@@ -351,7 +351,6 @@ const IgnoreWrapper = styled('div')`
 `;
 
 const IgnoredButtonActionWrapper = styled('div')`
-  margin-right: 5px;
   display: inline-flex;
   align-self: baseline;
 `;

--- a/src/sentry/static/sentry/app/components/actions/resolve.tsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.tsx
@@ -302,7 +302,6 @@ const actionLinkCss = p => css`
 `;
 
 const ResolvedActionWrapper = styled('div')`
-  margin-right: 5px;
   display: inline-flex;
 `;
 

--- a/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
@@ -62,7 +62,7 @@ function ActionSet({
   return (
     <Wrapper hasInbox={hasInbox}>
       {hasInbox && (
-        <div className="btn-group hidden-sm hidden-xs">
+        <div className="hidden-sm hidden-xs">
           <StyledActionLink
             className="btn btn-primary btn-sm action-merge"
             data-test-id="button-acknowledge"
@@ -127,7 +127,7 @@ function ActionSet({
         confirmLabel={label('ignore')}
         disabled={!anySelected}
       />
-      <div className="btn-group hidden-md hidden-sm hidden-xs">
+      <div className="hidden-md hidden-sm hidden-xs">
         <ActionLink
           className="btn btn-default btn-sm action-merge"
           disabled={mergeDisabled}
@@ -140,122 +140,118 @@ function ActionSet({
           {t('Merge')}
         </ActionLink>
       </div>
-      <div className="btn-group">
-        <DropdownLink
-          key="actions"
-          caret={false}
-          className="btn btn-sm btn-default action-more"
-          title={
-            <IconPad>
-              <IconEllipsis size="xs" />
-            </IconPad>
-          }
-        >
-          <MenuItem noAnchor>
-            <ActionLink
-              className="action-merge hidden-lg hidden-xl"
-              disabled={mergeDisabled}
-              onAction={onMerge}
-              shouldConfirm={onShouldConfirm(ConfirmAction.MERGE)}
-              message={confirm(ConfirmAction.MERGE, false)}
-              confirmLabel={label('merge')}
-              title={t('Merge Selected Issues')}
-            >
-              {t('Merge')}
-            </ActionLink>
-          </MenuItem>
-          {hasInbox && (
-            <React.Fragment>
-              <MenuItem divider className="hidden-md hidden-lg hidden-xl" />
-              <MenuItem noAnchor>
-                <ActionLink
-                  className="action-acknowledge hidden-md hidden-lg hidden-xl"
-                  disabled={!anySelected}
-                  onAction={() => onUpdate({inbox: false})}
-                  shouldConfirm={onShouldConfirm(ConfirmAction.ACKNOWLEDGE)}
-                  message={confirm(ConfirmAction.ACKNOWLEDGE, false)}
-                  confirmLabel={label('acknowledge')}
-                  title={t('Acknowledge')}
-                >
-                  {t('Acknowledge')}
-                </ActionLink>
-              </MenuItem>
-            </React.Fragment>
-          )}
-          <MenuItem divider className="hidden-lg hidden-xl" />
-          <MenuItem noAnchor>
-            <ActionLink
-              className="action-bookmark"
-              disabled={!anySelected}
-              onAction={() => onUpdate({isBookmarked: true})}
-              shouldConfirm={onShouldConfirm(ConfirmAction.BOOKMARK)}
-              message={confirm(ConfirmAction.BOOKMARK, false)}
-              confirmLabel={label('bookmark')}
-              title={t('Add to Bookmarks')}
-            >
-              {t('Add to Bookmarks')}
-            </ActionLink>
-          </MenuItem>
-          <MenuItem divider />
-          <MenuItem noAnchor>
-            <ActionLink
-              className="action-remove-bookmark"
-              disabled={!anySelected}
-              onAction={() => onUpdate({isBookmarked: false})}
-              shouldConfirm={onShouldConfirm(ConfirmAction.UNBOOKMARK)}
-              message={confirm('remove', false, ' from your bookmarks')}
-              confirmLabel={label('remove', ' from your bookmarks')}
-              title={t('Remove from Bookmarks')}
-            >
-              {t('Remove from Bookmarks')}
-            </ActionLink>
-          </MenuItem>
-          <MenuItem divider />
-          <MenuItem noAnchor>
-            <ActionLink
-              className="action-unresolve"
-              disabled={!anySelected}
-              onAction={() => onUpdate({status: ResolutionStatus.UNRESOLVED})}
-              shouldConfirm={onShouldConfirm(ConfirmAction.UNRESOLVE)}
-              message={confirm(ConfirmAction.UNRESOLVE, true)}
-              confirmLabel={label('unresolve')}
-              title={t('Set status to: Unresolved')}
-            >
-              {t('Set status to: Unresolved')}
-            </ActionLink>
-          </MenuItem>
-          <MenuItem divider />
-          <MenuItem noAnchor>
-            <ActionLink
-              className="action-delete"
-              disabled={!anySelected}
-              onAction={onDelete}
-              shouldConfirm={onShouldConfirm(ConfirmAction.DELETE)}
-              message={confirm(ConfirmAction.DELETE, false)}
-              confirmLabel={label('delete')}
-              title={t('Delete Issues')}
-            >
-              {t('Delete Issues')}
-            </ActionLink>
-          </MenuItem>
-        </DropdownLink>
-      </div>
-      {!hasInbox && (
-        <div className="btn-group">
-          <Tooltip
-            title={t('%s real-time updates', realtimeActive ? t('Pause') : t('Enable'))}
+      <DropdownLink
+        key="actions"
+        caret={false}
+        className="btn btn-sm btn-default action-more"
+        title={
+          <IconPad>
+            <IconEllipsis size="xs" />
+          </IconPad>
+        }
+      >
+        <MenuItem noAnchor>
+          <ActionLink
+            className="action-merge hidden-lg hidden-xl"
+            disabled={mergeDisabled}
+            onAction={onMerge}
+            shouldConfirm={onShouldConfirm(ConfirmAction.MERGE)}
+            message={confirm(ConfirmAction.MERGE, false)}
+            confirmLabel={label('merge')}
+            title={t('Merge Selected Issues')}
           >
-            <a
-              data-test-id="realtime-control"
-              className="btn btn-default btn-sm hidden-xs"
-              onClick={onRealtimeChange}
-            >
-              <IconPad>
-                {realtimeActive ? <IconPause size="xs" /> : <IconPlay size="xs" />}
-              </IconPad>
-            </a>
-          </Tooltip>
-        </div>
+            {t('Merge')}
+          </ActionLink>
+        </MenuItem>
+        {hasInbox && (
+          <React.Fragment>
+            <MenuItem divider className="hidden-md hidden-lg hidden-xl" />
+            <MenuItem noAnchor>
+              <ActionLink
+                className="action-acknowledge hidden-md hidden-lg hidden-xl"
+                disabled={!anySelected}
+                onAction={() => onUpdate({inbox: false})}
+                shouldConfirm={onShouldConfirm(ConfirmAction.ACKNOWLEDGE)}
+                message={confirm(ConfirmAction.ACKNOWLEDGE, false)}
+                confirmLabel={label('acknowledge')}
+                title={t('Acknowledge')}
+              >
+                {t('Acknowledge')}
+              </ActionLink>
+            </MenuItem>
+          </React.Fragment>
+        )}
+        <MenuItem divider className="hidden-lg hidden-xl" />
+        <MenuItem noAnchor>
+          <ActionLink
+            className="action-bookmark"
+            disabled={!anySelected}
+            onAction={() => onUpdate({isBookmarked: true})}
+            shouldConfirm={onShouldConfirm(ConfirmAction.BOOKMARK)}
+            message={confirm(ConfirmAction.BOOKMARK, false)}
+            confirmLabel={label('bookmark')}
+            title={t('Add to Bookmarks')}
+          >
+            {t('Add to Bookmarks')}
+          </ActionLink>
+        </MenuItem>
+        <MenuItem divider />
+        <MenuItem noAnchor>
+          <ActionLink
+            className="action-remove-bookmark"
+            disabled={!anySelected}
+            onAction={() => onUpdate({isBookmarked: false})}
+            shouldConfirm={onShouldConfirm(ConfirmAction.UNBOOKMARK)}
+            message={confirm('remove', false, ' from your bookmarks')}
+            confirmLabel={label('remove', ' from your bookmarks')}
+            title={t('Remove from Bookmarks')}
+          >
+            {t('Remove from Bookmarks')}
+          </ActionLink>
+        </MenuItem>
+        <MenuItem divider />
+        <MenuItem noAnchor>
+          <ActionLink
+            className="action-unresolve"
+            disabled={!anySelected}
+            onAction={() => onUpdate({status: ResolutionStatus.UNRESOLVED})}
+            shouldConfirm={onShouldConfirm(ConfirmAction.UNRESOLVE)}
+            message={confirm(ConfirmAction.UNRESOLVE, true)}
+            confirmLabel={label('unresolve')}
+            title={t('Set status to: Unresolved')}
+          >
+            {t('Set status to: Unresolved')}
+          </ActionLink>
+        </MenuItem>
+        <MenuItem divider />
+        <MenuItem noAnchor>
+          <ActionLink
+            className="action-delete"
+            disabled={!anySelected}
+            onAction={onDelete}
+            shouldConfirm={onShouldConfirm(ConfirmAction.DELETE)}
+            message={confirm(ConfirmAction.DELETE, false)}
+            confirmLabel={label('delete')}
+            title={t('Delete Issues')}
+          >
+            {t('Delete Issues')}
+          </ActionLink>
+        </MenuItem>
+      </DropdownLink>
+      {!hasInbox && (
+        <Tooltip
+          title={t('%s real-time updates', realtimeActive ? t('Pause') : t('Enable'))}
+        >
+          <a
+            data-test-id="realtime-control"
+            className="btn btn-default btn-sm hidden-xs"
+            onClick={onRealtimeChange}
+          >
+            <IconPad>
+              {realtimeActive ? <IconPause size="xs" /> : <IconPlay size="xs" />}
+            </IconPad>
+          </a>
+        </Tooltip>
       )}
     </Wrapper>
   );
@@ -291,17 +287,16 @@ const Wrapper = styled('div')<{hasInbox?: boolean}>`
   flex: 1;
   margin-left: ${space(1)};
   margin-right: ${space(1)};
-  display: flex;
+  display: grid;
+  gap: ${space(0.5)};
+  grid-auto-flow: column;
+  justify-content: flex-start;
+
   ${p =>
     p.hasInbox &&
     css`
       animation: 0.15s linear ZoomUp forwards;
     `};
-
-  .btn-group {
-    display: flex;
-    margin-right: 6px;
-  }
 
   @keyframes ZoomUp {
     0% {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/deleteAction.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/deleteAction.tsx
@@ -162,8 +162,6 @@ const StyledLinkWithConfirmation = styled(LinkWithConfirmation)`
 `;
 
 const DeleteDiscardWrapper = styled('div')`
-  display: inline-block;
-  margin-right: 5px;
   ${dropdownTipCss}
   & span {
     position: relative;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
@@ -201,11 +201,8 @@ class Actions extends React.Component<Props, State> {
     });
   };
 
-  handleClick(
-    disabled: boolean,
-    onClick: (event: React.MouseEvent<HTMLDivElement>) => void
-  ) {
-    return function (event: React.MouseEvent<HTMLDivElement>) {
+  handleClick(disabled: boolean, onClick: (event: React.MouseEvent) => void) {
+    return function (event: React.MouseEvent) {
       if (disabled) {
         event.preventDefault();
         event.stopPropagation();
@@ -298,7 +295,6 @@ class Actions extends React.Component<Props, State> {
         <SubscribeAction
           group={group}
           onClick={this.handleClick(disabled, this.onToggleSubscribe)}
-          className={buttonClassName}
         />
 
         {projectFeatures.has('reprocessing-v2') && (

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
@@ -235,7 +235,7 @@ class Actions extends React.Component<Props, State> {
     }
 
     return (
-      <div className="group-actions">
+      <Wrapper>
         <GuideAnchor target="resolve" position="bottom" offset={space(3)}>
           <ResolveActions
             disabled={disabled}
@@ -265,62 +265,55 @@ class Actions extends React.Component<Props, State> {
           onDiscard={this.onDiscard}
         />
         {orgFeatures.has('shared-issues') && (
-          <div className="btn-group">
-            <ShareIssue
-              disabled={disabled}
-              loading={this.state.shareBusy}
-              isShared={group.isPublic}
-              shareUrl={this.getShareUrl(group.shareId)}
-              onToggle={this.onToggleShare}
-              onReshare={() => this.onShare(true)}
-            />
-          </div>
+          <ShareIssue
+            disabled={disabled}
+            loading={this.state.shareBusy}
+            isShared={group.isPublic}
+            shareUrl={this.getShareUrl(group.shareId)}
+            onToggle={this.onToggleShare}
+            onReshare={() => this.onShare(true)}
+          />
         )}
         {orgFeatures.has('discover-basic') && (
-          <div className="btn-group">
-            <Link
-              className={buttonClassName}
-              title={t('Open in Discover')}
-              to={disabled ? '' : this.getDiscoverUrl()}
-            >
-              {t('Open in Discover')}
-            </Link>
-          </div>
-        )}
-        <div className="btn-group">
-          <BookmarkButton
+          <Link
             className={buttonClassName}
-            role="button"
-            isActive={group.isBookmarked}
-            title={bookmarkTitle}
-            aria-label={bookmarkTitle}
-            onClick={this.handleClick(disabled, this.onToggleBookmark)}
+            title={t('Open in Discover')}
+            to={disabled ? '' : this.getDiscoverUrl()}
           >
-            <IconWrapper>
-              <IconStar isSolid size="xs" />
-            </IconWrapper>
-          </BookmarkButton>
-        </div>
+            {t('Open in Discover')}
+          </Link>
+        )}
+        <BookmarkButton
+          className={buttonClassName}
+          role="button"
+          isActive={group.isBookmarked}
+          title={bookmarkTitle}
+          aria-label={bookmarkTitle}
+          onClick={this.handleClick(disabled, this.onToggleBookmark)}
+        >
+          <IconWrapper>
+            <IconStar isSolid size="xs" />
+          </IconWrapper>
+        </BookmarkButton>
         <SubscribeAction
           group={group}
           onClick={this.handleClick(disabled, this.onToggleSubscribe)}
           className={buttonClassName}
         />
+
         {projectFeatures.has('reprocessing-v2') && (
-          <div className="btn-group">
-            <Tooltip title={t('Reprocess this issue')}>
-              <div
-                className={buttonClassName}
-                onClick={this.handleClick(disabled, this.onReprocess)}
-              >
-                <IconWrapper>
-                  <IconRefresh size="xs" />
-                </IconWrapper>
-              </div>
-            </Tooltip>
-          </div>
+          <Tooltip title={t('Reprocess this issue')}>
+            <div
+              className={buttonClassName}
+              onClick={this.handleClick(disabled, this.onReprocess)}
+            >
+              <IconWrapper>
+                <IconRefresh size="xs" />
+              </IconWrapper>
+            </div>
+          </Tooltip>
         )}
-      </div>
+      </Wrapper>
     );
   }
 }
@@ -339,6 +332,15 @@ const BookmarkButton = styled('div')<{isActive: boolean}>`
     border-color: ${p.theme.yellow300};
     text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
   `}
+`;
+
+const Wrapper = styled('div')`
+  display: grid;
+  justify-content: flex-start;
+  align-items: center;
+  grid-auto-flow: column;
+  gap: ${space(0.5)};
+  margin-top: ${space(2)};
 `;
 
 export {Actions};

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/subscribeAction.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/subscribeAction.tsx
@@ -25,19 +25,17 @@ function SubscribeAction({group, onClick, className}: Props) {
   const subscribedClassName = `group-subscribe ${group.isSubscribed ? ' active' : ''}`;
 
   return (
-    <div className="btn-group">
-      <Tooltip title={getSubscriptionReason(group, true)}>
-        <div
-          className={classNames(className, subscribedClassName)}
-          title={t('Subscribe')}
-          onClick={onClick}
-        >
-          <IconWrapper>
-            <IconBell size="xs" />
-          </IconWrapper>
-        </div>
-      </Tooltip>
-    </div>
+    <Tooltip title={getSubscriptionReason(group, true)}>
+      <div
+        className={classNames(className, subscribedClassName)}
+        title={t('Subscribe')}
+        onClick={onClick}
+      >
+        <IconWrapper>
+          <IconBell size="xs" />
+        </IconWrapper>
+      </div>
+    </Tooltip>
   );
 }
 

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/subscribeAction.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/subscribeAction.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import classNames from 'classnames';
 
-import Tooltip from 'app/components/tooltip';
+import Button from 'app/components/button';
 import {IconBell} from 'app/icons';
 import {t} from 'app/locale';
 import {Group} from 'app/types';
@@ -11,37 +10,30 @@ import {getSubscriptionReason} from './utils';
 
 type Props = {
   group: Group;
-  onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
-  className?: string;
+  onClick: (event: React.MouseEvent) => void;
 };
 
-function SubscribeAction({group, onClick, className}: Props) {
+function SubscribeAction({group, onClick}: Props) {
   const canChangeSubscriptionState = !(group.subscriptionDetails?.disabled ?? false);
 
   if (!canChangeSubscriptionState) {
     return null;
   }
 
-  const subscribedClassName = `group-subscribe ${group.isSubscribed ? ' active' : ''}`;
-
   return (
-    <Tooltip title={getSubscriptionReason(group, true)}>
-      <div
-        className={classNames(className, subscribedClassName)}
-        title={t('Subscribe')}
-        onClick={onClick}
-      >
-        <IconWrapper>
-          <IconBell size="xs" />
-        </IconWrapper>
-      </div>
-    </Tooltip>
+    <SubscribeButton
+      title={getSubscriptionReason(group, true)}
+      priority={group.isSubscribed ? 'primary' : 'default'}
+      size="zero"
+      label={t('Subscribe')}
+      onClick={onClick}
+      icon={<IconBell size="xs" />}
+    />
   );
 }
 
 export default SubscribeAction;
 
-const IconWrapper = styled('span')`
-  position: relative;
-  top: 1px;
+const SubscribeButton = styled(Button)`
+  padding: 6px 9px; /* needed to match existing buttons */
 `;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -60,36 +60,26 @@
     color: #949ea4;
   }
 
-  .group-actions {
-    margin-top: 15px;
+  .group-resolve.active {
+    background: @green;
+    color: #fff;
+    border-color: @green-dark;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
+  }
 
-    .btn-group {
-      margin-right: 5px;
-    }
+  .group-remove:hover {
+    color: #fff;
+    background: @red;
+    border-color: @red-dark;
+    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
+  }
 
-    .group-resolve.active {
-      background: @green;
-      color: #fff;
-      border-color: @green-dark;
-      text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
-    }
-
-    .group-remove:hover {
-      color: #fff;
-      background: @red;
-      border-color: @red-dark;
-      text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
-    }
-
-    .clearfix;
-
-    .id-label {
-      background: #fff;
-      max-width: 200px;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
+  .id-label {
+    background: #fff;
+    max-width: 200px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .severity {

--- a/tests/js/spec/views/organizationGroupDetails/actions.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/actions.spec.jsx
@@ -65,7 +65,7 @@ describe('GroupActions', function () {
           })}
         />
       );
-      const btn = wrapper.find('.group-subscribe');
+      const btn = wrapper.find('button[aria-label="Subscribe"]');
       btn.simulate('click');
 
       expect(issuesApi).toHaveBeenCalledWith(


### PR DESCRIPTION
This was only used to add margins, replace with css grid+gap. Use `space()` for padding.

<details><summary>Issues stream</summary>

![image](https://user-images.githubusercontent.com/79684/102409386-ce66e100-3fa3-11eb-905b-93b25bec98bf.png)

</details>

<details><summary>Issues stream - Inbox</summary>

![image](https://user-images.githubusercontent.com/79684/102409443-e9d1ec00-3fa3-11eb-8238-82ec2091e7d1.png)


</details>

<details><summary>Issue details</summary>

![image](https://user-images.githubusercontent.com/79684/102409485-feae7f80-3fa3-11eb-8e44-da8e173b1a83.png)


</details>