### PR TITLE
ref(stacktrace-link): Remove inApp check

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/context.tsx
@@ -97,7 +97,6 @@ const Context = ({
                 !isHoverPreviewed &&
                 isActive &&
                 isExpanded &&
-                frame.inApp &&
                 frame.filename && (
                   <ErrorBoundary mini>
                     <StacktraceLink


### PR DESCRIPTION
**Context:**
When a user has a stack trace linking config (aka a code mapping) set up for a project we attempt to find a source code link for any stack trace that you click on in that project. Sometimes we aren't able to find a link and when we don't, we render a call to action to fix your configuration. 

Because you can have third party libs in your stack trace, telling you to fix your config isn't exactly helpful since that code is not something we can link you to anyway. To fix this I had added in a check to see if the frame was `in_app` because I wanted to prevent the call to action to fix a config from showing up for frames that weren't part of the code base. Adding this check in *does* do that, but it also happens to have a side effect where it prevents valid stack frames from not showing up because we have deemed `in_app` to be False for other reasons. 

**What are 'other reasons'?**
I'm still looking into this more, but likely due to grouping reasons. In the future it would be nice to either 
* render a different message when the frame is truly not part of the code base (versus a failed configuration)
* attempt to link to open source libs/projects 

But for now, I want to remove this check so that we don't block valid attempts of finding the source code links. 