### PR TITLE
fix(workflow): Catching Commit.DoesNotExist

### DIFF
--- a/src/sentry/tasks/groupowner.py
+++ b/src/sentry/tasks/groupowner.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from django.core.cache import cache
 from django.utils import timezone
 
-from sentry.models import Project, Release
+from sentry.models import Commit, Project, Release
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.utils import metrics
 from sentry.utils.committers import get_event_file_committers
@@ -95,4 +95,9 @@ def process_suspect_commits(event, **kwargs):
                     logger.info(
                         "process_suspect_commits.skipped",
                         extra={"event": event.id, "reason": "no_release"},
+                    )
+                except Commit.DoesNotExist:
+                    logger.info(
+                        "process_suspect_commits.skipped",
+                        extra={"event": event.id, "reason": "no_commits"},
                     )


### PR DESCRIPTION
This exception should be caught and shouldn't create issues in Sentry.

I'll probably come back to this and add a test after my meeting.

https://sentry.io/organizations/sentry/issues/2145830596/
Resolves SENTRY-KH1

