### PR TITLE
feat(workflow): Add `owner:me_or_none` to inbox query (WOR-517)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -933,6 +933,8 @@ SENTRY_FEATURES = {
     "organizations:inbox": False,
     # Set default tab to inbox
     "organizations:inbox-tab-default": False,
+    # Add `owner:me_or_none` to inbox tab query
+    "organizations:inbox-owners-query": False,
     # Enable the new images loaded design and features
     "organizations:images-loaded-v2": False,
     # Return unhandled information on the issue level

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -108,6 +108,7 @@ default_manager.add("organizations:transaction-comparison", OrganizationFeature)
 default_manager.add("organizations:usage-stats-graph", OrganizationFeature)  # NOQA
 default_manager.add("organizations:inbox", OrganizationFeature)  # NOQA
 default_manager.add("organizations:inbox-tab-default", OrganizationFeature)  # NOQA
+default_manager.add("organizations:inbox-owners-query", OrganizationFeature)  # NOQA
 default_manager.add("organizations:unhandled-issue-flag", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members-rate-limits", OrganizationFeature)  # NOQA
 default_manager.add("organizations:dashboards-v2", OrganizationFeature)  # NOQA

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -144,7 +144,7 @@ class StreamGroup extends React.Component<Props, State> {
       // On the inbox tab and the inbox reason is removed
       const reviewed =
         state.reviewed ||
-        (query === Query.NEEDS_REVIEW &&
+        ((query === Query.NEEDS_REVIEW || query === Query.NEEDS_REVIEW_OWNER) &&
           state.data.inbox?.reason !== undefined &&
           data.inbox === false);
       return {data, reviewed};

--- a/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
@@ -68,7 +68,7 @@ function ActionSet({
       {hasInbox && (
         <div className="hidden-sm hidden-xs">
           <ReviewAction
-            primary={query === Query.NEEDS_REVIEW}
+            primary={query === Query.NEEDS_REVIEW || query === Query.NEEDS_REVIEW_OWNER}
             disabled={!anySelected}
             onUpdate={onUpdate}
           />

--- a/src/sentry/static/sentry/app/views/issueList/utils.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/utils.tsx
@@ -47,7 +47,7 @@ export function getTabs(organization: Organization) {
       Query.IGNORED,
       {
         name: t('Ignored'),
-        count: false,
+        count: true,
         enabled: true,
       },
     ],

--- a/src/sentry/static/sentry/app/views/issueList/utils.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/utils.tsx
@@ -17,6 +17,9 @@ type OverviewTab = {
   enabled: boolean;
 };
 
+/**
+ * Get a list of currently active tabs
+ */
 export function getTabs(organization: Organization) {
   const tabs: Array<[string, OverviewTab]> = [
     [
@@ -61,13 +64,15 @@ export function getTabs(organization: Organization) {
     ],
   ];
 
-  return tabs.filter(pair => pair[1].enabled);
+  return tabs.filter(([_query, tab]) => tab.enabled);
 }
 
-// These tabs will have the counts displayed
+/**
+ * @returns queries that should have counts fetched
+ */
 export function getTabsWithCounts(organization: Organization) {
   const tabs = getTabs(organization);
-  return tabs.filter(([_, value]) => value.count).map(([key]) => key);
+  return tabs.filter(([_query, tab]) => tab.count).map(([query]) => query);
 }
 
 // the tab counts will look like 99+

--- a/src/sentry/static/sentry/app/views/issueList/utils.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/utils.tsx
@@ -1,27 +1,80 @@
+import {t} from 'app/locale';
+import {Organization} from 'app/types';
+
 export enum Query {
   NEEDS_REVIEW = 'is:unresolved is:needs_review',
+  NEEDS_REVIEW_OWNER = 'is:unresolved is:needs_review owner:me_or_none',
   UNRESOLVED = 'is:unresolved',
   IGNORED = 'is:ignored',
   REPROCESSING = 'is:reprocessing',
 }
 
+type OverviewTab = {
+  name: string;
+  /** Will fetch a count to display on this tab */
+  count: boolean;
+  /** Tabs can be disabled via flag */
+  enabled: boolean;
+};
+
+export function getTabs(organization: Organization) {
+  const tabs: Array<[string, OverviewTab]> = [
+    [
+      Query.NEEDS_REVIEW_OWNER,
+      {
+        name: t('Needs Review'),
+        count: true,
+        enabled: organization.features.includes('inbox-owners-query'),
+      },
+    ],
+    [
+      Query.NEEDS_REVIEW,
+      {
+        name: t('Needs Review'),
+        count: true,
+        enabled: !organization.features.includes('inbox-owners-query'),
+      },
+    ],
+    [
+      Query.UNRESOLVED,
+      {
+        name: t('All Unresolved'),
+        count: true,
+        enabled: true,
+      },
+    ],
+    [
+      Query.IGNORED,
+      {
+        name: t('Ignored'),
+        count: false,
+        enabled: true,
+      },
+    ],
+    [
+      Query.REPROCESSING,
+      {
+        name: t('Reprocessing'),
+        count: false,
+        enabled: organization.features.includes('reprocessing-v2'),
+      },
+    ],
+  ];
+
+  return tabs.filter(pair => pair[1].enabled);
+}
+
 // These tabs will have the counts displayed
-export const TabQueriesWithCounts = [Query.NEEDS_REVIEW, Query.UNRESOLVED, Query.IGNORED];
+export function getTabsWithCounts(organization: Organization) {
+  const tabs = getTabs(organization);
+  return tabs.filter(([_, value]) => value.count).map(([key]) => key);
+}
 
 // the tab counts will look like 99+
 export const TAB_MAX_COUNT = 99;
 
-export type QueryCounts = {
-  [Query.NEEDS_REVIEW]?: {
-    count: number;
-    hasMore: boolean;
-  };
-  [Query.UNRESOLVED]?: {
-    count: number;
-    hasMore: boolean;
-  };
-  [Query.IGNORED]?: {
-    count: number;
-    hasMore: boolean;
-  };
+type QueryCount = {
+  count: number;
+  hasMore: boolean;
 };
+export type QueryCounts = Partial<Record<Query, QueryCount>>;

--- a/tests/js/spec/views/issueList/header.spec.jsx
+++ b/tests/js/spec/views/issueList/header.spec.jsx
@@ -5,6 +5,10 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import IssueListHeader from 'app/views/issueList/header';
 
 const queryCounts = {
+  'is:unresolved is:needs_review owner:me_or_none': {
+    count: 22,
+    hasMore: false,
+  },
   'is:unresolved is:needs_review': {
     count: 1,
     hasMore: false,
@@ -35,9 +39,15 @@ const queryCountsMaxed = {
 };
 
 describe('IssueListHeader', () => {
+  let organization;
+  beforeEach(() => {
+    organization = TestStubs.Organization();
+  });
+
   it('renders active tab with count when query matches inbox', () => {
     const wrapper = mountWithTheme(
       <IssueListHeader
+        organization={organization}
         query="is:unresolved is:needs_review"
         queryCounts={queryCounts}
         projectIds={[]}
@@ -46,16 +56,52 @@ describe('IssueListHeader', () => {
     expect(wrapper.find('.active').text()).toBe('Needs Review 1');
   });
 
+  it('renders active tab with count when query matches inbox with owners:me_or_none', () => {
+    organization.features = ['inbox-owners-query'];
+    const wrapper = mountWithTheme(
+      <IssueListHeader
+        organization={organization}
+        query="is:unresolved is:needs_review owner:me_or_none"
+        queryCounts={queryCounts}
+        projectIds={[]}
+      />
+    );
+    expect(wrapper.find('.active').text()).toBe('Needs Review 22');
+  });
+
+  it('renders reprocessing tab', () => {
+    organization.features = ['reprocessing-v2'];
+    const wrapper = mountWithTheme(
+      <IssueListHeader
+        organization={organization}
+        query=""
+        queryCounts={queryCounts}
+        projectIds={[]}
+      />
+    );
+    expect(wrapper.find('li').at(3).text()).toBe('Reprocessing ');
+  });
+
   it("renders all tabs inactive when query doesn't match", () => {
     const wrapper = mountWithTheme(
-      <IssueListHeader query="" queryCounts={queryCounts} projectIds={[]} />
+      <IssueListHeader
+        organization={organization}
+        query=""
+        queryCounts={queryCounts}
+        projectIds={[]}
+      />
     );
     expect(wrapper.find('.active').exists()).toBe(false);
   });
 
   it('renders all tabs with counts', () => {
     const wrapper = mountWithTheme(
-      <IssueListHeader query="" queryCounts={queryCounts} projectIds={[]} />
+      <IssueListHeader
+        organization={organization}
+        query=""
+        queryCounts={queryCounts}
+        projectIds={[]}
+      />
     );
     expect(wrapper.find('li').at(0).text()).toBe('Needs Review 1');
     expect(wrapper.find('li').at(1).text()).toBe('All Unresolved 1');
@@ -64,7 +110,12 @@ describe('IssueListHeader', () => {
 
   it('renders limited counts for tabs and exact for selected', () => {
     const wrapper = mountWithTheme(
-      <IssueListHeader query="" queryCounts={queryCountsMaxed} projectIds={[]} />
+      <IssueListHeader
+        organization={organization}
+        query=""
+        queryCounts={queryCountsMaxed}
+        projectIds={[]}
+      />
     );
     expect(wrapper.find('li').at(0).text()).toBe('Needs Review 321');
     expect(wrapper.find('li').at(1).text()).toBe('All Unresolved 99+');
@@ -75,6 +126,7 @@ describe('IssueListHeader', () => {
     const handleTabChange = jest.fn();
     const wrapper = mountWithTheme(
       <IssueListHeader
+        organization={organization}
         onTabChange={handleTabChange}
         queryCounts={queryCounts}
         projectIds={[]}


### PR DESCRIPTION
Refactors how tabs are enabled/disabled. Inbox tabs are decided in one function that returns the current set of tabs to display and get counts for.

Treats `is:unresolved is:needs_review owner:me_or_none` as a new tab with the same "needs review" display name.