### PR TITLE
ref(vitals): Restructure vitals cards

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/content.tsx
@@ -26,7 +26,7 @@ import {
   LANDING_DISPLAYS,
   LandingDisplayField,
 } from './utils';
-import VitalsCards from './vitalsCards';
+import {FrontendCards} from './vitalsCards';
 
 type Props = {
   organization: Organization;
@@ -133,11 +133,11 @@ class LandingContent extends React.Component<Props, State> {
                       </DropdownControl>
                     </ProjectTypeDropdown>
                   </SearchContainer>
-                  <VitalsCards
+                  <FrontendCards
                     eventView={frontendEventView}
                     organization={organization}
                     location={location}
-                    isAlwaysShown
+                    projects={projects}
                   />
                   {currentLandingDisplay.field === LandingDisplayField.FRONTEND && (
                     <FrontendDisplay
@@ -173,10 +173,12 @@ class LandingContent extends React.Component<Props, State> {
                   onSearch={handleSearch}
                 />
                 <Feature features={['performance-vitals-overview']}>
-                  <VitalsCards
+                  <FrontendCards
                     eventView={eventView}
                     organization={organization}
                     location={location}
+                    projects={projects}
+                    frontendOnly
                   />
                 </Feature>
                 <Charts

--- a/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
@@ -3,7 +3,9 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import Card from 'app/components/card';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
 import Link from 'app/components/links/link';
+import Placeholder from 'app/components/placeholder';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
@@ -145,7 +147,7 @@ type VitalBarProps = {
   vital: WebVital | WebVital[];
   value?: string;
   showBar?: boolean;
-  showEmptyState?: boolean;
+  showStates?: boolean;
   showDurationDetail?: boolean;
   showVitalPercentNames?: boolean;
 };
@@ -157,17 +159,21 @@ export function VitalBar(props: VitalBarProps) {
     vital,
     value,
     showBar = true,
-    showEmptyState = true,
+    showStates = false,
     showDurationDetail = false,
     showVitalPercentNames = false,
   } = props;
 
-  if (isLoading || !result) {
-    if (showEmptyState) {
-      // TODO(tonyx): loading state?
-      return null;
-    }
-    return null;
+  if (isLoading) {
+    return showStates ? <Placeholder height="48px" /> : null;
+  }
+
+  const emptyState = showStates ? (
+    <EmptyStateWarning small>{t('No data available')}</EmptyStateWarning>
+  ) : null;
+
+  if (!result) {
+    return emptyState;
   }
 
   const counts: Counts = {
@@ -183,7 +189,7 @@ export function VitalBar(props: VitalBarProps) {
   });
 
   if (!counts.baseCount) {
-    return null;
+    return emptyState;
   }
 
   const p75: React.ReactNode = Array.isArray(vital)

--- a/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
@@ -80,21 +80,31 @@ export function FrontendCards(props: VitalsCardsProps) {
         const result = tableData?.data?.[0];
         return (
           <VitalsContainer>
-            {vitals.map(vitalName => {
+            {vitals.map(vital => {
               const target = vitalDetailRouteWithQuery({
                 orgSlug: organization.slug,
                 query: eventView.generateQueryStringObject(),
-                vitalName,
+                vitalName: vital,
                 projectID: decodeList(location.query.project),
               });
 
+              const value = isLoading ? '\u2014' : getP75(result, vital);
+              const chart = (
+                <VitalBar isLoading={isLoading} vital={vital} result={result} />
+              );
+
               return (
                 <Link
-                  key={vitalName}
+                  key={vital}
                   to={target}
-                  data-test-id={`vitals-linked-card-${vitalAbbreviations[vitalName]}`}
+                  data-test-id={`vitals-linked-card-${vitalAbbreviations[vital]}`}
                 >
-                  <FrontendCard isLoading={isLoading} result={result} vital={vitalName} />
+                  <VitalCard
+                    title={vitalMap[vital] ?? ''}
+                    tooltip={vitalDescription[vital] ?? ''}
+                    value={isLoading ? '\u2014' : value}
+                    chart={chart}
+                  />
                 </Link>
               );
             })}
@@ -118,28 +128,6 @@ const VitalsContainer = styled('div')`
     grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   }
 `;
-
-type FrontendCardProps = {
-  isLoading: boolean;
-  result: any;
-  vital: WebVital;
-};
-
-function FrontendCard(props: FrontendCardProps) {
-  const {isLoading, result, vital} = props;
-
-  const value = isLoading ? '\u2014' : getP75(result, vital);
-  const chart = <VitalBar isLoading={isLoading} vital={vital} result={result} />;
-
-  return (
-    <VitalCard
-      title={vitalMap[vital] ?? ''}
-      tooltip={vitalDescription[vital] ?? ''}
-      value={isLoading ? '\u2014' : value}
-      chart={chart}
-    />
-  );
-}
 
 type VitalBarProps = {
   isLoading: boolean;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -13,7 +13,7 @@ import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
-import {getAggregateAlias} from 'app/utils/discover/fields';
+import {getAggregateAlias, WebVital} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
 import {getTermHelp} from 'app/views/performance/data';
 import {
@@ -23,7 +23,7 @@ import {
 } from 'app/views/performance/transactionVitals/constants';
 import {vitalsRouteWithQuery} from 'app/views/performance/transactionVitals/utils';
 
-import VitalsCards from '../landing/vitalsCards';
+import VitalInfo from '../vitalDetail/vitalInfo';
 
 type Props = {
   eventView: EventView;
@@ -125,11 +125,13 @@ function UserStats({eventView, totals, location, organization, transactionName}:
                     <IconOpen />
                   </Link>
                 </VitalsHeading>
-                <VitalsCards
+                <VitalInfo
                   eventView={eventView}
                   organization={organization}
                   location={location}
-                  hasCondensedVitals
+                  vital={[WebVital.FCP, WebVital.LCP, WebVital.FID, WebVital.CLS]}
+                  hideVitalPercentNames
+                  hideDurationDetail
                 />
               </SidebarWrapper>
             );

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -305,7 +305,7 @@ class VitalCard extends React.Component<Props, State> {
                   location={location}
                   vital={vital}
                   hideBar
-                  hideEmptyState
+                  hideStates
                   hideVitalPercentNames
                   hideDurationDetail
                 />

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -303,11 +303,11 @@ class VitalCard extends React.Component<Props, State> {
                   eventView={eventView}
                   organization={organization}
                   location={location}
-                  vitalName={vital}
+                  vital={vital}
                   hideBar
+                  hideEmptyState
                   hideVitalPercentNames
                   hideDurationDetail
-                  hideEmptyState
                 />
               </PercentContainer>
             </Feature>

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalDetailContent.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalDetailContent.tsx
@@ -184,7 +184,7 @@ class VitalDetailContent extends React.Component<Props, State> {
                 eventView={eventView}
                 organization={organization}
                 location={location}
-                vitalName={vital}
+                vital={vital}
               />
             </StyledVitalInfo>
             <Table

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalInfo.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalInfo.tsx
@@ -6,13 +6,13 @@ import EventView from 'app/utils/discover/eventView';
 import {WebVital} from 'app/utils/discover/fields';
 import VitalsCardDiscoverQuery from 'app/views/performance/vitalDetail/vitalsCardsDiscoverQuery';
 
-import {VitalsCard} from '../landing/vitalsCards';
+import {VitalBar} from '../landing/vitalsCards';
 
 type Props = {
   eventView: EventView;
   organization: Organization;
   location: Location;
-  vitalName: WebVital;
+  vital: WebVital | WebVital[];
   hideBar?: boolean;
   hideEmptyState?: boolean;
   hideVitalPercentNames?: boolean;
@@ -21,10 +21,12 @@ type Props = {
 
 export default function vitalInfo(props: Props) {
   const {
-    vitalName,
+    vital,
     eventView,
     organization,
     location,
+    hideBar,
+    hideEmptyState,
     hideVitalPercentNames,
     hideDurationDetail,
   } = props;
@@ -33,17 +35,18 @@ export default function vitalInfo(props: Props) {
       eventView={eventView}
       orgSlug={organization.slug}
       location={location}
-      onlyVital={vitalName}
+      vitals={Array.isArray(vital) ? vital : [vital]}
     >
       {({isLoading, tableData}) => (
         <React.Fragment>
-          <VitalsCard
-            tableData={tableData}
+          <VitalBar
             isLoading={isLoading}
-            {...props}
-            noBorder
+            showBar={!hideBar}
+            showEmptyState={!hideEmptyState}
             showVitalPercentNames={!hideVitalPercentNames}
             showDurationDetail={!hideDurationDetail}
+            result={tableData?.data?.[0]}
+            vital={vital}
           />
         </React.Fragment>
       )}

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalInfo.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalInfo.tsx
@@ -14,7 +14,7 @@ type Props = {
   location: Location;
   vital: WebVital | WebVital[];
   hideBar?: boolean;
-  hideEmptyState?: boolean;
+  hideStates?: boolean;
   hideVitalPercentNames?: boolean;
   hideDurationDetail?: boolean;
 };
@@ -26,7 +26,7 @@ export default function vitalInfo(props: Props) {
     organization,
     location,
     hideBar,
-    hideEmptyState,
+    hideStates,
     hideVitalPercentNames,
     hideDurationDetail,
   } = props;
@@ -38,17 +38,15 @@ export default function vitalInfo(props: Props) {
       vitals={Array.isArray(vital) ? vital : [vital]}
     >
       {({isLoading, tableData}) => (
-        <React.Fragment>
-          <VitalBar
-            isLoading={isLoading}
-            showBar={!hideBar}
-            showEmptyState={!hideEmptyState}
-            showVitalPercentNames={!hideVitalPercentNames}
-            showDurationDetail={!hideDurationDetail}
-            result={tableData?.data?.[0]}
-            vital={vital}
-          />
-        </React.Fragment>
+        <VitalBar
+          isLoading={isLoading}
+          result={tableData?.data?.[0]}
+          vital={vital}
+          showBar={!hideBar}
+          showStates={!hideStates}
+          showVitalPercentNames={!hideVitalPercentNames}
+          showDurationDetail={!hideDurationDetail}
+        />
       )}
     </VitalsCardDiscoverQuery>
   );

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalsCardsDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalsCardsDiscoverQuery.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {MetaType} from 'app/utils/discover/eventView';
+import {WebVital} from 'app/utils/discover/fields';
 import GenericDiscoverQuery, {
   DiscoverQueryProps,
 } from 'app/utils/discover/genericDiscoverQuery';
@@ -23,25 +24,22 @@ export type TableData = {
 };
 
 type Props = DiscoverQueryProps & {
-  onlyVital?: string;
+  vitals: WebVital[];
 };
 
 function getRequestPayload(props: Props) {
-  const {eventView, onlyVital} = props;
+  const {eventView, vitals} = props;
   const apiPayload = eventView?.getEventsAPIPayload(props.location);
-  const vitalFields = onlyVital
-    ? [
-        vitalsPoorFields[onlyVital],
-        vitalsBaseFields[onlyVital],
-        vitalsMehFields[onlyVital],
-        vitalsP75Fields[onlyVital],
-      ]
-    : [
-        ...Object.values(vitalsPoorFields),
-        ...Object.values(vitalsMehFields),
-        ...Object.values(vitalsBaseFields),
-        ...Object.values(vitalsP75Fields),
-      ];
+  const vitalFields: string[] = vitals
+    .map(vital =>
+      [
+        vitalsPoorFields[vital],
+        vitalsBaseFields[vital],
+        vitalsMehFields[vital],
+        vitalsP75Fields[vital],
+      ].filter(Boolean)
+    )
+    .reduce((fields, fs) => fields.concat(fs), []);
   apiPayload.field = [...vitalFields];
   delete apiPayload.sort;
   return apiPayload;
@@ -49,7 +47,7 @@ function getRequestPayload(props: Props) {
 
 function VitalsCardDiscoverQuery(props: Props) {
   return (
-    <GenericDiscoverQuery<TableData, {}>
+    <GenericDiscoverQuery<TableData, Props>
       getRequestPayload={getRequestPayload}
       route="eventsv2"
       noPagination


### PR DESCRIPTION
Restructure vitals cards to prepare for the upcoming backend cards. This
restructure lifts the chart component of the cards to be customizable via a prop
and simplifies the card for easier reuse.