### PR TITLE
fix(issues): Use optional chaining when iterating on projects that might be undefined

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -200,7 +200,7 @@ class GroupDetails extends React.Component<Props, State> {
 
       const projects = organization.projects;
       const projectId = data.project.id;
-      const features = projects.find(proj => proj.id === projectId)?.features ?? [];
+      const features = projects?.find(proj => proj.id === projectId)?.features ?? [];
       // Check for the reprocessing-v2 feature flag
       const hasReprocessingV2Feature = features.includes('reprocessing-v2');
       const reprocessingStatus = getGroupReprocessingStatus(data);


### PR DESCRIPTION
Projects on the organization payload may be undefined since it has a lightweight org shape.

Fixes JAVASCRIPT-23K4