### PR TITLE
feat(ui): Fix and refactor loading panel for "Processing Issues"

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.tsx
@@ -9,14 +9,22 @@ import AlertLink from 'app/components/alertLink';
 import AutoSelectText from 'app/components/autoSelectText';
 import Button from 'app/components/button';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
+import ExternalLink from 'app/components/links/externalLink';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
-import {Panel, PanelAlert, PanelTable} from 'app/components/panels';
+import {
+  Panel,
+  PanelAlert,
+  PanelBody,
+  PanelHeader,
+  PanelTable,
+} from 'app/components/panels';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import TimeSince from 'app/components/timeSince';
 import formGroups from 'app/data/forms/processingIssues';
 import {IconQuestion, IconSettings} from 'app/icons';
 import {t, tn} from 'app/locale';
+import {inputStyles} from 'app/styles/input';
 import {Organization, ProcessingIssue, ProcessingIssueItem} from 'app/types';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
@@ -129,11 +137,16 @@ class ProjectProcessingIssues extends React.Component<Props, State> {
     );
   };
 
-  sendReprocessing = () => {
+  sendReprocessing = (e: React.MouseEvent<Element>) => {
+    e.preventDefault();
+
     this.setState({
+      loading: true,
       reprocessing: true,
     });
+
     addLoadingMessage(t('Started reprocessing\u2026'));
+
     const {orgId, projectId} = this.props.params;
     this.props.api.request(`/projects/${orgId}/${projectId}/reprocessing/`, {
       method: 'POST',
@@ -263,13 +276,14 @@ class ProjectProcessingIssues extends React.Component<Props, State> {
   renderProblem(item: ProcessingIssueItem) {
     const description = this.getProblemDescription(item);
     const helpLink = HELP_LINKS[item.type];
+
     return (
-      <div className="processing-issue">
-        <span className="description">{description}</span>{' '}
+      <div>
+        <span>{description}</span>{' '}
         {helpLink && (
-          <a href={helpLink} className="help-link">
+          <ExternalLink href={helpLink}>
             <IconQuestion size="xs" />
-          </a>
+          </ExternalLink>
         )}
       </div>
     );
@@ -303,17 +317,20 @@ class ProjectProcessingIssues extends React.Component<Props, State> {
 
   renderResolveButton() {
     const issues = this.state.processingIssues;
+
     if (issues === null || this.state.reprocessing) {
       return null;
     }
     if (issues.resolveableIssues <= 0) {
       return null;
     }
+
     const fixButton = tn(
       'Click here to trigger processing for %s pending event',
       'Click here to trigger processing for %s pending events',
-      issues?.resolveableIssues
+      issues.resolveableIssues
     );
+
     return (
       <AlertLink priority="info" onClick={this.sendReprocessing}>
         {t('Pro Tip')}: {fixButton}
@@ -326,27 +343,27 @@ class ProjectProcessingIssues extends React.Component<Props, State> {
     const fixLink = processingIssues ? processingIssues.signedLink : false;
 
     let fixLinkBlock: React.ReactNode = null;
+
     if (fixLink) {
       fixLinkBlock = (
-        <div className="panel panel-info">
-          <div className="panel-heading">
-            <h3>{t('Having trouble uploading debug informations? We can help!')}</h3>
-          </div>
-          <div className="panel-body">
-            <div className="form-group" style={{marginBottom: 0}}>
-              <label>
-                {t(
-                  "Paste this command into your shell and we'll attempt to upload the missing symbols from your machine:"
-                )}
-              </label>
-              <AutoSelectText className="form-control disabled" style={{marginBottom: 6}}>
-                curl -sL "{fixLink}" | bash
-              </AutoSelectText>
-            </div>
-          </div>
-        </div>
+        <Panel>
+          <PanelHeader>
+            {t('Having trouble uploading debug informations? We can help!')}
+          </PanelHeader>
+          <PanelBody withPadding>
+            <label>
+              {t(
+                "Paste this command into your shell and we'll attempt to upload the missing symbols from your machine:"
+              )}
+            </label>
+            <AutoSelectTextInput readOnly>
+              curl -sL "{fixLink}" | bash
+            </AutoSelectTextInput>
+          </PanelBody>
+        </Panel>
       );
     }
+
     let processingRow: React.ReactNode = null;
     if (processingIssues && processingIssues.issuesProcessing > 0) {
       processingRow = (
@@ -361,7 +378,7 @@ class ProjectProcessingIssues extends React.Component<Props, State> {
     }
 
     return (
-      <div>
+      <React.Fragment>
         {fixLinkBlock}
         <h3>
           {t('Pending Issues')}
@@ -391,7 +408,7 @@ class ProjectProcessingIssues extends React.Component<Props, State> {
             </React.Fragment>
           ))}
         </PanelTable>
-      </div>
+      </React.Fragment>
     );
   }
 
@@ -454,6 +471,11 @@ class ProjectProcessingIssues extends React.Component<Props, State> {
 
 const StyledPanelAlert = styled(PanelAlert)`
   grid-column: 1/5;
+`;
+
+const AutoSelectTextInput = styled(AutoSelectText)<{readOnly: boolean}>`
+  font-family: ${p => p.theme.text.familyMono};
+  ${p => inputStyles(p)};
 `;
 
 export {ProjectProcessingIssues};

--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.tsx
@@ -5,6 +5,7 @@ import styled from '@emotion/styled';
 import {addLoadingMessage, clearIndicators} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
 import Access from 'app/components/acl/access';
+import AlertLink from 'app/components/alertLink';
 import AutoSelectText from 'app/components/autoSelectText';
 import Button from 'app/components/button';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
@@ -233,9 +234,9 @@ class ProjectProcessingIssues extends React.Component<Props, State> {
 
   renderLoading() {
     return (
-      <div className="box">
+      <Panel>
         <LoadingIndicator />
-      </div>
+      </Panel>
     );
   }
 
@@ -311,12 +312,12 @@ class ProjectProcessingIssues extends React.Component<Props, State> {
     const fixButton = tn(
       'Click here to trigger processing for %s pending event',
       'Click here to trigger processing for %s pending events',
-      issues.resolveableIssues
+      issues?.resolveableIssues
     );
     return (
-      <div className="alert alert-block alert-info">
-        Pro Tip: <a onClick={this.sendReprocessing}>{fixButton}</a>
-      </div>
+      <AlertLink priority="info" onClick={this.sendReprocessing}>
+        {t('Pro Tip')}: {fixButton}
+      </AlertLink>
     );
   }
 


### PR DESCRIPTION
Refactor to use components instead of CSS classes, which will also fix dark mode inconsistencies.

* Use `<Panel>` when possible
* Use `<AlertLink>` for triggering processing
![image](https://user-images.githubusercontent.com/79684/103700849-e9e95a00-4f59-11eb-9c32-ec00ac65082a.png)


Old:
![image](https://user-images.githubusercontent.com/79684/103701142-59f7e000-4f5a-11eb-9a3e-e3b2306d94b4.png)

New:
![image](https://user-images.githubusercontent.com/79684/103703034-b60f3400-4f5b-11eb-8337-620237fd53ec.png)


![image](https://user-images.githubusercontent.com/79684/103702860-a263cd80-4f5b-11eb-8485-36bce252c0b9.png)

