### PR TITLE
fix(dashboardsv2): Fix dashboard permissions

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -7,9 +7,12 @@ from sentry.api.bases.dashboard import OrganizationDashboardEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import DashboardDetailsSerializer
 from sentry.models.dashboard import DashboardTombstone
+from sentry.api.endpoints.organization_dashboards import OrganizationDashboardsPermission
 
 
 class OrganizationDashboardDetailsEndpoint(OrganizationDashboardEndpoint):
+    permission_classes = (OrganizationDashboardsPermission,)
+
     def get(self, request, organization, dashboard):
         """
         Retrieve an Organization's Dashboard

--- a/src/sentry/api/endpoints/organization_dashboard_widget_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_widget_details.py
@@ -4,9 +4,12 @@ from rest_framework.response import Response
 
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.serializers.rest_framework import DashboardWidgetSerializer
+from sentry.api.endpoints.organization_dashboards import OrganizationDashboardsPermission
 
 
 class OrganizationDashboardWidgetDetailsEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationDashboardsPermission,)
+
     def post(self, request, organization):
         """
         Validate a Widget

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django.db import IntegrityError, transaction
 
-from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import ChainPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.dashboard import DashboardListSerializer
@@ -11,7 +11,18 @@ from sentry.models import Dashboard
 from rest_framework.response import Response
 
 
+class OrganizationDashboardsPermission(OrganizationPermission):
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin"],
+        "POST": ["org:read", "org:write", "org:admin"],
+        "PUT": ["org:read", "org:write", "org:admin"],
+        "DELETE": ["org:read", "org:write", "org:admin"],
+    }
+
+
 class OrganizationDashboardsEndpoint(OrganizationEndpoint):
+    permission_classes = (OrganizationDashboardsPermission,)
+
     def get(self, request, organization):
         """
         Retrieve an Organization's Dashboards

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1023,3 +1023,10 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
             assert data["displayType"] == DashboardWidgetDisplayTypes.get_type_name(
                 expected_widget.display_type
             )
+
+    def create_user_member_role(self):
+        self.user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=self.user, organization=self.organization, role="member", teams=[self.team]
+        )
+        self.login_as(self.user)

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -117,6 +117,10 @@ class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCas
         assert not DashboardWidgetQuery.objects.filter(widget_id=self.widget_1.id).exists()
         assert not DashboardWidgetQuery.objects.filter(widget_id=self.widget_2.id).exists()
 
+    def test_delete_permission(self):
+        self.create_user_member_role()
+        self.test_delete()
+
     def test_dashboard_does_not_exist(self):
         response = self.client.delete(self.url(1234567890))
         assert response.status_code == 404
@@ -132,6 +136,7 @@ class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCas
 class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
     def setUp(self):
         super(OrganizationDashboardDetailsPutTest, self).setUp()
+        self.create_user_member_role()
         self.widget_3 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
             order=2,

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -22,6 +22,10 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         response = self.client.post(self.url(), data=data,)
         assert response.status_code == 200, response.data
 
+    def test_valid_widget_permissions(self):
+        self.create_user_member_role()
+        self.test_valid_widget()
+
     def test_invalid_query_conditions(self):
         data = {
             "title": "Invalid query",
@@ -34,6 +38,10 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert response.status_code == 400, response.data
         assert "queries" in response.data, response.data
         assert response.data["queries"][0]["conditions"], response.data
+
+    def test_invalid_widget_permissions(self):
+        self.create_user_member_role()
+        self.test_invalid_query_conditions()
 
     def test_invalid_query_fields(self):
         data = {

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -67,6 +67,11 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         )
         assert dashboard.created_by == self.user
 
+    def test_post_permissions(self):
+        self.create_user_member_role()
+        response = self.client.post(self.url, data={"title": "Dashboard from Post"})
+        assert response.status_code == 201
+
     def test_post_with_widgets(self):
         data = {
             "title": "Dashboard from Post",


### PR DESCRIPTION
Relax permissions to allow users with `member` role to be able to create and update dashboards.