### PR TITLE
fix(perf): Histogram uses nice bin values

### DIFF
--- a/src/sentry/utils/math.py
+++ b/src/sentry/utils/math.py
@@ -34,21 +34,23 @@ def mad(values, K=1.4826):
 
 def nice_int(x):
     """
-    Round up to the nearest "nice" number.
+    Round away from zero to the nearest "nice" number.
     """
 
     if x == 0:
         return 0
 
-    exp = int(math.log10(x))
+    sign = 1 if x > 0 else -1
+    x = abs(x)
 
     if x < 10:
-        rounded = 10 ** exp
+        rounded = 1
         steps = [1, 2, 5, 10]
     elif x < 100:
-        rounded = 10 ** (exp - 1)
+        rounded = 1
         steps = [10, 20, 25, 50, 100]
     else:
+        exp = int(math.log10(x))
         rounded = 10 ** (exp - 2)
         steps = [100, 120, 200, 250, 500, 750, 1000]
 
@@ -59,4 +61,4 @@ def nice_int(x):
             nice_frac = step
             break
 
-    return nice_frac * rounded
+    return sign * nice_frac * rounded

--- a/src/sentry/utils/math.py
+++ b/src/sentry/utils/math.py
@@ -30,3 +30,33 @@ def mad(values, K=1.4826):
     # http://en.wikipedia.org/wiki/Median_absolute_deviation
     med = median(values)
     return K * median([abs(val - med) for val in values])
+
+
+def nice_int(x):
+    """
+    Round up to the nearest "nice" number.
+    """
+
+    if x == 0:
+        return 0
+
+    exp = int(math.log10(x))
+
+    if x < 10:
+        rounded = 10 ** exp
+        steps = [1, 2, 5, 10]
+    elif x < 100:
+        rounded = 10 ** (exp - 1)
+        steps = [10, 20, 25, 50, 100]
+    else:
+        rounded = 10 ** (exp - 2)
+        steps = [100, 120, 200, 250, 500, 750, 1000]
+
+    nice_frac = steps[-1]
+    frac = x / rounded
+    for step in steps:
+        if frac <= step:
+            nice_frac = step
+            break
+
+    return nice_frac * rounded

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -2068,12 +2068,12 @@ class QueryTransformTest(TestCase):
         assert discover.find_histogram_params(10, 0, 9, 1) == (10, 1, 0, 1)
         assert discover.find_histogram_params(10, 0, 10, 1) == (10, 2, 0, 1)
         assert discover.find_histogram_params(10, 0, 99, 1) == (10, 10, 0, 1)
-        assert discover.find_histogram_params(10, 0, 100, 1) == (10, 11, 0, 1)
-        assert discover.find_histogram_params(5, 10, 19, 10) == (5, 19, 100, 10)
+        assert discover.find_histogram_params(10, 0, 100, 1) == (10, 20, 0, 1)
+        assert discover.find_histogram_params(5, 10, 19, 10) == (5, 20, 100, 10)
         assert discover.find_histogram_params(5, 10, 19.9, 10) == (5, 20, 100, 10)
         assert discover.find_histogram_params(10, 10, 20, 1) == (10, 2, 10, 1)
-        assert discover.find_histogram_params(10, 10, 20, 10) == (10, 11, 100, 10)
-        assert discover.find_histogram_params(10, 10, 20, 100) == (10, 101, 1000, 100)
+        assert discover.find_histogram_params(10, 10, 20, 10) == (10, 20, 100, 10)
+        assert discover.find_histogram_params(10, 10, 20, 100) == (10, 120, 1000, 100)
 
     def test_normalize_histogram_results_empty(self):
         results = {

--- a/tests/sentry/utils/test_math.py
+++ b/tests/sentry/utils/test_math.py
@@ -1,0 +1,53 @@
+from __future__ import absolute_import
+
+from sentry.utils.math import nice_int
+
+
+def linspace(start, stop, n):
+    if n == 1:
+        yield stop
+    else:
+        h = (stop - start) / (n - 1)
+        for i in range(n):
+            yield start + h * i
+
+
+def test_nice_int():
+    specs = [
+        (0, 1, 0),
+        (1, 2, 1),
+        (2, 3, 2),
+        (3, 6, 5),
+        (6, 11, 10),
+        (11, 21, 20),
+        (21, 26, 25),
+        (26, 51, 50),
+        (51, 101, 100),
+        (101, 121, 120),
+        (121, 201, 200),
+        (201, 251, 250),
+        (251, 501, 500),
+        (501, 751, 750),
+        (751, 1001, 1000),
+        (1001, 1201, 1200),
+        (1201, 2001, 2000),
+        (2001, 2501, 2500),
+        (2501, 5001, 5000),
+        (5001, 7501, 7500),
+        (7501, 10001, 10000),
+        (10001, 12001, 12000),
+        (12001, 20001, 20000),
+        (20001, 25001, 25000),
+        (25001, 50001, 50000),
+        (50001, 75001, 75000),
+        (75001, 100001, 100000),
+    ]
+
+    for start, stop, expected in specs:
+        for x in range(start, stop):
+            assert nice_int(x) == expected, "{} was rounded to {}, not {}".format(
+                x, nice_int(x), expected
+            )
+            assert nice_int(-x) == -expected, "{} was rounded to {}, not {}".format(
+                -x, nice_int(-x), -expected
+            )

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -248,8 +248,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
         }
 
     def test_histogram_empty(self):
-        specs = [(i, i + 1, [("measurements.foo", 0), ("measurements.bar", 0)]) for i in range(5)]
-
         query = {
             "project": [self.project.id],
             "field": ["measurements.foo", "measurements.bar"],
@@ -258,7 +256,10 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (i, i + 1, [("measurements.foo", 0), ("measurements.bar", 0)]) for i in range(5)
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_simple(self):
         # range is [0, 5), so it is divided into 5 buckets of width 1
@@ -266,7 +267,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             (0, 1, [("measurements.foo", 1)]),
             (1, 2, [("measurements.foo", 1)]),
             (2, 3, [("measurements.foo", 1)]),
-            (3, 4, [("measurements.foo", 0)]),
             (4, 5, [("measurements.foo", 1)]),
         ]
         self.populate_measurements(specs)
@@ -279,7 +279,14 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (0, 1, [("measurements.foo", 1)]),
+            (1, 2, [("measurements.foo", 1)]),
+            (2, 3, [("measurements.foo", 1)]),
+            (3, 4, [("measurements.foo", 0)]),
+            (4, 5, [("measurements.foo", 1)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_simple_using_min_max(self):
         # range is [0, 5), so it is divided into 5 buckets of width 1
@@ -287,7 +294,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             (0, 1, [("measurements.foo", 1)]),
             (1, 2, [("measurements.foo", 1)]),
             (2, 3, [("measurements.foo", 1)]),
-            (3, 4, [("measurements.foo", 0)]),
             (4, 5, [("measurements.foo", 1)]),
         ]
         self.populate_measurements(specs)
@@ -302,21 +308,23 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (0, 1, [("measurements.foo", 1)]),
+            (1, 2, [("measurements.foo", 1)]),
+            (2, 3, [("measurements.foo", 1)]),
+            (3, 4, [("measurements.foo", 0)]),
+            (4, 5, [("measurements.foo", 1)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_large_buckets(self):
         # make sure that it works for large width buckets
         # range is [0, 99], so it is divided into 5 buckets of width 20
         specs = [
             (0, 0, [("measurements.foo", 2)]),
-            (20, 40, [("measurements.foo", 0)]),
-            (40, 60, [("measurements.foo", 0)]),
-            (60, 80, [("measurements.foo", 0)]),
             (99, 99, [("measurements.foo", 2)]),
         ]
         self.populate_measurements(specs)
-        specs[0] = (0, 20, specs[0][2])
-        specs[4] = (80, 100, specs[4][2])
 
         query = {
             "project": [self.project.id],
@@ -326,13 +334,19 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (0, 20, [("measurements.foo", 2)]),
+            (20, 40, [("measurements.foo", 0)]),
+            (40, 60, [("measurements.foo", 0)]),
+            (60, 80, [("measurements.foo", 0)]),
+            (80, 100, [("measurements.foo", 2)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_non_zero_offset(self):
         # range is [10, 15), so it is divided into 5 buckets of width 1
         specs = [
             (10, 11, [("measurements.foo", 1)]),
-            (11, 12, [("measurements.foo", 0)]),
             (12, 13, [("measurements.foo", 1)]),
             (13, 14, [("measurements.foo", 1)]),
             (14, 15, [("measurements.foo", 1)]),
@@ -347,7 +361,14 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (10, 11, [("measurements.foo", 1)]),
+            (11, 12, [("measurements.foo", 0)]),
+            (12, 13, [("measurements.foo", 1)]),
+            (13, 14, [("measurements.foo", 1)]),
+            (14, 15, [("measurements.foo", 1)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_extra_data(self):
         # range is [11, 16), so it is divided into 5 buckets of width 1
@@ -362,8 +383,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             (16, 17, [("measurements.foo", 1)]),
         ]
         self.populate_measurements(specs)
-        del specs[-1]
-        del specs[0]
 
         query = {
             "project": [self.project.id],
@@ -375,20 +394,23 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (11, 12, [("measurements.foo", 1)]),
+            (12, 13, [("measurements.foo", 1)]),
+            (13, 14, [("measurements.foo", 1)]),
+            (14, 15, [("measurements.foo", 1)]),
+            (15, 16, [("measurements.foo", 1)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_non_zero_min_large_buckets(self):
         # range is [10, 59], so it is divided into 5 buckets of width 10
         specs = [
             (10, 10, [("measurements.foo", 1)]),
-            (20, 30, [("measurements.foo", 0)]),
-            (30, 40, [("measurements.foo", 0)]),
             (40, 50, [("measurements.foo", 1)]),
             (59, 59, [("measurements.foo", 2)]),
         ]
         self.populate_measurements(specs)
-        specs[0] = (10, 20, specs[0][2])
-        specs[4] = (50, 60, specs[4][2])
 
         query = {
             "project": [self.project.id],
@@ -398,16 +420,20 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (10, 20, [("measurements.foo", 1)]),
+            (20, 30, [("measurements.foo", 0)]),
+            (30, 40, [("measurements.foo", 0)]),
+            (40, 50, [("measurements.foo", 1)]),
+            (50, 60, [("measurements.foo", 2)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     @pytest.mark.xfail(reason="snuba does not allow - in alias names")
     def test_histogram_negative_values(self):
         # range is [-9, -4), so it is divided into 5 buckets of width 1
         specs = [
             (-9, -8, [("measurements.foo", 3)]),
-            (-8, -7, [("measurements.foo", 0)]),
-            (-7, -6, [("measurements.foo", 0)]),
-            (-6, -5, [("measurements.foo", 0)]),
             (-5, -4, [("measurements.foo", 1)]),
         ]
         self.populate_measurements(specs)
@@ -420,21 +446,24 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (-9, -8, [("measurements.foo", 3)]),
+            (-8, -7, [("measurements.foo", 0)]),
+            (-7, -6, [("measurements.foo", 0)]),
+            (-6, -5, [("measurements.foo", 0)]),
+            (-5, -4, [("measurements.foo", 1)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     @pytest.mark.xfail(reason="snuba does not allow - in alias names")
     def test_histogram_positive_and_negative_values(self):
         # range is [-50, 49], so it is divided into 5 buckets of width 10
         specs = [
             (-50, -50, [("measurements.foo", 1)]),
-            (-30, -10, [("measurements.foo", 0)]),
             (-10, 10, [("measurements.foo", 2)]),
-            (10, 30, [("measurements.foo", 0)]),
             (49, 49, [("measurements.foo", 1)]),
         ]
         self.populate_measurements(specs)
-        specs[0] = (-50, -30, specs[0][2])
-        specs[4] = (30, 50, specs[4][2])
 
         query = {
             "project": [self.project.id],
@@ -444,20 +473,22 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (-50, -30, [("measurements.foo", 1)]),
+            (-30, -10, [("measurements.foo", 0)]),
+            (-10, 10, [("measurements.foo", 2)]),
+            (10, 30, [("measurements.foo", 0)]),
+            (30, 50, [("measurements.foo", 1)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_increased_precision(self):
         # range is [1.00, 2.24], so it is divided into 5 buckets of width 0.25
         specs = [
             (1.00, 1.00, [("measurements.foo", 3)]),
-            (1.25, 1.50, [("measurements.foo", 0)]),
-            (1.50, 1.75, [("measurements.foo", 0)]),
-            (1.75, 2.00, [("measurements.foo", 0)]),
             (2.24, 2.24, [("measurements.foo", 1)]),
         ]
         self.populate_measurements(specs)
-        specs[0] = (1.00, 1.25, specs[0][2])
-        specs[4] = (2.00, 2.25, specs[4][2])
 
         query = {
             "project": [self.project.id],
@@ -468,20 +499,22 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (1.00, 1.25, [("measurements.foo", 3)]),
+            (1.25, 1.50, [("measurements.foo", 0)]),
+            (1.50, 1.75, [("measurements.foo", 0)]),
+            (1.75, 2.00, [("measurements.foo", 0)]),
+            (2.00, 2.25, [("measurements.foo", 1)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_increased_precision_with_min_max(self):
         # range is [1.25, 2.24], so it is divided into 5 buckets of width 0.25
         specs = [
             (1.00, 1.25, [("measurements.foo", 3)]),
-            (1.25, 1.25, [("measurements.foo", 0)]),
-            (1.50, 1.75, [("measurements.foo", 0)]),
-            (1.75, 1.75, [("measurements.foo", 0)]),
             (2.00, 2.25, [("measurements.foo", 1)]),
         ]
         self.populate_measurements(specs)
-        specs[1] = (1.25, 1.50, specs[1][2])
-        specs[3] = (1.75, 2.00, specs[1][2])
 
         query = {
             "project": [self.project.id],
@@ -494,20 +527,21 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs[1:4])
+        expected = [
+            (1.25, 1.50, [("measurements.foo", 0)]),
+            (1.50, 1.75, [("measurements.foo", 0)]),
+            (1.75, 2.00, [("measurements.foo", 0)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_increased_precision_large_buckets(self):
         # range is [10.0000, 59.9999] so it is divided into 5 buckets of width 10
         specs = [
             (10.0000, 10.0000, [("measurements.foo", 1)]),
-            (20.0000, 30.0000, [("measurements.foo", 0)]),
             (30.0000, 40.0000, [("measurements.foo", 1)]),
-            (40.0000, 50.0000, [("measurements.foo", 0)]),
             (59.9999, 59.9999, [("measurements.foo", 2)]),
         ]
         self.populate_measurements(specs)
-        specs[0] = (10.0000, 20.0000, specs[0][2])
-        specs[4] = (50.0000, 60.0000, specs[4][2])
 
         query = {
             "project": [self.project.id],
@@ -518,20 +552,23 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (10.0000, 20.0000, [("measurements.foo", 1)]),
+            (20.0000, 30.0000, [("measurements.foo", 0)]),
+            (30.0000, 40.0000, [("measurements.foo", 1)]),
+            (40.0000, 50.0000, [("measurements.foo", 0)]),
+            (50.0000, 60.0000, [("measurements.foo", 2)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_multiple_measures(self):
         # range is [10, 59] so it is divided into 5 buckets of width 10
         specs = [
             (10, 10, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
-            (20, 30, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
             (30, 40, [("measurements.bar", 2), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (40, 50, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
             (59, 59, [("measurements.bar", 0), ("measurements.baz", 1), ("measurements.foo", 0)]),
         ]
         self.populate_measurements(specs)
-        specs[0] = (10, 20, specs[0][2])
-        specs[4] = (50, 60, specs[4][2])
 
         query = {
             "project": [self.project.id],
@@ -541,16 +578,21 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (10, 20, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
+            (20, 30, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
+            (30, 40, [("measurements.bar", 2), ("measurements.baz", 0), ("measurements.foo", 0)]),
+            (40, 50, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
+            (50, 60, [("measurements.bar", 0), ("measurements.baz", 1), ("measurements.foo", 0)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_max_value_on_edge(self):
-        # range is [11, 21] so it is divided into 5 buckets of width 3
-        # because using buckets of width 2 will exclude 21
+        # range is [11, 21] so it is divided into 5 buckets of width 5
+        # because using buckets of width 2 will exclude 21, and the next
+        # nice number is 5
         specs = [
             (11, 11, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
-            (13, 15, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (15, 17, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (17, 19, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
             (21, 21, [("measurements.bar", 1), ("measurements.baz", 1), ("measurements.foo", 1)]),
         ]
         self.populate_measurements(specs)
@@ -561,27 +603,23 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             "numBuckets": 5,
         }
 
-        specs = [
-            (11, 14, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
-            (14, 17, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (17, 20, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (20, 23, [("measurements.bar", 1), ("measurements.baz", 1), ("measurements.foo", 1)]),
-            (23, 26, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-        ]
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (10, 15, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
+            (15, 20, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
+            (20, 25, [("measurements.bar", 1), ("measurements.baz", 1), ("measurements.foo", 1)]),
+            (25, 30, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
+            (30, 35, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_bins_exceed_max(self):
         specs = [
-            (10, 13, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
-            (13, 16, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (16, 19, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (19, 22, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (24, 24, [("measurements.bar", 1), ("measurements.baz", 1), ("measurements.foo", 1)]),
+            (10, 15, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
+            (30, 30, [("measurements.bar", 1), ("measurements.baz", 1), ("measurements.foo", 1)]),
         ]
         self.populate_measurements(specs)
-        specs[4] = (22, 25, specs[4][2])
 
         query = {
             "project": [self.project.id],
@@ -593,7 +631,14 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = [
+            (10, 15, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
+            (15, 20, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
+            (20, 25, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
+            (25, 30, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
+            (30, 35, [("measurements.bar", 1), ("measurements.baz", 1), ("measurements.foo", 1)]),
+        ]
+        assert response.data == self.as_response_data(expected)
 
     def test_bad_params_invalid_data_filter(self):
         query = {
@@ -612,7 +657,7 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
     def test_histogram_all_data_filter(self):
         specs = [
             (0, 1, [("measurements.foo", 4)]),
-            (4000, 4001, [("measurements.foo", 1)]),
+            (4000, 5000, [("measurements.foo", 1)]),
         ]
         self.populate_measurements(specs)
 
@@ -625,15 +670,13 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-
         expected = [
-            (0, 1, [("measurements.foo", 4)]),
-            (801, 801, [("measurements.foo", 0)]),
-            (1602, 1602, [("measurements.foo", 0)]),
-            (2403, 2403, [("measurements.foo", 0)]),
-            (3204, 4001, [("measurements.foo", 1)]),
+            (0, 1000, [("measurements.foo", 4)]),
+            (1000, 2000, [("measurements.foo", 0)]),
+            (2000, 3000, [("measurements.foo", 0)]),
+            (3000, 4000, [("measurements.foo", 0)]),
+            (4000, 5000, [("measurements.foo", 1)]),
         ]
-
         assert response.data == self.as_response_data(expected)
 
     def test_histogram_exclude_outliers_data_filter(self):
@@ -652,7 +695,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-
         expected = [
             (0, 1, [("measurements.foo", 4)]),
             (1, 1, [("measurements.foo", 0)]),
@@ -660,7 +702,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             (3, 3, [("measurements.foo", 0)]),
             (4, 4, [("measurements.foo", 0)]),
         ]
-
         assert response.data == self.as_response_data(expected)
 
     def test_histogram_missing_measurement_data(self):
@@ -680,7 +721,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-
         expected = [
             (0, 1, [("measurements.bar", 0)]),
             (1, 1, [("measurements.bar", 0)]),
@@ -688,7 +728,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             (3, 3, [("measurements.bar", 0)]),
             (4, 4, [("measurements.bar", 0)]),
         ]
-
         assert response.data == self.as_response_data(expected)
 
     def test_histogram_missing_measurement_data_with_explicit_bounds(self):
@@ -709,7 +748,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-
         expected = [
             (10, 11, [("measurements.bar", 0)]),
             (11, 11, [("measurements.bar", 0)]),
@@ -717,7 +755,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             (13, 13, [("measurements.bar", 0)]),
             (14, 14, [("measurements.bar", 0)]),
         ]
-
         assert response.data == self.as_response_data(expected)
 
     def test_histogram_ignores_aggregate_conditions(self):
@@ -740,7 +777,8 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = specs
+        assert response.data == self.as_response_data(expected)
 
     def test_histogram_outlier_filtering_with_no_rows(self):
         specs = [
@@ -760,4 +798,5 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        assert response.data == self.as_response_data(specs)
+        expected = specs
+        assert response.data == self.as_response_data(expected)


### PR DESCRIPTION
Histograms currently use the min value as the starting bin and an arbitrary
value as the bin width. This usually means that the resulting bins are difficult
to understand at a glance. This change rounds the bins to use some numbers that
are perceived to be nice.