### PR TITLE
ref(metrics): Add capture envelope metric

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -183,6 +183,9 @@ def configure_sdk():
 
     class MultiplexingTransport(sentry_sdk.transport.Transport):
         def capture_envelope(self, envelope):
+            # Temporarily capture envelope counts to compare to ingested
+            # transactions.
+            metrics.incr("internal.captured.events.envelopes")
             # Assume only transactions get sent via envelopes
             if options.get("transaction-events.force-disable-internal-project"):
                 return


### PR DESCRIPTION
### Summary
This will add a metric to immediately capture envelope count, to split between Sentry specific code and the sdk. This should help split the problem space by comparing the number of overall envelopes against properly ingested transactions.

![Screen Shot 2021-01-21 at 11 28 24 AM](https://user-images.githubusercontent.com/6111995/105402452-4bf1c280-5bdc-11eb-8136-d2595bc823b0.png)
