### PR TITLE
fix(vitals): Remove pagination from vitals query

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalsCardsDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalsCardsDiscoverQuery.tsx
@@ -52,6 +52,7 @@ function VitalsCardDiscoverQuery(props: Props) {
     <GenericDiscoverQuery<TableData, {}>
       getRequestPayload={getRequestPayload}
       route="eventsv2"
+      noPagination
       {...props}
     />
   );


### PR DESCRIPTION
### Summary

This is avoiding issues with large headers by removing pagination from vitals query.