### PR TITLE
feat(organization-settings): Add Filters & Sampling tab - Part 1

### DIFF
--- a/src/sentry/static/sentry/app/routes.jsx
+++ b/src/sentry/static/sentry/app/routes.jsx
@@ -751,6 +751,17 @@ function routes() {
         component={errorHandler(LazyLoad)}
       />
 
+      <Route
+        name={t('Filters & Sampling')}
+        path="filters-and-sampling/"
+        componentPromise={() =>
+          import(
+            /* webpackChunkName: "OrganizationFiltersAndSampling" */ 'app/views/settings/organizationFiltersAndSampling'
+          )
+        }
+        component={errorHandler(LazyLoad)}
+      />
+
       <Route name="Teams" path="teams/">
         <IndexRoute
           componentPromise={() =>

--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
@@ -29,6 +29,14 @@ const organizationNavigation: NavigationSection[] = [
         id: 'security-and-privacy',
       },
       {
+        path: `${pathPrefix}/filters-and-sampling/`,
+        title: t('Filters & Sampling'),
+        show: ({features}) => features!.has('filters-and-sampling'),
+        description: t("Manage an organization's inboud data"),
+        id: 'filters-and-sampling',
+        badge: () => 'new',
+      },
+      {
         path: `${pathPrefix}/teams/`,
         title: t('Teams'),
         description: t("Manage an organization's teams"),

--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
@@ -34,7 +34,6 @@ const organizationNavigation: NavigationSection[] = [
         show: ({features}) => features!.has('filters-and-sampling'),
         description: t("Manage an organization's inbound data"),
         id: 'filters-and-sampling',
-        badge: () => 'new',
       },
       {
         path: `${pathPrefix}/teams/`,

--- a/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/navigationConfiguration.tsx
@@ -32,7 +32,7 @@ const organizationNavigation: NavigationSection[] = [
         path: `${pathPrefix}/filters-and-sampling/`,
         title: t('Filters & Sampling'),
         show: ({features}) => features!.has('filters-and-sampling'),
-        description: t("Manage an organization's inboud data"),
+        description: t("Manage an organization's inbound data"),
         id: 'filters-and-sampling',
         badge: () => 'new',
       },

--- a/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import Feature from 'app/components/acl/feature';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
+import {PanelAlert} from 'app/components/panels';
+import {t} from 'app/locale';
+import {Organization} from 'app/types';
+import withOrganization from 'app/utils/withOrganization';
+
+import OrganizationFiltersAndSampling from './organizationFiltersAndSampling';
+
+type Props = {
+  organization: Organization;
+};
+
+const Index = ({organization}: Props) => (
+  <Feature
+    features={['filters-and-sampling']}
+    organization={organization}
+    renderDisabled={() => (
+      <FeatureDisabled
+        alert={PanelAlert}
+        features={organization.features}
+        featureName={t('Filters & Sampling')}
+      />
+    )}
+  >
+    <OrganizationFiltersAndSampling />
+  </Feature>
+);
+
+export default withOrganization(Index);

--- a/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/organizationFiltersAndSampling.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/organizationFiltersAndSampling.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import {t} from 'app/locale';
+import AsyncView from 'app/views/asyncView';
+import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
+import TextBlock from 'app/views/settings/components/text/textBlock';
+import PermissionAlert from 'app/views/settings/organization/permissionAlert';
+
+type Props = AsyncView['props'];
+
+type State = AsyncView['state'];
+
+class OrganizationFiltersAndSampling extends AsyncView<Props, State> {
+  getTitle() {
+    return t('Filters & Sampling');
+  }
+
+  render() {
+    return (
+      <React.Fragment>
+        <SettingsPageHeader title={this.getTitle()} />
+        <PermissionAlert />
+        <TextBlock>
+          {t(
+            'Manage the inbound data you want to store. To change the sampling rate or rate limits, update your SDK configuration. The rules added below will apply on top of your SDK configuration.'
+          )}
+        </TextBlock>
+      </React.Fragment>
+    );
+  }
+}
+
+export default OrganizationFiltersAndSampling;

--- a/src/sentry/static/sentry/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -191,6 +191,7 @@ class RelayWrapper extends AsyncView<Props, State> {
     );
   }
 }
+
 export default RelayWrapper;
 
 const StyledTextBlock = styled(TextBlock)`


### PR DESCRIPTION
**Description:** Add Filters & Sampling tab (Organization level - only)

**It looks like:** 

![image](https://user-images.githubusercontent.com/29228205/104451008-3a3b6a00-55a1-11eb-81dd-6bd0c5f8e50a.png)

**closes:** https://app.asana.com/0/1182975495223897/1199539528645954

ps: Maybe we will still move this tab to another place
