### PR TITLE
feat(landing): Add backend cards to performance landing V2

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/utils.tsx
+++ b/src/sentry/static/sentry/app/components/charts/utils.tsx
@@ -47,7 +47,7 @@ export function getInterval(datetimeObj: DateTimeObject, highFidelity = false) {
   const diffInMinutes = getDiffInMinutes(datetimeObj);
 
   if (diffInMinutes >= SIXTY_DAYS) {
-    // Greater than or equal to 30 days
+    // Greater than or equal to 60 days
     if (highFidelity) {
       return '4h';
     } else {

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -298,7 +298,7 @@ export const ALIASES = {
 
 assert(AGGREGATIONS as Readonly<{[key in keyof typeof AGGREGATIONS]: Aggregation}>);
 
-export type AggregationKey = keyof typeof AGGREGATIONS | '';
+export type AggregationKey = keyof typeof AGGREGATIONS | keyof typeof ALIASES | '';
 
 export type AggregationOutputType = Extract<
   ColumnType,

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -48,7 +48,6 @@ class Container extends React.Component<Props> {
     const start = globalSelection.datetime.start
       ? getUtcToLocalDateObject(globalSelection.datetime.start)
       : undefined;
-
     const end = globalSelection.datetime.end
       ? getUtcToLocalDateObject(globalSelection.datetime.end)
       : undefined;

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -156,7 +156,9 @@ function generateGenericPerformanceEventView(
   const searchQuery = decodeScalar(query.query) || '';
   const conditions = tokenizeSearch(searchQuery);
   conditions.setTagValues('event.type', ['transaction']);
-  conditions.setTagValues('transaction.duration', ['<15m']);
+  if (!conditions.hasTag('transaction.duration')) {
+    conditions.setTagValues('transaction.duration', ['<15m']);
+  }
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -223,6 +223,7 @@ export function generatePerformanceEventView(organization, location) {
   switch (display?.field) {
     case LandingDisplayField.FRONTEND:
       return generateFrontendPerformanceEventView(organization, location);
+    case LandingDisplayField.BACKEND:
     default:
       return generateGenericPerformanceEventView(organization, location);
   }

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -83,6 +83,23 @@ export function getFrontendAxisOptions(
   ];
 }
 
+export function getBackendAxisOptions(
+  organization: LightWeightOrganization
+): TooltipOption[] {
+  return [
+    {
+      tooltip: getTermHelp(organization, 'p75'),
+      value: `p75()`,
+      label: t('Duration p75'),
+    },
+    {
+      tooltip: getTermHelp(organization, ''),
+      value: 'duration_distribution',
+      label: t('Duration Distribution'),
+    },
+  ];
+}
+
 type TermFormatter = (organization: LightWeightOrganization) => string;
 
 const PERFORMANCE_TERMS: Record<string, TermFormatter> = {
@@ -96,6 +113,7 @@ const PERFORMANCE_TERMS: Record<string, TermFormatter> = {
       'Failure rate is the percentage of recorded transactions that had a known and unsuccessful status.'
     ),
   p50: () => t('p50 indicates the duration that 50% of transactions are faster than.'),
+  p75: () => t('p75 indicates the duration that 75% of transactions are faster than.'),
   p95: () => t('p95 indicates the duration that 95% of transactions are faster than.'),
   p99: () => t('p99 indicates the duration that 99% of transactions are faster than.'),
   lcp: () =>

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -93,7 +93,7 @@ export function getBackendAxisOptions(
       label: t('Duration p75'),
     },
     {
-      tooltip: getTermHelp(organization, ''),
+      tooltip: getTermHelp(organization, 'durationDistribution'),
       value: 'duration_distribution',
       label: t('Duration Distribution'),
     },
@@ -126,6 +126,10 @@ const PERFORMANCE_TERMS: Record<string, TermFormatter> = {
   statusBreakdown: () =>
     t(
       'The breakdown of transaction statuses. This may indicate what type of failure it is.'
+    ),
+  durationDistribution: () =>
+    t(
+      'Distribution buckets counts of transactions at specifics times for your current date range'
     ),
 };
 

--- a/src/sentry/static/sentry/app/views/performance/landing/backendDisplay.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/backendDisplay.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import {Panel} from 'app/components/panels';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {Organization} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import withApi from 'app/utils/withApi';
+
+import _Footer from '../charts/footer';
+import {getBackendAxisOptions} from '../data';
+import {getTransactionSearchQuery} from '../utils';
+
+import DurationChart from './durationChart';
+import HistogramChart from './histogramChart';
+
+type Props = {
+  location: Location;
+  organization: Organization;
+  eventView: EventView;
+};
+
+function BackendDisplay(props: Props) {
+  const {eventView, location, organization} = props;
+  const field = 'transaction.duration';
+
+  const onFilterChange = (minValue, maxValue) => {
+    const filterString = getTransactionSearchQuery(location);
+    const conditions = tokenizeSearch(filterString);
+    conditions.setTagValues(field, [
+      `>=${Math.round(minValue)}`,
+      `<${Math.round(maxValue)}`,
+    ]);
+    const query = stringifyQueryObject(conditions);
+
+    browserHistory.push({
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        query: String(query).trim(),
+      },
+    });
+  };
+
+  const axisOptions = getBackendAxisOptions(organization);
+  const leftAxis = axisOptions[0].value; // TODO: Temporary until backend changes
+  const rightAxis = axisOptions[1].value; // TODO: Temporary until backend changes
+
+  return (
+    <Panel>
+      <DoubleChartContainer>
+        <DurationChart
+          field="p75(transaction.duration)"
+          eventView={eventView}
+          organization={organization}
+          title={t('Duration p75')}
+          titleTooltip={t(
+            'This is the 75th percentile over time of the duration of the transaction.'
+          )}
+        />
+        <HistogramChart
+          field="transaction.duration"
+          {...props}
+          onFilterChange={onFilterChange}
+          title={t('Duration Distribution')}
+          titleTooltip={t('This is a histogram of the duration of the transaction.')}
+        />
+      </DoubleChartContainer>
+
+      <Footer
+        options={getBackendAxisOptions(organization)}
+        leftAxis={leftAxis}
+        rightAxis={rightAxis}
+        organization={organization}
+        eventView={eventView}
+        location={location}
+      />
+    </Panel>
+  );
+}
+
+const DoubleChartContainer = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: ${space(3)};
+`;
+
+const Footer = withApi(_Footer);
+
+export default BackendDisplay;

--- a/src/sentry/static/sentry/app/views/performance/landing/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/content.tsx
@@ -17,6 +17,7 @@ import Charts from '../charts/index';
 import Table from '../table';
 import {getTransactionSearchQuery} from '../utils';
 
+import BackendDisplay from './backendDisplay';
 import {FRONTEND_COLUMN_TITLES} from './data';
 import FrontendDisplay from './frontendDisplay';
 import {getCurrentLandingDisplay, LANDING_DISPLAYS, LandingDisplayField} from './utils';
@@ -143,6 +144,11 @@ class LandingContent extends React.Component<Props, State> {
     return (
       <React.Fragment>
         <BackendCards
+          eventView={eventView}
+          organization={organization}
+          location={location}
+        />
+        <BackendDisplay
           eventView={eventView}
           organization={organization}
           location={location}

--- a/src/sentry/static/sentry/app/views/performance/landing/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/content.tsx
@@ -19,8 +19,8 @@ import {getTransactionSearchQuery} from '../utils';
 
 import {FRONTEND_COLUMN_TITLES} from './data';
 import FrontendDisplay from './frontendDisplay';
-import {getCurrentLandingDisplay, LANDING_DISPLAYS} from './utils';
-import {FrontendCards} from './vitalsCards';
+import {getCurrentLandingDisplay, LANDING_DISPLAYS, LandingDisplayField} from './utils';
+import {BackendCards, FrontendCards} from './vitalsCards';
 
 type Props = {
   organization: Organization;
@@ -52,15 +52,8 @@ class LandingContent extends React.Component<Props, State> {
     });
   };
 
-  renderLandingFrontend() {
-    const {
-      organization,
-      location,
-      projects,
-      eventView,
-      setError,
-      handleSearch,
-    } = this.props;
+  renderLandingV2() {
+    const {organization, location, eventView, handleSearch} = this.props;
 
     const currentLandingDisplay = getCurrentLandingDisplay(location);
     const filterString = getTransactionSearchQuery(location);
@@ -99,6 +92,27 @@ class LandingContent extends React.Component<Props, State> {
             </DropdownControl>
           </ProjectTypeDropdown>
         </SearchContainer>
+        {this.renderSelectedDisplay(currentLandingDisplay.field, summaryConditions)}
+      </React.Fragment>
+    );
+  }
+
+  renderSelectedDisplay(display, summaryConditions) {
+    switch (display) {
+      case LandingDisplayField.FRONTEND:
+        return this.renderLandingFrontend(summaryConditions);
+      case LandingDisplayField.BACKEND:
+        return this.renderLandingBackend(summaryConditions);
+      default:
+        throw new Error(`Unknown display: ${display}`);
+    }
+  }
+
+  renderLandingFrontend(summaryConditions) {
+    const {organization, location, projects, eventView, setError} = this.props;
+
+    return (
+      <React.Fragment>
         <FrontendCards
           eventView={eventView}
           organization={organization}
@@ -123,8 +137,26 @@ class LandingContent extends React.Component<Props, State> {
     );
   }
 
-  renderLandingV2() {
-    return this.renderLandingFrontend();
+  renderLandingBackend(summaryConditions) {
+    const {organization, location, projects, eventView, setError} = this.props;
+
+    return (
+      <React.Fragment>
+        <BackendCards
+          eventView={eventView}
+          organization={organization}
+          location={location}
+        />
+        <Table
+          eventView={eventView}
+          projects={projects}
+          organization={organization}
+          location={location}
+          setError={setError}
+          summaryConditions={summaryConditions}
+        />
+      </React.Fragment>
+    );
   }
 
   renderLandingV1 = () => {

--- a/src/sentry/static/sentry/app/views/performance/landing/histogramChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/histogramChart.tsx
@@ -106,6 +106,7 @@ export function HistogramChart(props: Props) {
         orgSlug={organization.slug}
         eventView={eventView}
         numBuckets={NUM_BUCKETS}
+        precision={PRECISION}
         fields={[field]}
         dataFilter="exclude_outliers"
       >

--- a/src/sentry/static/sentry/app/views/performance/landing/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/utils.tsx
@@ -76,7 +76,7 @@ export const backendCardDetails = {
   p75: {
     title: 'Duration (p75)',
     tooltip: 'Duration (p75)',
-    formatter: value => getDuration(value / 1000, 0, true),
+    formatter: value => getDuration(value / 1000, 3, true),
   },
   tpm: {
     title: 'Throughput',

--- a/src/sentry/static/sentry/app/views/performance/landing/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/utils.tsx
@@ -1,5 +1,13 @@
 import {Location} from 'history';
 
+import {Organization} from 'app/types';
+import {AggregationKey, Column} from 'app/utils/discover/fields';
+import {
+  formatAbbreviatedNumber,
+  formatFloat,
+  formatPercentage,
+  getDuration,
+} from 'app/utils/formatters';
 import {decodeScalar} from 'app/utils/queryString';
 
 import {HistogramData, Rectangle} from '../transactionVitals/types';
@@ -11,12 +19,17 @@ type LandingDisplay = {
 
 export enum LandingDisplayField {
   FRONTEND = 'frontend',
+  BACKEND = 'backend',
 }
 
 export const LANDING_DISPLAYS = [
   {
     label: 'Frontend',
     field: LandingDisplayField.FRONTEND,
+  },
+  {
+    label: 'Backend',
+    field: LandingDisplayField.BACKEND,
   },
 ];
 
@@ -37,3 +50,47 @@ export function getChartWidth(
     chartWidth,
   };
 }
+
+export function getBackendFunction(
+  functionName: AggregationKey,
+  organization: Organization
+): Column {
+  switch (functionName) {
+    case 'p75':
+      return {kind: 'function', function: ['p75', 'transaction.duration', undefined]};
+    case 'tpm':
+      return {kind: 'function', function: ['tpm', '', undefined]};
+    case 'failure_rate':
+      return {kind: 'function', function: ['failure_rate', '', undefined]};
+    case 'apdex':
+      return {
+        kind: 'function',
+        function: ['apdex', `${organization.apdexThreshold}`, undefined],
+      };
+    default:
+      throw new Error(`Unsupported backend function: ${functionName}`);
+  }
+}
+
+export const backendCardDetails = {
+  p75: {
+    title: 'Duration (p75)',
+    tooltip: 'Duration (p75)',
+    formatter: value => getDuration(value, 0, true),
+  },
+  tpm: {
+    title: 'Throughput',
+    tooltip: 'Throughput',
+    formatter: formatAbbreviatedNumber,
+  },
+  failure_rate: {
+    title: 'Failure Rate',
+    tooltip: 'Failure Rate',
+    formatter: value => formatPercentage(value, 2),
+  },
+  apdex: {
+    title: 'Apdex',
+    tooltip: 'Apdex',
+    formatter: value => formatFloat(value, 4),
+  },
+};

--- a/src/sentry/static/sentry/app/views/performance/landing/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/utils.tsx
@@ -76,7 +76,7 @@ export const backendCardDetails = {
   p75: {
     title: 'Duration (p75)',
     tooltip: 'Duration (p75)',
-    formatter: value => getDuration(value, 0, true),
+    formatter: value => getDuration(value / 1000, 0, true),
   },
   tpm: {
     title: 'Throughput',

--- a/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
@@ -232,7 +232,7 @@ type SparklineChartProps = {
   data: number[];
 };
 
-export function SparklineChart(props: SparklineChartProps) {
+function SparklineChart(props: SparklineChartProps) {
   const {data} = props;
   return (
     <SparklineContainer data-test-id="sparkline">

--- a/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
@@ -10,6 +10,8 @@ import EmptyStateWarning from 'app/components/emptyStateWarning';
 import Link from 'app/components/links/link';
 import Placeholder from 'app/components/placeholder';
 import QuestionTooltip from 'app/components/questionTooltip';
+import Sparklines from 'app/components/sparklines';
+import SparklinesLine from 'app/components/sparklines/line';
 import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -40,13 +42,6 @@ import {
 import VitalPercents from '../vitalDetail/vitalPercents';
 
 import {backendCardDetails, getBackendFunction} from './utils';
-
-const Sparklines = React.lazy(
-  () => import(/* webpackChunkName: "Sparklines" */ 'app/components/sparklines')
-);
-const SparklinesLine = React.lazy(
-  () => import(/* webpackChunkName: "SparklinesLine" */ 'app/components/sparklines/line')
-);
 
 // Temporary list of platforms to only show web vitals for.
 const VITALS_PLATFORMS = [
@@ -181,14 +176,11 @@ function _BackendCards(props: BackendCardsProps) {
           environment={globalSelection.environments}
           start={start}
           end={end}
-          interval={getInterval(
-            {
-              start: start || null,
-              end: end || null,
-              period: globalSelection.datetime.period,
-            },
-            true
-          )}
+          interval={getInterval({
+            start: start || null,
+            end: end || null,
+            period: globalSelection.datetime.period,
+          })}
           query={eventView.getEventsAPIPayload(location).query}
           includePrevious={false}
           yAxis={eventView.getFields()}
@@ -243,13 +235,11 @@ type SparklineChartProps = {
 export function SparklineChart(props: SparklineChartProps) {
   const {data} = props;
   return (
-    <React.Suspense fallback={null}>
-      <SparklineContainer data-test-id="sparkline">
-        <Sparklines data={data} width={240} height={24}>
-          <SparklinesLine style={{stroke: theme.gray300, fill: 'none', strokeWidth: 4}} />
-        </Sparklines>
-      </SparklineContainer>
-    </React.Suspense>
+    <SparklineContainer data-test-id="sparkline">
+      <Sparklines data={data} width={240} height={24}>
+        <SparklinesLine style={{stroke: theme.gray300, fill: 'none', strokeWidth: 4}} />
+      </Sparklines>
+    </SparklineContainer>
   );
 }
 

--- a/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
+import {Client} from 'app/api';
 import Card from 'app/components/card';
+import EventsRequest from 'app/components/charts/eventsRequest';
+import {getInterval} from 'app/components/charts/utils';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import Link from 'app/components/links/link';
 import Placeholder from 'app/components/placeholder';
@@ -11,9 +14,13 @@ import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
+import {getUtcToLocalDateObject} from 'app/utils/dates';
+import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
 import {getAggregateAlias, WebVital} from 'app/utils/discover/fields';
 import {decodeList} from 'app/utils/queryString';
+import theme from 'app/utils/theme';
+import withApi from 'app/utils/withApi';
 import VitalsCardsDiscoverQuery from 'app/views/performance/vitalDetail/vitalsCardsDiscoverQuery';
 
 import {HeaderTitle} from '../styles';
@@ -32,6 +39,15 @@ import {
 } from '../vitalDetail/utils';
 import VitalPercents from '../vitalDetail/vitalPercents';
 
+import {backendCardDetails, getBackendFunction} from './utils';
+
+const Sparklines = React.lazy(
+  () => import(/* webpackChunkName: "Sparklines" */ 'app/components/sparklines')
+);
+const SparklinesLine = React.lazy(
+  () => import(/* webpackChunkName: "SparklinesLine" */ 'app/components/sparklines/line')
+);
+
 // Temporary list of platforms to only show web vitals for.
 const VITALS_PLATFORMS = [
   'javascript',
@@ -44,7 +60,7 @@ const VITALS_PLATFORMS = [
   'javascript-vue',
 ];
 
-type VitalsCardsProps = {
+type FrontendCardsProps = {
   eventView: EventView;
   location: Location;
   organization: Organization;
@@ -52,7 +68,7 @@ type VitalsCardsProps = {
   frontendOnly?: boolean;
 };
 
-export function FrontendCards(props: VitalsCardsProps) {
+export function FrontendCards(props: FrontendCardsProps) {
   const {eventView, location, organization, projects, frontendOnly = false} = props;
 
   if (frontendOnly) {
@@ -90,7 +106,9 @@ export function FrontendCards(props: VitalsCardsProps) {
 
               const value = isLoading ? '\u2014' : getP75(result, vital);
               const chart = (
-                <VitalBar isLoading={isLoading} vital={vital} result={result} />
+                <VitalBarContainer>
+                  <VitalBar isLoading={isLoading} vital={vital} result={result} />
+                </VitalBarContainer>
               );
 
               return (
@@ -104,6 +122,7 @@ export function FrontendCards(props: VitalsCardsProps) {
                     tooltip={vitalDescription[vital] ?? ''}
                     value={isLoading ? '\u2014' : value}
                     chart={chart}
+                    minHeight={150}
                   />
                 </Link>
               );
@@ -114,6 +133,132 @@ export function FrontendCards(props: VitalsCardsProps) {
     </VitalsCardsDiscoverQuery>
   );
 }
+
+const VitalBarContainer = styled('div')`
+  margin-top: ${space(1.5)};
+`;
+
+type BackendCardsProps = {
+  api: Client;
+  eventView: EventView;
+  location: Location;
+  organization: Organization;
+};
+
+function _BackendCards(props: BackendCardsProps) {
+  const {api, eventView: baseEventView, location, organization} = props;
+  const functionNames = [
+    'p75' as const,
+    'tpm' as const,
+    'failure_rate' as const,
+    'apdex' as const,
+  ];
+  const functions = functionNames.map(fn => getBackendFunction(fn, organization));
+  const eventView = baseEventView.withColumns(functions);
+
+  // construct request parameters for fetching chart data
+  const globalSelection = eventView.getGlobalSelection();
+  const start = globalSelection.datetime.start
+    ? getUtcToLocalDateObject(globalSelection.datetime.start)
+    : undefined;
+  const end = globalSelection.datetime.end
+    ? getUtcToLocalDateObject(globalSelection.datetime.end)
+    : undefined;
+
+  return (
+    <DiscoverQuery
+      location={location}
+      eventView={eventView}
+      orgSlug={organization.slug}
+      limit={1}
+    >
+      {({isLoading: isSummaryLoading, tableData}) => (
+        <EventsRequest
+          api={api}
+          organization={organization}
+          period={globalSelection.datetime.period}
+          project={globalSelection.projects}
+          environment={globalSelection.environments}
+          start={start}
+          end={end}
+          interval={getInterval(
+            {
+              start: start || null,
+              end: end || null,
+              period: globalSelection.datetime.period,
+            },
+            true
+          )}
+          query={eventView.getEventsAPIPayload(location).query}
+          includePrevious={false}
+          yAxis={eventView.getFields()}
+        >
+          {({results}) => {
+            const series = results?.reduce((allSeries, oneSeries) => {
+              allSeries[oneSeries.seriesName] = oneSeries.data.map(item => item.value);
+              return allSeries;
+            }, {});
+            const fields = eventView
+              .getFields()
+              .map((fn, i) => [functionNames[i], fn, series?.[fn]]);
+
+            return (
+              <VitalsContainer>
+                {fields.map(([name, fn, data]) => {
+                  const {title, tooltip, formatter} = backendCardDetails[name];
+                  const alias = getAggregateAlias(fn);
+                  const rawValue = tableData?.data?.[0]?.[alias];
+                  const value =
+                    isSummaryLoading || rawValue === undefined
+                      ? '\u2014'
+                      : formatter(rawValue);
+                  const chart = <SparklineChart data={data} />;
+                  return (
+                    <VitalCard
+                      key={name}
+                      title={title}
+                      tooltip={tooltip}
+                      value={value}
+                      chart={chart}
+                      horizontal
+                      minHeight={102}
+                    />
+                  );
+                })}
+              </VitalsContainer>
+            );
+          }}
+        </EventsRequest>
+      )}
+    </DiscoverQuery>
+  );
+}
+
+export const BackendCards = withApi(_BackendCards);
+
+type SparklineChartProps = {
+  data: number[];
+};
+
+export function SparklineChart(props: SparklineChartProps) {
+  const {data} = props;
+  return (
+    <React.Suspense fallback={null}>
+      <SparklineContainer data-test-id="sparkline">
+        <Sparklines data={data} width={240} height={24}>
+          <SparklinesLine style={{stroke: theme.gray300, fill: 'none', strokeWidth: 4}} />
+        </Sparklines>
+      </SparklineContainer>
+    </React.Suspense>
+  );
+}
+
+const SparklineContainer = styled('div')`
+  flex-grow: 4;
+  max-height: 24px;
+  max-width: 240px;
+  margin: ${space(1)} ${space(0)} ${space(1.5)} ${space(3)};
+`;
 
 const VitalsContainer = styled('div')`
   display: grid;
@@ -210,28 +355,39 @@ type VitalCardProps = {
   tooltip: string;
   value: string;
   chart: React.ReactNode;
+  minHeight?: number;
+  horizontal?: boolean;
 };
 
 function VitalCard(props: VitalCardProps) {
-  const {chart, title, tooltip, value} = props;
+  const {chart, minHeight, horizontal, title, tooltip, value} = props;
   return (
-    <StyledCard interactive>
+    <StyledCard interactive minHeight={minHeight}>
       <HeaderTitle>
         <OverflowEllipsis>{t(title)}</OverflowEllipsis>
         <QuestionTooltip size="sm" position="top" title={tooltip} />
       </HeaderTitle>
-      <CardValue>{value}</CardValue>
-      {chart}
+      <CardContent horizontal={horizontal}>
+        <CardValue>{value}</CardValue>
+        {chart}
+      </CardContent>
     </StyledCard>
   );
 }
 
-const StyledCard = styled(Card)`
+const CardContent = styled('div')<{horizontal?: boolean}>`
+  width: 100%;
+  display: flex;
+  flex-direction: ${p => (p.horizontal ? 'row' : 'column')};
+  justify-content: space-between;
+`;
+
+const StyledCard = styled(Card)<{minHeight?: number}>`
   color: ${p => p.theme.textColor};
   padding: ${space(2)} ${space(3)};
   align-items: flex-start;
-  min-height: 150px;
   margin-bottom: ${space(2)};
+  ${p => p.minHeight && `min-height: ${p.minHeight}px`};
 `;
 
 function getP75(result: any, vitalName: WebVital): string {
@@ -316,7 +472,6 @@ const BarDetail = styled('div')`
 const CardValue = styled('div')`
   font-size: 32px;
   margin-top: ${space(1)};
-  margin-bottom: ${space(1.5)};
 `;
 
 const OverflowEllipsis = styled('div')`


### PR DESCRIPTION
Add backend cards to the performance landing v2 under the backend display.

# Screenshots

![image](https://user-images.githubusercontent.com/10239353/104967820-4f096a80-59b2-11eb-9006-441566b82917.png)
