### PR TITLE
fix(slack): fixes bug for duplicate display name

### DIFF
--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -83,14 +83,14 @@ class SlackNotifyServiceForm(forms.Form):
                 channel_prefix, channel_id, timed_out = self.channel_transformer(
                     integration, channel
                 )
-            except DuplicateDisplayNameError as e:
+            except DuplicateDisplayNameError:
                 domain = integration.metadata["domain_name"]
 
-                params = {"channel": e.message, "domain": domain}
+                params = {"channel": channel, "domain": domain}
 
                 raise forms.ValidationError(
                     _(
-                        'Multiple users were found with display name "%(channel)s". Please use your username, found at %(domain)s/account/settings.',
+                        'Multiple users were found with display name "%(channel)s". Please use your username, found at %(domain)s/account/settings#username.',
                     ),
                     code="invalid",
                     params=params,

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -374,15 +374,15 @@ def strip_channel_name(name):
 
 def get_channel_id(organization, integration, name, use_async_lookup=False):
     """
-   Fetches the internal slack id of a channel.
-   :param organization: The organization that is using this integration
-   :param integration: The slack integration
-   :param name: The name of the channel
-   :return: a tuple of three values
-       1. prefix: string (`"#"` or `"@"`)
-       2. channel_id: string or `None`
-       3. timed_out: boolean (whether we hit our self-imposed time limit)
-   """
+    Fetches the internal slack id of a channel.
+    :param organization: The organization that is using this integration
+    :param integration: The slack integration
+    :param name: The name of the channel
+    :return: a tuple of three values
+        1. prefix: string (`"#"` or `"@"`)
+        2. channel_id: string or `None`
+        3. timed_out: boolean (whether we hit our self-imposed time limit)
+    """
 
     name = strip_channel_name(name)
 


### PR DESCRIPTION
Fixes: SENTRY-JVS

Basically, there is no `message` property on the `DuplicateDisplayNameError` error but we should have been reading from the channel anyways.