### PR TITLE
feat(metric_alerts): Add time selector to metric chart

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -110,7 +110,7 @@ class AlertListRow extends AsyncComponent<Props, State> {
       .as('seconds');
     const slug = incident.projects[0];
     const incidentLink = organization.features.includes('alert-details-redesign')
-      ? `/organizations/${orgId}/alerts/details/${incident.identifier}/`
+      ? `/organizations/${orgId}/alerts/rules/details/${incident.identifier}/`
       : `/organizations/${orgId}/alerts/${incident.identifier}/`;
 
     return (

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import LineChart from 'app/components/charts/lineChart';
+import space from 'app/styles/space';
+import {Series} from 'app/types/echarts';
+
+type Props = {
+  data: Series[];
+};
+
+const MetricChart = ({data}: Props) => {
+  return (
+    <LineChart
+      isGroupedByDate
+      showTimeInTooltip
+      grid={{
+        left: 0,
+        right: 0,
+        top: space(2),
+        bottom: 0,
+      }}
+      series={data}
+    />
+  );
+};
+
+export default MetricChart;


### PR DESCRIPTION
As part of the metric details redesign, the metric chart is no longer locked to an active incident. Instead it will mimic the metric alert builder with the user being able to specify a time range to view.

![image](https://user-images.githubusercontent.com/9372512/104681940-867dcb80-56c1-11eb-9fc6-fe614e20ed46.png)

Main change in this PR is the addition of the time selector. Eventually we will add another selector to select roll-up periods (1m, 5m, 10m) and also highlight areas of the chart that exceed the warning/critical threshold