### PR TITLE
feat(ui): Add dark mode for `<AvatarCropper>`

### DIFF
--- a/src/sentry/static/sentry/app/components/avatarCropper.tsx
+++ b/src/sentry/static/sentry/app/components/avatarCropper.tsx
@@ -429,10 +429,14 @@ const ImageCropper = styled('div')<{resizeDirection: Position | null}>`
   background-size: 20px 20px;
   background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
   background-color: ${p => p.theme.background};
-  background-image: linear-gradient(45deg, #eee 25%, rgba(0, 0, 0, 0) 25%),
-    linear-gradient(-45deg, #eee 25%, rgba(0, 0, 0, 0) 25%),
-    linear-gradient(45deg, rgba(0, 0, 0, 0) 75%, #eee 75%),
-    linear-gradient(-45deg, rgba(0, 0, 0, 0) 75%, #eee 75%);
+  background-image: linear-gradient(
+      45deg,
+      ${p => p.theme.backgroundSecondary} 25%,
+      rgba(0, 0, 0, 0) 25%
+    ),
+    linear-gradient(-45deg, ${p => p.theme.backgroundSecondary} 25%, rgba(0, 0, 0, 0) 25%),
+    linear-gradient(45deg, rgba(0, 0, 0, 0) 75%, ${p => p.theme.backgroundSecondary} 75%),
+    linear-gradient(-45deg, rgba(0, 0, 0, 0) 75%, ${p => p.theme.backgroundSecondary} 75%);
 `;
 
 const CropContainer = styled('div')`


### PR DESCRIPTION
Use `backgroundSecondary` instead of `#eee`, which causes it in light mode to be a bit lighter.


Old:
![image](https://user-images.githubusercontent.com/79684/103706620-f40f5680-4f61-11eb-8ce2-3dc441e44971.png)
![image](https://user-images.githubusercontent.com/79684/103706631-fa053780-4f61-11eb-93f5-de0d90db013d.png)


New:
![image](https://user-images.githubusercontent.com/79684/103706553-d0e4a700-4f61-11eb-94d8-45d3aefd1664.png)
![image](https://user-images.githubusercontent.com/79684/103706588-de9a2c80-4f61-11eb-9682-e1325bbd8f3b.png)
