### PR TITLE
fix(api) Fix a 500 on invalid since/until values.

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -378,20 +378,27 @@ class StatsMixin(object):
         resolution = request.GET.get("resolution")
         if resolution:
             resolution = self._parse_resolution(resolution)
-            assert resolution in tsdb.get_rollups()
+            if resolution not in tsdb.get_rollups():
+                raise ParseError(detail="Invalid resolution")
 
-        end = request.GET.get("until")
-        if end:
-            end = to_datetime(float(end))
-        else:
-            end = datetime.utcnow().replace(tzinfo=utc)
+        try:
+            end = request.GET.get("until")
+            if end:
+                end = to_datetime(float(end))
+            else:
+                end = datetime.utcnow().replace(tzinfo=utc)
+        except ValueError:
+            raise ParseError(detail="until must be a numeric timestamp.")
 
-        start = request.GET.get("since")
-        if start:
-            start = to_datetime(float(start))
-            assert start <= end, "start must be before or equal to end"
-        else:
-            start = end - timedelta(days=1, seconds=-1)
+        try:
+            start = request.GET.get("since")
+            if start:
+                start = to_datetime(float(start))
+                assert start <= end, "start must be before or equal to end"
+            else:
+                start = end - timedelta(days=1, seconds=-1)
+        except ValueError:
+            raise ParseError(detail="since must be a numeric timestamp")
 
         if not resolution:
             resolution = tsdb.get_optimal_rollup(start, end)

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import
-import six
 
 from rest_framework.response import Response
-from rest_framework.exceptions import ParseError
 
 from sentry import tsdb
 from sentry.api.base import EnvironmentMixin, StatsMixin
@@ -91,12 +89,9 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMix
 
         if stat_model is None:
             raise ValueError("Invalid group: %s, stat: %s" % (group, stat))
-
-        try:
-            stats_args = self._parse_args(request, **query_kwargs)
-        except ValueError as err:
-            raise ParseError(detail="Invalid value %s" % six.text_type(err))
-        data = tsdb.get_range(model=stat_model, keys=keys, **stats_args)
+        data = tsdb.get_range(
+            model=stat_model, keys=keys, **self._parse_args(request, **query_kwargs)
+        )
 
         if group == "organization":
             data = data[organization.id]

--- a/tests/sentry/api/endpoints/test_organization_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_stats.py
@@ -40,6 +40,13 @@ class OrganizationStatsTest(APITestCase):
         assert response.data[-1][1] == 3, response.data
         assert len(response.data) == 1
 
+    def test_resolution_invalid(self):
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-organization-stats", args=[self.organization.slug])
+        response = self.client.get(u"{}?resolution=lol-nope".format(url))
+
+        assert response.status_code == 400, response.content
+
     def test_id_filtering(self):
         self.login_as(user=self.user)
 

--- a/tests/sentry/api/endpoints/test_sentry_app_interaction.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_interaction.py
@@ -57,7 +57,7 @@ class GetSentryAppInteractionTest(SentryAppInteractionTest):
 
         url = "%s?since=1569523068&until=1566931068" % self.owned_url
         response = self.client.get(url, format="json")
-        assert response.status_code == 500
+        assert response.status_code == 400
 
 
 class PostSentryAppInteractionTest(SentryAppInteractionTest):

--- a/tests/sentry/api/endpoints/test_sentry_app_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_stats.py
@@ -110,4 +110,4 @@ class GetSentryAppStatsTest(SentryAppStatsTest):
             "sentry-api-0-sentry-app-stats", args=[self.published_app.slug]
         )
         response = self.client.get(url, format="json")
-        assert response.status_code == 500
+        assert response.status_code == 400


### PR DESCRIPTION
Convert the ValueError raised by _parse_args() into a 400 response.

Fixes SENTRY-KB9