### PR TITLE
ref(search): Show release:latest first

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -602,7 +602,7 @@ class SmartSearchBar extends React.Component<Props, State> {
         return [];
       }
       if (tag.key === 'release' && !values.includes('latest')) {
-        values.push('latest');
+        values.unshift('latest');
       }
 
       const noValueQuery = values.length === 0 && query.length > 0 ? query : undefined;


### PR DESCRIPTION
Seems like customers do not know that we support `release:latest` in the search bar due to only showing a handful of tag values. This PR just changes `latest` to be the first value suggested to the user similar to `firstRelease` in order to help with discoverability here.

![image](https://user-images.githubusercontent.com/9372512/102934102-84816d80-4471-11eb-987e-54c4565e719d.png)
