### PR TITLE
fix(search): Don't error on substrings with boolean

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -128,7 +128,7 @@ key_val_term         = spaces (tag_filter / time_filter / rel_time_filter / spec
                        / aggregate_filter / aggregate_date_filter / aggregate_rel_date_filter
                        / has_filter / is_filter / quoted_basic_filter / basic_filter)
                        spaces
-raw_search           = (!key_val_term ~r"\ *(?!(?i)OR)(?!(?i)AND)([^\ ^\n ()]+)\ *" )*
+raw_search           = (!key_val_term ~r"\ *(?!(?i)OR(?![^\s]))(?!(?i)AND(?![^\s]))([^\ ^\n ()]+)\ *" )*
 quoted_raw_search    = spaces quoted_value spaces
 
 # standard key:val filter

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1054,6 +1054,13 @@ class ParseBooleanSearchQueryTest(TestCase):
         result = get_filter("user.email:foo@example.com AND user.email:bar@example.com")
         assert result.conditions == [self.ofoo, self.obar]
 
+    def test_words_with_boolean_substrings(self):
+        result = get_filter("ORder")
+        assert result.conditions == [_om("ORder")]
+
+        result = get_filter("ANDroid")
+        assert result.conditions == [_om("ANDroid")]
+
     def test_single_term(self):
         result = get_filter("user.email:foo@example.com")
         assert result.conditions == [self.ofoo]


### PR DESCRIPTION
- This prevents us from erroring when search strings have AND/OR as a
  substring, eg. "android" or "order" would error, but should just be
  plaintext searches