### PR TITLE
ref(css): Remove caret css

### DIFF
--- a/src/sentry/static/sentry/less/includes/bootstrap/button-groups.less
+++ b/src/sentry/static/sentry/less/includes/bootstrap/button-groups.less
@@ -128,20 +128,6 @@
   }
 }
 
-// Reposition the caret
-.btn .caret {
-  margin-left: 0;
-}
-// Carets in other button sizes
-.btn-lg .caret {
-  border-width: @caret-width-large @caret-width-large 0;
-  border-bottom-width: 0;
-}
-// Upside down carets for .dropup
-.dropup .btn-lg .caret {
-  border-width: 0 @caret-width-large @caret-width-large;
-}
-
 // Vertical button groups
 // ----------------------
 

--- a/src/sentry/static/sentry/less/includes/bootstrap/dropdowns.less
+++ b/src/sentry/static/sentry/less/includes/bootstrap/dropdowns.less
@@ -2,19 +2,6 @@
 // Dropdown menus
 // --------------------------------------------------
 
-// Dropdown arrow/caret
-.caret {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  margin-left: 2px;
-  vertical-align: middle;
-  border-top: @caret-width-base dashed;
-  border-top: @caret-width-base solid ~'\9'; // IE8
-  border-right: @caret-width-base solid transparent;
-  border-left: @caret-width-base solid transparent;
-}
-
 // The dropdown wrapper (div)
 .dropup,
 .dropdown {
@@ -178,13 +165,6 @@
 
 .dropup,
 .navbar-fixed-bottom .dropdown {
-  // Reverse the caret
-  .caret {
-    content: '';
-    border-top: 0;
-    border-bottom: @caret-width-base dashed;
-    border-bottom: @caret-width-base solid ~'\9'; // IE8
-  }
   // Different positioning for bottom up menu
   .dropdown-menu {
     top: auto;

--- a/src/sentry/static/sentry/less/includes/bootstrap/print.less
+++ b/src/sentry/static/sentry/less/includes/bootstrap/print.less
@@ -74,12 +74,6 @@
   .navbar {
     display: none;
   }
-  .btn,
-  .dropup > .btn {
-    > .caret {
-      border-top-color: #000 !important;
-    }
-  }
   .label {
     border: 1px solid #000;
   }

--- a/src/sentry/static/sentry/less/includes/bootstrap/variables.less
+++ b/src/sentry/static/sentry/less/includes/bootstrap/variables.less
@@ -105,11 +105,6 @@
 //** Global background color for active items (e.g., navs or dropdowns).
 @component-active-bg: @brand-primary;
 
-//** Width of the `border` for generating carets that indicate dropdowns.
-@caret-width-base: 4px;
-//** Carets increase slightly in size for larger components.
-@caret-width-large: 5px;
-
 //== Tables
 //
 //## Customizes the `.table` component with basic values, each used across all table variations.
@@ -249,9 +244,6 @@
 
 //** Text color for headers within dropdown menus.
 @dropdown-header-color: @gray-light;
-
-//** Deprecated `@dropdown-caret-color` as of v3.1.0
-@dropdown-caret-color: #000;
 
 //-- Z-index master list
 //


### PR DESCRIPTION
This removes the `.caret` css def from bootstrap we are not using it. We use an SVG icon instead.