### PR TITLE
fix(perf-view): No web vitals on non front end transactions

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -107,7 +107,7 @@ function UserStats({eventView, totals, location, organization, transactionName}:
       </SidebarWrapper>
       <Feature features={['organizations:performance-vitals-overview']}>
         {({hasFeature}) => {
-          if (hasFeature) {
+          if (vitalsPassRate !== null && hasFeature) {
             return (
               <SidebarWrapper>
                 <VitalsHeading>


### PR DESCRIPTION
Web vitals should not appear on the transaction summary of a non front end
transaction.

# Screenshot

## Before

![image](https://user-images.githubusercontent.com/10239353/102644168-5b3da600-412e-11eb-9a5a-375cfb21a412.png)

## After

![image](https://user-images.githubusercontent.com/10239353/102644127-4b25c680-412e-11eb-826f-8e9c6cec12ab.png)