### PR TITLE
feat(images-loaded): Add images loaded row details dialog - Part 1

### DIFF
--- a/docs-ui/components/issueDebugMeta.stories.js
+++ b/docs-ui/components/issueDebugMeta.stories.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import {withInfo} from '@storybook/addon-info';
 
-import SentryTypes from 'app/sentryTypes';
 import DebugMeta from 'app/components/events/interfaces/debugMeta';
+import SentryTypes from 'app/sentryTypes';
 
 const event = {
   id: 'deadbeef',
@@ -114,7 +114,7 @@ export const Default = withInfo('Various debug image metadata states')(() => (
       <DebugMeta
         event={event}
         data={event.entries[0].data}
-        orgId={organization.id}
+        organization={organization}
         projectId="1"
       />
     </OrganizationContext>

--- a/src/sentry/static/sentry/app/components/events/eventEntries.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.tsx
@@ -164,8 +164,8 @@ class EventEntries extends React.Component<Props> {
         return (
           <Component
             key={'entry-' + entryIdx}
-            projectId={project ? project.slug : null}
-            orgId={organization ? organization.slug : null}
+            projectId={project?.slug ?? null}
+            organization={organization}
             event={event}
             type={entry.type}
             data={entry.data}

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -11,7 +11,7 @@ import SearchBar from 'app/components/searchBar';
 import {IconWarning} from 'app/icons/iconWarning';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {Event} from 'app/types';
+import {Event, Organization} from 'app/types';
 import {defined} from 'app/utils';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
@@ -33,7 +33,7 @@ type FilterOptions = FilterProps['options'];
 
 type Props = {
   event: Event;
-  orgId: string | null;
+  organization: Organization;
   type: string;
   data: {
     values: Array<Breadcrumb>;
@@ -335,7 +335,7 @@ class Breadcrumbs extends React.Component<Props, State> {
   };
 
   render() {
-    const {type, event, orgId} = this.props;
+    const {type, event, organization} = this.props;
     const {
       filterOptions,
       searchTerm,
@@ -369,7 +369,7 @@ class Breadcrumbs extends React.Component<Props, State> {
             <List
               breadcrumbs={filteredBySearch}
               event={event}
-              orgId={orgId}
+              orgId={organization.slug}
               onSwitchTimeFormat={this.handleSwitchTimeFormat}
               displayRelativeTime={displayRelativeTime}
               searchTerm={searchTerm}

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/candidate/featureStatusIcon.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/candidate/featureStatusIcon.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import {IconCheckmark, IconClose} from 'app/icons';
+
+type Props = {
+  status: boolean;
+};
+
+function FeatureStatusIcon({status}: Props) {
+  if (status) {
+    <IconCheckmark color="green300" size="xs" />;
+  }
+
+  return <IconClose color="red300" size="xs" />;
+}
+
+export default FeatureStatusIcon;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/candidate/stacktraceStatusIcon.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/candidate/stacktraceStatusIcon.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import Tooltip from 'app/components/tooltip';
+import {IconCheckmark, IconClose, IconWarning} from 'app/icons';
+import {CandidateStacktraceInfo, CandidateStacktraceStatus} from 'app/types/debugImage';
+
+type Props = {
+  stacktraceInfo: CandidateStacktraceInfo;
+};
+
+function StacktraceStatusIcon({stacktraceInfo}: Props) {
+  switch (stacktraceInfo.status) {
+    case CandidateStacktraceStatus.OK:
+      return <IconCheckmark color="green300" size="xs" />;
+    case CandidateStacktraceStatus.ERROR: {
+      const {details} = stacktraceInfo;
+      const icon = <IconClose color="red300" size="xs" />;
+
+      if (!details) {
+        return icon;
+      }
+
+      return <Tooltip title={details}>{icon}</Tooltip>;
+    }
+    case CandidateStacktraceStatus.MALFORMED: {
+      const {details} = stacktraceInfo;
+      const icon = <IconWarning color="yellow300" size="xs" />;
+
+      if (!details) {
+        return icon;
+      }
+
+      return <Tooltip title={details}>{icon}</Tooltip>;
+    }
+    default:
+      return null; //this should never happen
+  }
+}
+
+export default StacktraceStatusIcon;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/candidate/statusTag.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/candidate/statusTag.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import Tag from 'app/components/tag';
+import {t} from 'app/locale';
+import {CandiateDownloadStatus} from 'app/types/debugImage';
+
+type Props = {
+  status: CandiateDownloadStatus;
+};
+
+function StatusTag({status}: Props) {
+  switch (status) {
+    case CandiateDownloadStatus.OK: {
+      return <Tag type="success">{t('Successful')}</Tag>;
+    }
+    case CandiateDownloadStatus.MALFORMED: {
+      return <Tag type="error">{t('Failed')}</Tag>;
+    }
+    case CandiateDownloadStatus.NOT_FOUND: {
+      return <Tag>{t('Not Found')}</Tag>;
+    }
+    case CandiateDownloadStatus.NO_PERMISSION: {
+      return <Tag type="warning">{t('Permission')}</Tag>;
+    }
+    default:
+      return <Tag type="highlight">{t('Not applied')}</Tag>;
+  }
+}
+
+export default StatusTag;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/index.tsx
@@ -68,7 +68,7 @@ function DebugFileDetails({
         <Content>
           <GeneralInfo>
             <Label>{t('Address Range')}</Label>
-            <Value>{image_addr}</Value>
+            <Value>{image_addr ?? <NotAvailable />}</Value>
 
             <Label coloredBg>{t('Architecture')}</Label>
             <Value coloredBg>{architecture ?? <NotAvailable />}</Value>

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/index.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import {css} from '@emotion/core';
+import styled from '@emotion/styled';
+
+import {ModalRenderProps} from 'app/actionCreators/modal';
+import {Client} from 'app/api';
+import Button from 'app/components/button';
+import TextOverflow from 'app/components/textOverflow';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {Organization, Project} from 'app/types';
+import {Image} from 'app/types/debugImage';
+import theme from 'app/utils/theme';
+import withApi from 'app/utils/withApi';
+
+import NotAvailable from './notAvailable';
+import Panel from './panel';
+
+const UPLOADED_TO_SENTRY = 'sentry:project';
+
+type Props = ModalRenderProps & {
+  api: Client;
+  projectId: Project['id'];
+  organization: Organization;
+  image: Image;
+  title?: string;
+};
+
+function DebugFileDetails({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  title,
+  image,
+  organization,
+  api,
+  projectId,
+}: Props) {
+  const {debug_id, image_addr, arch: architecture, code_file, candidates = []} = image;
+
+  const uploadedCandidates = candidates.filter(
+    candidate => candidate.source === UPLOADED_TO_SENTRY
+  );
+
+  const externalCandidates = candidates.filter(
+    candidate => candidate.source !== UPLOADED_TO_SENTRY
+  );
+
+  // TODO(PRISCILA): Should we perform a new request to fetch the debug files?
+  // because at the moment the payload of the event is not being updated
+  // async function handleDelete(debugId: string) {
+  //   api.request(
+  //     `/projects/${organization.slug}/${projectId}/files/dsyms/?id=${debugId}`,
+  //     {
+  //       method: 'DELETE',
+  //       complete: () => {
+  //
+  //       },
+  //     }
+  //   );
+  // }
+
+  return (
+    <React.Fragment>
+      <Header closeButton>{title ?? t('Unknown name')}</Header>
+      <Body>
+        <Content>
+          <GeneralInfo>
+            <Label>{t('Address Range')}</Label>
+            <Value>{image_addr}</Value>
+
+            <Label coloredBg>{t('Architecture')}</Label>
+            <Value coloredBg>{architecture ?? <NotAvailable />}</Value>
+
+            <Label>{t('Debug ID')}</Label>
+            <Value>{debug_id}</Value>
+
+            <Label coloredBg>{t('Code File')}</Label>
+            <Value coloredBg>{code_file}</Value>
+          </GeneralInfo>
+          <Panel
+            title={t('Uploaded Debug Files')}
+            description="this is a description"
+            candidates={uploadedCandidates}
+            organization={organization}
+            projectId={projectId}
+            api={api}
+            emptyMessage={t("You haven't uploaded any debug file")}
+            onDelete={() => {}} // TODO(PRISCILA): finalize the delete button
+          />
+          <Panel
+            title={t('External Debug Files')}
+            description="this is a description"
+            candidates={externalCandidates}
+            organization={organization}
+            projectId={projectId}
+            api={api}
+            emptyMessage={t('No external debug files were found')}
+          />
+        </Content>
+      </Body>
+      <Footer>
+        <Button onClick={closeModal}>{t('Close')}</Button>
+      </Footer>
+    </React.Fragment>
+  );
+}
+
+export default withApi(DebugFileDetails);
+
+const Content = styled('div')`
+  display: grid;
+  grid-gap: ${space(4)};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const GeneralInfo = styled('div')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+`;
+
+const Label = styled('div')<{coloredBg?: boolean}>`
+  color: ${p => p.theme.gray500};
+  ${p => p.coloredBg && `background-color: ${p.theme.backgroundSecondary};`}
+  padding: ${space(1)};
+`;
+
+const Value = styled(TextOverflow)<{coloredBg?: boolean}>`
+  color: ${p => p.theme.gray400};
+  ${p => p.coloredBg && `background-color: ${p.theme.backgroundSecondary};`}
+  padding: ${space(1)};
+  font-family: ${p => p.theme.text.familyMono};
+`;
+
+export const modalCss = css`
+  .modal-content {
+    overflow: initial;
+  }
+
+  @media (min-width: ${theme.breakpoints[0]}) {
+    .modal-dialog {
+      width: 60%;
+      margin-left: -30%;
+    }
+  }
+`;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/notAvailable.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/notAvailable.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+function NotAvailable() {
+  return <Wrapper>{'\u2014'}</Wrapper>;
+}
+
+// TODO(PRISCILA): make this a common component
+const Wrapper = styled('div')`
+  color: ${p => p.theme.gray200};
+`;
+
+export default NotAvailable;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/panel.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugFileDetails/panel.tsx
@@ -1,0 +1,257 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {Client} from 'app/api';
+import Access from 'app/components/acl/access';
+import Role from 'app/components/acl/role';
+import Button from 'app/components/button';
+import ButtonBar from 'app/components/buttonBar';
+import Confirm from 'app/components/confirm';
+import PanelTable from 'app/components/panels/panelTable';
+import QuestionTooltip from 'app/components/questionTooltip';
+import TextOverflow from 'app/components/textOverflow';
+import Tooltip from 'app/components/tooltip';
+import {IconDelete, IconDownload} from 'app/icons';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {Organization, Project} from 'app/types';
+import {CandiateDownloadStatus, Image} from 'app/types/debugImage';
+
+import StacktraceStatusIcon from './candidate/stacktraceStatusIcon';
+import StatusTag from './candidate/statusTag';
+import NotAvailable from './notAvailable';
+
+type Props = {
+  title: string;
+  description: string;
+  api: Client;
+  candidates: Image['candidates'];
+  projectId: Project['id'];
+  organization: Organization;
+  emptyMessage: string;
+  onDelete?: (debugId: string) => void;
+};
+
+function Panel({
+  title,
+  description,
+  candidates,
+  projectId,
+  emptyMessage,
+  organization,
+  onDelete,
+  api,
+}: Props) {
+  function renderStacktraces(download: Image['candidates'][0]['download']) {
+    if (
+      download.status === CandiateDownloadStatus.OK &&
+      (download.unwind || download.debug)
+    ) {
+      const stacktraces: Array<React.ReactElement> = [];
+
+      if (download.unwind) {
+        stacktraces.push(
+          <Stacktrace>
+            <StacktraceStatusIcon stacktraceInfo={download.unwind} />
+            {t('Stack unwinding')}
+          </Stacktrace>
+        );
+      }
+
+      if (download.debug) {
+        stacktraces.push(
+          <Stacktrace>
+            <StacktraceStatusIcon stacktraceInfo={download.debug} />
+            {t('Symbolication')}
+          </Stacktrace>
+        );
+      }
+
+      return <Stacktraces>{stacktraces}</Stacktraces>;
+    }
+
+    return <NotAvailable />;
+  }
+
+  function renderFeatures(download: Image['candidates'][0]['download']) {
+    if (download.status === CandiateDownloadStatus.OK) {
+      const features = Object.entries(download.features).filter(([_key, value]) => value);
+
+      if (!!features.length) {
+        return (
+          <Features>
+            {Object.entries(download.features)
+              .filter(([_key, value]) => value)
+              .map(([key]) => (
+                <Feature key={key}>{key.split('_')[1]}</Feature>
+              ))}
+          </Features>
+        );
+      }
+
+      return <NotAvailable />;
+    }
+
+    return <NotAvailable />;
+  }
+
+  return (
+    <Wrapper>
+      <Title>
+        {title}
+        <QuestionTooltip title={description} size="xs" position="top" />
+      </Title>
+      <StyledPanelTable
+        headers={[t('Status'), t('Debug File'), t('Stacktrace'), t('Features'), ' ']}
+        isEmpty={!candidates.length}
+        emptyMessage={emptyMessage}
+      >
+        {candidates.map(({location, download, source}) => {
+          const {status} = download;
+          return (
+            <React.Fragment key={location}>
+              <StatusColumn>
+                <StatusTag status={status} />
+              </StatusColumn>
+
+              <DebugFileColumn>
+                <SourceName>{source}</SourceName>
+                <Tooltip title={location} disabled={!location} isHoverable>
+                  <Location>{location}</Location>
+                </Tooltip>
+              </DebugFileColumn>
+
+              <StacktraceColumn>{renderStacktraces(download)}</StacktraceColumn>
+
+              <FeaturesColumn>{renderFeatures(download)}</FeaturesColumn>
+
+              <ActionsColumn>
+                {onDelete && (
+                  <ButtonBar gap={0.5}>
+                    <Role role={organization.debugFilesRole} organization={organization}>
+                      {({hasRole}) => (
+                        <Tooltip
+                          disabled={hasRole}
+                          title={t('You do not have permission to download debug files.')}
+                        >
+                          <Button
+                            size="xsmall"
+                            icon={<IconDownload size="xs" />}
+                            href={`${api.baseUrl}/projects/${organization.slug}/${projectId}/files/dsyms/?id=${location}`}
+                            disabled={!hasRole}
+                          >
+                            {t('Download')}
+                          </Button>
+                        </Tooltip>
+                      )}
+                    </Role>
+                    <Access access={['project:write']} organization={organization}>
+                      {() => (
+                        <Tooltip
+                          // disabled={hasAccess}
+                          // title={t('You do not have permission to delete debug files.')}
+                          title={t('Deletion is not yet available')}
+                        >
+                          <Confirm
+                            confirmText={t('Delete')}
+                            message={t('Are you sure you wish to delete this file?')}
+                            onConfirm={() => onDelete(location)}
+                            // disabled={!hasAccess}
+                            disabled
+                          >
+                            <Button
+                              priority="danger"
+                              icon={<IconDelete size="xs" />}
+                              size="xsmall"
+                              // disabled={!hasAccess}
+                              disabled
+                            />
+                          </Confirm>
+                        </Tooltip>
+                      )}
+                    </Access>
+                  </ButtonBar>
+                )}
+              </ActionsColumn>
+            </React.Fragment>
+          );
+        })}
+      </StyledPanelTable>
+    </Wrapper>
+  );
+}
+
+export default Panel;
+
+const Wrapper = styled('div')`
+  display: grid;
+  grid-gap: ${space(2)};
+`;
+
+// TODO(PRISCILA): Make it looks better on smaller devices (still to be decided by Robin)
+const StyledPanelTable = styled(PanelTable)`
+  grid-template-columns: 112px minmax(185px, 1fr) 257px 245px 68px;
+`;
+
+// Table Title
+const Title = styled('div')`
+  display: grid;
+  grid-gap: ${space(0.5)};
+  grid-template-columns: repeat(2, max-content);
+  align-items: center;
+  font-weight: 600;
+  color: ${p => p.theme.gray400};
+`;
+
+// Status Column
+const StatusColumn = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+// Debug File Info Column
+const DebugFileColumn = styled(StatusColumn)`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
+
+const SourceName = styled(TextOverflow)`
+  color: ${p => p.theme.gray500};
+`;
+
+const Location = styled(TextOverflow)`
+  color: ${p => p.theme.gray300};
+`;
+
+// Actions Column
+const ActionsColumn = styled(StatusColumn)`
+  justify-content: flex-end;
+`;
+
+// Stacktrace Column
+const StacktraceColumn = styled(StatusColumn)``;
+
+const Stacktraces = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
+  grid-column-gap: ${space(2)};
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const Stacktrace = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  grid-gap: ${space(0.75)};
+  align-items: center;
+`;
+
+// Features Column
+const FeaturesColumn = styled(StatusColumn)``;
+
+const Features = styled(Stacktraces)`
+  color: ${p => p.theme.gray300};
+  grid-column-gap: ${space(1)};
+`;
+
+const Feature = styled(Stacktrace)``;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugImage.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/debugImage.tsx
@@ -2,17 +2,20 @@ import React from 'react';
 import styled from '@emotion/styled';
 import isNil from 'lodash/isNil';
 
+import {openModal} from 'app/actionCreators/modal';
 import Access from 'app/components/acl/access';
 import Button from 'app/components/button';
 import DebugFileFeature from 'app/components/debugFileFeature';
 import {formatAddress, getImageRange} from 'app/components/events/interfaces/utils';
 import {PanelItem} from 'app/components/panels';
 import Tooltip from 'app/components/tooltip';
-import {IconCheckmark, IconCircle, IconFlag, IconSearch} from 'app/icons';
+import {IconCheckmark, IconCircle, IconFlag, IconSearch, IconStack} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
+import {Image} from 'app/types/debugImage';
 
+import DebugFileDetails, {modalCss} from './debugFileDetails';
 import {DebugImage as DebugImageType, DebugStatus} from './types';
 import {combineStatus, getFileName} from './utils';
 
@@ -61,189 +64,227 @@ function getImageStatusDetails(status: Status) {
 type Props = {
   image: DebugImageType;
   showDetails: boolean;
+  organization: Organization;
+  projectId: Project['id'];
   style?: React.CSSProperties;
-  orgId?: Organization['id'];
-  projectId?: Project['id'];
 };
 
-const DebugImage = React.memo(({image, orgId, projectId, showDetails, style}: Props) => {
-  const getSettingsLink = () => {
-    if (!orgId || !projectId || !image.debug_id) {
-      return null;
-    }
-    return `/settings/${orgId}/projects/${projectId}/debug-symbols/?query=${image.debug_id}`;
-  };
+const DebugImage = React.memo(
+  ({image, organization, projectId, showDetails, style}: Props) => {
+    const orgSlug = organization.slug;
 
-  const renderStatus = (title: string, status: DebugStatus) => {
-    if (isNil(status)) {
-      return null;
-    }
+    const getSettingsLink = () => {
+      if (!orgSlug || !projectId || !image.debug_id) {
+        return null;
+      }
+      return `/settings/${orgSlug}/projects/${projectId}/debug-symbols/?query=${image.debug_id}`;
+    };
 
-    const text = getImageStatusText(status);
-    if (!text) {
-      return null;
-    }
+    const renderStatus = (title: string, status: DebugStatus) => {
+      if (isNil(status)) {
+        return null;
+      }
+
+      const text = getImageStatusText(status);
+      if (!text) {
+        return null;
+      }
+
+      return (
+        <SymbolicationStatus>
+          <Tooltip title={getImageStatusDetails(status)}>
+            <span>
+              <ImageProp>{title}</ImageProp>: {text}
+            </span>
+          </Tooltip>
+        </SymbolicationStatus>
+      );
+    };
+
+    const combinedStatus = combineStatus(image.debug_status, image.unwind_status);
+    const [startAddress, endAddress] = getImageRange(image);
+
+    const renderIconElement = () => {
+      switch (combinedStatus) {
+        case 'unused':
+          return (
+            <IconWrapper>
+              <IconCircle />
+            </IconWrapper>
+          );
+        case 'found':
+          return (
+            <IconWrapper>
+              <IconCheckmark isCircled color="green300" />
+            </IconWrapper>
+          );
+        default:
+          return (
+            <IconWrapper>
+              <IconFlag color="red300" />
+            </IconWrapper>
+          );
+      }
+    };
+
+    const codeFile = getFileName(image.code_file);
+    const debugFile = image.debug_file && getFileName(image.debug_file);
+
+    // The debug file is only realistically set on Windows. All other platforms
+    // either leave it empty or set it to a filename thats equal to the code
+    // file name. In this case, do not show it.
+    const showDebugFile = debugFile && codeFile !== debugFile;
+
+    // Availability only makes sense if the image is actually referenced.
+    // Otherwise, the processing pipeline does not resolve this kind of
+    // information and it will always be false.
+    const showAvailability = !isNil(image.features) && combinedStatus !== 'unused';
+
+    // The code id is sometimes missing, and sometimes set to the equivalent of
+    // the debug id (e.g. for Mach symbols). In this case, it is redundant
+    // information and we do not want to show it.
+    const showCodeId = !!image.code_id && image.code_id !== image.debug_id;
+
+    // Old versions of the event pipeline did not store the symbolication
+    // status. In this case, default to display the debug_id instead of stack
+    // unwind information.
+    const legacyRender = isNil(image.debug_status);
+
+    const debugIdElement = (
+      <ImageSubtext>
+        <ImageProp>{t('Debug ID')}</ImageProp>: <Formatted>{image.debug_id}</Formatted>
+      </ImageSubtext>
+    );
+
+    const handleOpenDebugFileDetails = () => {
+      openModal(
+        modalProps => (
+          <DebugFileDetails
+            {...modalProps}
+            image={image as Image}
+            title={codeFile}
+            organization={organization}
+            projectId={projectId}
+          />
+        ),
+        {
+          modalCss,
+        }
+      );
+    };
+
+    const hasImagesLoadedV2Feature = organization.features.includes('images-loaded-v2');
 
     return (
-      <SymbolicationStatus>
-        <Tooltip title={getImageStatusDetails(status)}>
-          <span>
-            <ImageProp>{title}</ImageProp>: {text}
-          </span>
-        </Tooltip>
-      </SymbolicationStatus>
+      <DebugImageItem style={style}>
+        <ImageInfoGroup>{renderIconElement()}</ImageInfoGroup>
+
+        <ImageInfoGroup>
+          {startAddress && endAddress ? (
+            <React.Fragment>
+              <Formatted>{formatAddress(startAddress, IMAGE_ADDR_LEN)}</Formatted> &ndash;{' '}
+              <AddressDivider />
+              <Formatted>{formatAddress(endAddress, IMAGE_ADDR_LEN)}</Formatted>
+            </React.Fragment>
+          ) : null}
+        </ImageInfoGroup>
+
+        <ImageInfoGroup fullWidth>
+          <ImageTitle>
+            <Tooltip title={image.code_file}>
+              <CodeFile>{codeFile}</CodeFile>
+            </Tooltip>
+            {showDebugFile && <DebugFile> ({debugFile})</DebugFile>}
+          </ImageTitle>
+
+          {legacyRender ? (
+            debugIdElement
+          ) : (
+            <StatusLine>
+              {renderStatus(t('Stack Unwinding'), image.unwind_status)}
+              {renderStatus(t('Symbolication'), image.debug_status)}
+            </StatusLine>
+          )}
+
+          {showDetails && (
+            <React.Fragment>
+              {showAvailability && (
+                <ImageSubtext>
+                  <ImageProp>{t('Availability')}</ImageProp>:
+                  <DebugFileFeature
+                    feature="symtab"
+                    available={image.features.has_symbols}
+                  />
+                  <DebugFileFeature
+                    feature="debug"
+                    available={image.features.has_debug_info}
+                  />
+                  <DebugFileFeature
+                    feature="unwind"
+                    available={image.features.has_unwind_info}
+                  />
+                  <DebugFileFeature
+                    feature="sources"
+                    available={image.features.has_sources}
+                  />
+                </ImageSubtext>
+              )}
+
+              {!legacyRender && debugIdElement}
+
+              {showCodeId && (
+                <ImageSubtext>
+                  <ImageProp>{t('Code ID')}</ImageProp>:{' '}
+                  <Formatted>{image.code_id}</Formatted>
+                </ImageSubtext>
+              )}
+
+              {!!image.arch && (
+                <ImageSubtext>
+                  <ImageProp>{t('Architecture')}</ImageProp>: {image.arch}
+                </ImageSubtext>
+              )}
+            </React.Fragment>
+          )}
+        </ImageInfoGroup>
+
+        <Access access={['project:releases']}>
+          {({hasAccess}) => {
+            if (!hasAccess) {
+              return null;
+            }
+            const settingsUrl = getSettingsLink();
+            if (!settingsUrl) {
+              return null;
+            }
+
+            return (
+              <ImageActions>
+                {hasImagesLoadedV2Feature ? (
+                  <Button
+                    size="xsmall"
+                    icon={<IconStack size="xs" />}
+                    onClick={handleOpenDebugFileDetails}
+                  >
+                    {t('View')}
+                  </Button>
+                ) : (
+                  <Tooltip title={t('Search for debug files in settings')}>
+                    <Button
+                      size="xsmall"
+                      icon={<IconSearch size="xs" />}
+                      to={settingsUrl}
+                    />
+                  </Tooltip>
+                )}
+              </ImageActions>
+            );
+          }}
+        </Access>
+      </DebugImageItem>
     );
-  };
-
-  const combinedStatus = combineStatus(image?.debug_status, image.unwind_status);
-  const [startAddress, endAddress] = getImageRange(image);
-
-  const renderIconElement = () => {
-    switch (combinedStatus) {
-      case 'unused':
-        return (
-          <IconWrapper>
-            <IconCircle />
-          </IconWrapper>
-        );
-      case 'found':
-        return (
-          <IconWrapper>
-            <IconCheckmark isCircled color="green300" />
-          </IconWrapper>
-        );
-      default:
-        return (
-          <IconWrapper>
-            <IconFlag color="red300" />
-          </IconWrapper>
-        );
-    }
-  };
-
-  const codeFile = getFileName(image.code_file);
-  const debugFile = image.debug_file && getFileName(image.debug_file);
-
-  // The debug file is only realistically set on Windows. All other platforms
-  // either leave it empty or set it to a filename thats equal to the code
-  // file name. In this case, do not show it.
-  const showDebugFile = debugFile && codeFile !== debugFile;
-
-  // Availability only makes sense if the image is actually referenced.
-  // Otherwise, the processing pipeline does not resolve this kind of
-  // information and it will always be false.
-  const showAvailability = !isNil(image.features) && combinedStatus !== 'unused';
-
-  // The code id is sometimes missing, and sometimes set to the equivalent of
-  // the debug id (e.g. for Mach symbols). In this case, it is redundant
-  // information and we do not want to show it.
-  const showCodeId = !!image.code_id && image.code_id !== image.debug_id;
-
-  // Old versions of the event pipeline did not store the symbolication
-  // status. In this case, default to display the debug_id instead of stack
-  // unwind information.
-  const legacyRender = isNil(image.debug_status);
-
-  const debugIdElement = (
-    <ImageSubtext>
-      <ImageProp>{t('Debug ID')}</ImageProp>: <Formatted>{image.debug_id}</Formatted>
-    </ImageSubtext>
-  );
-
-  return (
-    <DebugImageItem style={style}>
-      <ImageInfoGroup>{renderIconElement()}</ImageInfoGroup>
-
-      <ImageInfoGroup>
-        {startAddress && endAddress ? (
-          <React.Fragment>
-            <Formatted>{formatAddress(startAddress, IMAGE_ADDR_LEN)}</Formatted> &ndash;{' '}
-            <AddressDivider />
-            <Formatted>{formatAddress(endAddress, IMAGE_ADDR_LEN)}</Formatted>
-          </React.Fragment>
-        ) : null}
-      </ImageInfoGroup>
-
-      <ImageInfoGroup fullWidth>
-        <ImageTitle>
-          <Tooltip title={image.code_file}>
-            <CodeFile>{codeFile}</CodeFile>
-          </Tooltip>
-          {showDebugFile && <DebugFile> ({debugFile})</DebugFile>}
-        </ImageTitle>
-
-        {legacyRender ? (
-          debugIdElement
-        ) : (
-          <StatusLine>
-            {renderStatus(t('Stack Unwinding'), image.unwind_status)}
-            {renderStatus(t('Symbolication'), image.debug_status)}
-          </StatusLine>
-        )}
-
-        {showDetails && (
-          <React.Fragment>
-            {showAvailability && (
-              <ImageSubtext>
-                <ImageProp>{t('Availability')}</ImageProp>:
-                <DebugFileFeature
-                  feature="symtab"
-                  available={image.features.has_symbols}
-                />
-                <DebugFileFeature
-                  feature="debug"
-                  available={image.features.has_debug_info}
-                />
-                <DebugFileFeature
-                  feature="unwind"
-                  available={image.features.has_unwind_info}
-                />
-                <DebugFileFeature
-                  feature="sources"
-                  available={image.features.has_sources}
-                />
-              </ImageSubtext>
-            )}
-
-            {!legacyRender && debugIdElement}
-
-            {showCodeId && (
-              <ImageSubtext>
-                <ImageProp>{t('Code ID')}</ImageProp>:{' '}
-                <Formatted>{image.code_id}</Formatted>
-              </ImageSubtext>
-            )}
-
-            {!!image.arch && (
-              <ImageSubtext>
-                <ImageProp>{t('Architecture')}</ImageProp>: {image.arch}
-              </ImageSubtext>
-            )}
-          </React.Fragment>
-        )}
-      </ImageInfoGroup>
-
-      <Access access={['project:releases']}>
-        {({hasAccess}) => {
-          if (!hasAccess) {
-            return null;
-          }
-          const settingsUrl = getSettingsLink();
-          if (!settingsUrl) {
-            return null;
-          }
-          return (
-            <ImageActions>
-              <Tooltip title={t('Search for debug files in settings')}>
-                <Button size="xsmall" icon={<IconSearch size="xs" />} to={settingsUrl} />
-              </Tooltip>
-            </ImageActions>
-          );
-        }}
-      </Access>
-    </DebugImageItem>
-  );
-});
+  }
+);
 
 export default DebugImage;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta/index.tsx
@@ -41,7 +41,7 @@ type DefaultProps = {
 
 type Props = DefaultProps & {
   event: Event;
-  orgId: Organization['id'];
+  organization: Organization;
   projectId: Project['id'];
 };
 
@@ -311,7 +311,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
   }
 
   renderRow = ({index, key, parent, style}: ListRowProps) => {
-    const {orgId, projectId} = this.props;
+    const {organization, projectId} = this.props;
     const {filteredImages, showDetails} = this.state;
 
     return (
@@ -325,7 +325,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
         <DebugImage
           style={style}
           image={filteredImages[index]}
-          orgId={orgId}
+          organization={organization}
           projectId={projectId}
           showDetails={showDetails}
         />
@@ -350,14 +350,14 @@ class DebugMeta extends React.PureComponent<Props, State> {
 
   renderImageList() {
     const {filteredImages, showDetails, panelBodyHeight} = this.state;
-    const {orgId, projectId} = this.props;
+    const {organization, projectId} = this.props;
 
     if (!panelBodyHeight) {
       return filteredImages.map(filteredImage => (
         <DebugImage
           key={filteredImage.debug_id}
           image={filteredImage}
-          orgId={orgId}
+          organization={organization}
           projectId={projectId}
           showDetails={showDetails}
         />
@@ -485,6 +485,7 @@ const ToolbarWrapper = styled('div')`
     margin-top: ${space(1)};
   }
 `;
+
 const SearchInputWrapper = styled('div')`
   width: 100%;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as ReactRouter from 'react-router';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Alert from 'app/components/alert';
 import {Panel} from 'app/components/panels';
@@ -28,7 +27,6 @@ import {ParsedTraceType} from './types';
 import {getTraceDateTimeRange, parseTrace} from './utils';
 
 type Props = {
-  orgId: string;
   event: SentryTransactionEvent;
   organization: Organization;
 } & ReactRouter.WithRouterProps;
@@ -42,7 +40,7 @@ type State = {
 class SpansInterface extends React.Component<Props, State> {
   static propTypes = {
     event: SentryTypes.Event.isRequired,
-    orgId: PropTypes.string.isRequired,
+    organization: SentryTypes.Organization.isRequired,
   };
 
   state: State = {
@@ -112,8 +110,10 @@ class SpansInterface extends React.Component<Props, State> {
   };
 
   render() {
-    const {event, orgId, location, organization} = this.props;
+    const {event, location, organization} = this.props;
     const {parsedTrace} = this.state;
+
+    const orgSlug = organization.slug;
 
     // construct discover query to fetch error events associated with this transaction
 
@@ -161,7 +161,7 @@ class SpansInterface extends React.Component<Props, State> {
         <DiscoverQuery
           location={location}
           eventView={traceErrorsEventView}
-          orgSlug={orgId}
+          orgSlug={orgSlug}
         >
           {({isLoading, tableData}) => {
             const spansWithErrors = filterSpansWithErrors(parsedTrace, tableData);
@@ -192,7 +192,7 @@ class SpansInterface extends React.Component<Props, State> {
                   <TraceView
                     event={event}
                     searchQuery={this.state.searchQuery}
-                    orgId={orgId}
+                    orgId={orgSlug}
                     organization={organization}
                     parsedTrace={parsedTrace}
                     spansWithErrors={spansWithErrors}

--- a/src/sentry/static/sentry/app/types/debugImage.tsx
+++ b/src/sentry/static/sentry/app/types/debugImage.tsx
@@ -1,0 +1,93 @@
+// Candidate Stacktrace Info
+export enum CandidateStacktraceStatus {
+  OK = 'ok',
+  MALFORMED = 'malformed',
+  ERROR = 'error',
+}
+
+type CandidateStacktraceInfoOkStatus = {
+  status: CandidateStacktraceStatus.OK;
+};
+
+type CandidateStacktraceInfoOtherStatus = {
+  status: CandidateStacktraceStatus.MALFORMED | CandidateStacktraceStatus.ERROR;
+  details?: string;
+};
+
+export type CandidateStacktraceInfo =
+  | CandidateStacktraceInfoOkStatus
+  | CandidateStacktraceInfoOtherStatus;
+
+// Candidate Download Status
+export enum CandiateDownloadStatus {
+  OK = 'ok',
+  MALFORMED = 'malformed',
+  NOT_FOUND = 'notfound',
+  ERROR = 'error',
+  NO_PERMISSION = 'noperm',
+}
+
+type Features = {
+  has_sources: boolean;
+  has_debug_info: boolean;
+  has_unwind_info: boolean;
+  has_symbols: boolean;
+};
+
+type CandidateDownloadOkStatus = {
+  status: CandiateDownloadStatus.OK;
+  features: Features;
+  details?: string;
+  unwind?: CandidateStacktraceInfo;
+  debug?: CandidateStacktraceInfo;
+};
+
+type CandidateDownloadNotFoundStatus = {
+  status: CandiateDownloadStatus.NOT_FOUND;
+  details?: string;
+};
+
+type CandidateDownloadOtherStatus = {
+  status:
+    | CandiateDownloadStatus.MALFORMED
+    | CandiateDownloadStatus.NO_PERMISSION
+    | CandiateDownloadStatus.ERROR;
+};
+
+export type CandidateDownload =
+  | CandidateDownloadNotFoundStatus
+  | CandidateDownloadOkStatus
+  | CandidateDownloadOtherStatus;
+
+type Candidate = {
+  download: CandidateDownload;
+  location: string;
+  source: string;
+  source_name: string;
+};
+
+// Debug Status
+export enum ImageStackTraceInfo {
+  FOUND = 'found',
+  UNUSED = 'unused',
+  MISSING = 'missing',
+  MALFORMED = 'malformed',
+  TIMEOUT = 'timeout',
+  FETCHING_FAILED = 'fetching_failed',
+  OTHER = 'other',
+}
+
+export type Image = {
+  debug_file: string;
+  debug_id: string;
+  code_file: string;
+  code_id: string;
+  type: string;
+  image_addr: string;
+  image_size: number;
+  debug_status: ImageStackTraceInfo;
+  unwind_status: ImageStackTraceInfo;
+  features: Features;
+  candidates: Array<Candidate>;
+  arch?: string;
+};

--- a/src/sentry/static/sentry/app/types/debugImage.tsx
+++ b/src/sentry/static/sentry/app/types/debugImage.tsx
@@ -83,11 +83,11 @@ export type Image = {
   code_file: string;
   code_id: string;
   type: string;
-  image_addr: string;
   image_size: number;
   debug_status: ImageStackTraceInfo;
   unwind_status: ImageStackTraceInfo;
   features: Features;
   candidates: Array<Candidate>;
   arch?: string;
+  image_addr?: string;
 };

--- a/tests/js/spec/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/breadcrumbs/breadcrumbs.spec.tsx
@@ -9,6 +9,8 @@ describe('BreadcrumbsInterface', () => {
 
   beforeEach(() => {
     props = {
+      // @ts-ignore Cannot find TestStubs
+      organization: TestStubs.Organization(),
       event: {
         entries: [],
         id: '4',


### PR DESCRIPTION
closes https://app.asana.com/0/1182975495223914/1199597399712880

This is only the first part. 

The second part will contain:
. The dropdownMenu action (this was removed from this PR due to some issues)
. Finish the delete button (some doubts need to be clarified)
. Source Name + Tooltip with a copy to clipboard functionality (There is already an open PR https://github.com/getsentry/sentry/pull/22797)
. Add Translations + Tooltips
. Polishing 

The third part will contain:
. Remotion of the `overflow: auto` from the table and make it look better on smaller devices

![image](https://user-images.githubusercontent.com/29228205/102644591-580fdd80-4161-11eb-9590-f6d5f767e7d1.png)

