### PR TITLE
fix(msteams): Handle no resolve or ignore input

### DIFF
--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -267,16 +267,17 @@ class MsTeamsWebhookEndpoint(Endpoint):
         if action_type == ACTION_TYPE.UNRESOLVE:
             action_data = {"status": "unresolved"}
         elif action_type == ACTION_TYPE.RESOLVE:
-            status = data["resolveInput"]
-            # status might look something like "resolved:inCurrentRelease" or just "resolved"
-            status_data = status.split(":", 1)
-            resolve_type = status_data[-1]
+            status = data.get("resolveInput")
+            if status:
+                # status might look something like "resolved:inCurrentRelease" or just "resolved"
+                status_data = status.split(":", 1)
+                resolve_type = status_data[-1]
 
-            action_data = {"status": "resolved"}
-            if resolve_type == "inNextRelease":
-                action_data.update({"statusDetails": {"inNextRelease": True}})
-            elif resolve_type == "inCurrentRelease":
-                action_data.update({"statusDetails": {"inRelease": "latest"}})
+                action_data = {"status": "resolved"}
+                if resolve_type == "inNextRelease":
+                    action_data.update({"statusDetails": {"inNextRelease": True}})
+                elif resolve_type == "inCurrentRelease":
+                    action_data.update({"statusDetails": {"inRelease": "latest"}})
         elif action_type == ACTION_TYPE.IGNORE:
             action_data = {"status": "ignored"}
             ignore_count = int(data["ignoreInput"])

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -279,10 +279,11 @@ class MsTeamsWebhookEndpoint(Endpoint):
                 elif resolve_type == "inCurrentRelease":
                     action_data.update({"statusDetails": {"inRelease": "latest"}})
         elif action_type == ACTION_TYPE.IGNORE:
-            action_data = {"status": "ignored"}
-            ignore_count = int(data["ignoreInput"])
-            if ignore_count > 0:
-                action_data.update({"statusDetails": {"ignoreCount": ignore_count}})
+            ignore_count = data.get("ignoreInput")
+            if ignore_count:
+                action_data = {"status": "ignored"}
+                if int(ignore_count) > 0:
+                    action_data.update({"statusDetails": {"ignoreCount": int(ignore_count)}})
         elif action_type == ACTION_TYPE.ASSIGN:
             assignee = data["assignInput"]
             if assignee == "ME":

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -167,6 +167,15 @@ class StatusActionTest(BaseEventTest):
 
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
+    def test_no_ignore_input(self, verify):
+        resp = self.post_webhook(action_type=ACTION_TYPE.IGNORE, ignore_input="")
+        self.group1 = Group.objects.get(id=self.group1.id)
+
+        assert resp.status_code == 200, resp.content
+        assert self.group1.get_status() == GroupStatus.UNRESOLVED
+
+    @responses.activate
+    @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_ignore_issue_with_additional_user_auth(self, verify):
         auth_idp = AuthProvider.objects.create(organization=self.org, provider="nobody")
         AuthIdentity.objects.create(auth_provider=auth_idp, user=self.user)

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -289,6 +289,16 @@ class StatusActionTest(BaseEventTest):
 
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
+    def test_no_resolve_input(self, verify):
+        resp = self.post_webhook(action_type=ACTION_TYPE.RESOLVE, resolve_input="")
+        self.group1 = Group.objects.get(id=self.group1.id)
+
+        assert resp.status_code == 200, resp.content
+        assert self.group1.get_status() == GroupStatus.UNRESOLVED
+        assert b"Resolve" in responses.calls[0].request.body
+
+    @responses.activate
+    @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_unassign_issue(self, verify):
         GroupAssignee.objects.create(group=self.group1, project=self.project1, user=self.user)
         resp = self.post_webhook(action_type=ACTION_TYPE.UNASSIGN, resolve_input="resolved")


### PR DESCRIPTION
Handle the cases where a user doesn't select anything from the resolve or ignore dropdown in the MSTeams integration, but still hits submit. Fixes [SENTRY-MZD](https://sentry.io/organizations/sentry/issues/2164707380/events/7082f51b96bf41da9587f76eb924b9cb/?project=1&referrer=slack) and [SENTRY-MEB](https://sentry.io/organizations/sentry/issues/2167145000/?project=1&referrer=slack)