### PR TITLE
feat: Polish stack trace previews III

### DIFF
--- a/src/sentry/static/sentry/app/components/stacktracePreview.tsx
+++ b/src/sentry/static/sentry/app/components/stacktracePreview.tsx
@@ -118,7 +118,7 @@ class StacktracePreview extends React.Component<Props, State> {
         .find(e => e.type === 'exception')
         ?.data?.values.filter(({stacktrace}) => defined(stacktrace)) ?? [];
 
-    const stacktrace = !isStacktraceNewestFirst()
+    const stacktrace = isStacktraceNewestFirst()
       ? exceptionsWithStacktrace[exceptionsWithStacktrace.length - 1]?.stacktrace
       : exceptionsWithStacktrace[0]?.stacktrace;
 

--- a/src/sentry/static/sentry/app/components/stacktracePreview.tsx
+++ b/src/sentry/static/sentry/app/components/stacktracePreview.tsx
@@ -11,6 +11,7 @@ import space from 'app/styles/space';
 import {Organization, PlatformType} from 'app/types';
 import {Event} from 'app/types/event';
 import {StacktraceType} from 'app/types/stacktrace';
+import {defined} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
 
@@ -42,7 +43,7 @@ class StacktracePreview extends React.Component<Props, State> {
 
     this.loaderTimeout = window.setTimeout(() => {
       this.setState({loadingVisible: true});
-    }, 1500);
+    }, 1000);
 
     const {api, issueId} = this.props;
     try {
@@ -66,7 +67,7 @@ class StacktracePreview extends React.Component<Props, State> {
     if (loading && loadingVisible) {
       return (
         <NoStackTraceWrapper>
-          <LoadingIndicator hideMessage />
+          <LoadingIndicator hideMessage size={48} />
         </NoStackTraceWrapper>
       );
     }
@@ -78,7 +79,7 @@ class StacktracePreview extends React.Component<Props, State> {
     if (!stacktrace) {
       return (
         <NoStackTraceWrapper onClick={this.handleStacktracePreviewClick}>
-          {t('There is no stack trace available for this issue.')}
+          {t("There's no stack trace available for this issue.")}
         </NoStackTraceWrapper>
       );
     }
@@ -96,7 +97,6 @@ class StacktracePreview extends React.Component<Props, State> {
           <StacktraceContent
             data={stacktrace}
             expandFirstFrame={false}
-            // includeSystemFrames={!exception.hasSystemFrames} // (chainedException && stacktrace.frames.every(frame => !frame.inApp))
             includeSystemFrames={stacktrace.frames.every(frame => !frame.inApp)}
             platform={(event.platform ?? 'other') as PlatformType}
             newestFirst={isStacktraceNewestFirst()}
@@ -112,8 +112,15 @@ class StacktracePreview extends React.Component<Props, State> {
 
   render() {
     const {children, organization, disablePreview} = this.props;
-    const {stacktrace} =
-      this.state.event?.entries.find(e => e.type === 'exception')?.data?.values[0] ?? {};
+
+    const exceptionsWithStacktrace =
+      this.state.event?.entries
+        .find(e => e.type === 'exception')
+        ?.data?.values.filter(({stacktrace}) => defined(stacktrace)) ?? [];
+
+    const stacktrace = !isStacktraceNewestFirst()
+      ? exceptionsWithStacktrace[exceptionsWithStacktrace.length - 1]?.stacktrace
+      : exceptionsWithStacktrace[0]?.stacktrace;
 
     if (!organization.features.includes('stacktrace-hover-preview') || disablePreview) {
       return children;
@@ -147,7 +154,6 @@ const StyledHovercard = styled(Hovercard)`
 
   ${Body} {
     padding: 0;
-    min-height: 150px;
     max-height: 300px;
     overflow-y: auto;
     border-bottom-left-radius: ${p => p.theme.borderRadius};
@@ -171,7 +177,7 @@ const NoStackTraceWrapper = styled('div')`
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 150px;
+  height: 80px;
 `;
 
 export default withApi(StacktracePreview);


### PR DESCRIPTION
- lower the time after which we show loading indicator
- lower the padding on loading/empty state
- make loading spinner smaller
- trigger recalculation of hovercard position after data loads
- respect the `isStacktraceNewestFirst ` setting when multiple exceptions are present