### PR TITLE
fix(ui): Fix `<MergedToolbar>` and remove deprecated components

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupMerged/mergedItem.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupMerged/mergedItem.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import GroupingActions from 'app/actions/groupingActions';
 import Checkbox from 'app/components/checkbox';
 import EventOrGroupHeader from 'app/components/eventOrGroupHeader';
-import FlowLayout from 'app/components/flowLayout';
 import {IconChevron} from 'app/icons';
 import GroupingStore from 'app/stores/groupingStore';
 import space from 'app/styles/space';
@@ -95,21 +94,19 @@ class MergedItem extends React.Component<Props, State> {
     return (
       <MergedGroup busy={busy}>
         <Controls expanded={!collapsed}>
-          <FlowLayout onClick={this.handleToggle}>
-            <ActionColumn>
-              <Checkbox
-                id={fingerprint}
-                value={fingerprint}
-                checked={checked}
-                disabled={checkboxDisabled}
-                onChange={this.handleCheckClick}
-              />
-            </ActionColumn>
+          <ActionWrapper onClick={this.handleToggle}>
+            <Checkbox
+              id={fingerprint}
+              value={fingerprint}
+              checked={checked}
+              disabled={checkboxDisabled}
+              onChange={this.handleCheckClick}
+            />
 
             <Fingerprint onClick={this.handleLabelClick} htmlFor={fingerprint}>
               {fingerprint}
             </Fingerprint>
-          </FlowLayout>
+          </ActionWrapper>
 
           <div>
             <Collapse onClick={this.handleToggleEvents}>
@@ -122,14 +119,12 @@ class MergedItem extends React.Component<Props, State> {
           <MergedEventList className="event-list">
             {event && (
               <EventDetails className="event-details">
-                <FlowLayout>
-                  <EventOrGroupHeader
-                    data={event}
-                    organization={organization}
-                    hideIcons
-                    hideLevel
-                  />
-                </FlowLayout>
+                <EventOrGroupHeader
+                  data={event}
+                  organization={organization}
+                  hideIcons
+                  hideLevel
+                />
               </EventDetails>
             )}
           </MergedEventList>
@@ -143,12 +138,14 @@ const MergedGroup = styled('div')<{busy: boolean}>`
   ${p => p.busy && 'opacity: 0.2'};
 `;
 
-const ActionColumn = styled('div')`
-  display: flex;
-  padding: 0 ${space(1)};
+const ActionWrapper = styled('div')`
+  display: grid;
+  grid-auto-flow: column;
   align-items: center;
+  gap: ${space(1)};
 
-  input {
+  /* Can't use styled components for this because of broad selector */
+  input[type='checkbox'] {
     margin: 0;
   }
 `;
@@ -158,7 +155,7 @@ const Controls = styled('div')<{expanded: boolean}>`
   justify-content: space-between;
   border-top: 1px solid ${p => p.theme.innerBorder};
   background-color: ${p => p.theme.gray100};
-  padding: ${space(0.5)} 0;
+  padding: ${space(0.5)} ${space(1)};
   ${p => p.expanded && `border-bottom: 1px solid ${p.theme.innerBorder}`};
 
   ${MergedGroup} {
@@ -183,7 +180,6 @@ const Fingerprint = styled('label')`
 
 const Collapse = styled('span')`
   cursor: pointer;
-  padding: 0 ${space(1)};
 `;
 
 const MergedEventList = styled('div')`

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupMerged/mergedList.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupMerged/mergedList.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import styled from '@emotion/styled';
 
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import Pagination from 'app/components/pagination';
-import {Panel} from 'app/components/panels';
+import {Panel, PanelBody} from 'app/components/panels';
 import QueryCount from 'app/components/queryCount';
 import {t} from 'app/locale';
 import {Fingerprint} from 'app/stores/groupingStore';
@@ -60,33 +59,30 @@ function MergedList({
         <QueryCount count={fingerprintsWithLatestEvent.length} />
       </h2>
 
-      <MergedToolbar
-        onToggleCollapse={onToggleCollapse}
-        onUnmerge={onUnmerge}
-        orgId={organization.slug}
-        project={project}
-        groupId={groupId}
-      />
+      <Panel>
+        <MergedToolbar
+          onToggleCollapse={onToggleCollapse}
+          onUnmerge={onUnmerge}
+          orgId={organization.slug}
+          project={project}
+          groupId={groupId}
+        />
 
-      <MergedItems>
-        {fingerprintsWithLatestEvent.map(({id, latestEvent}) => (
-          <MergedItem
-            key={id}
-            organization={organization}
-            disabled={fingerprintsWithLatestEvent.length === 1}
-            event={latestEvent}
-            fingerprint={id}
-          />
-        ))}
-      </MergedItems>
+        <PanelBody>
+          {fingerprintsWithLatestEvent.map(({id, latestEvent}) => (
+            <MergedItem
+              key={id}
+              organization={organization}
+              disabled={fingerprintsWithLatestEvent.length === 1}
+              event={latestEvent}
+              fingerprint={id}
+            />
+          ))}
+        </PanelBody>
+      </Panel>
       {pageLinks && <Pagination pageLinks={pageLinks} />}
     </React.Fragment>
   );
 }
 
 export default withOrganization(MergedList);
-
-const MergedItems = styled('div')`
-  border: 1px solid ${p => p.theme.border};
-  border-top: none;
-`;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupMerged/mergedToolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupMerged/mergedToolbar.tsx
@@ -4,9 +4,8 @@ import pick from 'lodash/pick';
 
 import {openDiffModal} from 'app/actionCreators/modal';
 import Button from 'app/components/button';
-import LinkWithConfirmation from 'app/components/links/linkWithConfirmation';
-import SpreadLayout from 'app/components/spreadLayout';
-import Toolbar from 'app/components/toolbar';
+import Confirm from 'app/components/confirm';
+import {PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
 import GroupingStore from 'app/stores/groupingStore';
 import space from 'app/styles/space';
@@ -52,7 +51,7 @@ class MergedToolbar extends React.Component<Props, State> {
 
   listener = GroupingStore.listen(data => this.onGroupChange(data), undefined);
 
-  onGroupChange = ({updateObj}) => {
+  onGroupChange = updateObj => {
     const allowedKeys = [
       'unmergeLastCollapsed',
       'unmergeDisabled',
@@ -102,34 +101,32 @@ class MergedToolbar extends React.Component<Props, State> {
     const unmergeCount = (unmergeList && unmergeList.size) || 0;
 
     return (
-      <StyledToolbar>
-        <SpreadLayout>
-          <div>
-            <LinkWithConfirmation
-              disabled={unmergeDisabled}
-              title={t('Unmerging %s events', unmergeCount)}
-              message={t(
-                'These events will be unmerged and grouped into a new issue. Are you sure you want to unmerge these events?'
-              )}
-              className="btn btn-sm btn-default"
-              onConfirm={onUnmerge}
-            >
-              {t('Unmerge')} ({unmergeCount})
-            </LinkWithConfirmation>
+      <PanelHeader hasButtons>
+        <div>
+          <Confirm
+            disabled={unmergeDisabled}
+            onConfirm={onUnmerge}
+            message={t(
+              'These events will be unmerged and grouped into a new issue. Are you sure you want to unmerge these events?'
+            )}
+          >
+            <Button size="small" title={t(`Unmerging ${unmergeCount} events`)}>
+              {t('Unmerge')} ({unmergeCount || 0})
+            </Button>
+          </Confirm>
 
-            <CompareButton
-              size="small"
-              disabled={!enableFingerprintCompare}
-              onClick={this.handleShowDiff}
-            >
-              {t('Compare')}
-            </CompareButton>
-          </div>
-          <Button size="small" onClick={onToggleCollapse}>
-            {unmergeLastCollapsed ? t('Expand All') : t('Collapse All')}
-          </Button>
-        </SpreadLayout>
-      </StyledToolbar>
+          <CompareButton
+            size="small"
+            disabled={!enableFingerprintCompare}
+            onClick={this.handleShowDiff}
+          >
+            {t('Compare')}
+          </CompareButton>
+        </div>
+        <Button size="small" onClick={onToggleCollapse}>
+          {unmergeLastCollapsed ? t('Expand All') : t('Collapse All')}
+        </Button>
+      </PanelHeader>
     );
   }
 }
@@ -138,8 +135,4 @@ export default MergedToolbar;
 
 const CompareButton = styled(Button)`
   margin-left: ${space(1)};
-`;
-
-const StyledToolbar = styled(Toolbar)`
-  padding: ${space(0.5)} ${space(1)};
 `;


### PR DESCRIPTION
This fixes a bug introduced in #22993 where the state from the store was not syncing properly.

I have also gone ahead and refactored out some deprecated components and use our more standardized components.