### PR TITLE
feat(relay): Expose DSN endpoint in project options

### DIFF
--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -78,6 +78,22 @@ def get_browser_sdk_version(project_key):
         return settings.JS_SDK_LOADER_SDK_VERSION
 
 
+def get_js_sdk_url(project_key=None, sdk_version=None):
+    if sdk_version is None:
+        if project_key is None:
+            raise TypeError("Project key needed if SDK version is not set")
+        sdk_version = get_browser_sdk_version(project_key)
+    try:
+        if "%s" in settings.JS_SDK_LOADER_DEFAULT_SDK_URL:
+            sdk_url = settings.JS_SDK_LOADER_DEFAULT_SDK_URL % (sdk_version,)
+        else:
+            sdk_url = settings.JS_SDK_LOADER_DEFAULT_SDK_URL
+    except TypeError:
+        # Ignore misconfiguration here and disable the URL in that case
+        sdk_url = None
+    return sdk_url
+
+
 def get_selected_browser_sdk_version(project_key):
     return project_key.data.get("browserSdkVersion") or get_default_sdk_version_for_project(
         project_key.project

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -121,6 +121,7 @@ def get_project_config(project, full_config=True, project_keys=None):
             "publicKeys": public_keys,
             "config": {
                 "allowedDomains": list(get_origins(project)),
+                "dsnEndpoint": project.get_dsn_endpoint(),
                 "trustedRelays": [
                     r["public_key"]
                     for r in project.organization.get_option("sentry:trusted-relays", [])

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -23,6 +23,7 @@ from sentry.utils.sdk import configure_scope
 from sentry.relay.utils import to_camel_case_name
 from sentry.datascrubbing import get_pii_config, get_datascrubbing_settings
 from sentry.models.projectkey import ProjectKeyStatus
+from sentry.loader.browsersdkversion import get_js_sdk_url
 
 
 def get_project_key_config(project_key):
@@ -38,6 +39,7 @@ def get_public_key_configs(project, full_config, project_keys=None):
             "publicKey": project_key.public_key,
             "numericId": project_key.id,
             "isEnabled": project_key.status == ProjectKeyStatus.ACTIVE,
+            "jsSdkUrl": get_js_sdk_url(project_key),
         }
 
         if full_config:

--- a/src/sentry/web/frontend/js_sdk_loader.py
+++ b/src/sentry/web/frontend/js_sdk_loader.py
@@ -2,14 +2,12 @@ from __future__ import absolute_import
 
 import time
 
-from django.conf import settings
-
 from sentry.relay import config
 from sentry.utils import metrics
 from sentry.models import ProjectKey, Project
 from sentry.web.frontend.base import BaseView
 from sentry.web.helpers import render_to_response
-from sentry.loader.browsersdkversion import get_browser_sdk_version
+from sentry.loader.browsersdkversion import get_js_sdk_url, get_browser_sdk_version
 
 
 CACHE_CONTROL = (
@@ -26,17 +24,11 @@ class JavaScriptSdkLoader(BaseView):
             return ({}, None, None)
 
         sdk_version = get_browser_sdk_version(key)
-        try:
-            if "%s" in settings.JS_SDK_LOADER_DEFAULT_SDK_URL:
-                sdk_url = settings.JS_SDK_LOADER_DEFAULT_SDK_URL % (sdk_version,)
-            else:
-                sdk_url = settings.JS_SDK_LOADER_DEFAULT_SDK_URL
-        except TypeError:
-            sdk_url = ""  # It fails if it cannot inject the version in the string
-
+        sdk_url = get_js_sdk_url(key, sdk_version=sdk_version) or ""
         return (
             {
                 "config": config.get_project_key_config(key),
+                # It fails if it cannot inject the version in the string
                 "jsSdkUrl": sdk_url,
                 "publicKey": key.public_key,
             },

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/False.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/False.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-03-03T15:00:37.986304Z'
+created: '2021-01-12T10:01:57.932141Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -12,6 +12,7 @@ config:
     scrubDefaults: true
     scrubIpAddresses: false
     sensitiveFields: []
+  dsnEndpoint: http://testserver
   piiConfig:
     applications:
       $string:

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/True.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/True.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-08T19:22:25.717243Z'
+created: '2021-01-12T10:01:58.073215Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -12,6 +12,7 @@ config:
     scrubDefaults: true
     scrubIpAddresses: false
     sensitiveFields: []
+  dsnEndpoint: http://testserver
   eventRetention: null
   filterSettings:
     browserExtensions:

--- a/tests/sentry/tasks/test_relay.py
+++ b/tests/sentry/tasks/test_relay.py
@@ -90,9 +90,6 @@ def test_debounce(monkeypatch, default_project, default_organization, redis_cach
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("entire_organization", (True, False))
-@override_settings(
-    JS_SDK_LOADER_DEFAULT_SDK_URL="https://browser.sentry-cdn.invalid/%s/bundle.min.js"
-)
 def test_generate(
     monkeypatch,
     default_project,
@@ -110,8 +107,13 @@ def test_generate(
         kwargs = {"organization_id": default_organization.id}
 
     with task_runner():
-        with patch("sentry.loader.browsersdkversion.get_browser_sdk_version", return_value="1.2.3"):
-            schedule_update_config_cache(generate=True, **kwargs)
+        with override_settings(
+            JS_SDK_LOADER_DEFAULT_SDK_URL="https://browser.sentry-cdn.invalid/%s/bundle.min.js"
+        ):
+            with patch(
+                "sentry.loader.browsersdkversion.get_browser_sdk_version", return_value="1.2.3"
+            ):
+                schedule_update_config_cache(generate=True, **kwargs)
 
     cfg = redis_cache.get(default_project.id)
 


### PR DESCRIPTION
This exposes the DSN endpoint in the project options as well as the JS SDK URL in the key options. This is necessary to render the loader in relay.