### PR TITLE
fix(jira glance view): Make links open in a new tab

### DIFF
--- a/src/sentry/templates/sentry/integrations/jira-issue.html
+++ b/src/sentry/templates/sentry/integrations/jira-issue.html
@@ -47,7 +47,7 @@
 
       <div>
         <h2>{{ type }}</h2>
-        <p><a href="{{ title_url }}">{{title}}</a></p>
+        <p><a href="{{ title_url }}" target="_blank">{{title}}</a></p>
         <br />
         <div class="aui-group">
           <div class="aui-item">
@@ -86,7 +86,7 @@
         </div>
         <div class="aui-item">
           <span class="right-grid"
-            ><a href="{{ first_release_url}}">{{first_release}}</a></span
+            ><a href="{{ first_release_url}}" target="_blank">{{first_release}}</a></span
           >
         </div>
       </div>
@@ -115,7 +115,7 @@
         </div>
         <div class="aui-item">
           <span class="right-grid"
-            ><a href="{{ last_release_url}}">{{last_release}}</a></span
+            ><a href="{{ last_release_url}}" target="_blank">{{last_release}}</a></span
           >
         </div>
       </div>


### PR DESCRIPTION
Add `target="_blank"` to force links in the Jira glance view to open in a new tab since they aren't going to load in the tiny iframe anyway. 