### PR TITLE
feat(ticket rules): Turn on Ticket Rules

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -882,7 +882,7 @@ SENTRY_FEATURES = {
     # management integrations)
     "organizations:integrations-incident-management": True,
     # Allow orgs to automatically create Tickets in Issue Alerts
-    "organizations:integrations-ticket-rules": False,
+    "organizations:integrations-ticket-rules": True,
     # Allow orgs to install AzureDevops with limited scopes
     "organizations:integrations-vsts-limited-scopes": False,
     # Allow orgs to use the stacktrace linking feature

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -102,6 +102,7 @@ class IntegrationFeatures(Enum):
     DATA_FORWARDING = "data-forwarding"
     SESSION_REPLAY = "session-replay"
     DEPLOYMENT = "deployment"
+    TICKET_RULES = "ticket-rules"
 
 
 class IntegrationProvider(PipelineProvider):

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -90,12 +90,12 @@ class IntegrationFeatures(Enum):
     *must* match the suffix of the organization feature flag name.
     """
 
+    ALERT_RULE = "alert-rule"
+    CHAT_UNFURL = "chat-unfurl"
+    COMMITS = "commits"
     INCIDENT_MANAGEMENT = "incident-management"
     ISSUE_BASIC = "issue-basic"
     ISSUE_SYNC = "issue-sync"
-    COMMITS = "commits"
-    CHAT_UNFURL = "chat-unfurl"
-    ALERT_RULE = "alert-rule"
     MOBILE = "mobile"
     SERVERLESS = "serverless"
     # features currently only existing on plugins:

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -98,11 +98,12 @@ class IntegrationFeatures(Enum):
     ISSUE_SYNC = "issue-sync"
     MOBILE = "mobile"
     SERVERLESS = "serverless"
+    TICKET_RULES = "ticket-rules"
+
     # features currently only existing on plugins:
     DATA_FORWARDING = "data-forwarding"
     SESSION_REPLAY = "session-replay"
     DEPLOYMENT = "deployment"
-    TICKET_RULES = "ticket-rules"
 
 
 class IntegrationProvider(PipelineProvider):

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -62,6 +62,12 @@ FEATURE_DESCRIPTIONS = [
         """,
         IntegrationFeatures.ISSUE_SYNC,
     ),
+    FeatureDescription(
+        """
+        Automatically create Jira tickets based on Alert Rule conditions.
+        """,
+        IntegrationFeatures.TICKET_RULES,
+    ),
 ]
 
 INSTALL_NOTICE_TEXT = """

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -64,7 +64,7 @@ FEATURE_DESCRIPTIONS = [
     ),
     FeatureDescription(
         """
-        Automatically create Jira tickets based on Alert Rule conditions.
+        Automatically create Jira tickets based on Issue Alert conditions.
         """,
         IntegrationFeatures.TICKET_RULES,
     ),

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -951,6 +951,7 @@ class JiraIntegrationProvider(IntegrationProvider):
     features = frozenset([
         IntegrationFeatures.ISSUE_BASIC,
         IntegrationFeatures.ISSUE_SYNC,
+        IntegrationFeatures.TICKET_RULES,
     ])
 
     can_add = False

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -948,11 +948,13 @@ class JiraIntegrationProvider(IntegrationProvider):
     metadata = metadata
     integration_cls = JiraIntegration
 
-    features = frozenset([
-        IntegrationFeatures.ISSUE_BASIC,
-        IntegrationFeatures.ISSUE_SYNC,
-        IntegrationFeatures.TICKET_RULES,
-    ])
+    features = frozenset(
+        [
+            IntegrationFeatures.ISSUE_BASIC,
+            IntegrationFeatures.ISSUE_SYNC,
+            IntegrationFeatures.TICKET_RULES,
+        ]
+    )
 
     can_add = False
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -948,7 +948,10 @@ class JiraIntegrationProvider(IntegrationProvider):
     metadata = metadata
     integration_cls = JiraIntegration
 
-    features = frozenset([IntegrationFeatures.ISSUE_BASIC, IntegrationFeatures.ISSUE_SYNC])
+    features = frozenset([
+        IntegrationFeatures.ISSUE_BASIC,
+        IntegrationFeatures.ISSUE_SYNC,
+    ])
 
     can_add = False
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -77,6 +77,12 @@ FEATURES = [
         """,
         IntegrationFeatures.ISSUE_SYNC,
     ),
+    FeatureDescription(
+        """
+        Automatically create Azure DevOps work items based on Alert Rule conditions.
+        """,
+        IntegrationFeatures.TICKET_RULES,
+    ),
 ]
 
 metadata = IntegrationMetadata(

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -79,7 +79,7 @@ FEATURES = [
     ),
     FeatureDescription(
         """
-        Automatically create Azure DevOps work items based on Alert Rule conditions.
+        Automatically create Azure DevOps work items based on Issue Alert conditions.
         """,
         IntegrationFeatures.TICKET_RULES,
     ),

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -318,12 +318,14 @@ class VstsIntegrationProvider(IntegrationProvider):
     needs_default_identity = True
     integration_cls = VstsIntegration
 
-    features = frozenset([
-        IntegrationFeatures.COMMITS,
-        IntegrationFeatures.ISSUE_BASIC,
-        IntegrationFeatures.ISSUE_SYNC,
-        IntegrationFeatures.TICKET_RULES,
-    ])
+    features = frozenset(
+        [
+            IntegrationFeatures.COMMITS,
+            IntegrationFeatures.ISSUE_BASIC,
+            IntegrationFeatures.ISSUE_SYNC,
+            IntegrationFeatures.TICKET_RULES,
+        ]
+    )
 
     setup_dialog_config = {"width": 600, "height": 800}
 

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -322,6 +322,7 @@ class VstsIntegrationProvider(IntegrationProvider):
         IntegrationFeatures.COMMITS,
         IntegrationFeatures.ISSUE_BASIC,
         IntegrationFeatures.ISSUE_SYNC,
+        IntegrationFeatures.TICKET_RULES,
     ])
 
     setup_dialog_config = {"width": 600, "height": 800}

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -318,13 +318,11 @@ class VstsIntegrationProvider(IntegrationProvider):
     needs_default_identity = True
     integration_cls = VstsIntegration
 
-    features = frozenset(
-        [
-            IntegrationFeatures.ISSUE_BASIC,
-            IntegrationFeatures.ISSUE_SYNC,
-            IntegrationFeatures.COMMITS,
-        ]
-    )
+    features = frozenset([
+        IntegrationFeatures.COMMITS,
+        IntegrationFeatures.ISSUE_BASIC,
+        IntegrationFeatures.ISSUE_SYNC,
+    ])
 
     setup_dialog_config = {"width": 600, "height": 800}
 

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -25,7 +25,7 @@ class ProjectRuleConfigurationTest(APITestCase):
 
         response = self.get_valid_response(self.organization.slug, project1.slug)
 
-        assert len(response.data["actions"]) == 5
+        assert len(response.data["actions"]) == 7
         assert len(response.data["conditions"]) == 6
         assert len(response.data["filters"]) == 7
 
@@ -93,11 +93,4 @@ class ProjectRuleConfigurationTest(APITestCase):
 
         action_ids = [action["id"] for action in response.data["actions"]]
         assert EMAIL_ACTION in action_ids
-        assert JIRA_ACTION not in action_ids
-
-    def test_ticket_rules_in_available_actions(self):
-        with self.feature("organizations:integrations-ticket-rules"):
-            response = self.get_valid_response(self.organization.slug, self.project.slug)
-            action_ids = [action["id"] for action in response.data["actions"]]
-            assert EMAIL_ACTION in action_ids
-            assert JIRA_ACTION in action_ids
+        assert JIRA_ACTION in action_ids

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -94,3 +94,10 @@ class ProjectRuleConfigurationTest(APITestCase):
         action_ids = [action["id"] for action in response.data["actions"]]
         assert EMAIL_ACTION in action_ids
         assert JIRA_ACTION in action_ids
+
+    def test_ticket_rules_not_in_available_actions(self):
+        with self.feature({"organizations:integrations-ticket-rules": False}):
+            response = self.get_valid_response(self.organization.slug, self.project.slug)
+            action_ids = [action["id"] for action in response.data["actions"]]
+            assert EMAIL_ACTION in action_ids
+            assert JIRA_ACTION not in action_ids

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -22,31 +22,30 @@ class OrganizationSerializerTest(TestCase):
         result = serialize(organization, user)
 
         assert result["id"] == six.text_type(organization.id)
-        assert result["features"] == set(
-            [
-                "advanced-search",
-                "custom-event-title",
-                "shared-issues",
-                "open-membership",
-                "event-attachments",
-                "integrations-issue-basic",
-                "integrations-issue-sync",
-                "integrations-alert-rule",
-                "integrations-chat-unfurl",
-                "integrations-incident-management",
-                "integrations-event-hooks",
-                "invite-members-rate-limits",
-                "data-forwarding",
-                "invite-members",
-                "sso-saml2",
-                "sso-basic",
-                "symbol-sources",
-                "custom-symbol-sources",
-                "discover-basic",
-                "discover-query",
-                "relay",
-            ]
-        )
+        assert result["features"] == {
+            "advanced-search",
+            "custom-event-title",
+            "custom-symbol-sources",
+            "data-forwarding",
+            "discover-basic",
+            "discover-query",
+            "event-attachments",
+            "integrations-alert-rule",
+            "integrations-chat-unfurl",
+            "integrations-event-hooks",
+            "integrations-incident-management",
+            "integrations-issue-basic",
+            "integrations-issue-sync",
+            "integrations-ticket-rules",
+            "invite-members",
+            "invite-members-rate-limits",
+            "open-membership",
+            "relay",
+            "shared-issues",
+            "sso-basic",
+            "sso-saml2",
+            "symbol-sources",
+        }
 
     @mock.patch("sentry.features.batch_has")
     def test_organization_batch_has(self, mock_batch):


### PR DESCRIPTION
This PR adds Ticket Rules as a feature for Jira and Azure Devops so that it can be used Business for AM1 plans only.
<img width="814" alt="Screen Shot 2021-01-21 at 10 28 07 AM" src="https://user-images.githubusercontent.com/31750075/105395251-607d8d00-5bd3-11eb-9e8c-1e31abcd06f6.png">
