### PR TITLE
fix: Add reason tag for unsafe stacktrace

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -214,7 +214,11 @@ def configure_sdk():
                     metrics.incr("internal.captured.events.relay")
                     getattr(relay_transport, method_name)(*args, **kwargs)
                 else:
-                    metrics.incr("internal.uncaptured.events.relay", skip_internal=False)
+                    metrics.incr(
+                        "internal.uncaptured.events.relay",
+                        skip_internal=False,
+                        tags={"reason": "unsafe"},
+                    )
 
     sentry_sdk.init(
         transport=MultiplexingTransport(),


### PR DESCRIPTION
we send a tag when the reason is queue_full, let's set another tag so the metrics product is actually usable