### PR TITLE
fix: Optimise Dashboard v2 widget charts

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -146,10 +146,7 @@ class WidgetCard extends React.Component<Props> {
                       errorMessage={errorMessage}
                       loading={loading}
                       location={location}
-                      widget={{
-                        ...widget,
-                        title: '',
-                      }}
+                      widget={widget}
                       selection={selection}
                       router={router}
                     />

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -69,6 +69,193 @@ class WidgetCard extends React.Component<Props> {
     return false;
   }
 
+  renderToolbar() {
+    if (!this.props.isEditing) {
+      return null;
+    }
+
+    if (this.props.hideToolbar) {
+      return <ToolbarPanel />;
+    }
+
+    const {onEdit, onDelete, startWidgetDrag} = this.props;
+
+    return (
+      <ToolbarPanel>
+        <IconContainer data-component="icon-container">
+          <StyledIconGrabbable
+            color="gray500"
+            size="md"
+            onMouseDown={event => startWidgetDrag(event)}
+            onTouchStart={event => startWidgetDrag(event)}
+          />
+          <IconClick
+            data-test-id="widget-edit"
+            onClick={() => {
+              onEdit();
+            }}
+          >
+            <IconEdit color="gray500" size="md" />
+          </IconClick>
+          <IconClick
+            data-test-id="widget-delete"
+            onClick={() => {
+              onDelete();
+            }}
+          >
+            <IconDelete color="gray500" size="md" />
+          </IconClick>
+        </IconContainer>
+      </ToolbarPanel>
+    );
+  }
+
+  render() {
+    const {
+      widget,
+      isDragging,
+      api,
+      organization,
+      selection,
+      renderErrorMessage,
+      location,
+      router,
+    } = this.props;
+    return (
+      <ErrorBoundary
+        customComponent={<ErrorCard>{t('Error loading widget data')}</ErrorCard>}
+      >
+        <StyledPanel isDragging={isDragging}>
+          <WidgetQueries
+            api={api}
+            organization={organization}
+            widget={widget}
+            selection={selection}
+          >
+            {({tableResults, timeseriesResults, errorMessage, loading}) => {
+              return (
+                <React.Fragment>
+                  {typeof renderErrorMessage === 'function'
+                    ? renderErrorMessage(errorMessage)
+                    : null}
+                  <ChartContainer>
+                    <HeaderTitleLegend>{widget.title}</HeaderTitleLegend>
+                    <WidgetCardVisuals
+                      timeseriesResults={timeseriesResults}
+                      tableResults={tableResults}
+                      errorMessage={errorMessage}
+                      loading={loading}
+                      location={location}
+                      widget={{
+                        ...widget,
+                        title: '',
+                      }}
+                      selection={selection}
+                      router={router}
+                    />
+                    {this.renderToolbar()}
+                  </ChartContainer>
+                </React.Fragment>
+              );
+            }}
+          </WidgetQueries>
+        </StyledPanel>
+      </ErrorBoundary>
+    );
+  }
+}
+
+export default withApi(
+  withOrganization(withGlobalSelection(ReactRouter.withRouter(WidgetCard)))
+);
+
+const ErrorCard = styled(Placeholder)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: ${p => p.theme.alert.error.backgroundLight};
+  border: 1px solid ${p => p.theme.alert.error.border};
+  color: ${p => p.theme.alert.error.textLight};
+  border-radius: ${p => p.theme.borderRadius};
+  margin-bottom: ${space(2)};
+`;
+
+const StyledPanel = styled(Panel, {
+  shouldForwardProp: prop => prop !== 'isDragging',
+})<{
+  isDragging: boolean;
+}>`
+  margin: 0;
+  visibility: ${p => (p.isDragging ? 'hidden' : 'visible')};
+`;
+
+const ToolbarPanel = styled('div')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+
+  width: 100%;
+  height: 100%;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  background-color: rgba(255, 255, 255, 0.5);
+`;
+
+const IconContainer = styled('div')`
+  display: flex;
+
+  > * + * {
+    margin-left: 50px;
+  }
+`;
+
+const IconClick = styled('div')`
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+const StyledIconGrabbable = styled(IconGrabbable)`
+  &:hover {
+    cursor: grab;
+  }
+`;
+
+type WidgetCardVisualsProps = Pick<ReactRouter.WithRouterProps, 'router'> &
+  Pick<
+    WidgetQueries['state'],
+    'timeseriesResults' | 'tableResults' | 'errorMessage' | 'loading'
+  > & {
+    location: Location;
+    widget: Widget;
+    selection: GlobalSelection;
+  };
+class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
+  shouldComponentUpdate(nextProps: WidgetCardVisualsProps): boolean {
+    // Widget title changes should not update the WidgetCardVisuals component tree
+    const currentProps = {
+      ...this.props,
+      widget: {
+        ...this.props.widget,
+        title: '',
+      },
+    };
+
+    nextProps = {
+      ...nextProps,
+      widget: {
+        ...nextProps.widget,
+        title: '',
+      },
+    };
+
+    return !isEqual(currentProps, nextProps);
+  }
+
   tableResultComponent({
     loading,
     errorMessage,
@@ -116,16 +303,9 @@ class WidgetCard extends React.Component<Props> {
     }
   }
 
-  renderVisual({
-    tableResults,
-    timeseriesResults,
-    errorMessage,
-    loading,
-  }: Pick<
-    WidgetQueries['state'],
-    'timeseriesResults' | 'tableResults' | 'errorMessage' | 'loading'
-  >): React.ReactNode {
-    const {widget} = this.props;
+  render() {
+    const {tableResults, timeseriesResults, errorMessage, loading, widget} = this.props;
+
     if (widget.displayType === 'table') {
       return (
         <TransitionChart loading={loading} reloading={loading}>
@@ -229,150 +409,4 @@ class WidgetCard extends React.Component<Props> {
       </ChartZoom>
     );
   }
-
-  renderToolbar() {
-    if (!this.props.isEditing) {
-      return null;
-    }
-
-    if (this.props.hideToolbar) {
-      return <ToolbarPanel />;
-    }
-
-    const {onEdit, onDelete, startWidgetDrag} = this.props;
-
-    return (
-      <ToolbarPanel>
-        <IconContainer data-component="icon-container">
-          <StyledIconGrabbable
-            color="gray500"
-            size="md"
-            onMouseDown={event => startWidgetDrag(event)}
-            onTouchStart={event => startWidgetDrag(event)}
-          />
-          <IconClick
-            data-test-id="widget-edit"
-            onClick={() => {
-              onEdit();
-            }}
-          >
-            <IconEdit color="gray500" size="md" />
-          </IconClick>
-          <IconClick
-            data-test-id="widget-delete"
-            onClick={() => {
-              onDelete();
-            }}
-          >
-            <IconDelete color="gray500" size="md" />
-          </IconClick>
-        </IconContainer>
-      </ToolbarPanel>
-    );
-  }
-
-  render() {
-    const {
-      widget,
-      isDragging,
-      api,
-      organization,
-      selection,
-      renderErrorMessage,
-    } = this.props;
-    return (
-      <ErrorBoundary
-        customComponent={<ErrorCard>{t('Error loading widget data')}</ErrorCard>}
-      >
-        <StyledPanel isDragging={isDragging}>
-          <WidgetQueries
-            api={api}
-            organization={organization}
-            widget={widget}
-            selection={selection}
-          >
-            {({tableResults, timeseriesResults, errorMessage, loading}) => {
-              return (
-                <React.Fragment>
-                  {typeof renderErrorMessage === 'function'
-                    ? renderErrorMessage(errorMessage)
-                    : null}
-                  <ChartContainer>
-                    <HeaderTitleLegend>{widget.title}</HeaderTitleLegend>
-                    {this.renderVisual({
-                      timeseriesResults,
-                      tableResults,
-                      errorMessage,
-                      loading,
-                    })}
-                    {this.renderToolbar()}
-                  </ChartContainer>
-                </React.Fragment>
-              );
-            }}
-          </WidgetQueries>
-        </StyledPanel>
-      </ErrorBoundary>
-    );
-  }
 }
-
-export default withApi(
-  withOrganization(withGlobalSelection(ReactRouter.withRouter(WidgetCard)))
-);
-
-const ErrorCard = styled(Placeholder)`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: ${p => p.theme.alert.error.backgroundLight};
-  border: 1px solid ${p => p.theme.alert.error.border};
-  color: ${p => p.theme.alert.error.textLight};
-  border-radius: ${p => p.theme.borderRadius};
-  margin-bottom: ${space(2)};
-`;
-
-const StyledPanel = styled(Panel, {
-  shouldForwardProp: prop => prop !== 'isDragging',
-})<{
-  isDragging: boolean;
-}>`
-  margin: 0;
-  visibility: ${p => (p.isDragging ? 'hidden' : 'visible')};
-`;
-
-const ToolbarPanel = styled('div')`
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 1;
-
-  width: 100%;
-  height: 100%;
-
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  background-color: rgba(255, 255, 255, 0.5);
-`;
-
-const IconContainer = styled('div')`
-  display: flex;
-
-  > * + * {
-    margin-left: 50px;
-  }
-`;
-
-const IconClick = styled('div')`
-  &:hover {
-    cursor: pointer;
-  }
-`;
-
-const StyledIconGrabbable = styled(IconGrabbable)`
-  &:hover {
-    cursor: grab;
-  }
-`;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
@@ -119,6 +119,7 @@ class WidgetQueries extends React.Component<Props, State> {
       !isEqual(widget.displayType, prevProps.widget.displayType) ||
       !isEqual(widget.interval, prevProps.widget.interval) ||
       !isEqual(widget.queries, prevProps.widget.queries) ||
+      !isEqual(widget.displayType, prevProps.widget.displayType) ||
       !isEqual(selection, prevProps.selection)
     ) {
       this.fetchData();


### PR DESCRIPTION
Updating the dashboard widget title (e.g. typing it out) will re-render the echarts chart components on every keystroke; which can cause memory and cpu pressure on the document.

This change moves dashboard widget charts into its own dedicated React component with a `shouldComponentUpdate()` method to re-render only whenever the relevant props has changed.

Also fixes a bug where switching the widget chart types between area/line/bar and table (and vice versa) doesn't refetch the data. Since tables and area/line/bar have different data sources. 