### PR TITLE
fix(vitals): Vitals percentages should not show when there is no vital data

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -307,6 +307,7 @@ class VitalCard extends React.Component<Props, State> {
                   hideBar
                   hideVitalPercentNames
                   hideDurationDetail
+                  hideEmptyState
                 />
               </PercentContainer>
             </Feature>

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalInfo.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalInfo.tsx
@@ -14,6 +14,7 @@ type Props = {
   location: Location;
   vitalName: WebVital;
   hideBar?: boolean;
+  hideEmptyState?: boolean;
   hideVitalPercentNames?: boolean;
   hideDurationDetail?: boolean;
 };

--- a/src/sentry/static/sentry/app/views/performance/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalsCards.tsx
@@ -37,6 +37,7 @@ type Props = {
   location: Location;
   showVitalPercentNames?: boolean;
   showDurationDetail?: boolean;
+  showEmptyState?: boolean;
   hasCondensedVitals?: boolean;
   projects: Project[];
 };
@@ -206,7 +207,7 @@ function getColorStopsFromPercents(percents: Percent[]) {
 }
 
 export function VitalsCard(props: CardProps) {
-  const {isLoading, tableData, vitalName, noBorder, hideBar} = props;
+  const {isLoading, tableData, vitalName, noBorder, hideBar, hideEmptyState} = props;
 
   const measurement = vitalMap[vitalName];
 
@@ -216,6 +217,7 @@ export function VitalsCard(props: CardProps) {
         noBorder={noBorder}
         measurement={measurement}
         titleDescription={vitalName ? vitalDescription[vitalName] || '' : ''}
+        hideEmptyState={hideEmptyState}
       />
     );
   }
@@ -229,6 +231,7 @@ export function VitalsCard(props: CardProps) {
         noBorder={noBorder}
         measurement={measurement}
         titleDescription={vitalName ? vitalDescription[vitalName] || '' : ''}
+        hideEmptyState={hideEmptyState}
       />
     );
   }
@@ -253,6 +256,7 @@ export function VitalsCard(props: CardProps) {
 }
 
 type CondensedCardProps = Props & {
+  hideEmptyState: boolean;
   tableData: any;
   isLoading?: boolean;
   condensedVitals: WebVital[];
@@ -354,10 +358,15 @@ type BlankCardProps = {
   noBorder?: boolean;
   measurement?: string;
   titleDescription?: string;
+  hideEmptyState?: boolean;
 };
 
 const BlankCard = (props: BlankCardProps) => {
   const Container = props.noBorder ? NonPanel : VitalCard;
+
+  if (props.hideEmptyState) {
+    return null;
+  }
 
   return (
     <Container interactive>

--- a/src/sentry/static/sentry/app/views/performance/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalsCards.tsx
@@ -37,7 +37,6 @@ type Props = {
   location: Location;
   showVitalPercentNames?: boolean;
   showDurationDetail?: boolean;
-  showEmptyState?: boolean;
   hasCondensedVitals?: boolean;
   projects: Project[];
 };
@@ -124,6 +123,7 @@ type CardProps = Omit<Props, 'projects'> & {
   isLoading?: boolean;
   noBorder?: boolean;
   hideBar?: boolean;
+  hideEmptyState?: boolean;
 };
 
 const NonPanel = styled('div')``;
@@ -256,7 +256,6 @@ export function VitalsCard(props: CardProps) {
 }
 
 type CondensedCardProps = Props & {
-  hideEmptyState: boolean;
   tableData: any;
   isLoading?: boolean;
   condensedVitals: WebVital[];


### PR DESCRIPTION
On the transaction vitals page, when there is no data for any of the web vitals,
the percentages currently display as emdash. This should not be displayed at
all when there is no data.

# Screenshot

## Before

![image](https://user-images.githubusercontent.com/10239353/103823408-0790ef00-5040-11eb-8ed2-1e0e6ad59cea.png)

## After

![image](https://user-images.githubusercontent.com/10239353/103823350-ef20d480-503f-11eb-9e71-c220a2320dae.png)
