### PR TITLE
build(dev): Add libxslt to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -9,6 +9,7 @@ brew 'watchman'
 
 # required to build some of sentry's dependencies
 brew 'pkgconfig'
+brew 'libxslt'
 brew 'libxmlsec1'
 brew 'geoip'
 


### PR DESCRIPTION
Hey!

I was trying to setup Sentry dev environment in Windows / WSL 2 / Ubuntu 18.04, and received the following error when running `make bootstrap`:

```
error: Package 'libxslt', required by 'xmlsec1', not found
```

Re-running the problematic `pip` command with additional troubleshooting flags didn't help much:

```
$ SENTRY_LIGHT_BUILD=1 python -m pip --disable-pip-version-check install -e ".[dev]" -v --no-clean 2>&1 | tee pip.log
```

After digging a little bit I discovered that this error is produced when `pkgconfig` Python package cannot find the 'xmlsec1' package, which seemed strange because it _was_ listed by the `pkg-config` utility in the system:

```
$ pkg-config --list-all | grep xmlsec
xmlsec1-gnutls    xmlsec1-gnutls - XML Security Library implements XML Signature and XML Encryption standards
xmlsec1           xmlsec1-openssl - XML Security Library implements XML Signature and XML Encryption standards
xmlsec1-gcrypt    xmlsec1-gcrypt - XML Security Library implements XML Signature and XML Encryption standards
xmlsec1-openssl   xmlsec1-openssl - XML Security Library implements XML Signature and XML Encryption standards
```

After another couple of hours I discovered that there was indeed a problem with xmlsec1:

```
$ pkg-config --cflags xmlsec1
Package libxslt was not found in the pkg-config search path.
Perhaps you should add the directory containing `libxslt.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libxslt', required by 'xmlsec1', not found
```

I tried installing libxml, libxslt and some other packages system-wide with `apt-get`, but to no avail.

Only adding `libxslt` to Brewfile solved the problem for me.

I don't think that adding `libxslt` to Brewfile will harm anyone (because it really seems a dependency of xmlsec1, even if Linux version of Brew apparently doesn't always know that), and it might possibly save a great deal of time for those trying to setup Sentry dev environment in system configuration like mine.


