### PR TITLE
fix(ui): removed extra word spacing from search terms

### DIFF
--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -1305,7 +1305,6 @@ const StyledInput = styled('input')`
   background: transparent;
   border: 0;
   outline: none;
-  word-spacing: ${space(0.5)};
   font-size: ${p => p.theme.fontSizeMedium};
   width: 100%;
   height: 40px;


### PR DESCRIPTION
I tried to fix the bad spacing between search terms with CSS alone but I hadn’t considered that you can search for messages `"just like this"`. Today that looks busted so I'm reverting these changes for now until I can think of a better solution.