### PR TITLE
fix(dashboardsv2): Do not warn on route navigation change when deleting a dashboard

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/controls.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/controls.tsx
@@ -54,7 +54,7 @@ class Controls extends React.Component<Props> {
       </Button>
     );
 
-    if (dashboardState === 'edit') {
+    if (['edit', 'pending_delete'].includes(dashboardState)) {
       return (
         <ButtonBar gap={1} key="edit-controls">
           {cancelButton}

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -67,7 +67,7 @@ class DashboardDetail extends React.Component<Props, State> {
   };
 
   onRouteLeave = (): string | undefined => {
-    if (this.state.dashboardState !== 'view') {
+    if (!['view', 'pending_delete'].includes(this.state.dashboardState)) {
       return UNSAVED_MESSAGE;
     }
     // eslint-disable-next-line consistent-return
@@ -75,7 +75,7 @@ class DashboardDetail extends React.Component<Props, State> {
   };
 
   onUnload = (event: BeforeUnloadEvent) => {
-    if (this.state.dashboardState === 'view') {
+    if (['view', 'pending_delete'].includes(this.state.dashboardState)) {
       return;
     }
     event.preventDefault();
@@ -102,14 +102,29 @@ class DashboardDetail extends React.Component<Props, State> {
       return;
     }
 
-    deleteDashboard(api, organization.slug, dashboard.id).then(() => {
-      addSuccessMessage(t('Dashboard deleted'));
+    const previousDashboardState = this.state.dashboardState;
 
-      browserHistory.replace({
-        pathname: `/organizations/${organization.slug}/dashboards/`,
-        query: {},
-      });
-    });
+    this.setState(
+      {
+        dashboardState: 'pending_delete',
+      },
+      () => {
+        deleteDashboard(api, organization.slug, dashboard.id)
+          .then(() => {
+            addSuccessMessage(t('Dashboard deleted'));
+
+            browserHistory.replace({
+              pathname: `/organizations/${organization.slug}/dashboards/`,
+              query: {},
+            });
+          })
+          .catch(() => {
+            this.setState({
+              dashboardState: previousDashboardState,
+            });
+          });
+      }
+    );
   };
 
   onCommit = ({
@@ -227,6 +242,8 @@ class DashboardDetail extends React.Component<Props, State> {
     const {api, location, params, organization} = this.props;
     const {modifiedDashboard, dashboardState} = this.state;
 
+    const isEditing = ['edit', 'create', 'pending_delete'].includes(dashboardState);
+
     return (
       <GlobalSelectionHeader
         skipLoadLastUsed={organization.features.includes('global-views')}
@@ -244,7 +261,7 @@ class DashboardDetail extends React.Component<Props, State> {
                   <DashboardTitle
                     dashboard={modifiedDashboard || dashboard}
                     onUpdate={this.setModifiedDashboard}
-                    isEditing={dashboardState !== 'view'}
+                    isEditing={isEditing}
                   />
                   <Controls
                     organization={organization}
@@ -264,7 +281,7 @@ class DashboardDetail extends React.Component<Props, State> {
                   <Dashboard
                     dashboard={modifiedDashboard || dashboard}
                     organization={organization}
-                    isEditing={dashboardState === 'edit' || dashboardState === 'create'}
+                    isEditing={isEditing}
                     onUpdate={this.onWidgetChange}
                   />
                 ) : (

--- a/src/sentry/static/sentry/app/views/dashboardsV2/types.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/types.tsx
@@ -35,4 +35,4 @@ export type DashboardDetails = {
   createdBy: string;
 };
 
-export type DashboardState = 'view' | 'edit' | 'create';
+export type DashboardState = 'view' | 'edit' | 'create' | 'pending_delete';


### PR DESCRIPTION
Deleting a dashboard will redirect to another org dashboard. But the user will be warned of any unsaved changes as shown here.

https://user-images.githubusercontent.com/139499/104072709-ef54d780-51d9-11eb-9312-8c88737051ea.mp4

