### PR TITLE
Development environment workflow

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,15 +35,15 @@ jobs:
 
       - name: Install pre-requisites
         if: ${{ runner.os == 'macOS' }}
-        # Installing Python 3.9 does not link (collition with /usr/local/bin/2to3) and it then affects
-        # installing watchman. We can solve this forcing the linking
+        # TODO: CHECK FOR IDEMPOTENT COMMAND
+        # We either remove python3.9 with --ignore-dependencies or brew bundle cleanup to start from fresh state
         # Xcode CLI is already installed; No need to call xcode-select install
         # XXX: Can the Brew set up be cached?
         run: |
-          which brew
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew list -1 | sort
-          brew reinstall python@3.9
+          brew list --formula -1 | sort
+          brew bundle -f cleanup
+          brew list --formula -1 | sort
+          brew bundle check
           brew bundle --verbose
 
       - name: Install Python via Pyenv

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -12,8 +12,8 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
-        os: [ ubuntu-20.04]
+        python-version: [ 3.6, 3.7 ]
+        os: [ ubuntu-20.04, macos-11.0 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -35,6 +35,8 @@ jobs:
             ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}
 
       - name: Set up Python environment (as per direnv)
+        env:
+          SENTRY_PYTHON_VERSION: yes  # This permits using non-default Python
         run: |
           python -m pip install virtualenv
           python -m virtualenv .venv

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -51,7 +51,8 @@ jobs:
         # pyenv needs to be setup here in order that we can use the correct Pip cache
         run: |
           echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
-          exec "$SHELL"
+          pyenv versions
+          echo $PATH
           make setup-pyenv
           which python && python -V
           which pip && pip freeze
@@ -60,6 +61,12 @@ jobs:
         id: python-version
         shell: bash
         run: |
+          echo $PATH
+          which python && python -V
+          env | sort
+          eval "$(pyenv init -)"
+          echo $PATH
+          which python && python -V
           echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
 
       - name: Setup pip

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -1,0 +1,42 @@
+name: Development Environment
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  dev-environment:
+    name: Python set up
+    runs-on: macos-11.0
+    timeout-minutes: 5
+    strategy:
+    matrix:
+      python-version: [3.6, 3.7, 3.8, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Setup pip
+        uses: ./.github/actions/setup-pip
+        id: pip
+
+      - name: pip cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip.outputs.pip-cache-dir }}
+          key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}
+
+      - name: Set up Python environment (as per direnv)
+        run: |
+          python -m virtualenv .venv
+          source .venv/bin/activate
+          make install-py-dev
+          make setup-git
+          touch foo.txt && git add foo.txt && git commit -m "Test git hooks"

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -39,18 +39,17 @@ jobs:
         # Xcode CLI is already installed; No need to call xcode-select install
         # XXX: Can the Brew set up be cached?
         run: |
-          brew bundle verbose
+          brew bundle --verbose
           brew list --formula -1 | sort
           pyenv
           export PYENV_ROOT="$HOME/.pyenv"
           export PATH="$PYENV_ROOT/bin:$PATH"
+          pyenv
 
       - name: Install Python via Pyenv
         # pyenv needs to be setup here in order that we can use the correct Pip cache
         run: |
-          echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
-          env | grep PYENV
-          env | grep pyenv
+          env | sort
           echo $PATH
           make setup-pyenv
           pyenv versions

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -7,6 +7,8 @@ on:
     - '.github/workflows/development-environment.yml'
     - 'requirements-*.txt'
     - 'scripts/*'
+    - 'src/sentry/runner/commands/devserver.py'
+    - 'src/sentry/runner/commands/devservices.py'
 
 jobs:
   dev-environment:

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -40,7 +40,14 @@ jobs:
         # Xcode CLI is already installed; No need to call xcode-select install
         # XXX: Can the Brew set up be cached?
         run: |
+          brew update
+          brew install watchman
+          brew info python@3.9
           brew uninstall --ignore-dependencies python@3.9
+          brew install watchman
+          /usr/local/bin/python3.9 -c "import platform; print(platform.platform())"
+          brew link --overwrite python@3.9
+          brew install watchman
           brew bundle --verbose
 
       - name: Install Python via Pyenv

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -5,8 +5,6 @@ on:
     - 'Brewfile'
     - 'Makefile'
     - '.github/workflows/development-environment.yml'
-    - '.pre-commit-config.yaml'
-    - 'config/hooks/pre-commit'
     - 'requirements-*.txt'
     - 'scripts/*'
 
@@ -81,6 +79,3 @@ jobs:
         run: |
           source .venv/bin/activate
           make develop init-config
-          git config --global user.email "you@example.com"
-          git config --global user.name "Your Name"
-          touch foo.txt && git add foo.txt && git commit -m "Test git hooks"

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install pre-requisites
         if: ${{ runner.os == 'macOS' }}
-        run:
+        run: |
           xcode-select --install
           brew bundle --verbose
 

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Install pre-requisites
         if: ${{ runner.os == 'macOS' }}
+        continue-on-error: true
         run: |  # Xcode CLI is already installed
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           brew bundle --verbose

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,11 +35,10 @@ jobs:
 
       - name: Install prerequisites
         if: ${{ runner.os == 'macOS' }}
-        # Depending on the host watchman will not install (read intermittent)
-        # The other option is to call brew bundle -f clean which clears all other
-        # installed packages
+        # Depending on the host watchman will not install (read as intermittent issue),
+        # thus, we mark this as continue-on-error
         continue-on-error: true
-        # Xcode CLI is already installed; No need to call xcode-select install
+        # Xcode CLI & brew are already installed, thus, no need to call xcode-select install
         # XXX: Can the Brew set up be cached?
         run: |
           brew bundle
@@ -54,74 +53,45 @@ jobs:
       - name: Install Python (via Pyenv)
         id: python-version
         shell: bash
-        # pyenv needs to be setup here in order that we can use the correct Pip cache
-        # We set the global version to be 3.6.10 since in order for that version to be picked we need
-        # to be inside the source checkout (that's how pyenv activates it)
-        # XXX: Locally pyenv makes 3.6.10 be the Python version in use because of the order within .python-version
+        # XXX: Locally pyenv makes 3.6.10 be the selected version in use due,
+        # however, in here it selects /usr/local/bin/python. I'm using `pyenv global` to work around it
+        # XXX: Can we cache the installed Python environments?
         run: |
-          echo $PATH
-          which python && python -V
           make setup-pyenv
-          echo $PATH
-          which python && python -V
-          export PATH=$HOME/.pyenv/shims:$PATH
-          echo $PATH
-          which python && python -V
           pyenv global 3.6.10
           which python && python -V
           echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
 
-      # - name: Set python-version
-      #   id: python-version
-      #   shell: bash
-      #   run: |
-      #     cd ~/work/sentry/sentry
-      #     echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
+      - name: Setup pip
+        uses: ./.github/actions/setup-pip
+        id: pip
 
-      # - name: Setup pip
-      #   uses: ./.github/actions/setup-pip
-      #   id: pip
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.pip.outputs.pip-cache-dir }}
+            ~/.pyenv
+          key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-py${{ matrix.python-version }}
 
-      # XXX: Will it work to cache ~/.venv ?
-      # - name: Cache
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ${{ steps.pip.outputs.pip-cache-dir }}
-      #       ~/.pyenv
-      #       .venv
-      #     key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-pip-py${{ matrix.python-version }}
-
-      - name: Set up Python environment (as per docs)
-        # We cannot call make bootstrap directly since run-dependent-services requires some Docker magic.
-        # We have the magic in the getsentry/bootstrap-develop. We will handle this situation in the next pass of this.
-        # make init-config will *not* prompt about overwriting ~/.sentry/config.yml' since we're on a pristine state
+      - name: Set up development environment (as per docs)
         run: |
-          echo $PATH
-          which python && python -V
-          export PATH=$HOME/.pyenv/shims:$PATH
-          pwd
-          which python && python -V
-          which pip && pip freeze
           python -m pip install virtualenv
           python -m virtualenv .venv
           source .venv/bin/activate
           make install-py-dev
           make setup-git
+          curl https://get.volta.sh | bash
 
-      - name: Set up Node environment (as per docs)
+      - name: Set up Sentry and others
         # We cannot call make bootstrap directly since run-dependent-services requires some Docker magic.
         # We have the magic in the getsentry/bootstrap-develop. We will handle this situation in the next pass of this.
         # make init-config will *not* prompt about overwriting ~/.sentry/config.yml' since we're on a pristine state
+        # We cannot test the git hooks until the `sentry.lint.engine` gets installed
         run: |
-          curl https://get.volta.sh | bash
-          node -v
-
-      - name: Set up Sentry and others
-        run: |
+          make develop init-config
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
           touch foo.txt && git add foo.txt && git commit -m "Test git hooks"
-          make develop init-config

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -48,12 +48,14 @@ jobs:
           brew bundle
 
       - name: Install Python via Pyenv
+        # Temp:
+        continue-on-error: true
         # pyenv needs to be setup here in order that we can use the correct Pip cache
         run: |
           echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
-          pyenv versions
           echo $PATH
           make setup-pyenv
+          pyenv versions
           which python && python -V
           which pip && pip freeze
 

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -43,12 +43,15 @@ jobs:
         # XXX: Can the Brew set up be cached?
         run: |
           brew bundle
-          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
-          echo "PATH=$PYENV_ROOT/shims:$PATH" >> $GITHUB_ENV
-          echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
-          echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
 
-      - name: Install Python via Pyenv
+      - name: Set environment variables
+        shell: bash
+        run: |
+          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
+          echo "VOLTA_HOME=$HOME/.volta" >> $GITHUB_ENV
+          echo "PATH=$HOME/.pyenv/shims:$HOME/.volta/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Install Python (via Pyenv)
         id: python-version
         shell: bash
         # pyenv needs to be setup here in order that we can use the correct Pip cache
@@ -57,12 +60,15 @@ jobs:
         # XXX: Locally pyenv makes 3.6.10 be the Python version in use because of the order within .python-version
         run: |
           echo $PATH
+          which python && python -V
           make setup-pyenv
+          echo $PATH
+          which python && python -V
           export PATH=$HOME/.pyenv/shims:$PATH
           echo $PATH
+          which python && python -V
           pyenv global 3.6.10
-          python -V
-          which python
+          which python && python -V
           echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
 
       # - name: Set python-version
@@ -94,6 +100,7 @@ jobs:
         # make init-config will *not* prompt about overwriting ~/.sentry/config.yml' since we're on a pristine state
         run: |
           echo $PATH
+          which python && python -V
           export PATH=$HOME/.pyenv/shims:$PATH
           pwd
           which python && python -V
@@ -103,11 +110,17 @@ jobs:
           source .venv/bin/activate
           make install-py-dev
           make setup-git
+
+      - name: Set up Node environment (as per docs)
+        # We cannot call make bootstrap directly since run-dependent-services requires some Docker magic.
+        # We have the magic in the getsentry/bootstrap-develop. We will handle this situation in the next pass of this.
+        # make init-config will *not* prompt about overwriting ~/.sentry/config.yml' since we're on a pristine state
+        run: |
           curl https://get.volta.sh | bash
-          export VOLTA_HOME="~/.volta"
-          export PATH="$VOLTA_HOME/bin:$PATH"
-          echo $PATH
           node -v
+
+      - name: Set up Sentry and others
+        run: |
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
           touch foo.txt && git add foo.txt && git commit -m "Test git hooks"

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -9,7 +9,7 @@ jobs:
   dev-environment:
     name: Python set up
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: [ 3.6 ]

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -28,35 +28,47 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: [ 3.6 ]  # It does not matter since we use pyenv
         os: [ macos-11.0 ]
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.pip.outputs.pip-cache-dir }}
-          key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}
-
       - name: Install pre-requisites
         if: ${{ runner.os == 'macOS' }}
-        continue-on-error: true
-        # Xcode CLI is already installed
-        # pyenv needs to configure the right Python for the rest of the workflow
+        # Xcode CLI is already installed; No need to call xcode-select install
+        # XXX: Can the Brew set up be cached?
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           brew bundle --verbose
+
+      - name: Install Python via Pyenv
+        # pyenv needs to be setup here in order that we can use the correct Pip cache
+        run: |
           make setup-pyenv
           which python && python -V
           which pip && pip freeze
 
+      - name: Set python-version
+        id: python-version
+        shell: bash
+        run: |
+          echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
+
       - name: Setup pip
         uses: ./.github/actions/setup-pip
         id: pip
+
+      # XXX: Will it work to cache ~/.venv ?
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.pip.outputs.pip-cache-dir }}
+            ~/.pyenv
+            .venv
+          key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-py${{ matrix.python-version }}
 
       - name: Set up Python environment (as per docs)
         # We cannot call make bootstrap directly since run-dependent-services requires some Docker magic.

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -12,8 +12,8 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7 ]
-        os: [ ubuntu-20.04, macos-11.0 ]
+        python-version: [ 3.6 ]
+        os: [ macos-11.0 ]
 
     steps:
       - uses: actions/checkout@v2
@@ -34,10 +34,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}
 
-      - name: Set up Python environment (as per direnv)
+      - name: Install pre-requisites
+        if: ${{ os.runner == 'macOS' }}
+        run:
+          xcode-select --install
+          brew bundle --verbose
+
+      - name: Set up Python environment (as per docs)
         env:
           SENTRY_PYTHON_VERSION: yes  # This permits using non-default Python
-        run: |
+        run: | # Not using pyenv for now & make bootstrap
           python -m pip install virtualenv
           python -m virtualenv .venv
           source .venv/bin/activate

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,15 +35,15 @@ jobs:
 
       - name: Install pre-requisites
         if: ${{ runner.os == 'macOS' }}
-        continue-on-error: true
-        # I can't get watchman to install. I will only add missing brew packages
+        continue-on-error: true  # I can't get watchman to install
         # Xcode CLI is already installed; No need to call xcode-select install
         # XXX: Can the Brew set up be cached?
         run: |
-          brew install pyenv
-          brew install geoip
-          brew install librdkafka
-          brew bundle check
+          brew bundle verbose
+          brew list --formula -1 | sort
+          pyenv
+          export PYENV_ROOT="$HOME/.pyenv"
+          export PATH="$PYENV_ROOT/bin:$PATH"
 
       - name: Install Python via Pyenv
         # pyenv needs to be setup here in order that we can use the correct Pip cache

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -52,6 +52,8 @@ jobs:
           make install-py-dev
           make setup-git
           curl https://get.volta.sh | bash
+          export VOLTA_HOME="~/.volta"
+          export PATH="$VOLTA_HOME/bin:$PATH"
           echo $PATH
           node -v
           git config --global user.email "you@example.com"

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -45,17 +45,26 @@ jobs:
       - name: Install pre-requisites
         if: ${{ runner.os == 'macOS' }}
         continue-on-error: true
-        run: |  # Xcode CLI is already installed
+        # Xcode CLI is already installed
+        # pyenv needs to configure the right Python for the rest of the workflow
+        run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           brew bundle --verbose
+          make setup-pyenv
+          which python && python -V
+          which pip && pip freeze
+
+      - name: Setup pip
+        uses: ./.github/actions/setup-pip
+        id: pip
 
       - name: Set up Python environment (as per docs)
         # We cannot call make bootstrap directly since run-dependent-services requires some Docker magic.
         # We have the magic in the getsentry/bootstrap-develop. We will handle this situation in the next pass of this.
         # make init-config will *not* prompt about overwriting ~/.sentry/config.yml' since we're on a pristine state
         run: |
-          make setup-pyenv
           which python && python -V
+          which pip && pip freeze
           python -m pip install virtualenv
           python -m virtualenv .venv
           source .venv/bin/activate

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -45,14 +45,24 @@ jobs:
           brew bundle
           echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
           echo "PYENV_ROOT/bin:$PATH" >> $GITHUB_ENV
+          echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
+          echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
 
       - name: Install Python via Pyenv
         # pyenv needs to be setup here in order that we can use the correct Pip cache
+        # XXX: Locally pyenv makes 3.6.10 be the Python version in use because of the order within .python-version
+        # XXX: For some reason is not quite working
         run: |
           make setup-pyenv
           pyenv versions
           which python && python -V
           which pip && pip freeze
+          exec "$SHELL"
+          pyenv versions
+          which python && python -V
+          pyenv local 3.6.10
+          pyenv versions
+          which python && python -V
 
       - name: Set python-version
         id: python-version

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,15 +35,16 @@ jobs:
 
       - name: Install pre-requisites
         if: ${{ runner.os == 'macOS' }}
-        # I have noticed the installation being a little flaky
-        continue-on-error: true
         # Installing Python 3.9 does not link (collition with /usr/local/bin/2to3) and it then affects
         # installing watchman. We can solve this forcing the linking
         # Xcode CLI is already installed; No need to call xcode-select install
         # XXX: Can the Brew set up be cached?
         run: |
+          which brew
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew bundle
+          brew list -1 | sort
+          brew reinstall python@3.9
+          brew bundle --verbose
 
       - name: Install Python via Pyenv
         # pyenv needs to be setup here in order that we can use the correct Pip cache

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,20 +35,15 @@ jobs:
 
       - name: Install pre-requisites
         if: ${{ runner.os == 'macOS' }}
-        # We need to install again python@3.9 as it conflicts with python 3.9.1 and watchman
-        # not installing properly.
+        continue-on-error: true
+        # I can't get watchman to install. I will only add missing brew packages
         # Xcode CLI is already installed; No need to call xcode-select install
         # XXX: Can the Brew set up be cached?
         run: |
-          brew update
-          brew install watchman
-          brew info python@3.9
-          brew uninstall --ignore-dependencies python@3.9
-          brew install watchman
-          /usr/local/bin/python3.9 -c "import platform; print(platform.platform())"
-          brew link --overwrite python@3.9
-          brew install watchman
-          brew bundle --verbose
+          brew install pyenv
+          brew install geoip
+          brew install librdkafka
+          brew bundle check
 
       - name: Install Python via Pyenv
         # pyenv needs to be setup here in order that we can use the correct Pip cache

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ macosx-11.0, ubuntu-16.04]
+        os: [ ubuntu-16.04]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -1,9 +1,25 @@
 name: Development Environment
 on:
   push:
+    paths:
+    - 'Brewfile'
+    - 'Makefile'
+    - 'setup.py'  # For changes in the sentry CLI used in make bootstrap
+    - 'requirements-*.txt'
+    - 'scripts/*'
+    - 'src/sentry/*'  # Imported in setup.py
+    - '.github/workflows/development-environment.yml'
     branches:
       - master
   pull_request:
+    paths:
+    - 'Brewfile'
+    - 'Makefile'
+    - 'setup.py'  # For changes in the sentry CLI used in make bootstrap
+    - 'requirements-*.txt'
+    - 'scripts/*'
+    - 'src/sentry/*'  # Imported in setup.py
+    - '.github/workflows/development-environment.yml'
 
 jobs:
   dev-environment:
@@ -12,15 +28,11 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: [ 3.6 ]
+        python-version: [ 3.6 ]  # It does not matter since we use pyenv
         os: [ macos-11.0 ]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -25,7 +25,7 @@ jobs:
   dev-environment:
     name: Python set up
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 20
     strategy:
       matrix:
         os: [ macos-11.0 ]
@@ -33,24 +33,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install pre-requisites
+      - name: Install prerequisites
         if: ${{ runner.os == 'macOS' }}
-        continue-on-error: true  # I can't get watchman to install
+        # Depending on the host watchman will not install (read intermittent)
+        # The other option is to call brew bundle -f clean which clears all other
+        # installed packages
+        continue-on-error: true
         # Xcode CLI is already installed; No need to call xcode-select install
         # XXX: Can the Brew set up be cached?
         run: |
-          brew bundle --verbose
-          brew list --formula -1 | sort
-          pyenv
-          export PYENV_ROOT="$HOME/.pyenv"
-          export PATH="$PYENV_ROOT/bin:$PATH"
-          pyenv
+          brew bundle
+          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
+          echo "PYENV_ROOT/bin:$PATH" >> $GITHUB_ENV
 
       - name: Install Python via Pyenv
         # pyenv needs to be setup here in order that we can use the correct Pip cache
         run: |
-          env | sort
-          echo $PATH
           make setup-pyenv
           pyenv versions
           which python && python -V
@@ -60,12 +58,6 @@ jobs:
         id: python-version
         shell: bash
         run: |
-          echo $PATH
-          which python && python -V
-          env | sort
-          eval "$(pyenv init -)"
-          echo $PATH
-          which python && python -V
           echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
 
       - name: Setup pip

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -37,16 +37,22 @@ jobs:
         if: ${{ runner.os == 'macOS' }}
         # I have noticed the installation being a little flaky
         continue-on-error: true
+        # Installing Python 3.9 does not link (collition with /usr/local/bin/2to3) and it then affects
+        # installing watchman. We can solve this forcing the linking
         # Xcode CLI is already installed; No need to call xcode-select install
         # XXX: Can the Brew set up be cached?
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          brew install python@3.9
+          brew link --overwrite python@3.9
           brew bundle
 
       - name: Install Python via Pyenv
         # pyenv needs to be setup here in order that we can use the correct Pip cache
         run: |
           make setup-pyenv
+          echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
+          exec "$SHELL"
           which python && python -V
           which pip && pip freeze
 

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -42,14 +42,19 @@ jobs:
           brew bundle --verbose
 
       - name: Set up Python environment (as per docs)
-        env:
-          SENTRY_PYTHON_VERSION: yes  # This permits using non-default Python
-        run: | # Not using pyenv for now & make bootstrap
+        # make bootstrap will *not* prompt about overwriting ~/.sentry/config.yml' since we're on a pristine state
+        run: |
+          make setup-pyenv
+          which python && python -V
           python -m pip install virtualenv
           python -m virtualenv .venv
           source .venv/bin/activate
           make install-py-dev
           make setup-git
+          curl https://get.volta.sh | bash
+          echo $PATH
+          node -v
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
           touch foo.txt && git add foo.txt && git commit -m "Test git hooks"
+          make bootstrap

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,11 +35,13 @@ jobs:
 
       - name: Install pre-requisites
         if: ${{ runner.os == 'macOS' }}
+        # I have noticed the installation being a little flaky
+        continue-on-error: true
         # Xcode CLI is already installed; No need to call xcode-select install
         # XXX: Can the Brew set up be cached?
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew bundle --verbose
+          brew bundle
 
       - name: Install Python via Pyenv
         # pyenv needs to be setup here in order that we can use the correct Pip cache

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -12,8 +12,8 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        os: [ ubuntu-16.04]
+        python-version: [3.6, 3.7]
+        os: [ ubuntu-20.04]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -5,7 +5,6 @@ on:
     - 'Brewfile'
     - 'Makefile'
     - '.github/workflows/development-environment.yml'
-    - 'requirements-*.txt'
     - 'scripts/*'
     - 'src/sentry/runner/commands/devserver.py'
     - 'src/sentry/runner/commands/devservices.py'

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -9,7 +9,7 @@ jobs:
   dev-environment:
     name: Python set up
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 5
+    timeout-minutes: 10
     strategy:
       matrix:
         python-version: [ 3.6 ]

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -34,11 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup pip
-        uses: ./.github/actions/setup-pip
-        id: pip
-
-      - name: pip cache
+      - name: Cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
@@ -54,7 +50,9 @@ jobs:
           brew bundle --verbose
 
       - name: Set up Python environment (as per docs)
-        # make bootstrap will *not* prompt about overwriting ~/.sentry/config.yml' since we're on a pristine state
+        # We cannot call make bootstrap directly since run-dependent-services requires some Docker magic.
+        # We have the magic in the getsentry/bootstrap-develop. We will handle this situation in the next pass of this.
+        # make init-config will *not* prompt about overwriting ~/.sentry/config.yml' since we're on a pristine state
         run: |
           make setup-pyenv
           which python && python -V
@@ -71,4 +69,4 @@ jobs:
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"
           touch foo.txt && git add foo.txt && git commit -m "Test git hooks"
-          make bootstrap
+          make develop init-config

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -72,9 +72,9 @@ jobs:
       #     cd ~/work/sentry/sentry
       #     echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
 
-      - name: Setup pip
-        uses: ./.github/actions/setup-pip
-        id: pip
+      # - name: Setup pip
+      #   uses: ./.github/actions/setup-pip
+      #   id: pip
 
       # XXX: Will it work to cache ~/.venv ?
       # - name: Cache

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -41,4 +41,6 @@ jobs:
           source .venv/bin/activate
           make install-py-dev
           make setup-git
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
           touch foo.txt && git add foo.txt && git commit -m "Test git hooks"

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -49,26 +49,27 @@ jobs:
           echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
 
       - name: Install Python via Pyenv
-        # pyenv needs to be setup here in order that we can use the correct Pip cache
-        # XXX: Locally pyenv makes 3.6.10 be the Python version in use because of the order within .python-version
-        # XXX: For some reason is not quite working
-        run: |
-          make setup-pyenv
-          ls -la $HOME
-          pyenv versions
-          pwd
-          python -V
-          echo $PATH
-          export PATH=$HOME/.pyenv/shims:$PATH
-          pyenv local 3.6.10
-          pyenv versions
-          python -V
-
-      - name: Set python-version
         id: python-version
         shell: bash
+        # pyenv needs to be setup here in order that we can use the correct Pip cache
+        # We set the global version to be 3.6.10 since in order for that version to be picked we need
+        # to be inside the source checkout (that's how pyenv activates it)
+        # XXX: Locally pyenv makes 3.6.10 be the Python version in use because of the order within .python-version
         run: |
+          make setup-pyenv
+          export PATH=$HOME/.pyenv/shims:$PATH
+          echo $PATH
+          pyenv global 3.6.10
+          python -V
+          env | sort
           echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
+
+      # - name: Set python-version
+      #   id: python-version
+      #   shell: bash
+      #   run: |
+      #     cd ~/work/sentry/sentry
+      #     echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,15 +35,12 @@ jobs:
 
       - name: Install pre-requisites
         if: ${{ runner.os == 'macOS' }}
-        # TODO: CHECK FOR IDEMPOTENT COMMAND
-        # We either remove python3.9 with --ignore-dependencies or brew bundle cleanup to start from fresh state
+        # We need to install again python@3.9 as it conflicts with python 3.9.1 and watchman
+        # not installing properly.
         # Xcode CLI is already installed; No need to call xcode-select install
         # XXX: Can the Brew set up be cached?
         run: |
-          brew list --formula -1 | sort
-          brew bundle -f cleanup
-          brew list --formula -1 | sort
-          brew bundle check
+          brew uninstall --ignore-dependencies python@3.9
           brew bundle --verbose
 
       - name: Install Python via Pyenv

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Set up Python environment (as per direnv)
         run: |
+          python -m pip install virtualenv
           python -m virtualenv .venv
           source .venv/bin/activate
           make install-py-dev

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,7 +35,7 @@ jobs:
             ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}
 
       - name: Install pre-requisites
-        if: ${{ os.runner == 'macOS' }}
+        if: ${{ runner.os == 'macOS' }}
         run:
           xcode-select --install
           brew bundle --verbose

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -58,7 +58,10 @@ jobs:
           pyenv versions
           pwd
           python -V
+          echo $PATH
+          export PATH=$HOME/.pyenv/shims:$PATH
           pyenv local 3.6.10
+          pyenv versions
           python -V
 
       - name: Set python-version

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -43,16 +43,14 @@ jobs:
         # XXX: Can the Brew set up be cached?
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-          brew install python@3.9
-          brew link --overwrite python@3.9
           brew bundle
 
       - name: Install Python via Pyenv
-        # Temp:
-        continue-on-error: true
         # pyenv needs to be setup here in order that we can use the correct Pip cache
         run: |
           echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
+          env | grep PYENV
+          env | grep pyenv
           echo $PATH
           make setup-pyenv
           pyenv versions

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     strategy:
-    matrix:
-      python-version: [3.6, 3.7, 3.8, 3.9]
-      os: [ macosx-11.0, ubuntu-16.04]
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ macosx-11.0, ubuntu-16.04]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install prerequisites
         if: ${{ runner.os == 'macOS' }}
-        # Depending on the host watchman will not install (read as intermittent issue),
+        # Depending on the host watchman will not install (read: intermittent issue),
         # thus, we mark this as continue-on-error
         continue-on-error: true
         # Xcode CLI & brew are already installed, thus, no need to call xcode-select install
@@ -53,13 +53,12 @@ jobs:
       - name: Install Python (via Pyenv)
         id: python-version
         shell: bash
-        # XXX: Locally pyenv makes 3.6.10 be the selected version in use due,
+        # XXX: Locally, pyenv makes 3.6.10 be the selected version in use,
         # however, in here it selects /usr/local/bin/python. I'm using `pyenv global` to work around it
         # XXX: Can we cache the installed Python environments?
         run: |
           make setup-pyenv
           pyenv global 3.6.10
-          which python && python -V
           echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
 
       - name: Setup pip
@@ -74,7 +73,7 @@ jobs:
             ~/.pyenv
           key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
           restore-keys: |
-            ${{ runner.os }}-pip-py${{ matrix.python-version }}
+            ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}
 
       - name: Set up development environment (as per docs)
         run: |
@@ -91,6 +90,7 @@ jobs:
         # make init-config will *not* prompt about overwriting ~/.sentry/config.yml' since we're on a pristine state
         # We cannot test the git hooks until the `sentry.lint.engine` gets installed
         run: |
+          source .venv/bin/activate
           make develop init-config
           git config --global user.email "you@example.com"
           git config --global user.name "Your Name"

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -1,29 +1,18 @@
-name: Development Environment
+name: development environment
 on:
-  push:
-    paths:
-    - 'Brewfile'
-    - 'Makefile'
-    - 'setup.py'  # For changes in the sentry CLI used in make bootstrap
-    - 'requirements-*.txt'
-    - 'scripts/*'
-    - 'src/sentry/*'  # Imported in setup.py
-    - '.github/workflows/development-environment.yml'
-    branches:
-      - master
   pull_request:
     paths:
     - 'Brewfile'
     - 'Makefile'
-    - 'setup.py'  # For changes in the sentry CLI used in make bootstrap
+    - '.github/workflows/development-environment.yml'
+    - '.pre-commit-config.yaml'
+    - 'config/hooks/pre-commit'
     - 'requirements-*.txt'
     - 'scripts/*'
-    - 'src/sentry/*'  # Imported in setup.py
-    - '.github/workflows/development-environment.yml'
 
 jobs:
   dev-environment:
-    name: Python set up
+    name: python set up
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -54,15 +54,12 @@ jobs:
         # XXX: For some reason is not quite working
         run: |
           make setup-pyenv
+          ls -la $HOME
           pyenv versions
-          which python && python -V
-          which pip && pip freeze
-          exec "$SHELL"
-          pyenv versions
-          which python && python -V
+          pwd
+          python -V
           pyenv local 3.6.10
-          pyenv versions
-          which python && python -V
+          python -V
 
       - name: Set python-version
         id: python-version

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -72,16 +72,16 @@ jobs:
         id: pip
 
       # XXX: Will it work to cache ~/.venv ?
-      - name: Cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ${{ steps.pip.outputs.pip-cache-dir }}
-            ~/.pyenv
-            .venv
-          key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-py${{ matrix.python-version }}
+      # - name: Cache
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: |
+      #       ${{ steps.pip.outputs.pip-cache-dir }}
+      #       ~/.pyenv
+      #       .venv
+      #     key: ${{ runner.os }}-pip-py${{ steps.python-version.outputs.python-version }}-${{ hashFiles('**/requirements-*.txt') }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-pip-py${{ matrix.python-version }}
 
       - name: Set up Python environment (as per docs)
         # We cannot call make bootstrap directly since run-dependent-services requires some Docker magic.

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Install pre-requisites
         if: ${{ runner.os == 'macOS' }}
-        run: |
-          xcode-select --install
+        run: |  # Xcode CLI is already installed
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
           brew bundle --verbose
 
       - name: Set up Python environment (as per docs)

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           brew bundle
           echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
-          echo "PYENV_ROOT/bin:$PATH" >> $GITHUB_ENV
+          echo "PATH=$PYENV_ROOT/bin:$PATH" >> $GITHUB_ENV
           echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
           echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
 

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           brew bundle
           echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
-          echo "PATH=$PYENV_ROOT/bin:$PATH" >> $GITHUB_ENV
+          echo "PATH=$PYENV_ROOT/shims:$PATH" >> $GITHUB_ENV
           echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.bash_profile
           echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
 
@@ -56,12 +56,13 @@ jobs:
         # to be inside the source checkout (that's how pyenv activates it)
         # XXX: Locally pyenv makes 3.6.10 be the Python version in use because of the order within .python-version
         run: |
+          echo $PATH
           make setup-pyenv
           export PATH=$HOME/.pyenv/shims:$PATH
           echo $PATH
           pyenv global 3.6.10
           python -V
-          env | sort
+          which python
           echo "::set-output name=python-version::$(python -V  | sed s/Python\ //g)"
 
       # - name: Set python-version
@@ -92,6 +93,9 @@ jobs:
         # We have the magic in the getsentry/bootstrap-develop. We will handle this situation in the next pass of this.
         # make init-config will *not* prompt about overwriting ~/.sentry/config.yml' since we're on a pristine state
         run: |
+          echo $PATH
+          export PATH=$HOME/.pyenv/shims:$PATH
+          pwd
           which python && python -V
           which pip && pip freeze
           python -m pip install virtualenv

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -8,11 +8,12 @@ on:
 jobs:
   dev-environment:
     name: Python set up
-    runs-on: macos-11.0
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 5
     strategy:
     matrix:
       python-version: [3.6, 3.7, 3.8, 3.9]
+      os: [ macosx-11.0, ubuntu-16.04]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Install Python via Pyenv
         # pyenv needs to be setup here in order that we can use the correct Pip cache
         run: |
-          make setup-pyenv
           echo -e 'if command -v pyenv 1>/dev/null 2>&1; then\n  eval "$(pyenv init -)"\nfi' >> ~/.zshrc
           exec "$SHELL"
+          make setup-pyenv
           which python && python -V
           which pip && pip freeze
 


### PR DESCRIPTION
This PR adds Mac OS 11 testing of the development environment set up steps as per the documentation.
We also specify a minimum set of files that would trigger this workflow.

This is missing the full set up (we miss calling `make bootstrap`) because we miss some Docker automation logic that lives in `bootstrap-develop`. We will handle it in a future pass.