### PR TITLE
fix(discover): Prevent invalid yaxis options

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -23,6 +23,7 @@ import {
   Column,
   ColumnType,
   Field,
+  aggregateOutputType,
   generateFieldAsString,
   getAggregateAlias,
   isAggregateField,
@@ -998,10 +999,11 @@ class EventView {
     // Make option set and add the default options in.
     return uniqBy(
       this.getAggregateFields()
-        // Exclude last_seen and latest_event as they don't produce useful graphs.
-        .filter(
-          (field: Field) =>
-            ['last_seen()', 'latest_event()'].includes(field.field) === false
+        // Exclude aggregates on dates as they don't produce useful graphs.
+        .filter((field: Field) =>
+          ['number', 'integer', 'duration', 'percentage'].includes(
+            aggregateOutputType(field.field)
+          )
         )
         .map((field: Field) => ({label: field.field, value: field.field}))
         .concat(CHART_AXIS_OPTIONS),

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -20,10 +20,10 @@ import {statsPeriodToDays} from '../dates';
 
 import {getSortField} from './fieldRenderers';
 import {
+  aggregateOutputType,
   Column,
   ColumnType,
   Field,
-  aggregateOutputType,
   generateFieldAsString,
   getAggregateAlias,
   isAggregateField,

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -999,7 +999,7 @@ class EventView {
     // Make option set and add the default options in.
     return uniqBy(
       this.getAggregateFields()
-        // Exclude aggregates on dates as they don't produce useful graphs.
+        // Only include aggregates that make sense to be graphable (eg. not string or date)
         .filter((field: Field) =>
           ['number', 'integer', 'duration', 'percentage'].includes(
             aggregateOutputType(field.field)

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -151,11 +151,6 @@ export const AGGREGATIONS = {
     outputType: 'date',
     isSortable: true,
   },
-  latest_event: {
-    parameters: [],
-    outputType: 'string',
-    isSortable: true,
-  },
 
   // Tracing functions.
   p50: {

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -150,7 +150,11 @@ export const AGGREGATIONS = {
     parameters: [],
     outputType: 'date',
     isSortable: true,
-    multiPlotType: 'area',
+  },
+  latest_event: {
+    parameters: [],
+    outputType: 'string',
+    isSortable: true,
   },
 
   // Tracing functions.
@@ -303,7 +307,7 @@ export type AggregationKey = keyof typeof AGGREGATIONS | '';
 
 export type AggregationOutputType = Extract<
   ColumnType,
-  'number' | 'integer' | 'date' | 'duration' | 'percentage'
+  'number' | 'integer' | 'date' | 'duration' | 'percentage' | 'string'
 >;
 
 export type PlotType = 'line' | 'area';
@@ -333,8 +337,9 @@ export type Aggregation = {
   isSortable: boolean;
   /**
    * How this function should be plotted when shown in a multiseries result (top5)
+   * Optional because some functions cannot be plotted (strings/dates)
    */
-  multiPlotType: PlotType;
+  multiPlotType?: PlotType;
 };
 
 enum FieldKey {

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -2338,6 +2338,8 @@ describe('EventView.getYAxisOptions()', function () {
         'count_unique(issue)',
         'last_seen()',
         'latest_event()',
+        'min(time)',
+        'max(timestamp)',
       ]),
     });
 

--- a/tests/js/spec/utils/discover/eventView.spec.jsx
+++ b/tests/js/spec/utils/discover/eventView.spec.jsx
@@ -2337,7 +2337,6 @@ describe('EventView.getYAxisOptions()', function () {
         'ignored-field',
         'count_unique(issue)',
         'last_seen()',
-        'latest_event()',
         'min(time)',
         'max(timestamp)',
       ]),
@@ -2369,12 +2368,7 @@ describe('EventView.getYAxis()', function () {
   it('should return valid yAxis', function () {
     const thisEventView = new EventView({
       ...state,
-      fields: generateFields([
-        'ignored-field',
-        'count_unique(user)',
-        'last_seen',
-        'latest_event',
-      ]),
+      fields: generateFields(['ignored-field', 'count_unique(user)', 'last_seen']),
       yAxis: 'count_unique(user)',
     });
 

--- a/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
+++ b/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
@@ -27,7 +27,6 @@ describe('getFieldRenderer', function () {
       numeric: 1.23,
       createdAt: new Date(2019, 9, 3, 12, 13, 14),
       url: '/example',
-      latest_event: 'deadbeef',
       project: project.slug,
       release: 'F2520C43515BD1F0E8A6BD46233324641A370BF6',
       user,

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -282,7 +282,6 @@ describe('getExpandedResults()', function () {
       ...state,
       fields: [
         {field: 'last_seen()'}, // expect this to be transformed to timestamp
-        {field: 'latest_event()'},
         {field: 'title'},
         {field: 'avg(transaction.duration)'}, // expect this to be dropped
         {field: 'p50()'},


### PR DESCRIPTION
- We used to only exclude `last_seen` and `latest_event`, but we should
  limit anything that has an output of date.
  - This is currently via an allowlist of output types, not sure if a
    denylist would be better instead, but I figure this way we'd have to
    consider whether new types should be graphable or not.
- This adds `latest_event` as a new function in discover, based on #17395 
  we didn't want to add it until multi-param support, but might have been missed
  in #17513. Not sure if there was any other reason it wasn't included.