### PR TITLE
fix(issues): Make the poller not use collapse=stats

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -488,7 +488,10 @@ class IssueListOverview extends React.Component<Props, State> {
     // Only resume polling if we're on the first page of results
     const links = parseLinkHeader(this.state.pageLinks);
     if (links && !links.previous.results && this.state.realtimeActive) {
-      this._poller.setEndpoint(links.previous.href);
+      // Remove collapse stats from endpoint before supplying to poller
+      const issueEndpoint = new URL(links.previous.href);
+      issueEndpoint.searchParams.delete('collapse');
+      this._poller.setEndpoint(decodeURIComponent(issueEndpoint.href));
       this._poller.enable();
     }
   };


### PR DESCRIPTION
Previously I introduced a change to decompose the request for issue data https://github.com/getsentry/sentry/pull/22656, 

Unfortunately this caused the live updates on the issue stream to also `collapse=stats` with no extra call to get the stats for the issue causing **permanent placeholders**:

![Kapture 2020-12-18 at 14 21 22](https://user-images.githubusercontent.com/9372512/102655240-f723dd80-413f-11eb-9a47-74c74636c184.gif)

To fix this I stripped the `collapse=stats` from the poller's endpoint so it makes a request for the whole issue row with all stats:

![Kapture 2020-12-18 at 14 25 32](https://user-images.githubusercontent.com/9372512/102655651-ac569580-4140-11eb-9c8d-8733c05a771f.gif)

