### PR TITLE
feat(aws-lambda): adds tests and set up integration name

### DIFF
--- a/src/sentry/integrations/aws_lambda/client.py
+++ b/src/sentry/integrations/aws_lambda/client.py
@@ -18,7 +18,7 @@ def gen_aws_client(arn, aws_external_id, service_name="lambda"):
     account_id = parsed_arn["account"]
     region = parsed_arn["region"]
 
-    role_arn = "arn:aws:iam::%s:role/SentryRole" % (account_id)
+    role_arn = u"arn:aws:iam::%s:role/SentryRole" % (account_id)
 
     client = boto3.client(
         service_name="sts",
@@ -33,13 +33,9 @@ def gen_aws_client(arn, aws_external_id, service_name="lambda"):
 
     credentials = assumed_role_object["Credentials"]
 
-    tmp_access_key = credentials["AccessKeyId"]
-    tmp_secret_key = credentials["SecretAccessKey"]
-    security_token = credentials["SessionToken"]
-
     boto3_session = boto3.Session(
-        aws_access_key_id=tmp_access_key,
-        aws_secret_access_key=tmp_secret_key,
-        aws_session_token=security_token,
+        aws_access_key_id=credentials["AccessKeyId"],
+        aws_secret_access_key=credentials["SecretAccessKey"],
+        aws_session_token=credentials["SessionToken"],
     )
     return boto3_session.client(service_name=service_name, region_name=region)

--- a/src/sentry/integrations/aws_lambda/client.py
+++ b/src/sentry/integrations/aws_lambda/client.py
@@ -7,12 +7,12 @@ from sentry import options
 from .utils import parse_arn
 
 
-def gen_aws_lambda_client(arn, aws_external_id, session_name="MySession"):
+def gen_aws_client(arn, aws_external_id, service_name="lambda"):
     """
-        arn - the arn of the cloudformation stack
-        aws_external_id - the external_id used to assume the role
+    arn - the arn of the cloudformation stack
+    aws_external_id - the external_id used to assume the role
 
-        Returns an aws_lambda_client
+    Returns an aws_lambda_client
     """
     parsed_arn = parse_arn(arn)
     account_id = parsed_arn["account"]
@@ -24,11 +24,11 @@ def gen_aws_lambda_client(arn, aws_external_id, session_name="MySession"):
         service_name="sts",
         aws_access_key_id=options.get("aws-lambda.access-key-id"),
         aws_secret_access_key=options.get("aws-lambda.secret-access-key"),
-        region_name=options.get("aws-lambda.region"),
+        region_name=options.get("aws-lambda.host-region"),
     )
 
     assumed_role_object = client.assume_role(
-        RoleSessionName="MySession", RoleArn=role_arn, ExternalId=aws_external_id
+        RoleSessionName="Sentry", RoleArn=role_arn, ExternalId=aws_external_id
     )
 
     credentials = assumed_role_object["Credentials"]
@@ -42,4 +42,4 @@ def gen_aws_lambda_client(arn, aws_external_id, session_name="MySession"):
         aws_secret_access_key=tmp_secret_key,
         aws_session_token=security_token,
     )
-    return boto3_session.client(service_name="lambda", region_name=region)
+    return boto3_session.client(service_name=service_name, region_name=region)

--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -23,8 +23,8 @@ from sentry.web.helpers import render_to_response
 from sentry.utils.compat import filter, map
 from sentry.utils import json
 
-from .client import gen_aws_lambda_client
-from .utils import parse_arn
+from .client import gen_aws_client
+from .utils import parse_arn, get_index_of_sentry_layer, get_aws_node_arn
 
 logger = logging.getLogger("sentry.integrations.aws_lambda")
 
@@ -76,20 +76,24 @@ class AwsLambdaIntegrationProvider(IntegrationProvider):
         ]
 
     def build_integration(self, state):
-        # TODO: unhardcode
-        integration_name = "Serverless Hack Bootstrap"
-
         arn = state["arn"]
+        aws_external_id = state["aws_external_id"]
+
         parsed_arn = parse_arn(arn)
         account_id = parsed_arn["account"]
         region = parsed_arn["region"]
+
+        org_client = gen_aws_client(arn, aws_external_id, service_name="organizations")
+        account = org_client.describe_account(AccountId=account_id)["Account"]
+
+        integration_name = u"{} {}".format(account["Name"], region)
 
         external_id = u"{}-{}".format(account_id, region)
 
         integration = {
             "name": integration_name,
             "external_id": external_id,
-            "metadata": {"arn": state["arn"], "aws_external_id": state["aws_external_id"]},
+            "metadata": {"arn": arn, "aws_external_id": aws_external_id},
         }
         return integration
 
@@ -102,7 +106,7 @@ class AwsLambdaProjectSelectPipelineView(PipelineView):
 
         organization = pipeline.organization
         # TODO: check status of project
-        projects = Project.objects.filter(organization=organization)
+        projects = Project.objects.filter(organization=organization).order_by("id")
         serialized_projects = map(lambda x: serialize(x, request.user), projects)
 
         return self.render_react_view(
@@ -144,17 +148,21 @@ class AwsLambdaCloudFormationPipelineView(PipelineView):
 
 class AwsLambdaListFunctionsPipelineView(PipelineView):
     def dispatch(self, request, pipeline):
-        if request.method == "POST":
-            # TODO: find better way to determine if the POST is from the previous step
-            if not request.POST.get("aws_external_id"):
-                data = json.loads(request.body)
-                pipeline.bind_state("enabled_lambdas", data)
-                return pipeline.next_step()
+        # the previous pipeline step will have be POST and will reach this line here
+        # we need to check our state to determine what to do
+        if request.method == "POST" and pipeline.fetch_state("ready_for_enabled_lambdas_post"):
+            # accept form data or json data
+            data = request.POST or json.loads(request.body)
+            pipeline.bind_state("enabled_lambdas", data)
+            return pipeline.next_step()
+
+        # bind the state now so we are ready to accept the enabled_lambdas in the post pdy
+        pipeline.bind_state("ready_for_enabled_lambdas_post", True)
 
         arn = pipeline.fetch_state("arn")
         aws_external_id = pipeline.fetch_state("aws_external_id")
 
-        lambda_client = gen_aws_lambda_client(arn, aws_external_id)
+        lambda_client = gen_aws_client(arn, aws_external_id)
 
         lambda_functions = filter(
             lambda x: x.get("Runtime") in SUPPORTED_RUNTIMES,
@@ -174,6 +182,10 @@ class AwsLambdaSetupLayerPipelineView(PipelineView):
         organization = pipeline.organization
 
         arn = pipeline.fetch_state("arn")
+        region = parse_arn(arn)["region"]
+        # the layer ARN has to be located within a specific region
+        node_layer_arn = get_aws_node_arn(region)
+
         project_id = pipeline.fetch_state("project_id")
         aws_external_id = pipeline.fetch_state("aws_external_id")
         enabled_lambdas = pipeline.fetch_state("enabled_lambdas")
@@ -188,7 +200,7 @@ class AwsLambdaSetupLayerPipelineView(PipelineView):
             raise IntegrationError("Project does not have DSN enabled")
         sentry_project_dsn = enabled_dsn.get_dsn(public=True)
 
-        lambda_client = gen_aws_lambda_client(arn, aws_external_id)
+        lambda_client = gen_aws_client(arn, aws_external_id)
 
         lambda_functions = filter(
             lambda x: x.get("Runtime") in SUPPORTED_RUNTIMES,
@@ -203,18 +215,27 @@ class AwsLambdaSetupLayerPipelineView(PipelineView):
             # check to see if the user wants to enable this function
             if not enabled_lambdas.get(name):
                 continue
-            # TODO: load existing layers and environment and append to them
             try:
+                # update the env variables
+                env_variables = function.get("Environment", {}).get("Variables", {})
+                env_variables.update(
+                    {
+                        "NODE_OPTIONS": "-r @sentry/serverless/dist/auto",
+                        "SENTRY_DSN": sentry_project_dsn,
+                        "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                    }
+                )
+
+                # find the sentry layer and update it or insert new layer to end
+                layers = function.get("Layers", [])
+                sentry_layer_index = get_index_of_sentry_layer(layers, node_layer_arn)
+                if sentry_layer_index > -1:
+                    layers[sentry_layer_index] = node_layer_arn
+                else:
+                    layers.append(node_layer_arn)
+
                 lambda_client.update_function_configuration(
-                    FunctionName=name,
-                    Layers=[options.get("aws-lambda.node-layer-arn")],
-                    Environment={
-                        "Variables": {
-                            "NODE_OPTIONS": "-r @sentry/serverless/dist/auto",
-                            "SENTRY_DSN": sentry_project_dsn,
-                            "SENTRY_TRACES_SAMPLE_RATE": "1.0",
-                        }
-                    },
+                    FunctionName=name, Layers=layers, Environment={"Variables": env_variables},
                 )
             except Exception as e:
                 failures.append(function)

--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from sentry import options
+
 
 # Taken from: https://gist.github.com/gene1wood/5299969edc4ef21d8efcfea52158dd40
 def parse_arn(arn):
@@ -19,3 +21,32 @@ def parse_arn(arn):
     elif ":" in result["resource"]:
         result["resource_type"], result["resource"] = result["resource"].split(":", 1)
     return result
+
+
+def get_aws_node_arn(region):
+    return u"arn:aws:lambda:{}:{}:layer:{}:{}".format(
+        region,
+        options.get("aws-lambda.host-account-id"),
+        options.get("aws-lambda.node-layer-name"),
+        options.get("aws-lambda.node-layer-version"),
+    )
+
+
+def get_arn_without_version(arn):
+    return arn.rpartition(":")[0]
+
+
+def get_index_of_sentry_layer(layers, arn_to_match):
+    """
+    Find the index of the Sentry layer in a list of layers.
+    If the version is different, we still consider that a match
+
+    :param layers: list of layer
+    :return: index of layer or -1 if no match
+    """
+    target_arn_without_version = get_arn_without_version(arn_to_match)
+    for i, layer in enumerate(layers):
+        local_arn_without_version = get_arn_without_version(layer["Arn"])
+        if local_arn_without_version == target_arn_without_version:
+            return i
+    return -1

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -171,8 +171,11 @@ register("msteams.app-id")
 register("aws-lambda.access-key-id", flags=FLAG_PRIORITIZE_DISK)
 register("aws-lambda.secret-access-key", flags=FLAG_PRIORITIZE_DISK)
 register("aws-lambda.cloudformation-url")
-register("aws-lambda.node-layer-arn")
-register("aws-lambda.region", default="us-east-2")
+register("aws-lambda.node-layer-name")
+register("aws-lambda.node-layer-version")
+# the region of the host account we use for assuming the role
+register("aws-lambda.host-account-id")
+register("aws-lambda.host-region", default="us-east-2")
 
 # Snuba
 register("snuba.search.pre-snuba-candidates-optimizer", type=Bool, default=False)

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -131,6 +131,8 @@ def pytest_configure(config):
             "vercel.client-secret": "vercel-client-secret",
             "msteams.client-id": "msteams-client-id",
             "msteams.client-secret": "msteams-client-secret",
+            "aws-lambda.access-key-id": "aws-key-id",
+            "aws-lambda.secret-access-key": "aws-secret-access-key",
             "aws-lambda.node-layer-name": "my-layer",
             "aws-lambda.node-layer-version": "3",
             "aws-lambda.host-account-id": "1234",

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -131,6 +131,9 @@ def pytest_configure(config):
             "vercel.client-secret": "vercel-client-secret",
             "msteams.client-id": "msteams-client-id",
             "msteams.client-secret": "msteams-client-secret",
+            "aws-lambda.node-layer-name": "my-layer",
+            "aws-lambda.node-layer-version": "3",
+            "aws-lambda.host-account-id": "1234",
         }
     )
 

--- a/tests/sentry/integrations/aws_lambda/__init__.py
+++ b/tests/sentry/integrations/aws_lambda/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import absolute_import

--- a/tests/sentry/integrations/aws_lambda/test_client.py
+++ b/tests/sentry/integrations/aws_lambda/test_client.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import
+
+import boto3
+
+from sentry.integrations.aws_lambda.client import gen_aws_client
+from sentry.testutils import TestCase
+from sentry.testutils.helpers.faux import Mock
+from sentry.utils.compat.mock import patch, MagicMock
+
+
+class ParseArnTest(TestCase):
+    @patch.object(boto3, "Session")
+    @patch.object(boto3, "client")
+    def test_simple(self, mock_get_client, mock_get_session):
+        arn = (
+            "arn:aws:cloudformation:us-west-1:599817902985:stack/"
+            "Sentry-Monitoring-Stack-Filter/e42083d0-3e3f-11eb-b66a-0ac9b5db7f30"
+        )
+
+        aws_external_id = "124-343"
+
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        credentials = {
+            "AccessKeyId": "my_access_key_id",
+            "SecretAccessKey": "my_secret_access_key",
+            "SessionToken": "my_session_token",
+        }
+        mock_client.assume_role = MagicMock(return_value={"Credentials": credentials})
+
+        mock_session = Mock()
+        mock_session.client = MagicMock(return_value="expected_output")
+
+        mock_get_session.return_value = mock_session
+
+        assert "expected_output" == gen_aws_client(arn, aws_external_id)
+
+        mock_get_client.assert_called_once_with(
+            service_name="sts",
+            aws_access_key_id="aws-key-id",
+            aws_secret_access_key="aws-secret-access-key",
+            region_name="us-east-2",
+        )
+
+        role_arn = "arn:aws:iam::599817902985:role/SentryRole"
+
+        mock_client.assume_role.assert_called_once_with(
+            RoleSessionName="Sentry", RoleArn=role_arn, ExternalId=aws_external_id
+        )
+
+        mock_get_session.assert_called_once_with(
+            aws_access_key_id=credentials["AccessKeyId"],
+            aws_secret_access_key=credentials["SecretAccessKey"],
+            aws_session_token=credentials["SessionToken"],
+        )
+
+        mock_session.client.assert_called_once_with(service_name="lambda", region_name="us-west-1")

--- a/tests/sentry/integrations/aws_lambda/test_client.py
+++ b/tests/sentry/integrations/aws_lambda/test_client.py
@@ -8,7 +8,7 @@ from sentry.testutils.helpers.faux import Mock
 from sentry.utils.compat.mock import patch, MagicMock
 
 
-class ParseArnTest(TestCase):
+class AwsLambdaClientTest(TestCase):
     @patch.object(boto3, "Session")
     @patch.object(boto3, "client")
     def test_simple(self, mock_get_client, mock_get_session):

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -23,11 +23,11 @@ arn = (
 )
 
 
-class AWsLambdaIntegrationTest(IntegrationTestCase):
+class AwsLambdaIntegrationTest(IntegrationTestCase):
     provider = AwsLambdaIntegrationProvider
 
     def setUp(self):
-        super(AWsLambdaIntegrationTest, self).setUp()
+        super(AwsLambdaIntegrationTest, self).setUp()
         self.projectA = self.create_project(organization=self.organization)
         self.projectB = self.create_project(organization=self.organization)
 

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -1,0 +1,134 @@
+from __future__ import absolute_import
+
+
+from django.http import HttpResponse
+
+from sentry.api.serializers import serialize
+from sentry.integrations.aws_lambda import AwsLambdaIntegrationProvider
+from sentry.models import (
+    Integration,
+    OrganizationIntegration,
+    ProjectKey,
+)
+from sentry.testutils import IntegrationTestCase
+from sentry.utils.compat import map
+from sentry.utils.compat.mock import patch, ANY, MagicMock
+from sentry.testutils.helpers.faux import Mock
+from sentry.pipeline import PipelineView
+
+
+arn = (
+    "arn:aws:cloudformation:us-east-2:599817902985:stack/"
+    "Sentry-Monitoring-Stack-Filter/e42083d0-3e3f-11eb-b66a-0ac9b5db7f30"
+)
+
+
+class AWsLambdaIntegrationTest(IntegrationTestCase):
+    provider = AwsLambdaIntegrationProvider
+
+    def setUp(self):
+        super(AWsLambdaIntegrationTest, self).setUp()
+        self.projectA = self.create_project(organization=self.organization)
+        self.projectB = self.create_project(organization=self.organization)
+
+    @patch.object(PipelineView, "render_react_view", return_value=HttpResponse())
+    def test_project_select(self, mock_react_view):
+        resp = self.client.get(self.setup_path)
+        assert resp.status_code == 200
+        serialized_projects = map(lambda x: serialize(x, self.user), [self.projectA, self.projectB])
+        mock_react_view.assert_called_with(
+            ANY, "awsLambdaProjectSelect", {"projects": serialized_projects}
+        )
+
+    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    @patch.object(PipelineView, "render_react_view", return_value=HttpResponse())
+    def test_lambda_list(self, mock_react_view, mock_gen_aws_client):
+        mock_client = Mock()
+        mock_client.list_functions = MagicMock(
+            return_value={
+                "Functions": [
+                    {"FunctionName": "lambdaA", "Runtime": "nodejs12.x"},
+                    {"FunctionName": "lambdaB", "Runtime": "nodejs10.x"},
+                    {"FunctionName": "lambdaC", "Runtime": "python3.6"},
+                ]
+            }
+        )
+        mock_gen_aws_client.return_value = mock_client
+        aws_external_id = "12-323"
+        self.pipeline.state.step_index = 2
+        self.pipeline.state.data = {
+            "arn": arn,
+            "aws_external_id": aws_external_id,
+            "project_id": self.projectA.id,
+        }
+        resp = self.client.get(self.setup_path)
+        assert resp.status_code == 200
+        mock_react_view.assert_called_with(
+            ANY,
+            "awsLambdaFunctionSelect",
+            {
+                "lambdaFunctions": [
+                    {"FunctionName": "lambdaA", "Runtime": "nodejs12.x"},
+                    {"FunctionName": "lambdaB", "Runtime": "nodejs10.x"},
+                ]
+            },
+        )
+
+    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    def test_lambda_setup_layer_success(self, mock_gen_aws_client):
+        mock_client = Mock()
+        mock_gen_aws_client.return_value = mock_client
+
+        mock_client.list_functions = MagicMock(
+            return_value={
+                "Functions": [
+                    {"FunctionName": "lambdaA", "Runtime": "nodejs12.x"},
+                    {"FunctionName": "lambdaB", "Runtime": "nodejs10.x"},
+                    {"FunctionName": "lambdaC", "Runtime": "python3.6"},
+                ]
+            }
+        )
+
+        mock_client.update_function_configuration = MagicMock()
+        mock_client.describe_account = MagicMock(return_value={"Account": {"Name": "my_name"}})
+
+        aws_external_id = "12-323"
+        self.pipeline.state.step_index = 2
+        self.pipeline.state.data = {
+            "arn": arn,
+            "aws_external_id": aws_external_id,
+            "project_id": self.projectA.id,
+            "ready_for_enabled_lambdas_post": True,
+        }
+
+        sentry_project_dsn = ProjectKey.get_default(project=self.projectA).get_dsn(public=True)
+
+        resp = self.client.post(
+            self.setup_path,
+            {"lambdaB": True},
+            format="json",
+            HTTP_ACCEPT="application/json",
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+
+        assert resp.status_code == 200
+
+        mock_client.update_function_configuration.assert_called_with(
+            FunctionName="lambdaB",
+            Layers=["arn:aws:lambda:us-east-2:1234:layer:my-layer:3"],
+            Environment={
+                "Variables": {
+                    "NODE_OPTIONS": "-r @sentry/serverless/dist/auto",
+                    "SENTRY_DSN": sentry_project_dsn,
+                    "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                }
+            },
+        )
+
+        integration = Integration.objects.get(provider=self.provider.key)
+        assert integration.name == "my_name us-east-2"
+        assert integration.external_id == "599817902985-us-east-2"
+        assert integration.metadata == {"arn": arn, "aws_external_id": aws_external_id}
+        assert OrganizationIntegration.objects.filter(
+            integration=integration, organization=self.organization
+        )

--- a/tests/sentry/integrations/aws_lambda/test_utils.py
+++ b/tests/sentry/integrations/aws_lambda/test_utils.py
@@ -1,0 +1,16 @@
+from __future__ import absolute_import
+
+from sentry.integrations.aws_lambda.utils import parse_arn
+
+from sentry.testutils import TestCase
+
+
+class ParseArnTest(TestCase):
+    def test_simple(self):
+        arn = (
+            "arn:aws:cloudformation:us-east-2:599817902985:stack/"
+            "Sentry-Monitoring-Stack-Filter/e42083d0-3e3f-11eb-b66a-0ac9b5db7f30"
+        )
+        parsed = parse_arn(arn)
+        assert parsed["account"] == "599817902985"
+        assert parsed["region"] == "us-east-2"


### PR DESCRIPTION
This PR does the following:
1. Uses the AWS org name + the region as the integration name
2. Updates and modify AWS env variables and layers for the Lambda instead of blowing them away each time we do an installation
3. Adds tests
4. Small miscellaneous changes to make things cleaner
![Screen Shot 2020-12-21 at 9 57 01 AM](https://user-images.githubusercontent.com/8533851/102807198-135b9080-4373-11eb-8eac-ab4665b0481f.png)
