### PR TITLE
fix(tagstore): Make tagstore Snuba queries more deterministic

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -561,6 +561,7 @@ class SnubaTagStorage(TagStorage):
             conditions=conditions,
             filter_keys=filters,
             aggregations=aggregations,
+            orderby="-times_seen",
             referrer="tagstore.get_release_tags",
         )
 
@@ -633,6 +634,7 @@ class SnubaTagStorage(TagStorage):
             conditions=None,
             filter_keys=filters,
             aggregations=aggregations,
+            orderby="-count",
             referrer="tagstore.get_groups_user_counts",
         )
 


### PR DESCRIPTION
Ensure the Snuba queries in tagstore.get_release_tags() and
tagstore.get_groups_user_counts() return consistent results.
This is important because we are currently in the process of switching
between Snuba storages and are running these queries on two separate
Snuba storages and diffing the results as part of that process. This
should help align the results.

This change also ensures that consistent results are returned to the
user in the case where the limit (1000) is reached.