### PR TITLE
feat(ui): Display duration as months when > 4 weeks

### DIFF
--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -47,6 +47,7 @@ function roundWithFixed(
 }
 
 // in milliseconds
+export const MONTH = 2629800000;
 export const WEEK = 604800000;
 export const DAY = 86400000;
 export const HOUR = 3600000;
@@ -60,6 +61,10 @@ export function getDuration(
 ): string {
   const value = Math.abs(seconds * 1000);
 
+  if (value >= MONTH) {
+    const {label, result} = roundWithFixed(value / MONTH, fixedDigits);
+    return `${label}${abbreviation ? t('mos') : ` ${tn('month', 'months', result)}`}`;
+  }
   if (value >= WEEK) {
     const {label, result} = roundWithFixed(value / WEEK, fixedDigits);
     return `${label}${abbreviation ? t('wk') : ` ${tn('week', 'weeks', result)}`}`;

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -63,7 +63,9 @@ export function getDuration(
 
   if (value >= MONTH) {
     const {label, result} = roundWithFixed(value / MONTH, fixedDigits);
-    return `${label}${abbreviation ? t('mos') : ` ${tn('month', 'months', result)}`}`;
+    return `${label}${
+      abbreviation ? tn('mo', 'mos', result) : ` ${tn('month', 'months', result)}`
+    }`;
   }
   if (value >= WEEK) {
     const {label, result} = roundWithFixed(value / WEEK, fixedDigits);

--- a/tests/js/spec/utils/formatters.spec.jsx
+++ b/tests/js/spec/utils/formatters.spec.jsx
@@ -19,6 +19,9 @@ describe('getDuration()', function () {
     expect(getDuration(86400)).toBe('24 hours');
     expect(getDuration(86400 * 2)).toBe('2 days');
     expect(getDuration(604800)).toBe('1 week');
+    expect(getDuration(604800 * 4)).toBe('4 weeks');
+    expect(getDuration(2629800)).toBe('1 month');
+    expect(getDuration(604800 * 12)).toBe('3 months');
   });
 
   it('should format numbers and abbreviate units', function () {
@@ -32,6 +35,9 @@ describe('getDuration()', function () {
     expect(getDuration(86400, 0, true)).toBe('24hr');
     expect(getDuration(86400 * 2, 0, true)).toBe('2d');
     expect(getDuration(604800, 0, true)).toBe('1wk');
+    expect(getDuration(604800 * 2, 0, true)).toBe('2wk');
+    expect(getDuration(2629800, 0, true)).toBe('1mos');
+    expect(getDuration(604800 * 12, 0, true)).toBe('3mos');
   });
 });
 

--- a/tests/js/spec/utils/formatters.spec.jsx
+++ b/tests/js/spec/utils/formatters.spec.jsx
@@ -36,7 +36,7 @@ describe('getDuration()', function () {
     expect(getDuration(86400 * 2, 0, true)).toBe('2d');
     expect(getDuration(604800, 0, true)).toBe('1wk');
     expect(getDuration(604800 * 2, 0, true)).toBe('2wk');
-    expect(getDuration(2629800, 0, true)).toBe('1mos');
+    expect(getDuration(2629800, 0, true)).toBe('1mo');
     expect(getDuration(604800 * 12, 0, true)).toBe('3mos');
   });
 });


### PR DESCRIPTION
Will display 10 months instead of 42 weeks.
`2629800000` seems to be the accepted amount of time for a month and is `4.34821428571` weeks.