### PR TITLE
fix(breadcrumb): Fix breadcrumb boolean data ui

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/data/summary.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/data/summary.tsx
@@ -42,7 +42,10 @@ class Summary extends React.Component<Props, State> {
       .filter(key => defined(kvData[key]) && !!kvData[key])
       .map(key => {
         const value =
-          typeof kvData[key] === 'object' ? JSON.stringify(kvData[key]) : kvData[key];
+          typeof kvData[key] === 'object'
+            ? JSON.stringify(kvData[key])
+            : String(kvData[key]);
+
         return (
           <Data key={key}>
             <StyledPre>


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/29228205/104128377-8307de80-5367-11eb-9e5c-e40f18781c7a.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/104128398-99ae3580-5367-11eb-961b-ef27644a4f76.png)


closes: https://github.com/getsentry/sentry/issues/16637

