### PR TITLE
chore(py3): Make attachment storage not rely on `CACHE_VERSION`

### DIFF
--- a/src/sentry/attachments/redis.py
+++ b/src/sentry/attachments/redis.py
@@ -4,10 +4,17 @@ import logging
 
 from django.conf import settings
 
-from sentry.cache.redis import RedisClusterCache, RbCache
+from sentry.cache.redis import RedisClusterCache
 from .base import BaseAttachmentCache
 
 logger = logging.getLogger(__name__)
+
+# This constant modifies the cache version for `RedisClusterAttachmentCache`.
+# The attachment cache is not actually a cache, but a short term data storage system.
+# It inherits from cache backends, and so we're naming this setting to match this.
+# Bumping this cache version will likely result in dropping events, so be very careful
+# if you're doing so.
+ATTACHMENT_CACHE_VERSION = 1
 
 
 class RedisClusterAttachmentCache(BaseAttachmentCache):
@@ -15,12 +22,9 @@ class RedisClusterAttachmentCache(BaseAttachmentCache):
         cluster_id = options.pop("cluster_id", None)
         if cluster_id is None:
             cluster_id = getattr(settings, "SENTRY_ATTACHMENTS_REDIS_CLUSTER", "rc-short")
-        BaseAttachmentCache.__init__(self, inner=RedisClusterCache(cluster_id, **options))
-
-
-class RbAttachmentCache(BaseAttachmentCache):
-    def __init__(self, **options):
-        BaseAttachmentCache.__init__(self, inner=RbCache(**options))
+        BaseAttachmentCache.__init__(
+            self, inner=RedisClusterCache(cluster_id, version=ATTACHMENT_CACHE_VERSION, **options),
+        )
 
 
 # Confusing legacy name for RediscClusterCache

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -16,6 +16,7 @@ import sentry
 from sentry.utils.celery import crontab_with_minute_jitter
 from sentry.utils.types import type_from_value
 
+import six
 from datetime import timedelta
 from six.moves.urllib.parse import urlparse
 
@@ -1141,7 +1142,7 @@ CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 # The cache version affects both Django's internal cache (at runtime) as well
 # as Sentry's cache. This automatically overrides VERSION on the default
 # CACHES backend.
-CACHE_VERSION = 1
+CACHE_VERSION = 2 if six.PY3 else 1
 
 # Digests backend
 SENTRY_DIGESTS = "sentry.digests.backends.dummy.DummyBackend"

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -318,7 +318,7 @@ def initialize_app(config, skip_service_validation=False):
 
     for key in settings.CACHES:
         if not hasattr(settings.CACHES[key], "VERSION"):
-            settings.CACHES[key]["VERSION"] = 2 if six.PY3 else 1
+            settings.CACHES[key]["VERSION"] = settings.CACHE_VERSION
 
     settings.ASSET_VERSION = get_asset_version(settings)
     settings.STATIC_URL = settings.STATIC_URL.format(version=settings.ASSET_VERSION)

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -6,7 +6,7 @@ from sentry.utils.compat import mock
 import zlib
 import pytest
 
-from sentry.cache.redis import RedisClusterCache, RbCache
+from sentry.cache.redis import RedisClusterCache
 from sentry.utils.imports import import_string
 
 
@@ -26,32 +26,14 @@ def mock_client():
     return FakeClient()
 
 
-@pytest.fixture(params=["rb", "rediscluster"])
-def mocked_attachment_cache(request, mock_client):
-    class RbCluster(object):
-        def get_routing_client(self):
-            return mock_client
-
-    if request.param == "rb":
-        with mock.patch(
-            "sentry.cache.redis.get_cluster_from_options", return_value=(RbCluster(), {})
-        ) as cluster_get:
-            attachment_cache = import_string("sentry.attachments.redis.RbAttachmentCache")(hosts=[])
-            cluster_get.assert_any_call("SENTRY_CACHE_OPTIONS", {"hosts": []})
-            assert isinstance(attachment_cache.inner, RbCache)
-
-    elif request.param == "rediscluster":
-        with mock.patch(
-            "sentry.utils.redis.redis_clusters.get", return_value=mock_client
-        ) as cluster_get:
-            attachment_cache = import_string(
-                "sentry.attachments.redis.RedisClusterAttachmentCache"
-            )()
-            cluster_get.assert_any_call("rc-short")
-            assert isinstance(attachment_cache.inner, RedisClusterCache)
-
-    else:
-        assert False
+@pytest.fixture()
+def mocked_attachment_cache(mock_client):
+    with mock.patch(
+        "sentry.utils.redis.redis_clusters.get", return_value=mock_client
+    ) as cluster_get:
+        attachment_cache = import_string("sentry.attachments.redis.RedisClusterAttachmentCache")()
+        cluster_get.assert_any_call("rc-short")
+        assert isinstance(attachment_cache.inner, RedisClusterCache)
 
     assert attachment_cache.inner.client is mock_client
     yield attachment_cache


### PR DESCRIPTION
Follow up to the py3 release. When we released, this change broke the attachment "cache" and caused
us to drop events: https://github.com/getsentry/sentry/pull/22283
We fixed this here: https://github.com/getsentry/sentry/pull/22408

This was caused by a coupling between the cache and our short term attachment storage system, which
is not actually a cache, even though it inherits from the cache base. Bumping the version here means
we lose a bunch of events, and so isn't desirable.

This change makes sure that the `CACHE_VERSION` setting doesn't have any effect on the attachment
cache.

I also removed `RBAttachmentCache` because as far as I can tell it is unused.