### PR TITLE
feat(jira): Support "parent", "epic link" and "sprint" fields

### DIFF
--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -86,9 +86,9 @@ metadata = IntegrationMetadata(
     aspects={"externalInstall": external_install},
 )
 
-# hide sprint, epic link, parent and linked issues fields because they don't work
-# since sprint and epic link are "custom" we need to search for them by name
-HIDDEN_ISSUE_FIELDS = {"keys": ["parent", "issuelinks"], "names": ["Sprint", "Epic Link"]}
+# Hide linked issues fields because we don't have the necessary UI for fully specifying
+# a valid link (e.g. "is blocked by ISSUE-1").
+HIDDEN_ISSUE_FIELDS = ["issuelinks"]
 
 # A list of common builtin custom field types for Jira for easy reference.
 JIRA_CUSTOM_FIELD_TYPES = {
@@ -96,6 +96,8 @@ JIRA_CUSTOM_FIELD_TYPES = {
     "textarea": "com.atlassian.jira.plugin.system.customfieldtypes:textarea",
     "multiuserpicker": "com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker",
     "tempo_account": "com.tempoplugin.tempo-accounts:accounts.customfield",
+    "sprint": "com.pyxis.greenhopper.jira:gh-sprint",
+    "epic": "com.pyxis.greenhopper.jira:gh-epic-link",
 }
 
 
@@ -422,8 +424,15 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         ):
             fieldtype = "select"
             fkwargs["choices"] = self.make_choices(field_meta.get("allowedValues"))
-        elif field_meta.get("autoCompleteUrl") and (
-            schema.get("items") == "user" or schema["type"] == "user"
+        elif (
+            # Assignee and reporter fields
+            field_meta.get("autoCompleteUrl")
+            and (schema.get("items") == "user" or schema["type"] == "user")
+            # Sprint and "Epic Link" fields
+            or schema.get("custom")
+            in (JIRA_CUSTOM_FIELD_TYPES["sprint"], JIRA_CUSTOM_FIELD_TYPES["epic"])
+            # Parent field
+            or schema["type"] == "issuelink"
         ):
             fieldtype = "select"
             organization = (
@@ -629,12 +638,8 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
 
         # title is renamed to summary before sending to Jira
         standard_fields = [f["name"] for f in fields] + ["summary"]
-        ignored_fields = set(
-            k
-            for k, v in six.iteritems(issue_type_meta["fields"])
-            if v["name"] in HIDDEN_ISSUE_FIELDS["names"]
-        )
-        ignored_fields.update(HIDDEN_ISSUE_FIELDS["keys"])
+        ignored_fields = set()
+        ignored_fields.update(HIDDEN_ISSUE_FIELDS)
         ignored_fields.update(self.get_persisted_ignored_fields())
 
         # apply ordering to fields based on some known built-in Jira fields.
@@ -754,6 +759,15 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
                     elif schema.get("custom") == JIRA_CUSTOM_FIELD_TYPES.get("multiuserpicker"):
                         # custom multi-picker
                         v = [{user_id_field: v}]
+                    elif schema["type"] == "issuelink":  # used by Parent field
+                        v = {"key": v}
+                    elif schema.get("custom") == JIRA_CUSTOM_FIELD_TYPES["epic"]:
+                        v = v
+                    elif schema.get("custom") == JIRA_CUSTOM_FIELD_TYPES["sprint"]:
+                        try:
+                            v = int(v)
+                        except ValueError:
+                            raise IntegrationError("Invalid sprint ({}) specified".format(v))
                     elif schema["type"] == "array" and schema.get("items") == "option":
                         v = [{"value": vx} for vx in v]
                     elif schema["type"] == "array" and schema.get("items") == "string":

--- a/tests/fixtures/integrations/jira/stubs/createmeta_response.json
+++ b/tests/fixtures/integrations/jira/stubs/createmeta_response.json
@@ -125,6 +125,48 @@
                 {"value": "Feature 2", "id": "10106"}
               ]
             },
+            "customfield_10400": {
+              "operations": [
+                "set"
+              ],
+              "name": "Epic Link",
+              "required": false,
+              "hasDefaultValue": false,
+              "key": "customfield_10400",
+              "schema": {
+                "customId": 10400,
+                "type": "any",
+                "custom": "com.pyxis.greenhopper.jira:gh-epic-link"
+              }
+            },
+            "customfield_10500": {
+              "operations": [
+                "set"
+              ],
+              "name": "Sprint",
+              "required": false,
+              "hasDefaultValue": false,
+              "key": "customfield_10500",
+              "schema": {
+                "items": "json",
+                "customId": 10500,
+                "type": "array",
+                "custom": "com.pyxis.greenhopper.jira:gh-sprint"
+              }
+            },
+            "parent": {
+              "operations": [
+                "set"
+              ],
+              "name": "Parent",
+              "required": false,
+              "hasDefaultValue": false,
+              "key": "parent",
+              "schema": {
+                "type": "issuelink",
+                "system": "parent"
+              }
+            },
             "reporter": {
               "operations": [
                 "set"

--- a/tests/sentry/integrations/jira/test_client.py
+++ b/tests/sentry/integrations/jira/test_client.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import
+
+import responses
+
+from sentry.integrations.jira.client import JiraCloud
+from sentry.models import Integration
+from sentry.testutils import TestCase
+from sentry.utils import json
+from sentry.utils.compat import mock
+
+
+class StubJiraCloud(JiraCloud):
+    def request_hook(self, *args, **kwargs):
+        r = super(StubJiraCloud, self).request_hook(*args, **kwargs)
+        r["params"]["jwt"] = "my-jwt-token"
+        return r
+
+
+class JiraClientTest(TestCase):
+    @mock.patch("sentry.integrations.jira.integration.JiraCloud", new=StubJiraCloud)
+    def setUp(self):
+        integration = Integration.objects.create(
+            provider="jira",
+            name="Jira Cloud",
+            metadata={
+                "oauth_client_id": "oauth-client-id",
+                "shared_secret": "a-super-secret-key-from-atlassian",
+                "base_url": "https://example.atlassian.net",
+                "domain_name": "example.atlassian.net",
+            },
+        )
+        integration.add_organization(self.organization, self.user)
+        install = integration.get_installation(self.organization.id)
+        self.client = install.get_client()
+
+    @responses.activate
+    def test_get_field_autocomplete_for_non_customfield(self):
+        body = {"results": [{"value": "ISSUE-1", "displayName": "My Issue (ISSUE-1)"}]}
+        responses.add(
+            method=responses.GET,
+            url="https://example.atlassian.net/rest/api/2/jql/autocompletedata/suggestions?fieldName=my_field&fieldValue=abc&jwt=my-jwt-token",
+            body=json.dumps(body),
+            status=200,
+            content_type="application/json",
+            match_querystring=True,
+        )
+        res = self.client.get_field_autocomplete("my_field", "abc")
+        assert res == body
+
+    @responses.activate
+    def test_get_field_autocomplete_for_customfield(self):
+        body = {"results": [{"value": "ISSUE-1", "displayName": "My Issue (ISSUE-1)"}]}
+        responses.add(
+            method=responses.GET,
+            url="https://example.atlassian.net/rest/api/2/jql/autocompletedata/suggestions?fieldName=cf[0123]&fieldValue=abc&jwt=my-jwt-token",
+            body=json.dumps(body),
+            status=200,
+            content_type="application/json",
+            match_querystring=True,
+        )
+        res = self.client.get_field_autocomplete("customfield_0123", "abc")
+        assert res == body

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -64,9 +64,10 @@ class JiraIntegrationTest(APITestCase):
             project_id=self.project.id,
         )
         group = event.group
-
         installation = self.integration.get_installation(self.organization.id)
-
+        search_url = reverse(
+            "sentry-extensions-jira-search", args=[self.organization.slug, self.integration.id],
+        )
         with mock.patch.object(installation, "get_client", get_client):
             assert installation.get_create_issue_config(group, self.user) == [
                 {
@@ -130,18 +131,39 @@ class JiraIntegrationTest(APITestCase):
                     "type": "select",
                 },
                 {
+                    "name": "customfield_10400",
+                    "url": search_url,
+                    "choices": [],
+                    "label": "Epic Link",
+                    "required": False,
+                    "type": "select",
+                },
+                {
+                    "name": "customfield_10500",
+                    "url": search_url,
+                    "choices": [],
+                    "label": "Sprint",
+                    "required": False,
+                    "type": "select",
+                },
+                {
+                    "name": "labels",
                     "default": "",
                     "required": False,
                     "type": "text",
-                    "name": "labels",
                     "label": "Labels",
                 },
                 {
+                    "name": "parent",
+                    "url": search_url,
+                    "choices": [],
+                    "label": "Parent",
+                    "required": False,
+                    "type": "select",
+                },
+                {
                     "name": "reporter",
-                    "url": reverse(
-                        "sentry-extensions-jira-search",
-                        args=[self.organization.slug, self.integration.id],
-                    ),
+                    "url": search_url,
                     "required": True,
                     "choices": [],
                     "label": "Reporter",
@@ -223,7 +245,10 @@ class JiraIntegrationTest(APITestCase):
                 "issuetype",
                 "customfield_10200",
                 "customfield_10300",
+                "customfield_10400",
+                "customfield_10500",
                 "labels",
+                "parent",
                 "reporter",
             ]
 
@@ -238,7 +263,10 @@ class JiraIntegrationTest(APITestCase):
                 "description",
                 "issuetype",
                 "customfield_10300",
+                "customfield_10400",
+                "customfield_10500",
                 "labels",
+                "parent",
                 "reporter",
             ]
 


### PR DESCRIPTION
- The "epic link" and "sprint" fields can be identified by `schema.custom` and
  queried via the JQL autocomplete API endpoint.
  See: https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-jql/
- The "parent" field can be identified by `schema.type` == `issuelink` and
  queried in the same way that the "external issue id" field is

It's worth noting that there is a non-obvious parallel maintainence between
the following 3 methods that ideally could be refactored:
 - src/sentry/integrations/jira/search.py:JiraSearchEndpoint.get
 - src/sentry/integrations/jira/integration.py:JiraIntegration.build_dynamic_field
 - src/sentry/integrations/jira/integration.py:JiraIntegration.create_issue

Closes #18303