### PR TITLE
fix: More nodestore stats fixes

### DIFF
--- a/tests/sentry/eventstore/test_compressor.py
+++ b/tests/sentry/eventstore/test_compressor.py
@@ -23,6 +23,8 @@ def _assert_roundtrip(data, assert_extra_keys=None):
 
 
 def test_basic():
+    assert deduplicate({}) == ({}, {})
+
     _assert_roundtrip({})
     _assert_roundtrip({"debug_meta": {}})
     _assert_roundtrip({"debug_meta": None})


### PR DESCRIPTION
* sizes are not comparable if they compress differently, use sort_keys
* Using the event class goes through renormalization while we don't want
that
* Going through interfaces, in all likelihood, mutates the event dict
in-place