### PR TITLE
fix(perf): Histogram query should not error on nan duration percentiles

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1122,10 +1122,17 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
                 first_quartile = row[q1_alias]
                 third_quartile = row[q3_alias]
 
-                if first_quartile is not None and third_quartile is not None:
-                    interquartile_range = abs(third_quartile - first_quartile)
-                    upper_outer_fence = third_quartile + 3 * interquartile_range
-                    fences.append(upper_outer_fence)
+                if (
+                    first_quartile is None
+                    or third_quartile is None
+                    or math.isnan(first_quartile)
+                    or math.isnan(third_quartile)
+                ):
+                    continue
+
+                interquartile_range = abs(third_quartile - first_quartile)
+                upper_outer_fence = third_quartile + 3 * interquartile_range
+                fences.append(upper_outer_fence)
 
         max_fence_value = max(fences) if fences else None
 

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -741,3 +741,23 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
         response = self.do_request(query)
         assert response.status_code == 200
         assert response.data == self.as_response_data(specs)
+
+    def test_histogram_outlier_filtering_with_no_rows(self):
+        specs = [
+            (0, 1, [("transaction.duration", 0)]),
+            (1, 2, [("transaction.duration", 0)]),
+            (2, 3, [("transaction.duration", 0)]),
+            (3, 4, [("transaction.duration", 0)]),
+            (4, 5, [("transaction.duration", 0)]),
+        ]
+
+        query = {
+            "project": [self.project.id],
+            "field": ["transaction.duration"],
+            "numBuckets": 5,
+            "dataFilter": "exclude_outliers",
+        }
+
+        response = self.do_request(query)
+        assert response.status_code == 200
+        assert response.data == self.as_response_data(specs)


### PR DESCRIPTION
When generating the duration histogram with outlier filtering, if no rows remain
after applying the query conditions, the percentile column can return `NaN`.
This change makes sure to handle this case and not error.

Fixes SENTRY-MCD