### PR TITLE
Revert "fix(email): Sendgrid categories"

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -87,7 +87,7 @@ class EmailActionHandler(ActionHandler):
             html_template=u"sentry/emails/incidents/trigger.html",
             type="incident.alert_rule_{}".format(display.lower()),
             context=context,
-            headers={"X-SMTPAPI": {"category": "metric_alert_email"}},
+            headers={"category": "metric_alert_email"},
         )
 
 

--- a/src/sentry/mail/activity/base.py
+++ b/src/sentry/mail/activity/base.py
@@ -133,10 +133,7 @@ class ActivityEmail(object):
         project = self.project
         group = self.group
 
-        headers = {
-            "X-Sentry-Project": project.slug,
-            "X-SMTPAPI": {"category": self.get_category()},
-        }
+        headers = {"X-Sentry-Project": project.slug}
 
         if group:
             headers.update(
@@ -144,6 +141,7 @@ class ActivityEmail(object):
                     "X-Sentry-Logger": group.logger,
                     "X-Sentry-Logger-Level": group.get_level_display(),
                     "X-Sentry-Reply-To": group_id_to_email(group.id),
+                    "category": self.get_category(),
                 }
             )
 

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -444,7 +444,7 @@ class MailAdapter(object):
 
             headers = {
                 "X-Sentry-Project": project.slug,
-                "X-SMTPAPI": {"category": "digest_email"},
+                "category": "digest_email",
             }
 
             group = six.next(iter(counts))
@@ -520,7 +520,7 @@ class MailAdapter(object):
 
         headers = {
             "X-Sentry-Project": project.slug,
-            "X-SMTPAPI": {"category": "user_report_email"},
+            "category": "user_report_email",
         }
 
         # TODO(dcramer): this is copypasta'd from activity notifications

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -545,7 +545,7 @@ def build_message(timestamp, duration, organization, user, reports):
             "report": to_context(organization, interval, reports),
             "user": user,
         },
-        headers={"X-SMTPAPI": {"category": "organization_report_email"}},
+        headers={"category": "organization_report_email"},
     )
 
     message.add_users((user.id,))


### PR DESCRIPTION
Reverts getsentry/sentry#22677

some emails are getting dropped now due to invalid headers :(

I need to have another look at this, I think the way the headers are getting serialized is not valid with the SMTP-API