### PR TITLE
fix(dashv2): cleanup UI

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/controls.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/controls.tsx
@@ -76,7 +76,7 @@ class Controls extends React.Component<Props> {
             }}
             priority="primary"
           >
-            {t('Finish Editing')}
+            {t('Save and Finish')}
           </Button>
         </ButtonBar>
       );
@@ -93,9 +93,8 @@ class Controls extends React.Component<Props> {
               onCommit();
             }}
             priority="primary"
-            icon={<IconAdd size="xs" isCircled />}
           >
-            {t('Create Dashboard')}
+            {t('Save and Finish')}
           </Button>
         </ButtonBar>
       );
@@ -138,25 +137,25 @@ class Controls extends React.Component<Props> {
           />
         </DashboardSelect>
         <Button
-          data-test-id="dashboard-edit"
-          onClick={e => {
-            e.preventDefault();
-            onEdit();
-          }}
-          icon={<IconEdit size="xs" />}
-        >
-          {t('Edit')}
-        </Button>
-        <Button
           data-test-id="dashboard-create"
           onClick={e => {
             e.preventDefault();
             onCreate();
           }}
-          priority="primary"
           icon={<IconAdd size="xs" isCircled />}
         >
           {t('Create Dashboard')}
+        </Button>
+        <Button
+          data-test-id="dashboard-edit"
+          onClick={e => {
+            e.preventDefault();
+            onEdit();
+          }}
+          priority="primary"
+          icon={<IconEdit size="xs" />}
+        >
+          {t('Edit Dashboard')}
         </Button>
       </StyledButtonBar>
     );

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -188,7 +188,7 @@ class WidgetCard extends React.Component<Props> {
         <IconContainer data-component="icon-container">
           <StyledIconGrabbable
             color="gray500"
-            size="lg"
+            size="md"
             onMouseDown={event => startWidgetDrag(event)}
             onTouchStart={event => startWidgetDrag(event)}
           />
@@ -198,7 +198,7 @@ class WidgetCard extends React.Component<Props> {
               onEdit();
             }}
           >
-            <IconEdit color="gray500" size="lg" />
+            <IconEdit color="gray500" size="md" />
           </IconClick>
           <IconClick
             data-test-id="widget-delete"
@@ -206,7 +206,7 @@ class WidgetCard extends React.Component<Props> {
               onDelete();
             }}
           >
-            <IconDelete color="gray500" size="lg" />
+            <IconDelete color="gray500" size="md" />
           </IconClick>
         </IconContainer>
       </ToolbarPanel>


### PR DESCRIPTION
- Switched Edit Dashboard and Create Dashboard
- Updated 2nd Create Dashboard and Finish Editing to both be "Save and Finish"
- Make widget icons smaller

**Before:**
![Screen Shot 2021-01-14 at 1 23 49 PM](https://user-images.githubusercontent.com/4830259/104650943-d2058a80-566b-11eb-8b73-77a2db27037d.png)
![Screen Shot 2021-01-14 at 1 24 03 PM](https://user-images.githubusercontent.com/4830259/104650948-d5007b00-566b-11eb-9bb6-978f454e7184.png)
![Screen Shot 2021-01-14 at 1 23 56 PM](https://user-images.githubusercontent.com/4830259/104650946-d467e480-566b-11eb-84ca-fe003007f998.png)

**After:**
![Screen Shot 2021-01-14 at 1 18 47 PM](https://user-images.githubusercontent.com/4830259/104650630-560b4280-566b-11eb-9e09-c6bb51d262a3.png)
![Screen Shot 2021-01-14 at 2 13 45 PM](https://user-images.githubusercontent.com/4830259/104656221-ca49e400-5673-11eb-8370-ad8f25f0de48.png)
![Screen Shot 2021-01-14 at 2 13 52 PM](https://user-images.githubusercontent.com/4830259/104656228-cd44d480-5673-11eb-949b-618749ef825c.png)