### PR TITLE
fix(dashboardsv2): Correctly pass the displayType value for widget charts

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -246,7 +246,9 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
                 name="displayType"
                 label={t('Chart Style')}
                 value={state.displayType}
-                onChange={this.handleFieldChange('displayType')}
+                onChange={(option: {label: string; value: Widget['displayType']}) => {
+                  this.handleFieldChange('displayType')(option.value);
+                }}
               />
             </Field>
           </DoubleFieldWrapper>


### PR DESCRIPTION
Updating or setting the widget chart value will fail the validation as shown here:

<img width="663" alt="Screen Shot 2021-01-04 at 5 01 33 PM" src="https://user-images.githubusercontent.com/139499/103584335-185e2b00-4eaf-11eb-9507-6029948e4071.png">

This PR fixes that. 