### PR TITLE
fix(databass): Stop using `EventAttachment.file` relation and replace with `file_id` instead.

### DIFF
--- a/src/sentry/api/endpoints/event_attachment_details.py
+++ b/src/sentry/api/endpoints/event_attachment_details.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import
 
 import posixpath
-import six
 
 from django.http import StreamingHttpResponse
 
 from sentry import eventstore, features, roles
 from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
+from sentry.api.serializers import serialize
 from sentry.auth.superuser import is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.constants import ATTACHMENTS_ROLE_DEFAULT
-from sentry.models import EventAttachment, OrganizationMember
+from sentry.models import EventAttachment, File, OrganizationMember
 
 
 class EventAttachmentDetailsPermission(ProjectPermission):
@@ -51,7 +51,7 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
     permission_classes = (EventAttachmentDetailsPermission,)
 
     def download(self, attachment):
-        file = attachment.file
+        file = File.objects.get(id=attachment.file_id)
         fp = file.getfile()
         response = StreamingHttpResponse(
             iter(lambda: fp.read(4096), b""),
@@ -86,30 +86,16 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
             return self.respond({"detail": "Event not found"}, status=404)
 
         try:
-            attachment = (
-                EventAttachment.objects.filter(
-                    project_id=project.id, event_id=event.event_id, id=attachment_id
-                )
-                .select_related("file")
-                .get()
-            )
+            attachment = EventAttachment.objects.filter(
+                project_id=project.id, event_id=event.event_id, id=attachment_id
+            ).get()
         except EventAttachment.DoesNotExist:
             return self.respond({"detail": "Attachment not found"}, status=404)
 
         if request.GET.get("download") is not None:
             return self.download(attachment)
 
-        return self.respond(
-            {
-                "id": six.text_type(attachment.id),
-                "name": attachment.name,
-                "headers": attachment.file.headers,
-                "mimetype": attachment.mimetype,
-                "size": attachment.file.size,
-                "sha1": attachment.file.checksum,
-                "dateCreated": attachment.file.timestamp,
-            }
-        )
+        return self.respond(serialize(attachment, request.user))
 
     def delete(self, request, project, event_id, attachment_id):
         """
@@ -128,13 +114,9 @@ class EventAttachmentDetailsEndpoint(ProjectEndpoint):
             return self.respond(status=404)
 
         try:
-            attachment = (
-                EventAttachment.objects.filter(
-                    project_id=project.id, event_id=event_id, id=attachment_id
-                )
-                .select_related("file")
-                .get()
-            )
+            attachment = EventAttachment.objects.filter(
+                project_id=project.id, event_id=event_id, id=attachment_id
+            ).get()
         except EventAttachment.DoesNotExist:
             return self.respond({"detail": "Attachment not found"}, status=404)
 

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -32,9 +32,7 @@ class EventAttachmentsEndpoint(ProjectEndpoint):
         if event is None:
             return self.respond({"detail": "Event not found"}, status=404)
 
-        queryset = EventAttachment.objects.filter(
-            project_id=project.id, event_id=event.event_id
-        ).select_related("file")
+        queryset = EventAttachment.objects.filter(project_id=project.id, event_id=event.event_id)
 
         query = request.GET.get("query")
         if query:

--- a/src/sentry/api/endpoints/group_attachments.py
+++ b/src/sentry/api/endpoints/group_attachments.py
@@ -38,7 +38,7 @@ class GroupAttachmentsEndpoint(GroupEndpoint, EnvironmentMixin):
         ):
             return self.respond(status=404)
 
-        attachments = EventAttachment.objects.filter(group_id=group.id).select_related("file")
+        attachments = EventAttachment.objects.filter(group_id=group.id)
 
         types = request.GET.getlist("types") or ()
         if types:

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -7,26 +7,26 @@ from django.utils import timezone
 from sentry_relay import meta_with_chunks
 
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.eventstore.models import Event
 from sentry.models import EventAttachment, EventError, Release, UserReport
+from sentry.sdk_updates import get_suggested_updates, SdkSetupState
 from sentry.search.utils import convert_user_tag_to_query
+from sentry.utils.compat import zip
 from sentry.utils.json import prune_empty_keys
 from sentry.utils.safe import get_path
-from sentry.sdk_updates import get_suggested_updates, SdkSetupState
-from sentry.eventstore.models import Event
-
 
 CRASH_FILE_TYPES = set(["event.minidump"])
 
 
 def get_crash_files(events):
     event_ids = [x.event_id for x in events if x.platform == "native"]
-    rv = {}
     if event_ids:
-        attachments = EventAttachment.objects.filter(event_id__in=event_ids).select_related("file")
-        for attachment in attachments:
-            if attachment.type in CRASH_FILE_TYPES:
-                rv[attachment.event_id] = attachment
-    return rv
+        return [
+            ea
+            for ea in EventAttachment.objects.filter(event_id__in=event_ids)
+            if ea.type in CRASH_FILE_TYPES
+        ]
+    return []
 
 
 @register(Event)
@@ -170,6 +170,10 @@ class EventSerializer(Serializer):
 
     def get_attrs(self, item_list, user, is_public=False):
         crash_files = get_crash_files(item_list)
+        serialized_files = {
+            file.event_id: serialized
+            for file, serialized in zip(crash_files, serialize(crash_files, user=user))
+        }
         results = {}
         for item in item_list:
             # TODO(dcramer): convert to get_api_context
@@ -181,14 +185,12 @@ class EventSerializer(Serializer):
 
             (entries, entries_meta) = self._get_entries(item, user, is_public=is_public)
 
-            crash_file = crash_files.get(item.event_id)
-
             results[item] = {
                 "entries": entries,
                 "user": user_data,
                 "contexts": contexts_data or {},
                 "sdk": sdk_data,
-                "crash_file": serialize(crash_file, user=user),
+                "crash_file": serialized_files.get(item.event_id),
                 "_meta": {
                     "entries": entries_meta,
                     "user": user_meta,
@@ -346,10 +348,11 @@ class SimpleEventSerializer(EventSerializer):
 
     def get_attrs(self, item_list, user):
         crash_files = get_crash_files(item_list)
-        return {
-            event: {"crash_file": serialize(crash_files.get(event.event_id), user=user)}
-            for event in item_list
+        serialized_files = {
+            file.event_id: serialized
+            for file, serialized in zip(crash_files, serialize(crash_files, user=user))
         }
+        return {event: {"crash_file": serialized_files.get(event.event_id)} for event in item_list}
 
     def serialize(self, obj, attrs, user):
         tags = [{"key": key.split("sentry:", 1)[-1], "value": value} for key, value in obj.tags]

--- a/src/sentry/api/serializers/models/eventattachment.py
+++ b/src/sentry/api/serializers/models/eventattachment.py
@@ -3,19 +3,24 @@ from __future__ import absolute_import
 import six
 
 from sentry.api.serializers import Serializer, register
-from sentry.models import EventAttachment
+from sentry.models import EventAttachment, File
 
 
 @register(EventAttachment)
 class EventAttachmentSerializer(Serializer):
+    def get_attrs(self, item_list, user, **kwargs):
+        files = {f.id for f in File.objects.filter(id__in=[ea.file_id for ea in item_list])}
+        return {ea: {"file": files[ea.file_id]} for ea in item_list}
+
     def serialize(self, obj, attrs, user):
+        file = attrs["file"]
         return {
             "id": six.text_type(obj.id),
             "name": obj.name,
-            "headers": obj.file.headers,
+            "headers": file.headers,
             "mimetype": obj.mimetype,
-            "size": obj.file.size,
-            "sha1": obj.file.checksum,
-            "dateCreated": obj.file.timestamp,
+            "size": file.size,
+            "sha1": file.checksum,
+            "dateCreated": file.timestamp,
             "type": obj.type,
         }

--- a/src/sentry/api/serializers/models/eventattachment.py
+++ b/src/sentry/api/serializers/models/eventattachment.py
@@ -9,7 +9,7 @@ from sentry.models import EventAttachment, File
 @register(EventAttachment)
 class EventAttachmentSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
-        files = {f.id for f in File.objects.filter(id__in=[ea.file_id for ea in item_list])}
+        files = {f.id: f for f in File.objects.filter(id__in=[ea.file_id for ea in item_list])}
         return {ea: {"file": files[ea.file_id]} for ea in item_list}
 
     def serialize(self, obj, attrs, user):

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1324,7 +1324,7 @@ def save_attachment(
         project_id=project.id,
         group_id=group_id,
         name=attachment.name,
-        file=file,
+        file_id=file.id,
         type=attachment.type,
     )
 

--- a/src/sentry/migrations/0101_backfill_file_type_on_event_attachment.py
+++ b/src/sentry/migrations/0101_backfill_file_type_on_event_attachment.py
@@ -14,13 +14,15 @@ logger = logging.getLogger(__name__)
 
 def backfill_file_type(apps, schema_editor):
     """
-    Fill the new EventAttachment.type column with values from EventAttachment.file.type.
+    Fill the new EventAttachment.type column with values from the related File.type.
     """
     EventAttachment = apps.get_model("sentry", "EventAttachment")
-    all_event_attachments = EventAttachment.objects.select_related("file").all()
+    File = apps.get_model("sentry", "File")
+    all_event_attachments = EventAttachment.objects.all()
     for event_attachment in RangeQuerySetWrapper(all_event_attachments, step=1000):
         if event_attachment.type is None:
-            event_attachment.type = event_attachment.file.type
+            file = File.objects.get(event_attachment.file_id)
+            event_attachment.type = file.type
             event_attachment.save(update_fields=["type"])
 
 

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -576,7 +576,7 @@ class Factories(object):
         return EventAttachment.objects.create(
             project_id=event.project_id,
             event_id=event.event_id,
-            file=file,
+            file_id=file.id,
             type=file.type,
             **kwargs
         )

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -27,7 +27,7 @@ class CreateAttachmentMixin(object):
         self.attachment = EventAttachment.objects.create(
             event_id=self.event.event_id,
             project_id=self.event.project_id,
-            file=self.file,
+            file_id=self.file.id,
             type=self.file.type,
             name="hello.png",
         )

--- a/tests/sentry/api/endpoints/test_event_attachments.py
+++ b/tests/sentry/api/endpoints/test_event_attachments.py
@@ -22,14 +22,14 @@ class EventAttachmentsTest(APITestCase):
         attachment1 = EventAttachment.objects.create(
             event_id=event1.event_id,
             project_id=event1.project_id,
-            file=File.objects.create(name="hello.png", type="image/png"),
+            file_id=File.objects.create(name="hello.png", type="image/png").id,
             name="hello.png",
         )
         file = File.objects.create(name="hello.png", type="image/png")
         EventAttachment.objects.create(
             event_id=event2.event_id,
             project_id=event2.project_id,
-            file=file,
+            file_id=file.id,
             type=file.type,
             name="hello.png",
         )

--- a/tests/sentry/api/endpoints/test_group_attachments.py
+++ b/tests/sentry/api/endpoints/test_group_attachments.py
@@ -19,7 +19,7 @@ class GroupEventAttachmentsTest(APITestCase):
             event_id=self.event.event_id,
             project_id=self.event.project_id,
             group_id=self.group.id,
-            file=self.file,
+            file_id=self.file.id,
             type=self.file.type,
             name="hello.png",
         )

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -69,7 +69,7 @@ class DeleteGroupTest(TestCase, SnubaTestCase):
         EventAttachment.objects.create(
             event_id=self.event.event_id,
             project_id=self.event.project_id,
-            file=file,
+            file_id=file.id,
             type=file.type,
             name="hello.png",
         )

--- a/tests/sentry/deletions/test_project.py
+++ b/tests/sentry/deletions/test_project.py
@@ -66,7 +66,7 @@ class DeleteProjectTest(TestCase):
         EventAttachment.objects.create(
             event_id=event.event_id,
             project_id=event.project_id,
-            file=file_attachment,
+            file_id=file_attachment.id,
             type=file_attachment.type,
             name="hello.png",
         )

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -12,7 +12,7 @@ from sentry.ingest.ingest_consumer import (
     process_userreport,
 )
 from sentry.event_manager import EventManager
-from sentry.models import EventAttachment, UserReport, EventUser
+from sentry.models import EventAttachment, EventUser, File, UserReport
 
 
 def get_normalized_event(data, project):
@@ -117,18 +117,17 @@ def test_with_attachments(default_project, task_runner, missing_chunks, monkeypa
         )
 
     persisted_attachments = list(
-        EventAttachment.objects.filter(project_id=project_id, event_id=event_id).select_related(
-            "file"
-        )
+        EventAttachment.objects.filter(project_id=project_id, event_id=event_id)
     )
 
     if not missing_chunks:
         (attachment,) = persisted_attachments
-        assert attachment.file.type == "custom.attachment"
-        assert attachment.file.headers == {"Content-Type": "text/plain"}
-        file = attachment.file.getfile()
-        assert file.read() == b"Hello World!"
-        assert file.name == "lol.txt"
+        file = File.objects.get(id=attachment.file_id)
+        assert file.type == "custom.attachment"
+        assert file.headers == {"Content-Type": "text/plain"}
+        file_contents = file.getfile()
+        assert file_contents.read() == b"Hello World!"
+        assert file_contents.name == "lol.txt"
     else:
         assert not persisted_attachments
 
@@ -187,22 +186,19 @@ def test_individual_attachments(
         projects={default_project.id: default_project},
     )
 
-    attachments = list(
-        EventAttachment.objects.filter(project_id=project_id, event_id=event_id).select_related(
-            "file"
-        )
-    )
+    attachments = list(EventAttachment.objects.filter(project_id=project_id, event_id=event_id))
 
     if not event_attachments:
         assert not attachments
     else:
         (attachment,) = attachments
-        assert attachment.file.type == "event.attachment"
-        assert attachment.file.headers == {"Content-Type": "application/octet-stream"}
+        file = File.objects.get(id=attachment.file_id)
+        assert file.type == "event.attachment"
+        assert file.headers == {"Content-Type": "application/octet-stream"}
         assert attachment.group_id == group_id
-        file = attachment.file.getfile()
-        assert file.read() == b"".join(chunks)
-        assert file.name == "foo.txt"
+        file_contents = file.getfile()
+        assert file_contents.read() == b"".join(chunks)
+        assert file_contents.name == "foo.txt"
 
 
 @pytest.mark.django_db
@@ -314,10 +310,6 @@ def test_individual_attachments_missing_chunks(default_project, factories, monke
         projects={default_project.id: default_project},
     )
 
-    attachments = list(
-        EventAttachment.objects.filter(project_id=project_id, event_id=event_id).select_related(
-            "file"
-        )
-    )
+    attachments = list(EventAttachment.objects.filter(project_id=project_id, event_id=event_id))
 
     assert not attachments

--- a/tests/sentry/tasks/test_reprocessing2.py
+++ b/tests/sentry/tasks/test_reprocessing2.py
@@ -280,7 +280,7 @@ def test_attachments_and_userfeedback(
                 event_id=evt.event_id,
                 group_id=evt.group_id,
                 project_id=default_project.id,
-                file=file,
+                file_id=file.id,
                 type=file.type,
                 name="foo",
             )

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -12,7 +12,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from sentry import eventstore
 from sentry.testutils import TransactionTestCase, RelayStoreHelper
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
-from sentry.models import EventAttachment
+from sentry.models import EventAttachment, File
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 
 from tests.symbolicator import get_fixture_path, insta_snapshot_stacktrace_data
@@ -89,12 +89,14 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
         hello, minidump = attachments
 
         assert hello.name == "hello.txt"
-        assert hello.file.type == "event.attachment"
-        assert hello.file.checksum == "2ef7bde608ce5404e97d5f042f95f89f1c232871"
+        hello_file = File.objects.get(id=hello.file_id)
+        assert hello_file.type == "event.attachment"
+        assert hello_file.checksum == "2ef7bde608ce5404e97d5f042f95f89f1c232871"
 
         assert minidump.name == "windows.dmp"
-        assert minidump.file.type == "event.minidump"
-        assert minidump.file.checksum == "74bb01c850e8d65d3ffbc5bad5cabc4668fce247"
+        minidump_file = File.objects.get(id=minidump.file_id)
+        assert minidump_file.type == "event.minidump"
+        assert minidump_file.checksum == "74bb01c850e8d65d3ffbc5bad5cabc4668fce247"
 
     def test_full_minidump_json_extra(self):
         self.project.update_option("sentry:store_crash_reports", STORE_CRASH_REPORTS_ALL)
@@ -170,5 +172,6 @@ class SymbolicatorMinidumpIntegrationTest(RelayStoreHelper, TransactionTestCase)
             )
 
             assert minidump.name == "windows.dmp"
-            assert minidump.file.type == "event.minidump"
-            assert minidump.file.checksum == "74bb01c850e8d65d3ffbc5bad5cabc4668fce247"
+            minidump_file = File.objects.get(id=minidump.file_id)
+            assert minidump_file.type == "event.minidump"
+            assert minidump_file.checksum == "74bb01c850e8d65d3ffbc5bad5cabc4668fce247"

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -10,7 +10,7 @@ from django.core.urlresolvers import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from sentry.testutils import TransactionTestCase, RelayStoreHelper
-from sentry.models import EventAttachment
+from sentry.models import EventAttachment, File
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 
 from tests.symbolicator import get_fixture_path
@@ -101,20 +101,24 @@ class SymbolicatorUnrealIntegrationTest(RelayStoreHelper, TransactionTestCase):
         context, config, minidump, log = attachments
 
         assert context.name == "CrashContext.runtime-xml"
-        assert context.file.type == "unreal.context"
-        assert context.file.checksum == "835d3e10db5d1799dc625132c819c047261ddcfb"
+        context_file = File.objects.get(id=context.file_id)
+        assert context_file.type == "unreal.context"
+        assert context_file.checksum == "835d3e10db5d1799dc625132c819c047261ddcfb"
 
         assert config.name == "CrashReportClient.ini"
-        assert config.file.type == "event.attachment"
-        assert config.file.checksum == "5839c750bdde8cba4d2a979ea857b8154cffdab5"
+        config_file = File.objects.get(id=config.file_id)
+        assert config_file.type == "event.attachment"
+        assert config_file.checksum == "5839c750bdde8cba4d2a979ea857b8154cffdab5"
 
         assert minidump.name == "UE4Minidump.dmp"
-        assert minidump.file.type == "event.minidump"
-        assert minidump.file.checksum == "089d9fd3b5c0cc4426339ab46ec3835e4be83c0f"
+        minidump_file = File.objects.get(id=minidump.file_id)
+        assert minidump_file.type == "event.minidump"
+        assert minidump_file.checksum == "089d9fd3b5c0cc4426339ab46ec3835e4be83c0f"
 
         assert log.name == "YetAnother.log"  # Log file is named after the project
-        assert log.file.type == "unreal.logs"
-        assert log.file.checksum == "24d1c5f75334cd0912cc2670168d593d5fe6c081"
+        log_file = File.objects.get(id=log.file_id)
+        assert log_file.type == "unreal.logs"
+        assert log_file.checksum == "24d1c5f75334cd0912cc2670168d593d5fe6c081"
 
     def test_unreal_apple_crash_with_attachments(self):
         attachments = self.unreal_crash_test_impl(get_unreal_crash_apple_file())
@@ -123,25 +127,31 @@ class SymbolicatorUnrealIntegrationTest(RelayStoreHelper, TransactionTestCase):
         context, config, diagnostics, log, info, minidump = attachments
 
         assert context.name == "CrashContext.runtime-xml"
-        assert context.file.type == "unreal.context"
-        assert context.file.checksum == "5d2723a7d25111645702fcbbcb8e1d038db56c6e"
+        context_file = File.objects.get(id=context.file_id)
+        assert context_file.type == "unreal.context"
+        assert context_file.checksum == "5d2723a7d25111645702fcbbcb8e1d038db56c6e"
 
         assert config.name == "CrashReportClient.ini"
-        assert config.file.type == "event.attachment"
-        assert config.file.checksum == "4d6a2736e3e4969a68b7adbe197b05c171c29ea0"
+        config_file = File.objects.get(id=config.file_id)
+        assert config_file.type == "event.attachment"
+        assert config_file.checksum == "4d6a2736e3e4969a68b7adbe197b05c171c29ea0"
 
         assert diagnostics.name == "Diagnostics.txt"
-        assert diagnostics.file.type == "event.attachment"
-        assert diagnostics.file.checksum == "aa271bf4e307a78005410234081945352e8fb236"
+        diagnostics_file = File.objects.get(id=diagnostics.file_id)
+        assert diagnostics_file.type == "event.attachment"
+        assert diagnostics_file.checksum == "aa271bf4e307a78005410234081945352e8fb236"
 
         assert log.name == "YetAnotherMac.log"  # Log file is named after the project
-        assert log.file.type == "unreal.logs"
-        assert log.file.checksum == "735e751a8b6b943dbc0abce0e6d096f4d48a0c1e"
+        log_file = File.objects.get(id=log.file_id)
+        assert log_file.type == "unreal.logs"
+        assert log_file.checksum == "735e751a8b6b943dbc0abce0e6d096f4d48a0c1e"
 
         assert info.name == "info.txt"
-        assert info.file.type == "event.attachment"
-        assert info.file.checksum == "279b27ac5d0e6792d088e0662ce1a18413b772bc"
+        info_file = File.objects.get(id=info.file_id)
+        assert info_file.type == "event.attachment"
+        assert info_file.checksum == "279b27ac5d0e6792d088e0662ce1a18413b772bc"
 
         assert minidump.name == "minidump.dmp"
-        assert minidump.file.type == "event.applecrashreport"
-        assert minidump.file.checksum == "728d0f4b09cf5a7942da3893b6db79ac842b701a"
+        minidump_file = File.objects.get(id=minidump.file_id)
+        assert minidump_file.type == "event.applecrashreport"
+        assert minidump_file.checksum == "728d0f4b09cf5a7942da3893b6db79ac842b701a"


### PR DESCRIPTION
We're moving `EventAttachment` to a separate database, and so can no longer rely on Django's
automatic join behaviour. In https://github.com/getsentry/sentry/pull/23194 we will remove the
foreign key entirely and replace with just `file_id`. This pr prepares us for that and
attempts to remove all join behaviour, as well as replacing uses of `.file` with `.file_id`.

We also modify `EventAttachmentSerializer` to be able to serialize in bulk in an efficient way, and
`EventSerializer` and `SimpleEventSerializer` to take advantage of this so that we don't start
performing a query for each file.

General searches used for reference:
 - `EventAttachment`
 - `.file` (word match)
 - `__file`
 - `.select_related("file")`