### PR TITLE
fix(integrations): Separate key and metadata.display_name in ExternalIssue

### DIFF
--- a/src/sentry/integrations/jira/notify_action.py
+++ b/src/sentry/integrations/jira/notify_action.py
@@ -25,7 +25,6 @@ class JiraCreateTicketAction(TicketEventAction):
     ticket_type = "a Jira issue"
     link = "https://docs.sentry.io/product/integrations/jira/#issue-sync"
     provider = "jira"
-    issue_key_path = "key"
     integration_key = INTEGRATION_KEY
 
     def render_label(self):

--- a/src/sentry/integrations/vsts/notify_action.py
+++ b/src/sentry/integrations/vsts/notify_action.py
@@ -20,7 +20,6 @@ class AzureDevopsCreateTicketAction(TicketEventAction):
     ticket_type = "an Azure DevOps work item"
     link = "https://docs.sentry.io/product/integrations/azure-devops/#issue-sync"
     provider = "vsts"
-    issue_key_path = "metadata.display_name"
     integration_key = INTEGRATION_KEY
 
     def render_label(self):

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -125,12 +125,23 @@ def has_linked_issue(event, integration):
 
 
 def create_link(integration, installation, event, response):
+    """
+    After creating the event on a third-party service, create a link to the
+    external resource in the DB. TODO make this a transaction.
+    :param integration: Integration object.
+    :param installation: Installation object.
+    :param event: The event object that was recorded on an external service.
+    :param response: The API response from creating the new resource.
+        - key: String. The unique ID of the external resource
+        - metadata: Optional Object. Can contain `display_name`.
+    """
     external_issue = ExternalIssue.objects.create(
         organization_id=event.group.project.organization_id,
         integration_id=integration.id,
         key=response["key"],
         title=event.title,
         description=installation.get_group_description(event.group, event),
+        metadata=response.get("metadata"),
     )
     GroupLink.objects.create(
         group_id=event.group.id,

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -271,6 +271,5 @@ class TicketEventAction(IntegrationEventAction):
             data=self.data,
             generate_footer=self.generate_footer,
             integration_id=integration_id,
-            issue_key_path=self.issue_key_path,
             provider=self.provider,
         )

--- a/src/sentry/rules/actions/base.py
+++ b/src/sentry/rules/actions/base.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import, print_function
 
-import functools
 import logging
-import operator
 import six
 
 from django import forms
@@ -126,11 +124,11 @@ def has_linked_issue(event, integration):
     return _linked_issues(event, integration).exists()
 
 
-def create_link(key, integration, installation, event):
+def create_link(integration, installation, event, response):
     external_issue = ExternalIssue.objects.create(
         organization_id=event.group.project.organization_id,
         integration_id=integration.id,
-        key=key,
+        key=response["key"],
         title=event.title,
         description=installation.get_group_description(event.group, event),
     )
@@ -196,9 +194,7 @@ def create_issue(event, futures):
             )
             return
         response = installation.create_issue(data)
-        issue_key_path = future.kwargs.get("issue_key_path")
-        issue_key = functools.reduce(operator.getitem, issue_key_path.split("."), response)
-        create_link(issue_key, integration, installation, event)
+        create_link(integration, installation, event, response)
 
 
 class TicketEventAction(IntegrationEventAction):

--- a/tests/sentry/integrations/vsts/test_notify_action.py
+++ b/tests/sentry/integrations/vsts/test_notify_action.py
@@ -72,7 +72,7 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
         assert data["fields"]["System.Title"] == "Hello"
         assert data["fields"]["System.Description"] == "Fix this."
 
-        external_issue = ExternalIssue.objects.get(key="Fabrikam-Fiber-Git#309")
+        external_issue = ExternalIssue.objects.get(key="309")
         assert external_issue
 
     @responses.activate
@@ -84,7 +84,7 @@ class AzureDevopsCreateTicketActionTest(RuleTestCase, VstsIssueBase):
         external_issue = ExternalIssue.objects.create(
             organization_id=self.organization.id,
             integration_id=self.integration.model.id,
-            key="TEST#6",
+            key="6",
             title=event.title,
             description="Fix this.",
         )


### PR DESCRIPTION
When Azure DevOps Ticket Rule is triggered, the external issue is created correctly but the link in the Sentry issue 404s. We were using `metadata.display_name` instead of key so the URL was wrong. This PR uses the right field and cleans up the code.