### PR TITLE
fix(tag): Use team slug for issue search autocomplete

### DIFF
--- a/src/sentry/static/sentry/app/utils/withIssueTags.tsx
+++ b/src/sentry/static/sentry/app/utils/withIssueTags.tsx
@@ -85,7 +85,7 @@ const withIssueTags = <P extends InjectedTagsProps>(
       const usernames: string[] = users.map(getUsername);
       const teamnames: string[] = teams
         .filter(team => team.isMember)
-        .map(team => `#${team.name}`);
+        .map(team => `#${team.slug}`);
       const allAssigned = usernames.concat(teamnames);
       allAssigned.unshift('me');
       usernames.unshift('me');

--- a/tests/js/spec/utils/withIssueTags.spec.jsx
+++ b/tests/js/spec/utils/withIssueTags.spec.jsx
@@ -55,7 +55,7 @@ describe('withIssueTags HoC', function () {
 
     const users = [TestStubs.User(), TestStubs.User({username: 'joe@example.com'})];
     TeamStore.loadInitialData([
-      {slug: 'best-team-na', name: 'best-team-na', isMember: true},
+      {slug: 'best-team-na', name: 'Best Team NA', isMember: true},
     ]);
     MemberListStore.loadInitialData(users);
     await wrapper.update();


### PR DESCRIPTION
On the backend we search `assigned` and `owner` by the actor `slug` not the `name`. Typically these are the same, but in some cases these differ which cause the search results to return nothing.