### PR TITLE
ref(tsdb): Break down TSDB Snuba referrer by model

### DIFF
--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -284,7 +284,7 @@ class SnubaTSDB(BaseTSDB):
                 aggregations=aggregations,
                 rollup=rollup,
                 limit=limit,
-                referrer="tsdb",
+                referrer=f"tsdb-modelid:{model.value}",
                 is_grouprelease=(model == TSDBModel.frequent_releases_by_group),
             )
         else:

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -284,7 +284,7 @@ class SnubaTSDB(BaseTSDB):
                 aggregations=aggregations,
                 rollup=rollup,
                 limit=limit,
-                referrer=f"tsdb-modelid:{model.value}",
+                referrer="tsdb-modelid:{}".format(model.value),
                 is_grouprelease=(model == TSDBModel.frequent_releases_by_group),
             )
         else:


### PR DESCRIPTION
TSDB accounts for the largest share of queries from Sentry to Snuba.
Breaking this down by model is intended to give us better data
on query patterns and identify which types of queries result in
the most discrepancies between Snuba's errors and events storage.