### PR TITLE
fix(btn-secondary): fixed paginator icon

### DIFF
--- a/src/sentry/static/sentry/app/components/pagination.tsx
+++ b/src/sentry/static/sentry/app/components/pagination.tsx
@@ -61,13 +61,7 @@ class Pagination extends React.Component<Props> {
       <div className={className}>
         <ButtonBar merged>
           <Button
-            icon={
-              <IconChevron
-                direction="left"
-                size="sm"
-                color={previousDisabled ? 'gray200' : 'purple300'}
-              />
-            }
+            icon={<IconChevron direction="left" size="sm" />}
             aria-label={t('Previous')}
             size={size}
             disabled={previousDisabled}
@@ -76,13 +70,7 @@ class Pagination extends React.Component<Props> {
             }}
           />
           <Button
-            icon={
-              <IconChevron
-                direction="right"
-                size="sm"
-                color={nextDisabled ? 'gray200' : 'purple300'}
-              />
-            }
+            icon={<IconChevron direction="right" size="sm" />}
             aria-label={t('Next')}
             size={size}
             disabled={nextDisabled}

--- a/src/sentry/static/sentry/app/components/pagination.tsx
+++ b/src/sentry/static/sentry/app/components/pagination.tsx
@@ -65,7 +65,7 @@ class Pagination extends React.Component<Props> {
               <IconChevron
                 direction="left"
                 size="sm"
-                color={previousDisabled ? 'gray200' : 'gray500'}
+                color={previousDisabled ? 'gray200' : 'purple300'}
               />
             }
             aria-label={t('Previous')}
@@ -80,7 +80,7 @@ class Pagination extends React.Component<Props> {
               <IconChevron
                 direction="right"
                 size="sm"
-                color={nextDisabled ? 'gray200' : 'gray500'}
+                color={nextDisabled ? 'gray200' : 'purple300'}
               />
             }
             aria-label={t('Next')}


### PR DESCRIPTION
**Before:**
![Screen Shot 2021-01-04 at 9 18 14 AM](https://user-images.githubusercontent.com/4830259/103563984-96501100-4e72-11eb-8cb7-b557210d7639.png)

**After:**
![Screen Shot 2021-01-04 at 9 17 50 AM](https://user-images.githubusercontent.com/4830259/103563997-9d771f00-4e72-11eb-9ee8-5d4432207be3.png)
![Screen Shot 2021-01-04 at 9 50 56 AM](https://user-images.githubusercontent.com/4830259/103564003-a0720f80-4e72-11eb-9a1c-30b29ba722e9.png)
![Screen Shot 2021-01-04 at 10 03 55 AM](https://user-images.githubusercontent.com/4830259/103564936-3fe3d200-4e74-11eb-83ab-bad9f80edf90.png)
