### PR TITLE
ref(integration-platform): Use Zepel icon

### DIFF
--- a/src/sentry/static/sentry/app/components/sentryAppIcon.tsx
+++ b/src/sentry/static/sentry/app/components/sentryAppIcon.tsx
@@ -7,6 +7,7 @@ import {
   IconLinear,
   IconRookout,
   IconTeamwork,
+  IconZepel,
 } from 'app/icons';
 import {SentryAppComponent} from 'app/types';
 
@@ -26,6 +27,8 @@ const SentryAppIcon = ({slug}: Props) => {
       return <IconTeamwork size="md" />;
     case 'linear':
       return <IconLinear size="md" />;
+    case 'zepel':
+      return <IconZepel size="md" />;
     default:
       return <IconGeneric size="md" />;
   }

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1591,7 +1591,7 @@ export type SentryAppComponent = {
   schema: SentryAppSchemaStacktraceLink;
   sentryApp: {
     uuid: string;
-    slug: 'clickup' | 'clubhouse' | 'rookout' | 'teamwork' | 'linear';
+    slug: 'clickup' | 'clubhouse' | 'rookout' | 'teamwork' | 'linear' | 'zepel';
     name: string;
   };
 };


### PR DESCRIPTION
The Zepel icon was added in https://github.com/getsentry/sentry/pull/22613 but we never updated the code to use it. 