### PR TITLE
ref(discover): Remove unused imports

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -6,7 +6,6 @@ import six
 import logging
 
 from collections import namedtuple
-from math import ceil, floor
 
 from sentry import options
 from sentry.api.event_search import (


### PR DESCRIPTION
These imports are no longer used. Missed them in #23173.