### PR TITLE
chore(alerts): Make it clearer there's a filter

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -175,10 +175,10 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
         icon={<IconCheckmark isCircled size="48" />}
         title={
           !hasAlertRule
-            ? t('No metric alert rules exist for these projects.')
+            ? t('No metric alert rules exist for the selected projects.')
             : status === 'open'
-            ? t('No unresolved metric alerts in these projects.')
-            : t('No resolved metric alerts in these projects.')
+            ? t('No unresolved metric alerts in the selected projects.')
+            : t('No resolved metric alerts in the selected projects.')
         }
         description={tct('Learn more about [link:Metric Alerts]', {
           link: <ExternalLink href={DOCS_URL} />,

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -170,7 +170,7 @@ describe('IncidentsList', function () {
     wrapper.update();
 
     expect(wrapper.find('PanelItem')).toHaveLength(0);
-    expect(wrapper.text()).toContain('No metric alert rules exist for these projects');
+    expect(wrapper.text()).toContain('No metric alert rules exist for the selected projects');
   });
 
   it('displays empty state (rules created)', async function () {

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -170,7 +170,9 @@ describe('IncidentsList', function () {
     wrapper.update();
 
     expect(wrapper.find('PanelItem')).toHaveLength(0);
-    expect(wrapper.text()).toContain('No metric alert rules exist for the selected projects');
+    expect(wrapper.text()).toContain(
+      'No metric alert rules exist for the selected projects'
+    );
   });
 
   it('displays empty state (rules created)', async function () {

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -198,7 +198,7 @@ describe('IncidentsList', function () {
     wrapper.update();
 
     expect(wrapper.find('PanelItem')).toHaveLength(0);
-    expect(wrapper.text()).toContain('No unresolved metric alerts in these projects');
+    expect(wrapper.text()).toContain('No unresolved metric alerts in the selected projects');
   });
 
   it('toggles open/closed', async function () {

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -198,7 +198,9 @@ describe('IncidentsList', function () {
     wrapper.update();
 
     expect(wrapper.find('PanelItem')).toHaveLength(0);
-    expect(wrapper.text()).toContain('No unresolved metric alerts in the selected projects');
+    expect(wrapper.text()).toContain(
+      'No unresolved metric alerts in the selected projects'
+    );
   });
 
   it('toggles open/closed', async function () {


### PR DESCRIPTION
Global state carries over, so sometimes people can get misled by seeing no alerts on the page. Probably needs a bigger change but this is something simple for now.