### PR TITLE
fix(nodestore): More verbose logging

### DIFF
--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -491,8 +491,10 @@ def capture_nodestore_stats(project_id, event_id):
     if total_size > old_event_size:
         nodestore_stats_logger.info(
             "events.size.deduplicated.details",
-            project_id=project_id,
-            event_id=event_id,
-            total_size=total_size,
-            old_event_size=old_event_size,
+            extra={
+                "project_id": project_id,
+                "event_id": event_id,
+                "total_size": total_size,
+                "old_event_size": old_event_size,
+            },
         )

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -488,7 +488,11 @@ def capture_nodestore_stats(project_id, event_id):
     metrics.timing("events.size.deduplicated.ratio", event_size / old_event_size)
     metrics.timing("events.size.deduplicated.total_written.ratio", total_size / old_event_size)
 
-    if total_size / old_event_size > 4.0:
+    if total_size > old_event_size:
         nodestore_stats_logger.info(
-            "events.size.deduplicated.terrible", project_id=project_id, event_id=event_id
+            "events.size.deduplicated.details",
+            project_id=project_id,
+            event_id=event_id,
+            total_size=total_size,
+            old_event_size=old_event_size,
         )


### PR DESCRIPTION
After introducing zstd there is no way it would reach the 4.0 threshold.
Just log way more verbosely. We will regulate log spam using sample
rate.