### PR TITLE
fix(search): Go to Integration Details page of integration results

### DIFF
--- a/src/sentry/static/sentry/app/components/search/sources/apiSource.jsx
+++ b/src/sentry/static/sentry/app/components/search/sources/apiSource.jsx
@@ -121,7 +121,7 @@ async function createIntegrationResults(integrationsPromise, orgId) {
         model: provider,
         sourceType: 'integration',
         resultType: 'integration',
-        to: `/settings/${orgId}/integrations/`,
+        to: `/settings/${orgId}/integrations/${provider.slug}/`,
       }))) ||
     []
   );


### PR DESCRIPTION
## Objective
Searching for an integration in the global search should bring us to the Integration Details page. This PR will also fix the Command Palette search results.