### PR TITLE
fix(ui):replaced calendar colors with theme aliases

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/index.jsx
@@ -233,10 +233,43 @@ const StyledDateRange = styled(DateRange)`
 const StyledDateRangePicker = styled(DateRangePicker)`
   padding: 21px; /* this is specifically so we can align borders */
 
+  .rdrSelected,
+  .rdrInRange,
+  .rdrStartEdge,
+  .rdrEndEdge {
+    background-color: ${p => p.theme.active};
+  }
+
+  .rdrDayHovered .rdrDayStartPreview,
+  .rdrDayHovered .rdrDayEndPreview,
+  .rdrDay .rdrDayInPreview {
+    background-color: ${p => p.theme.focus};
+  }
+
+  .rdrStartEdge + .rdrDayStartPreview {
+    background-color: transparent;
+  }
+
+  .rdrDayToday .rdrDayNumber span {
+    color: ${p => p.theme.active};
+  }
+
+  .rdrDayNumber span:after {
+    background-color: ${p => p.theme.active};
+  }
+
   .rdrDefinedRangesWrapper,
   .rdrDateDisplayWrapper,
   .rdrWeekDays {
     display: none;
+  }
+
+  .rdrInRange {
+    background: ${p => p.theme.active};
+  }
+
+  .rdrDayInPreview {
+    background: ${p => p.theme.focus};
   }
 
   .rdrMonth {

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/index.jsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/index.jsx
@@ -342,7 +342,8 @@ const StyledDateRangePicker = styled(DateRangePicker)`
   }
 
   .rdrNextPrevButton {
-    background-color: ${p => p.theme.gray200};
+    background-color: transparent;
+    border: 1px solid ${p => p.theme.border};
   }
 
   .rdrPprevButton i {


### PR DESCRIPTION
### Before 

<img width="532" alt="Screen Shot 2020-12-18 at 6 06 05 PM" src="https://user-images.githubusercontent.com/1900676/102678192-ce114600-415b-11eb-8599-49627d32e994.png">


### After

<img width="519" alt="Screen Shot 2020-12-18 at 6 17 41 PM" src="https://user-images.githubusercontent.com/1900676/102678446-5f34ec80-415d-11eb-9b4f-b7642718128d.png">

