### PR TITLE
fix(discover): Account for top events when calculating rollup

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -212,7 +212,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         request,
         organization,
         get_event_stats,
-        top_events=False,
+        top_events=0,
         query_column="count()",
         params=None,
         query=None,
@@ -241,6 +241,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
                         "Your interval and date range would create too many results. "
                         "Use a larger interval, or a smaller date range."
                     ),
+                    top_events=top_events,
                 )
                 # Backwards compatibility for incidents which uses the old
                 # column aliases as it straddles both versions of events/discover.
@@ -262,10 +263,10 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         serializer = SnubaTSResultSerializer(organization, None, request.user)
 
         with sentry_sdk.start_span(op="discover.endpoint", description="base.stats_serialization"):
-            # When top_events mode is True, result can be a SnubaTSResult in the event that
+            # When the request is for top_events, result can be a SnubaTSResult in the event that
             # there were no top events found. In this case, result contains a zerofilled series
             # that acts as a placeholder.
-            if top_events and isinstance(result, dict):
+            if top_events > 0 and isinstance(result, dict):
                 results = {}
                 for key, event_result in six.iteritems(result):
                     if len(query_columns) > 1:

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -23,24 +23,23 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                 span.set_data("using_v1_results", True)
                 return self.get_v1_results(request, organization)
 
-            top_events = "topEvents" in request.GET
-            limit = None
+            top_events = 0
 
-            if top_events:
+            if "topEvents" in request.GET:
                 try:
-                    limit = int(request.GET.get("topEvents", 0))
+                    top_events = int(request.GET.get("topEvents", 0))
                 except ValueError:
                     return Response({"detail": "topEvents must be an integer"}, status=400)
-                if limit > MAX_TOP_EVENTS:
+                if top_events > MAX_TOP_EVENTS:
                     return Response(
                         {"detail": "Can only get up to {} top events".format(MAX_TOP_EVENTS)},
                         status=400,
                     )
-                elif limit <= 0:
+                elif top_events <= 0:
                     return Response({"detail": "If topEvents needs to be at least 1"}, status=400)
 
         def get_event_stats(query_columns, query, params, rollup):
-            if top_events:
+            if top_events > 0:
                 return discover.top_events_timeseries(
                     timeseries_columns=query_columns,
                     selected_columns=request.GET.getlist("field")[:],
@@ -48,7 +47,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
                     params=params,
                     orderby=self.get_orderby(request),
                     rollup=rollup,
-                    limit=limit,
+                    limit=top_events,
                     organization=organization,
                     referrer="api.organization-event-stats.find-topn",
                     allow_empty=False,


### PR DESCRIPTION
- This changes the top_events param to an int so that the rollup
  function can use it to properly calculate the number of points that
  snuba will have to return for the rollup & interval selected.
- This means that we can error when rollup/interval would mean part of
  the top events chart would go missing from being over the 10k data
  point limit