### PR TITLE
feat(inbox): Remove confirmation on mark reviewed WOR-478

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
@@ -68,13 +68,9 @@ function ActionSet({
       {hasInbox && (
         <div className="hidden-sm hidden-xs">
           <ReviewAction
-            orgSlug={orgSlug}
             primary={query === Query.NEEDS_REVIEW}
             disabled={!anySelected}
-            confirm={confirm}
-            label={label}
             onUpdate={onUpdate}
-            onShouldConfirm={onShouldConfirm}
           />
         </div>
       )}
@@ -168,9 +164,6 @@ function ActionSet({
             className="hidden-md hidden-lg hidden-xl"
             disabled={!anySelected}
             onAction={() => onUpdate({inbox: false})}
-            shouldConfirm={onShouldConfirm(ConfirmAction.ACKNOWLEDGE)}
-            message={confirm('mark', false, ' as reviewed')}
-            confirmLabel={label('Mark', ' as reviewed')}
             title={t('Mark Reviewed')}
           >
             {t('Mark Reviewed')}

--- a/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
@@ -218,7 +218,6 @@ class IssueListActions extends React.Component<Props, State> {
       case ConfirmAction.RESOLVE:
       case ConfirmAction.UNRESOLVE:
       case ConfirmAction.IGNORE:
-      case ConfirmAction.ACKNOWLEDGE:
       case ConfirmAction.UNBOOKMARK: {
         const {pageSelected} = this.state;
         return pageSelected && selectedItems.size > 1;

--- a/src/sentry/static/sentry/app/views/issueList/actions/reviewAction.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/reviewAction.tsx
@@ -3,37 +3,20 @@ import React from 'react';
 import ActionLink from 'app/components/actions/actionLink';
 import {IconIssues} from 'app/icons';
 import {t} from 'app/locale';
-import {Organization} from 'app/types';
-
-import {ConfirmAction, getConfirm, getLabel} from './utils';
 
 type Props = {
-  orgSlug: Organization['slug'];
   onUpdate: (data?: any) => void;
   primary?: boolean;
   disabled?: boolean;
-  confirm?: ReturnType<typeof getConfirm>;
-  label?: ReturnType<typeof getLabel>;
-  onShouldConfirm?: (action: ConfirmAction) => boolean;
 };
 
-function ReviewAction({
-  disabled,
-  primary,
-  onShouldConfirm,
-  onUpdate,
-  confirm,
-  label,
-}: Props) {
+function ReviewAction({disabled, primary, onUpdate}: Props) {
   return (
     <ActionLink
       type="button"
       priority={primary ? 'primary' : 'default'}
       disabled={disabled}
       onAction={() => onUpdate({inbox: false})}
-      shouldConfirm={onShouldConfirm?.(ConfirmAction.ACKNOWLEDGE)}
-      message={confirm?.('mark', false, ' as reviewed')}
-      confirmLabel={label?.('Mark', ' as reviewed')}
       title={t('Mark Reviewed')}
       icon={<IconIssues size="xs" />}
     >

--- a/src/sentry/static/sentry/app/views/issueList/actions/utils.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/utils.tsx
@@ -12,7 +12,6 @@ export const BULK_LIMIT_STR = BULK_LIMIT.toLocaleString();
 export enum ConfirmAction {
   RESOLVE = 'resolve',
   UNRESOLVE = 'unresolve',
-  ACKNOWLEDGE = 'acknowledge',
   IGNORE = 'ignore',
   BOOKMARK = 'bookmark',
   UNBOOKMARK = 'unbookmark',

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
@@ -233,11 +233,7 @@ class Actions extends React.Component<Props, State> {
       <Wrapper>
         {orgFeatures.has('inbox') && (
           <Tooltip disabled={!!group.inbox} title={t('Issue has been reviewed')}>
-            <ReviewAction
-              orgSlug={organization.slug}
-              onUpdate={this.onUpdate}
-              disabled={!group.inbox}
-            />
+            <ReviewAction onUpdate={this.onUpdate} disabled={!group.inbox} />
           </Tooltip>
         )}
         <GuideAnchor target="resolve" position="bottom" offset={space(3)}>

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -412,8 +412,6 @@ describe('IssueListActions', function () {
       });
       wrapper.find('button[aria-label="Mark Reviewed"]').simulate('click');
 
-      expect(wrapper.find('Modal')).toSnapshot();
-      wrapper.find('Modal Button[priority="primary"]').simulate('click');
       expect(apiMock).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({


### PR DESCRIPTION
Will no longer show modal asking for confirmation when marking reviewed even if pages > 1