### PR TITLE
feat(ui): Fix `<Pill>` for dark mode

### DIFF
--- a/src/sentry/static/sentry/app/components/pill.tsx
+++ b/src/sentry/static/sentry/app/components/pill.tsx
@@ -61,6 +61,7 @@ const getPillStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
   switch (type) {
     case 'error':
       return `
+        color: ${theme.black};
         background: ${theme.red100};
         background: ${theme.red100};
         border: 1px solid ${theme.red300};
@@ -76,6 +77,7 @@ const getPillValueStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
   switch (type) {
     case 'positive':
       return `
+        color: ${theme.black};
         background: ${theme.green100};
         border: 1px solid ${theme.green300};
         border-left-color: ${theme.green300};
@@ -84,6 +86,7 @@ const getPillValueStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
       `;
     case 'error':
       return `
+        color: ${theme.black};
         border-left-color: ${theme.red300};
         background: ${theme.red100};
         border: 1px solid ${theme.red300};
@@ -91,6 +94,7 @@ const getPillValueStyle = ({type, theme}: {type?: PillType; theme: Theme}) => {
       `;
     case 'negative':
       return `
+        color: ${theme.black};
         border-left-color: ${theme.red300};
         background: ${theme.red100};
         border: 1px solid ${theme.red300};


### PR DESCRIPTION
This component has different states where we always use a light background, so we need to make sure text color stays dark.