### PR TITLE
chore: Fix bug in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -180,8 +180,8 @@ build-utils/        @getsentry/owners-js-build
 /src/sentry/models/project.py                 @getsentry/data
 /src/sentry/models/projectoption.py           @getsentry/data
 /src/sentry/models/release.py                 @getsentry/data
-/src/sentry/models/sentryapp.py               @getsentry/data
-/src/sentry/models/sentryappinstallation.py   @getsentry/data
+/src/sentry/models/sentryapp.py               @getsentry/data @getsentry/ecosystem
+/src/sentry/models/sentryappinstallation.py   @getsentry/data @getsentry/ecosystem
 /src/sentry/models/user.py                    @getsentry/data
 
 ### End of Data ###

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -150,7 +150,6 @@ build-utils/        @getsentry/owners-js-build
 /src/sentry/mediators/                        @getsentry/ecosystem
 
 
-/src/sentry/models/integration.py             @getsentry/ecosystem
 /src/sentry/models/integrationfeature.py      @getsentry/ecosystem
 
 /src/sentry/tasks/integrations.py             @getsentry/ecosystem
@@ -174,7 +173,7 @@ build-utils/        @getsentry/owners-js-build
 /src/sentry/models/grouphash.py               @getsentry/data
 /src/sentry/models/grouprelease.py            @getsentry/data
 /src/sentry/models/groupresolution.py         @getsentry/data
-/src/sentry/models/integration.py             @getsentry/data
+/src/sentry/models/integration.py             @getsentry/data @getsentry/ecosystem
 /src/sentry/models/organization.py            @getsentry/data
 /src/sentry/models/organizationmember.py      @getsentry/data
 /src/sentry/models/organizationoption.py      @getsentry/data


### PR DESCRIPTION
Turns out codeowners only matches one rule per file, and the last matching rule wins. So we have a
few cases here where a team is expecting a rule to match and it's overridden by a later rule.