### PR TITLE
fix(ui): moved issue reason to far left side

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
@@ -46,6 +46,7 @@ function EventOrGroupExtraDetails({data, showAssignee, params, organization}: Pr
 
   return (
     <GroupExtra hasInbox={hasInbox}>
+      {hasInbox && inbox && <InboxReason inbox={inbox} />}
       {shortId &&
         (hasInbox ? (
           <InboxShortId
@@ -68,7 +69,6 @@ function EventOrGroupExtraDetails({data, showAssignee, params, organization}: Pr
             }}
           />
         ))}
-      {hasInbox && inbox && <InboxReason inbox={inbox} />}
       {isUnhandled && hasInbox && <UnhandledTag organization={organization} />}
       {!lifetime && !firstSeen && !lastSeen ? (
         <Placeholder height="14px" width="100px" />


### PR DESCRIPTION
## Problem
The inbox tags are distracting in the position they are today so moving them to the left makes this entire table easier to scan.

## Before

![Screen Shot 2020-12-21 at 11 13 04 AM](https://user-images.githubusercontent.com/1900676/102813362-866a0480-437d-11eb-840c-851e79775548.png)


## After
![Screen Shot 2020-12-21 at 11 13 28 AM](https://user-images.githubusercontent.com/1900676/102813399-984ba780-437d-11eb-85b9-757dd2428e70.png)
