### PR TITLE
ref(slack): Feature gate  workspace app functionality

### DIFF
--- a/src/sentry/api/endpoints/organization_integrations.py
+++ b/src/sentry/api/endpoints/organization_integrations.py
@@ -33,7 +33,7 @@ class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
                     slack_integrations,
                 )
             ]
-            integrations = integrations.filter(id__in=workspace_ids)
+            integrations = integrations.exclude(id__in=workspace_ids)
 
         # include the configurations by default if no param
         include_config = True

--- a/src/sentry/api/endpoints/organization_integrations.py
+++ b/src/sentry/api/endpoints/organization_integrations.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import
 
+from sentry import features
+
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationIntegrationsPermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.models import ObjectStatus, OrganizationIntegration
+from sentry.integrations.slack.utils import get_integration_type
+from sentry.utils.compat import filter
 
 
 class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
@@ -16,6 +20,20 @@ class OrganizationIntegrationsEndpoint(OrganizationEndpoint):
 
         if "provider_key" in request.GET:
             integrations = integrations.filter(integration__provider=request.GET["provider_key"])
+
+        # XXX(meredith): Filter out workspace apps if there are any.
+        if not features.has(
+            "organizations:slack-allow-workspace", organization=organization, actor=request.user
+        ):
+            slack_integrations = integrations.filter(integration__provider="slack")
+            workspace_ids = [
+                workspace_app.id
+                for workspace_app in filter(
+                    lambda i: get_integration_type(i.integration) == "workspace_app",
+                    slack_integrations,
+                )
+            ]
+            integrations = integrations.filter(id__in=workspace_ids)
 
         # include the configurations by default if no param
         include_config = True

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -883,6 +883,9 @@ SENTRY_FEATURES = {
     "organizations:integrations-stacktrace-link": False,
     # Enables aws lambda integration
     "organizations:integrations-aws_lambda": False,
+    # Temporary safety measure, turned on for specific orgs only if
+    # absolutely necessary, to be removed Jan 31, 2021
+    "organizations:slack-allow-workspace": False,
     # Enable data forwarding functionality for organizations.
     "organizations:data-forwarding": True,
     # Enable custom dashboards (dashboards 2)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -884,7 +884,7 @@ SENTRY_FEATURES = {
     # Enables aws lambda integration
     "organizations:integrations-aws_lambda": False,
     # Temporary safety measure, turned on for specific orgs only if
-    # absolutely necessary, to be removed Jan 31, 2021
+    # absolutely necessary, to be removed shortly
     "organizations:slack-allow-workspace": False,
     # Enable data forwarding functionality for organizations.
     "organizations:data-forwarding": True,

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -83,6 +83,7 @@ default_manager.add("organizations:integrations-ticket-rules", OrganizationFeatu
 default_manager.add("organizations:integrations-vsts-limited-scopes", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-stacktrace-link", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-aws_lambda", OrganizationFeature)  # NOQA
+default_manager.add("organizations:slack-allow-workspace", OrganizationFeature)  # NOQA
 default_manager.add("organizations:internal-catchall", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members", OrganizationFeature)  # NOQA
 default_manager.add("organizations:images-loaded-v2", OrganizationFeature)  # NOQA

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -13,11 +13,11 @@ from .exceptions import FeatureNotRegistered
 
 class RegisteredFeatureManager(object):
     """
-        Feature functions that are built around the need to register feature
-        handlers
+    Feature functions that are built around the need to register feature
+    handlers
 
-        TODO: Once features have been audited and migrated to the entity
-        handler, remove this class entirely
+    TODO: Once features have been audited and migrated to the entity
+    handler, remove this class entirely
     """
 
     def __init__(self):

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1269,7 +1269,7 @@ def get_alert_rule_trigger_action_slack_channel_id(
     # XXX(meredith): Will be removed when we rip out workspace app support completely.
     except DeprecatedIntegrationError:
         raise InvalidTriggerActionError(
-            "This workspace is using the deprecated Slack integration. Please upgrade your integration to enable Slack alerting again."
+            "This workspace is using the deprecated Slack integration. Please re-install your integration to enable Slack alerting again."
         )
 
     except DuplicateDisplayNameError as e:

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -238,12 +238,12 @@ class SlackIntegrationProvider(IntegrationProvider):
 
 class SlackReAuthIntro(PipelineView):
     """
-        This pipeline step handles rendering the migration
-        intro with context about the migration.
+    This pipeline step handles rendering the migration
+    intro with context about the migration.
 
-        If the `integration_id` is not present in the request
-        then we can fast forward through the pipeline to move
-        on to installing the integration as normal.
+    If the `integration_id` is not present in the request
+    then we can fast forward through the pipeline to move
+    on to installing the integration as normal.
 
     """
 
@@ -296,15 +296,15 @@ class SlackReAuthIntro(PipelineView):
 
 class SlackReAuthChannels(PipelineView):
     """
-        This pipeline step handles making requests to Slack and
-        displaying the channels (if any) that are problematic:
+    This pipeline step handles making requests to Slack and
+    displaying the channels (if any) that are problematic:
 
-        1. private
-        2. removed
-        3. unauthorized
+    1. private
+    2. removed
+    3. unauthorized
 
-        Any private channels in alert rules will also be binded
-        to the pipeline state to be used later.
+    Any private channels in alert rules will also be binded
+    to the pipeline state to be used later.
 
     """
 

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -92,7 +92,7 @@ class SlackNotifyServiceForm(forms.Form):
             except DeprecatedIntegrationError:
                 raise forms.ValidationError(
                     _(
-                        'Workspace "%(workspace)s" is using the deprecated Slack integration. Please upgrade your integration to enable Slack alerting again.',
+                        'Workspace "%(workspace)s" is using the deprecated Slack integration. Please re-install your integration to enable Slack alerting again.',
                     ),
                     code="invalid",
                     params={

--- a/src/sentry/integrations/slack/notify_action.py
+++ b/src/sentry/integrations/slack/notify_action.py
@@ -168,7 +168,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
             return
 
         # XXX:(meredith) No longer support sending workspace app notifications unless explicitly
-        # flagged in. Flag is temporary and will be taken out Jan 31, 2021
+        # flagged in. Flag is temporary and will be taken out shortly
         if get_integration_type(integration) == "workspace_app" and not features.has(
             "organizations:slack-allow-workspace", event.group.project.organization
         ):

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -500,6 +500,11 @@ def send_incident_alert_notification(action, incident, metric_value):
         "attachments": json.dumps([attachment]),
     }
 
+    if get_integration_type(integration) == "workspace_app" and not features.has(
+        "organizations:slack-allow-workspace", incident.organization
+    ):
+        return
+
     client = SlackClient()
     try:
         client.post("/chat.postMessage", data=payload, timeout=5)

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -424,8 +424,9 @@ def get_channel_id_with_timeout(integration, name, timeout):
     # workspace tokens are the only tokens that don't works with the conversations.list endpoint,
     # once eveyone is migrated we can remove this check and usages of channels.list
 
-    # todo(meredith): flag this out. so no editing or creating new rules with workspace apps.
-    # raise WorkspaceApp
+    # XXX(meredith): Prevent anyone from creating new rules or editing existing rules that
+    # have workspace app integrations. For them to either remove slack action or re-install
+    # their integration.
     integration_type = get_integration_type(integration)
     if integration_type == "workspace_app" and not any(
         [

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -425,7 +425,7 @@ def get_channel_id_with_timeout(integration, name, timeout):
     # once eveyone is migrated we can remove this check and usages of channels.list
 
     # XXX(meredith): Prevent anyone from creating new rules or editing existing rules that
-    # have workspace app integrations. For them to either remove slack action or re-install
+    # have workspace app integrations. Force them to either remove slack action or re-install
     # their integration.
     integration_type = get_integration_type(integration)
     if integration_type == "workspace_app" and not any(

--- a/src/sentry/shared_integrations/exceptions.py
+++ b/src/sentry/shared_integrations/exceptions.py
@@ -89,6 +89,10 @@ class DuplicateDisplayNameError(IntegrationError):
     pass
 
 
+class DeprecatedIntegrationError(IntegrationError):
+    pass
+
+
 class IntegrationFormError(IntegrationError):
     def __init__(self, field_errors):
         super(IntegrationFormError, self).__init__("Invalid integration action")

--- a/tests/acceptance/test_organization_integration_detail_view.py
+++ b/tests/acceptance/test_organization_integration_detail_view.py
@@ -60,7 +60,7 @@ class OrganizationIntegrationDetailView(AcceptanceTestCase):
             provider="slack",
             external_id="some_slack",
             name="Test Slack",
-            metadata={"domain_name": "slack-test.slack.com"},
+            metadata={"domain_name": "slack-test.slack.com", "installation_type": "born_as_bot"},
         )
 
         model.add_organization(self.organization, self.user)

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -29,6 +29,7 @@ from sentry.incidents.models import (
 )
 from sentry.models import Integration, PagerDutyService, UserOption
 from sentry.testutils import TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 
@@ -194,7 +195,63 @@ class SlackActionHandlerTest(FireTest, TestCase):
 
         token = "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
         integration = Integration.objects.create(
-            external_id="1", provider="slack", metadata={"access_token": token}
+            external_id="1",
+            provider="slack",
+            metadata={"access_token": token, "installation_type": "born_as_bot"},
+        )
+        integration.add_organization(self.organization, self.user)
+        channel_id = "some_id"
+        channel_name = "#hello"
+        responses.add(
+            method=responses.GET,
+            url="https://slack.com/api/conversations.list",
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {"ok": "true", "channels": [{"name": channel_name[1:], "id": channel_id}]}
+            ),
+        )
+
+        action = self.create_alert_rule_trigger_action(
+            target_identifier=channel_name,
+            type=AlertRuleTriggerAction.Type.SLACK,
+            target_type=AlertRuleTriggerAction.TargetType.SPECIFIC,
+            integration=integration,
+        )
+        responses.add(
+            method=responses.POST,
+            url="https://slack.com/api/chat.postMessage",
+            status=200,
+            content_type="application/json",
+            body='{"ok": true}',
+        )
+        handler = SlackActionHandler(action, incident, self.project)
+        metric_value = 1000
+        with self.tasks():
+            getattr(handler, method)(metric_value)
+        data = parse_qs(responses.calls[1].request.body)
+        assert data["channel"] == [channel_id]
+        assert data["token"] == [token]
+        assert json.loads(data["attachments"][0])[0] == build_incident_attachment(
+            incident, metric_value
+        )
+
+    def test_fire_metric_alert(self):
+        self.run_fire_test()
+
+    def test_resolve_metric_alert(self):
+        self.run_fire_test("resolve")
+
+
+@freeze_time()
+class SlackWorkspaceActionHandlerTest(FireTest, TestCase):
+    @responses.activate
+    def run_test(self, incident, method):
+        from sentry.integrations.slack.utils import build_incident_attachment
+
+        token = "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"
+        integration = Integration.objects.create(
+            external_id="1", provider="slack", metadata={"access_token": token},
         )
         integration.add_organization(self.organization, self.user)
         channel_id = "some_id"
@@ -233,9 +290,11 @@ class SlackActionHandlerTest(FireTest, TestCase):
             incident, metric_value
         )
 
+    @with_feature("organizations:slack-allow-workspace")
     def test_fire_metric_alert(self):
         self.run_fire_test()
 
+    @with_feature("organizations:slack-allow-workspace")
     def test_resolve_metric_alert(self):
         self.run_fire_test("resolve")
 

--- a/tests/sentry/integrations/slack/test_notify_action.py
+++ b/tests/sentry/integrations/slack/test_notify_action.py
@@ -154,7 +154,6 @@ class SlackNotifyActionTest(RuleTestCase):
         self.assert_form_valid(form, "chan-id", "#my-channel")
 
     @responses.activate
-    @with_feature("organizations:slack-allow-workspace")
     def test_valid_bot_channel_selected(self):
         integration = Integration.objects.create(
             provider="slack",

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -28,7 +28,10 @@ class SlackTasksTest(TestCase):
             provider="slack",
             name="Team A",
             external_id="TXXXXXXX1",
-            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+            metadata={
+                "access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
+                "installation_type": "born_as_bot",
+            },
         )
         self.uuid = uuid4().hex
         self.integration.add_organization(self.org, self.user)
@@ -37,7 +40,7 @@ class SlackTasksTest(TestCase):
 
         responses.add(
             method=responses.GET,
-            url="https://slack.com/api/channels.list",
+            url="https://slack.com/api/conversations.list",
             status=200,
             content_type="application/json",
             body=json.dumps(channels),


### PR DESCRIPTION
**Context:**
We are at the tail end of our migration from the deprecated Slack workspace app to the supported Slack bot app. The high level outline of this project is as follows:
1. Build out new Slack integration as a bot app
1. Have all new installations of Slack be on this new bot app
1.  Enable migration path for workspace app to bot app
1.  Rip out support for workspace apps

*For more context on steps 1-3 for the Slack migration you can look through [these PRs](https://github.com/getsentry/sentry/pulls?q=is%3Apr+"slack-migration"+is%3Aclosed+).*

**Rip out support for workspace apps:**
We've notified users that still have Slack integrations on the workspace app that they have until **January 14th, 2021** to upgrade their installation. On that date their integration will be "removed" and their alerts will stop working. 

This removal will be a two part process. Ultimately we will run a migration that will remove the Slack integrations from our DB, but since that is a very permanent operation, we are doing a test run prior. 

**The Test Run:** Using the flag `organizations:slack-allow-workspace` we are going to simulate the integration being remove by preventing the user from seeing it installed in their integration settings and from creating/editing alert rules that have that integration included as an action. Additionally alerts will stop firing for those with workspace app alert rules. 

Why have the flag at all?
* Slack is widely used and people depend on their alerts, though we have sent many emails, in the event that someone cannot reinstall their integration but needs their alerts we can easily flag them in. Additionally we can then follow up with them to make sure they upgrade (since when flagged in, the upgrade flow is available again)  

Will installing the bot app while the workspace app is installed break anything?
* No. If they are installing the same exact workspace, the integration record will actually stay the same, the metadata will be updated to reflect the new access token information and installation type (will have `born_as_bot` added). This also means because the integration id will be the same, alert rules won't need to be updated either, they will start working again immediately. (*at least for issue alerts*)