### PR TITLE
feat(ui): Enable dark mode for everyone

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/accountPreferences.tsx
+++ b/src/sentry/static/sentry/app/data/forms/accountPreferences.tsx
@@ -19,9 +19,8 @@ const formGroups: JsonFormObject[] = [
         name: 'theme',
         type: 'choice',
         label: t('Theme'),
-        visible: ({user}) => user.isStaff,
         help: t(
-          "Select your theme preference. It can be synced to your system's theme, always Light mode, or always Dark mode."
+          "Select your theme preference. It can be synced to your system's theme, always light mode, or always dark mode."
         ),
         choices: [
           ['light', t('Light')],

--- a/src/sentry/static/sentry/app/stores/configStore.tsx
+++ b/src/sentry/static/sentry/app/stores/configStore.tsx
@@ -53,10 +53,7 @@ const configStoreConfig: Reflux.StoreDefinition & ConfigStoreInterface = {
   },
 
   loadInitialData(config): void {
-    // TODO(dark): Remove staff requirement and add dark mode user preference
-    const shouldUseDarkMode =
-      // @ts-ignore
-      config.user?.isStaff && config.user?.options.theme === 'dark';
+    const shouldUseDarkMode = config.user?.options.theme === 'dark';
 
     this.config = {
       ...config,

--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -10,7 +10,6 @@ const styles = (theme: Theme, isDark: boolean) => css`
       z-index: ${theme.zIndex.sentryErrorEmbed};
     }
 
-    /* TODO(dark): Move this to base.less when ready */
     color: ${theme.textColor};
     background: ${theme.backgroundSecondary};
   }


### PR DESCRIPTION
This enables dark mode for everyone. More specifically, this allows everyone to set their user preference to sync with their system UI, or always dark/light mode. Also allows everyone to toggle dark mode from command palette (or the `cmd/meta + L` hotkey)