### PR TITLE
fix: Initialize project and team reflux stores only after API calls are finished

### DIFF
--- a/tests/js/spec/actionCreators/organization.spec.jsx
+++ b/tests/js/spec/actionCreators/organization.spec.jsx
@@ -3,9 +3,9 @@ import * as OrganizationsActionCreator from 'app/actionCreators/organizations';
 import OrganizationActions from 'app/actions/organizationActions';
 import ProjectActions from 'app/actions/projectActions';
 import TeamActions from 'app/actions/teamActions';
+import OrganizationStore from 'app/stores/organizationStore';
 import ProjectsStore from 'app/stores/projectsStore';
 import TeamStore from 'app/stores/teamStore';
-import OrganizationStore from 'app/stores/organizationStore';
 
 describe('OrganizationActionCreator', function () {
   const detailedOrg = TestStubs.Organization({


### PR DESCRIPTION
There is a race condition whereby if the org API call (i.e. `/organizations/${slug}/`) is completed after the projects and teams reflux stores are populated, then the org will be missing the projects and teams data. 

This was a regression from https://github.com/getsentry/sentry/pull/23123 in an attempt to parallelize the API calls of the organization, projects, and teams.

Before  https://github.com/getsentry/sentry/pull/23123 , projects and teams were guaranteed to load after the org was loaded. 

This PR fixes this by keeping the parallelization of the API calls, but maintain the guarantee that the projects and teams are loaded into reflux after the organization was loaded into reflux. 