### PR TITLE
fix(discover): Persist function parameter if valid

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -110,7 +110,9 @@ class QueryField extends React.Component<Props> {
           if (field === null) {
             fieldValue.function[i + 1] = param.defaultValue || '';
           } else if (
-            (field.kind === FieldValueKind.FIELD || field.kind === FieldValueKind.TAG) &&
+            (field.kind === FieldValueKind.FIELD ||
+              field.kind === FieldValueKind.TAG ||
+              field.kind === FieldValueKind.MEASUREMENT) &&
             validateColumnTypes(param.columnTypes as ValidateColumnTypes, field)
           ) {
             // New function accepts current field.
@@ -120,8 +122,7 @@ class QueryField extends React.Component<Props> {
             fieldValue.function[i + 1] = param.defaultValue || '';
             fieldValue.function[i + 2] = undefined;
           }
-        }
-        if (param.kind === 'value') {
+        } else if (param.kind === 'value') {
           fieldValue.function[i + 1] = param.defaultValue || '';
         }
       });


### PR DESCRIPTION
When changing functions in the column editor, measurement parameters should also
be persisted when they are allowed under the new function. This change ensures
that like fields and tags, measurements parameters will be checked and persisted
where possible.