### PR TITLE
Lockbot is caught up, dial back to twice a day

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,7 +1,7 @@
 name: 'lock closed issues/PRs'
 on:
   schedule:
-    - cron: '*/2 * * * *'
+    - cron: '* */12 * * *'
 jobs:
   lock:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Putting this up now in case anyone cares that the lockbot action is going to run [about twice an hour (about 20 seconds per run)](https://github.com/getsentry/sentry/actions?query=workflow%3A%22lock+closed+issues%2FPRs%22) while we're code frozen. I don't expect to be back here until Jan 4, soooo if you're seeing this and you care and you do not wish to beware the frozen heart, feel free to merge without me. :)

![](https://media.giphy.com/media/119L8lo5KQ5qJq/giphy.gif)