### PR TITLE
fix(integrations): Ticket Rules edit form fields

### DIFF
--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -42,7 +42,7 @@ export type IssueAlertRuleAction = Omit<
   'formFields' | 'enabled'
 > & {
   // These are the same values as the keys in `formFields` for a template
-  [key: string]: number | string;
+  [key: string]: number | string | string[];
 };
 
 export type IssueAlertRuleCondition = Omit<

--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -1,3 +1,5 @@
+import {IssueConfigField} from 'app/types/index';
+
 export type IssueAlertRuleFormField =
   | {
       type: 'choice';
@@ -41,14 +43,18 @@ export type IssueAlertRuleAction = Omit<
   IssueAlertRuleActionTemplate,
   'formFields' | 'enabled'
 > & {
+  dynamic_form_fields?: IssueConfigField[];
+} & {
   // These are the same values as the keys in `formFields` for a template
-  [key: string]: number | string | string[];
+  [key: string]: number | string;
 };
 
 export type IssueAlertRuleCondition = Omit<
   IssueAlertRuleConditionTemplate,
   'formFields' | 'enabled'
 > & {
+  dynamic_form_fields?: IssueConfigField[];
+} & {
   // These are the same values as the keys in `formFields` for a template
   [key: string]: number | string;
 };

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1653,6 +1653,8 @@ export type SelectValue<T> = {
   tooltip?: string;
 };
 
+export type IssueConfigFieldChoices = [number | string, number | string][];
+
 /**
  * The issue config form fields we get are basically the form fields we use in
  * the UI but with some extra information. Some fields marked optional in the
@@ -1661,7 +1663,7 @@ export type SelectValue<T> = {
 export type IssueConfigField = Field & {
   name: string;
   default?: string | number;
-  choices?: [number | string, number | string][];
+  choices?: IssueConfigFieldChoices;
   url?: string;
   multiple?: boolean;
 };

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ruleNode.tsx
@@ -9,7 +9,7 @@ import ExternalLink from 'app/components/links/externalLink';
 import {IconDelete, IconSettings} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
-import {Organization, Project} from 'app/types';
+import {IssueConfigFieldChoices, Organization, Project} from 'app/types';
 import {
   AssigneeTargetType,
   IssueAlertRuleAction,
@@ -287,7 +287,7 @@ class RuleNode extends React.Component<Props> {
    */
   updateParent = (
     formData: {[key: string]: string},
-    fetchedFieldOptionsCache: {[key: string]: [string, string][]}
+    fetchedFieldOptionsCache: {[key: string]: IssueConfigFieldChoices}
   ): void => {
     const {data, index, onPropertyChange} = this.props;
     for (const [name, value] of Object.entries(formData)) {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -9,7 +9,7 @@ import AbstractExternalIssueForm from 'app/components/externalIssues/abstractExt
 import ExternalLink from 'app/components/links/externalLink';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
-import {IssueConfigField, Organization} from 'app/types';
+import {IssueConfigField, IssueConfigFieldChoices, Organization} from 'app/types';
 import {IssueAlertRuleAction} from 'app/types/alerts';
 import AsyncView from 'app/views/asyncView';
 import Form from 'app/views/settings/components/forms/form';
@@ -23,7 +23,7 @@ type Props = ModalRenderProps & {
   link?: string;
   onSubmitAction: (
     data: {[key: string]: string},
-    fetchedFieldOptionsCache: {[key: string]: [string, string][]}
+    fetchedFieldOptionsCache: {[key: string]: IssueConfigFieldChoices}
   ) => void;
   organization: Organization;
   ticketType?: string;
@@ -31,7 +31,7 @@ type Props = ModalRenderProps & {
 
 type State = {
   issueConfigFieldsCache: IssueConfigField[];
-  fetchedFieldOptionsCache: {[key: string]: [string, string][]};
+  fetchedFieldOptionsCache: {[key: string]: IssueConfigFieldChoices};
 } & AbstractExternalIssueForm['state'];
 
 class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
@@ -41,7 +41,10 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
     return {
       ...super.getDefaultState(),
       fetchedFieldOptionsCache: Object.fromEntries(
-        issueConfigFieldsCache.map(field => [field.name, field.choices])
+        issueConfigFieldsCache.map(field => [
+          field.name,
+          field.choices as IssueConfigFieldChoices,
+        ])
       ),
       issueConfigFieldsCache,
     };
@@ -49,7 +52,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {instance, organization} = this.props;
-    const query = ((instance.dynamic_form_fields as {[key: string]: any}) || [])
+    const query = (instance.dynamic_form_fields || [])
       .filter(field => field.updatesForm)
       .filter(field => instance.hasOwnProperty(field.name))
       .reduce(

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -49,10 +49,21 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {instance, organization} = this.props;
+    const query = ((instance.dynamic_form_fields as {[key: string]: any}) || [])
+      .filter(field => field.updatesForm)
+      .filter(field => instance.hasOwnProperty(field.name))
+      .reduce(
+        (accumulator, {name}) => {
+          accumulator[name] = instance[name];
+          return accumulator;
+        },
+        {action: 'create'}
+      );
     return [
       [
         'integrationDetails',
-        `/organizations/${organization.slug}/integrations/${instance.integration}/?action=create`,
+        `/organizations/${organization.slug}/integrations/${instance.integration}/`,
+        {query},
       ],
     ];
   }


### PR DESCRIPTION
When a user first loads the `TicketRuleModal` to edit their Ticket Rule action, some of the text fields weren't showing up because we were grabbing configs for the wrong `project` and `issuetype`.
In this PR we include the saved rule data in the first API call to get `createIssueConfig`.
