### PR TITLE
Create comment when linking to existing JIRA issue

### DIFF
--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -235,7 +235,7 @@ class JiraServerIntegration(JiraIntegration):
         )
 
     def get_link_issue_config(self, group, **kwargs):
-        fields = super(JiraServerIntegration, self).get_link_issue_config(group, **kwargs)
+        fields = super().get_link_issue_config(group, **kwargs)
 
         org = group.organization
         autocomplete_url = reverse(
@@ -267,7 +267,7 @@ class JiraServerIntegration(JiraIntegration):
         return reverse("sentry-extensions-jiraserver-search", args=[org_slug, self.model.id])
 
     def after_link_issue(self, external_issue, data=None, **kwargs):
-        super(JiraServerIntegration, self).after_link_issue(external_issue, **kwargs)
+        super().after_link_issue(external_issue, **kwargs)
 
         if data:
             comment = data.get("comment")

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -18,8 +18,9 @@ from sentry.integrations import (
 from sentry.shared_integrations.exceptions import IntegrationError, ApiError
 from sentry.integrations.jira import JiraIntegration
 from sentry.pipeline import PipelineView
-from sentry.utils.hashlib import sha1_text
 from sentry.utils.decorators import classproperty
+from sentry.utils.hashlib import sha1_text
+from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response
 from .client import JiraServer, JiraServerSetupClient, JiraServerClient
 
@@ -234,7 +235,8 @@ class JiraServerIntegration(JiraIntegration):
         )
 
     def get_link_issue_config(self, group, **kwargs):
-        fields = super(JiraIntegration, self).get_link_issue_config(group, **kwargs)
+        fields = super(JiraServerIntegration, self).get_link_issue_config(group, **kwargs)
+
         org = group.organization
         autocomplete_url = reverse(
             "sentry-extensions-jiraserver-search", args=[org.slug, self.model.id]
@@ -243,10 +245,34 @@ class JiraServerIntegration(JiraIntegration):
             if field["name"] == "externalIssue":
                 field["url"] = autocomplete_url
                 field["type"] = "select"
+
+        default_comment = "Linked Sentry Issue: [{}|{}]".format(
+            group.qualified_short_id,
+            absolute_uri(group.get_absolute_url(params={"referrer": "jira_server"})),
+        )
+        fields.append(
+            {
+                "name": "comment",
+                "label": "Comment",
+                "default": default_comment,
+                "type": "textarea",
+                "autosize": True,
+                "maxRows": 10,
+            }
+        )
+
         return fields
 
     def search_url(self, org_slug):
         return reverse("sentry-extensions-jiraserver-search", args=[org_slug, self.model.id])
+
+    def after_link_issue(self, external_issue, data=None, **kwargs):
+        super(JiraServerIntegration, self).after_link_issue(external_issue, **kwargs)
+
+        if data:
+            comment = data.get("comment")
+            if comment:
+                self.get_client().create_comment(external_issue.key, comment)
 
 
 class JiraServerIntegrationProvider(IntegrationProvider):


### PR DESCRIPTION
Fixes #21865

![image](https://user-images.githubusercontent.com/52021/104333184-02c9b080-5502-11eb-83aa-86d116c5f388.png)

A brief feature description:
  - Users get a pre-populated Description field on the Link tab
  - The default description is what you would have in a newly created issue, but starting with "Linked Sentry Issue" instead of "Sentry Issue". If you don't think this change is necessary, I will gladly remove it.
  - On the backend, when the JIRA integration receives a non-empty description field, it creates a comment in the linked JIRA ticket.
  -  JIRA and JIRA Server integrations are affected.

Please have mercy on me and don't ask me to implement additional features like adding a comment when JIRA issue is unlinked. Setting up development environment in WSL (and development itself) is a torture, and I have spend at least 3 days on this trivial feature. Assuming that it would take ~10x less time for Sentry developers to implement this themselves, I don't think my time is so dirt cheap. (Although, I must admit that this torture was somewhat educational).

I am ready to add tests if required.