### PR TITLE
feat(issue): Add autocomplete for me_or_none

### DIFF
--- a/src/sentry/static/sentry/app/utils/withIssueTags.tsx
+++ b/src/sentry/static/sentry/app/utils/withIssueTags.tsx
@@ -89,6 +89,7 @@ const withIssueTags = <P extends InjectedTagsProps>(
       const allAssigned = usernames.concat(teamnames);
       allAssigned.unshift('me');
       usernames.unshift('me');
+      const allOwners = ['me_or_none', ...allAssigned];
 
       this.setState({
         tags: {
@@ -103,7 +104,7 @@ const withIssueTags = <P extends InjectedTagsProps>(
           },
           owner: {
             ...tags.owner,
-            values: allAssigned,
+            values: allOwners,
           },
         },
       });

--- a/tests/js/spec/utils/withIssueTags.spec.jsx
+++ b/tests/js/spec/utils/withIssueTags.spec.jsx
@@ -68,6 +68,7 @@ describe('withIssueTags HoC', function () {
       '#best-team-na',
     ]);
     expect(tagsProp.owner.values).toEqual([
+      'me_or_none',
       'me',
       'foo@example.com',
       'joe@example.com',


### PR DESCRIPTION
This adds `me_or_none` to autocomplete on issue search which was supported back in https://github.com/getsentry/sentry/pull/22561 but wasn't discoverable on the frontend

![image](https://user-images.githubusercontent.com/9372512/102648462-87105a00-4135-11eb-9dec-8c41a084d9bf.png)
