### PR TITLE
feat(inbox): Support assignees in owner search

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -137,7 +137,7 @@ def owner_filter(owner, projects):
             )
             .values_list("group_id", flat=True)
             .distinct()
-        )
+        ) | assigned_to_filter(owner, projects)
     elif isinstance(owner, User):
         teams = Team.objects.filter(
             id__in=OrganizationMemberTeam.objects.filter(
@@ -155,7 +155,7 @@ def owner_filter(owner, projects):
             id__in=relevant_owners.filter(filter_query)
             .values_list("group_id", flat=True)
             .distinct()
-        )
+        ) | assigned_to_filter(owner, projects)
     elif isinstance(owner, list) and owner[0] == "me_or_none":
         teams = Team.objects.filter(
             id__in=OrganizationMemberTeam.objects.filter(
@@ -166,14 +166,21 @@ def owner_filter(owner, projects):
             ).values("team")
         )
 
-        owned_team = Q(groupowner__team__in=teams)
-        owned_me = Q(groupowner__user=owner[1])
-        no_owner = Q(groupowner__isnull=True)
-        return no_owner | Q(
-            owned_me | owned_team,
-            groupowner__project_id__in=project_ids,
-            groupowner__organization_id=organization_id,
+        owned_me = Q(
+            id__in=GroupOwner.objects.filter(
+                Q(user_id=owner[1].id) | Q(team__in=teams),
+                project_id__in=[p.id for p in projects],
+                organization_id=organization_id,
+            )
+            .values_list("group_id", flat=True)
+            .distinct()
         )
+        no_owner = unassigned_filter(True, projects) & ~Q(
+            id__in=GroupOwner.objects.filter(project_id__in=[p.id for p in projects]).values_list(
+                "group_id", flat=True
+            )
+        )
+        return no_owner | owned_me | assigned_to_filter(owner[1], projects)
 
     raise InvalidSearchQuery(u"Unsupported owner type.")
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -698,25 +698,32 @@ class GroupListTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:workflow-owners"):
             event = self.store_event(
                 data={
-                    "timestamp": iso_format(before_now(seconds=200)),
-                    "fingerprint": ["group-2"],
+                    "timestamp": iso_format(before_now(seconds=180)),
+                    "fingerprint": ["group-1"],
                     "tags": {"server": "example.com", "trace": "woof", "message": "foo"},
                 },
                 project_id=self.project.id,
             )
             event1 = self.store_event(
                 data={
-                    "timestamp": iso_format(before_now(seconds=200)),
-                    "fingerprint": ["group-3"],
+                    "timestamp": iso_format(before_now(seconds=185)),
+                    "fingerprint": ["group-2"],
                     "tags": {"server": "example.com", "trace": "woof", "message": "foo"},
                 },
                 project_id=self.project.id,
             )
             event2 = self.store_event(
                 data={
-                    "timestamp": iso_format(before_now(seconds=200)),
-                    "fingerprint": ["group-1"],
+                    "timestamp": iso_format(before_now(seconds=190)),
+                    "fingerprint": ["group-3"],
                     "tags": {"server": "example.com", "trace": "woof", "message": "foo"},
+                },
+                project_id=self.project.id,
+            )
+            assigned_event = self.store_event(
+                data={
+                    "timestamp": iso_format(before_now(seconds=195)),
+                    "fingerprint": ["group-4"],
                 },
                 project_id=self.project.id,
             )
@@ -740,12 +747,23 @@ class GroupListTest(APITestCase, SnubaTestCase):
             assert len(response.data) == 1
             assert int(response.data[0]["id"]) == event.group.id
 
+            GroupAssignee.objects.create(
+                group=assigned_event.group, project=assigned_event.group.project, user=self.user
+            )
+
+            response = self.get_response(sort_by="date", limit=10, query="owner:me")
+            assert response.status_code == 200
+            assert len(response.data) == 2
+            assert int(response.data[0]["id"]) == event.group.id
+            assert int(response.data[1]["id"]) == assigned_event.group.id
+
             response = self.get_response(
                 sort_by="date", limit=10, query="owner:{}".format(self.user.email)
             )
             assert response.status_code == 200
-            assert len(response.data) == 1
+            assert len(response.data) == 2
             assert int(response.data[0]["id"]) == event.group.id
+            assert int(response.data[1]["id"]) == assigned_event.group.id
 
             response = self.get_response(
                 sort_by="date", limit=10, query="owner:#{}".format(self.team.slug)
@@ -769,10 +787,12 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
             response = self.get_response(sort_by="date", limit=10, query="owner:me_or_none")
             assert response.status_code == 200
-            assert len(response.data) == 3
-            assert int(response.data[0]["id"]) == event2.group.id
+            assert len(response.data) == 4
+            print([d["id"] for d in response.data])
+            assert int(response.data[0]["id"]) == event.group.id
             assert int(response.data[1]["id"]) == event1.group.id
-            assert int(response.data[2]["id"]) == event.group.id
+            assert int(response.data[2]["id"]) == event2.group.id
+            assert int(response.data[3]["id"]) == assigned_event.group.id
 
             not_me = self.create_user(email="notme@sentry.io")
             GroupOwner.objects.create(
@@ -785,9 +805,10 @@ class GroupListTest(APITestCase, SnubaTestCase):
             )
             response = self.get_response(sort_by="date", limit=10, query="owner:me_or_none")
             assert response.status_code == 200
-            assert len(response.data) == 2
-            assert int(response.data[0]["id"]) == event1.group.id
-            assert int(response.data[1]["id"]) == event.group.id
+            assert len(response.data) == 3
+            assert int(response.data[0]["id"]) == event.group.id
+            assert int(response.data[1]["id"]) == event1.group.id
+            assert int(response.data[2]["id"]) == assigned_event.group.id
 
             GroupOwner.objects.create(
                 group=event2.group,
@@ -800,10 +821,11 @@ class GroupListTest(APITestCase, SnubaTestCase):
             # Should now include event2 as it has shared ownership.
             response = self.get_response(sort_by="date", limit=10, query="owner:me_or_none")
             assert response.status_code == 200
-            assert len(response.data) == 3
-            assert int(response.data[0]["id"]) == event2.group.id
+            assert len(response.data) == 4
+            assert int(response.data[0]["id"]) == event.group.id
             assert int(response.data[1]["id"]) == event1.group.id
-            assert int(response.data[2]["id"]) == event.group.id
+            assert int(response.data[2]["id"]) == event2.group.id
+            assert int(response.data[3]["id"]) == assigned_event.group.id
 
     def test_aggregate_stats_regression_test(self):
         self.store_event(


### PR DESCRIPTION
We need to include assignees as part of owner search. Also spent some time optmizing the query, the
joins we were doing before were not the right idea, because then we end up having to use a DISTINCT
on the results, which is slow for all columns in a group. This seems to be pretty fast from my
testing.