### PR TITLE
feat(ui): Support `<DropdownLink>` for `<ButtonBar>`

### DIFF
--- a/docs-ui/components/button.stories.js
+++ b/docs-ui/components/button.stories.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import {withInfo} from '@storybook/addon-info';
 import {action} from '@storybook/addon-actions';
+import {withInfo} from '@storybook/addon-info';
 import {boolean, number} from '@storybook/addon-knobs';
 
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
-import NavigationButtonGroup from 'app/components/navigationButtonGroup';
 import DropdownButton from 'app/components/dropdownButton';
+import DropdownLink from 'app/components/dropdownLink';
+import NavigationButtonGroup from 'app/components/navigationButtonGroup';
 import {IconDelete} from 'app/icons/iconDelete';
 
 const Item = styled('span')`
@@ -188,6 +189,25 @@ export const _ButtonBar = withInfo('Buttons in a Bar container')(() => (
         <Button barId="4">Fourth Button</Button>
       </ButtonBar>
     </div>
+
+    <div className="section">
+      <h3>Works with DropdownLink</h3>
+      <StartButtonBar merged>
+        <DropdownLink customTitle={<Button>First DropdownLink</Button>} />
+        <DropdownLink customTitle={<Button>Second DropdownLink</Button>} />
+        <DropdownLink customTitle={<Button>Third DropdownLink</Button>} />
+      </StartButtonBar>
+      <StartButtonBar merged>
+        <Button>First Button</Button>
+        <DropdownLink customTitle={<Button>Second DropdownLink</Button>} />
+        <Button>Third Button</Button>
+      </StartButtonBar>
+      <StartButtonBar merged>
+        <DropdownLink customTitle={<Button>First DropdownLink</Button>} />
+        <Button>Second Button</Button>
+        <DropdownLink customTitle={<Button>Third DropdownLink</Button>} />
+      </StartButtonBar>
+    </div>
   </div>
 ));
 
@@ -207,3 +227,8 @@ export const _NavigationButtonGroup = withInfo('Navigation Buttons Group')(() =>
 _NavigationButtonGroup.story = {
   name: 'NavigationButtonGroup',
 };
+
+const StartButtonBar = styled(ButtonBar)`
+  justify-content: flex-start;
+  margin-bottom: 6px;
+`;

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -369,3 +369,8 @@ const Icon = styled('span')<IconProps & Omit<StyledButtonProps, 'theme'>>`
   margin-right: ${getIconMargin};
   height: ${getFontSize};
 `;
+
+/**
+ * Also export these styled components so we can use them as selectors
+ */
+export {StyledButton, ButtonLabel, Icon};

--- a/src/sentry/static/sentry/app/components/buttonBar.tsx
+++ b/src/sentry/static/sentry/app/components/buttonBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 
-import Button from 'app/components/button';
+import Button, {StyledButton} from 'app/components/button';
 import space, {ValidSize} from 'app/styles/space';
 
 type ButtonBarProps = {
@@ -59,46 +59,66 @@ const ButtonGrid = styled('div')<{gap: ValidSize; merged: boolean}>`
   ${p =>
     p.merged &&
     `
-    & > button,
-    & > a {
-      position: relative;
-    }
-
     /* Raised buttons show borders on both sides. Useful to create pill bars */
     & > .active {
       z-index: 2;
     }
 
-    /* First button is square on the right side */
-    & > button:first-child:not(:last-child),
-    & > a:first-child:not(:last-child) {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-    /* Middle buttons are square */
-    & > button:not(:last-child):not(:first-child),
-    & > a:not(:last-child):not(:first-child) {
-      border-radius: 0;
-    }
+    & > .dropdown,
+    & > button,
+    & > a {
+      position: relative;
 
-    /* Middle buttons only need one border so we don't get a double line */
-    & > a:first-child + a:not(:last-child),
-    & > button:first-child + button:not(:last-child) {
-      margin-left: -1px;
-    }
+      /* First button is square on the right side */
+      &:first-child:not(:last-child) {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
 
-    /* Middle buttons only need one border so we don't get a double line */
-    & > button:not(:last-child):not(:first-child) + button,
-    & > a:not(:last-child):not(:first-child) + a {
-      margin-left: -1px;
-    }
+        & > .dropdown-actor > ${StyledButton} {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
+      }
 
-    /* Last button is square on the left side */
-    & > button:last-child:not(:first-child),
-    & > a:last-child:not(:first-child) {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-      margin-left: -1px;
+      /* Middle buttons are square */
+      &:not(:last-child):not(:first-child) {
+        border-radius: 0;
+
+        & > .dropdown-actor > ${StyledButton} {
+          border-radius: 0;
+        }
+      }
+
+      /* Middle buttons only need one border so we don't get a double line */
+      &:first-child {
+        & + .dropdown:not(:last-child),
+        & + a:not(:last-child),
+        & + button:not(:last-child) {
+          margin-left: -1px;
+        }
+      }
+
+      /* Middle buttons only need one border so we don't get a double line */
+      &:not(:last-child):not(:first-child) {
+        & + .dropdown,
+        & + button,
+        & + a {
+          margin-left: -1px;
+        }
+      }
+
+      /* Last button is square on the left side */
+      &:last-child:not(:first-child) {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        margin-left: -1px;
+
+        & > .dropdown-actor > ${StyledButton} {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+          margin-left: -1px;
+        }
+      }
     }
   `}
 `;


### PR DESCRIPTION
This adds support for `<DropdownLink>` in `<ButtonBar>`, as well as mixing and matching of `<DropdownLink>` with `<Button>` and `<a>` as well.

![image](https://user-images.githubusercontent.com/79684/102810255-3d638180-4378-11eb-8322-9ad71d746fcb.png)
