### PR TITLE
fix(databass): Stop using `UserReport` foreign key relations, and replace with `_id` instead.

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -203,10 +203,10 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 group.project_id, group.id, environment_ids, limit=100
             )
             if not environment_ids:
-                user_reports = UserReport.objects.filter(group=group)
+                user_reports = UserReport.objects.filter(group_id=group.id)
             else:
                 user_reports = UserReport.objects.filter(
-                    group=group, environment_id__in=environment_ids
+                    group_id=group.id, environment_id__in=environment_ids
                 )
 
             now = timezone.now()

--- a/src/sentry/api/endpoints/group_user_reports.py
+++ b/src/sentry/api/endpoints/group_user_reports.py
@@ -25,9 +25,9 @@ class GroupUserReportsEndpoint(GroupEndpoint, EnvironmentMixin):
         except Environment.DoesNotExist:
             report_list = UserReport.objects.none()
         else:
-            report_list = UserReport.objects.filter(group=group)
+            report_list = UserReport.objects.filter(group_id=group.id)
             if environment is not None:
-                report_list = report_list.filter(environment=environment)
+                report_list = report_list.filter(environment_id=environment.id)
         return self.paginate(
             request=request,
             queryset=report_list,

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -41,14 +41,13 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
         except Environment.DoesNotExist:
             queryset = UserReport.objects.none()
         else:
-            queryset = UserReport.objects.filter(
-                project=project, group__isnull=False
-            ).select_related("group")
+            queryset = UserReport.objects.filter(project_id=project.id, group_id__isnull=False)
             if environment is not None:
-                queryset = queryset.filter(environment=environment)
+                queryset = queryset.filter(environment_id=environment.id)
 
             status = request.GET.get("status", "unresolved")
             if status == "unresolved":
+                # TODO: Figure out cross db join
                 queryset = queryset.filter(group__status=GroupStatus.UNRESOLVED)
             elif status:
                 return self.respond({"status": "Invalid status choice"}, status=400)

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -6,9 +6,10 @@ from rest_framework import serializers
 from sentry.api.authentication import DSNAuthentication
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.helpers.user_reports import user_reports_filter_to_unresolved
 from sentry.api.serializers import serialize, UserReportWithGroupSerializer
 from sentry.api.paginator import DateTimePaginator
-from sentry.models import Environment, GroupStatus, ProjectKey, UserReport
+from sentry.models import Environment, ProjectKey, UserReport
 from sentry.ingest.userreport import save_userreport, Conflict
 
 
@@ -36,6 +37,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
         if isinstance(request.auth, ProjectKey):
             return self.respond(status=401)
 
+        paginate_kwargs = {}
         try:
             environment = self._get_environment_from_request(request, project.organization_id)
         except Environment.DoesNotExist:
@@ -47,8 +49,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
 
             status = request.GET.get("status", "unresolved")
             if status == "unresolved":
-                # TODO: Figure out cross db join
-                queryset = queryset.filter(group__status=GroupStatus.UNRESOLVED)
+                paginate_kwargs["post_query_filter"] = user_reports_filter_to_unresolved
             elif status:
                 return self.respond({"status": "Invalid status choice"}, status=400)
 
@@ -64,6 +65,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
                 ),
             ),
             paginator_cls=DateTimePaginator,
+            **paginate_kwargs
         )
 
     def post(self, request, project):

--- a/src/sentry/api/helpers/user_reports.py
+++ b/src/sentry/api/helpers/user_reports.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+
+from sentry.models import Group, GroupStatus
+
+
+def user_reports_filter_to_unresolved(user_reports):
+    group_ids = set([ur.group_id for ur in user_reports if ur.group_id])
+    unresolved_group_ids = set()
+    if group_ids:
+        unresolved_group_ids = set(
+            Group.objects.filter(id__in=group_ids, status=GroupStatus.UNRESOLVED).values_list(
+                "id", flat=True
+            )
+        )
+    return [ur for ur in user_reports if ur.group_id is None or ur.group_id in unresolved_group_ids]

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -163,7 +163,9 @@ class EventSerializer(Serializer):
 
     def _get_user_report(self, user, event):
         try:
-            user_report = UserReport.objects.get(event_id=event.event_id, project=event.project)
+            user_report = UserReport.objects.get(
+                event_id=event.event_id, project_id=event.project_id
+            )
         except UserReport.DoesNotExist:
             user_report = None
         return serialize(user_report, user)

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -414,7 +414,9 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
         attrs = super(ProjectSummarySerializer, self).get_attrs(item_list, user)
 
         projects_with_user_reports = set(
-            UserReport.objects.filter(project_id__in=item_list).values_list("project", flat=True)
+            UserReport.objects.filter(project_id__in=[item.id for item in item_list]).values_list(
+                "project_id", flat=True
+            )
         )
 
         project_envs = (

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -55,7 +55,9 @@ class UserReportWithGroupSerializer(UserReportSerializer):
     def get_attrs(self, item_list, user):
         from sentry.api.serializers import GroupSerializer
 
-        groups = list(Group.objects.filter(id__in=[i.group_id for i in item_list if i.group_id]))
+        groups = list(
+            Group.objects.filter(id__in=set([i.group_id for i in item_list if i.group_id]))
+        )
         serialized_groups = {}
         if groups:
             serialized_groups = {

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import six
 
 from sentry.api.serializers import register, serialize, Serializer
-from sentry.models import EventUser, UserReport
+from sentry.models import EventUser, Group, UserReport
 from sentry.utils.compat import zip
 
 
@@ -55,20 +55,24 @@ class UserReportWithGroupSerializer(UserReportSerializer):
     def get_attrs(self, item_list, user):
         from sentry.api.serializers import GroupSerializer
 
-        # TODO(dcramer); assert on relations
-        groups = {
-            d["id"]: d
-            for d in serialize(
-                set(i.group for i in item_list if i.group_id),
-                user,
-                GroupSerializer(environment_func=self.environment_func),
-            )
-        }
+        groups = Group.objects.filter(id__in=[i.group_id for i in item_list if i.group_id])
+        serialized_groups = {}
+        if groups:
+            serialized_groups = {
+                d["id"]: d
+                for d in serialize(
+                    groups, user, GroupSerializer(environment_func=self.environment_func),
+                )
+            }
 
         attrs = super(UserReportWithGroupSerializer, self).get_attrs(item_list, user)
         for item in item_list:
             attrs[item].update(
-                {"group": groups[six.text_type(item.group_id)] if item.group_id else None}
+                {
+                    "group": serialized_groups[six.text_type(item.group_id)]
+                    if item.group_id
+                    else None
+                }
             )
         return attrs
 

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -55,7 +55,7 @@ class UserReportWithGroupSerializer(UserReportSerializer):
     def get_attrs(self, item_list, user):
         from sentry.api.serializers import GroupSerializer
 
-        groups = Group.objects.filter(id__in=[i.group_id for i in item_list if i.group_id])
+        groups = list(Group.objects.filter(id__in=[i.group_id for i in item_list if i.group_id]))
         serialized_groups = {}
         if groups:
             serialized_groups = {

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -434,8 +434,8 @@ class EventManager(object):
         _tsdb_record_all_metrics(jobs)
 
         if job["group"]:
-            UserReport.objects.filter(project=project, event_id=job["event"].event_id).update(
-                group=job["group"], environment=job["environment"]
+            UserReport.objects.filter(project_id=project.id, event_id=job["event"].event_id).update(
+                group_id=job["group"].id, environment_id=job["environment"].id
             )
 
         with metrics.timer("event_manager.filter_attachments_for_group"):

--- a/src/sentry/ingest/userreport.py
+++ b/src/sentry/ingest/userreport.py
@@ -75,9 +75,7 @@ def save_userreport(project, report, start_time=None):
         if report_instance.group_id:
             report_instance.notify()
 
-    user_feedback_received.send(
-        project=project, group=event.group, sender=save_userreport,
-    )
+    user_feedback_received.send(project=project, sender=save_userreport)
 
     return report_instance
 

--- a/src/sentry/migrations/0028_user_reports.py
+++ b/src/sentry/migrations/0028_user_reports.py
@@ -24,7 +24,7 @@ def backfill_user_reports(apps, schema_editor):
     """
     UserReport = apps.get_model("sentry", "UserReport")
 
-    user_reports = UserReport.objects.filter(group__isnull=True, environment__isnull=True)
+    user_reports = UserReport.objects.filter(group_id__isnull=True, environment_id__isnull=True)
 
     for report in RangeQuerySetWrapper(user_reports, step=1000):
         try:
@@ -37,7 +37,7 @@ def backfill_user_reports(apps, schema_editor):
             continue
 
         if event:
-            report.update(group_id=event.group_id, environment=event.get_environment())
+            report.update(group_id=event.group_id, environment_id=event.get_environment().id)
 
 
 class Migration(migrations.Migration):

--- a/src/sentry/tasks/unmerge.py
+++ b/src/sentry/tasks/unmerge.py
@@ -223,7 +223,7 @@ def migrate_events(
     event_id_set = set(event.event_id for event in events)
 
     UserReport.objects.filter(project_id=project.id, event_id__in=event_id_set).update(
-        group=destination_id
+        group_id=destination_id
     )
     EventAttachment.objects.filter(project_id=project.id, event_id__in=event_id_set).update(
         group_id=destination_id

--- a/src/sentry/tasks/update_user_reports.py
+++ b/src/sentry/tasks/update_user_reports.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 def update_user_reports(**kwargs):
     now = timezone.now()
     user_reports = UserReport.objects.filter(
-        group__isnull=True, environment__isnull=True, date_added__gte=now - timedelta(days=1)
+        group_id__isnull=True, environment_id__isnull=True, date_added__gte=now - timedelta(days=1)
     )
 
     # We do one query per project, just to avoid the small case that two projects have the same event ID
@@ -46,7 +46,7 @@ def update_user_reports(**kwargs):
             report = report_by_event.get(event.event_id)
             if report:
                 reports_with_event += 1
-                report.update(group_id=event.group_id, environment=event.get_environment())
+                report.update(group_id=event.group_id, environment_id=event.get_environment().id)
                 updated_reports += 1
 
         if not samples and len(reports) <= 10:

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -776,9 +776,9 @@ class Factories(object):
     @staticmethod
     def create_userreport(group, project=None, event_id=None, **kwargs):
         return UserReport.objects.create(
-            group=group,
+            group_id=group.id,
             event_id=event_id or "a" * 32,
-            project=project or group.project,
+            project_id=project.id if project is not None else group.project.id,
             name="Jane Bloggs",
             email="jane@example.com",
             comments="the application crashed",

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry import eventstore
-from sentry.models import ProjectKey, ProjectOption, UserReport
+from sentry.models import Group, Project, ProjectKey, ProjectOption, UserReport
 from sentry.web.helpers import render_to_response, render_to_string
 from sentry.signals import user_feedback_received
 from sentry.utils import json
@@ -146,14 +146,14 @@ class ErrorPageEmbedView(View):
         if form.is_valid():
             # TODO(dcramer): move this to post to the internal API
             report = form.save(commit=False)
-            report.project = key.project
+            report.project_id = key.project_id
             report.event_id = event_id
 
-            event = eventstore.get_event_by_id(report.project.id, report.event_id)
+            event = eventstore.get_event_by_id(report.project_id, report.event_id)
 
             if event is not None:
-                report.environment = event.get_environment()
-                report.group = event.group
+                report.environment_id = event.get_environment().id
+                report.group_id = event.group.id
 
             try:
                 with transaction.atomic():
@@ -165,7 +165,9 @@ class ErrorPageEmbedView(View):
                 # something wrong with the SDK, but this behavior is
                 # more reasonable than just hard erroring and is more
                 # expected.
-                UserReport.objects.filter(project=report.project, event_id=report.event_id).update(
+                UserReport.objects.filter(
+                    project_id=report.project_id, event_id=report.event_id
+                ).update(
                     name=report.name,
                     email=report.email,
                     comments=report.comments,
@@ -173,10 +175,14 @@ class ErrorPageEmbedView(View):
                 )
 
             else:
-                if report.group:
+                if report.group_id:
                     report.notify()
 
-            user_feedback_received.send(project=report.project, group=report.group, sender=self)
+            user_feedback_received.send(
+                project=Project.objects.get(id=report.project_id),
+                group=Group.objects.get(id=report.group_id),
+                sender=self,
+            )
 
             return self._smart_response(request)
         elif request.method == "POST":

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -153,7 +153,7 @@ class ErrorPageEmbedView(View):
 
             if event is not None:
                 report.environment_id = event.get_environment().id
-                report.group_id = event.group.id
+                report.group_id = event.group_id
 
             try:
                 with transaction.atomic():

--- a/src/sentry/web/frontend/error_page_embed.py
+++ b/src/sentry/web/frontend/error_page_embed.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import csrf_exempt
 
 from sentry import eventstore
-from sentry.models import Group, Project, ProjectKey, ProjectOption, UserReport
+from sentry.models import Project, ProjectKey, ProjectOption, UserReport
 from sentry.web.helpers import render_to_response, render_to_string
 from sentry.signals import user_feedback_received
 from sentry.utils import json
@@ -179,9 +179,7 @@ class ErrorPageEmbedView(View):
                     report.notify()
 
             user_feedback_received.send(
-                project=Project.objects.get(id=report.project_id),
-                group=Group.objects.get(id=report.group_id),
-                sender=self,
+                project=Project.objects.get(id=report.project_id), sender=self,
             )
 
             return self._smart_response(request)

--- a/tests/sentry/api/endpoints/test_group_user_reports.py
+++ b/tests/sentry/api/endpoints/test_group_user_reports.py
@@ -54,13 +54,13 @@ class GroupUserReport(APITestCase, SnubaTestCase):
         for i, event in enumerate(events):
             reports.append(
                 UserReport.objects.create(
-                    group=group,
-                    project=project,
+                    group_id=group.id,
+                    project_id=project.id,
                     event_id=event.event_id,
                     name="foo%d" % i,
                     email="bar%d@example.com" % i,
                     comments="It Broke!!!",
-                    environment=environment,
+                    environment_id=environment.id,
                 )
             )
         return reports

--- a/tests/sentry/api/endpoints/test_organization_user_reports.py
+++ b/tests/sentry/api/endpoints/test_organization_user_reports.py
@@ -29,18 +29,18 @@ class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
         self.env_2 = self.create_environment(name="dev", project=self.project_1)
 
         self.report_1 = UserReport.objects.create(
-            project=self.project_1,
+            project_id=self.project_1.id,
             event_id="a" * 32,
             name="Foo",
             email="foo@example.com",
             comments="Hello world",
-            group=self.group_1,
-            environment=self.env_1,
+            group_id=self.group_1.id,
+            environment_id=self.env_1.id,
         )
 
         # should not be included due to missing link
         UserReport.objects.create(
-            project=self.project_1,
+            project_id=self.project_1.id,
             event_id="b" * 32,
             name="Bar",
             email="bar@example.com",
@@ -48,22 +48,22 @@ class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
         )
 
         self.report_resolved_1 = UserReport.objects.create(
-            project=self.project_1,
+            project_id=self.project_1.id,
             event_id="c" * 32,
             name="Baz",
             email="baz@example.com",
             comments="Hello world",
-            group=self.group_2,
+            group_id=self.group_2.id,
         )
 
         self.report_2 = UserReport.objects.create(
-            project=self.project_2,
+            project_id=self.project_2.id,
             event_id="d" * 32,
             name="Wat",
             email="wat@example.com",
             comments="Hello world",
-            group=self.group_1,
-            environment=self.env_2,
+            group_id=self.group_1.id,
+            environment_id=self.env_2.id,
             date_added=datetime.now() - timedelta(days=7),
         )
 

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -394,6 +394,6 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert (
-            UserReport.objects.get(event_id=self.event.event_id).environment.id
+            UserReport.objects.get(event_id=self.event.event_id).environment_id
             == self.environment.id
         )

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -33,21 +33,21 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
             project_id=self.project.id,
         )
         self.report = UserReport.objects.create(
-            project=self.project,
-            environment=self.environment,
+            project_id=self.project.id,
+            environment_id=self.environment.id,
             event_id="a" * 32,
             name="Foo",
             email="foo@example.com",
             comments="Hello world",
-            group=self.event.group,
+            group_id=self.event.group.id,
         )
         self.report2 = UserReport.objects.create(
-            project=self.project,
+            project_id=self.project.id,
             event_id="b" * 32,
             name="Foo",
             email="foo@example.com",
             comments="Hello world",
-            group=self.event.group,
+            group_id=self.event.group.id,
         )
 
     def test_simple(self):
@@ -57,17 +57,17 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
         group = self.create_group(project=project)
         group2 = self.create_group(project=project, status=GroupStatus.RESOLVED)
         report_1 = UserReport.objects.create(
-            project=project,
+            project_id=project.id,
             event_id="a" * 32,
             name="Foo",
             email="foo@example.com",
             comments="Hello world",
-            group=group,
+            group_id=group.id,
         )
 
         # should not be included due to missing link
         UserReport.objects.create(
-            project=project,
+            project_id=project.id,
             event_id="b" * 32,
             name="Bar",
             email="bar@example.com",
@@ -76,12 +76,12 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         # should not be included due to resolution
         UserReport.objects.create(
-            project=project,
+            project_id=project.id,
             event_id="c" * 32,
             name="Baz",
             email="baz@example.com",
             comments="Hello world",
-            group=group2,
+            group_id=group2.id,
         )
 
         url = u"/api/0/projects/{}/{}/user-feedback/".format(
@@ -112,12 +112,12 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
         project = self.create_project()
         group = self.create_group(project=project, status=GroupStatus.RESOLVED)
         report_1 = UserReport.objects.create(
-            project=project,
+            project_id=project.id,
             event_id="a" * 32,
             name="Foo",
             email="foo@example.com",
             comments="Hello world",
-            group=group,
+            group_id=group.id,
         )
 
         url = u"/api/0/projects/{}/{}/user-feedback/".format(
@@ -203,8 +203,8 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
 
         report = UserReport.objects.get(id=response.data["id"])
-        assert report.project == self.project
-        assert report.group == self.event.group
+        assert report.project_id == self.project.id
+        assert report.group_id == self.event.group.id
         assert report.email == "foo@example.com"
         assert report.name == "Foo Bar"
         assert report.comments == "It broke!"
@@ -255,8 +255,8 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         UserReport.objects.create(
-            group=self.event.group,
-            project=self.project,
+            group_id=self.event.group.id,
+            project_id=self.project.id,
             event_id=self.event.event_id,
             name="foo",
             email="bar@example.com",
@@ -280,8 +280,8 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
 
         report = UserReport.objects.get(id=response.data["id"])
-        assert report.project == self.project
-        assert report.group == self.event.group
+        assert report.project_id == self.project.id
+        assert report.group_id == self.event.group.id
         assert report.email == "foo@example.com"
         assert report.name == "Foo Bar"
         assert report.comments == "It broke!"
@@ -292,8 +292,8 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         euser = EventUser.objects.get(project_id=self.project.id, email="foo@example.com")
 
         UserReport.objects.create(
-            group=self.event.group,
-            project=self.project,
+            group_id=self.event.group.id,
+            project_id=self.project.id,
             event_id=self.event.event_id,
             name="foo",
             email="bar@example.com",
@@ -317,8 +317,8 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
 
         report = UserReport.objects.get(id=response.data["id"])
-        assert report.project == self.project
-        assert report.group == self.event.group
+        assert report.project_id == self.project.id
+        assert report.group_id == self.event.group.id
         assert report.email == "foo@example.com"
         assert report.name == "Foo Bar"
         assert report.comments == "It broke!"
@@ -331,8 +331,8 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         UserReport.objects.create(
-            group=self.old_event.group,
-            project=self.project,
+            group_id=self.old_event.group.id,
+            project_id=self.project.id,
             event_id=self.old_event.event_id,
             name="foo",
             email="bar@example.com",
@@ -393,4 +393,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert UserReport.objects.get(event_id=self.event.event_id).environment == self.environment
+        assert (
+            UserReport.objects.get(event_id=self.event.event_id).environment.id
+            == self.environment.id
+        )

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -285,14 +285,14 @@ class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
         assert result["hasUserReports"] is False
 
         UserReport.objects.create(
-            project=self.project,
+            project_id=self.project.id,
             event_id="1",
             name="foo",
             email="bar@example.com",
             comments="It broke!",
         )
         UserReport.objects.create(
-            project=self.project,
+            project_id=self.project.id,
             event_id="2",
             name="foo",
             email="bar@example.com",

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -888,7 +888,7 @@ class EventManagerTest(TestCase):
         event_id = "a" * 32
 
         UserReport.objects.create(
-            project=project,
+            project_id=project.id,
             event_id=event_id,
             name="foo",
             email="bar@example.com",
@@ -899,7 +899,7 @@ class EventManagerTest(TestCase):
             data=make_event(environment=environment.name, event_id=event_id), project_id=project.id
         )
 
-        assert UserReport.objects.get(event_id=event_id).environment == environment
+        assert UserReport.objects.get(event_id=event_id).environment_id == environment.id
 
     def test_default_event_type(self):
         manager = EventManager(make_event(message="foo bar"))

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -794,8 +794,8 @@ class MailAdapterHandleSignalTest(BaseMailAdapterTest, TestCase):
         self.project.teams.first().organization.member_set.create(user=user_foo)
 
         return UserReport.objects.create(
-            project=self.project,
-            group=self.group,
+            project_id=self.project.id,
+            group_id=self.group.id,
             name="Homer Simpson",
             email="homer.simpson@example.com",
         )

--- a/tests/sentry/tasks/test_merge.py
+++ b/tests/sentry/tasks/test_merge.py
@@ -178,7 +178,9 @@ class MergeGroupTest(TestCase):
 
         project2 = self.create_project()
         group2 = self.create_group(project2)
-        ur = UserReport.objects.create(project=project1, group=group1, event_id=event1.event_id)
+        ur = UserReport.objects.create(
+            project_id=project1.id, group_id=group1.id, event_id=event1.event_id
+        )
 
         with self.tasks():
             merge_groups([group1.id], group2.id)

--- a/tests/sentry/tasks/test_update_user_reports.py
+++ b/tests/sentry/tasks/test_update_user_reports.py
@@ -14,23 +14,23 @@ class UpdateUserReportTest(TestCase):
         now = timezone.now()
         project = self.create_project()
         event1 = self.store_event(data={}, project_id=project.id)
-        report1 = UserReport.objects.create(project=project, event_id=event1.event_id)
+        UserReport.objects.create(project_id=project.id, event_id=event1.event_id)
         event2 = self.store_event(data={}, project_id=project.id)
-        report2 = UserReport.objects.create(project=project, event_id=event2.event_id)
+        UserReport.objects.create(project_id=project.id, event_id=event2.event_id)
         event3 = self.store_event(data={}, project_id=project.id)
-        report3 = UserReport.objects.create(
-            project=project, event_id=event3.event_id, date_added=now - timedelta(days=2)
+        UserReport.objects.create(
+            project_id=project.id, event_id=event3.event_id, date_added=now - timedelta(days=2)
         )
 
         with self.tasks():
             update_user_reports()
 
-        report1 = UserReport.objects.get(project=project, event_id=event1.event_id)
-        report2 = UserReport.objects.get(project=project, event_id=event2.event_id)
-        report3 = UserReport.objects.get(project=project, event_id=event3.event_id)
+        report1 = UserReport.objects.get(project_id=project.id, event_id=event1.event_id)
+        report2 = UserReport.objects.get(project_id=project.id, event_id=event2.event_id)
+        report3 = UserReport.objects.get(project_id=project.id, event_id=event3.event_id)
         assert report1.group_id == event1.group_id
-        assert report1.environment == event1.get_environment()
+        assert report1.environment_id == event1.get_environment().id
         assert report2.group_id == event2.group_id
-        assert report2.environment == event2.get_environment()
-        assert report3.group is None
-        assert report3.environment is None
+        assert report2.environment_id == event2.get_environment().id
+        assert report3.group_id is None
+        assert report3.environment_id is None

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -143,8 +143,8 @@ class ErrorPageEmbedTest(TestCase):
         assert report.email == "jane@example.com"
         assert report.comments == "This is an example!"
         assert report.event_id == self.event_id
-        assert report.project == self.project
-        assert report.group is None
+        assert report.project_id == self.project.id
+        assert report.group_id is None
 
         resp = self.client.post(
             self.path_with_qs,
@@ -159,8 +159,8 @@ class ErrorPageEmbedTest(TestCase):
         assert report.email == "joe@example.com"
         assert report.comments == "haha I updated it!"
         assert report.event_id == self.event_id
-        assert report.project == self.project
-        assert report.group is None
+        assert report.project_id == self.project.id
+        assert report.group_id is None
 
     def test_submission_invalid_event_id(self):
         self.event_id = "x" * 100
@@ -221,7 +221,7 @@ class ErrorPageEmbedEnvironmentTest(TestCase):
         )
 
         assert response.status_code == 200, response.content
-        assert UserReport.objects.get(event_id=self.event_id).environment == self.environment
+        assert UserReport.objects.get(event_id=self.event_id).environment_id == self.environment.id
 
     def test_user_report_gets_environment(self):
         self.login_as(user=self.user)
@@ -232,4 +232,4 @@ class ErrorPageEmbedEnvironmentTest(TestCase):
         )
         self.make_event(environment=self.environment.name, event_id=self.event_id)
         assert response.status_code == 200, response.content
-        assert UserReport.objects.get(event_id=self.event_id).environment == self.environment
+        assert UserReport.objects.get(event_id=self.event_id).environment_id == self.environment.id


### PR DESCRIPTION
We're moving `UserReport` to a separate database, and so can no longer rely on  Django's
automatic join behaviour. In https://github.com/getsentry/sentry/pull/23194 we will remove teh
foreign keys entirely and replace with just the `_id` columns instead. This pr prepares us for that,
and attempts to remove all join behaviour as well as replacing uses of the FKs with `*_id`.

Not 100% done - we have a cross db join to groups in a couple places. I'll figure out how to handle
that shortly.