### PR TITLE
feat(workflow): Update inbox reason tooltip (WOR-482)

### DIFF
--- a/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
+++ b/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import Tag from 'app/components/tag';
+import {getRelativeDate} from 'app/components/timeSince';
 import {t} from 'app/locale';
 import {InboxDetails} from 'app/types';
 import {getDuration} from 'app/utils/formatters';
-import {getRelativeDate} from 'app/components/timeSince';
 
 const GroupInboxReason = {
   NEW: 0,
@@ -25,7 +25,10 @@ const EVENT_ROUND_LIMIT = 1000;
 function InboxReason({inbox, fontSize = 'sm'}: Props) {
   const {reason, reason_details, date_added: dateAdded} = inbox;
 
-  const getCountText = (count: number) => count > EVENT_ROUND_LIMIT ? `More than ${Math.round(count / EVENT_ROUND_LIMIT)}k` : `${count}`;
+  const getCountText = (count: number) =>
+    count > EVENT_ROUND_LIMIT
+      ? `More than ${Math.round(count / EVENT_ROUND_LIMIT)}k`
+      : `${count}`;
 
   function getReasonDetails(): {
     tagType: React.ComponentProps<typeof Tag>['type'];
@@ -38,7 +41,11 @@ function InboxReason({inbox, fontSize = 'sm'}: Props) {
         return {
           tagType: 'default',
           reasonBadgeText: t('Unignored'),
-          tooltipText: dateAdded && t('Unignored %(relative)s', {relative: getRelativeDate(dateAdded, 'ago', true)}),
+          tooltipText:
+            dateAdded &&
+            t('Unignored %(relative)s', {
+              relative: getRelativeDate(dateAdded, 'ago', true),
+            }),
           tooltipDescription: t('%(count)s events in %(window)s', {
             count: getCountText(reason_details?.count || 0),
             window: getDuration((reason_details?.window || 0) * 60, 0, true),
@@ -48,7 +55,11 @@ function InboxReason({inbox, fontSize = 'sm'}: Props) {
         return {
           tagType: 'error',
           reasonBadgeText: t('Regression'),
-          tooltipText: dateAdded && t('Regressed %(relative)s', {relative: getRelativeDate(dateAdded, 'ago', true)}),
+          tooltipText:
+            dateAdded &&
+            t('Regressed %(relative)s', {
+              relative: getRelativeDate(dateAdded, 'ago', true),
+            }),
           // TODO: Add tooltip description for regression move when resolver is added to reason
           // Resolved by {full_name} {time} ago.
         };
@@ -57,7 +68,9 @@ function InboxReason({inbox, fontSize = 'sm'}: Props) {
         return {
           tagType: 'highlight',
           reasonBadgeText: t('Manual'),
-          tooltipText: dateAdded && t('Moved %(relative)s', {relative: getRelativeDate(dateAdded, 'ago', true)}),
+          tooltipText:
+            dateAdded &&
+            t('Moved %(relative)s', {relative: getRelativeDate(dateAdded, 'ago', true)}),
           // TODO: IF manual moves stay then add tooltip description for manual move
           // Moved to inbox by {full_name}.
         };
@@ -65,13 +78,21 @@ function InboxReason({inbox, fontSize = 'sm'}: Props) {
         return {
           tagType: 'info',
           reasonBadgeText: t('Reprocessed'),
-          tooltipText: dateAdded && t('Reprocessed %(relative)s', {relative: getRelativeDate(dateAdded, 'ago', true)}),
+          tooltipText:
+            dateAdded &&
+            t('Reprocessed %(relative)s', {
+              relative: getRelativeDate(dateAdded, 'ago', true),
+            }),
         };
       default:
         return {
           tagType: 'warning',
           reasonBadgeText: t('New Issue'),
-          tooltipText: dateAdded && t('Created %(relative)s', {relative: getRelativeDate(dateAdded, 'ago', true)}),
+          tooltipText:
+            dateAdded &&
+            t('Created %(relative)s', {
+              relative: getRelativeDate(dateAdded, 'ago', true),
+            }),
         };
     }
   }

--- a/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
+++ b/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
@@ -20,10 +20,12 @@ type Props = {
   fontSize?: 'sm' | 'md';
 };
 
+const EVENT_ROUND_LIMIT = 1000;
+
 function InboxReason({inbox, fontSize = 'sm'}: Props) {
   const {reason, reason_details, date_added: dateAdded} = inbox;
 
-  const getCountText = (count: number) => count > 1000 ? `More than ${Math.round(count / 1000)}k` : `${count}`;
+  const getCountText = (count: number) => count > EVENT_ROUND_LIMIT ? `More than ${Math.round(count / EVENT_ROUND_LIMIT)}k` : `${count}`;
 
   function getReasonDetails(): {
     tagType: React.ComponentProps<typeof Tag>['type'];
@@ -76,7 +78,7 @@ function InboxReason({inbox, fontSize = 'sm'}: Props) {
 
   const {tooltipText, tooltipDescription, reasonBadgeText, tagType} = getReasonDetails();
 
-  const tooltip = (
+  const tooltip = (tooltipText || tooltipDescription) && (
     <TooltipWrapper>
       {tooltipText && <div>{tooltipText}</div>}
       {tooltipDescription && (

--- a/src/sentry/static/sentry/app/components/queryCount.tsx
+++ b/src/sentry/static/sentry/app/components/queryCount.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
-import styled from 'app/styled';
 import space from 'app/styles/space';
 import {defined} from 'app/utils';
 

--- a/src/sentry/static/sentry/app/components/queryCount.tsx
+++ b/src/sentry/static/sentry/app/components/queryCount.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {defined} from 'app/utils';
 import styled from 'app/styled';
 import space from 'app/styles/space';
+import {defined} from 'app/utils';
 
 type Props = {
   count?: number;
@@ -34,9 +34,9 @@ const QueryCount = ({
   }
 
   if (backgroundColor) {
-    return <StyledBackground backgroundColor={backgroundColor}>
-      {countOrMax}
-    </StyledBackground>;
+    return (
+      <StyledBackground backgroundColor={backgroundColor}>{countOrMax}</StyledBackground>
+    );
   }
 
   return (

--- a/src/sentry/static/sentry/app/components/queryCount.tsx
+++ b/src/sentry/static/sentry/app/components/queryCount.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Tag from 'app/components/tag';
 import {defined} from 'app/utils';
-import {Theme} from 'app/utils/theme';
+import styled from 'app/styled';
+import space from 'app/styles/space';
 
 type Props = {
   count?: number;
   max?: number;
   hideIfEmpty?: boolean;
   hideParens?: boolean;
-  tagType?: keyof Theme['tag'];
+  backgroundColor?: string;
 };
 
 /**
@@ -25,7 +25,7 @@ const QueryCount = ({
   max,
   hideIfEmpty = true,
   hideParens = false,
-  tagType,
+  backgroundColor,
 }: Props) => {
   const countOrMax = defined(count) && defined(max) && count >= max ? `${max}+` : count;
 
@@ -33,8 +33,10 @@ const QueryCount = ({
     return null;
   }
 
-  if (tagType) {
-    return <Tag type={tagType}>{countOrMax}</Tag>;
+  if (backgroundColor) {
+    return <StyledBackground backgroundColor={backgroundColor}>
+      {countOrMax}
+    </StyledBackground>;
   }
 
   return (
@@ -51,5 +53,17 @@ QueryCount.propTypes = {
   hideIfEmpty: PropTypes.bool,
   hideParens: PropTypes.bool,
 };
+
+const StyledBackground = styled('div')<{backgroundColor?: string}>`
+  display: inline-flex;
+  align-items: center;
+  height: 20px;
+  border-radius: 20px;
+  color: ${p => p.theme.gray500};
+  background-color: ${p => p.backgroundColor};
+  padding: 0 ${space(1)};
+  line-height: 20px;
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
 
 export default QueryCount;

--- a/src/sentry/static/sentry/app/components/timeSince.tsx
+++ b/src/sentry/static/sentry/app/components/timeSince.tsx
@@ -142,18 +142,20 @@ function getDateObj(date: RelaxedDateType): Date {
   return date;
 }
 
-function getRelativeDate(
+export function getRelativeDate(
   currentDateTime: RelaxedDateType,
   suffix?: string,
   shorten?: boolean
 ): string {
   const date = getDateObj(currentDateTime);
 
-  if (shorten) {
+  if (shorten && suffix) {
     return t('%(time)s %(suffix)s', {
       time: getDuration(moment().diff(moment(date), 'seconds'), 0, true),
       suffix,
     });
+  } else if (shorten && !suffix) {
+    return getDuration(moment().diff(moment(date), 'seconds'), 0, true);
   } else if (!suffix) {
     return moment(date).fromNow(true);
   } else if (suffix === 'ago') {

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -13,8 +13,8 @@ import {IconPause, IconPlay, IconUser} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
-import withProjects from 'app/utils/withProjects';
 import theme from 'app/utils/theme';
+import withProjects from 'app/utils/withProjects';
 
 import {Query, QueryCounts, TAB_MAX_COUNT} from './utils';
 

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -14,6 +14,7 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import withProjects from 'app/utils/withProjects';
+import theme from 'app/utils/theme';
 
 import {Query, QueryCounts, TAB_MAX_COUNT} from './utils';
 
@@ -124,11 +125,9 @@ function IssueListHeader({
                   <StyledQueryCount
                     count={queryCounts[tabQuery].count}
                     max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
-                    tagType={
-                      (tabQuery === Query.NEEDS_REVIEW && 'warning') ||
-                      (tabQuery === Query.UNRESOLVED && 'default') ||
-                      (tabQuery === Query.IGNORED && 'default') ||
-                      undefined
+                    backgroundColor={
+                      (tabQuery === Query.NEEDS_REVIEW && theme.yellow300) ||
+                      theme.gray100
                     }
                   />
                 )}


### PR DESCRIPTION
This updates the inbox tooltip reasons based on designs in the issue linked. There is no resolving user for regressions yet left a TODO for it. Also manual resolves will be removed so don't worry about those.

Also fixed an issue where `getRelativeDate` assumed `shorten=true` assumed `suffix` was also passed.

Also changed the inbox tab count background color from yellow100 to yellow300

[WOR-482](https://getsentry.atlassian.net/browse/WOR-482)