### PR TITLE
feat(ui): Remove `deprecatedSelectControl` from `<FieldFromConfig>`

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
@@ -133,7 +133,7 @@ export default class FieldFromConfig extends React.Component<Props> {
         // return <SelectAsyncField {...props} />;
         // }
 
-        return <SelectField deprecatedSelectControl {...props} />;
+        return <SelectField {...props} />;
       case 'choice_mapper':
         return <ChoiceMapperField {...props} />;
       case 'radio':

--- a/tests/js/spec/components/forms/jsonForm.spec.tsx
+++ b/tests/js/spec/components/forms/jsonForm.spec.tsx
@@ -130,7 +130,8 @@ describe('JsonForm', function () {
       // slug and platform have no visible prop, that means they will be always visible
       const wrapper = mountWithTheme(<JsonForm fields={jsonFormFields} />);
       expect(wrapper.find('FormPanel')).toHaveLength(1);
-      expect(wrapper.find('input')).toHaveLength(2);
+      expect(wrapper.find('input[name="slug"]')).toHaveLength(1);
+      expect(wrapper.find('input[name="platform"]')).toHaveLength(1);
     });
 
     it('should NOT hide panel, if at least one field has visible set to true -  visible prop is of type boolean', function () {
@@ -139,7 +140,8 @@ describe('JsonForm', function () {
         <JsonForm fields={jsonFormFields.map(field => ({...field, visible: true}))} />
       );
       expect(wrapper.find('FormPanel')).toHaveLength(1);
-      expect(wrapper.find('input')).toHaveLength(2);
+      expect(wrapper.find('input[name="slug"]')).toHaveLength(1);
+      expect(wrapper.find('input[name="platform"]')).toHaveLength(1);
     });
 
     it('should NOT hide panel, if at least one field has visible set to true -  visible prop is of type func', function () {
@@ -150,7 +152,8 @@ describe('JsonForm', function () {
         />
       );
       expect(wrapper.find('FormPanel')).toHaveLength(1);
-      expect(wrapper.find('input')).toHaveLength(2);
+      expect(wrapper.find('input[name="slug"]')).toHaveLength(1);
+      expect(wrapper.find('input[name="platform"]')).toHaveLength(1);
     });
 
     it('should ALWAYS hide panel, if all fields have visible set to false -  visible prop is of type boolean', function () {

--- a/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
-import {selectByValue} from 'sentry-test/select';
+import {selectByValue} from 'sentry-test/select-new';
 
 import ProjectsStore from 'app/stores/projectsStore';
 import ProjectContext from 'app/views/projects/projectContext';


### PR DESCRIPTION
The biggest blind spot here are integrations. I could not find any to test and from a quick scan of the `src/sentry/integrations` dir, there doesnt seem to be leakage of `react-select` props.