### PR TITLE
fix(save_event): No longer store trace context as tags

### DIFF
--- a/docs-ui/components/tagsTable.stories.js
+++ b/docs-ui/components/tagsTable.stories.js
@@ -17,10 +17,6 @@ const event = {
     {value: 'internal_error', key: 'status', _meta: null},
     {value: 'sentry.tasks.store.save_event', key: 'task_name', _meta: null},
     {value: '3c75bc89a4d4442b81af4cb41b6a1571', key: 'trace', _meta: null},
-    {
-      value: '3c75bc89a4d4442b81af4cb41b6a1571-8662ecdaef1bbbaf',
-      key: 'trace.ctx',
-    },
     {value: '8662ecdaef1bbbaf', key: 'trace.span', _meta: null},
     {value: 'sentry.tasks.store.save_event', key: 'transaction', _meta: null},
   ],

--- a/src/sentry/data/samples/javascript-transaction.json
+++ b/src/sentry/data/samples/javascript-transaction.json
@@ -27,18 +27,6 @@
          "ip:127.0.0.1"
       ],
       [
-         "trace",
-         "a7d67cf796774551a95be6543cacd459"
-      ],
-      [
-         "trace.ctx",
-         "a7d67cf796774551a95be6543cacd459-babaae0d4b7512d9"
-      ],
-      [
-         "trace.span",
-         "babaae0d4b7512d9"
-      ],
-      [
          "transaction",
          "/country/:countryCode"
       ],

--- a/src/sentry/data/samples/transaction.json
+++ b/src/sentry/data/samples/transaction.json
@@ -27,18 +27,6 @@
          "ip:127.0.0.1"
       ],
       [
-         "trace",
-         "a7d67cf796774551a95be6543cacd459"
-      ],
-      [
-         "trace.ctx",
-         "a7d67cf796774551a95be6543cacd459-babaae0d4b7512d9"
-      ],
-      [
-         "trace.span",
-         "babaae0d4b7512d9"
-      ],
-      [
          "transaction",
          "/country_by_code/"
       ],

--- a/src/sentry/interfaces/contexts.py
+++ b/src/sentry/interfaces/contexts.py
@@ -135,7 +135,7 @@ class MonitorContextType(ContextType):
 @contexttype
 class TraceContextType(ContextType):
     type = "trace"
-    indexed_fields = {"": u"{trace_id}", "span": u"{span_id}", "ctx": u"{trace_id}-{span_id}"}
+    indexed_fields = {}
 
 
 class Contexts(Interface):

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -772,6 +772,7 @@ def get_facets(query, params, limit=10, referrer=None):
         snuba_filter, translated_columns = resolve_discover_aliases(snuba_filter)
 
     # Exclude tracing tags as they are noisy and generally not helpful.
+    # TODO(markus): Tracing tags are no longer written but may still reside in DB.
     excluded_tags = ["tags_key", "NOT IN", ["trace", "trace.ctx", "trace.span", "project"]]
 
     # Sampling keys for multi-project results as we don't need accuracy

--- a/src/sentry/utils/samples.py
+++ b/src/sentry/utils/samples.py
@@ -182,8 +182,6 @@ def load_data(
         for tag in data["tags"]:
             if tag[0] == "trace":
                 tag[1] = trace
-            elif tag[0] == "trace.ctx":
-                tag[1] = trace + "-" + span
             elif tag[0] == "trace.span":
                 tag[1] = span
         data["contexts"]["trace"]["trace_id"] = trace


### PR DESCRIPTION
Trace context is already stored and indexed as context, adding those tags should not be necessary. This should not affect search at all with the exception of `trace.ctx` being gone too. However that column/search field does not seem to be referenced in sourcecode or sentry-docs.

The context for this change is to reduce storage usage of nodestore. See also #22876. We have not verified whether these changes actually improve storage usage much or if those duplicated IDs compressed really well all this time, but we should not store this stuff twice regardless.

assigning @HazAT for review because he initially authored the context definition in https://github.com/getsentry/sentry/commit/69cdde9185c4e824fd9edaf8b77d93b18f2dc7a7, and the rest for general visibility.