### PR TITLE
feat(integration-platform): Make optional fields clearable

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -277,7 +277,7 @@ const SelectControl = props => {
       components={{...replacedComponents, ...components}}
       async={async}
       creatable={creatable}
-      clearable={clearable}
+      isClearable={clearable}
       backspaceRemovesValue={clearable}
       value={mappedValue}
       isMulti={props.multiple || props.multi}

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.tsx
@@ -270,6 +270,7 @@ export class SentryAppExternalIssueForm extends React.Component<Props, State> {
         label,
       }));
       const options = this.state.optionsByField.get(field.name) || defaultOptions;
+      const allowClear = !required;
       //filter by what the user is typing
       const filterOption = createFilter({});
       fieldToPass = {
@@ -277,6 +278,7 @@ export class SentryAppExternalIssueForm extends React.Component<Props, State> {
         options,
         defaultOptions,
         filterOption,
+        allowClear,
       };
       //default message for async select fields
       if (isAsync) {

--- a/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/type.tsx
@@ -106,7 +106,7 @@ type InputType = {type: 'string' | 'secret'} & {
 
 type SelectControlType = {type: 'choice' | 'select'} & {
   multiple?: boolean;
-
+  allowClear?: boolean;
   options?: Array<{label: string; value: any}>; //for new select
   defaultOptions?: Array<{label: string; value: any}> | boolean;
   filterOption?: ReturnType<typeof createFilter>;


### PR DESCRIPTION
## Objective:
For an optional field defined by the UI Component schema for an Integration Platform integration, once you set it, you cannot unset it. We should be able clear our selection for optional fields. 

## UI
**Before:**
![Screen Shot 2020-08-14 at 1 28 06 PM](https://user-images.githubusercontent.com/10491193/103682542-e1832600-4f3d-11eb-8fdf-10e38942307a.png)

**After:**
<img width="621" alt="Screen Shot 2021-01-05 at 9 52 00 AM" src="https://user-images.githubusercontent.com/10491193/103682501-d3350a00-4f3d-11eb-90c9-99d7394e42bf.png">
