### PR TITLE
ref(stacktrace-link): Hide CTA for gitlab on prem

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -153,7 +153,13 @@ class StacktraceLink extends AsyncComponent<Props, State> {
     const filename = this.props.frame.filename;
     const platform = this.props.event.platform;
 
-    if (this.project && this.integrations.length > 0 && filename) {
+    // filter out self hosted GitLab integrations from getting
+    // the CTA for now
+    const integrations = this.integrations.filter(
+      i => !(!i.domainName.startsWith('gitlab.com') && i.provider.key === 'gitlab')
+    );
+
+    if (this.project && integrations.length > 0 && filename) {
       return (
         <CodeMappingButtonContainer columnQuantity={2}>
           {t('Enable source code stack trace linking by setting up a code mapping.')}

--- a/tests/js/sentry-test/fixtures/gitlabintegration.js
+++ b/tests/js/sentry-test/fixtures/gitlabintegration.js
@@ -1,0 +1,18 @@
+export function GitLabIntegration(params = {}) {
+  return {
+    domainName: 'gitlab.com/test-integration',
+    icon: 'http://example.com/integration_icon.png',
+    id: '1',
+    name: 'Test Integration',
+    provider: {
+      name: 'GitLab',
+      key: 'gitlab',
+      canAdd: true,
+      features: [],
+    },
+    projects: [],
+    configOrganization: [],
+    configData: {},
+    ...params,
+  };
+}

--- a/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
@@ -25,7 +25,7 @@ describe('StacktraceLink', function () {
       query: {file: frame.filename, commitId: 'master', platform},
       body: {config: null, sourceUrl: null, integrations: [integration]},
     });
-    mountWithTheme(
+    const wrapper = mountWithTheme(
       <StacktraceLink
         frame={frame}
         event={event}
@@ -35,6 +35,29 @@ describe('StacktraceLink', function () {
       />,
       TestStubs.routerContext()
     );
+    expect(wrapper.find('CodeMappingButtonContainer').text()).toContain(
+      'Enable source code stack trace linking by setting up a code mapping.'
+    );
+  });
+
+  it('does not render setup CTA with on prem gitlab integration but no configs', async function () {
+    const GitLabIntegration = TestStubs.GitLabIntegration({domainName: 'custom.io'});
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      query: {file: frame.filename, commitId: 'master', platform},
+      body: {config: null, sourceUrl: null, integrations: [GitLabIntegration]},
+    });
+    const wrapper = mountWithTheme(
+      <StacktraceLink
+        frame={frame}
+        event={event}
+        projects={[project]}
+        organization={org}
+        lineNo={frame.lineNo}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.find('CodeMappingButtonContainer').exists()).toBe(false);
   });
 
   it('renders source url link', async function () {


### PR DESCRIPTION
Stack trace linking has not been successful for anyone using a self hosted version of GitLab (anything not on `gitlab.com`). We are still looking into why that is the case, but for GA we want to prevent those users from seeing the call to action, There is no point encouraging them to take an action we know will fail for them.
