### PR TITLE
feat(aws-lambda): allows cross account access and renames pipeline views

### DIFF
--- a/src/sentry/static/sentry/app/views/integrationPipeline/pipelineView.tsx
+++ b/src/sentry/static/sentry/app/views/integrationPipeline/pipelineView.tsx
@@ -12,9 +12,9 @@ import AwsLambdaProjectSelect from './awsLambdaProjectSelect';
  */
 
 const pipelineMapper: Record<string, [React.ElementType, string]> = {
-  awsLambdaProjectSelect: [AwsLambdaProjectSelect, 'Select Project'],
-  awsLambdaFunctionSelect: [AwsLambdaFunctionSelect, 'Select Lambdas'],
-  awsLambdaFailureDetails: [AwsLambdaFailureDetails, 'View Failures'],
+  awsLambdaProjectSelect: [AwsLambdaProjectSelect, 'AWS Lambda Select Project'],
+  awsLambdaFunctionSelect: [AwsLambdaFunctionSelect, 'AWS Lambda Select Lambdas'],
+  awsLambdaFailureDetails: [AwsLambdaFailureDetails, 'AWS Lambda View Failures'],
 };
 
 type Props = {


### PR DESCRIPTION
This PR does the following:
1. Adds the `Policy` argument to `assume_role` which is needed for cross-account access
2. Renames the pipeline view titles