### PR TITLE
fix(stacktrace-linking): allow for dashes in branch name

### DIFF
--- a/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
+++ b/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
@@ -26,7 +26,7 @@ class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
     stack_root = gen_path_regex_field()
     source_root = gen_path_regex_field()
     default_branch = serializers.RegexField(
-        r"^\w+$",
+        r"^[\w-]+$",
         required=True,
         error_messages={
             "invalid": _("Branch name may only have letters, numbers, underscores, and dashes")


### PR DESCRIPTION
The regex we had prevented people from using a `-` in the branch name which is not the intended behavior. At least one user has complained.