### PR TITLE
fix(assignee): Fix suggested assignees when we receive empty array

### DIFF
--- a/src/sentry/static/sentry/app/components/assigneeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.tsx
@@ -400,7 +400,7 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
               <DropdownButton {...getActorProps({})}>
                 {assignedTo ? (
                   <ActorAvatar actor={assignedTo} className="avatar" size={24} />
-                ) : suggestedActors ? (
+                ) : suggestedActors && suggestedActors.length ? (
                   <SuggestedAvatarStack size={24} owners={suggestedActors} />
                 ) : (
                   <StyledIconUser size="20px" color="gray400" />

--- a/src/sentry/static/sentry/app/components/assigneeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.tsx
@@ -400,7 +400,7 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
               <DropdownButton {...getActorProps({})}>
                 {assignedTo ? (
                   <ActorAvatar actor={assignedTo} className="avatar" size={24} />
-                ) : suggestedActors && suggestedActors.length ? (
+                ) : suggestedActors && suggestedActors.length > 0 ? (
                   <SuggestedAvatarStack size={24} owners={suggestedActors} />
                 ) : (
                   <StyledIconUser size="20px" color="gray400" />


### PR DESCRIPTION
When we receive an empty array of suggested assignees from the backend, we should just show the regular user icon instead of attempting to show suggested assignees which causes an error due to the empty array.

Fixes: JAVASCRIPT-23EA