### PR TITLE
feat(api): Add sdk_updates API using discover

### DIFF
--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -1,0 +1,78 @@
+from itertools import groupby, chain
+from datetime import timedelta
+
+from distutils.version import LooseVersion
+from django.utils import timezone
+from rest_framework.response import Response
+
+from sentry.sdk_updates import SdkIndexState, SdkSetupState, get_suggested_updates
+from sentry.api.bases import OrganizationEventsEndpointBase
+from sentry.snuba import discover
+
+
+def by_sdk_name(sdk):
+    return sdk["sdk.name"]
+
+
+def by_project_id(sdk):
+    return sdk["project.id"]
+
+
+def serialize(data, projects):
+    # Build datastructure of the latest version of each SDK in use for each
+    # project we have events for.
+    latest_sdks = chain.from_iterable(
+        [
+            {
+                "projectId": project_id,
+                "sdkName": sdk_name,
+                "sdkVersion": max((s["sdk.version"] for s in sdks), key=LooseVersion),
+            }
+            for sdk_name, sdks in groupby(sorted(sdks_used, key=by_sdk_name), key=by_sdk_name)
+        ]
+        for project_id, sdks_used in groupby(data, key=by_project_id)
+    )
+
+    # Determine suggested upgrades for each project
+    index_state = SdkIndexState()
+
+    return [
+        dict(
+            **latest,
+            suggestions=list(
+                get_suggested_updates(
+                    # TODO: In the future it would be nice to also add
+                    # the integrations and modules the SDK is using.
+                    # However this isn't currently available in the
+                    # discover dataset from snuba.
+                    SdkSetupState(latest["sdkName"], latest["sdkVersion"], (), ()),
+                    index_state,
+                    ignore_patch_version=True,
+                )
+            ),
+        )
+        for latest in latest_sdks
+    ]
+
+
+class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
+    def get(self, request, organization):
+
+        project_ids = self.get_requested_project_ids(request)
+        projects = self.get_projects(request, organization, project_ids)
+
+        with self.handle_query_errors():
+            result = discover.query(
+                query="has:sdk.version",
+                selected_columns=["project", "sdk.name", "sdk.version", "last_seen()"],
+                orderby="-project",
+                params={
+                    "start": timezone.now() - timedelta(days=1),
+                    "end": timezone.now(),
+                    "organization_id": organization.id,
+                    "project_id": [p.id for p in projects],
+                },
+                referrer="api.organization-sdk-updates",
+            )
+
+        return Response(serialize(result["data"], projects))

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -190,6 +190,7 @@ from .endpoints.organization_user_issues import OrganizationUserIssuesEndpoint
 from .endpoints.organization_user_issues_search import OrganizationUserIssuesSearchEndpoint
 from .endpoints.organization_user_reports import OrganizationUserReportsEndpoint
 from .endpoints.organization_users import OrganizationUsersEndpoint
+from .endpoints.organization_sdk_updates import OrganizationSdkUpdatesEndpoint
 from .endpoints.project_agnostic_rule_conditions import ProjectAgnosticRuleConditionsEndpoint
 from .endpoints.project_avatar import ProjectAvatarEndpoint
 from .endpoints.project_create_sample import ProjectCreateSampleEndpoint
@@ -825,6 +826,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/events/$",
                     OrganizationEventsEndpoint.as_view(),
                     name="sentry-api-0-organization-events",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/sdk-updates/$",
+                    OrganizationSdkUpdatesEndpoint.as_view(),
+                    name="sentry-api-0-organization-sdk-updates",
                 ),
                 # This is temporary while we alpha test eventsv2
                 url(

--- a/tests/sentry/api/endpoints/test_organization_sdk_updates.py
+++ b/tests/sentry/api/endpoints/test_organization_sdk_updates.py
@@ -1,0 +1,116 @@
+from __future__ import absolute_import
+
+from sentry.sdk_updates import SdkIndexState
+
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now, iso_format
+
+from sentry.utils.compat import mock
+
+
+class OrganizationSdkUpdates(APITestCase, SnubaTestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.project2 = self.create_project(organization=self.organization)
+
+        self.url = reverse(
+            "sentry-api-0-organization-sdk-updates",
+            kwargs={"organization_slug": self.organization.slug},
+        )
+
+    @mock.patch(
+        "sentry.api.endpoints.organization_sdk_updates.SdkIndexState",
+        return_value=SdkIndexState(sdk_versions={"example.sdk": "2.0.0"}),
+    )
+    def test_simple(self, mock_index_state):
+        min_ago = iso_format(before_now(minutes=1))
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "oh no",
+                "timestamp": min_ago,
+                "fingerprint": ["group-1"],
+                "sdk": {"name": "example.sdk", "version": "1.0.0"},
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+
+        response = self.client.get(self.url)
+
+        update_suggestions = response.data
+        assert len(update_suggestions) == 1
+        assert update_suggestions[0]["suggestions"][0] == {
+            "type": "updateSdk",
+            "sdkName": "example.sdk",
+            "newSdkVersion": "2.0.0",
+            "sdkUrl": None,
+            "enables": [],
+        }
+
+    def test_filtered_project(self):
+        min_ago = iso_format(before_now(minutes=1))
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "oh no",
+                "timestamp": min_ago,
+                "fingerprint": ["group-1"],
+                "sdk": {"name": "example.sdk", "version": "1.0.0"},
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+
+        response = self.client.get(f"{self.url}?project={self.project2.id}")
+
+        assert len(response.data) == 0
+
+    @mock.patch(
+        "sentry.api.endpoints.organization_sdk_updates.SdkIndexState",
+        return_value=SdkIndexState(sdk_versions={"example.sdk": "2.0.0"}),
+    )
+    def test_multiple_versions_with_latest(self, mock_index_state):
+        min_ago = iso_format(before_now(minutes=1))
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "message": "a",
+                "timestamp": min_ago,
+                "fingerprint": ["group-1"],
+                "sdk": {"name": "example.sdk", "version": "1.0.0"},
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "message": "b",
+                "timestamp": min_ago,
+                "fingerprint": ["group-2"],
+                "sdk": {"name": "example.sdk", "version": "1.1.0"},
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+        self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "message": "c",
+                "timestamp": min_ago,
+                "fingerprint": ["group-3"],
+                "sdk": {"name": "example.sdk", "version": "2.0.0"},
+            },
+            project_id=self.project.id,
+            assert_no_errors=False,
+        )
+
+        response = self.client.get(self.url)
+
+        update_suggestions = response.data
+        assert len(update_suggestions) == 1
+        assert len(update_suggestions[0]["suggestions"]) == 0


### PR DESCRIPTION
This will be used for globally providing notice for when the SDKs for projects are out of date.

The only context needed is the org, and optionally some project Ids