### PR TITLE
Revert "chore(py3): Make attachment storage not rely on `CACHE_VERSIO…N` (#22935)"

### DIFF
--- a/src/sentry/attachments/redis.py
+++ b/src/sentry/attachments/redis.py
@@ -4,17 +4,10 @@ import logging
 
 from django.conf import settings
 
-from sentry.cache.redis import RedisClusterCache
+from sentry.cache.redis import RedisClusterCache, RbCache
 from .base import BaseAttachmentCache
 
 logger = logging.getLogger(__name__)
-
-# This constant modifies the cache version for `RedisClusterAttachmentCache`.
-# The attachment cache is not actually a cache, but a short term data storage system.
-# It inherits from cache backends, and so we're naming this setting to match this.
-# Bumping this cache version will likely result in dropping events, so be very careful
-# if you're doing so.
-ATTACHMENT_CACHE_VERSION = 1
 
 
 class RedisClusterAttachmentCache(BaseAttachmentCache):
@@ -22,9 +15,12 @@ class RedisClusterAttachmentCache(BaseAttachmentCache):
         cluster_id = options.pop("cluster_id", None)
         if cluster_id is None:
             cluster_id = getattr(settings, "SENTRY_ATTACHMENTS_REDIS_CLUSTER", "rc-short")
-        BaseAttachmentCache.__init__(
-            self, inner=RedisClusterCache(cluster_id, version=ATTACHMENT_CACHE_VERSION, **options),
-        )
+        BaseAttachmentCache.__init__(self, inner=RedisClusterCache(cluster_id, **options))
+
+
+class RbAttachmentCache(BaseAttachmentCache):
+    def __init__(self, **options):
+        BaseAttachmentCache.__init__(self, inner=RbCache(**options))
 
 
 # Confusing legacy name for RediscClusterCache

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -16,7 +16,6 @@ import sentry
 from sentry.utils.celery import crontab_with_minute_jitter
 from sentry.utils.types import type_from_value
 
-import six
 from datetime import timedelta
 from six.moves.urllib.parse import urlparse
 
@@ -1142,7 +1141,7 @@ CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 # The cache version affects both Django's internal cache (at runtime) as well
 # as Sentry's cache. This automatically overrides VERSION on the default
 # CACHES backend.
-CACHE_VERSION = 2 if six.PY3 else 1
+CACHE_VERSION = 1
 
 # Digests backend
 SENTRY_DIGESTS = "sentry.digests.backends.dummy.DummyBackend"

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -318,7 +318,7 @@ def initialize_app(config, skip_service_validation=False):
 
     for key in settings.CACHES:
         if not hasattr(settings.CACHES[key], "VERSION"):
-            settings.CACHES[key]["VERSION"] = settings.CACHE_VERSION
+            settings.CACHES[key]["VERSION"] = 2 if six.PY3 else 1
 
     settings.ASSET_VERSION = get_asset_version(settings)
     settings.STATIC_URL = settings.STATIC_URL.format(version=settings.ASSET_VERSION)


### PR DESCRIPTION
This reverts commit 390c93551c9dd2f54744bd68a8b47a1dc5d2d3ea.