### PR TITLE
ref(slack): Gather metrics on shared links

### DIFF
--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -4,6 +4,8 @@ import re
 import six
 from collections import defaultdict
 
+import sentry_sdk
+
 from django.db.models import Q
 
 from sentry import eventstore
@@ -16,7 +18,7 @@ from sentry.utils import json
 
 from .client import SlackClient
 from .requests import SlackEventRequest, SlackRequestError
-from .utils import build_group_attachment, build_incident_attachment, logger
+from .utils import build_group_attachment, build_incident_attachment, parse_link, logger
 
 # XXX(dcramer): this could be more tightly bound to our configured domain,
 # but slack limits what we can unfurl anyways so its probably safe
@@ -165,46 +167,50 @@ class SlackEventEndpoint(Endpoint):
         return self.respond()
 
     def on_link_shared(self, request, integration, token, data):
-        parsed_issues = defaultdict(dict)
-        event_id_by_url = {}
-        for item in data["links"]:
-            event_type, instance_id, event_id = self._parse_url(item["url"])
-            if not instance_id:
-                continue
-            # note that because we store the url by the issue,
-            # we will only unfurl one link per issue even if there are
-            # multiple links to different events
-            parsed_issues[event_type][instance_id] = item["url"]
-            event_id_by_url[item["url"]] = event_id
+        with sentry_sdk.start_transaction(
+            op=u"slack.link_shared", name=u"SlackLinkShared", sampled=1.0
+        ) as span:
+            parsed_issues = defaultdict(dict)
+            event_id_by_url = {}
+            for item in data["links"]:
+                span.set_tag("link", parse_link(item["url"]))
+                event_type, instance_id, event_id = self._parse_url(item["url"])
+                if not instance_id:
+                    continue
+                # note that because we store the url by the issue,
+                # we will only unfurl one link per issue even if there are
+                # multiple links to different events
+                parsed_issues[event_type][instance_id] = item["url"]
+                event_id_by_url[item["url"]] = event_id
 
-        if not parsed_issues:
-            return
+            if not parsed_issues:
+                return
 
-        results = {}
-        for event_type, instance_map in parsed_issues.items():
-            results.update(
-                self.event_handlers[event_type](integration, instance_map, event_id_by_url)
-            )
+            results = {}
+            for event_type, instance_map in parsed_issues.items():
+                results.update(
+                    self.event_handlers[event_type](integration, instance_map, event_id_by_url)
+                )
 
-        if not results:
-            return
+            if not results:
+                return
 
-        access_token = self._get_access_token(integration)
+            access_token = self._get_access_token(integration)
 
-        payload = {
-            "token": access_token,
-            "channel": data["channel"],
-            "ts": data["message_ts"],
-            "unfurls": json.dumps(results),
-        }
+            payload = {
+                "token": access_token,
+                "channel": data["channel"],
+                "ts": data["message_ts"],
+                "unfurls": json.dumps(results),
+            }
 
-        client = SlackClient()
-        try:
-            client.post("/chat.unfurl", data=payload)
-        except ApiError as e:
-            logger.error("slack.event.unfurl-error", extra={"error": six.text_type(e)})
+            client = SlackClient()
+            try:
+                client.post("/chat.unfurl", data=payload)
+            except ApiError as e:
+                logger.error("slack.event.unfurl-error", extra={"error": six.text_type(e)})
 
-        return self.respond()
+            return self.respond()
 
     # TODO(dcramer): implement app_uninstalled and tokens_revoked
     @transaction_start("SlackEventEndpoint")

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -173,7 +173,10 @@ class SlackEventEndpoint(Endpoint):
             parsed_issues = defaultdict(dict)
             event_id_by_url = {}
             for item in data["links"]:
-                span.set_tag("link", parse_link(item["url"]))
+                try:
+                    span.set_tag("link", parse_link(item["url"]))
+                except Exception as e:
+                    logger.error("slack.parse-link-error", extra={"error": six.text_type(e)})
                 event_type, instance_id, event_id = self._parse_url(item["url"])
                 if not instance_id:
                     continue

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -555,6 +555,6 @@ def parse_link(url):
 
     parsed_path = "/".join(new_path)
 
-    parsed_path += "/" + six.binary_type(url_parts[4])
+    parsed_path += "/" + six.text_type(url_parts[4])
 
     return parsed_path

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -10,8 +10,9 @@ from sentry.integrations.slack.utils import (
     build_incident_attachment,
     CHANNEL_PREFIX,
     get_channel_id,
-    RESOLVED_COLOR,
     MEMBER_PREFIX,
+    RESOLVED_COLOR,
+    parse_link,
 )
 from sentry.models import Integration
 from sentry.testutils import TestCase
@@ -396,3 +397,20 @@ class BuildIncidentAttachmentTest(TestCase):
         warning_event = self.store_event(data={"level": "warning"}, project_id=self.project.id)
         assert build_group_attachment(warning_event.group)["color"] == "#FFC227"
         assert build_group_attachment(warning_event.group, warning_event)["color"] == "#FFC227"
+
+    def test_parse_link(self):
+        link = "https://meowlificent.ngrok.io/organizations/sentry/issues/167/?project=2&amp;query=is%3Aunresolved"
+        link2 = "https://meowlificent.ngrok.io/organizations/sentry/issues/1/events/2d113519854c4f7a85bae8b69c7404ad/?project=2"
+        link3 = "https://meowlificent.ngrok.io/organizations/sentry/issues/9998089891/events/198e93sfa99d41b993ac8ae5dc384642/events/"
+        assert (
+            parse_link(link)
+            == "organizations/{organization}/issues/{issue_id}/project=%7Bproject%7D&query=%5B%27is%3Aunresolved%27%5D"
+        )
+        assert (
+            parse_link(link2)
+            == "organizations/{organization}/issues/{issue_id}/events/{event_id}/project=%7Bproject%7D"
+        )
+        assert (
+            parse_link(link3)
+            == "organizations/{organization}/issues/{issue_id}/events/{event_id}/events/"
+        )


### PR DESCRIPTION
We want to be able to see what (Sentry) links users are sharing in Slack as we think about the future (an example is unfurling performance graphs). In order to aggregate the data, the URL is parsed to replace organization specific information. I realize this won't account for 100% of the URLs available on the site, but cruising through [urls.py](https://github.com/getsentry/sentry/blob/master/src/sentry/api/urls.py) and clicking around the product led me to the decisions made here. The organization, team id, issue id, and event ids are 'scrubbed' and replaced with text.