### PR TITLE
feat(discover): Add support for top 5 graphs in query cards

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -5,6 +5,7 @@ import isEqual from 'lodash/isEqual';
 
 import {Client} from 'app/api';
 import AreaChart from 'app/components/charts/areaChart';
+import BarChart from 'app/components/charts/barChart';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import {getInterval} from 'app/components/charts/utils';
 import LoadingContainer from 'app/components/loading/loadingContainer';
@@ -14,6 +15,8 @@ import {Organization} from 'app/types';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import {axisLabelFormatter} from 'app/utils/discover/charts';
 import EventView from 'app/utils/discover/eventView';
+import {DisplayModes, TOP_N} from 'app/utils/discover/types';
+import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 
@@ -45,6 +48,16 @@ class MiniGraph extends React.Component<Props> {
     const end = apiPayload.end ? getUtcToLocalDateObject(apiPayload.end) : null;
     const period: string | undefined = apiPayload.statsPeriod as any;
 
+    const display = eventView.getDisplayMode();
+    const isTopEvents =
+      display === DisplayModes.TOP5 || display === DisplayModes.DAILYTOP5;
+    const isDaily = display === DisplayModes.DAILYTOP5 || display === DisplayModes.DAILY;
+
+    const field = isTopEvents ? apiPayload.field : undefined;
+    const topEvents = isTopEvents ? TOP_N : undefined;
+    const orderby = isTopEvents ? decodeScalar(apiPayload.sort) : undefined;
+    const interval = isDaily ? '1d' : getInterval({start, end, period}, true);
+
     return {
       organization,
       apiPayload,
@@ -52,10 +65,24 @@ class MiniGraph extends React.Component<Props> {
       start,
       end,
       period,
+      interval,
       project: eventView.project,
       environment: eventView.environment,
       yAxis: eventView.getYAxis(),
+      field,
+      topEvents,
+      orderby,
+      showDaily: isDaily,
     };
+  }
+
+  getChartComponent(
+    showDaily: boolean
+  ): React.ComponentType<BarChart['props']> | React.ComponentType<AreaChart['props']> {
+    if (showDaily) {
+      return BarChart;
+    }
+    return AreaChart;
   }
 
   render() {
@@ -65,12 +92,16 @@ class MiniGraph extends React.Component<Props> {
       start,
       end,
       period,
+      interval,
       organization,
       project,
       environment,
       yAxis,
+      field,
+      topEvents,
+      orderby,
+      showDaily,
     } = this.getRefreshProps(this.props);
-    const colors = theme.charts.getColorPalette(1);
 
     return (
       <EventsRequest
@@ -80,13 +111,16 @@ class MiniGraph extends React.Component<Props> {
         start={start}
         end={end}
         period={period}
-        interval={getInterval({start, end, period}, true)}
+        interval={interval}
         project={project as number[]}
         environment={environment as string[]}
         includePrevious={false}
         yAxis={yAxis}
+        field={field}
+        topEvents={topEvents}
+        orderby={orderby}
       >
-        {({loading, timeseriesData, errored}) => {
+        {({loading, timeseriesData, results, errored}) => {
           if (errored) {
             return (
               <StyledGraphContainer>
@@ -102,63 +136,63 @@ class MiniGraph extends React.Component<Props> {
             );
           }
 
-          const data = (timeseriesData || []).map(series => ({
+          const allSeries = timeseriesData ?? results ?? [];
+          const data = allSeries.map(series => ({
             ...series,
-            areaStyle: {
-              color: colors[0],
-              opacity: 1,
-            },
             lineStyle: {
               opacity: 0,
             },
             smooth: true,
           }));
 
-          return (
-            <AreaChart
-              height={100}
-              series={[...data]}
-              xAxis={{
+          const chartOptions = {
+            colors: [...theme.charts.getColorPalette(allSeries.length - 2)],
+            height: 100,
+            series: [...data],
+            xAxis: {
+              show: false,
+              axisPointer: {
                 show: false,
-                axisPointer: {
-                  show: false,
-                },
-              }}
-              yAxis={{
-                show: true,
-                axisLine: {
-                  show: false,
-                },
-                axisLabel: {
-                  color: theme.chartLabel,
-                  fontFamily: theme.text.family,
-                  fontSize: 12,
-                  formatter: (value: number) => axisLabelFormatter(value, yAxis, true),
-                  inside: true,
-                  showMinLabel: false,
-                  showMaxLabel: false,
-                },
-                splitNumber: 3,
-                splitLine: {
-                  show: false,
-                },
-                zlevel: theme.zIndex.header,
-              }}
-              tooltip={{
+              },
+            },
+            yAxis: {
+              show: true,
+              axisLine: {
                 show: false,
-              }}
-              toolBox={{
+              },
+              axisLabel: {
+                color: theme.chartLabel,
+                fontFamily: theme.text.family,
+                fontSize: 12,
+                formatter: (value: number) => axisLabelFormatter(value, yAxis, true),
+                inside: true,
+                showMinLabel: false,
+                showMaxLabel: false,
+              },
+              splitNumber: 3,
+              splitLine: {
                 show: false,
-              }}
-              grid={{
-                left: 0,
-                top: 0,
-                right: 0,
-                bottom: 0,
-                containLabel: false,
-              }}
-            />
-          );
+              },
+              zlevel: theme.zIndex.header,
+            },
+            tooltip: {
+              show: false,
+            },
+            toolBox: {
+              show: false,
+            },
+            grid: {
+              left: 0,
+              top: 0,
+              right: 0,
+              bottom: 0,
+              containLabel: false,
+            },
+            stacked: typeof topEvents === 'number' && topEvents > 0,
+          };
+
+          const Component = this.getChartComponent(showDaily);
+          return <Component {...chartOptions} />;
         }}
       </EventsRequest>
     );


### PR DESCRIPTION
Query cards do not respect top 5 modes in the graphs, meaning that the graph
shown is showing the totals rather than the top 5. This can be disorienting as
the totals and the top 5 can have very different shapes. This change adds support
for top 5 graphs in the query cards so they show the same graph when clicking
into them.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/103025257-6d995480-451f-11eb-9b3e-3ca45dda849d.png)

## After

![image](https://user-images.githubusercontent.com/10239353/103025215-58242a80-451f-11eb-91bc-4085be3cedbe.png)
