### PR TITLE
fix(performance): Histogram endpoint should not error with no measure…

### DIFF
--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -2063,7 +2063,7 @@ class QueryTransformTest(TestCase):
         # min is None
         assert discover.find_histogram_params(1, None, 1, 10) == (1, 1, 0, 10)
         # max is None
-        assert discover.find_histogram_params(1, 1, None, 100) == (1, 1, 0, 100)
+        assert discover.find_histogram_params(1, 1, None, 100) == (1, 1, 100, 100)
 
         assert discover.find_histogram_params(10, 0, 9, 1) == (10, 1, 0, 1)
         assert discover.find_histogram_params(10, 0, 10, 1) == (10, 2, 0, 1)


### PR DESCRIPTION
…ment data

Measurements are nullable. This means that when there are transactions but no
measurements, querying for a single measurme may cause snuba to return a single
row with `None` for the bucket. This is counting undesired transactions. To
guard against this, we stop early and return a zero filled histogram.

Fixes SENTRY-M7Q