### PR TITLE
Add tooltips to blank vitals cards

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalsCards.tsx
@@ -185,14 +185,26 @@ export function VitalsCard(props: CardProps) {
   const measurement = vitalMap[vitalName];
 
   if (isLoading || !tableData || !tableData.data || !tableData.data[0]) {
-    return <BlankCard noBorder={noBorder} measurement={measurement} />;
+    return (
+      <BlankCard
+        noBorder={noBorder}
+        measurement={measurement}
+        titleDescription={vitalName ? vitalDescription[vitalName] || '' : ''}
+      />
+    );
   }
 
   const result = tableData.data[0];
   const base = result[getAggregateAlias(vitalsBaseFields[vitalName])];
 
   if (!base) {
-    return <BlankCard noBorder={noBorder} measurement={measurement} />;
+    return (
+      <BlankCard
+        noBorder={noBorder}
+        measurement={measurement}
+        titleDescription={vitalName ? vitalDescription[vitalName] || '' : ''}
+      />
+    );
   }
 
   const percents = getPercentsFromCounts(getCounts(result, vitalName));
@@ -315,15 +327,18 @@ function VitalsCardContent(props: CardContentProps) {
 type BlankCardProps = {
   noBorder?: boolean;
   measurement?: string;
+  titleDescription?: string;
 };
 
 const BlankCard = (props: BlankCardProps) => {
   const Container = props.noBorder ? NonPanel : VitalCard;
+
   return (
     <Container interactive>
       {props.noBorder || (
         <HeaderTitle>
           <OverflowEllipsis>{t(`${props.measurement}`)}</OverflowEllipsis>
+          <QuestionTooltip size="sm" position="top" title={props.titleDescription} />
         </HeaderTitle>
       )}
       <CardValue>{'\u2014'}</CardValue>


### PR DESCRIPTION
When a project is missing vital data the tooltips aren't displayed. We want to show these tooltips incase people are trying to figure out what these boxes are for.

Before:
![Screen Shot 2020-12-17 at 12 10 00 PM](https://user-images.githubusercontent.com/155016/102520022-3d563f80-4061-11eb-95e7-48b90f50d821.png)

After:
![Screen Shot 2020-12-17 at 12 09 41 PM](https://user-images.githubusercontent.com/155016/102520041-41825d00-4061-11eb-855c-2a6ceb9ab899.png)

