### PR TITLE
feat(dashboards) Defer loading widgets that are out of viewport

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import LazyLoad from 'react-lazyload';
 import styled from '@emotion/styled';
 
 import {openAddDashboardWidgetModal} from 'app/actionCreators/modal';
@@ -93,14 +94,16 @@ class Dashboard extends React.Component<Props, State> {
     const {isEditing} = this.props;
     // TODO add drag state and drag re-sorting.
     return (
-      <WidgetWrapper key={`${widget.id}:${index}`}>
-        <WidgetCard
-          widget={widget}
-          isEditing={isEditing}
-          onDelete={this.handleDeleteWidget(index)}
-          onEdit={this.handleEditWidget(widget, index)}
-        />
-      </WidgetWrapper>
+      <LazyLoad key={`${widget.id}:${index}`} once height={240} offset={100}>
+        <WidgetWrapper>
+          <WidgetCard
+            widget={widget}
+            isEditing={isEditing}
+            onDelete={this.handleDeleteWidget(index)}
+            onEdit={this.handleEditWidget(widget, index)}
+          />
+        </WidgetWrapper>
+      </LazyLoad>
     );
   }
 


### PR DESCRIPTION
Don't load widgets until they get close to being in the viewport. This will help improve performance of larger dashboards by only loading data that is visible.