### PR TITLE
feat(dashboards) Improve dashboard widget authoring for table widgets

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/simpleTableChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/simpleTableChart.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import PanelTable from 'app/components/panels/panelTable';
+import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {TableData, TableDataRow} from 'app/utils/discover/discoverQuery';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
@@ -42,7 +43,7 @@ class SimpleTableChart extends React.Component<Props> {
     return (
       <TableWrapper>
         {title && <h4>{title}</h4>}
-        <PanelTable
+        <StyledPanelTable
           isLoading={loading}
           headers={columns.map((column, index) => {
             return (
@@ -53,18 +54,27 @@ class SimpleTableChart extends React.Component<Props> {
           })}
         >
           {data.map((row, index) => this.renderRow(index, row, meta, columns))}
-        </PanelTable>
+        </StyledPanelTable>
       </TableWrapper>
     );
   }
 }
 const TableWrapper = styled('div')`
   /* align height with charts */
-  height: 170px;
+  height: 160px;
   overflow-y: scroll;
 
   /* Space away from where the widget title is */
-  margin-top: 30px;
+  margin-top: 40px;
+`;
+
+// Tighten the padding up on the table to make results denser.
+const StyledPanelTable = styled(PanelTable)`
+  > * {
+    font-size: ${p => p.theme.fontSizeSmall};
+    line-height: 1.1;
+    padding: ${space(1)};
+  }
 `;
 
 type HeadCellProps = {

--- a/src/sentry/static/sentry/app/components/charts/simpleTableChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/simpleTableChart.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import PanelTable from 'app/components/panels/panelTable';
-import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {TableData, TableDataRow} from 'app/utils/discover/discoverQuery';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
@@ -15,6 +14,7 @@ type Props = {
   organization: Organization;
   location: Location;
   loading: boolean;
+  fields: string[];
   title: string;
   metadata: TableData['meta'];
   data: TableData['data'];
@@ -37,13 +37,13 @@ class SimpleTableChart extends React.Component<Props> {
   }
 
   render() {
-    const {loading, metadata, data, title} = this.props;
+    const {loading, fields, metadata, data, title} = this.props;
     const meta = metadata ?? {};
-    const columns = decodeColumnOrder(Object.keys(meta).map(col => ({field: col})));
+    const columns = decodeColumnOrder(fields.map(field => ({field})));
     return (
       <TableWrapper>
         {title && <h4>{title}</h4>}
-        <StyledPanelTable
+        <PanelTable
           isLoading={loading}
           headers={columns.map((column, index) => {
             return (
@@ -54,7 +54,7 @@ class SimpleTableChart extends React.Component<Props> {
           })}
         >
           {data.map((row, index) => this.renderRow(index, row, meta, columns))}
-        </StyledPanelTable>
+        </PanelTable>
       </TableWrapper>
     );
   }
@@ -66,15 +66,6 @@ const TableWrapper = styled('div')`
 
   /* Space away from where the widget title is */
   margin-top: 40px;
-`;
-
-// Tighten the padding up on the table to make results denser.
-const StyledPanelTable = styled(PanelTable)`
-  > * {
-    font-size: ${p => p.theme.fontSizeSmall};
-    line-height: 1.1;
-    padding: ${space(1)};
-  }
 `;
 
 type HeadCellProps = {

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -113,12 +113,7 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
         </QueryFieldWrapper>
       ))}
       <div>
-        <Button
-          data-test-id="add-field"
-          size="small"
-          onClick={handleAdd}
-          icon={<IconAdd isCircled />}
-        >
+        <Button size="small" onClick={handleAdd} icon={<IconAdd isCircled />}>
           {t('Add an overlay')}
         </Button>
       </div>

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -1,0 +1,144 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import Button from 'app/components/button';
+import {IconAdd, IconDelete} from 'app/icons';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {
+  explodeField,
+  generateFieldAsString,
+  QueryFieldValue,
+} from 'app/utils/discover/fields';
+import {Widget} from 'app/views/dashboardsV2/types';
+import ColumnEditCollection from 'app/views/eventsV2/table/columnEditCollection';
+import {QueryField} from 'app/views/eventsV2/table/queryField';
+import {generateFieldOptions} from 'app/views/eventsV2/utils';
+import Field from 'app/views/settings/components/forms/field';
+
+type Props = {
+  /**
+   * The widget type. Used to render different fieldsets.
+   */
+  displayType: Widget['displayType'];
+  fieldOptions: ReturnType<typeof generateFieldOptions>;
+  /**
+   * Any errors that need to be rendered.
+   */
+  errors: undefined | Record<string, any>;
+  /**
+   * The field list for the widget.
+   */
+  fields: string[];
+  /**
+   * Fired when fields are added/removed/modified/reordered.
+   */
+  onChange: (fields: string[]) => void;
+};
+
+function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}: Props) {
+  // Handle new fields being added.
+  function handleAdd(event: React.MouseEvent) {
+    event.preventDefault();
+
+    const newFields = [...fields, ''];
+    onChange(newFields);
+  }
+
+  function handleRemove(event: React.MouseEvent, fieldIndex: number) {
+    event.preventDefault();
+
+    const newFields = [...fields];
+    newFields.splice(fieldIndex, fieldIndex + 1);
+    onChange(newFields);
+  }
+
+  function handleChangeField(value: QueryFieldValue, fieldIndex: number) {
+    const newFields = [...fields];
+    newFields[fieldIndex] = generateFieldAsString(value);
+    onChange(newFields);
+  }
+
+  function handleColumnChange(columns: QueryFieldValue[]) {
+    const newFields = columns.map(generateFieldAsString);
+    onChange(newFields);
+  }
+
+  if (displayType === 'table') {
+    return (
+      <Field
+        data-test-id="columns"
+        label="Columns"
+        inline={false}
+        flexibleControlStateSize
+        stacked
+        error={errors?.fields}
+        required
+      >
+        <StyledColumnEditCollection
+          columns={fields.map(field => explodeField({field}))}
+          onChange={handleColumnChange}
+          fieldOptions={fieldOptions}
+        />
+      </Field>
+    );
+  }
+
+  return (
+    <Field
+      data-test-id="y-axis"
+      label={t('Y-Axis')}
+      inline={false}
+      flexibleControlStateSize
+      stacked
+      error={errors?.fields}
+      required
+    >
+      {fields.map((field, i) => (
+        <QueryFieldWrapper key={`${field}:${i}`}>
+          <QueryField
+            fieldValue={explodeField({field})}
+            fieldOptions={fieldOptions}
+            onChange={value => handleChangeField(value, i)}
+          />
+          {fields.length > 1 && (
+            <Button
+              size="zero"
+              borderless
+              onClick={event => handleRemove(event, i)}
+              icon={<IconDelete />}
+              title={t('Remove this overlay')}
+            />
+          )}
+        </QueryFieldWrapper>
+      ))}
+      <div>
+        <Button
+          data-test-id="add-field"
+          size="small"
+          onClick={handleAdd}
+          icon={<IconAdd isCircled />}
+        >
+          {t('Add an overlay')}
+        </Button>
+      </div>
+    </Field>
+  );
+}
+
+const StyledColumnEditCollection = styled(ColumnEditCollection)`
+  margin-top: ${space(1)};
+`;
+
+export const QueryFieldWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: ${space(1)};
+
+  > * + * {
+    margin-left: ${space(1)};
+  }
+`;
+
+export default WidgetQueryFields;

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -30,7 +30,7 @@ type Props = {
    * Fired when fields are added/removed/modified/reordered.
    */
   onChange: (fields: string[]) => void;
-    /**
+  /**
    * Any errors that need to be rendered.
    */
   errors?: Record<string, any>;
@@ -68,7 +68,7 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
     return (
       <Field
         data-test-id="columns"
-        label={t("Columns")}
+        label={t('Columns')}
         inline={false}
         flexibleControlStateSize
         stacked

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -23,10 +23,6 @@ type Props = {
   displayType: Widget['displayType'];
   fieldOptions: ReturnType<typeof generateFieldOptions>;
   /**
-   * Any errors that need to be rendered.
-   */
-  errors: undefined | Record<string, any>;
-  /**
    * The field list for the widget.
    */
   fields: string[];
@@ -34,6 +30,10 @@ type Props = {
    * Fired when fields are added/removed/modified/reordered.
    */
   onChange: (fields: string[]) => void;
+    /**
+   * Any errors that need to be rendered.
+   */
+  errors?: Record<string, any>;
 };
 
 function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}: Props) {
@@ -68,7 +68,7 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
     return (
       <Field
         data-test-id="columns"
-        label="Columns"
+        label={t("Columns")}
         inline={false}
         flexibleControlStateSize
         stacked

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -108,6 +108,7 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
               onClick={event => handleRemove(event, i)}
               icon={<IconDelete />}
               title={t('Remove this overlay')}
+              label={t('Remove this overlay')}
             />
           )}
         </QueryFieldWrapper>

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
@@ -71,7 +71,10 @@ class WidgetQueryForm extends React.Component<Props, State> {
     const {onChange, displayType, widgetQuery} = this.props;
 
     const newQuery = cloneDeep(widgetQuery);
-   newQuery.fields = displayType === 'table' ? [...option.query.fields] : [option.query.yAxis ?? 'count()'];
+    newQuery.fields =
+      displayType === 'table'
+        ? [...option.query.fields]
+        : [option.query.yAxis ?? 'count()'];
     newQuery.conditions = option.query.query ?? '';
     newQuery.name = option.query.name;
     onChange(newQuery);

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
@@ -71,11 +71,7 @@ class WidgetQueryForm extends React.Component<Props, State> {
     const {onChange, displayType, widgetQuery} = this.props;
 
     const newQuery = cloneDeep(widgetQuery);
-    if (displayType === 'table') {
-      newQuery.fields = [...option.query.fields];
-    } else {
-      newQuery.fields = [option.query.yAxis ?? 'count()'];
-    }
+   newQuery.fields = displayType === 'table' ? [...option.query.fields] : [option.query.yAxis ?? 'count()'];
     newQuery.conditions = option.query.query ?? '';
     newQuery.name = option.query.name;
     onChange(newQuery);

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -424,6 +424,8 @@ const WidgetContainer = styled('div')`
 
 const WidgetWrapper = styled('div')`
   position: relative;
+  /* Min-width prevents grid items from stretching the grid */
+  min-width: 200px;
 `;
 
 const AddWidgetWrapper = styled('a')`

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -74,7 +74,7 @@ class WidgetCard extends React.Component<Props> {
     errorMessage,
     tableResults,
   }: TableResultProps): React.ReactNode {
-    const {location} = this.props;
+    const {location, widget} = this.props;
     if (errorMessage) {
       return (
         <ErrorPanel>
@@ -88,11 +88,13 @@ class WidgetCard extends React.Component<Props> {
       return <Placeholder height="200px" />;
     }
 
-    return tableResults.map(result => {
+    return tableResults.map((result, i) => {
+      const fields = widget.queries[i]?.fields ?? [];
       return (
         <SimpleTableChart
-          key={result.title}
+          key={`table:${result.title}`}
           location={location}
+          fields={fields}
           title={tableResults.length > 1 ? result.title : ''}
           loading={loading}
           metadata={result.meta}

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
@@ -116,6 +116,7 @@ class WidgetQueries extends React.Component<Props, State> {
   componentDidUpdate(prevProps: Props) {
     const {selection, widget} = this.props;
     if (
+      !isEqual(widget.displayType, prevProps.widget.displayType) ||
       !isEqual(widget.interval, prevProps.widget.interval) ||
       !isEqual(widget.queries, prevProps.widget.queries) ||
       !isEqual(selection, prevProps.selection)
@@ -133,6 +134,7 @@ class WidgetQueries extends React.Component<Props, State> {
     const {projects, environments} = selection;
 
     if (widget.displayType === 'table') {
+      const tableResults: TableDataWithTitle[] = [];
       // Table and stat widgets use table results and need
       // to do a discover 'table' query instead of a 'timeseries' query.
       this.setState({tableResults: []});
@@ -164,7 +166,7 @@ class WidgetQueries extends React.Component<Props, State> {
 
           completed++;
           this.setState(prevState => {
-            const tableResults = [...prevState.tableResults, tableData];
+            tableResults.push(tableData);
             return {
               ...prevState,
               tableResults,

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
@@ -134,7 +134,7 @@ class WidgetQueries extends React.Component<Props, State> {
     const {projects, environments} = selection;
 
     if (widget.displayType === 'table') {
-      const tableResults: TableDataWithTitle[] = [];
+      let tableResults: TableDataWithTitle[] = [];
       // Table and stat widgets use table results and need
       // to do a discover 'table' query instead of a 'timeseries' query.
       this.setState({tableResults: []});
@@ -164,11 +164,14 @@ class WidgetQueries extends React.Component<Props, State> {
           const tableData = data as TableDataWithTitle;
           tableData.title = widget.queries[i]?.name ?? '';
 
+          // Overwrite the local var to work around state being stale in tests.
+          tableResults = [...tableResults, tableData];
+
           completed++;
           this.setState(prevState => {
             return {
               ...prevState,
-              tableResults: [...tableResults, tableData],
+              tableResults,
               loading: completed === promises.length ? false : true,
             };
           });

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
@@ -166,10 +166,9 @@ class WidgetQueries extends React.Component<Props, State> {
 
           completed++;
           this.setState(prevState => {
-            tableResults.push(tableData);
             return {
               ...prevState,
-              tableResults,
+              tableResults: [...tableResults, tableData],
               loading: completed === promises.length ? false : true,
             };
           });

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -7,7 +7,6 @@ import {SectionHeading} from 'app/components/charts/styles';
 import {IconAdd, IconDelete, IconGrabbable} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
-import {LightWeightOrganization, SelectValue} from 'app/types';
 import {Column} from 'app/utils/discover/fields';
 import theme from 'app/utils/theme';
 import {getPointerPosition} from 'app/utils/touch';
@@ -16,14 +15,11 @@ import {setBodyUserSelect, UserSelectValues} from 'app/utils/userselect';
 import {generateFieldOptions} from '../utils';
 
 import {QueryField} from './queryField';
-import {FieldValue} from './types';
 
 type Props = {
   // Input columns
   columns: Column[];
-  organization: LightWeightOrganization;
-  tagKeys: null | string[];
-  measurementKeys: null | string[];
+  fieldOptions: ReturnType<typeof generateFieldOptions>;
   // Fired when columns are added/removed/modified
   onChange: (columns: Column[]) => void;
 };
@@ -35,8 +31,6 @@ type State = {
   draggingGrabbedOffset: undefined | {x: number; y: number};
   left: undefined | number;
   top: undefined | number;
-  // Stored as a object so we can find elements later.
-  fieldOptions: Record<string, SelectValue<FieldValue>>;
 };
 
 const DRAG_CLASS = 'draggable-item';
@@ -56,7 +50,6 @@ class ColumnEditCollection extends React.Component<Props, State> {
     draggingGrabbedOffset: void 0,
     left: void 0,
     top: void 0,
-    fieldOptions: this.fieldOptions,
   };
 
   componentDidMount() {
@@ -74,15 +67,6 @@ class ColumnEditCollection extends React.Component<Props, State> {
     }
   }
 
-  componentDidUpdate(prevProps: Props) {
-    if (
-      this.props.tagKeys !== prevProps.tagKeys ||
-      this.props.measurementKeys !== prevProps.measurementKeys
-    ) {
-      this.syncFields();
-    }
-  }
-
   componentWillUnmount() {
     if (this.portal) {
       document.body.removeChild(this.portal);
@@ -93,18 +77,6 @@ class ColumnEditCollection extends React.Component<Props, State> {
   previousUserSelect: UserSelectValues | null = null;
   portal: HTMLElement | null = null;
   dragGhostRef = React.createRef<HTMLDivElement>();
-
-  get fieldOptions() {
-    return generateFieldOptions({
-      organization: this.props.organization,
-      tagKeys: this.props.tagKeys,
-      measurementKeys: this.props.measurementKeys,
-    });
-  }
-
-  syncFields() {
-    this.setState({fieldOptions: this.fieldOptions});
-  }
 
   keyForColumn(column: Column, isGhost: boolean): string {
     if (column.kind === 'function') {
@@ -301,7 +273,8 @@ class ColumnEditCollection extends React.Component<Props, State> {
       gridColumns = 2,
     }: {canDelete?: boolean; isGhost?: boolean; gridColumns: number}
   ) {
-    const {isDragging, draggingTargetIndex, draggingIndex, fieldOptions} = this.state;
+    const {fieldOptions} = this.props;
+    const {isDragging, draggingTargetIndex, draggingIndex} = this.state;
 
     let placeholder: React.ReactNode = null;
     // Add a placeholder above the target row.

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditCollection.tsx
@@ -22,6 +22,7 @@ type Props = {
   fieldOptions: ReturnType<typeof generateFieldOptions>;
   // Fired when columns are added/removed/modified
   onChange: (columns: Column[]) => void;
+  className?: string;
 };
 
 type State = {
@@ -338,7 +339,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
   }
 
   render() {
-    const {columns} = this.props;
+    const {className, columns} = this.props;
     const canDelete = columns.length > 1;
     const canAdd = columns.length < MAX_COL_COUNT;
     const title = canAdd
@@ -354,7 +355,7 @@ class ColumnEditCollection extends React.Component<Props, State> {
     );
 
     return (
-      <div>
+      <div className={className}>
         {this.renderGhost(gridColumns)}
         <RowContainer>
           <Heading gridColumns={gridColumns}>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
@@ -57,7 +57,7 @@ class ColumnEditModal extends React.Component<Props, State> {
   render() {
     const {Header, Body, Footer, tagKeys, measurementKeys, organization} = this.props;
     const fieldOptions = generateFieldOptions({
-      organization: this.props.organization,
+      organization,
       tagKeys,
       measurementKeys,
     });

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
@@ -13,6 +13,7 @@ import {LightWeightOrganization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {Column} from 'app/utils/discover/fields';
 import theme from 'app/utils/theme';
+import {generateFieldOptions} from 'app/views/eventsV2/utils';
 
 import ColumnEditCollection from './columnEditCollection';
 
@@ -55,6 +56,11 @@ class ColumnEditModal extends React.Component<Props, State> {
 
   render() {
     const {Header, Body, Footer, tagKeys, measurementKeys, organization} = this.props;
+    const fieldOptions = generateFieldOptions({
+      organization: this.props.organization,
+      tagKeys,
+      measurementKeys,
+    });
     return (
       <React.Fragment>
         <Header>
@@ -75,10 +81,8 @@ class ColumnEditModal extends React.Component<Props, State> {
             )}
           </Instruction>
           <ColumnEditCollection
-            organization={organization}
             columns={this.state.columns}
-            tagKeys={tagKeys}
-            measurementKeys={measurementKeys}
+            fieldOptions={fieldOptions}
             onChange={this.handleChange}
           />
         </Body>

--- a/tests/js/sentry-test/select-new.js
+++ b/tests/js/sentry-test/select-new.js
@@ -34,16 +34,12 @@ export function findOption(wrapper, {value, label} = {}, options) {
 
 export function selectByLabel(wrapper, label, options = {}) {
   openMenu(wrapper, options);
-  findOption(wrapper, {label}, options)
-    .at(options.at || 0)
-    .simulate('click');
+  findOption(wrapper, {label}, options).at(0).simulate('click');
 }
 
 export function selectByValue(wrapper, value, options = {}) {
   openMenu(wrapper, options);
-  findOption(wrapper, {value}, options)
-    .at(options.at || 0)
-    .simulate('click');
+  findOption(wrapper, {value}, options).at(0).simulate('click');
 }
 
 //used for the text input to replicate a user typing

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -133,7 +133,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     });
 
     // Click the add button
-    const add = wrapper.find('Button[data-test-id="add-field"] button');
+    const add = wrapper.find('button[aria-label="Add an overlay"]');
     add.simulate('click');
     wrapper.update();
 

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -32,6 +32,13 @@ describe('Dashboards > WidgetQueries', function () {
     displayType: 'table',
     queries: [{conditions: 'event.type:error', fields: ['sdk.name'], name: 'sdk'}],
   };
+  const selection = {
+    projects: [1],
+    environments: ['prod'],
+    datetime: {
+      period: '14d',
+    },
+  };
 
   const api = new Client();
 
@@ -54,14 +61,6 @@ describe('Dashboards > WidgetQueries', function () {
         },
       }
     );
-    const selection = {
-      projects: [1],
-      environments: ['prod'],
-      datetime: {
-        period: '14d',
-      },
-    };
-
     const wrapper = mountWithTheme(
       <WidgetQueries
         api={api}
@@ -106,14 +105,6 @@ describe('Dashboards > WidgetQueries', function () {
       }
     );
 
-    const selection = {
-      projects: [1],
-      environments: ['prod'],
-      datetime: {
-        period: '14d',
-      },
-    };
-
     let error = '';
     const wrapper = mountWithTheme(
       <WidgetQueries
@@ -144,21 +135,21 @@ describe('Dashboards > WidgetQueries', function () {
       url: '/organizations/org-slug/events-stats/',
       body: [],
     });
-    const selection = {
+    const widget = {...singleQueryWidget, interval: '1m'};
+
+    const longSelection = {
       projects: [1],
       environments: ['prod'],
       datetime: {
         period: '90d',
       },
     };
-    const widget = {...singleQueryWidget, interval: '1m'};
-
     const wrapper = mountWithTheme(
       <WidgetQueries
         api={api}
         widget={widget}
         organization={initialData.organization}
-        selection={selection}
+        selection={longSelection}
       >
         {() => <div data-test-id="child" />}
       </WidgetQueries>,
@@ -182,13 +173,6 @@ describe('Dashboards > WidgetQueries', function () {
       url: '/organizations/org-slug/events-stats/',
       body: [],
     });
-    const selection = {
-      projects: [1],
-      environments: ['prod'],
-      datetime: {
-        period: '14d',
-      },
-    };
     const widget = {...singleQueryWidget, interval: '1m'};
 
     const wrapper = mountWithTheme(
@@ -223,13 +207,6 @@ describe('Dashboards > WidgetQueries', function () {
         data: [{'sdk.name': 'python'}],
       },
     });
-    const selection = {
-      projects: [1],
-      environments: ['prod'],
-      datetime: {
-        period: '14d',
-      },
-    };
 
     let childProps = undefined;
     const wrapper = mountWithTheme(
@@ -255,5 +232,73 @@ describe('Dashboards > WidgetQueries', function () {
     expect(childProps.timeseriesResults).toBeUndefined();
     expect(childProps.tableResults[0].data).toHaveLength(1);
     expect(childProps.tableResults[0].meta).toBeDefined();
+  });
+
+  it('can send multiple table queries', async function () {
+    const firstQuery = MockApiClient.addMockResponse(
+      {
+        url: '/organizations/org-slug/eventsv2/',
+        body: {
+          meta: {'sdk.name': 'string'},
+          data: [{'sdk.name': 'python'}],
+        },
+      },
+      {
+        predicate(_url, options) {
+          return options.query.query === 'event.type:error';
+        },
+      }
+    );
+    const secondQuery = MockApiClient.addMockResponse(
+      {
+        url: '/organizations/org-slug/eventsv2/',
+        body: {
+          meta: {title: 'string'},
+          data: [{title: 'ValueError'}],
+        },
+      },
+      {
+        predicate(_url, options) {
+          return options.query.query === 'title:ValueError';
+        },
+      }
+    );
+
+    const widget = {
+      title: 'SDK',
+      interval: '5m',
+      displayType: 'table',
+      queries: [
+        {conditions: 'event.type:error', fields: ['sdk.name'], name: 'sdk'},
+        {conditions: 'title:ValueError', fields: ['title'], name: 'title'},
+      ],
+    };
+
+    let childProps = undefined;
+    const wrapper = mountWithTheme(
+      <WidgetQueries
+        api={api}
+        widget={widget}
+        organization={initialData.organization}
+        selection={selection}
+      >
+        {props => {
+          childProps = props;
+          return <div data-test-id="child" />;
+        }}
+      </WidgetQueries>,
+      initialData.routerContext
+    );
+    await tick();
+    await tick();
+
+    // Child should be rendered and 2 requests should be sent.
+    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(firstQuery).toHaveBeenCalledTimes(1);
+    expect(secondQuery).toHaveBeenCalledTimes(1);
+
+    expect(childProps.tableResults).toHaveLength(2);
+    expect(childProps.tableResults[0].data[0]['sdk.name']).toBeDefined();
+    expect(childProps.tableResults[1].data[0].title).toBeDefined();
   });
 });


### PR DESCRIPTION
Use the discover column editor to make table widgets work well. Also simplify the column editor to accept fewer props.

Fix a bug in select helpers that would make it impossible to work with anything except the 0th select box.

![Screen Shot 2021-01-20 at 1 01 38 PM](https://user-images.githubusercontent.com/24086/105215828-c9a3c880-5b1f-11eb-9f0c-9f5bda7ae661.png)
