### PR TITLE
fix(discover): Handle has filters on array fields

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -214,6 +214,17 @@ RELEASE_ALIAS = "release"
 USER_DISPLAY_ALIAS = "user.display"
 ERROR_UNHANDLED_ALIAS = "error.unhandled"
 KEY_TRANSACTION_ALIAS = "key_transaction"
+ARRAY_FIELDS = {
+    "stack.abs_path",
+    "stack.filename",
+    "stack.package",
+    "stack.module",
+    "stack.function",
+    "stack.in_app",
+    "stack.colno",
+    "stack.lineno",
+    "stack.stack_level",
+}
 
 
 class InvalidSearchQuery(Exception):
@@ -896,6 +907,8 @@ def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
         raise InvalidSearchQuery(
             "Invalid value for key_transaction condition. Accepted values are 1, 0"
         )
+    elif name in ARRAY_FIELDS and search_filter.value.raw_value == "":
+        return [["notEmpty", [name]], "=", 1 if search_filter.operator == "!=" else 0]
     else:
         value = (
             int(to_timestamp(value)) * 1000

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -215,14 +215,17 @@ USER_DISPLAY_ALIAS = "user.display"
 ERROR_UNHANDLED_ALIAS = "error.unhandled"
 KEY_TRANSACTION_ALIAS = "key_transaction"
 ARRAY_FIELDS = {
+    "error.mechanism",
+    "error.type",
+    "error.value",
     "stack.abs_path",
+    "stack.colno",
     "stack.filename",
-    "stack.package",
-    "stack.module",
     "stack.function",
     "stack.in_app",
-    "stack.colno",
     "stack.lineno",
+    "stack.module",
+    "stack.package",
     "stack.stack_level",
 }
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1695,6 +1695,13 @@ class GetSnubaQueryArgsTest(TestCase):
         ]
         assert _filter.filter_keys == {}
 
+    def test_existence_array_field(self):
+        _filter = get_filter("has:stack.filename !has:stack.lineno")
+        _filter.conditions == [
+            [["notEmpty", ["stack.filename"]], "=", 1],
+            [["notEmpty", ["stack.lineno"]], "=", 0],
+        ]
+
     def test_wildcard_with_trailing_backslash(self):
         results = get_filter("title:*misgegaan\\")
         assert results.conditions == [[["match", ["title", u"'(?i)^.*misgegaan\\\\$'"]], "=", 1]]

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1696,10 +1696,11 @@ class GetSnubaQueryArgsTest(TestCase):
         assert _filter.filter_keys == {}
 
     def test_existence_array_field(self):
-        _filter = get_filter("has:stack.filename !has:stack.lineno")
+        _filter = get_filter("has:stack.filename !has:stack.lineno error.value:''")
         _filter.conditions == [
             [["notEmpty", ["stack.filename"]], "=", 1],
             [["notEmpty", ["stack.lineno"]], "=", 0],
+            [["notEmpty", ["error.value"]], "=", 0],
         ]
 
     def test_wildcard_with_trailing_backslash(self):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1696,8 +1696,8 @@ class GetSnubaQueryArgsTest(TestCase):
         assert _filter.filter_keys == {}
 
     def test_existence_array_field(self):
-        _filter = get_filter("has:stack.filename !has:stack.lineno error.value:''")
-        _filter.conditions == [
+        _filter = get_filter('has:stack.filename !has:stack.lineno error.value:""')
+        assert _filter.conditions == [
             [["notEmpty", ["stack.filename"]], "=", 1],
             [["notEmpty", ["stack.lineno"]], "=", 0],
             [["notEmpty", ["error.value"]], "=", 0],


### PR DESCRIPTION
- Array fields were being treated as strings, which meant that the
  conditions we were building were incorrect, this uses the notEmpty
  function to check if the array instead.