### PR TITLE
fix: Add "route" to symbolicator response metric

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -154,7 +154,10 @@ class Symbolicator(object):
 
             metrics.incr(
                 "events.symbolicator.response",
-                tags={"response": json_response.get("status") or "null"},
+                tags={
+                    "response": json_response.get("status") or "null",
+                    "task_type": getattr(create_task, "__name__", None) or "null",
+                },
             )
 
             # Symbolication is still in progress. Bail out and try again

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -152,8 +152,6 @@ class Symbolicator(object):
                 # If there is no response attached, it's a connection error.
                 raise RetrySymbolication(retry_after=settings.SYMBOLICATOR_MAX_RETRY_AFTER)
 
-            raise Exception(create_task.__name__)
-
             metrics.incr(
                 "events.symbolicator.response",
                 tags={"response": json_response.get("status") or "null", "task_name": task_name},


### PR DESCRIPTION
If 100% of minidumps are failing, we would not catch this via this metric as minidump traffic is very small compared to overall traffic.