### PR TITLE
ref(tooltip): Add variant prop

### DIFF
--- a/docs-ui/components/tooltip.stories.js
+++ b/docs-ui/components/tooltip.stories.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import {withInfo} from '@storybook/addon-info';
-import {text, boolean, select} from '@storybook/addon-knobs';
+import {boolean, select, text} from '@storybook/addon-knobs';
 
-import Tooltip from 'app/components/tooltip';
 import Button from 'app/components/button';
+import Tooltip from 'app/components/tooltip';
 
 class CustomThing extends React.Component {
   render() {
@@ -31,7 +31,9 @@ export const _Tooltip = withInfo({
     {top: 'top', bottom: 'bottom', left: 'left', right: 'right'},
     'top'
   );
+
   const isHoverable = boolean('isHoverable', false);
+  const variant = isHoverable ? 'hoverable' : 'default';
 
   return (
     <React.Fragment>
@@ -42,7 +44,7 @@ export const _Tooltip = withInfo({
           position={position}
           disabled={disabled}
           containerDisplayMode={displayMode}
-          isHoverable={isHoverable}
+          variant={variant}
         >
           <Button>Styled button</Button>
         </Tooltip>
@@ -50,12 +52,7 @@ export const _Tooltip = withInfo({
 
       <h3>With class component trigger</h3>
       <p>
-        <Tooltip
-          title={title}
-          position={position}
-          disabled={disabled}
-          isHoverable={isHoverable}
-        >
+        <Tooltip title={title} position={position} disabled={disabled} variant={variant}>
           <CustomThing>Custom React Component</CustomThing>
         </Tooltip>
       </p>
@@ -73,7 +70,7 @@ export const _Tooltip = withInfo({
             position={position}
             disabled={disabled}
             containerDisplayMode={displayMode}
-            isHoverable={isHoverable}
+            variant={variant}
           >
             <circle cx="50" cy="50" r="50" />
           </Tooltip>
@@ -91,9 +88,22 @@ export const _Tooltip = withInfo({
           containerDisplayMode={displayMode}
           position={position}
           disabled={disabled}
-          isHoverable={isHoverable}
+          variant={variant}
         >
           <button>Native button</button>
+        </Tooltip>
+      </p>
+
+      <h3>With a copy to clipboard button</h3>
+      <p>
+        <Tooltip
+          title="This is a description"
+          containerDisplayMode={displayMode}
+          position={position}
+          disabled={disabled}
+          variant="copyable"
+        >
+          The tooltip of this text has a copy to clipboard button
         </Tooltip>
       </p>
     </React.Fragment>

--- a/src/sentry/static/sentry/app/components/version.tsx
+++ b/src/sentry/static/sentry/app/components/version.tsx
@@ -5,14 +5,10 @@ import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
-import Clipboard from 'app/components/clipboard';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
 import Link from 'app/components/links/link';
 import Tooltip from 'app/components/tooltip';
-import {IconCopy} from 'app/icons';
 import SentryTypes from 'app/sentryTypes';
-import overflowEllipsis from 'app/styles/overflowEllipsis';
-import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {formatVersion} from 'app/utils/formatters';
 import theme from 'app/utils/theme';
@@ -111,22 +107,6 @@ const Version = ({
     );
   };
 
-  const renderTooltipContent = () => (
-    <TooltipContent
-      onClick={e => {
-        e.stopPropagation();
-      }}
-    >
-      <TooltipVersionWrapper>{version}</TooltipVersionWrapper>
-
-      <Clipboard value={version}>
-        <TooltipClipboardIconWrapper>
-          <IconCopy size="xs" color="white" />
-        </TooltipClipboardIconWrapper>
-      </Clipboard>
-    </TooltipContent>
-  );
-
   const getPopperStyles = () => {
     // if the version name is not a hash (sha1 or sha265) and we are not on mobile, allow tooltip to be as wide as 500px
     if (/(^[a-f0-9]{40}$)|(^[a-f0-9]{64}$)/.test(version)) {
@@ -142,11 +122,11 @@ const Version = ({
 
   return (
     <Tooltip
-      title={renderTooltipContent()}
+      title={version}
       disabled={!tooltipRawVersion}
-      isHoverable
       containerDisplayMode={truncate ? 'block' : 'inline-block'}
       popperStyle={getPopperStyles()}
+      variant="copyable"
     >
       {renderVersion()}
     </Tooltip>
@@ -181,25 +161,6 @@ const VersionText = styled('span')<{truncate?: boolean}>`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;`}
-`;
-
-const TooltipContent = styled('span')`
-  display: flex;
-  align-items: center;
-`;
-
-const TooltipVersionWrapper = styled('span')`
-  ${overflowEllipsis}
-`;
-
-const TooltipClipboardIconWrapper = styled('span')`
-  margin-left: ${space(0.5)};
-  position: relative;
-  bottom: -${space(0.25)};
-
-  &:hover {
-    cursor: pointer;
-  }
 `;
 
 type PropsWithoutOrg = Omit<Props, 'organization'>;

--- a/tests/js/spec/components/version.spec.jsx
+++ b/tests/js/spec/components/version.spec.jsx
@@ -33,8 +33,8 @@ describe('Version', () => {
   it('shows raw version in tooltip', () => {
     const wrapper = mount(<Version version={VERSION} tooltipRawVersion />, routerContext);
 
-    const tooltipContent = mount(wrapper.find('Tooltip').prop('title'));
+    const tooltipContent = wrapper.find('Tooltip').prop('title');
 
-    expect(tooltipContent.text()).toBe(VERSION);
+    expect(tooltipContent).toBe(VERSION);
   });
 });


### PR DESCRIPTION

. Removes the prop `isHoverable`
. Introduces the prop `variant` which can be of type ` 'default' | 'hoverable' | 'copyable'`

If variant equals `'copyable' ` the title has to be of type `string` and the tooltip will be rendered like below:

![image](https://user-images.githubusercontent.com/29228205/102607651-eae05600-4128-11eb-91c6-3cac7ba785cd.png)
