### PR TITLE
ref: Add nodestore stats for reprocessing payloads

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -450,7 +450,7 @@ class EventManager(object):
             job["event_metrics"][key] = old_bytes + attachment.size
 
         _nodestore_save_many(jobs)
-        save_unprocessed_event(project, job["event"].event_id, cache_key)
+        save_unprocessed_event(project, job["event"].event_id)
 
         if job["release"]:
             if job["is_new"]:

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -450,7 +450,7 @@ class EventManager(object):
             job["event_metrics"][key] = old_bytes + attachment.size
 
         _nodestore_save_many(jobs)
-        save_unprocessed_event(project, event_id=job["event"].event_id)
+        save_unprocessed_event(project, job["event"].event_id, cache_key)
 
         if job["release"]:
             if job["is_new"]:

--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -39,8 +39,9 @@ class BaseEventProcessingStore(object):
 
     def delete_by_key(self, key):
         self.inner.delete(key)
-        self.inner.delete(_get_unprocessed_key(key))
 
-    def delete(self, event):
+    def delete(self, event, unprocessed=False):
         key = cache_key_for_event(event)
+        if unprocessed:
+            key = _get_unprocessed_key(key)
         self.delete_by_key(key)

--- a/src/sentry/nodestore/bigtable/backend.py
+++ b/src/sentry/nodestore/bigtable/backend.py
@@ -17,6 +17,7 @@ from sentry.nodestore.base import NodeStorage
 # Cache an instance of the encoder we want to use
 json_dumps = json.JSONEncoder(
     separators=(",", ":"),
+    sort_keys=True,
     skipkeys=False,
     ensure_ascii=True,
     check_circular=True,

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -86,15 +86,15 @@ import six
 
 from django.conf import settings
 
-from sentry import nodestore, features, eventstore
+from sentry import nodestore, features, eventstore, options
 from sentry.attachments import CachedAttachment, attachment_cache
 from sentry import models
 from sentry.utils import snuba
 from sentry.utils.safe import set_path, get_path
-from sentry.utils.cache import cache_key_for_event
 from sentry.utils.redis import redis_clusters
 from sentry.eventstore.processing import event_processing_store
 from sentry.deletions.defaults.group import DIRECT_GROUP_RELATED_MODELS
+from sentry.eventstore.processing.base import _get_unprocessed_key
 
 logger = logging.getLogger("sentry.reprocessing")
 
@@ -111,7 +111,7 @@ def _generate_unprocessed_event_node_id(project_id, event_id):
     ).hexdigest()
 
 
-def save_unprocessed_event(project, event_id):
+def save_unprocessed_event(project, event_id, cache_key):
     """
     Move event from event_processing_store into nodestore. Only call if event
     has outcome=accepted.
@@ -122,9 +122,7 @@ def save_unprocessed_event(project, event_id):
     with sentry_sdk.start_span(
         op="sentry.reprocessing2.save_unprocessed_event.get_unprocessed_event"
     ):
-        data = event_processing_store.get(
-            cache_key_for_event({"project": project.id, "event_id": event_id}), unprocessed=True
-        )
+        data = event_processing_store.get(cache_key, unprocessed=True)
         if data is None:
             return
 
@@ -133,16 +131,43 @@ def save_unprocessed_event(project, event_id):
         nodestore.set(node_id, data)
 
 
+def _should_capture_nodestore_stats(event_id):
+    """
+    Computes a sample rate consistent per-event ID.
+
+    event IDs are assumed to be random, so this is like random sampling but
+    gives the same value for the same event ID.
+    """
+
+    try:
+        assert event_id
+        rate = options.get("store.nodestore-stats-sample-rate") or 0
+        return (int(event_id, 16) % 10000) < (rate * 10000)
+    except Exception:
+        logger.exception("nodestore-stats.error")
+        return False
+
+
+def spawn_capture_nodestore_stats(cache_key, project_id, event_id):
+    if not _should_capture_nodestore_stats(event_id):
+        event_processing_store.delete_by_key(_get_unprocessed_key(cache_key))
+        return
+
+    from sentry.tasks.reprocessing2 import capture_nodestore_stats
+
+    capture_nodestore_stats.delay(cache_key=cache_key, project_id=project_id, event_id=event_id)
+
+
 def backup_unprocessed_event(project, data):
     """
     Backup unprocessed event payload into redis. Only call if event should be
     able to be reprocessed.
     """
 
-    if not features.has("organizations:reprocessing-v2", project.organization, actor=None):
-        return
-
-    event_processing_store.store(data, unprocessed=True)
+    if features.has(
+        "organizations:reprocessing-v2", project.organization, actor=None
+    ) or _should_capture_nodestore_stats(data.get("event_id")):
+        event_processing_store.store(data, unprocessed=True)
 
 
 def delete_unprocessed_events(project_id, event_ids):

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1,24 +1,20 @@
 from __future__ import absolute_import, print_function
 
-import six
 import logging
 import sentry_sdk
-import random
-import zstandard
 
-from sentry import features, options
+from sentry import features
 from sentry.app import locks
 from sentry.utils.cache import cache
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.exceptions import PluginError
 from sentry.signals import event_processed, issue_unignored
 from sentry.tasks.base import instrumented_task
-from sentry.utils import metrics, json
+from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 from sentry.utils.sdk import set_current_project, bind_organization_context
 
 logger = logging.getLogger("sentry")
-nodestore_stats_logger = logging.getLogger("sentry.nodestore.stats")
 
 
 def _get_service_hooks(project_id):
@@ -248,7 +244,10 @@ def post_process_group(
         bind_organization_context(event.project.organization)
 
         _capture_stats(event, is_new)
-        _spawn_capture_nodestore_stats(event)
+
+        from sentry.reprocessing2 import spawn_capture_nodestore_stats
+
+        spawn_capture_nodestore_stats(cache_key, event.project_id, event.event_id)
 
         if event.group_id and is_reprocessed and is_new:
             add_group_to_inbox(event.group, GroupInboxReason.REPROCESSED)
@@ -416,71 +415,3 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
         expected_errors=(PluginError,),
         **kwargs
     )
-
-
-def _spawn_capture_nodestore_stats(event):
-    rate = options.get("store.nodestore-stats-sample-rate") or 0
-    metrics.timing("eventstore.compressor.sample_rate", rate)
-
-    if not rate:
-        return
-
-    if random.random() >= rate:
-        return
-
-    capture_nodestore_stats.delay(project_id=event.project_id, event_id=event.event_id)
-
-
-def _json_size(data):
-    bytestring = json.dumps(data, sort_keys=True).encode("utf8")
-    cctx = zstandard.ZstdCompressor()
-    return len(cctx.compress(bytestring))
-
-
-@instrumented_task(name="sentry.tasks.post_process.capture_nodestore_stats")
-def capture_nodestore_stats(project_id, event_id):
-    set_current_project(project_id)
-
-    from sentry import nodestore
-    from sentry.eventstore.compressor import deduplicate
-    from sentry.eventstore.models import Event
-
-    node_id = Event.generate_node_id(project_id, event_id)
-    data = nodestore.get(node_id)
-
-    if not data:
-        metrics.incr("eventstore.compressor.error", tags={"reason": "no_data"})
-        return
-
-    old_event_size = _json_size(data)
-    new_data, extra_keys = deduplicate(dict(data))
-    total_size = event_size = _json_size(new_data)
-
-    for key, value in six.iteritems(extra_keys):
-        if nodestore.get(key) is not None:
-            metrics.incr("eventstore.compressor.hits")
-            # do not continue, nodestore.set() should bump TTL
-        else:
-            metrics.incr("eventstore.compressor.misses")
-            total_size += _json_size(value)
-
-        # key is md5sum of content
-        # do not store actual value to keep prod impact to a minimum
-        nodestore.set(key, {})
-
-    metrics.timing("events.size.deduplicated", event_size)
-    metrics.timing("events.size.deduplicated.total_written", total_size)
-
-    metrics.timing("events.size.deduplicated.ratio", event_size / old_event_size)
-    metrics.timing("events.size.deduplicated.total_written.ratio", total_size / old_event_size)
-
-    if total_size > old_event_size:
-        nodestore_stats_logger.info(
-            "events.size.deduplicated.details",
-            extra={
-                "project_id": project_id,
-                "event_id": event_id,
-                "total_size": total_size,
-                "old_event_size": old_event_size,
-            },
-        )

--- a/src/sentry/tasks/reprocessing2.py
+++ b/src/sentry/tasks/reprocessing2.py
@@ -1,16 +1,24 @@
 from __future__ import absolute_import
 
 import time
+import logging
+import six
+import zstandard
 
 from django.db import transaction
 
 from sentry import eventstore, eventstream, models, nodestore
 from sentry.eventstore.models import Event
 from sentry.utils.query import celery_run_batch_query
-
+from sentry.utils import metrics
+from sentry.utils.sdk import set_current_project
+from sentry.eventstore.processing import event_processing_store
 from sentry.tasks.base import instrumented_task, retry
+from sentry.eventstore.processing.base import _get_unprocessed_key
 
 GROUP_REPROCESSING_CHUNK_SIZE = 100
+
+nodestore_stats_logger = logging.getLogger("sentry.nodestore.stats")
 
 
 @instrumented_task(
@@ -162,3 +170,84 @@ def finish_reprocessing(project_id, group_id):
     from sentry import similarity
 
     similarity.delete(None, group)
+
+
+def _json_size(*json_blobs):
+    from sentry.nodestore.bigtable.backend import json_dumps
+
+    bytestring = b"\n".join(json_dumps(data).encode("utf8") for data in json_blobs)
+    cctx = zstandard.ZstdCompressor()
+    return len(cctx.compress(bytestring))
+
+
+@instrumented_task(name="sentry.tasks.reprocessing2.capture_nodestore_stats")
+def capture_nodestore_stats(cache_key, project_id, event_id):
+    set_current_project(project_id)
+
+    from sentry.eventstore.compressor import deduplicate
+    from sentry.eventstore.models import Event
+
+    node_id = Event.generate_node_id(project_id, event_id)
+    data = nodestore.get(node_id)
+
+    if not data:
+        metrics.incr("eventstore.compressor.error", tags={"reason": "no_data"})
+        return
+
+    old_event_size = _json_size(data)
+
+    unprocessed_data = event_processing_store.get(_get_unprocessed_key(cache_key))
+    event_processing_store.delete_by_key(_get_unprocessed_key(cache_key))
+
+    if unprocessed_data:
+        metrics.incr("nodestore_stats.with_reprocessing")
+
+        concatenated_size = _json_size(data, unprocessed_data)
+        metrics.timing("events.size.concatenated", concatenated_size)
+        metrics.timing("events.size.concatenated.ratio", concatenated_size / old_event_size)
+
+        _data = dict(data)
+        _data["__nodestore_reprocessing"] = unprocessed_data
+        simple_concatenated_size = _json_size(_data)
+        metrics.timing("events.size.simple_concatenated", simple_concatenated_size)
+        metrics.timing(
+            "events.size.simple_concatenated.ratio", simple_concatenated_size / old_event_size
+        )
+    else:
+        metrics.incr("nodestore_stats.without_reprocessing")
+
+    tags = {"with_reprocessing": bool(unprocessed_data)}
+
+    new_data, extra_keys = deduplicate(dict(data))
+    total_size = event_size = _json_size(new_data)
+
+    for key, value in six.iteritems(extra_keys):
+        if nodestore.get(key) is not None:
+            metrics.incr("eventstore.compressor.hits", tags=tags)
+            # do not continue, nodestore.set() should bump TTL
+        else:
+            metrics.incr("eventstore.compressor.misses", tags=tags)
+            total_size += _json_size(value)
+
+        # key is md5sum of content
+        # do not store actual value to keep prod impact to a minimum
+        nodestore.set(key, {})
+
+    metrics.timing("events.size.deduplicated", event_size, tags=tags)
+    metrics.timing("events.size.deduplicated.total_written", total_size, tags=tags)
+
+    metrics.timing("events.size.deduplicated.ratio", event_size / old_event_size, tags=tags)
+    metrics.timing(
+        "events.size.deduplicated.total_written.ratio", total_size / old_event_size, tags=tags
+    )
+
+    if total_size > old_event_size:
+        nodestore_stats_logger.info(
+            "events.size.deduplicated.details",
+            extra={
+                "project_id": project_id,
+                "event_id": event_id,
+                "total_size": total_size,
+                "old_event_size": old_event_size,
+            },
+        )


### PR DESCRIPTION
Modify processing pipeline to write unprocessed event into Redis if
either condition is met:

* the project has reprocessing feature enabled
* nodestore-stats sampling decision is true

However, only based on the first condition the additional payload is
written into nodestore, and only based on the second condition the stats
task is spawned. For this to work, stats-sampling has been changed to be
consistent per event ID instead of using random.random.

Other changes:

* stats task now uses the same json encoder as the bigtable nodestore
  backend

* stats task now captures how reprocessing payload concatenated to
  regular payload would compress. This comes in two flavors:
  Concatenation of two json objects, and "concatenation" by nesting one
  json object into the other. The latter is likely inferior but would be
  easier to implement given current abstraction layers.

* **the bigtable backend now sorts dict keys before encoding** to get
  more predictable compression (not necessarily better compression)