### PR TITLE
feat(native): Merge source names into symbolicator responses

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -367,9 +367,8 @@ class SymbolicatorSession(object):
 
         for module in json.get("modules") or ():
             for candidate in module.get("candidates") or ():
-                candidate["source_name"] = (
-                    source_names.get(candidate["source"]) or "Unnamed Repository"
-                )
+                if candidate.get("source"):
+                    candidate["source_name"] = source_names.get(candidate["source"])
 
         return json
 


### PR DESCRIPTION
Symbolicator has a limited concept of sources compared to Sentry. Most notably,
it does not know about names assigned to sources in settings. This attaches the
additional source name to the symbolication response so that the UI can render
it conveniently with the list of candidates.

In follow-up work, the list of candidates will be trimmed at this spot.

