### PR TITLE
feat(ui): Fix legacy `<Select>` focus text color

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
@@ -206,7 +206,7 @@ const StyledSelect = styled(SelectPicker)`
     color: ${p => p.theme.textColor};
 
     &.is-focused {
-      color: ${p => p.theme.black};
+      color: ${p => p.theme.textColor};
       background-color: ${p => p.theme.focus};
     }
     &.is-selected {

--- a/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControlLegacy.tsx
@@ -246,6 +246,7 @@ const StyledSelect = styled(SelectPicker)`
   }
 
   .Select-menu-outer {
+    border-color: ${p => p.theme.border};
     z-index: ${p => p.theme.zIndex.dropdown};
   }
 


### PR DESCRIPTION
Fix select option text color when focused (and not selected). Previously was always black, but we need it to match the theme text color.

Old:
![image](https://user-images.githubusercontent.com/79684/103705540-1011f880-4f60-11eb-9f7c-90d92569836a.png)


New:
![image](https://user-images.githubusercontent.com/79684/103705496-fb356500-4f5f-11eb-9222-a3bfa52afcb5.png)
![image](https://user-images.githubusercontent.com/79684/103705510-01c3dc80-4f60-11eb-96b8-5978e16fbf7a.png)