### PR TITLE
 fix: Properly reset OrganizationContext state when switching orgs

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -117,7 +117,7 @@ class OrganizationContext extends React.Component<Props, State> {
         prevProps,
       };
     }
-    
+
     return {
       loading: true,
       error: null,

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -138,7 +138,7 @@ class OrganizationContext extends React.Component<Props, State> {
   static isOrgChanging(props: Props) {
     const {organization} = OrganizationStore.get();
     return (
-      organization && organization.slug !== OrganizationContext.getOrganizationSlug(props)
+      organization?.slug !== OrganizationContext.getOrganizationSlug(props)
     );
   }
 

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -138,11 +138,11 @@ class OrganizationContext extends React.Component<Props, State> {
   static isOrgChanging(props: Props): boolean {
     const {organization} = OrganizationStore.get();
 
-    if (organization) {
-      return organization.slug !== OrganizationContext.getOrganizationSlug(props);
-    }
-
-    return false;
+   if (!organization) {
+     return false
+   }
+   
+   return organization.slug !== OrganizationContext.getOrganizationSlug(props);
   }
 
   static isOrgStorePopulatedCorrectly(props: Props) {

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -117,6 +117,7 @@ class OrganizationContext extends React.Component<Props, State> {
         prevProps,
       };
     }
+    
     return {
       loading: true,
       error: null,

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -78,7 +78,7 @@ class OrganizationContext extends React.Component<Props, State> {
     };
   }
 
-  static shouldRemount(prevProps: State['prevProps'], props): boolean {
+  static shouldRemount(prevProps: State['prevProps'], props: Props): boolean {
     const hasOrgIdAndChanged =
       prevProps.orgId && props.params.orgId && prevProps.orgId !== props.params.orgId;
 

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -138,11 +138,11 @@ class OrganizationContext extends React.Component<Props, State> {
   static isOrgChanging(props: Props): boolean {
     const {organization} = OrganizationStore.get();
 
-   if (!organization) {
-     return false
-   }
-   
-   return organization.slug !== OrganizationContext.getOrganizationSlug(props);
+    if (!organization) {
+      return false;
+    }
+
+    return organization.slug !== OrganizationContext.getOrganizationSlug(props);
   }
 
   static isOrgStorePopulatedCorrectly(props: Props) {

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -137,9 +137,7 @@ class OrganizationContext extends React.Component<Props, State> {
 
   static isOrgChanging(props: Props) {
     const {organization} = OrganizationStore.get();
-    return (
-      organization && organization.slug !== OrganizationContext.getOrganizationSlug(props)
-    );
+    return organization?.slug !== OrganizationContext.getOrganizationSlug(props);
   }
 
   static isOrgStorePopulatedCorrectly(props: Props) {

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -135,9 +135,14 @@ class OrganizationContext extends React.Component<Props, State> {
     );
   }
 
-  static isOrgChanging(props: Props) {
+  static isOrgChanging(props: Props): boolean {
     const {organization} = OrganizationStore.get();
-    return organization?.slug !== OrganizationContext.getOrganizationSlug(props);
+
+    if (organization) {
+      return organization.slug !== OrganizationContext.getOrganizationSlug(props);
+    }
+
+    return false;
   }
 
   static isOrgStorePopulatedCorrectly(props: Props) {

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -66,12 +66,14 @@ class OrganizationContext extends React.Component<Props, State> {
       return OrganizationContext.getDefaultState(props);
     }
 
+   const {organizationsLoading, location, params} = props;
+   const {orgId} = params;
     return {
       ...prevState,
       prevProps: {
-        orgId: props.params.orgId,
-        organizationsLoading: props.organizationsLoading,
-        location: props.location,
+        orgId,
+        organizationsLoading,
+        location,
       },
     };
   }

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -66,8 +66,8 @@ class OrganizationContext extends React.Component<Props, State> {
       return OrganizationContext.getDefaultState(props);
     }
 
-   const {organizationsLoading, location, params} = props;
-   const {orgId} = params;
+    const {organizationsLoading, location, params} = props;
+    const {orgId} = params;
     return {
       ...prevState,
       prevProps: {
@@ -78,7 +78,7 @@ class OrganizationContext extends React.Component<Props, State> {
     };
   }
 
-  static shouldRemount(prevProps: State['prevProps'], props: Props): boolean {
+  static shouldRemount(prevProps: State['prevProps'], props): boolean {
     const hasOrgIdAndChanged =
       prevProps.orgId && props.params.orgId && prevProps.orgId !== props.params.orgId;
 
@@ -138,7 +138,7 @@ class OrganizationContext extends React.Component<Props, State> {
   static isOrgChanging(props: Props) {
     const {organization} = OrganizationStore.get();
     return (
-      organization?.slug !== OrganizationContext.getOrganizationSlug(props)
+      organization && organization.slug !== OrganizationContext.getOrganizationSlug(props)
     );
   }
 

--- a/tests/js/spec/views/organizationContext.spec.jsx
+++ b/tests/js/spec/views/organizationContext.spec.jsx
@@ -96,19 +96,43 @@ describe('OrganizationContext', function () {
   });
 
   it('fetches new org when router params change', async function () {
+    const newOrg = TestStubs.Organization({
+      teams: [TestStubs.Team()],
+      projects: [TestStubs.Project()],
+      slug: 'new-slug',
+    });
+
     wrapper = createWrapper();
+    const instance = wrapper.instance();
+    jest.spyOn(instance, 'render');
+
+    // initial render
     await tick();
     await tick();
+    expect(instance.state.organization).toEqual(org);
+    expect(instance.render).toHaveBeenCalledTimes(1);
+
     const mock = MockApiClient.addMockResponse({
       url: '/organizations/new-slug/',
-      body: org,
+      body: newOrg,
     });
-    wrapper.setProps({params: {orgId: 'new-slug'}});
+
+    wrapper.setProps({params: {orgId: newOrg.slug}}, () => {
+      // state should be reset based on props
+      expect(instance.state.organization).toEqual(null);
+      expect(instance.render).toHaveBeenCalledTimes(2);
+    });
+
     // await fetching new org
+    await tick();
     await tick();
     wrapper.update();
 
     expect(mock).toHaveBeenLastCalledWith('/organizations/new-slug/', expect.anything());
+
+    expect(wrapper.state('loading')).toBe(false);
+    expect(wrapper.state('error')).toBe(null);
+    expect(wrapper.state('organization')).toEqual(newOrg);
   });
 
   it('shows loading error for non-superusers on 403s', async function () {


### PR DESCRIPTION
When switching orgs, the state of the `OrganizationContext` component isn't properly reset, and will result in inconsistent UI. 

For example, any global selection settings from the previous org will be improperly persisted from localstorage after switching to another org.