### PR TITLE
fix(histograms): Remove aggregate conditions from histogram query

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -996,8 +996,6 @@ def histogram_query(
         orderby=[histogram_alias],
         limit=len(fields) * num_buckets,
         referrer=referrer,
-        auto_fields=True,
-        use_aggregate_conditions=True,
         functions_acl=["array_join", "histogram"],
     )
 
@@ -1094,9 +1092,6 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
         params=params,
         limit=1,
         referrer="api.organization-events-histogram-min-max",
-        auto_fields=True,
-        auto_aggregations=True,
-        use_aggregate_conditions=True,
     )
 
     data = results.get("data")

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -719,3 +719,25 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
         ]
 
         assert response.data == self.as_response_data(expected)
+
+    def test_histogram_ignores_aggregate_conditions(self):
+        # range is [0, 5), so it is divided into 5 buckets of width 1
+        specs = [
+            (0, 1, [("measurements.foo", 1)]),
+            (1, 2, [("measurements.foo", 1)]),
+            (2, 3, [("measurements.foo", 1)]),
+            (3, 4, [("measurements.foo", 0)]),
+            (4, 5, [("measurements.foo", 1)]),
+        ]
+        self.populate_measurements(specs)
+
+        query = {
+            "project": [self.project.id],
+            "field": ["measurements.foo"],
+            "numBuckets": 5,
+            "query": "tpm():>0.001",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200
+        assert response.data == self.as_response_data(specs)


### PR DESCRIPTION
Histogram queries should not allow aggregate conditions. This change removes
them from the query.