### PR TITLE
feat(discover): Don't order when only aggregates are present

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -2701,7 +2701,7 @@ def resolve_field_list(
         raise InvalidSearchQuery("You cannot use rollup without an aggregate field.")
 
     orderby = snuba_filter.orderby
-    # Only sort if there's columns, when there's only aggregates there's no need to sort
+    # Only sort if there are columns. When there are only aggregates there's no need to sort
     if orderby and len(columns) > 0:
         orderby = resolve_orderby(orderby, columns, aggregations)
     else:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -2701,8 +2701,11 @@ def resolve_field_list(
         raise InvalidSearchQuery("You cannot use rollup without an aggregate field.")
 
     orderby = snuba_filter.orderby
-    if orderby:
+    # Only sort if there's columns, when there's only aggregates there's no need to sort
+    if orderby and len(columns) > 0:
         orderby = resolve_orderby(orderby, columns, aggregations)
+    else:
+        orderby = []
 
     # If aggregations are present all columns
     # need to be added to the group by so that the query is valid.

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -2705,7 +2705,7 @@ def resolve_field_list(
     if orderby and len(columns) > 0:
         orderby = resolve_orderby(orderby, columns, aggregations)
     else:
-        orderby = []
+        orderby = None
 
     # If aggregations are present all columns
     # need to be added to the group by so that the query is valid.

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2854,7 +2854,7 @@ class ResolveFieldListTest(unittest.TestCase):
         """ When there's only aggregates don't sort """
         fields = ["count(id)", "count_unique(user)"]
         result = resolve_field_list(fields, eventstore.Filter(orderby="-count(id)"))
-        assert result["orderby"] == []
+        assert result["orderby"] is None
         assert result["aggregations"] == [
             ["count", None, "count_id"],
             ["uniq", "user", "count_unique_user"],

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2851,14 +2851,25 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["groupby"] == []
 
     def test_orderby_field_aggregate(self):
+        """ When there's only aggregates don't sort """
         fields = ["count(id)", "count_unique(user)"]
+        result = resolve_field_list(fields, eventstore.Filter(orderby="-count(id)"))
+        assert result["orderby"] == []
+        assert result["aggregations"] == [
+            ["count", None, "count_id"],
+            ["uniq", "user", "count_unique_user"],
+        ]
+        assert result["groupby"] == []
+
+    def test_orderby_field_aggregate_only(self):
+        fields = ["transaction.name", "count(id)", "count_unique(user)"]
         result = resolve_field_list(fields, eventstore.Filter(orderby="-count(id)"))
         assert result["orderby"] == ["-count_id"]
         assert result["aggregations"] == [
             ["count", None, "count_id"],
             ["uniq", "user", "count_unique_user"],
         ]
-        assert result["groupby"] == []
+        assert result["groupby"] == ["transaction.name"]
 
     def test_orderby_issue_alias(self):
         fields = ["issue"]


### PR DESCRIPTION
- This means that when there's only aggregates we don't add an orderby
  when its not useful