### PR TITLE
fix(workflow): Update inbox tab counts on selection and show on all tabs (WOR-528)

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -15,10 +15,7 @@ import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import withProjects from 'app/utils/withProjects';
 
-import {Query, QueryCounts} from './utils';
-
-// the tab counts will look like 99+
-const TAB_MAX_COUNT = 99;
+import {Query, QueryCounts, TAB_MAX_COUNT} from './utils';
 
 type Props = {
   query: string;
@@ -123,15 +120,16 @@ function IssueListHeader({
             <li key={tabQuery} className={query === tabQuery ? 'active' : ''}>
               <a onClick={() => onTabChange(tabQuery)}>
                 {queryName}{' '}
-                <StyledQueryCount
-                  count={queryCounts[tabQuery]}
-                  max={TAB_MAX_COUNT}
+                {queryCounts[tabQuery] && <StyledQueryCount
+                  count={queryCounts[tabQuery].count}
+                  max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
                   tagType={
                     (tabQuery === Query.NEEDS_REVIEW && 'warning') ||
                     (tabQuery === Query.UNRESOLVED && 'default') ||
+                    (tabQuery === Query.IGNORED && 'default') ||
                     undefined
                   }
-                />
+                />}
               </a>
             </li>
           ))}

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -120,16 +120,18 @@ function IssueListHeader({
             <li key={tabQuery} className={query === tabQuery ? 'active' : ''}>
               <a onClick={() => onTabChange(tabQuery)}>
                 {queryName}{' '}
-                {queryCounts[tabQuery] && <StyledQueryCount
-                  count={queryCounts[tabQuery].count}
-                  max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
-                  tagType={
-                    (tabQuery === Query.NEEDS_REVIEW && 'warning') ||
-                    (tabQuery === Query.UNRESOLVED && 'default') ||
-                    (tabQuery === Query.IGNORED && 'default') ||
-                    undefined
-                  }
-                />}
+                {queryCounts[tabQuery] && (
+                  <StyledQueryCount
+                    count={queryCounts[tabQuery].count}
+                    max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
+                    tagType={
+                      (tabQuery === Query.NEEDS_REVIEW && 'warning') ||
+                      (tabQuery === Query.UNRESOLVED && 'default') ||
+                      (tabQuery === Query.IGNORED && 'default') ||
+                      undefined
+                    }
+                  />
+                )}
               </a>
             </li>
           ))}

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -394,7 +394,10 @@ class IssueListOverview extends React.Component<Props, State> {
       : null;
 
     // If all tabs' counts are fetched, skip and only set
-    if (fetchAllCounts || !TabQueriesWithCounts.every(tabQuery => queryCounts[tabQuery] !== undefined)) {
+    if (
+      fetchAllCounts ||
+      !TabQueriesWithCounts.every(tabQuery => queryCounts[tabQuery] !== undefined)
+    ) {
       const requestParams: CountsEndpointParams = {
         ...omit(endpointParams, 'query'),
         // fetch the counts for the tabs whose counts haven't been fetched yet
@@ -416,8 +419,11 @@ class IssueListOverview extends React.Component<Props, State> {
         // Counts coming from the counts endpoint is limited to 100, for >= 100 we display 99+
         queryCounts = {
           ...queryCounts,
-          ...mapValues(response, (count: number) => ({count, hasMore: count > TAB_MAX_COUNT})),
-        }
+          ...mapValues(response, (count: number) => ({
+            count,
+            hasMore: count > TAB_MAX_COUNT,
+          })),
+        };
       } catch (e) {
         this.setState({
           error: parseApiError(e),
@@ -481,7 +487,8 @@ class IssueListOverview extends React.Component<Props, State> {
 
     this._poller.disable();
 
-    const fetchAllCounts = this.props.organization.features.includes('inbox') && !!selectionChanged;
+    const fetchAllCounts =
+      this.props.organization.features.includes('inbox') && !!selectionChanged;
 
     this._lastRequest = this.props.api.request(this.getGroupListEndpoint(), {
       method: 'GET',

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -6,6 +6,7 @@ import {withProfiler} from '@sentry/react';
 import {Location} from 'history';
 import Cookies from 'js-cookie';
 import isEqual from 'lodash/isEqual';
+import mapValues from 'lodash/mapValues';
 import omit from 'lodash/omit';
 import pickBy from 'lodash/pickBy';
 import * as qs from 'query-string';
@@ -60,7 +61,7 @@ import IssueListFilters from './filters';
 import IssueListHeader from './header';
 import NoGroupsHandler from './noGroupsHandler';
 import IssueListSidebar from './sidebar';
-import {Query, QueryCounts, TabQueriesWithCounts} from './utils';
+import {Query, QueryCounts, TAB_MAX_COUNT, TabQueriesWithCounts} from './utils';
 
 const MAX_ITEMS = 25;
 const DEFAULT_SORT = 'date';
@@ -216,6 +217,8 @@ class IssueListOverview extends React.Component<Props, State> {
     const prevQuery = prevProps.location.query;
     const newQuery = this.props.location.query;
 
+    const selectionChanged = !isEqual(prevProps.selection, this.props.selection);
+
     // If any important url parameter changed or saved search changed
     // reload data.
     if (
@@ -227,7 +230,7 @@ class IssueListOverview extends React.Component<Props, State> {
       prevQuery.groupStatsPeriod !== newQuery.groupStatsPeriod ||
       prevProps.savedSearch !== this.props.savedSearch
     ) {
-      this.fetchData();
+      this.fetchData(selectionChanged);
     } else if (
       !this._lastRequest &&
       prevState.issuesLoading === false &&
@@ -381,7 +384,7 @@ class IssueListOverview extends React.Component<Props, State> {
     }
   };
 
-  fetchCounts = async (currentQueryCount: number) => {
+  fetchCounts = async (currentQueryCount: number, fetchAllCounts: boolean) => {
     const {queryCounts: _queryCounts} = this.state;
     let queryCounts: QueryCounts = {..._queryCounts};
 
@@ -391,7 +394,7 @@ class IssueListOverview extends React.Component<Props, State> {
       : null;
 
     // If all tabs' counts are fetched, skip and only set
-    if (!TabQueriesWithCounts.every(tabQuery => queryCounts[tabQuery] !== undefined)) {
+    if (fetchAllCounts || !TabQueriesWithCounts.every(tabQuery => queryCounts[tabQuery] !== undefined)) {
       const requestParams: CountsEndpointParams = {
         ...omit(endpointParams, 'query'),
         // fetch the counts for the tabs whose counts haven't been fetched yet
@@ -412,8 +415,8 @@ class IssueListOverview extends React.Component<Props, State> {
         );
         queryCounts = {
           ...queryCounts,
-          ...response,
-        };
+          ...mapValues(response, (count: number) => ({count, hasMore: count > TAB_MAX_COUNT})),
+        }
       } catch (e) {
         this.setState({
           error: parseApiError(e),
@@ -423,13 +426,16 @@ class IssueListOverview extends React.Component<Props, State> {
     }
 
     if (currentTabQuery) {
-      queryCounts[currentTabQuery] = currentQueryCount;
+      queryCounts[currentTabQuery] = {
+        count: currentQueryCount,
+        hasMore: false,
+      };
     }
 
     this.setState({queryCounts});
   };
 
-  fetchData = () => {
+  fetchData = (selectionChanged?: boolean) => {
     GroupStore.loadInitialData([]);
 
     this.setState({
@@ -473,6 +479,8 @@ class IssueListOverview extends React.Component<Props, State> {
 
     this._poller.disable();
 
+    const fetchAllCounts = this.props.organization.features.includes('inbox') && !!selectionChanged;
+
     this._lastRequest = this.props.api.request(this.getGroupListEndpoint(), {
       method: 'GET',
       data: qs.stringify(requestParams),
@@ -512,7 +520,7 @@ class IssueListOverview extends React.Component<Props, State> {
         const pageLinks = jqXHR.getResponseHeader('Link');
 
         if (this.props.organization.features.includes('inbox')) {
-          this.fetchCounts(queryCount);
+          this.fetchCounts(queryCount, fetchAllCounts);
         }
 
         this.setState({

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -413,6 +413,7 @@ class IssueListOverview extends React.Component<Props, State> {
             data: qs.stringify(requestParams),
           }
         );
+        // Counts coming from the counts endpoint is limited to 100, for >= 100 we display 99+
         queryCounts = {
           ...queryCounts,
           ...mapValues(response, (count: number) => ({count, hasMore: count > TAB_MAX_COUNT})),
@@ -425,6 +426,7 @@ class IssueListOverview extends React.Component<Props, State> {
       }
     }
 
+    // Update the count based on the exact number of issues, these shown as is
     if (currentTabQuery) {
       queryCounts[currentTabQuery] = {
         count: currentQueryCount,

--- a/src/sentry/static/sentry/app/views/issueList/utils.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/utils.tsx
@@ -5,10 +5,23 @@ export enum Query {
   REPROCESSING = 'is:reprocessing',
 }
 
-export const TabQueriesWithCounts = [Query.NEEDS_REVIEW, Query.UNRESOLVED];
+// These tabs will have the counts displayed
+export const TabQueriesWithCounts = [Query.NEEDS_REVIEW, Query.UNRESOLVED, Query.IGNORED];
 
-// These two tabs are the only two that will have the counts displayed currently
+// the tab counts will look like 99+
+export const TAB_MAX_COUNT = 99;
+
 export type QueryCounts = {
-  [Query.NEEDS_REVIEW]?: number;
-  [Query.UNRESOLVED]?: number;
+  [Query.NEEDS_REVIEW]?: {
+    count: number;
+    hasMore: boolean;
+  };
+  [Query.UNRESOLVED]?: {
+    count: number;
+    hasMore: boolean;
+  };
+  [Query.IGNORED]?: {
+    count: number;
+    hasMore: boolean;
+  };
 };

--- a/tests/js/spec/views/issueList/header.spec.jsx
+++ b/tests/js/spec/views/issueList/header.spec.jsx
@@ -9,7 +9,7 @@ const queryCounts = {
     count: 1,
     hasMore: false,
   },
-  'is:unresolved':  {
+  'is:unresolved': {
     count: 1,
     hasMore: false,
   },
@@ -20,7 +20,7 @@ const queryCounts = {
 };
 
 const queryCountsMaxed = {
-  'is:unresolved is:needs_review':  {
+  'is:unresolved is:needs_review': {
     count: 321,
     hasMore: false,
   },

--- a/tests/js/spec/views/issueList/header.spec.jsx
+++ b/tests/js/spec/views/issueList/header.spec.jsx
@@ -5,13 +5,33 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import IssueListHeader from 'app/views/issueList/header';
 
 const queryCounts = {
-  'is:unresolved is:needs_review': 1,
-  'is:unresolved': 1,
+  'is:unresolved is:needs_review': {
+    count: 1,
+    hasMore: false,
+  },
+  'is:unresolved':  {
+    count: 1,
+    hasMore: false,
+  },
+  'is:ignored': {
+    count: 0,
+    hasMore: false,
+  },
 };
 
 const queryCountsMaxed = {
-  'is:unresolved is:needs_review': 1000,
-  'is:unresolved': 1000,
+  'is:unresolved is:needs_review':  {
+    count: 321,
+    hasMore: false,
+  },
+  'is:unresolved': {
+    count: 100,
+    hasMore: true,
+  },
+  'is:ignored': {
+    count: 100,
+    hasMore: true,
+  },
 };
 
 describe('IssueListHeader', () => {
@@ -42,13 +62,13 @@ describe('IssueListHeader', () => {
     expect(wrapper.find('li').at(2).text()).toBe('Ignored ');
   });
 
-  it('renders limited counts for tabs', () => {
+  it('renders limited counts for tabs and exact for selected', () => {
     const wrapper = mountWithTheme(
       <IssueListHeader query="" queryCounts={queryCountsMaxed} projectIds={[]} />
     );
-    expect(wrapper.find('li').at(0).text()).toBe('Needs Review 99+');
+    expect(wrapper.find('li').at(0).text()).toBe('Needs Review 321');
     expect(wrapper.find('li').at(1).text()).toBe('All Unresolved 99+');
-    expect(wrapper.find('li').at(2).text()).toBe('Ignored ');
+    expect(wrapper.find('li').at(2).text()).toBe('Ignored 99+');
   });
 
   it('transitions to new query on tab click', () => {


### PR DESCRIPTION
This adds counts to Ignored tab, updates counts if the selection changes, shows the exact number of issues on the selected tab once users selects a tab.

[WOR-528](https://getsentry.atlassian.net/browse/WOR-528)