### PR TITLE
fix(integrations): MultiSelect Defaults

### DIFF
--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -215,13 +215,11 @@ export default class AbstractExternalIssueForm<
   }
 
   renderForm = (formFields?: IssueConfigField[]) => {
-    const initialData = (formFields || []).reduce(
-      (accumulator: {[key: string]: any}, field: FormField) => {
-        // passing an empty array breaks multi select
-        // TODO(jess): figure out why this is breaking and fix
-        if (!accumulator.hasOwnProperty(field.name)) {
-          accumulator[field.name] = field.multiple ? '' : field.default;
-        }
+    const initialData: {[key: string]: any} = (formFields || []).reduce(
+      (accumulator, field: FormField) => {
+        accumulator[field.name] =
+          // Passing an empty array breaks MultiSelect.
+          field.multiple && field.default === [] ? '' : field.default;
         return accumulator;
       },
       {}

--- a/src/sentry/static/sentry/app/views/discover/conditions/condition.tsx
+++ b/src/sentry/static/sentry/app/views/discover/conditions/condition.tsx
@@ -210,34 +210,33 @@ export default class ConditionRow extends React.Component<
   };
 
   render() {
-    const {disabled, value} = this.props;
     return (
       <Box>
         <SelectControl
-          autoBlur
-          backspaceRemoves={false}
-          clearable={false}
-          closeOnSelect
-          creatable
-          deleteRemoves={false}
           deprecatedSelectControl
-          disabled={disabled}
-          filterOptions={this.filterOptions}
-          inputRenderer={this.inputRenderer}
-          isValidNewOption={this.isValidNewOption}
-          newOptionCreator={this.newOptionCreator}
-          onBlur={this.handleBlur}
-          onChange={this.handleChange}
-          onInputChange={this.handleInputChange}
-          onOpen={this.handleOpen}
-          openOnFocus
-          options={this.getOptions()}
-          placeholder={<PlaceholderText>{t('Add condition...')}</PlaceholderText>}
-          promptTextCreator={(text: string) => text}
           ref={this.selectRef}
-          shouldKeyDownEventCreateNewOption={this.shouldKeyDownEventCreateNewOption}
-          value={getInternal(value)}
+          value={getInternal(this.props.value)}
+          placeholder={<PlaceholderText>{t('Add condition...')}</PlaceholderText>}
+          options={this.getOptions()}
+          filterOptions={this.filterOptions}
+          onChange={this.handleChange}
+          onOpen={this.handleOpen}
+          closeOnSelect
+          openOnFocus
+          autoBlur
+          clearable={false}
+          backspaceRemoves={false}
+          deleteRemoves={false}
+          isValidNewOption={this.isValidNewOption}
+          inputRenderer={this.inputRenderer}
           valueComponent={this.valueComponent}
+          onInputChange={this.handleInputChange}
+          onBlur={this.handleBlur}
+          creatable
+          promptTextCreator={(text: string) => text}
+          shouldKeyDownEventCreateNewOption={this.shouldKeyDownEventCreateNewOption}
+          disabled={this.props.disabled}
+          newOptionCreator={this.newOptionCreator}
         />
       </Box>
     );

--- a/src/sentry/static/sentry/app/views/discover/conditions/condition.tsx
+++ b/src/sentry/static/sentry/app/views/discover/conditions/condition.tsx
@@ -210,33 +210,34 @@ export default class ConditionRow extends React.Component<
   };
 
   render() {
+    const {disabled, value} = this.props;
     return (
       <Box>
         <SelectControl
-          deprecatedSelectControl
-          ref={this.selectRef}
-          value={getInternal(this.props.value)}
-          placeholder={<PlaceholderText>{t('Add condition...')}</PlaceholderText>}
-          options={this.getOptions()}
-          filterOptions={this.filterOptions}
-          onChange={this.handleChange}
-          onOpen={this.handleOpen}
-          closeOnSelect
-          openOnFocus
           autoBlur
-          clearable={false}
           backspaceRemoves={false}
-          deleteRemoves={false}
-          isValidNewOption={this.isValidNewOption}
-          inputRenderer={this.inputRenderer}
-          valueComponent={this.valueComponent}
-          onInputChange={this.handleInputChange}
-          onBlur={this.handleBlur}
+          clearable={false}
+          closeOnSelect
           creatable
-          promptTextCreator={(text: string) => text}
-          shouldKeyDownEventCreateNewOption={this.shouldKeyDownEventCreateNewOption}
-          disabled={this.props.disabled}
+          deleteRemoves={false}
+          deprecatedSelectControl
+          disabled={disabled}
+          filterOptions={this.filterOptions}
+          inputRenderer={this.inputRenderer}
+          isValidNewOption={this.isValidNewOption}
           newOptionCreator={this.newOptionCreator}
+          onBlur={this.handleBlur}
+          onChange={this.handleChange}
+          onInputChange={this.handleInputChange}
+          onOpen={this.handleOpen}
+          openOnFocus
+          options={this.getOptions()}
+          placeholder={<PlaceholderText>{t('Add condition...')}</PlaceholderText>}
+          promptTextCreator={(text: string) => text}
+          ref={this.selectRef}
+          shouldKeyDownEventCreateNewOption={this.shouldKeyDownEventCreateNewOption}
+          value={getInternal(value)}
+          valueComponent={this.valueComponent}
         />
       </Box>
     );

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -192,11 +192,12 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
   };
 
   renderBodyText = () => {
+    // `ticketType` already includes indefinite article.
     const {ticketType, link} = this.props;
     return (
       <BodyText>
         {tct(
-          'When this alert is triggered a [ticketType] will be ' +
+          'When this alert is triggered [ticketType] will be ' +
             'created with the following fields. It will also [linkToDocs] ' +
             'with the new Sentry Issue.',
           {


### PR DESCRIPTION
MultiSelects in the TicketRulesModal aren't rendering the Rule's values. We pass these as `default` which is an array of values. This PR fixes a bug where arrays are being set to `''`.

Before: 
![Screen Shot 2020-12-21 at 3 53 04 PM](https://user-images.githubusercontent.com/31750075/102832960-a103a400-43a4-11eb-9f29-3f6ab3d46174.png)

After:
![Screen Shot 2020-12-21 at 3 52 57 PM](https://user-images.githubusercontent.com/31750075/102832952-9f39e080-43a4-11eb-8b5f-99b9282ff1e9.png)
