### PR TITLE
Revert "feat(apm): Resolve urls, and always sample for a subset of URLs (#22749)"

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -40,6 +40,7 @@ from sentry.snuba.sessions import (
 from sentry.utils.cache import cache
 from sentry.utils.compat import zip as izip
 from sentry.utils.sdk import configure_scope, bind_organization_context
+from sentry.web.decorators import transaction_start
 
 
 ERR_INVALID_STATS_PERIOD = "Invalid %s. Valid choices are %s"
@@ -139,6 +140,7 @@ def debounce_update_release_health_data(organization, project_ids):
 class OrganizationReleasesEndpoint(
     OrganizationReleasesBaseEndpoint, EnvironmentMixin, ReleaseAnalyticsMixin
 ):
+    @transaction_start("OrganizationReleasesEndpoint.get")
     def get(self, request, organization):
         """
         List an Organization's Releases
@@ -267,6 +269,7 @@ class OrganizationReleasesEndpoint(
             **paginator_kwargs
         )
 
+    @transaction_start("OrganizationReleasesEndpoint.post")
     def post(self, request, organization):
         """
         Create a New Release for an Organization
@@ -428,6 +431,7 @@ class OrganizationReleasesEndpoint(
 
 
 class OrganizationReleasesStatsEndpoint(OrganizationReleasesBaseEndpoint, EnvironmentMixin):
+    @transaction_start("OrganizationReleasesStatsEndpoint.get")
     def get(self, request, organization):
         """
         List an Organization's Releases specifically for building timeseries

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -4,7 +4,6 @@ import inspect
 import six
 
 from django.conf import settings
-from django.urls import resolve
 
 import sentry_sdk
 
@@ -23,11 +22,6 @@ UNSAFE_FILES = (
     # This consumer lives outside of sentry but is just as unsafe.
     "outcomes_consumer.py",
 )
-
-# URLs that should always be sampled
-SAMPLED_URL_NAMES = {
-    "sentry-api-0-organization-releases",
-}
 
 UNSAFE_TAG = "_unsafe"
 
@@ -130,25 +124,6 @@ def _override_on_full_queue(transport, metric_name):
     transport._worker.on_full_queue = on_full_queue
 
 
-def traces_sampler(sampling_context):
-    # If there's already a sampled decision, just use that
-    if sampling_context["parent_sampled"] is not None:
-        return sampling_context["parent_sampled"]
-
-    # Resolve the url, and see if we want to set our own sampling
-    if "wsgi_environ" in sampling_context:
-        try:
-            match = resolve(sampling_context["wsgi_environ"].get("PATH_INFO"))
-            if match and match.url_name in SAMPLED_URL_NAMES:
-                return 1.0
-        except Exception:
-            # On errors or 404, continue to default sampling decision
-            pass
-
-    # Default to the sampling rate in settings
-    return float(settings.SENTRY_APM_SAMPLING or 0)
-
-
 def configure_sdk():
     from sentry_sdk.integrations.logging import LoggingIntegration
     from sentry_sdk.integrations.django import DjangoIntegration
@@ -162,7 +137,6 @@ def configure_sdk():
     relay_dsn = sdk_options.pop("relay_dsn", None)
     internal_project_key = get_project_key()
     upstream_dsn = sdk_options.pop("dsn", None)
-    sdk_options["traces_sampler"] = traces_sampler
 
     if upstream_dsn:
         upstream_transport = make_transport(get_options(dsn=upstream_dsn, **sdk_options))

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -21,7 +21,7 @@ class IssueDetailsPage(BasePage):
         self.browser.wait_until(".group-detail")
 
     def visit_tag_values(self, org, groupid, tag):
-        self.browser.get(u"/organizations/{}/issues/{}/tags/{}/".format(org, groupid, tag))
+        self.browser.get(u"/organizations/{}/issues/{}/tags/{}".format(org, groupid, tag))
         self.browser.wait_until_not(".loading-indicator")
 
     def get_environment(self):


### PR DESCRIPTION
- This reverts commit 81cef81c4524c0ee27b47eee30a9d492f15ea02b.
- I'm not sure why yet, but this seems to have changed the sampling decision for tasks. Reverting for now while I investigate more.