### PR TITLE
feat(ui): Fix chart title + legend dark mode colors

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.tsx
@@ -423,7 +423,7 @@ class BaseChart extends React.Component<Props> {
                     ...tooltip,
                   })
                 : undefined,
-            legend: legend ? Legend({...legend}) : undefined,
+            legend: legend ? Legend({theme, ...legend}) : undefined,
             yAxis: yAxisOrCustom,
             xAxis: xAxisOrCustom,
             series: this.getSeries(),

--- a/src/sentry/static/sentry/app/components/charts/components/legend.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/legend.tsx
@@ -4,13 +4,16 @@ import 'echarts/lib/component/legendScroll';
 import {EChartOption} from 'echarts';
 
 import BaseChart from 'app/components/charts/baseChart';
+import {Theme} from 'app/utils/theme';
 
 import {truncationFormatter} from '../utils';
 
 type ChartProps = React.ComponentProps<typeof BaseChart>;
 
-export default function Legend(props: ChartProps['legend'] = {}): EChartOption.Legend {
-  const {truncate, ...rest} = props ?? {};
+export default function Legend(
+  props: ChartProps['legend'] & {theme?: Theme} = {}
+): EChartOption.Legend {
+  const {truncate, theme, ...rest} = props ?? {};
   const formatter = (value: string) => truncationFormatter(value, truncate ?? 0);
 
   return {
@@ -18,6 +21,9 @@ export default function Legend(props: ChartProps['legend'] = {}): EChartOption.L
     type: 'scroll',
     padding: 0,
     formatter,
+    textStyle: {
+      color: theme?.subText,
+    },
     ...rest,
   };
 }

--- a/src/sentry/static/sentry/app/components/charts/components/legend.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/legend.tsx
@@ -22,7 +22,7 @@ export default function Legend(
     padding: 0,
     formatter,
     textStyle: {
-      color: theme?.subText,
+      color: theme?.textColor,
     },
     ...rest,
   };

--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -181,7 +181,7 @@ class Chart extends React.Component<ChartProps, State> {
       itemGap: 12,
       align: 'left',
       textStyle: {
-        color: theme.subText,
+        color: theme.textColor,
         verticalAlign: 'top',
         fontSize: 11,
         fontFamily: 'Rubik',

--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -181,6 +181,7 @@ class Chart extends React.Component<ChartProps, State> {
       itemGap: 12,
       align: 'left',
       textStyle: {
+        color: theme.subText,
         verticalAlign: 'top',
         fontSize: 11,
         fontFamily: 'Rubik',

--- a/src/sentry/static/sentry/app/views/performance/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/styles.tsx
@@ -27,7 +27,7 @@ export const HeaderTitle = styled('div')`
 `;
 
 export const HeaderTitleLegend = styled(HeaderTitle)`
-  background-color: ${p => p.theme.white};
+  background-color: ${p => p.theme.background};
   border-radius: ${p => p.theme.borderRadius};
   position: absolute;
   z-index: 1;


### PR DESCRIPTION
This fixes the chart title and legend for dark mode.

![image](https://user-images.githubusercontent.com/79684/102550021-f91f6b00-4071-11eb-9829-be65315a04b2.png)
![image](https://user-images.githubusercontent.com/79684/102550046-02a8d300-4072-11eb-9b27-8da4e3012dec.png)
