### PR TITLE
feat(ui): Fix "banner summary" on Issue Details for dark mode

### DIFF
--- a/src/sentry/static/sentry/app/components/events/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/styles.tsx
@@ -14,10 +14,9 @@ export const DataSection = styled('div')`
 
 type BannerProps = {
   priority: 'default' | 'danger' | 'success';
-  theme: Theme;
 };
 
-function getColors({priority, theme}: BannerProps) {
+function getColors({priority, theme}: BannerProps & {theme: Theme}) {
   const COLORS = {
     default: {
       background: theme.backgroundSecondary,

--- a/src/sentry/static/sentry/app/components/events/styles.tsx
+++ b/src/sentry/static/sentry/app/components/events/styles.tsx
@@ -1,22 +1,7 @@
 import styled from '@emotion/styled';
 
 import space from 'app/styles/space';
-import theme from 'app/utils/theme';
-
-const COLORS = {
-  default: {
-    background: theme.backgroundSecondary,
-    border: theme.border,
-  },
-  danger: {
-    background: theme.alert.error.backgroundLight,
-    border: theme.alert.error.border,
-  },
-  success: {
-    background: theme.alert.success.backgroundLight,
-    border: theme.alert.success.border,
-  },
-} as const;
+import {Theme} from 'app/utils/theme';
 
 export const DataSection = styled('div')`
   padding: ${space(2)} 0;
@@ -29,14 +14,34 @@ export const DataSection = styled('div')`
 
 type BannerProps = {
   priority: 'default' | 'danger' | 'success';
+  theme: Theme;
 };
+
+function getColors({priority, theme}: BannerProps) {
+  const COLORS = {
+    default: {
+      background: theme.backgroundSecondary,
+      border: theme.border,
+    },
+    danger: {
+      background: theme.alert.error.backgroundLight,
+      border: theme.alert.error.border,
+    },
+    success: {
+      background: theme.alert.success.backgroundLight,
+      border: theme.alert.success.border,
+    },
+  } as const;
+
+  return COLORS[priority];
+}
 
 export const BannerContainer = styled('div')<BannerProps>`
   font-size: ${p => p.theme.fontSizeMedium};
 
-  background: ${p => COLORS[p.priority].background};
-  border-top: 1px solid ${p => COLORS[p.priority].border};
-  border-bottom: 1px solid ${p => COLORS[p.priority].border};
+  background: ${p => getColors(p).background};
+  border-top: 1px solid ${p => getColors(p).border};
+  border-bottom: 1px solid ${p => getColors(p).border};
 
   /* Muted box & processing errors are in different parts of the DOM */
   &


### PR DESCRIPTION
This updates `<BannerContainer>` to use theme from props instead of import
in order to make this work for dark mode

![image](https://user-images.githubusercontent.com/79684/102823494-db167b00-438f-11eb-89a4-7b73f82dabda.png)
