### PR TITLE
fix(ui): increased word-spacing in search bar

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -1305,7 +1305,7 @@ const StyledInput = styled('input')`
   background: transparent;
   border: 0;
   outline: none;
-
+  word-spacing: ${space(0.5)};
   font-size: ${p => p.theme.fontSizeMedium};
   width: 100%;
   height: 40px;


### PR DESCRIPTION
Search terms in the input need more spacing because they all get smushed together. Fixing that with more word-spacing:

## Before

![Screen Shot 2021-01-11 at 10 43 35 AM](https://user-images.githubusercontent.com/1900676/104229487-3375f100-5401-11eb-9ef9-27bc65631b56.png)


## After

![Screen Shot 2021-01-11 at 10 43 51 AM](https://user-images.githubusercontent.com/1900676/104229524-3ec91c80-5401-11eb-9532-87949679891b.png)
