### PR TITLE
chore(inbox): Clarify that needs-review is a subset of unresolved

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -35,7 +35,7 @@ type Props = {
 
 const queries = [
   [Query.NEEDS_REVIEW, t('Needs Review')],
-  [Query.UNRESOLVED, t('Unresolved')],
+  [Query.UNRESOLVED, t('All Unresolved')],
   [Query.IGNORED, t('Ignored')],
   [Query.REPROCESSING, t('Reprocessing')],
 ];

--- a/src/sentry/static/sentry/app/views/issueList/utils.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/utils.tsx
@@ -1,5 +1,5 @@
 export enum Query {
-  NEEDS_REVIEW = 'is:needs_review is:unresolved',
+  NEEDS_REVIEW = 'is:unresolved is:needs_review',
   UNRESOLVED = 'is:unresolved',
   IGNORED = 'is:ignored',
   REPROCESSING = 'is:reprocessing',

--- a/tests/js/spec/components/streamGroup.spec.jsx
+++ b/tests/js/spec/components/streamGroup.spec.jsx
@@ -66,7 +66,7 @@ describe('StreamGroup', function () {
         groupId="groupId"
         lastSeen="2017-07-25T22:56:12Z"
         firstSeen="2017-07-01T02:06:02Z"
-        query="is:needs_review is:unresolved"
+        query="is:unresolved is:needs_review"
         organization={organization}
         {...routerContext}
       />,

--- a/tests/js/spec/views/issueList/header.spec.jsx
+++ b/tests/js/spec/views/issueList/header.spec.jsx
@@ -5,12 +5,12 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import IssueListHeader from 'app/views/issueList/header';
 
 const queryCounts = {
-  'is:needs_review is:unresolved': 1,
+  'is:unresolved is:needs_review': 1,
   'is:unresolved': 1,
 };
 
 const queryCountsMaxed = {
-  'is:needs_review is:unresolved': 1000,
+  'is:unresolved is:needs_review': 1000,
   'is:unresolved': 1000,
 };
 
@@ -18,7 +18,7 @@ describe('IssueListHeader', () => {
   it('renders active tab with count when query matches inbox', () => {
     const wrapper = mountWithTheme(
       <IssueListHeader
-        query="is:needs_review is:unresolved"
+        query="is:unresolved is:needs_review"
         queryCounts={queryCounts}
         projectIds={[]}
       />
@@ -38,7 +38,7 @@ describe('IssueListHeader', () => {
       <IssueListHeader query="" queryCounts={queryCounts} projectIds={[]} />
     );
     expect(wrapper.find('li').at(0).text()).toBe('Needs Review 1');
-    expect(wrapper.find('li').at(1).text()).toBe('Unresolved 1');
+    expect(wrapper.find('li').at(1).text()).toBe('All Unresolved 1');
     expect(wrapper.find('li').at(2).text()).toBe('Ignored ');
   });
 
@@ -47,7 +47,7 @@ describe('IssueListHeader', () => {
       <IssueListHeader query="" queryCounts={queryCountsMaxed} projectIds={[]} />
     );
     expect(wrapper.find('li').at(0).text()).toBe('Needs Review 99+');
-    expect(wrapper.find('li').at(1).text()).toBe('Unresolved 99+');
+    expect(wrapper.find('li').at(1).text()).toBe('All Unresolved 99+');
     expect(wrapper.find('li').at(2).text()).toBe('Ignored ');
   });
 
@@ -61,6 +61,6 @@ describe('IssueListHeader', () => {
       />
     );
     wrapper.find('a').at(0).simulate('click');
-    expect(handleTabChange).toHaveBeenCalledWith('is:needs_review is:unresolved');
+    expect(handleTabChange).toHaveBeenCalledWith('is:unresolved is:needs_review');
   });
 });

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -686,7 +686,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
             self.login_as(user=self.user)
             response = self.get_response(
-                sort_by="date", limit=10, query="is:needs_review is:unresolved", expand=["inbox"]
+                sort_by="date", limit=10, query="is:unresolved is:needs_review", expand=["inbox"]
             )
             assert response.status_code == 200
             assert len(response.data) == 1


### PR DESCRIPTION
- Change the "Unresolved" default tab to "All Unresolved". This should also give a small hint to think of these as searches, not issue states
- Swap the order of search terms in Needs Review to `is:unresolved is:needs_review`