### PR TITLE
fix(integrations): Increment data forwarding counter for Splunk

### DIFF
--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -20,7 +20,7 @@ import logging
 import six
 from requests.exceptions import ReadTimeout
 
-from sentry import http, tagstore
+from sentry import http, tagstore, tsdb
 from sentry.app import ratelimiter
 from sentry.plugins.base import Plugin
 from sentry.plugins.base.configuration import react_plugin_config
@@ -308,3 +308,4 @@ class SplunkPlugin(CorePluginMixin, Plugin):
                 "event_type": event.get_event_type(),
             },
         )
+        tsdb.incr(tsdb.models.project_total_forwarded, event.project.id, count=1)


### PR DESCRIPTION
## Objective
There was an issue where after setting up data forwarding for Splunk and successfully forwarding events, the "FORWARDED EVENTS IN THE LAST 30 DAYS (BY DAY)" graph here doesn’t display anything. 

It turns out that we weren't increment the counter.

Before:
![Screen Shot 2020-11-19 at 2 49 40 PM](https://user-images.githubusercontent.com/10491193/102413503-e3df0980-3fa9-11eb-9091-95c1759b6df7.png)

After:
![Screen Shot 2020-12-16 at 2 21 19 PM](https://user-images.githubusercontent.com/10491193/102413570-feb17e00-3fa9-11eb-80cd-6b9015e87d94.png)

## Future (Not in this PR)
The Splunk Plugin looks like a candidate for a refactor to use the DataForwardingPlugin class to remove a lot of duplicated logic.