### PR TITLE
ref(dashboardsv2): Let the default time range for Dashboards v2 be 24h

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/data.tsx
@@ -24,3 +24,5 @@ export const INTERVAL_CHOICES = [
   {label: t('1 Hour'), value: '1h'},
   {label: t('1 Day'), value: '1d'},
 ];
+
+export const DEFAULT_STATS_PERIOD = '24h';

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -21,7 +21,7 @@ import withOrganization from 'app/utils/withOrganization';
 
 import Controls from './controls';
 import Dashboard from './dashboard';
-import {EMPTY_DASHBOARD, DEFAULT_STATS_PERIOD} from './data';
+import {DEFAULT_STATS_PERIOD, EMPTY_DASHBOARD} from './data';
 import OrgDashboards from './orgDashboards';
 import DashboardTitle from './title';
 import {DashboardDetails, DashboardState, Widget} from './types';

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -21,7 +21,7 @@ import withOrganization from 'app/utils/withOrganization';
 
 import Controls from './controls';
 import Dashboard from './dashboard';
-import {EMPTY_DASHBOARD} from './data';
+import {EMPTY_DASHBOARD, DEFAULT_STATS_PERIOD} from './data';
 import OrgDashboards from './orgDashboards';
 import DashboardTitle from './title';
 import {DashboardDetails, DashboardState, Widget} from './types';
@@ -247,6 +247,14 @@ class DashboardDetail extends React.Component<Props, State> {
     return (
       <GlobalSelectionHeader
         skipLoadLastUsed={organization.features.includes('global-views')}
+        defaultSelection={{
+          datetime: {
+            start: null,
+            end: null,
+            utc: false,
+            period: DEFAULT_STATS_PERIOD,
+          },
+        }}
       >
         <OrgDashboards
           api={api}


### PR DESCRIPTION
Set the default time range for Dashboards v2 be `24h` instead of `14d` to let dashboard widgets load faster.

The Performance tab has the same default to optimize the latency of Discover queries. 