### PR TITLE
fix(dev): Enable line buffering for stderr

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -69,9 +69,6 @@ ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "production")
 IS_DEV = ENVIRONMENT == "development"
 
 DEBUG = IS_DEV
-if IS_DEV:
-    # Enable line buffering for stderr, TODO(py3.9) can be removed after py3.9, see bpo-13601
-    sys.stderr = os.fdopen(sys.stderr.fileno(), "w", 1)
 
 MAINTENANCE = False
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -69,6 +69,10 @@ ENVIRONMENT = os.environ.get("SENTRY_ENVIRONMENT", "production")
 IS_DEV = ENVIRONMENT == "development"
 
 DEBUG = IS_DEV
+if IS_DEV:
+    # Enable line buffering for stderr, TODO(py3.9) can be removed after py3.9, see bpo-13601
+    sys.stderr = os.fdopen(sys.stderr.fileno(), "w", 1)
+
 MAINTENANCE = False
 
 ADMINS = ()

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -4,6 +4,7 @@ import click
 import logging
 import os
 import six
+import sys
 
 from django.conf import settings
 
@@ -274,6 +275,10 @@ def configure_structlog():
 
 def initialize_app(config, skip_service_validation=False):
     settings = config["settings"]
+
+    if settings.DEBUG:
+        # Enable line buffering for stderr, TODO(py3.9) can be removed after py3.9, see bpo-13601
+        sys.stderr = os.fdopen(sys.stderr.fileno(), "w", 1)
 
     # Just reuse the integration app for Single Org / Self-Hosted as
     # it doesn't make much sense to use 2 separate apps for SSO and


### PR DESCRIPTION
- Even with the `PYTHONUNBUFFERED` envvar, in python3 stderr is still being
  buffered which means that errors don't show up until the server is killed.
  This enables line buffering so that even in py3.6 these
  errors show up in our console immediately
- In py3.9 stderr is line buffered by default so this change will no
  longer be required, but until then we'll need it.