### PR TITLE
fix(mocks): Mark has_transaction flag on project

### DIFF
--- a/bin/load-mocks
+++ b/bin/load-mocks
@@ -565,6 +565,9 @@ def main(num_events=1, extra_events=False, load_transactions=False):
                     )
 
             if load_transactions:
+                if not project.flags.has_transactions:
+                    project.update(flags=F("flags").bitor(Project.flags.has_transactions))
+
                 for day in range(14):
                     for hour in range(24):
                         timestamp = timezone.now() - timedelta(days=day, hours=hour)


### PR DESCRIPTION
When loading mock transactions on a project, make sure to mark the flag to
indicate the project received the first transactions. This ensures that Sentry
will not show the onboarding page when visiting the performance landing page.