### PR TITLE
ref(ts) Convert search/source/index to typescript

### DIFF
--- a/src/sentry/static/sentry/app/components/search/sources/apiSource.tsx
+++ b/src/sentry/static/sentry/app/components/search/sources/apiSource.tsx
@@ -18,7 +18,7 @@ import {
 } from 'app/types';
 import {Event} from 'app/types/event';
 import {defined} from 'app/utils';
-import {createFuzzySearch, isResultWithMatches} from 'app/utils/createFuzzySearch';
+import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import {singleLineRenderer as markedSingleLine} from 'app/utils/marked';
 import withLatestContext from 'app/utils/withLatestContext';
 import {documentIntegrationList} from 'app/views/organizationIntegrations/constants';
@@ -234,6 +234,7 @@ async function createShortIdLookupResult(
       resultType: 'issue',
       to: `/${shortIdLookup.organizationSlug}/${shortIdLookup.projectSlug}/issues/${shortIdLookup.groupId}/`,
     },
+    score: 1,
   };
 }
 
@@ -254,6 +255,7 @@ async function createEventIdLookupResult(
       resultType: 'event',
       to: `/${eventIdLookup.organizationSlug}/${eventIdLookup.projectSlug}/issues/${eventIdLookup.groupId}/events/${eventIdLookup.eventId}/`,
     },
+    score: 1,
   };
 }
 
@@ -490,24 +492,16 @@ class ApiSource extends React.Component<Props, State> {
   render() {
     const {children, query} = this.props;
     const {fuzzy, directResults} = this.state;
-    const results: Result[] = [];
+    let results: Result[] = [];
     if (fuzzy) {
-      const rawResults = fuzzy.search(query);
-      rawResults.forEach(result => {
-        if (!isResultWithMatches<ResultItem>(result)) {
-          return;
-        }
-        results.push(result);
-      });
+      results = fuzzy.search<ResultItem, true, true>(query);
     }
 
     return children({
       isLoading: this.state.loading,
-      allResults: [],
       results: flatten([results, directResults].filter(defined)) || [],
     });
   }
 }
 
-export {ApiSource};
 export default withLatestContext(withRouter(ApiSource));

--- a/src/sentry/static/sentry/app/components/search/sources/apiSource.tsx
+++ b/src/sentry/static/sentry/app/components/search/sources/apiSource.tsx
@@ -504,4 +504,5 @@ class ApiSource extends React.Component<Props, State> {
   }
 }
 
+export {ApiSource};
 export default withLatestContext(withRouter(ApiSource));

--- a/src/sentry/static/sentry/app/components/search/sources/formSource.tsx
+++ b/src/sentry/static/sentry/app/components/search/sources/formSource.tsx
@@ -5,7 +5,7 @@ import Reflux from 'reflux';
 
 import {loadSearchMap} from 'app/actionCreators/formSearch';
 import FormSearchStore, {FormSearchField} from 'app/stores/formSearchStore';
-import {createFuzzySearch, isResultWithMatches} from 'app/utils/createFuzzySearch';
+import {createFuzzySearch} from 'app/utils/createFuzzySearch';
 import replaceRouterParams from 'app/utils/replaceRouterParams';
 
 import {ChildProps, Result} from './types';
@@ -60,15 +60,12 @@ class FormSource extends React.Component<Props, State> {
   render() {
     const {searchMap, query, params, children} = this.props;
 
-    const results: Result[] = [];
+    let results: Result[] = [];
     if (this.state.fuzzy) {
-      const rawResults = this.state.fuzzy.search(query);
-      rawResults.forEach(value => {
-        if (!isResultWithMatches<FormSearchField>(value)) {
-          return;
-        }
+      const rawResults = this.state.fuzzy.search<FormSearchField, true, true>(query);
+      results = rawResults.map<Result>(value => {
         const {item, ...rest} = value;
-        results.push({
+        return {
           item: {
             ...item,
             sourceType: 'field',
@@ -78,13 +75,12 @@ class FormSource extends React.Component<Props, State> {
             )}`,
           },
           ...rest,
-        });
+        };
       });
     }
 
     return children({
       isLoading: searchMap === null,
-      allResults: [],
       results,
     });
   }

--- a/src/sentry/static/sentry/app/components/search/sources/helpSource.tsx
+++ b/src/sentry/static/sentry/app/components/search/sources/helpSource.tsx
@@ -78,7 +78,6 @@ class HelpSource extends React.Component<Props, State> {
   render() {
     return this.props.children({
       isLoading: this.state.loading,
-      allResults: this.state.results,
       results: this.state.results,
     });
   }
@@ -110,7 +109,7 @@ function mapSearchResults(results: SearchResult[]) {
         to: hit.url,
       };
 
-      return {item, matches: [title, description]};
+      return {item, matches: [title, description], score: 1};
     });
 
     // The first element should indicate the section.
@@ -131,7 +130,7 @@ function mapSearchResults(results: SearchResult[]) {
       empty: true,
     };
 
-    items.push({item: emptyHeaderItem});
+    items.push({item: emptyHeaderItem, score: 1});
   });
 
   return items;

--- a/src/sentry/static/sentry/app/components/search/sources/index.tsx
+++ b/src/sentry/static/sentry/app/components/search/sources/index.tsx
@@ -1,23 +1,28 @@
 import React from 'react';
 import flatten from 'lodash/flatten';
-import PropTypes from 'prop-types';
 
-class SearchSources extends React.Component {
-  static propTypes = {
-    sources: PropTypes.array.isRequired,
-    query: PropTypes.string,
-    /**
-     * Render function the passes:
-     *
-     * `isLoading`
-     * `results` - Array of results
-     * `hasAnyResults` - if any results were found
-     */
-    children: PropTypes.func,
-  };
+import {Result} from './types';
 
+type ChildProps = {
+  results: Result[];
+  isLoading: boolean;
+  hasAnyResults: boolean;
+};
+
+type Props = {
+  sources: React.ComponentClass[];
+  query: string;
+  children: (props: ChildProps) => React.ReactElement;
+};
+
+type SourceResult = {
+  isLoading: boolean;
+  results: Result[];
+};
+
+class SearchSources extends React.Component<Props> {
   // `allSources` will be an array of all result objects from each source
-  renderResults(allSources) {
+  renderResults(allSources: SourceResult[]) {
     const {children} = this.props;
 
     // loading means if any result has `isLoading` OR any result is null
@@ -37,14 +42,14 @@ class SearchSources extends React.Component {
     });
   }
 
-  renderSources(sources, results, idx) {
+  renderSources(sources: Props['sources'], results: SourceResult[], idx: number) {
     if (idx >= sources.length) {
       return this.renderResults(results);
     }
     const Source = sources[idx];
     return (
       <Source {...this.props}>
-        {args => {
+        {(args: SourceResult) => {
           // Mutate the array instead of pushing because we don't know how often
           // this child function will be called and pushing will cause duplicate
           // results to be pushed for all calls down the chain.

--- a/src/sentry/static/sentry/app/components/search/sources/types.tsx
+++ b/src/sentry/static/sentry/app/components/search/sources/types.tsx
@@ -46,6 +46,7 @@ export type ResultItem = {
 export type Result = {
   item: ResultItem;
   matches?: MarkedText[];
+  score: number;
 };
 
 /**
@@ -61,9 +62,4 @@ export type ChildProps = {
    * Matched results
    */
   results: Result[];
-  /**
-   * All potential results if available.
-   * @deprecated This isn't used by source consumers and will be removed soon.
-   */
-  allResults: Result[];
 };

--- a/src/sentry/static/sentry/app/utils/createFuzzySearch.tsx
+++ b/src/sentry/static/sentry/app/utils/createFuzzySearch.tsx
@@ -19,9 +19,3 @@ export async function createFuzzySearch<
   };
   return new Fuse(objects, opts);
 }
-
-export function isResultWithMatches<T>(
-  maybe: T | Fuse.FuseResultWithMatches<T>
-): maybe is Fuse.FuseResultWithMatches<T> {
-  return (maybe as Fuse.FuseResultWithMatches<T>).matches !== undefined;
-}

--- a/tests/js/spec/components/search/sources/apiSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/apiSource.spec.jsx
@@ -132,6 +132,7 @@ describe('ApiSource', function () {
               resultType: 'issue',
               to: '/org-slug/project-slug/issues/1/',
             }),
+            score: 1,
           },
         ],
       })
@@ -178,6 +179,7 @@ describe('ApiSource', function () {
               to:
                 '/org-slug/project-slug/issues/1/events/12345678901234567890123456789012/',
             }),
+            score: 1,
           },
         ],
       })
@@ -212,7 +214,6 @@ describe('ApiSource', function () {
     wrapper.update();
     expect(mock).toHaveBeenLastCalledWith({
       isLoading: false,
-      allResults: expect.anything(),
       results: expect.arrayContaining([
         expect.objectContaining({
           item: expect.objectContaining({
@@ -288,7 +289,6 @@ describe('ApiSource', function () {
     wrapper.update();
     expect(mock).toHaveBeenLastCalledWith({
       isLoading: false,
-      allResults: expect.anything(),
       results: expect.arrayContaining([
         expect.objectContaining({
           item: expect.objectContaining({

--- a/tests/js/spec/components/search/sources/formSource.spec.jsx
+++ b/tests/js/spec/components/search/sources/formSource.spec.jsx
@@ -79,7 +79,6 @@ describe('FormSource', function () {
     wrapper.update();
     expect(mock).toHaveBeenCalledWith({
       isLoading: false,
-      allResults: [],
       results: [],
     });
   });


### PR DESCRIPTION
Simplify a few of the sources by using fuse generics better and fix some missing properties that consumers of Source are expecting to get.