### PR TITLE
fix(inbox): Stop propagation when clicking mark reviewed

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
@@ -82,7 +82,7 @@ class GroupRowActions extends React.Component<Props> {
           disabled={!group.inbox}
           title={t('Mark Reviewed')}
           tooltipProps={{disabled: !group.inbox}}
-          icon={<IconIssues size="sm" color="gray300" />}
+          icon={<IconIssues size="sm" />}
           onClick={event => this.handleUpdate({inbox: false}, event)}
         />
 
@@ -91,7 +91,7 @@ class GroupRowActions extends React.Component<Props> {
           customTitle={
             <ActionButton
               label={t('More issue actions')}
-              icon={<IconEllipsis size="sm" color="gray300" />}
+              icon={<IconEllipsis size="sm" />}
             />
           }
           anchorRight

--- a/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
@@ -3,11 +3,9 @@ import styled from '@emotion/styled';
 
 import {addLoadingMessage, clearIndicators} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
-import ActionLink from 'app/components/actions/actionLink';
 import ResolveActions from 'app/components/actions/resolve';
 import DropdownLink from 'app/components/dropdownLink';
 import MenuItem from 'app/components/menuItem';
-import Tooltip from 'app/components/tooltip';
 import {IconEllipsis, IconIssues} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
@@ -27,7 +25,8 @@ type Props = {
 };
 
 class GroupRowActions extends React.Component<Props> {
-  handleUpdate = (data?: any) => {
+  handleUpdate = (data?: any, event?: React.MouseEvent) => {
+    event?.stopPropagation();
     const {api, group, orgId, query, selection} = this.props;
 
     addLoadingMessage(t('Saving changes\u2026'));
@@ -77,16 +76,15 @@ class GroupRowActions extends React.Component<Props> {
 
     return (
       <Wrapper>
-        <Tooltip title={group.inbox ? t('Mark Reviewed') : null}>
-          <ActionLink
-            type="button"
-            onAction={() => this.handleUpdate({inbox: false})}
-            shouldConfirm={false}
-            disabled={!group.inbox}
-            title={t('Mark Reviewed')}
-            icon={<IconIssues size="sm" color="gray300" />}
-          />
-        </Tooltip>
+        <ActionButton
+          type="button"
+          size="zero"
+          disabled={!group.inbox}
+          title={t('Mark Reviewed')}
+          tooltipProps={{disabled: !group.inbox}}
+          icon={<IconIssues size="sm" color="gray300" />}
+          onClick={event => this.handleUpdate({inbox: false}, event)}
+        />
 
         <StyledDropdownLink
           caret={false}

--- a/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
@@ -78,7 +78,6 @@ class GroupRowActions extends React.Component<Props> {
       <Wrapper>
         <ActionButton
           type="button"
-          size="zero"
           disabled={!group.inbox}
           title={t('Mark Reviewed')}
           tooltipProps={{disabled: !group.inbox}}


### PR DESCRIPTION
- Stop propagation to prevent selecting the row when using the button.
- Switch to directly using an action button since these actions do not need confirmation.

![image](https://user-images.githubusercontent.com/1400464/102940069-56496100-4464-11eb-9944-5767e93c3141.png)
