### PR TITLE
ref(ui): revert secondary button color changes

### DIFF
--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -127,9 +127,11 @@ const aliases = {
   linkColor: colors.purple300,
 
   /**
-   * ...
+   * Secondary button colors
    */
-  secondaryButton: colors.purple300,
+  secondaryButtonBorder: colors.gray200,
+
+  secondaryButtonText: colors.gray500,
 
   /**
    * Gradient for sidebar
@@ -265,12 +267,12 @@ const generateButtonTheme = alias => ({
   borderRadius: '3px',
 
   default: {
-    color: alias.secondaryButton,
-    colorActive: alias.secondaryButton,
+    color: alias.secondaryButtonText,
+    colorActive: alias.secondaryButtonText,
     background: alias.background,
     backgroundActive: alias.background,
-    border: alias.secondaryButton,
-    borderActive: alias.secondaryButton,
+    border: alias.secondaryButtonBorder,
+    borderActive: alias.secondaryButtonBorder,
     focusShadow: color(colors.gray200).alpha(0.5).string(),
   },
   primary: {
@@ -504,7 +506,8 @@ const darkAliases = {
   inactive: colors.gray200,
   error: colors.red300,
   success: colors.green300,
-  secondaryButton: colors.purple200,
+  secondaryButtonText: colors.purple200,
+  secondaryButtonBorder: colors.purple200,
   sidebarGradient: 'linear-gradient(6.01deg, #0A090F -8.44%, #1B0921 85.02%)',
   formPlaceholder: colors.gray400,
   formText: colors.white,


### PR DESCRIPTION
This reverts the secondary button text color and border back to gray.

**Before:**

<img width="589" alt="Screen Shot 2021-01-04 at 1 18 00 PM" src="https://user-images.githubusercontent.com/30713/103580767-9c081f80-4e8f-11eb-967c-b560abdfa11b.png">

**After:**

<img width="584" alt="Screen Shot 2021-01-04 at 1 18 55 PM" src="https://user-images.githubusercontent.com/30713/103580757-98749880-4e8f-11eb-9798-b71482c7c4a5.png">

The purple treatment looked great in certain areas, so we'll address potential paths forward in future PRs.