### PR TITLE
fix(ui): padding of issue row

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -298,6 +298,7 @@ class StreamGroup extends React.Component<Props, State> {
         data-test-id="group"
         onClick={isReprocessingQuery ? undefined : this.toggleSelect}
         reviewed={reviewed}
+        hasInbox={hasInbox}
       >
         {canSelect && (
           <GroupCheckBoxWrapper ml={2}>
@@ -484,10 +485,12 @@ class StreamGroup extends React.Component<Props, State> {
 export default withGlobalSelection(withOrganization(StreamGroup));
 
 // Position for wrapper is relative for overlay actions
-const Wrapper = styled(PanelItem)<{reviewed: boolean}>`
+const Wrapper = styled(PanelItem)<{reviewed: boolean; hasInbox: boolean}>`
   position: relative;
-  padding: ${space(1.5)} 0;
+  padding: ${p => (p.hasInbox ? `${space(1.5)} 0` : `${space(1)} 0`)};
   line-height: 1.1;
+
+  ${p => (p.hasInbox ? p.theme.textColor : p.theme.subText)};
 
   ${p =>
     p.reviewed &&

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -486,7 +486,7 @@ export default withGlobalSelection(withOrganization(StreamGroup));
 // Position for wrapper is relative for overlay actions
 const Wrapper = styled(PanelItem)<{reviewed: boolean}>`
   position: relative;
-  padding: ${space(1)} 0;
+  padding: ${space(1.5)} 0;
   line-height: 1.1;
 
   ${p =>


### PR DESCRIPTION
We need more white space around each issue row to make it easier to scan so I'm adding 4px above/below. Right now all the text is super intimidating and scrunched together and so this change fixes that. Ultimately this shows about 1 less issue at any screen size but that's worth the visual padding improvements. 

Make sure to flip back and forth between this deployed version and what's in production to compare, the gif here doesn't do it justice:

![2020-12-17 08 59 11](https://user-images.githubusercontent.com/1900676/102521579-f872de80-4049-11eb-88d7-71fbe780be2c.gif)
