### PR TITLE
fix(dashboards): Preserve global header selection when navigating to Dashboards

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -494,7 +494,12 @@ class Sidebar extends React.Component<Props, State> {
         <SidebarItem
           {...sidebarItemProps}
           index
-          onClick={this.hidePanel}
+          onClick={(_id, evt) =>
+            this.navigateWithGlobalSelection(
+              `/organizations/${organization.slug}/dashboards/`,
+              evt
+            )
+          }
           icon={<IconGraph size="md" />}
           label={t('Dashboards')}
           to={`/organizations/${organization.slug}/dashboards/`}

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -97,7 +97,7 @@ class DashboardDetail extends React.Component<Props, State> {
   };
 
   onDelete = (dashboard: State['modifiedDashboard']) => () => {
-    const {api, organization} = this.props;
+    const {api, organization, location} = this.props;
     if (!dashboard?.id) {
       return;
     }
@@ -115,7 +115,9 @@ class DashboardDetail extends React.Component<Props, State> {
 
             browserHistory.replace({
               pathname: `/organizations/${organization.slug}/dashboards/`,
-              query: {},
+              query: {
+                ...location.query,
+              },
             });
           })
           .catch(() => {

--- a/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
@@ -69,7 +69,7 @@ class OrgDashboards extends AsyncComponent<Props, State> {
   }
 
   onRequestSuccess({stateKey, data}) {
-    const {params, organization} = this.props;
+    const {params, organization, location} = this.props;
     if (params.dashboardId || stateKey === 'selectedDashboard') {
       return;
     }
@@ -78,7 +78,12 @@ class OrgDashboards extends AsyncComponent<Props, State> {
     // we can redirect to the first dashboard in the list.
     const dashboardId = data.length ? data[0].id : 'default-overview';
     const url = `/organizations/${organization.slug}/dashboards/${dashboardId}/`;
-    browserHistory.replace({pathname: url});
+    browserHistory.replace({
+      pathname: url,
+      query: {
+        ...location.query,
+      },
+    });
   }
 
   renderBody() {


### PR DESCRIPTION
Also preserved query strings when:
- redirecting to the default prebuilt dashboard
- after deleting a dashboard