### PR TITLE
feat(alerts): Add new scopes for editing/viewing alert rules

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -141,6 +141,15 @@ class OrganizationDataExportPermission(OrganizationPermission):
     }
 
 
+class OrganizationAlertRulePermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin", "alert_rule:read"],
+        "POST": ["org:write", "org:admin", "alert_rule:write"],
+        "PUT": ["org:write", "org:admin", "alert_rule:write"],
+        "DELETE": ["org:write", "org:admin", "alert_rule:write"],
+    }
+
+
 class OrganizationEndpoint(Endpoint):
     permission_classes = (OrganizationPermission,)
 

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -115,6 +115,15 @@ class RelaxedSearchPermission(ProjectPermission):
     }
 
 
+class ProjectAlertRulePermission(ProjectPermission):
+    scope_map = {
+        "GET": ["project:read", "project:write", "project:admin", "alerts:read"],
+        "POST": ["project:read", "project:write", "project:admin", "alerts:write"],
+        "PUT": ["project:read", "project:write", "project:admin", "alerts:write"],
+        "DELETE": ["project:read", "project:write", "project:admin", "alerts:write"],
+    }
+
+
 class ProjectEndpoint(Endpoint):
     permission_classes = (ProjectPermission,)
 

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -118,9 +118,9 @@ class RelaxedSearchPermission(ProjectPermission):
 class ProjectAlertRulePermission(ProjectPermission):
     scope_map = {
         "GET": ["project:read", "project:write", "project:admin", "alerts:read"],
-        "POST": ["project:read", "project:write", "project:admin", "alerts:write"],
-        "PUT": ["project:read", "project:write", "project:admin", "alerts:write"],
-        "DELETE": ["project:read", "project:write", "project:admin", "alerts:write"],
+        "POST": ["project:write", "project:admin", "alerts:write"],
+        "PUT": ["project:write", "project:admin", "alerts:write"],
+        "DELETE": ["project:write", "project:admin", "alerts:write"],
     }
 
 

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from rest_framework import status
 from rest_framework.response import Response
 
-from sentry.api.bases.project import ProjectEndpoint, ProjectSettingPermission
+from sentry.api.bases.project import ProjectEndpoint, ProjectAlertRulePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.rule import RuleSerializer
@@ -14,7 +14,7 @@ from sentry.web.decorators import transaction_start
 
 
 class ProjectRuleDetailsEndpoint(ProjectEndpoint):
-    permission_classes = [ProjectSettingPermission]
+    permission_classes = (ProjectAlertRulePermission,)
 
     def convert_args(self, request, rule_id, *args, **kwargs):
         args, kwargs = super(ProjectRuleDetailsEndpoint, self).convert_args(

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 from rest_framework import status
 from rest_framework.response import Response
 
-from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectAlertRulePermission
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import RuleSerializer
 from sentry.integrations.slack import tasks
@@ -15,6 +15,8 @@ from sentry.web.decorators import transaction_start
 
 
 class ProjectRulesEndpoint(ProjectEndpoint):
+    permission_classes = (ProjectAlertRulePermission,)
+
     @transaction_start("ProjectRulesEndpoint")
     def get(self, request, project):
         """

--- a/src/sentry/api/serializers/rest_framework/project.py
+++ b/src/sentry/api/serializers/rest_framework/project.py
@@ -8,6 +8,10 @@ ValidationError = serializers.ValidationError
 
 
 class ProjectField(serializers.Field):
+    def __init__(self, scope="project:write"):
+        self.scope = scope
+        super(ProjectField, self).__init__()
+
     def to_representation(self, value):
         return value
 
@@ -16,6 +20,6 @@ class ProjectField(serializers.Field):
             project = Project.objects.get(organization=self.context["organization"], slug=data)
         except Project.DoesNotExist:
             raise ValidationError("Invalid project")
-        if not self.context["access"].has_project_scope(project, "project:write"):
+        if not self.context["access"].has_project_scope(project, self.scope):
             raise ValidationError("Insufficient access to project")
         return project

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1283,6 +1283,8 @@ SENTRY_SCOPES = set(
         "event:read",
         "event:write",
         "event:admin",
+        "alerts:write",
+        "alerts:read",
     ]
 )
 
@@ -1314,6 +1316,7 @@ SENTRY_SCOPE_SETS = (
         ("event:write", "Read and write access to events."),
         ("event:read", "Read access to events."),
     ),
+    (("alerts:write", "Read and write alerts"), ("alerts:read", "Read alerts"),),
 )
 
 SENTRY_DEFAULT_ROLE = "member"
@@ -1337,6 +1340,8 @@ SENTRY_ROLES = (
                 "org:read",
                 "member:read",
                 "team:read",
+                "alerts:write",
+                "alerts:read",
             ]
         ),
     },
@@ -1362,6 +1367,8 @@ SENTRY_ROLES = (
                 "team:write",
                 "team:admin",
                 "org:integrations",
+                "alerts:write",
+                "alerts:read",
             ]
         ),
     },
@@ -1388,6 +1395,8 @@ SENTRY_ROLES = (
                 "org:read",
                 "org:write",
                 "org:integrations",
+                "alerts:write",
+                "alerts:read",
             ]
         ),
     },
@@ -1416,6 +1425,8 @@ SENTRY_ROLES = (
                 "event:read",
                 "event:write",
                 "event:admin",
+                "alerts:write",
+                "alerts:read",
             ]
         ),
     },

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1340,7 +1340,6 @@ SENTRY_ROLES = (
                 "org:read",
                 "member:read",
                 "team:read",
-                "alerts:write",
                 "alerts:read",
             ]
         ),

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -3,13 +3,15 @@ from __future__ import absolute_import
 from rest_framework.exceptions import PermissionDenied
 
 from sentry import features
-from sentry.api.bases.project import ProjectEndpoint
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectAlertRulePermission
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationAlertRulePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.incidents.models import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
 
 
 class ProjectAlertRuleEndpoint(ProjectEndpoint):
+    permission_classes = (ProjectAlertRulePermission,)
+
     def convert_args(self, request, alert_rule_id, *args, **kwargs):
         args, kwargs = super(ProjectAlertRuleEndpoint, self).convert_args(request, *args, **kwargs)
         project = kwargs["project"]
@@ -31,6 +33,8 @@ class ProjectAlertRuleEndpoint(ProjectEndpoint):
 
 
 class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationAlertRulePermission,)
+
     def convert_args(self, request, alert_rule_id, *args, **kwargs):
         args, kwargs = super(OrganizationAlertRuleEndpoint, self).convert_args(
             request, *args, **kwargs

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from sentry import features
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationAlertRulePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import (
     OffsetPaginator,
@@ -66,6 +66,8 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
 
 
 class OrganizationAlertRuleIndexEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationAlertRulePermission,)
+
     def get(self, request, organization):
         """
         Fetches alert rules for an organization

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -6,7 +6,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from sentry import features
-from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectAlertRulePermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import (
     OffsetPaginator,
@@ -52,6 +52,8 @@ class ProjectCombinedRuleIndexEndpoint(ProjectEndpoint):
 
 
 class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
+    permission_classes = (ProjectAlertRulePermission,)
+
     def get(self, request, project):
         """
         Fetches alert rules for a project

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -291,9 +291,9 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
     environment = EnvironmentField(required=False, allow_null=True)
     # TODO: These might be slow for many projects, since it will query for each
     # individually. If we find this to be a problem then we can look into batching.
-    projects = serializers.ListField(child=ProjectField(scope="alerts:write"), required=False)
+    projects = serializers.ListField(child=ProjectField(scope="projects:read"), required=False)
     excluded_projects = serializers.ListField(
-        child=ProjectField(scope="alerts:write"), required=False
+        child=ProjectField(scope="projects:read"), required=False
     )
     triggers = serializers.ListField(required=True)
     dataset = serializers.CharField(required=False)

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -291,9 +291,9 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
     environment = EnvironmentField(required=False, allow_null=True)
     # TODO: These might be slow for many projects, since it will query for each
     # individually. If we find this to be a problem then we can look into batching.
-    projects = serializers.ListField(child=ProjectField(scope="projects:read"), required=False)
+    projects = serializers.ListField(child=ProjectField(scope="project:read"), required=False)
     excluded_projects = serializers.ListField(
-        child=ProjectField(scope="projects:read"), required=False
+        child=ProjectField(scope="project:read"), required=False
     )
     triggers = serializers.ListField(required=True)
     dataset = serializers.CharField(required=False)

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -291,8 +291,10 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
     environment = EnvironmentField(required=False, allow_null=True)
     # TODO: These might be slow for many projects, since it will query for each
     # individually. If we find this to be a problem then we can look into batching.
-    projects = serializers.ListField(child=ProjectField(), required=False)
-    excluded_projects = serializers.ListField(child=ProjectField(), required=False)
+    projects = serializers.ListField(child=ProjectField(scope="alerts:write"), required=False)
+    excluded_projects = serializers.ListField(
+        child=ProjectField(scope="alerts:write"), required=False
+    )
     triggers = serializers.ListField(required=True)
     dataset = serializers.CharField(required=False)
     event_types = serializers.ListField(child=serializers.CharField(), required=False)

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -336,7 +336,7 @@ const CreateAlertButton = withRouter(
     }
 
     return (
-      <Access organization={organization} access={['project:write']}>
+      <Access organization={organization} access={['alerts:write']}>
         {({hasAccess}) => (
           <Button
             disabled={!hasAccess}

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -30,6 +30,8 @@ export const API_ACCESS_SCOPES = [
   'member:read',
   'member:write',
   'member:admin',
+  'alerts:read',
+  'alerts:write',
 ] as const;
 
 // Default API scopes when adding a new API token or org API token

--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -59,7 +59,7 @@ class RuleListRow extends React.Component<Props, State> {
         <CreatedBy>{rule?.createdBy?.name ?? '-'}</CreatedBy>
         <div>{dateCreated}</div>
         <RightColumn>
-          <Access access={['project:write']}>
+          <Access access={['alerts:write']}>
             {({hasAccess}) => (
               <ButtonBar gap={1}>
                 <Confirm

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -578,7 +578,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     );
 
     return (
-      <Access access={['project:write']}>
+      <Access access={['alerts:write']}>
         {({hasAccess}) => (
           <Feature features={['metric-alert-gui-filters']} organization={organization}>
             {({hasFeature}) => (

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/index.tsx
@@ -435,7 +435,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     // the form with a loading mask on top of it, but force a re-render by using
     // a different key when we have fetched the rule so that form inputs are filled in
     return (
-      <Access access={['project:write']}>
+      <Access access={['alerts:write']}>
         {({hasAccess}) => (
           <StyledForm
             key={isSavedAlertRule(rule) ? rule.id : undefined}

--- a/tests/js/sentry-test/fixtures/organization.js
+++ b/tests/js/sentry-test/fixtures/organization.js
@@ -15,6 +15,8 @@ export function Organization(params = {}) {
       'team:read',
       'team:write',
       'team:admin',
+      'alerts:read',
+      'alerts:write',
     ],
     status: {
       id: 'active',

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -239,7 +239,7 @@ describe('IncidentsList', function () {
     );
   });
 
-  it('disables the new alert button for members', async function () {
+  it('disables the new alert button for those without alert:write', async function () {
     const noAccessOrg = {
       ...organization,
       access: [],

--- a/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
@@ -194,7 +194,6 @@ describe('ProjectAlertsCreate', function () {
         const {wrapper, router} = createWrapper({
           organization: {
             features: ['alert-filters'],
-            access: ['alerts:write'],
           },
         });
         const mock = MockApiClient.addMockResponse({

--- a/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
+++ b/tests/js/spec/views/settings/projectAlerts/create.spec.jsx
@@ -194,6 +194,7 @@ describe('ProjectAlertsCreate', function () {
         const {wrapper, router} = createWrapper({
           organization: {
             features: ['alert-filters'],
+            access: ['alerts:write'],
           },
         });
         const mock = MockApiClient.addMockResponse({


### PR DESCRIPTION
This PR adds alerts permission group with `alerts:read` and `alerts:write`. These scopes are added to all roles within the app except owners and also added to the relevant issue alert and metric alert endpoints. Eventually we will have a setting to turn on `alerts:write` for owners

There are also some frontend changes to enable buttons which were previously behind `projects:write`