### PR TITLE
fix(csp) Use a minified ios-device-list

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -359,6 +359,13 @@ let appConfig = {
       less: path.join(staticPrefix, 'less'),
       'sentry-test': path.join(__dirname, 'tests', 'js', 'sentry-test'),
       'sentry-locale': path.join(__dirname, 'src', 'sentry', 'locale'),
+      'ios-device-list': path.join(
+        __dirname,
+        'node_modules',
+        'ios-device-list',
+        'dist',
+        'ios-device-list.min.js'
+      ),
     },
 
     modules: ['node_modules'],


### PR DESCRIPTION
The non-minified (default variant) includes eval statements which are not allowed by our CSP in sentry.io