### PR TITLE
ref(stacktrace-link): Better analytics

### DIFF
--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -7,13 +7,12 @@ from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.models import Integration, Repository
 from sentry.utils.compat import filter, map
-from sentry.web.decorators import transaction_start
 
 
 def find_roots(stack_path, source_path):
     """
-        Returns a tuple containing the stack_root, and the source_root.
-        If there is no overlap, raise an exception since this should not happen
+    Returns a tuple containing the stack_root, and the source_root.
+    If there is no overlap, raise an exception since this should not happen
     """
     overlap_to_check = stack_path
     stack_root = ""
@@ -92,13 +91,12 @@ class PathMappingSerializer(CamelSnakeSerializer):
 
 class ProjectRepoPathParsingEndpoint(ProjectEndpoint):
     """
-        Returns the parameters associated with the RepositoryProjectPathConfig
-        we would create based on a particular stack trace and source code URL.
-        Does validation to make sure we have an integration and repo
-        depending on the source code URL
+    Returns the parameters associated with the RepositoryProjectPathConfig
+    we would create based on a particular stack trace and source code URL.
+    Does validation to make sure we have an integration and repo
+    depending on the source code URL
     """
 
-    @transaction_start("ProjectRepoPathParsingEndpoint")
     def post(self, request, project):
         serializer = PathMappingSerializer(
             context={"organization_id": project.organization_id}, data=request.data,

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -91,6 +91,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                 provider=result["config"]["provider"]["key"],
                 config_id=result["config"]["id"],
                 project_id=project.id,
+                organization_id=project.organization_id,
                 filepath=filepath,
                 status=result.get("error") or "success",
             )

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from rest_framework.response import Response
 
+from sentry import analytics
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.models import Integration, RepositoryProjectPathConfig
 from sentry.api.serializers import serialize
@@ -83,5 +84,16 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                     scope.set_tag("stacktrace_link.found", True)
                     # if we found a match, we can break
                     break
+
+        if result["config"]:
+            analytics.record(
+                "integration.stacktrace.linked",
+                provider=result["config"]["provider"]["key"],
+                config_id=result["config"]["id"],
+                project_id=project.id,
+                platform=platform,
+                filepath=filepath,
+                status=result.get("error") or "success",
+            )
 
         return Response(result)

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -91,7 +91,6 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                 provider=result["config"]["provider"]["key"],
                 config_id=result["config"]["id"],
                 project_id=project.id,
-                platform=platform,
                 filepath=filepath,
                 status=result.get("error") or "success",
             )

--- a/src/sentry/integrations/analytics.py
+++ b/src/sentry/integrations/analytics.py
@@ -106,6 +106,7 @@ class IntegrationStacktraceLinkEvent(analytics.Event):
         analytics.Attribute("provider"),
         analytics.Attribute("config_id"),
         analytics.Attribute("project_id"),
+        analytics.Attribute("organization_id"),
         analytics.Attribute("filepath"),
         analytics.Attribute("status"),
     )

--- a/src/sentry/integrations/analytics.py
+++ b/src/sentry/integrations/analytics.py
@@ -106,7 +106,6 @@ class IntegrationStacktraceLinkEvent(analytics.Event):
         analytics.Attribute("provider"),
         analytics.Attribute("config_id"),
         analytics.Attribute("project_id"),
-        analytics.Attribute("platform"),
         analytics.Attribute("filepath"),
         analytics.Attribute("status"),
     )

--- a/src/sentry/integrations/analytics.py
+++ b/src/sentry/integrations/analytics.py
@@ -99,6 +99,19 @@ class IntegrationResolvePREvent(analytics.Event):
     )
 
 
+class IntegrationStacktraceLinkEvent(analytics.Event):
+    type = "integration.stacktrace.linked"
+
+    attributes = (
+        analytics.Attribute("provider"),
+        analytics.Attribute("config_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("platform"),
+        analytics.Attribute("filepath"),
+        analytics.Attribute("status"),
+    )
+
+
 analytics.register(IntegrationAddedEvent)
 analytics.register(IntegrationIssueCreatedEvent)
 analytics.register(IntegrationIssueLinkedEvent)
@@ -108,3 +121,4 @@ analytics.register(IntegrationIssueCommentsSyncedEvent)
 analytics.register(IntegrationRepoAddedEvent)
 analytics.register(IntegrationResolveCommitEvent)
 analytics.register(IntegrationResolvePREvent)
+analytics.register(IntegrationStacktraceLinkEvent)

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
@@ -96,6 +96,7 @@ const Context = ({
                 !hideStacktraceLink &&
                 isActive &&
                 isExpanded &&
+                frame.inApp &&
                 frame.filename && (
                   <ErrorBoundary mini>
                     <StacktraceLink

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -161,8 +161,8 @@ class StacktraceLink extends AsyncComponent<Props, State> {
             onClick={() => {
               trackIntegrationEvent(
                 {
-                  eventKey: 'integrations.stacktrace_open_modal',
-                  eventName: 'Integrations: Stacktrace Open Modal',
+                  eventKey: 'integrations.stacktrace_start_setup',
+                  eventName: 'Integrations: Stacktrace Start Setup',
                   view: 'stacktrace_issue_details',
                   platform,
                 },

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -161,8 +161,8 @@ class StacktraceLink extends AsyncComponent<Props, State> {
             onClick={() => {
               trackIntegrationEvent(
                 {
-                  eventKey: 'integrations.stacktrace_start_setup',
-                  eventName: 'Integrations: Stacktrace Start Setup',
+                  eventKey: 'integrations.stacktrace_open_modal',
+                  eventName: 'Integrations: Stacktrace Open Modal',
                   view: 'stacktrace_issue_details',
                   platform,
                 },

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -166,7 +166,7 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
                   key={integration.id}
                   type="button"
                   onClick={() => this.onManualSetup(integration.provider.key)}
-                  to={`${baseUrl}/${integration.provider.key}/${integration.id}/?tab=codeMappings`}
+                  to={`${baseUrl}/${integration.provider.key}/${integration.id}/?tab=codeMappings&referrer=stacktrace-issue-details`}
                 >
                   {getIntegrationIcon(integration.provider.key)}
                   <IntegrationName>{integration.name}</IntegrationName>

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -44,13 +44,13 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
   onManualSetup(provider: string) {
     trackIntegrationEvent(
       {
-        eventKey: 'integrations.stacktrace_manual_setup',
-        eventName: 'Integrations: Stacktrace Manual Setup',
+        eventKey: 'integrations.stacktrace_start_setup',
+        eventName: 'Integrations: Stacktrace Start Setup',
         view: 'stacktrace_issue_details',
+        setup_type: 'manual',
         provider,
       },
-      this.props.organization,
-      {startSession: true}
+      this.props.organization
     );
   }
 
@@ -59,12 +59,12 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
     const {organization, filename, project} = this.props;
     trackIntegrationEvent(
       {
-        eventKey: 'integrations.stacktrace_automatic_setup',
-        eventName: 'Integrations: Stacktrace Automatic Setup',
+        eventKey: 'integrations.stacktrace_submit_config',
+        eventName: 'Integrations: Stacktrace Submit Config',
+        setup_type: 'automatic',
         view: 'stacktrace_issue_details',
       },
-      this.props.organization,
-      {startSession: true}
+      this.props.organization
     );
 
     const parsingEndpoint = `/projects/${organization.slug}/${project.slug}/repo-path-parsing/`;
@@ -84,6 +84,16 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
       });
 
       addSuccessMessage(t('Stack trace configuration saved.'));
+      trackIntegrationEvent(
+        {
+          eventKey: 'integrations.stacktrace_complete_setup',
+          eventName: 'Integrations: Stacktrace Complete Setup',
+          setup_type: 'automatic',
+          provider: configData.config?.provider.key,
+          view: 'stacktrace_issue_details',
+        },
+        this.props.organization
+      );
       this.props.closeModal();
       this.props.onSubmit();
     } catch (err) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -59,6 +59,15 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
     const {organization, filename, project} = this.props;
     trackIntegrationEvent(
       {
+        eventKey: 'integrations.stacktrace_start_setup',
+        eventName: 'Integrations: Stacktrace Start Setup',
+        view: 'stacktrace_issue_details',
+        setup_type: 'automatic',
+      },
+      this.props.organization
+    );
+    trackIntegrationEvent(
+      {
         eventKey: 'integrations.stacktrace_submit_config',
         eventName: 'Integrations: Stacktrace Submit Config',
         setup_type: 'automatic',

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -44,8 +44,8 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
   onManualSetup(provider: string) {
     trackIntegrationEvent(
       {
-        eventKey: 'integrations.stacktrace_start_setup',
-        eventName: 'Integrations: Stacktrace Start Setup',
+        eventKey: 'integrations.stacktrace_manual_option_clicked',
+        eventName: 'Integrations: Stacktrace Manual Option Clicked',
         view: 'stacktrace_issue_details',
         setup_type: 'manual',
         provider,
@@ -57,15 +57,6 @@ class StacktraceLinkModal extends AsyncComponent<Props, State> {
   handleSubmit = async () => {
     const {sourceCodeInput} = this.state;
     const {organization, filename, project} = this.props;
-    trackIntegrationEvent(
-      {
-        eventKey: 'integrations.stacktrace_start_setup',
-        eventName: 'Integrations: Stacktrace Start Setup',
-        view: 'stacktrace_issue_details',
-        setup_type: 'automatic',
-      },
-      this.props.organization
-    );
     trackIntegrationEvent(
       {
         eventKey: 'integrations.stacktrace_submit_config',

--- a/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
+++ b/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
@@ -101,8 +101,7 @@ export default class RepositoryProjectPathConfigForm extends React.Component<Pro
         view: 'integration_configuration_detail',
         provider: this.props.integration.provider.key,
       },
-      this.props.organization,
-      {startSession: true}
+      this.props.organization
     );
   }
 

--- a/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
+++ b/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
@@ -9,10 +9,10 @@ import {
   Repository,
   RepositoryProjectPathConfig,
 } from 'app/types';
+import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 import {FieldFromConfig} from 'app/views/settings/components/forms';
 import Form from 'app/views/settings/components/forms/form';
 import {Field} from 'app/views/settings/components/forms/type';
-import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 
 type Props = {
   organization: Organization;

--- a/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
+++ b/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
@@ -12,6 +12,7 @@ import {
 import {FieldFromConfig} from 'app/views/settings/components/forms';
 import Form from 'app/views/settings/components/forms/form';
 import {Field} from 'app/views/settings/components/forms/type';
+import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 
 type Props = {
   organization: Organization;
@@ -91,6 +92,20 @@ export default class RepositoryProjectPathConfigForm extends React.Component<Pro
     ];
   }
 
+  handlePreSubmit() {
+    trackIntegrationEvent(
+      {
+        eventKey: 'integrations.stacktrace_submit_config',
+        eventName: 'Integrations: Stacktrace Submit Config',
+        setup_type: 'manual',
+        view: 'integration_configuration_detail',
+        provider: this.props.integration.provider.key,
+      },
+      this.props.organization,
+      {startSession: true}
+    );
+  }
+
   render() {
     const {
       organization,
@@ -110,6 +125,7 @@ export default class RepositoryProjectPathConfigForm extends React.Component<Pro
     return (
       <Form
         onSubmitSuccess={onSubmitSuccess}
+        onPreSubmit={() => this.handlePreSubmit()}
         initialData={this.initialData}
         apiEndpoint={endpoint}
         apiMethod={apiMethod}

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -64,7 +64,8 @@ export type SingleIntegrationEvent = {
     | 'integrations.resolve_now_clicked'
     | 'integrations.reauth_start'
     | 'integrations.reauth_complete'
-    | 'integrations.request_install';
+    | 'integrations.request_install'
+    | 'integrations.code_mappings_viewed';
   eventName:
     | 'Integrations: Install Modal Opened' //TODO: remove
     | 'Integrations: Installation Start'
@@ -82,7 +83,8 @@ export type SingleIntegrationEvent = {
     | 'Integrations: Resolve Now Clicked'
     | 'Integrations: Reauth Start'
     | 'Integrations: Reauth Complete'
-    | 'Integrations: Request Install';
+    | 'Integrations: Request Install'
+    | 'Integrations: Code Mappings Viewed';
   integration: string; //the slug
   integration_type: IntegrationType;
   already_installed?: boolean;
@@ -118,14 +120,16 @@ type IntegrationStacktraceLinkEvent = {
     | 'integrations.stacktrace_complete_setup'
     | 'integrations.stacktrace_manual_option_clicked'
     | 'integrations.stacktrace_link_clicked'
-    | 'integrations.reconfigure_stacktrace_setup';
+    | 'integrations.reconfigure_stacktrace_setup'
+    | 'integrations.stacktrace_docs_clicked';
   eventName:
     | 'Integrations: Stacktrace Start Setup'
     | 'Integrations: Stacktrace Submit Config'
     | 'Integrations: Stacktrace Complete Setup'
     | 'Integrations: Stacktrace Manual Option Clicked'
     | 'Integrations: Stacktrace Link Clicked'
-    | 'Integrations: Reconfigure Stacktrace Setup';
+    | 'Integrations: Reconfigure Stacktrace Setup'
+    | 'Integrations: Stacktrace Docs Clicked';
   provider?: string;
   setup_type?: 'automatic' | 'manual';
   error_reason?: 'file_not_found' | 'stack_root_mismatch';

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -113,17 +113,17 @@ type IntegrationCategorySelectEvent = {
 
 type IntegrationStacktraceLinkEvent = {
   eventKey:
-    | 'integrations.stacktrace_open_modal'
     | 'integrations.stacktrace_start_setup'
     | 'integrations.stacktrace_submit_config'
     | 'integrations.stacktrace_complete_setup'
+    | 'integrations.stacktrace_manual_option_clicked'
     | 'integrations.stacktrace_link_clicked'
     | 'integrations.reconfigure_stacktrace_setup';
   eventName:
-    | 'Integrations: Stacktrace Open Modal'
     | 'Integrations: Stacktrace Start Setup'
     | 'Integrations: Stacktrace Submit Config'
     | 'Integrations: Stacktrace Complete Setup'
+    | 'Integrations: Stacktrace Manual Option Clicked'
     | 'Integrations: Stacktrace Link Clicked'
     | 'Integrations: Reconfigure Stacktrace Setup';
   provider?: string;

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -113,18 +113,21 @@ type IntegrationCategorySelectEvent = {
 
 type IntegrationStacktraceLinkEvent = {
   eventKey:
+    | 'integrations.stacktrace_open_modal'
     | 'integrations.stacktrace_start_setup'
-    | 'integrations.stacktrace_automatic_setup'
-    | 'integrations.stacktrace_manual_setup'
+    | 'integrations.stacktrace_submit_config'
+    | 'integrations.stacktrace_complete_setup'
     | 'integrations.stacktrace_link_clicked'
     | 'integrations.reconfigure_stacktrace_setup';
   eventName:
+    | 'Integrations: Stacktrace Open Modal'
     | 'Integrations: Stacktrace Start Setup'
-    | 'Integrations: Stacktrace Automatic Setup'
-    | 'Integrations: Stacktrace Manual Setup'
+    | 'Integrations: Stacktrace Submit Config'
+    | 'Integrations: Stacktrace Complete Setup'
     | 'Integrations: Stacktrace Link Clicked'
     | 'Integrations: Reconfigure Stacktrace Setup';
   provider?: string;
+  setup_type?: 'automatic' | 'manual';
   error_reason?: 'file_not_found' | 'stack_root_mismatch';
 };
 
@@ -141,7 +144,8 @@ type IntegrationsEventParams = (
     | 'plugin_details'
     | 'integrations_directory'
     | 'integrations_directory_integration_detail'
-    | 'stacktrace_issue_details';
+    | 'stacktrace_issue_details'
+    | 'integration_configuration_detail';
   project_id?: string;
 } & Parameters<Hooks['analytics:track-event']>[0];
 

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -124,6 +124,16 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
 
   openModal = (pathConfig?: RepositoryProjectPathConfig) => {
     const {organization, integration} = this.props;
+    trackIntegrationEvent(
+      {
+        eventKey: 'integrations.stacktrace_start_setup',
+        eventName: 'Integrations: Stacktrace Start Setup',
+        setup_type: 'manual',
+        view: 'integration_configuration_detail',
+        provider: this.props.integration.provider.key,
+      },
+      this.props.organization
+    );
 
     openModal(({Body, Header, closeModal}) => (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import sortBy from 'lodash/sortBy';
+import * as qs from 'query-string';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {openModal} from 'app/actionCreators/modal';
@@ -83,6 +84,23 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
 
   getMatchingProject(pathConfig: RepositoryProjectPathConfig) {
     return this.projects.find(project => project.id === pathConfig.projectId);
+  }
+
+  componentDidMount() {
+    const {referrer} = qs.parse(window.location.search) || {};
+    // We don't start new session if the user was coming from choosing
+    // the manual setup option flow from the issue details page
+    const startSession = referrer == 'stacktrace-issue-details' ? false : true;
+    trackIntegrationEvent(
+      {
+        eventKey: 'integrations.code_mappings_viewed',
+        eventName: 'Integrations: Code Mappings Viewed',
+        integration: this.props.integration.provider.key,
+        integration_type: 'first_party',
+      },
+      this.props.organization,
+      {startSession}
+    );
   }
 
   handleDelete = async (pathConfig: RepositoryProjectPathConfig) => {
@@ -193,6 +211,17 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
                   <Button
                     href={`https://docs.sentry.io/product/integrations/${integration.provider.key}/#stack-trace-linking`}
                     size="small"
+                    onClick={() => {
+                      trackIntegrationEvent(
+                        {
+                          eventKey: 'integrations.stacktrace_docs_clicked',
+                          eventName: 'Integrations: Stacktrace Docs Clicked',
+                          view: 'integration_configuration_detail',
+                          provider: this.props.integration.provider.key,
+                        },
+                        this.props.organization
+                      );
+                    }}
                   >
                     View Documentation
                   </Button>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -90,7 +90,7 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
     const {referrer} = qs.parse(window.location.search) || {};
     // We don't start new session if the user was coming from choosing
     // the manual setup option flow from the issue details page
-    const startSession = referrer == 'stacktrace-issue-details' ? false : true;
+    const startSession = referrer === 'stacktrace-issue-details' ? false : true;
     trackIntegrationEvent(
       {
         eventKey: 'integrations.code_mappings_viewed',

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -24,7 +24,7 @@ import {
   Repository,
   RepositoryProjectPathConfig,
 } from 'app/types';
-import {getIntegrationIcon} from 'app/utils/integrationUtil';
+import {getIntegrationIcon, trackIntegrationEvent} from 'app/utils/integrationUtil';
 import withOrganization from 'app/utils/withOrganization';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
@@ -104,6 +104,16 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
   };
 
   handleSubmitSuccess = (pathConfig: RepositoryProjectPathConfig) => {
+    trackIntegrationEvent(
+      {
+        eventKey: 'integrations.stacktrace_complete_setup',
+        eventName: 'Integrations: Stacktrace Complete Setup',
+        setup_type: 'manual',
+        view: 'integration_configuration_detail',
+        provider: this.props.integration.provider.key,
+      },
+      this.props.organization
+    );
     let {pathConfigs} = this.state;
     pathConfigs = pathConfigs.filter(config => config.id !== pathConfig.id);
     // our getter handles the order of the configs


### PR DESCRIPTION
**Context:**
Some amplitude analytics were added in https://github.com/getsentry/sentry/pull/22471, but they weren't super complete and after playing around with the data we realized it was a bit hard to answer the questions we wanted with the current implementation. This PR structures the events a little differently so that we can do better funnel analysis, and I've also added events to be tracked in BigQuery. 

**Amplitude**: We want to do funnel analysis on users being able to successfully set up a configuration. Success is going to be determined by an actual `ProjectRepositoryConfigPath` being created in the database. The basic funnel events will be 

```python
'integrations.stacktrace_start_setup'
'integrations.stacktrace_submit_config'
'integrations.stacktrace_complete_setup'
```

*Automatic flow:*

`start_setup` -> `submit_config` -> `complete_setup` , all with `view` property of `stacktrace_issue_details` 

*Manual Flow (starting from integration configure settings):*

`start_setup` -> `submit_config` -> `complete_setup`, all with `view` property of `integration_configuration_details`

*Manual Flow (starting from issue details):*

`start_setup (stacktrace_issue_details)` -> `manual_option_clicked` -> Manual Flow (from above) 


**BigQuery**: While the above events capture how successful someone is at setting up a configuration, it doesn't tell us whether that configuration is working correctly or not. That's where the other analytics come in. These are meant to tell us for the configurations we _do_ have, are those successful in finding the source code links. 

The `IntegrationStacktraceLinkEvent` will be triggered every time we hit the `project_stacktrace_link.py` endpoint. This is when someone views an issue details page for a project that has a code mapping configuration set up for that project and when any additional frame in the stacktrace is clicked. I expect this to not be problematic because this feature is limited by EA organizations that have GH or GitLab installed AND have stack trace linking set up for that project. But am curious if we'd have to reconsider this for GA cc @getsentry/data 
