### PR TITLE
meta: auto-lock closed issues/PRs

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,15 @@
+name: 'lock closed issues/PRs'
+on:
+  schedule:
+    - cron: '*/2 * * * *'
+jobs:
+  lock:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v2
+        with:
+          github-token: ${{ github.token }}
+          issue-lock-inactive-days: 15
+          issue-lock-reason: ''
+          pr-lock-inactive-days: 15
+          pr-lock-reason: ''

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,7 +6,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@63786a6
         with:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: 15


### PR DESCRIPTION
https://app.asana.com/0/1199602781063150/1198192573081731

This locks all closed issues and PRs that have not been updated (e.g., commented on) for at least 15 days, via a third-party action initially vetted in https://github.com/getsentry/onpremise/pull/772 and also applied in https://github.com/getsentry/sentry-docs/pull/2780. It's set to run as frequently as possible in order to work down the initial backlog, which is about 22,000 issues/PRs. On `sentry-docs` I'm seeing real-world throughput of ~190/hr, which puts us at four or five days to catch up here on `sentry`. Once we do, I'll follow up with a second PR to back off to twice a day (should be plenty to keep up with the ~25/day we're seeing currently).