### PR TITLE
fix(jira): Add coop directive

### DIFF
--- a/src/sentry/integrations/jira/base_hook.py
+++ b/src/sentry/integrations/jira/base_hook.py
@@ -11,9 +11,8 @@ class JiraBaseHook(View):
     def get_response(self, context):
         context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
         res = render_to_response(self.html_file, context, self.request)
-        # we aren't actually displaying it on the same page but we don't want to set it to deny
-        # which security.py will do
-        res["X-Frame-Options"] = "SAMEORIGIN"
+        # COOP blocks the Jira glance view links from opening
+        res["Cross-Origin-Opener-Policy"] = "same-origin-allow-popups"
         res["Content-Security-Policy"] = u"frame-ancestors 'self' %s %s" % (
             self.request.GET["xdm_e"],
             options.get("system.url-prefix"),


### PR DESCRIPTION
Adds a cross origin opener policy directive to the Jira base hook so that we can open links from the Jira glance view iframe. https://github.com/getsentry/getsentry/pull/4954#pullrequestreview-571630274 was recently added to allow us to override this option. Also remove the deprecated `X-Frame-Options`. 