### PR TITLE
fix(splunk): Logging fails from wrong spelling

### DIFF
--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -297,7 +297,7 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
             logger.info(
                 metric,
                 extra={
-                    "instance": self.project_nstance,
+                    "instance": self.project_instance,
                     "project_id": event.project_id,
                     "organization_id": event.project.organization_id,
                     "error": six.text_type(exc),


### PR DESCRIPTION
## Objective:
Fixes SENTRY-K7B
