### PR TITLE
feat(workflow): Don't add issues into the inbox if they are manually unresolved

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -776,8 +776,6 @@ def update_groups(request, projects, organization_id, search_fn, has_inbox=False
                     ignore_until = None
                     result["statusDetails"] = {}
             else:
-                if has_inbox:
-                    result["inbox"] = None
                 result["statusDetails"] = {}
 
         if group_list and happened:

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -724,8 +724,6 @@ def update_groups(request, projects, organization_id, search_fn, has_inbox=False
 
             GroupResolution.objects.filter(group__in=group_ids).delete()
             if new_status == GroupStatus.UNRESOLVED:
-                for group in group_list:
-                    add_group_to_inbox(group, GroupInboxReason.MANUAL)
                 if has_inbox:
                     result["inbox"] = get_inbox_details([group_list[0]])[group_list[0].id]
                 result["statusDetails"] = {}

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -49,7 +49,7 @@ from sentry.models import (
     User,
     UserOption,
 )
-from sentry.models.groupinbox import add_group_to_inbox, get_inbox_details
+from sentry.models.groupinbox import add_group_to_inbox
 from sentry.models.group import looks_like_short_id, STATUS_UPDATE_CHOICES
 from sentry.api.issue_search import convert_query_values, InvalidSearchQuery, parse_search_query
 from sentry.signals import (
@@ -723,11 +723,7 @@ def update_groups(request, projects, organization_id, search_fn, has_inbox=False
             happened = queryset.exclude(status=new_status).update(status=new_status)
 
             GroupResolution.objects.filter(group__in=group_ids).delete()
-            if new_status == GroupStatus.UNRESOLVED:
-                if has_inbox:
-                    result["inbox"] = get_inbox_details([group_list[0]])[group_list[0].id]
-                result["statusDetails"] = {}
-            elif new_status == GroupStatus.IGNORED:
+            if new_status == GroupStatus.IGNORED:
                 metrics.incr("group.ignored", skip_internal=True)
                 for group in group_ids:
                     remove_group_from_inbox(group)
@@ -780,6 +776,8 @@ def update_groups(request, projects, organization_id, search_fn, has_inbox=False
                     ignore_until = None
                     result["statusDetails"] = {}
             else:
+                if has_inbox:
+                    result["inbox"] = None
                 result["statusDetails"] = {}
 
         if group_list and happened:

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -84,7 +84,6 @@ class UpdateGroupsTest(TestCase):
         resolved_group.refresh_from_db()
 
         assert resolved_group.status == GroupStatus.UNRESOLVED
-        assert GroupInbox.objects.filter(group=resolved_group).exists()
         assert not send_robust.called
         assert send_unresolved.called
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -2037,9 +2037,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         with self.feature("organizations:inbox"):
             response = self.get_valid_response(qs_params={"id": [group2.id]}, status="unresolved")
-        assert GroupInboxReason(response.data["inbox"]["reason"]) == GroupInboxReason.MANUAL
         assert not GroupInbox.objects.filter(group=group1).exists()
-        assert GroupInbox.objects.filter(group=group2).exists()
+        assert not GroupInbox.objects.filter(group=group2).exists()
 
 
 class GroupDeleteTest(APITestCase, SnubaTestCase):


### PR DESCRIPTION
This snippet of code was responsible for putting issues into the inbox when they are unresolved by a user. Since we don't want that behaviour anymore, I'm removing it.

I opted not to entirely remove `GroupInboxReason.MANUAL`  since it is used to manually put groups into the inbox via our API. We don't currently use this in production, but removing it completely wouldn't actually lead to significant code improvements and we'd also have to deal with the fact that there are a bunch of GroupInbox entries with the manual reason already (from manually unresolved issues I assume)

Resolves WOR-532