### PR TITLE
ref(ui): Rename some things in `<Button>` so that LSP works better

### DIFF
--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -193,7 +193,7 @@ const Button = React.forwardRef<ButtonElement, ButtonProps>((props, ref) => (
 
 // Some components use Button's propTypes
 Button.propTypes = Button.propTypes;
-Button.displayName = 'forwardRef<Button>';
+Button.displayName = 'Button';
 
 export default Button;
 

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -42,7 +42,7 @@ type ButtonProps = Omit<React.HTMLProps<ButtonElement>, keyof Props> & Props;
 
 type Url = ButtonProps['to'] | ButtonProps['href'];
 
-class Button extends React.Component<ButtonProps, {}> {
+class BaseButton extends React.Component<ButtonProps, {}> {
   static propTypes: any = {
     priority: PropTypes.oneOf(['default', 'primary', 'danger', 'link', 'success']),
     size: PropTypes.oneOf(['zero', 'xsmall', 'small']),
@@ -187,15 +187,15 @@ class Button extends React.Component<ButtonProps, {}> {
   }
 }
 
-const ButtonForwardRef = React.forwardRef<ButtonElement, ButtonProps>((props, ref) => (
-  <Button forwardRef={ref} {...props} />
+const Button = React.forwardRef<ButtonElement, ButtonProps>((props, ref) => (
+  <BaseButton forwardRef={ref} {...props} />
 ));
 
 // Some components use Button's propTypes
-ButtonForwardRef.propTypes = Button.propTypes;
-ButtonForwardRef.displayName = 'forwardRef<Button>';
+Button.propTypes = Button.propTypes;
+Button.displayName = 'forwardRef<Button>';
 
-export default ButtonForwardRef;
+export default Button;
 
 type StyledButtonProps = ButtonProps & {theme: Theme};
 

--- a/tests/js/spec/views/settings/components/dataScrubbing/dataScrubbing.spec.tsx
+++ b/tests/js/spec/views/settings/components/dataScrubbing/dataScrubbing.spec.tsx
@@ -106,7 +106,7 @@ describe('Data Scrubbing', () => {
       expect(panelBody.find('List').prop('isDisabled')).toEqual(true);
 
       // PanelAction
-      const actionButtons = wrapper.find('PanelAction').find('Button');
+      const actionButtons = wrapper.find('PanelAction').find('BaseButton');
       expect(actionButtons).toHaveLength(2);
       expect(actionButtons.at(0).prop('disabled')).toEqual(false);
       expect(actionButtons.at(1).prop('disabled')).toEqual(true);
@@ -168,7 +168,7 @@ describe('Data Scrubbing', () => {
       expect(panelBody.find('List').prop('isDisabled')).toEqual(true);
 
       // PanelAction
-      const actionButtons = wrapper.find('PanelAction').find('Button');
+      const actionButtons = wrapper.find('PanelAction').find('BaseButton');
       expect(actionButtons).toHaveLength(2);
       expect(actionButtons.at(0).prop('disabled')).toEqual(false);
       expect(actionButtons.at(1).prop('disabled')).toEqual(true);


### PR DESCRIPTION
This fixes imports w/ ts as the default export should match the component name. Otherwise you will not be able to type `Button` and have LSP import suggestion work.