### PR TITLE
fix: Show compressed sizes in nodestore stats

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -16,6 +16,7 @@ from sentry.utils.safe import safe_execute
 from sentry.utils.sdk import set_current_project, bind_organization_context
 
 logger = logging.getLogger("sentry")
+nodestore_stats_logger = logging.getLogger("sentry.nodestore.stats")
 
 
 def _get_service_hooks(project_id):
@@ -476,3 +477,8 @@ def capture_nodestore_stats(project_id, event_id):
 
     metrics.timing("events.size.deduplicated.ratio", event_size / old_event_size)
     metrics.timing("events.size.deduplicated.total_written.ratio", total_size / old_event_size)
+
+    if total_size / old_event_size > 4.0:
+        nodestore_stats_logger.info(
+            "events.size.deduplicated.terrible", project_id=project_id, event_id=event_id
+        )

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -4,6 +4,7 @@ import six
 import logging
 import sentry_sdk
 import random
+import zstandard
 
 from sentry import features, options
 from sentry.utils.cache import cache
@@ -425,6 +426,12 @@ def _spawn_capture_nodestore_stats(event):
     capture_nodestore_stats.delay(project_id=event.project_id, event_id=event.event_id)
 
 
+def _json_size(data):
+    bytestring = json.dumps(data).encode("utf8")
+    cctx = zstandard.ZstdCompressor()
+    return len(cctx.compress(bytestring))
+
+
 @instrumented_task(name="sentry.tasks.post_process.capture_nodestore_stats")
 def capture_nodestore_stats(project_id, event_id):
     set_current_project(project_id)
@@ -434,7 +441,7 @@ def capture_nodestore_stats(project_id, event_id):
     from sentry.eventstore.models import Event
 
     event = Event(project_id=project_id, event_id=event_id)
-    old_event_size = len(json.dumps(dict(event.data)).encode("utf8"))
+    old_event_size = _json_size(dict(event.data))
 
     if not event.data:
         metrics.incr("eventstore.compressor.error", tags={"reason": "no_data"})
@@ -443,14 +450,14 @@ def capture_nodestore_stats(project_id, event_id):
     platform = event.platform
 
     for key, value in six.iteritems(event.interfaces):
-        len_value = len(json.dumps(value.to_json()).encode("utf8"))
+        len_value = _json_size(value.to_json())
         metrics.timing(
             "events.size.interface", len_value, tags={"interface": key, "platform": platform}
         )
 
     new_data, extra_keys = deduplicate(dict(event.data))
 
-    total_size = event_size = len(json.dumps(new_data).encode("utf8"))
+    total_size = event_size = _json_size(new_data)
 
     for key, value in six.iteritems(extra_keys):
         if nodestore.get(key) is not None:
@@ -458,7 +465,7 @@ def capture_nodestore_stats(project_id, event_id):
             # do not continue, nodestore.set() should bump TTL
         else:
             metrics.incr("eventstore.compressor.misses")
-            total_size += len(json.dumps(value).encode("utf8"))
+            total_size += _json_size(value)
 
         # key is md5sum of content
         # do not store actual value to keep prod impact to a minimum


### PR DESCRIPTION
See #23005 

Seems like the recorded compression ratio isn't that great (avg above 1). Let's apply
zstd to get more realistic numbers. Hopefully realistic is good, not
worse.

Also add some hardcoded verbose logging for exceptionally bad cases.