### PR TITLE
fix(session-api): Round start/end to a multiple of interval

### DIFF
--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -112,6 +112,13 @@ def get_date_range_rollup_from_params(
 
     start, end = get_date_range_from_params(params)
     date_range = end - start
+
+    # round the range up to a multiple of the interval
+    if round_range:
+        date_range = timedelta(
+            seconds=int(interval * math.ceil(date_range.total_seconds() / interval))
+        )
+
     if date_range.total_seconds() / interval > max_points:
         raise InvalidParams(
             "Your interval and date range would create too many results. "

--- a/tests/sentry/api/test_utils.py
+++ b/tests/sentry/api/test_utils.py
@@ -95,3 +95,11 @@ class GetDateRangeRollupFromParamsTest(TestCase):
             start, end, interval = get_date_range_rollup_from_params(
                 {"interval": "1d"}, max_points=80
             )
+
+    def test_round_exact(self):
+        start, end, interval = get_date_range_rollup_from_params(
+            {"start": "2021-01-12T04:06:16", "end": "2021-01-17T08:26:13", "interval": "1d"},
+            round_range=True,
+        )
+        assert start == datetime.datetime(2021, 1, 12, tzinfo=timezone.utc)
+        assert end == datetime.datetime(2021, 1, 18, tzinfo=timezone.utc)

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -171,6 +171,34 @@ def test_massage_simple_timeseries():
     assert actual_result == expected_result
 
 
+def test_massage_exact_timeseries():
+    query = _make_query(
+        "start=2020-12-17T15:12:34Z&end=2020-12-18T11:14:17Z&interval=6h&field=sum(session)"
+    )
+    result_totals = [{"sessions": 4}]
+    result_timeseries = [
+        {"sessions": 2, "bucketed_started": "2020-12-17T12:00:00+00:00"},
+        {"sessions": 2, "bucketed_started": "2020-12-18T06:00:00+00:00"},
+    ]
+
+    expected_result = {
+        "query": "",
+        "intervals": [
+            "2020-12-17T12:00:00Z",
+            "2020-12-17T18:00:00Z",
+            "2020-12-18T00:00:00Z",
+            "2020-12-18T06:00:00Z",
+        ],
+        "groups": [
+            {"by": {}, "series": {"sum(session)": [2, 0, 0, 2]}, "totals": {"sum(session)": 4}}
+        ],
+    }
+
+    actual_result = result_sorted(massage_sessions_result(query, result_totals, result_timeseries))
+
+    assert actual_result == expected_result
+
+
 @freeze_time("2020-12-18T11:14:17.105Z")
 def test_massage_groupby_timeseries():
     query = _make_query("statsPeriod=1d&interval=6h&field=sum(session)&groupBy=release")


### PR DESCRIPTION
This fixes a bug where the timestamps that the API returns do not match the timestamps that snuba internally returns, thus resulting in the timeseries returning empty data.

CC @matejminar 