### PR TITLE
Feat(dynamic-sampling): Add transaction rule modal

### DIFF
--- a/src/sentry/static/sentry/app/types/dynamicSampling.tsx
+++ b/src/sentry/static/sentry/app/types/dynamicSampling.tsx
@@ -15,6 +15,10 @@ export enum DynamicSamplingRuleType {
 
 export enum DynamicSamplingConditionOperator {
   /**
+   * It uses all other operators
+   */
+  ALL = 'all',
+  /**
    * It uses glob matches for checking (e.g. releases use glob matching "1.1.*" will match release 1.1.1 and 1.1.2)
    */
   GLOB_MATCH = 'globMatch',

--- a/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/index.tsx
@@ -26,7 +26,10 @@ const Index = ({organization}: Props) => (
     )}
   >
     <OrganizationFiltersAndSampling
-      organization={{...organization, dynamicSampling: []}}
+      organization={{
+        ...organization,
+        dynamicSampling: [],
+      }}
     />
   </Feature>
 );

--- a/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/modals/matchField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/modals/matchField.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import {DynamicSamplingConditionOperator} from 'app/types/dynamicSampling';
+import Field from 'app/views/settings/components/forms/field';
+import TextareaField from 'app/views/settings/components/forms/textareaField';
+
+import {getMatchFieldDescription} from './utils';
+
+type Props = {
+  condition: DynamicSamplingConditionOperator;
+};
+
+function MatchField({condition}: Props) {
+  const {label, description} = getMatchFieldDescription(condition);
+
+  if (!label) {
+    return null;
+  }
+
+  return (
+    <Field
+      label={label}
+      help={description}
+      inline={false}
+      required
+      flexibleControlStateSize
+      stacked
+      showHelpInTooltip
+    >
+      <TextareaField
+        name="match"
+        style={{minHeight: 100}}
+        placeholder="ex. 1* or [I3].[0-9].*"
+        autosize
+        inline={false}
+        hideControlState
+        stacked
+      />
+    </Field>
+  );
+}
+
+export default MatchField;

--- a/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/modals/transactionRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/modals/transactionRuleModal.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {ModalRenderProps} from 'app/actionCreators/modal';
+import CheckboxFancy from 'app/components/checkboxFancy/checkboxFancy';
+import ExternalLink from 'app/components/links/externalLink';
+import {t, tct} from 'app/locale';
+import space from 'app/styles/space';
+import {Organization} from 'app/types';
+import {
+  DynamicSamplingConditionOperator,
+  DynamicSamplingRule,
+} from 'app/types/dynamicSampling';
+import {defined} from 'app/utils';
+import Field from 'app/views/settings/components/forms/field';
+import Form from 'app/views/settings/components/forms/form';
+import NumberField from 'app/views/settings/components/forms/numberField';
+import SelectField from 'app/views/settings/components/forms/selectField';
+
+import MatchField from './matchField';
+
+const conditionChoices = [
+  [DynamicSamplingConditionOperator.ALL, t('All Transactions')],
+  [DynamicSamplingConditionOperator.GLOB_MATCH, t('Releases')],
+  [DynamicSamplingConditionOperator.STR_EQUAL_NO_CASE, t('Enviroments')],
+  [DynamicSamplingConditionOperator.EQUAL, t('Users')],
+];
+
+type Props = ModalRenderProps & {
+  organization: Organization;
+  onSubmit: (rule: DynamicSamplingRule) => void;
+};
+
+type State = {
+  tracing: boolean;
+  condition: DynamicSamplingConditionOperator;
+  match: string;
+  sampleRate?: number;
+};
+
+class TransactionRuleModal extends React.Component<Props, State> {
+  state: State = {
+    tracing: true,
+    condition: DynamicSamplingConditionOperator.ALL,
+    match: '',
+  };
+
+  handleSubmit = async () => {
+    const {sampleRate} = this.state;
+
+    if (!defined(sampleRate)) {
+      return;
+    }
+
+    // TODO(PRISCILA): Finalize this logic according to the new structure
+  };
+
+  handleSubmitSuccess = () => {};
+
+  handleClickTracing = () => {
+    this.setState(prevState => ({tracing: !prevState.tracing}));
+  };
+
+  handleChange = <T extends keyof State>(field: keyof State, value: State[T]) => {
+    if (field === 'sampleRate') {
+      this.setState(prevState => ({
+        ...prevState,
+        sampleRate: value ? Number(value) : undefined,
+      }));
+      return;
+    }
+    this.setState(prevState => ({...prevState, [field]: value}));
+  };
+
+  render() {
+    const {Header, Body, closeModal} = this.props;
+    const {tracing, condition, sampleRate} = this.state;
+
+    const submitDisabled = !defined(sampleRate);
+
+    return (
+      <React.Fragment>
+        <Header closeButton onHide={closeModal}>
+          {t('Add a custom rule for transactions')}
+        </Header>
+        <Body>
+          <Form
+            submitLabel={t('Save')}
+            onCancel={closeModal}
+            apiEndpoint=""
+            onSubmit={this.handleSubmit}
+            initialData={{condition}}
+            onFieldChange={this.handleChange as Form['props']['onFieldChange']}
+            submitDisabled={submitDisabled}
+            requireChanges
+          >
+            <Field
+              label={t('Tracing')}
+              help={t('this is a description')}
+              inline={false}
+              flexibleControlStateSize
+              stacked
+              showHelpInTooltip
+            >
+              <TracingWrapper>
+                <StyledCheckboxFancy
+                  onClick={this.handleClickTracing}
+                  isChecked={tracing}
+                />
+                {tct(
+                  'Include all related transactions by trace ID. This can span across multiple projects. All related errors will remain. [link:Learn more about tracing].',
+                  {link: <ExternalLink href="/" />}
+                )}
+              </TracingWrapper>
+            </Field>
+            <Field
+              label={t('Condition')}
+              help={t('this is a description')}
+              inline={false}
+              required
+              flexibleControlStateSize
+              stacked
+              showHelpInTooltip
+            >
+              <SelectField
+                name="condition"
+                choices={conditionChoices}
+                inline={false}
+                hideControlState
+                stacked
+              />
+            </Field>
+            {condition !== DynamicSamplingConditionOperator.ALL && (
+              <MatchField condition={condition} />
+            )}
+            <Field
+              label={t('Sampling Rate')}
+              help={t('this is a description')}
+              inline={false}
+              required
+              flexibleControlStateSize
+              stacked
+              showHelpInTooltip
+            >
+              <NumberField name="sampleRate" inline={false} hideControlState stacked />
+            </Field>
+          </Form>
+        </Body>
+      </React.Fragment>
+    );
+  }
+}
+
+export default TransactionRuleModal;
+
+const TracingWrapper = styled('div')`
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  grid-gap: ${space(1)};
+`;
+
+const StyledCheckboxFancy = styled(CheckboxFancy)`
+  margin-top: ${space(0.5)};
+`;

--- a/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/modals/utils.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/modals/utils.tsx
@@ -1,0 +1,31 @@
+import {css} from '@emotion/core';
+
+import {t} from 'app/locale';
+import {DynamicSamplingConditionOperator} from 'app/types/dynamicSampling';
+import theme from 'app/utils/theme';
+
+export const modalCss = css`
+  .modal-content {
+    overflow: initial;
+  }
+
+  @media (min-width: ${theme.breakpoints[0]}) {
+    .modal-dialog {
+      width: 35%;
+      margin-left: -17.5%;
+    }
+  }
+`;
+
+export function getMatchFieldDescription(condition: DynamicSamplingConditionOperator) {
+  switch (condition) {
+    case DynamicSamplingConditionOperator.STR_EQUAL_NO_CASE:
+      return {label: t('Match Enviroments'), description: 'this is a description'};
+    case DynamicSamplingConditionOperator.GLOB_MATCH:
+      return {label: t('Match Releases'), description: 'this is a description'};
+    case DynamicSamplingConditionOperator.EQUAL:
+      return {label: t('Match Users'), description: 'this is a description'};
+    default:
+      return {};
+  }
+}

--- a/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/organizationFiltersAndSampling.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/organizationFiltersAndSampling.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import isEqual from 'lodash/isEqual';
 
+import {openModal} from 'app/actionCreators/modal';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {DynamicSamplingRules, DynamicSamplingRuleType} from 'app/types/dynamicSampling';
@@ -9,6 +10,8 @@ import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import PermissionAlert from 'app/views/settings/organization/permissionAlert';
 
+import TransactionRuleModal from './modals/transactionRuleModal';
+import {modalCss} from './modals/utils';
 import TransactionRules from './transactionRules';
 
 type Props = AsyncView['props'] & {
@@ -58,8 +61,24 @@ class OrganizationFiltersAndSampling extends AsyncView<Props, State> {
     this.setState({transactionRules});
   }
 
-  handleAddRule = () => {
-    // TODO(Priscila): Implement the request here
+  handleSaveRule = async () => {
+    // TODO(Priscila): Finalize this logic according to the new structure
+  };
+
+  handleAddTransactionRule = () => {
+    const {organization} = this.props;
+    return openModal(
+      modalProps => (
+        <TransactionRuleModal
+          {...modalProps}
+          organization={organization}
+          onSubmit={this.handleSaveRule}
+        />
+      ),
+      {
+        modalCss,
+      }
+    );
   };
 
   render() {
@@ -74,7 +93,10 @@ class OrganizationFiltersAndSampling extends AsyncView<Props, State> {
             'Manage the inbound data you want to store. To change the sampling rate or rate limits, update your SDK configuration. The rules added below will apply on top of your SDK configuration.'
           )}
         </TextBlock>
-        <TransactionRules rules={transactionRules} onAddRule={this.handleAddRule} />
+        <TransactionRules
+          rules={transactionRules}
+          onAddRule={this.handleAddTransactionRule}
+        />
       </React.Fragment>
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/rules/rule/projects.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/rules/rule/projects.tsx
@@ -19,7 +19,7 @@ function ProjectList({projectIds, organization}: Props) {
     .filter(project => projectIds.includes(Number(project.id)))
     .map(projectPlatform => projectPlatform?.platform ?? 'other');
 
-  return <PlatformList platforms={projectPlatforms} />;
+  return <PlatformList size={20} platforms={projectPlatforms} showCounter />;
 }
 
 export default withOrganization(ProjectList);

--- a/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/rules/rule/utils.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/rules/rule/utils.tsx
@@ -11,6 +11,8 @@ export function getOperatorLabel(operator: DynamicSamplingConditionOperator) {
       return t('User');
     case DynamicSamplingConditionOperator.STR_EQUAL_NO_CASE:
       return t('Enviroment');
+    case DynamicSamplingConditionOperator.ALL:
+      return t('All');
     default: {
       Sentry.withScope(scope => {
         scope.setLevel(Sentry.Severity.Warning);

--- a/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/rulesPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/rulesPanel.tsx
@@ -22,7 +22,7 @@ function RulesPanel({rules, docsUrl, onAddRule}: Props) {
       <Rules rules={rules} />
       <StyledPanelFooter>
         <ButtonBar gap={1}>
-          <Button href={docsUrl} external>
+          <Button href={docsUrl} target="_blank">
             {t('Read the docs')}
           </Button>
           <Button priority="primary" onClick={onAddRule}>

--- a/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/rulesPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationFiltersAndSampling/rulesPanel.tsx
@@ -22,7 +22,7 @@ function RulesPanel({rules, docsUrl, onAddRule}: Props) {
       <Rules rules={rules} />
       <StyledPanelFooter>
         <ButtonBar gap={1}>
-          <Button href={docsUrl} target="_blank">
+          <Button href={docsUrl} external>
             {t('Read the docs')}
           </Button>
           <Button priority="primary" onClick={onAddRule}>

--- a/src/sentry/static/sentry/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -43,6 +43,7 @@ class RelayWrapper extends AsyncView<Props, State> {
 
     super.componentDidUpdate(prevProps, prevState);
   }
+
   getTitle() {
     return t('Relay');
   }


### PR DESCRIPTION
We will no longer have Dynamic Sampling at the organization level, so the "Projects" field has been removed. The modal in this PR looks like this:

![image](https://user-images.githubusercontent.com/29228205/105063715-57c67300-5a7c-11eb-945c-780341c6949c.png)

New Design Updates will be done in a follow-up PR
