### PR TITLE
fix(perf): Format p75 card better

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/utils.tsx
@@ -76,7 +76,7 @@ export const backendCardDetails = {
   p75: {
     title: 'Duration (p75)',
     tooltip: 'Duration (p75)',
-    formatter: value => getDuration(value / 1000, 3, true),
+    formatter: value => getDuration(value / 1000, value >= 1000 ? 3 : 0, true),
   },
   tpm: {
     title: 'Throughput',


### PR DESCRIPTION
Currently, the p75 is formatted with 3 decimal places. When it is less than 1
second, this makes for 3 additional 0s. This change ensures that it only shows
decimals when it is greater than 1 second.