### PR TITLE
feat(nodestore): Add task to measure event compression

### DIFF
--- a/src/sentry/eventstore/compressor.py
+++ b/src/sentry/eventstore/compressor.py
@@ -1,0 +1,91 @@
+from __future__ import absolute_import
+
+"""
+Eventstore compressor is responsible for pulling out repeating data across
+events such that they can be stored only once. For example SDK modules list, or
+debug_meta.
+
+This is not used in production yet, we are still collecting metrics there.
+"""
+
+import hashlib
+
+from sentry.utils import json
+
+_INTERFACES = {}
+
+
+def _deduplicate_interface(*keys):
+    def inner(f):
+        for k in keys:
+            _INTERFACES[k] = f
+
+        return f
+
+    return inner
+
+
+@_deduplicate_interface("debug_meta")
+class DebugMeta:
+    _DEDUP_FIELDS = ("debug_id", "code_id", "code_file", "debug_file")
+
+    @staticmethod
+    def encode(data):
+        dedup = {}
+
+        if data:
+            for image in data.get("images") or []:
+                image = image or {}
+                for name in DebugMeta._DEDUP_FIELDS:
+                    dedup.setdefault(name, []).append(image.pop(name, None))
+
+        return dedup, data
+
+    @staticmethod
+    def decode(dedup, data):
+        if data:
+            for i, image in enumerate(data.get("images") or []):
+                for name, arr in dedup.items():
+                    value = arr[i]
+                    if value is not None:
+                        image[name] = value
+
+        return data
+
+
+def deduplicate(data):
+    patchsets = []
+    extra_keys = {}
+
+    for key, interface in _INTERFACES.items():
+        if key not in data:
+            continue
+
+        to_deduplicate, to_inline = interface.encode(data.pop(key))
+        to_deduplicate_serialized = json.dumps(to_deduplicate, sort_keys=True).encode("utf8")
+        checksum = hashlib.md5(to_deduplicate_serialized).hexdigest()
+        extra_keys[checksum] = to_deduplicate
+        patchsets.append([key, checksum, to_inline])
+
+    if patchsets:
+        data["__nodestore_patchsets"] = patchsets
+
+    return data, extra_keys
+
+
+def assemble(data, get_extra_keys):
+    if not data.get("__nodestore_patchsets"):
+        return data
+
+    checksums = []
+    for key, checksum, inlined in data["__nodestore_patchsets"]:
+        checksums.append(checksum)
+
+    deduplicated_interfaces = get_extra_keys(checksums)
+
+    for key, checksum, inlined in data["__nodestore_patchsets"]:
+        deduplicated = deduplicated_interfaces[checksum]
+        data[key] = _INTERFACES[key].decode(deduplicated, inlined)
+
+    del data["__nodestore_patchsets"]
+    return data

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -279,3 +279,6 @@ register("store.use-relay-dsn-sample-rate", default=1)
 
 # Mock out integrations and services for tests
 register("mocks.jira", default=False)
+
+# Record statistics about event payloads and their compressability
+register("store.nodestore-stats-sample-rate", default=0)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1,15 +1,16 @@
 from __future__ import absolute_import, print_function
 
+import six
 import logging
 import sentry_sdk
+import random
 
-
-from sentry import features
+from sentry import features, options
 from sentry.utils.cache import cache
 from sentry.exceptions import PluginError
 from sentry.signals import event_processed, issue_unignored
 from sentry.tasks.base import instrumented_task
-from sentry.utils import metrics
+from sentry.utils import metrics, json
 from sentry.utils.safe import safe_execute
 from sentry.utils.sdk import set_current_project, bind_organization_context
 
@@ -243,6 +244,7 @@ def post_process_group(
         bind_organization_context(event.project.organization)
 
         _capture_stats(event, is_new)
+        _spawn_capture_nodestore_stats(event)
 
         if event.group_id and is_reprocessed and is_new:
             add_group_to_inbox(event.group, GroupInboxReason.REPROCESSED)
@@ -408,3 +410,62 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
         expected_errors=(PluginError,),
         **kwargs
     )
+
+
+def _spawn_capture_nodestore_stats(event):
+    rate = options.get("store.nodestore-stats-sample-rate") or 0
+    metrics.timing("eventstore.compressor.sample_rate", rate)
+
+    if not rate:
+        return
+
+    if random.random() >= rate:
+        return
+
+    capture_nodestore_stats.delay(project_id=event.project_id, event_id=event.event_id)
+
+
+@instrumented_task(name="sentry.tasks.post_process.capture_nodestore_stats")
+def capture_nodestore_stats(project_id, event_id):
+    set_current_project(project_id)
+
+    from sentry import nodestore
+    from sentry.eventstore.compressor import deduplicate
+    from sentry.eventstore.models import Event
+
+    event = Event(project_id=project_id, event_id=event_id)
+    old_event_size = event.size
+
+    if not event.data:
+        metrics.incr("eventstore.compressor.error", tags={"reason": "no_data"})
+        return
+
+    platform = event.platform
+
+    for key, value in six.iteritems(event.interfaces):
+        len_value = len(json.dumps(value.to_json()).encode("utf8"))
+        metrics.timing(
+            "events.size.interface", len_value, tags={"interface": key, "platform": platform}
+        )
+
+    new_data, extra_keys = deduplicate(dict(event.data))
+
+    total_size = event_size = len(json.dumps(new_data).encode("utf8"))
+
+    for key, value in six.iteritems(extra_keys):
+        if nodestore.get(key) is not None:
+            metrics.incr("eventstore.compressor.hits")
+            # do not continue, nodestore.set() should bump TTL
+        else:
+            metrics.incr("eventstore.compressor.misses")
+            total_size += len(json.dumps(value).encode("utf8"))
+
+        # key is md5sum of content
+        # do not store actual value to keep prod impact to a minimum
+        nodestore.set(key, {})
+
+    metrics.timing("events.size.deduplicated", event_size)
+    metrics.timing("events.size.deduplicated.total_written", total_size)
+
+    metrics.timing("events.size.deduplicated.ratio", event_size / old_event_size)
+    metrics.timing("events.size.deduplicated.total_written.ratio", total_size / old_event_size)

--- a/tests/sentry/eventstore/test_compressor.py
+++ b/tests/sentry/eventstore/test_compressor.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import
+
+import copy
+
+from sentry.eventstore.compressor import deduplicate, assemble
+
+
+def _assert_roundtrip(data, assert_extra_keys=None):
+    new_data, extra_keys = deduplicate(copy.deepcopy(data))
+
+    if assert_extra_keys is not None:
+        assert extra_keys == assert_extra_keys
+
+    def get_extra_keys(checksums):
+        assert set(checksums) == set(extra_keys)
+        return extra_keys
+
+    new_new_data = assemble(copy.deepcopy(new_data), get_extra_keys)
+
+    assert new_new_data == data
+
+
+def test_basic():
+    _assert_roundtrip({})
+    _assert_roundtrip({"debug_meta": {}})
+    _assert_roundtrip({"debug_meta": None})
+    _assert_roundtrip({"debug_meta": {"images": []}})
+    _assert_roundtrip({"debug_meta": {"images": None}})
+    _assert_roundtrip({"debug_meta": {"images": [{}]}})
+
+    _assert_roundtrip(
+        {
+            "debug_meta": {
+                "images": [
+                    {
+                        "image_addr": "0xdeadbeef",
+                        "debug_file": "C:/Ding/bla.pdb",
+                        "code_file": "C:/Ding/bla.exe",
+                        "debug_id": "1234abcdef",
+                        "code_id": "1234abcdefgggg",
+                    }
+                ]
+            }
+        },
+        assert_extra_keys={
+            "1a3e017bec533f3f4e59e44a3f53784e": {
+                "code_file": ["C:/Ding/bla.exe"],
+                "code_id": ["1234abcdefgggg"],
+                "debug_file": ["C:/Ding/bla.pdb"],
+                "debug_id": ["1234abcdef"],
+            }
+        },
+    )

--- a/tests/sentry/eventstore/test_compressor.py
+++ b/tests/sentry/eventstore/test_compressor.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from six import PY2
+
 import copy
 
 from sentry.eventstore.compressor import deduplicate, assemble
@@ -28,6 +30,7 @@ def test_basic():
     _assert_roundtrip({"debug_meta": {"images": None}})
     _assert_roundtrip({"debug_meta": {"images": [{}]}})
 
+    checksum = "1a3e017bec533f3f4e59e44a3f53784e" if not PY2 else "557c616fbeb6324611944ebce945d06e"
     _assert_roundtrip(
         {
             "debug_meta": {
@@ -43,7 +46,7 @@ def test_basic():
             }
         },
         assert_extra_keys={
-            "1a3e017bec533f3f4e59e44a3f53784e": {
+            checksum: {
                 "code_file": ["C:/Ding/bla.exe"],
                 "code_id": ["1234abcdefgggg"],
                 "debug_file": ["C:/Ding/bla.pdb"],

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -714,3 +714,16 @@ class PostProcessGroupTest(TestCase):
         # assert GroupInbox.objects.filter(
         #     group=group, reason=GroupInboxReason.REGRESSION.value
         # ).exists()
+
+    def test_nodestore_stats(self):
+        event = self.store_event(data={"message": "testing"}, project_id=self.project.id)
+        cache_key = write_event_to_cache(event)
+
+        with self.options({"store.nodestore-stats-sample-rate": 1.0}), self.tasks():
+            post_process_group(
+                is_new=True,
+                is_regression=True,
+                is_new_group_environment=False,
+                cache_key=cache_key,
+                group_id=event.group_id,
+            )


### PR DESCRIPTION
Add a celery task that pulls an event from nodestore and records some
metrics

See also https://github.com/getsentry/getsentry/pull/4879