### PR TITLE
fix(msteams): UI improvements to mobile app

### DIFF
--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -421,6 +421,7 @@ def build_group_actions(group, event, rules, integration):
             "card": {
                 "type": "AdaptiveCard",
                 "body": [
+                    {"type": "TextBlock", "text": "Resolve", "weight": "Bolder"},
                     {
                         "type": "Input.ChoiceSet",
                         "id": "resolveInput",
@@ -432,7 +433,7 @@ def build_group_actions(group, event, rules, integration):
                             },
                             {"title": "In the next release", "value": "resolved:inNextRelease"},
                         ],
-                    }
+                    },
                 ],
                 "actions": [
                     {
@@ -461,6 +462,11 @@ def build_group_actions(group, event, rules, integration):
                 "type": "AdaptiveCard",
                 "body": [
                     {
+                        "type": "TextBlock",
+                        "text": "Ignore until this happens again...",
+                        "weight": "Bolder",
+                    },
+                    {
                         "type": "Input.ChoiceSet",
                         "id": "ignoreInput",
                         "choices": [
@@ -471,7 +477,7 @@ def build_group_actions(group, event, rules, integration):
                             {"title": "1,000 times", "value": 1000},
                             {"title": "10,000 times", "value": 10000},
                         ],
-                    }
+                    },
                 ],
                 "actions": [
                     {
@@ -519,64 +525,48 @@ def build_group_actions(group, event, rules, integration):
         }
 
     return {
-        "type": "ColumnSet",
-        "columns": [
-            {
-                "type": "Column",
-                "items": [{"type": "ActionSet", "actions": [resolve_action]}],
-                "width": "stretch",
-            },
-            {
-                "type": "Column",
-                "items": [{"type": "ActionSet", "actions": [ignore_action]}],
-                "width": "stretch",
-            },
-            {
-                "type": "Column",
-                "items": [{"type": "ActionSet", "actions": [assign_action]}],
-                "width": "stretch",
-            },
-        ],
+        "type": "Container",
+        "items": [{"type": "ActionSet", "actions": [resolve_action, ignore_action, assign_action]}],
     }
 
 
 def build_group_resolve_card(group, event, rules, integration):
-    title_card = {
-        "type": "TextBlock",
-        "size": "Large",
-        "text": "Resolve",
-        "weight": "Bolder",
-        "id": "resolveTitle",
-        "isVisible": False,
-    }
-
-    return [title_card]
+    return [
+        {
+            "type": "TextBlock",
+            "size": "Large",
+            "text": "Resolve",
+            "weight": "Bolder",
+            "id": "resolveTitle",
+            "isVisible": False,
+        }
+    ]
 
 
 def build_group_ignore_card(group, event, rules, integration):
-    title_card = {
-        "type": "TextBlock",
-        "size": "Large",
-        "text": "Ignore until this happens again...",
-        "weight": "Bolder",
-        "id": "ignoreTitle",
-        "isVisible": False,
-    }
-
-    return [title_card]
+    return [
+        {
+            "type": "TextBlock",
+            "size": "Large",
+            "text": "Ignore until this happens again...",
+            "weight": "Bolder",
+            "id": "ignoreTitle",
+            "isVisible": False,
+        }
+    ]
 
 
 def build_group_assign_card(group, event, rules, integration):
-    title_card = {
-        "type": "TextBlock",
-        "size": "Large",
-        "text": "Assign to...",
-        "weight": "Bolder",
-        "id": "assignTitle",
-        "isVisible": False,
-    }
-
-    return [title_card]
+    return [
+        {
+            "type": "TextBlock",
+            "size": "Large",
+            "text": "Assign to...",
+            "weight": "Bolder",
+            "id": "assignTitle",
+            "isVisible": False,
+        }
+    ]
 
 
 def build_group_action_cards(group, event, rules, integration):
@@ -617,9 +607,6 @@ def build_group_card(group, event, rules, integration):
 
     actions = build_group_actions(group, event, rules, integration)
     body.append(actions)
-
-    # action_cards = build_group_action_cards(group, event, rules, integration)
-    # body.append(action_cards)
 
     return {
         "type": "AdaptiveCard",

--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -407,47 +407,6 @@ def build_group_footer(group, rules, project, event):
 def build_group_actions(group, event, rules, integration):
     status = group.get_status()
 
-    # These targets are made so that the button will toggle its element
-    # on or off, and toggle the other elements off.
-
-    # Could probably be done in much fewer lines if we deep
-    # copied a template and then modified for each action
-    resolve_targets = [
-        {"elementId": "resolveTitle"},
-        {"elementId": "resolveInput"},
-        {"elementId": "resolveSubmit"},
-        {"elementId": "ignoreTitle", "isVisible": False},
-        {"elementId": "ignoreInput", "isVisible": False},
-        {"elementId": "ignoreSubmit", "isVisible": False},
-        {"elementId": "assignTitle", "isVisible": False},
-        {"elementId": "assignInput", "isVisible": False},
-        {"elementId": "assignSubmit", "isVisible": False},
-    ]
-
-    ignore_targets = [
-        {"elementId": "resolveTitle", "isVisible": False},
-        {"elementId": "resolveInput", "isVisible": False},
-        {"elementId": "resolveSubmit", "isVisible": False},
-        {"elementId": "ignoreTitle"},
-        {"elementId": "ignoreInput"},
-        {"elementId": "ignoreSubmit"},
-        {"elementId": "assignTitle", "isVisible": False},
-        {"elementId": "assignInput", "isVisible": False},
-        {"elementId": "assignSubmit", "isVisible": False},
-    ]
-
-    assign_targets = [
-        {"elementId": "resolveTitle", "isVisible": False},
-        {"elementId": "resolveInput", "isVisible": False},
-        {"elementId": "resolveSubmit", "isVisible": False},
-        {"elementId": "ignoreTitle", "isVisible": False},
-        {"elementId": "ignoreInput", "isVisible": False},
-        {"elementId": "ignoreSubmit", "isVisible": False},
-        {"elementId": "assignTitle"},
-        {"elementId": "assignInput"},
-        {"elementId": "assignSubmit"},
-    ]
-
     if status == GroupStatus.RESOLVED:
         resolve_action = {
             "type": "Action.Submit",
@@ -456,9 +415,35 @@ def build_group_actions(group, event, rules, integration):
         }
     else:
         resolve_action = {
-            "type": "Action.ToggleVisibility",
+            "type": "Action.ShowCard",
+            "version": "1.2",
             "title": "Resolve",
-            "targetElements": resolve_targets,
+            "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                    {
+                        "type": "Input.ChoiceSet",
+                        "id": "resolveInput",
+                        "choices": [
+                            {"title": "Immediately", "value": "resolved"},
+                            {
+                                "title": "In the current release",
+                                "value": "resolved:inCurrentRelease",
+                            },
+                            {"title": "In the next release", "value": "resolved:inNextRelease"},
+                        ],
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "Resolve",
+                        "data": generate_action_payload(
+                            ACTION_TYPE.RESOLVE, event, rules, integration
+                        ),
+                    }
+                ],
+            },
         }
 
     if status == GroupStatus.IGNORED:
@@ -469,9 +454,35 @@ def build_group_actions(group, event, rules, integration):
         }
     else:
         ignore_action = {
-            "type": "Action.ToggleVisibility",
+            "type": "Action.ShowCard",
+            "version": "1.2",
             "title": "Ignore",
-            "targetElements": ignore_targets,
+            "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                    {
+                        "type": "Input.ChoiceSet",
+                        "id": "ignoreInput",
+                        "choices": [
+                            {"title": "Ignore indefinitely", "value": -1},
+                            {"title": "1 time", "value": 1},
+                            {"title": "10 times", "value": 10},
+                            {"title": "100 times", "value": 100},
+                            {"title": "1,000 times", "value": 1000},
+                            {"title": "10,000 times", "value": 10000},
+                        ],
+                    }
+                ],
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "Ignore",
+                        "data": generate_action_payload(
+                            ACTION_TYPE.IGNORE, event, rules, integration
+                        ),
+                    }
+                ],
+            },
         }
 
     if get_assignee_string(group):
@@ -481,11 +492,30 @@ def build_group_actions(group, event, rules, integration):
             "data": generate_action_payload(ACTION_TYPE.UNASSIGN, event, rules, integration),
         }
     else:
-        assign_text = "Assign"
+        teams_list = group.project.teams.all().order_by("slug")
+        teams = [
+            {"title": u"#{}".format(u.slug), "value": u"team:{}".format(u.id)} for u in teams_list
+        ]
+        teams = [{"title": "Me", "value": ME}] + teams
         assign_action = {
-            "type": "Action.ToggleVisibility",
-            "title": assign_text,
-            "targetElements": assign_targets,
+            "type": "Action.ShowCard",
+            "version": "1.2",
+            "title": "Assign",
+            "card": {
+                "type": "AdaptiveCard",
+                "body": [
+                    {"type": "Input.ChoiceSet", "id": "assignInput", "value": ME, "choices": teams}
+                ],
+                "actions": [
+                    {
+                        "type": "Action.Submit",
+                        "title": "Assign",
+                        "data": generate_action_payload(
+                            ACTION_TYPE.ASSIGN, event, rules, integration
+                        ),
+                    }
+                ],
+            },
         }
 
     return {
@@ -494,17 +524,17 @@ def build_group_actions(group, event, rules, integration):
             {
                 "type": "Column",
                 "items": [{"type": "ActionSet", "actions": [resolve_action]}],
-                "width": "auto",
+                "width": "stretch",
             },
             {
                 "type": "Column",
                 "items": [{"type": "ActionSet", "actions": [ignore_action]}],
-                "width": "auto",
+                "width": "stretch",
             },
             {
                 "type": "Column",
                 "items": [{"type": "ActionSet", "actions": [assign_action]}],
-                "width": "auto",
+                "width": "stretch",
             },
         ],
     }
@@ -520,32 +550,7 @@ def build_group_resolve_card(group, event, rules, integration):
         "isVisible": False,
     }
 
-    input_card = {
-        "type": "Input.ChoiceSet",
-        "value": "resolved",
-        "id": "resolveInput",
-        "isVisible": False,
-        "choices": [
-            {"title": "Immediately", "value": "resolved"},
-            {"title": "In the current release", "value": "resolved:inCurrentRelease"},
-            {"title": "In the next release", "value": "resolved:inNextRelease"},
-        ],
-    }
-
-    submit_card = {
-        "type": "ActionSet",
-        "id": "resolveSubmit",
-        "isVisible": False,
-        "actions": [
-            {
-                "type": "Action.Submit",
-                "title": "Resolve",
-                "data": generate_action_payload(ACTION_TYPE.RESOLVE, event, rules, integration),
-            }
-        ],
-    }
-
-    return [title_card, input_card, submit_card]
+    return [title_card]
 
 
 def build_group_ignore_card(group, event, rules, integration):
@@ -558,41 +563,10 @@ def build_group_ignore_card(group, event, rules, integration):
         "isVisible": False,
     }
 
-    input_card = {
-        "type": "Input.ChoiceSet",
-        "value": -1,
-        "id": "ignoreInput",
-        "isVisible": False,
-        "choices": [
-            {"title": "Ignore indefinitely", "value": -1},
-            {"title": "1 time", "value": 1},
-            {"title": "10 times", "value": 10},
-            {"title": "100 times", "value": 100},
-            {"title": "1,000 times", "value": 1000},
-            {"title": "10,000 times", "value": 10000},
-        ],
-    }
-
-    submit_card = {
-        "type": "ActionSet",
-        "id": "ignoreSubmit",
-        "isVisible": False,
-        "actions": [
-            {
-                "type": "Action.Submit",
-                "title": "Ignore",
-                "data": generate_action_payload(ACTION_TYPE.IGNORE, event, rules, integration),
-            }
-        ],
-    }
-
-    return [title_card, input_card, submit_card]
+    return [title_card]
 
 
 def build_group_assign_card(group, event, rules, integration):
-    teams_list = group.project.teams.all().order_by("slug")
-    teams = [{"title": u"#{}".format(u.slug), "value": u"team:{}".format(u.id)} for u in teams_list]
-    teams = [{"title": "Me", "value": ME}] + teams
     title_card = {
         "type": "TextBlock",
         "size": "Large",
@@ -602,28 +576,7 @@ def build_group_assign_card(group, event, rules, integration):
         "isVisible": False,
     }
 
-    input_card = {
-        "type": "Input.ChoiceSet",
-        "id": "assignInput",
-        "value": ME,
-        "isVisible": False,
-        "choices": teams,
-    }
-
-    submit_card = {
-        "type": "ActionSet",
-        "id": "assignSubmit",
-        "isVisible": False,
-        "actions": [
-            {
-                "type": "Action.Submit",
-                "title": "Assign",
-                "data": generate_action_payload(ACTION_TYPE.ASSIGN, event, rules, integration),
-            }
-        ],
-    }
-
-    return [title_card, input_card, submit_card]
+    return [title_card]
 
 
 def build_group_action_cards(group, event, rules, integration):
@@ -665,8 +618,8 @@ def build_group_card(group, event, rules, integration):
     actions = build_group_actions(group, event, rules, integration)
     body.append(actions)
 
-    action_cards = build_group_action_cards(group, event, rules, integration)
-    body.append(action_cards)
+    # action_cards = build_group_action_cards(group, event, rules, integration)
+    # body.append(action_cards)
 
     return {
         "type": "AdaptiveCard",
@@ -690,6 +643,8 @@ def build_linking_card(url):
     }
     return {
         "type": "AdaptiveCard",
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.2",
         "body": [desc],
         "actions": [button],
     }

--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -330,7 +330,13 @@ def build_group_title(group):
     link = group.get_absolute_url()
 
     title_text = u"[{}]({})".format(text, link)
-    return {"type": "TextBlock", "size": "Large", "weight": "Bolder", "text": title_text}
+    return {
+        "type": "TextBlock",
+        "size": "Large",
+        "weight": "Bolder",
+        "text": title_text,
+        "wrap": True,
+    }
 
 
 def build_group_descr(group):
@@ -339,7 +345,13 @@ def build_group_descr(group):
     if ev_type == "error":
         ev_metadata = group.get_event_metadata()
         text = ev_metadata.get("value") or ev_metadata.get("function")
-        return {"type": "TextBlock", "size": "Medium", "weight": "Bolder", "text": text}
+        return {
+            "type": "TextBlock",
+            "size": "Medium",
+            "weight": "Bolder",
+            "text": text,
+            "wrap": True,
+        }
     else:
         return None
 


### PR DESCRIPTION
Based on a customer ticket, update the MSTeams integration to look better on mobile (while preserving how it looks on desktop) by removing duplicated buttons and allowing for text wrap. It's unclear exactly _why_ the submit buttons were appearing on mobile (I found a single mention of the problem on [Stack Overflow](https://stackoverflow.com/questions/60089939/can-we-set-isvisiblefalse-for-buttonsaction-submit-in-adaptive-card-designe) with no resolution except a suggestion to use `ShowCard`), we were using [Action.ToggleVisibility](https://adaptivecards.io/explorer/TextBlock.html) to show and hide the dropdowns and submit buttons, but on mobile they were not respecting `isVisible: False` in most cases. I rewrote the schema to use [Action.ShowCard](https://adaptivecards.io/explorer/Action.ShowCard.html) and had to use a `Container` rather than the previously used `ColumnSet` for the actions as they were resizing the width of the action buttons to the width of the dropdown and it looked really ugly/not like it was before (I have a screenshot of that if desired, but this is already image heavy). I also added the version to the card in `build_linking_card` since it wasn't showing up at all on mobile.

### Buttons 
**Before - Mobile**
Previously the submit buttons would show up when we didn't want them to:
![mobile-before-1](https://user-images.githubusercontent.com/29959063/104778153-c5e40080-5731-11eb-8e60-b6b0d212b599.jpg)

**After - Mobile**
![mobile-after-1](https://user-images.githubusercontent.com/29959063/104778257-edd36400-5731-11eb-9227-da031eb98b38.jpg)

The desktop view looks very slightly different when the dropdowns and submit buttons are shown - 
**Before - Desktop**
![desktop-before-resolving](https://user-images.githubusercontent.com/29959063/104778638-879b1100-5732-11eb-87f2-8a3d14eb5569.png)

**After -Desktop**
![desktop-after-3](https://user-images.githubusercontent.com/29959063/104778678-9da8d180-5732-11eb-8e46-c110809e3de3.png)

### Text Wrap
The customer also complained about the text being cut off so I implemented text wrapping. This looks the same on mobile so the screenshots are just from desktop.

**Before - Exception**
![text-wrap-before-1](https://user-images.githubusercontent.com/29959063/104779021-350e2480-5733-11eb-9c8a-aa6c6b77b077.png)

**After - Exception**
![text-wrap-after-2](https://user-images.githubusercontent.com/29959063/104779052-422b1380-5733-11eb-9ff0-6f426f8828c4.png)

**Before - Message**
![text-wrap-before-2](https://user-images.githubusercontent.com/29959063/104779069-49522180-5733-11eb-89e8-cf39691a8177.png)

**After - Message**
![text-wrap-after-1](https://user-images.githubusercontent.com/29959063/104779085-50792f80-5733-11eb-8699-7600f781214f.png)
