### PR TITLE
fix(inbox): Saved search tab font size, other fixes

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
@@ -101,6 +101,7 @@ const StyledDropdownLink = styled(DropdownLink)<{isActive?: boolean}>`
   text-align: center;
   /* TODO(scttcper): Replace hex color when nav-tabs is replaced */
   color: ${p => (p.isActive ? p.theme.textColor : '#7c6a8e')};
+  user-select: none;
 
   :hover {
     color: #2f2936;

--- a/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
@@ -99,6 +99,7 @@ const StyledDropdownLink = styled(DropdownLink)<{isActive?: boolean}>`
   border-radius: 0;
   font-size: ${p => p.theme.fontSizeLarge};
   text-align: center;
+  text-transform: capitalize;
   /* TODO(scttcper): Replace hex color when nav-tabs is replaced */
   color: ${p => (p.isActive ? p.theme.textColor : '#7c6a8e')};
   user-select: none;

--- a/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
@@ -33,6 +33,7 @@ function SavedSearchTab({
   return (
     <TabWrapper isActive={isActive} className="saved-search-tab">
       <StyledDropdownLink
+        alwaysRenderMenu={false}
         anchorMiddle
         caret
         title={<TitleWrapper>{title}</TitleWrapper>}
@@ -87,6 +88,7 @@ const TabWrapper = styled('li')<{isActive?: boolean}>`
 const TitleWrapper = styled('span')`
   margin-right: ${space(0.5)};
   max-width: 150px;
+  user-select: none;
   ${overflowEllipsis};
 `;
 
@@ -94,15 +96,12 @@ const StyledDropdownLink = styled(DropdownLink)<{isActive?: boolean}>`
   position: relative;
   display: block;
   padding: ${space(1)} 0;
-  border: 0;
-  background: none;
-  border-radius: 0;
-  font-size: ${p => p.theme.fontSizeLarge};
+  /* Important to override a media query from .nav-tabs */
+  font-size: ${p => p.theme.fontSizeLarge} !important;
   text-align: center;
   text-transform: capitalize;
   /* TODO(scttcper): Replace hex color when nav-tabs is replaced */
   color: ${p => (p.isActive ? p.theme.textColor : '#7c6a8e')};
-  user-select: none;
 
   :hover {
     color: #2f2936;

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -429,7 +429,6 @@ body.auth {
 
   .nav-tabs {
     > li {
-      text-transform: capitalize;
       margin-right: 11px;
 
       &:last-child {
@@ -437,7 +436,6 @@ body.auth {
       }
 
       a {
-        font-size: 14px;
         margin-right: 0;
 
         .badge {

--- a/src/sentry/static/sentry/less/layout.less
+++ b/src/sentry/static/sentry/less/layout.less
@@ -429,6 +429,7 @@ body.auth {
 
   .nav-tabs {
     > li {
+      text-transform: capitalize;
       margin-right: 11px;
 
       &:last-child {
@@ -436,6 +437,7 @@ body.auth {
       }
 
       a {
+        font-size: 14px;
         margin-right: 0;
 
         .badge {

--- a/tests/js/spec/views/issueList/header.spec.jsx
+++ b/tests/js/spec/views/issueList/header.spec.jsx
@@ -190,8 +190,8 @@ describe('IssueListHeader', () => {
         ]}
       />
     );
-    wrapper.find('StyledDropdownLink').simulate('click');
-    await wrapper.update();
+    wrapper.find('StyledDropdownLink').find('a').simulate('click');
+    await tick();
 
     const item = wrapper.find('MenuItem a').first();
     expect(item.text()).toContain('Unresolved Search');


### PR DESCRIPTION
- Disable alwaysRenderDropdown to unmount the tooltips and prevent them from appearing after the dropdown has closed
- Add `user-select: none;` to disable highlighting text when attempting to open the menu @adhiraj 
- override font size from nav tabs for small screen sizes