### PR TITLE
ref(buttons): Avoid wrapping with span when using `title`

### DIFF
--- a/src/sentry/static/sentry/app/utils/mergeRefs.tsx
+++ b/src/sentry/static/sentry/app/utils/mergeRefs.tsx
@@ -1,0 +1,16 @@
+/**
+ * Combine refs to allow assignment to all passed refs
+ */
+export default function mergeRefs<T = any>(
+  refs: Array<React.MutableRefObject<T> | React.LegacyRef<T> | undefined>
+): React.RefCallback<T> {
+  return value => {
+    refs.forEach(ref => {
+      if (typeof ref === 'function') {
+        ref(value);
+      } else if (ref !== null && ref !== undefined) {
+        (ref as React.MutableRefObject<T | null>).current = value;
+      }
+    });
+  };
+}


### PR DESCRIPTION
Using `title` would wrap the button with a Tooltip. Because we weren't
passing the `skipWrapper` prop to the tooltip it would wrap the button
in a span element.

This can cause a number of problems for testing as well as unexpected
rendering issues.