### PR TITLE
feat(ui): Change cell action and column reorder for dark mode

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Manager, Popper, Reference} from 'react-popper';
 import styled from '@emotion/styled';
+import color from 'color';
 import * as PopperJS from 'popper.js';
 
 import {IconEllipsis} from 'app/icons';
@@ -485,7 +486,7 @@ const MenuButton = styled('button')`
   justify-content: center;
   align-items: center;
 
-  background: rgba(255, 255, 255, 0.85);
+  background: ${p => color(p.theme.background).alpha(0.85).string()};
   border-radius: ${p => p.theme.borderRadius};
   border: 1px solid ${p => p.theme.border};
   cursor: pointer;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -333,7 +333,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
               aria-label={t('Drag to reorder')}
               onMouseDown={event => this.startDrag(event, i)}
               onTouchStart={event => this.startDrag(event, i)}
-              icon={<IconGrabbable size="xs" color="gray500" />}
+              icon={<IconGrabbable size="xs" />}
               size="zero"
               borderless
             />


### PR DESCRIPTION
This updates the cell action bg and column reorder text color to work for dark mode