### PR TITLE
ref(trends): Remove intervalRatio from trends

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -22,7 +22,6 @@ import {YAxis} from 'app/views/releases/detail/overview/chart/releaseChartContro
 import {NormalizedTrendsTransaction, TrendChangeType, TrendsStats} from './types';
 import {
   getCurrentTrendFunction,
-  getIntervalRatio,
   getUnselectedSeries,
   transformEventStatsSmoothed,
   trendToColor,
@@ -152,7 +151,7 @@ function getIntervalLine(
   };
 
   const seriesDiff = seriesEnd - seriesStart;
-  const seriesLine = seriesDiff * (intervalRatio || 0.5) + seriesStart;
+  const seriesLine = seriesDiff * intervalRatio + seriesStart;
 
   previousPeriod.markLine.data = [
     [
@@ -256,7 +255,6 @@ class Chart extends React.Component<Props> {
     const end = props.end ? getUtcToLocalDateObject(props.end) : null;
     const utc = decodeScalar(router.location.query.utc) !== 'false';
 
-    const intervalRatio = getIntervalRatio(router.location);
     const seriesSelection = (
       decodeList(location.query[getUnselectedSeries(trendChangeType)]) ?? []
     ).reduce((selection, metric) => {
@@ -326,11 +324,7 @@ class Chart extends React.Component<Props> {
               })
             : [];
 
-          const intervalSeries = getIntervalLine(
-            smoothedResults || [],
-            intervalRatio,
-            transaction
-          );
+          const intervalSeries = getIntervalLine(smoothedResults || [], 0.5, transaction);
 
           return (
             <ReleaseSeries

--- a/src/sentry/static/sentry/app/views/performance/trends/types.ts
+++ b/src/sentry/static/sentry/app/views/performance/trends/types.ts
@@ -16,7 +16,6 @@ export type TrendsQuery = EventQuery &
     trendFunction?: string;
     trendType?: TrendChangeType;
     middle?: string;
-    intervalRatio?: number;
     interval?: string;
   };
 

--- a/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/utils.tsx
@@ -129,11 +129,6 @@ export function getCurrentConfidenceLevel(location: Location): ConfidenceLevel {
   return confidenceLevel || CONFIDENCE_LEVELS[0];
 }
 
-export function getIntervalRatio(location: Location): number {
-  const intervalFromLocation = decodeScalar(location?.query?.intervalRatio);
-  return intervalFromLocation ? parseFloat(intervalFromLocation) : 0.5;
-}
-
 export function transformDeltaSpread(from: number, to: number) {
   const fromSeconds = from / 1000;
   const toSeconds = to / 1000;


### PR DESCRIPTION
The URL parameter `intervalRatio` is no longer used anywhere. This removes it.