### PR TITLE
ref(email): Add org to unable to fetch commits email

### DIFF
--- a/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
+++ b/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
@@ -2,12 +2,12 @@
 
 {% block main %}
   <h3>Unable to Fetch Commits</h3>
-  <p>We were unable to fetch the commit log for your release (<em>{{ release.version }}</em>) for repository <em>{{ repo.name }}</em> due to the following error:</p>
+  <p>We were unable to fetch the commit log for your release (<em>{{ release.version }}</em>) for repository <em>{{ repo.name }}</em> in the <em>{{ release.organization.slug }}</em> organization due to the following error:</p>
   <p>{{ error_message }}</p>
   <p><strong>Troubleshooting &amp; References</strong></p>
   <ul>
     <li><a href="https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-">Why am I receiving the email "Unable to Fetch Commits"?</a></li>
-    <li><a href="https://docs.sentry.io/workflow/releases/?platform=php#associate-commits-with-a-release">Associate Commits with a Release</a></li>
+    <li><a href="https://docs.sentry.io/product/releases/setup/">Associate Commits with a Release</a></li>
   </ul>
 {% endblock %}
 

--- a/src/sentry/templates/sentry/emails/unable-to-fetch-commits.txt
+++ b/src/sentry/templates/sentry/emails/unable-to-fetch-commits.txt
@@ -1,11 +1,11 @@
 Unable to Fetch Commits
 -----------------------
 
-We were unable to fetch the commit log for your release ({{ release.version }}) due to the following error:
+We were unable to fetch the commit log for your release ({{ release.version }}) for repository ({{ repo.name }}) in the ({{ release.organization.slug }}) organization due to the following error:
 
 {{ error_message }}
 
 Troubleshooting &amp; References
 
 https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-
-https://docs.sentry.io/workflow/releases/?platform=php#associate-commits-with-a-release
+https://docs.sentry.io/product/releases/setup/

--- a/src/sentry/web/frontend/debug/debug_unable_to_fetch_commits_email.py
+++ b/src/sentry/web/frontend/debug/debug_unable_to_fetch_commits_email.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function
 
 from django.views.generic import View
 
-from sentry.models import Release, Repository
+from sentry.models import Release, Repository, Organization
 from sentry.tasks.commits import generate_fetch_commits_error_email
 
 from .mail import MailPreview
@@ -10,7 +10,8 @@ from .mail import MailPreview
 
 class DebugUnableToFetchCommitsEmailView(View):
     def get(self, request):
-        release = Release(version="abcdef")
+        org = Organization(slug="myorg")
+        release = Release(version="abcdef", organization=org)
         repo = Repository(name="repo_name")
 
         email = generate_fetch_commits_error_email(

--- a/tests/fixtures/emails/unable_to_fetch_commits.txt
+++ b/tests/fixtures/emails/unable_to_fetch_commits.txt
@@ -1,11 +1,11 @@
 Unable to Fetch Commits
 -----------------------
 
-We were unable to fetch the commit log for your release (abcdef) due to the following error:
+We were unable to fetch the commit log for your release (abcdef) for repository (repo_name) in the (myorg) organization due to the following error:
 
 An internal server error occurred
 
 Troubleshooting &amp; References
 
 https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-
-https://docs.sentry.io/workflow/releases/?platform=php#associate-commits-with-a-release
+https://docs.sentry.io/product/releases/setup/

--- a/tests/fixtures/emails/unable_to_fetch_commits_py2.txt
+++ b/tests/fixtures/emails/unable_to_fetch_commits_py2.txt
@@ -1,11 +1,11 @@
 Unable to Fetch Commits
 -----------------------
 
-We were unable to fetch the commit log for your release (abcdef) due to the following error:
+We were unable to fetch the commit log for your release (abcdef) for repository (repo_name) in the (myorg) organization due to the following error:
 
 An internal server error occurred
 
 Troubleshooting &amp; References
 
 https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-
-https://docs.sentry.io/workflow/releases/?platform=php#associate-commits-with-a-release
+https://docs.sentry.io/product/releases/setup/


### PR DESCRIPTION
Update the "Unable to Fetch Commits" email to include the name of the organization in question. I also updated the docs link (they redirected so it was fine, but figured I might as well) about associating commits with a release. 

<img width="704" alt="Screen Shot 2021-01-06 at 4 54 09 PM" src="https://user-images.githubusercontent.com/29959063/103838060-f09ecc80-5040-11eb-8ad4-d1d22d42f68e.png">
