### PR TITLE
ref(modals): Always use IoC modal props

### DIFF
--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-// eslint-disable-next-line no-restricted-imports
-import {Modal} from 'react-bootstrap';
 import debounce from 'lodash/debounce';
 import * as queryString from 'query-string';
 
+import {ModalRenderProps} from 'app/actionCreators/modal';
 import AsyncComponent from 'app/components/asyncComponent';
 import {tct} from 'app/locale';
 import {IntegrationIssueConfig, IssueConfigField} from 'app/types';
@@ -14,7 +13,7 @@ import {FormField} from 'app/views/settings/projectAlerts/issueEditor/ruleNode';
 
 export type ExternalIssueAction = 'create' | 'link';
 
-type Props = AsyncComponent['props'];
+type Props = ModalRenderProps & AsyncComponent['props'];
 
 type State = {
   action: ExternalIssueAction;
@@ -233,13 +232,13 @@ export default class AbstractExternalIssueForm<
       {}
     );
 
+    const {Header, Body} = this.props as ModalRenderProps;
+
     return (
       <React.Fragment>
-        <Modal.Header closeButton>
-          <Modal.Title>{this.getTitle()}</Modal.Title>
-        </Modal.Header>
+        <Header closeButton>{this.getTitle()}</Header>
         {this.renderNavTabs()}
-        <Modal.Body>
+        <Body>
           {this.shouldRenderLoading() ? (
             this.renderLoading()
           ) : (
@@ -262,7 +261,7 @@ export default class AbstractExternalIssueForm<
               </Form>
             </React.Fragment>
           )}
-        </Modal.Body>
+        </Body>
       </React.Fragment>
     );
   };

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import * as Sentry from '@sentry/react';
 
 import {addSuccessMessage} from 'app/actionCreators/indicator';
-import {closeModal, ModalRenderProps} from 'app/actionCreators/modal';
 import AsyncComponent from 'app/components/asyncComponent';
 import AbstractExternalIssueForm, {
   ExternalIssueAction,
@@ -22,7 +21,7 @@ const SUBMIT_LABEL_BY_ACTION = {
   create: t('Create Issue'),
 };
 
-type Props = ModalRenderProps & {
+type Props = {
   group: Group;
   integration: Integration;
   onChange: (onSuccess?: () => void, onError?: () => void) => void;
@@ -70,7 +69,7 @@ export default class ExternalIssueForm extends AbstractExternalIssueForm<Props, 
   };
 
   onSubmitSuccess = (_data: IntegrationExternalIssue): void => {
-    const {onChange} = this.props;
+    const {onChange, closeModal} = this.props;
     const {action} = this.state;
     onChange(() => addSuccessMessage(MESSAGES_BY_ACTION[action]));
     closeModal();

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueEditor/ticketRuleModal.tsx
@@ -4,7 +4,6 @@ import cloneDeep from 'lodash/cloneDeep';
 import set from 'lodash/set';
 
 import {addSuccessMessage} from 'app/actionCreators/indicator';
-import {ModalRenderProps} from 'app/actionCreators/modal';
 import AbstractExternalIssueForm from 'app/components/externalIssues/abstractExternalIssueForm';
 import ExternalLink from 'app/components/links/externalLink';
 import {t, tct} from 'app/locale';
@@ -14,7 +13,7 @@ import {IssueAlertRuleAction} from 'app/types/alerts';
 import AsyncView from 'app/views/asyncView';
 import Form from 'app/views/settings/components/forms/form';
 
-type Props = ModalRenderProps & {
+type Props = {
   // Comes from the in-code definition of a `TicketEventAction`.
   formFields: {[key: string]: any};
   index: number;

--- a/tests/js/spec/components/group/externalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueForm.spec.jsx
@@ -40,7 +40,13 @@ describe('ExternalIssueForm', () => {
       body: formConfig,
     });
     const component = mountWithTheme(
-      <ExternalIssueForm group={group} integration={integration} onChange={onChange} />,
+      <ExternalIssueForm
+        Body={p => p.children}
+        Header={p => p.children}
+        group={group}
+        integration={integration}
+        onChange={onChange}
+      />,
       TestStubs.routerContext()
     );
     component.instance().handleClick(action);


### PR DESCRIPTION
Looks like some react-bootstrap usage snuck it's way back in