### PR TITLE
feat(alert): Update alert button tooltip

### DIFF
--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -25,7 +25,7 @@ type Props = {
   to?: string | object;
   href?: string;
   icon?: React.ReactNode;
-  title?: React.ReactNode;
+  title?: React.ComponentProps<typeof Tooltip>['title'];
   external?: boolean;
   borderless?: boolean;
   label?: string;
@@ -70,7 +70,7 @@ class BaseButton extends React.Component<ButtonProps, {}> {
     /**
      * Tooltip text
      */
-    title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    title: PropTypes.node,
     /**
      * Is an external link? (Will open in new tab)
      */

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -25,7 +25,7 @@ type Props = {
   to?: string | object;
   href?: string;
   icon?: React.ReactNode;
-  title?: string;
+  title?: string | React.ReactNode;
   external?: boolean;
   borderless?: boolean;
   label?: string;
@@ -70,7 +70,7 @@ class BaseButton extends React.Component<ButtonProps, {}> {
     /**
      * Tooltip text
      */
-    title: PropTypes.string,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     /**
      * Is an external link? (Will open in new tab)
      */

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -25,7 +25,7 @@ type Props = {
   to?: string | object;
   href?: string;
   icon?: React.ReactNode;
-  title?: string | React.ReactNode;
+  title?: React.ReactNode;
   external?: boolean;
   borderless?: boolean;
   label?: string;

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -335,22 +335,37 @@ const CreateAlertButton = withRouter(
       );
     }
 
+    const permissionTooltipText = tct(
+      'Users with admin permission or higher can create alert rules. Owners and managers can [settingsLink] for you.',
+      {
+        settingsLink: (
+          <StyledLink to={`/settings/${organization.slug}`}>
+            {t('change this setting')}
+          </StyledLink>
+        ),
+      }
+    );
+
     return (
       <Access organization={organization} access={['alerts:write']}>
         {({hasAccess}) => (
           <Button
             disabled={!hasAccess}
-            title={
-              !hasAccess
-                ? t('Users with admin permission or higher can create alert rules.')
-                : undefined
-            }
+            title={!hasAccess ? permissionTooltipText : undefined}
             icon={!hideIcon && <IconSiren {...iconProps} />}
             to={
               projectSlug
                 ? `/organizations/${organization.slug}/alerts/${projectSlug}/new/`
                 : undefined
             }
+            tooltipProps={{
+              isHoverable: true,
+              position: 'top',
+              popperStyle: {
+                maxWidth: '270px',
+                fontWeight: 'normal',
+              },
+            }}
             onClick={projectSlug ? undefined : handleClickWithoutProject}
             {...buttonProps}
           >
@@ -389,5 +404,15 @@ const StyledCloseButton = styled(Button)`
   &:focus {
     background-color: transparent;
     opacity: 1;
+  }
+`;
+
+const StyledLink = styled(Link)`
+  color: ${p => p.theme.bodyBackground};
+  text-decoration: underline;
+
+  &:hover {
+    color: ${p => p.theme.bodyBackground};
+    text-decoration: underline;
   }
 `;

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -336,14 +336,8 @@ const CreateAlertButton = withRouter(
     }
 
     const permissionTooltipText = tct(
-      'Users with admin permission or higher can create alert rules. Owners and managers can [settingsLink] for you.',
-      {
-        settingsLink: (
-          <StyledLink to={`/settings/${organization.slug}`}>
-            {t('change this setting')}
-          </StyledLink>
-        ),
-      }
+      'Users with admin permission or higher can create alert rules. Owners and managers can [settingsLink:change this setting] for you.',
+      {settingsLink: <Link to={`/settings/${organization.slug}`} />}
     );
 
     return (
@@ -404,15 +398,5 @@ const StyledCloseButton = styled(Button)`
   &:focus {
     background-color: transparent;
     opacity: 1;
-  }
-`;
-
-const StyledLink = styled(Link)`
-  color: ${p => p.theme.bodyBackground};
-  text-decoration: underline;
-
-  &:hover {
-    color: ${p => p.theme.bodyBackground};
-    text-decoration: underline;
   }
 `;

--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -363,6 +363,11 @@ const TooltipContent = styled(motion.div)<{hide: boolean} & Pick<Props, 'popperS
   text-align: center;
   ${p => p.popperStyle as any};
   ${p => p.hide && `display: none`};
+
+  a {
+    color: ${p => p.theme.bodyBackground};
+    text-decoration: underline;
+  }
 `;
 
 const TooltipArrow = styled('span')<{background: string | number}>`


### PR DESCRIPTION
We have a new setting introduced in https://github.com/getsentry/sentry/pull/22924 this PR updates the create alert button tooltip to reflect the option we now provide:

![image](https://user-images.githubusercontent.com/9372512/103936763-d8d55000-50f5-11eb-8d3d-24e066add958.png)

Link takes you to settings