### PR TITLE
feat(perf): Use histogram endpoint for latency chart

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import {Location} from 'history';
-import isEqual from 'lodash/isEqual';
-import pick from 'lodash/pick';
 
-import AsyncComponent from 'app/components/asyncComponent';
 import BarChart from 'app/components/charts/barChart';
 import BarChartZoom from 'app/components/charts/barChartZoom';
 import ErrorPanel from 'app/components/charts/errorPanel';
@@ -15,9 +12,12 @@ import {OrganizationSummary} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
 import {getDuration} from 'app/utils/formatters';
+import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 
 import {HeaderTitleLegend} from '../styles';
+import HistogramQuery from '../transactionVitals/histogramQuery';
+import {HistogramData} from '../transactionVitals/types';
 
 const NUM_BUCKETS = 15;
 const QUERY_KEYS = [
@@ -31,20 +31,13 @@ const QUERY_KEYS = [
 
 type ViewProps = Pick<EventView, typeof QUERY_KEYS[number]>;
 
-type ApiResult = {
-  histogram_deprecated_transaction_duration_15: number;
-  count: number;
+type Props = ViewProps & {
+  organization: OrganizationSummary;
+  location: Location;
 };
 
-type Props = AsyncComponent['props'] &
-  ViewProps & {
-    organization: OrganizationSummary;
-    location: Location;
-  };
-
-type State = AsyncComponent['state'] & {
-  chartData: {data: ApiResult[]} | null;
-  zoomError?: boolean;
+type State = {
+  zoomError: boolean;
 };
 
 /**
@@ -55,51 +48,10 @@ type State = AsyncComponent['state'] & {
  * This graph visualizes how many transactions were recorded
  * at each duration bucket, showing the modality of the transaction.
  */
-class LatencyChart extends AsyncComponent<Props, State> {
-  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {
-      organization,
-      query,
-      start,
-      end,
-      statsPeriod,
-      environment,
-      project,
-      location,
-    } = this.props;
-    const eventView = EventView.fromSavedQuery({
-      id: '',
-      name: '',
-      version: 2,
-      fields: [`histogram_deprecated(transaction.duration,${NUM_BUCKETS})`, 'count()'],
-      orderby: 'histogram_deprecated_transaction_duration_15',
-      projects: project,
-      range: statsPeriod,
-      query,
-      environment,
-      start,
-      end,
-    });
-    const apiPayload = eventView.getEventsAPIPayload(location);
-    apiPayload.referrer = 'api.performance.latencychart';
-
-    return [
-      ['chartData', `/organizations/${organization.slug}/eventsv2/`, {query: apiPayload}],
-    ];
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (this.shouldRefetchData(prevProps)) {
-      this.fetchData();
-    }
-  }
-
-  shouldRefetchData(prevProps: Props) {
-    if (this.state.loading) {
-      return false;
-    }
-    return !isEqual(pick(prevProps, QUERY_KEYS), pick(this.props, QUERY_KEYS));
-  }
+class LatencyChart extends React.Component<Props, State> {
+  state = {
+    zoomError: false,
+  };
 
   handleMouseOver = () => {
     // Hide the zoom error tooltip on the next hover.
@@ -122,18 +74,11 @@ class LatencyChart extends AsyncComponent<Props, State> {
     this.setState({zoomError: true});
   };
 
-  get bucketWidth() {
-    if (this.state.chartData === null) {
-      return 0;
-    }
+  bucketWidth(data: HistogramData[]) {
     // We can assume that all buckets are of equal width, use the first two
     // buckets to get the width. The value of each histogram function indicates
     // the beginning of the bucket.
-    const data = this.state.chartData.data;
-    return data.length > 2
-      ? data[1].histogram_deprecated_transaction_duration_15 -
-          data[0].histogram_deprecated_transaction_duration_15
-      : 0;
+    return data.length > 2 ? data[1].bin - data[0].bin : 0;
   }
 
   renderLoading() {
@@ -149,12 +94,10 @@ class LatencyChart extends AsyncComponent<Props, State> {
     );
   }
 
-  renderBody() {
+  renderChart(data: HistogramData[]) {
     const {location} = this.props;
-    const {chartData, zoomError} = this.state;
-    if (chartData === null) {
-      return null;
-    }
+    const {zoomError} = this.state;
+
     const xAxis = {
       type: 'category' as const,
       truncate: true,
@@ -163,6 +106,7 @@ class LatencyChart extends AsyncComponent<Props, State> {
         alignWithLabel: true,
       },
     };
+
     const colors = [...theme.charts.getColorPalette(1)];
 
     // Use a custom tooltip formatter as we need to replace
@@ -196,9 +140,9 @@ class LatencyChart extends AsyncComponent<Props, State> {
       },
     };
 
-    const bucketWidth = this.bucketWidth;
+    const bucketWidth = this.bucketWidth(data);
 
-    const buckets = computeBuckets(chartData.data, bucketWidth);
+    const buckets = computeBuckets(data, bucketWidth);
 
     return (
       <BarChartZoom
@@ -215,7 +159,7 @@ class LatencyChart extends AsyncComponent<Props, State> {
             grid={{left: '10px', right: '10px', top: '40px', bottom: '0px'}}
             xAxis={xAxis}
             yAxis={{type: 'value'}}
-            series={transformData(chartData.data, bucketWidth)}
+            series={transformData(data, bucketWidth)}
             tooltip={tooltip}
             colors={colors}
             onMouseOver={this.handleMouseOver}
@@ -227,6 +171,34 @@ class LatencyChart extends AsyncComponent<Props, State> {
   }
 
   render() {
+    const {
+      organization,
+      query,
+      start,
+      end,
+      statsPeriod,
+      environment,
+      project,
+      location,
+    } = this.props;
+    const eventView = EventView.fromNewQueryWithLocation(
+      {
+        id: undefined,
+        version: 2,
+        name: '',
+        fields: ['transaction.duration'],
+        projects: project,
+        range: statsPeriod,
+        query,
+        environment,
+        start,
+        end,
+      },
+      location
+    );
+
+    const min = parseInt(decodeScalar(location.query.startDuration) ?? '0', 10);
+
     return (
       <React.Fragment>
         <HeaderTitleLegend>
@@ -239,15 +211,34 @@ class LatencyChart extends AsyncComponent<Props, State> {
             )}
           />
         </HeaderTitleLegend>
-        {this.renderComponent()}
+        <HistogramQuery
+          location={location}
+          orgSlug={organization.slug}
+          eventView={eventView}
+          numBuckets={NUM_BUCKETS}
+          fields={['transaction.duration']}
+          min={min}
+          dataFilter="all"
+        >
+          {({histograms, isLoading, error}) => {
+            if (isLoading) {
+              return this.renderLoading();
+            } else if (error) {
+              return this.renderError();
+            }
+
+            const data = histograms?.['transaction.duration'] ?? [];
+            return this.renderChart(data);
+          }}
+        </HistogramQuery>
       </React.Fragment>
     );
   }
 }
 
-function computeBuckets(data: ApiResult[], bucketWidth: number) {
+function computeBuckets(data: HistogramData[], bucketWidth: number) {
   return data.map(item => {
-    const bucket = item.histogram_deprecated_transaction_duration_15;
+    const bucket = item.bin;
     return {
       start: bucket,
       end: bucket + bucketWidth,
@@ -258,7 +249,7 @@ function computeBuckets(data: ApiResult[], bucketWidth: number) {
 /**
  * Convert a discover response into a barchart compatible series
  */
-function transformData(data: ApiResult[], bucketWidth: number) {
+function transformData(data: HistogramData[], bucketWidth: number) {
   let precision;
   if (bucketWidth < 10) {
     precision = 4;
@@ -272,7 +263,7 @@ function transformData(data: ApiResult[], bucketWidth: number) {
     precision = 0;
   }
   const seriesData = data.map(item => {
-    const bucket = item.histogram_deprecated_transaction_duration_15;
+    const bucket = item.bin;
     const midPoint = bucketWidth > 1 ? Math.ceil(bucket + bucketWidth / 2) : bucket;
     return {
       value: item.count,

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/constants.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/constants.tsx
@@ -3,7 +3,7 @@ import {SelectValue} from 'app/types';
 import {measurementType, WebVital} from 'app/utils/discover/fields';
 import theme from 'app/utils/theme';
 
-import {Vital, VitalGroup} from './types';
+import {DataFilter, Vital, VitalGroup} from './types';
 
 export const NUM_BUCKETS = 100;
 
@@ -95,7 +95,7 @@ export const WEB_VITAL_ACRONYMS = Object.fromEntries(
   })
 );
 
-export const FILTER_OPTIONS: SelectValue<string>[] = [
+export const FILTER_OPTIONS: SelectValue<DataFilter>[] = [
   {label: t('Exclude Outliers'), value: 'exclude_outliers'},
   {label: t('View All'), value: 'all'},
 ];

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/histogramQuery.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/histogramQuery.tsx
@@ -8,7 +8,7 @@ import GenericDiscoverQuery, {
 } from 'app/utils/discover/genericDiscoverQuery';
 import withApi from 'app/utils/withApi';
 
-import {HistogramData} from './types';
+import {DataFilter, HistogramData} from './types';
 
 type Histograms = Record<string, HistogramData[]>;
 
@@ -18,7 +18,7 @@ type HistogramProps = {
   min?: number;
   max?: number;
   precision?: number;
-  dataFilter?: string;
+  dataFilter?: DataFilter;
 };
 
 type RequestProps = DiscoverQueryProps & HistogramProps;

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/types.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/types.tsx
@@ -31,3 +31,5 @@ export type Rectangle = {
   point1: Point;
   point2: Point;
 };
+
+export type DataFilter = 'all' | 'exclude_outliers';

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalsPanel.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalsPanel.tsx
@@ -11,14 +11,14 @@ import {decodeScalar} from 'app/utils/queryString';
 
 import {NUM_BUCKETS, PERCENTILE, VITAL_GROUPS, WEB_VITAL_DETAILS} from './constants';
 import HistogramQuery from './histogramQuery';
-import {HistogramData, VitalGroup} from './types';
+import {DataFilter, HistogramData, VitalGroup} from './types';
 import VitalCard from './vitalCard';
 
 type Props = {
   organization: Organization;
   location: Location;
   eventView: EventView;
-  dataFilter?: string;
+  dataFilter?: DataFilter;
 };
 
 class VitalsPanel extends React.Component<Props> {


### PR DESCRIPTION
Update the latency chart to make use of the new histogram endpoint. This does
not yet enable the outlier filtering.