### PR TITLE
fix(ui): Don't exclude Windows and Linux users on keyboard shortcuts

### DIFF
--- a/src/sentry/static/sentry/app/views/app/index.tsx
+++ b/src/sentry/static/sentry/app/views/app/index.tsx
@@ -198,14 +198,14 @@ class App extends React.Component<Props, State> {
     }
   }
 
-  @keydown('meta+shift+p', 'meta+k')
+  @keydown('meta+shift+p', 'meta+k', 'ctrl+shift+p', 'ctrl+k')
   openCommandPalette(e) {
     openCommandPalette();
     e.preventDefault();
     e.stopPropagation();
   }
 
-  @keydown('meta+shift+l')
+  @keydown('meta+shift+l', 'ctrl+shift+l')
   toggleDarkMode() {
     ConfigStore.set('theme', ConfigStore.get('theme') === 'light' ? 'dark' : 'light');
   }


### PR DESCRIPTION
Adds `ctrl+` equivalents for all `cmd+` shortcuts
