### PR TITLE
fix(ticket rules): Add rule validation

### DIFF
--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -95,6 +95,13 @@ class RuleSerializer(serializers.Serializer):
         # project_rule(_details) endpoints by setting it on attrs
         actions = attrs.get("actions", tuple())
         for action in actions:
+            # XXX(colleen): For rules that have the Jira integration as an action
+            # we need to ensure the user has selected a Jira project and issue type
+            if action["id"] == "sentry.integrations.jira.notify_action.JiraCreateTicketAction":
+                if not action.get("issuetype") and not action.get("project"):
+                    raise serializers.ValidationError(
+                        {"actions": u"Must select a project and issue type."}
+                    )
             # remove this attribute because we don't want it to be saved in the rule
             if action.pop("pending_save", None):
                 attrs["pending_save"] = True

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -98,7 +98,7 @@ class RuleSerializer(serializers.Serializer):
             # XXX(colleen): For ticket rules we need to ensure the user has
             # at least done minimal configuration
             if action["id"] in TICKET_ACTIONS:
-                if not action.get("issuetype") or not action.get("project"):
+                if not action.get("dynamic_form_fields"):
                     raise serializers.ValidationError(
                         {"actions": u"Must configure issue link settings."}
                     )


### PR DESCRIPTION
**Problem**
When creating a ticket rule, if you did not open the modal at all by clicking the "Issue Link Settings" button it was possible to save a rule without any configuration. When the rule fired, [create issue](https://github.com/getsentry/sentry/blob/master/src/sentry/integrations/jira/integration.py#L716) would fail because an issue type wasn't chosen (and would fail if it got down to project, too). 

**Solution**
Add a check to the serializer's `validate` method that these fields be present, and surface an error message to the user if they are not. If the user hasn't clicked the "Issue Link Settings" button at all, or clicked it but didn't hit "Apply Changes" (exited out w/o saving) the only fields present on the `action` are `id` and `integration`. If they have hit "Apply Changes" that means the front end validation has passed and there is now a `dynamic_form_fields` key in the `action`.
<img width="1143" alt="Screen Shot 2021-01-07 at 1 40 57 PM" src="https://user-images.githubusercontent.com/29959063/103948063-ff8f8880-50ed-11eb-8e93-ffb5785db6aa.png">



Fixes [SENTRY-KBW](https://sentry.io/organizations/sentry/issues/2133008986/?project=1&referrer=jira_integration) and [SENTRY-KD6](https://sentry.io/organizations/sentry/issues/2138083578/?project=1&referrer=slack)