### PR TITLE
fix(jira) Remove broken jira glance

### DIFF
--- a/src/sentry_plugins/jira_ac/templates/base.html
+++ b/src/sentry_plugins/jira_ac/templates/base.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <link rel="stylesheet" href="//aui-cdn.atlassian.com/aui-adg/5.10.1/css/aui.min.css" media="all">
+  <link rel="stylesheet" href="{% asset_url 'sentry' 'vendor/aui-prototyping.9.1.5.css' %}" media="all">
   <style type="text/css">
     ul {
       padding-left: 0px;
@@ -12,25 +12,6 @@
       list-style-type: none;
       margin: 0px;
       padding: 10px 0px;
-    }
-
-    .reporter {
-      position: relative;
-    }
-
-    .reporter img {
-      border-radius: 3px;
-      position: absolute;
-      left: 0;
-      top: 4px;
-      width: 32px;
-      height: 32px;
-    }
-
-    .reporter span {
-      display: block;
-      padding-left: 42px;
-      min-height: 32px;
     }
 
     .aui-item.error-level {
@@ -49,24 +30,8 @@
       padding-left: 10px;
     }
 
-    .aui-item.error-level .sentry-error {
-      background-color: #d04437;
-    }
-
-    .aui-item.error-level .sentry-info {
-      background-color: #205081;
-    }
-
-    .aui-item.error-level .sentry-warning {
-      background-color: #f6c342;
-    }
-
     #content {
       background-color: #ffffff;
-    }
-
-    .last-seen {
-      color: #999ca0;
     }
 
     #login .aui-page-panel {
@@ -80,6 +45,7 @@
     }
 
     body.aui-page-focused.aui-page-size-medium #page {
+      padding-top: 25px;
       padding-bottom: 25px;
     }
 
@@ -87,7 +53,10 @@
   {% script src=ac_js_src %}{% endscript %}
   {% asset_url 'sentry' 'vendor/jquery.2.2.4.min.js' as jquery_url %}
   {% script src=jquery_url %}{% endscript %}
-  {% script src="//aui-cdn.atlassian.com/aui-adg/5.10.1/js/aui.min.js" %}{% endscript %}
+
+  {% asset_url 'sentry' 'vendor/aui-prototyping.9.1.5.js' as aui_js_url %}
+  {% script src=aui_js_url %}{% endscript %}
+
   {% script type="text/javascript" %}
     <script>
     /*

--- a/src/sentry_plugins/jira_ac/templates/widget.html
+++ b/src/sentry_plugins/jira_ac/templates/widget.html
@@ -1,75 +1,11 @@
 {% extends 'base.html' %}
 
-{% load sentry_assets %}
-
 {% block content %}
-  <div id="reporter"></div>
-  <ul id="sentry-issues">
-  </ul>
-{% endblock %}
-{% block javascript %}
-  {% script type="text/x-template" title="reporter-template" %}
-    <div class="reporter">
-      <img src="{avatarURL}"/>
-      <span><strong>{email}</strong> experienced {count}</span>
-    </div>
-  {% endscript %}
-  {% script type="text/x-template" title="issue-template" %}
-    <li class="aui-group">
-      <div class="aui-item error-level">
-        <span class="sentry-{level}"></span>
-      </div>
-      <div class="aui-item">
-        <div><a href="{permalink}" target="_blank">{title}</a></div>
-        <div class="last-seen">{lastSeen} - {firstSeen}</div>
-      </div>
+  <ul>
+    <li class="aui-message">
+      No results could be found.
+      Please upgrade to the <a href="https://docs.sentry.io/product/integrations/jira/">Jira Integration</a>
+      to get results.
     </li>
-  {% endscript %}
-  {% script type="text/javascript" %}
-  <script>
-    (function() {
-      var issueKey = '{{ issue_key }}',
-          MAX_ISSUES = 5;
-
-      AP.require('request', function(request) {
-        request({
-          url: '/rest/api/latest/issue/' + issueKey,
-          success: function(responseText) {
-            var issue = JSON.parse(responseText),
-                reporter = issue.fields.reporter,
-                email = reporter.emailAddress,
-                url = ('{{ sentry_api_url }}' + '?limit=' + (MAX_ISSUES + 1) +
-                       '&email=' + encodeURIComponent(email));
-            $.get(url).done(function(issues) {
-              var $issuesEl = $('#sentry-issues'),
-                  $reporter = $('#reporter'),
-                  count = issues.length > MAX_ISSUES ? '5+' : issues.length;
-              $reporter.append(AJS.template.load('reporter-template').fill({
-                avatarURL: reporter.avatarUrls['48x48'],
-                email: email,
-                count: (count + ' issue' + (issues.length === 1 ? '' : 's') +
-                        (issues.length ? ':' : ''))
-              }));
-
-              var issue, level;
-              for (var i = 0; i < Math.min(issues.length, MAX_ISSUES); i++) {
-                issue = issues[i];
-                level = issue.level;
-                $issuesEl.append(AJS.template.load('issue-template').fill({
-                  level: level === 'fatal' ? 'error' : level,
-                  permalink: issue.permalink,
-                  title: issue.title,
-                  lastSeen: prettyDate(issue.lastSeen) + ' ago',
-                  firstSeen: prettyDate(issue.firstSeen) + ' old'
-                }));
-              }
-            }).fail(function() {
-              $('#reporter').text('Unable to fetch related issues. Please try again.')
-            });
-          }
-        });
-      });
-    })();
-  </script>
-  {% endscript %}
+  </ul>
 {% endblock %}

--- a/src/sentry_plugins/jira_ac/views.py
+++ b/src/sentry_plugins/jira_ac/views.py
@@ -74,15 +74,9 @@ class JiraUIWidgetView(BaseJiraWidgetView):
                 )
                 scope.set_tag("result", "error.no_org")
                 return self.get_response("error.html", context)
+
             bind_organization_context(org)
-            context.update(
-                {
-                    "sentry_api_url": absolute_uri(
-                        "/api/0/organizations/%s/users/issues/" % (org.slug,)
-                    ),
-                    "issue_key": self.request.GET.get("issueKey"),
-                }
-            )
+            context.update({"organization_slug": org.slug})
 
             scope.set_tag("result", "success")
             return self.get_response("widget.html", context)


### PR DESCRIPTION
The Jira-AC plugin was causing a number of CSP errors under our new rules. I started off trying to fix upgrade the implementation to use the new AUI version that doesn't contain eval/inline scripts. In doing that I discovered that this view never works as Jira no longer exposes `reporter.email` due to GDPR.

Because this plugin is deprecated it isn't worth investing additional time into to resolve the issue glance in a better way. Instead we can recommend people move to the Jira integration which has a working issue glance.

I've taken the liberty to update the CSS library so that the plugin connection flow is coherent with present day Jira.

### Before

![Screen Shot 2021-01-15 at 11 58 52 AM](https://user-images.githubusercontent.com/24086/104765863-99cb7e00-5737-11eb-9874-60e4917d319f.png)

### After

![Screen Shot 2021-01-15 at 12 10 10 PM](https://user-images.githubusercontent.com/24086/104765882-a223b900-5737-11eb-98a3-4dc09bdea113.png)
![Screen Shot 2021-01-15 at 12 10 23 PM](https://user-images.githubusercontent.com/24086/104765884-a2bc4f80-5737-11eb-8356-43ec98ecae33.png)
