### PR TITLE
fix(options): Fix type of option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -281,4 +281,4 @@ register("store.use-relay-dsn-sample-rate", default=1)
 register("mocks.jira", default=False)
 
 # Record statistics about event payloads and their compressability
-register("store.nodestore-stats-sample-rate", default=0)
+register("store.nodestore-stats-sample-rate", default=0.0)


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/23005

Right now we are not able to set any sampling rate, as the type is
assumed to be integer. I think this was a behavioral change when moving
to Python 3.

The correct type is float. options.set validates it. Users of this code
can deal with both, and options.get returns any value from the DB
regardless of type.

When testing this option out just now, I verified how options.get
behaves and applied the following workaround directly in the REPL just
to get started with sampling:

    del options.default_manager.registry['store.nodestore-stats-sample-rate']
    options.register("store.nodestore-stats-sample-rate", default=0.0)
    options.set("store.nodestore-stats-sample-rate", 0.0)

The initial default value has also been set in a similar fashion.