### PR TITLE
fix(discover): Use undefined for colors when no series

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -195,9 +195,11 @@ class Chart extends React.Component<ChartProps, State> {
       : undefined;
 
     const chartOptions = {
-      colors: colors?.slice(0, timeseriesData.length) ?? [
-        ...theme.charts.getColorPalette(timeseriesData.length - 2),
-      ],
+      colors: timeseriesData.length
+        ? colors?.slice(0, timeseriesData.length) ?? [
+            ...theme.charts.getColorPalette(timeseriesData.length - 2),
+          ]
+        : undefined,
       grid: {
         left: '24px',
         right: '24px',


### PR DESCRIPTION
When there is no timeseries data, `getColorPalette` returns `undefined` for
which the spread operator fails. This change ensures that this error does not
happen.

Fixes JAVASCRIPT-23H4