### PR TITLE
fix(sessions): Avoid internal errors with no projects or unbalanced s…

### DIFF
--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -365,13 +365,14 @@ def massage_sessions_result(query, result_totals, result_timeseries):
         }
 
     groups = []
-    for key, totals in total_groups.items():
+    keys = set(total_groups.keys()) | set(timeseries_groups.keys())
+    for key in keys:
         by = dict(key)
 
         group = {
             "by": by,
-            "totals": make_totals(totals, by),
-            "series": make_timeseries(timeseries_groups[key], by),
+            "totals": make_totals(total_groups.get(key, [None]), by),
+            "series": make_timeseries(timeseries_groups.get(key, []), by),
         }
 
         groups.append(group)

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -12,7 +12,7 @@ from sentry.snuba.sessions_v2 import (
 
 
 def _make_query(qs):
-    return QueryDefinition(QueryDict(qs), {})
+    return QueryDefinition(QueryDict(qs), [])
 
 
 def result_sorted(result):
@@ -70,6 +70,75 @@ def test_virtual_groupby_query():
         "users_errored",
     ]
     assert query.query_groupby == []
+
+
+@freeze_time("2020-12-18T11:14:17.105Z")
+def test_massage_empty():
+    query = _make_query("statsPeriod=1d&interval=1d&field=sum(session)")
+
+    result_totals = []
+    result_timeseries = []
+
+    expected_result = {
+        "query": "",
+        "intervals": ["2020-12-18T00:00:00Z"],
+        "groups": [],
+    }
+
+    actual_result = result_sorted(massage_sessions_result(query, result_totals, result_timeseries))
+
+    assert actual_result == expected_result
+
+
+@freeze_time("2020-12-18T11:14:17.105Z")
+def test_massage_unbalanced_results():
+    query = _make_query("statsPeriod=1d&interval=1d&field=sum(session)&groupBy=release")
+
+    result_totals = [
+        {"release": "test-example-release", "sessions": 1},
+    ]
+    result_timeseries = []
+
+    expected_result = {
+        "query": "",
+        "intervals": ["2020-12-18T00:00:00Z"],
+        "groups": [
+            {
+                "by": {"release": "test-example-release"},
+                "series": {"sum(session)": [0]},
+                "totals": {"sum(session)": 1},
+            }
+        ],
+    }
+
+    actual_result = result_sorted(massage_sessions_result(query, result_totals, result_timeseries))
+
+    assert actual_result == expected_result
+
+    result_totals = []
+    result_timeseries = [
+        {
+            "release": "test-example-release",
+            "sessions": 1,
+            "bucketed_started": "2020-12-18T00:00:00+00:00",
+        },
+    ]
+
+    expected_result = {
+        "query": "",
+        "intervals": ["2020-12-18T00:00:00Z"],
+        "groups": [
+            {
+                "by": {"release": "test-example-release"},
+                "series": {"sum(session)": [1]},
+                "totals": {"sum(session)": 0},
+            }
+        ],
+    }
+
+    actual_result = result_sorted(massage_sessions_result(query, result_totals, result_timeseries))
+
+    assert actual_result == expected_result
 
 
 @freeze_time("2020-12-18T11:14:17.105Z")


### PR DESCRIPTION
…nuba results

This fixes SENTRY-MBZ, returning an error message when no projects are accessible and defaults to all accessible projects fon non-super users.

Also fixes SENTRY-MD5, which I think is the result of skew between the totals/timeseries, which are run as two seperate queries and can thus return unbalanced data (groups).