### PR TITLE
meta: Tweak bot settings

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -2,11 +2,12 @@ name: 'lock closed issues/PRs'
 on:
   schedule:
     - cron: '* */12 * * *'
+  workflow_dispatch:
 jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@63786a6
+      - uses: getsentry/forked-action-lock-threads@master
         with:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: 15

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'close stale issues/PRs'
 on:
   schedule:
-    - cron: '* */6 * * *'
+    - cron: '* */3 * * *'
   workflow_dispatch:
 jobs:
   stale:


### PR DESCRIPTION
- run stalebot more frequently (@manuzope noticed we aren't keeping up with volume here)
- use forked lockbot (getsentry/team-ospo#6)
- allow for running lockbot manually (helps testing, etc.)