### PR TITLE
ref(stacktrace-link): Correctly encode file_path for GitLab

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -258,8 +258,11 @@ class GitLabApiClient(ApiClient):
 
         See https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository
         Path requires file path and ref
+        file_path must also be URL encoded Ex. lib%2Fclass%2Erb
         """
         self.base_url = self.metadata["base_url"]
         project_id = repo.config["project_id"]
-        request_path = GitLabApiClientPath.file.format(project=project_id, path=path)
+        encoded_path = quote(path, safe="")
+
+        request_path = GitLabApiClientPath.file.format(project=project_id, path=encoded_path)
         return self.head_cached(request_path, params={"ref": ref})

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -5,7 +5,6 @@ from django.core.urlresolvers import reverse
 from sentry.integrations.client import ApiClient
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized
 from sentry.utils.http import absolute_uri
-from sentry.web.decorators import transaction_start
 from six.moves.urllib.parse import quote
 
 
@@ -252,7 +251,6 @@ class GitLabApiClient(ApiClient):
         path = GitLabApiClientPath.diff.format(project=project_id, sha=sha)
         return self.get(path)
 
-    @transaction_start("GitLabApiClient.check_file")
     def check_file(self, repo, path, ref):
         """Fetch a file for stacktrace linking
 

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -128,12 +128,12 @@ class GitlabRefreshAuthTest(GitLabTestCase):
 
     @responses.activate
     def test_check_file(self):
-        path = "file.py"
+        path = "src/file.py"
         ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
         responses.add(
             responses.HEAD,
             "https://example.gitlab.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
-                self.gitlab_id, path, ref
+                self.gitlab_id, "src%2Ffile.py", ref
             ),
             json={"text": 200},
         )
@@ -144,12 +144,12 @@ class GitlabRefreshAuthTest(GitLabTestCase):
 
     @responses.activate
     def test_check_no_file(self):
-        path = "file.py"
+        path = "src/file.py"
         ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
         responses.add(
             responses.HEAD,
             "https://example.gitlab.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
-                self.gitlab_id, path, ref
+                self.gitlab_id, "src%2Ffile.py", ref
             ),
             status=404,
         )


### PR DESCRIPTION
**Problem:**
We've seen GitLab stack trace linking not work for a lot of organizations. Because it was all self-hosted and some Saas, I assumed it was a problem specific to those who were on self-hosted. Instead I think it's because of a different bug. 

According to GitLab's docs for the [repository file endpoint](https://docs.gitlab.com/ee/api/repository_files.html#get-file-from-repository): 

```
file_path (required) - URL encoded full path to new file. Ex. lib%2Fclass%2Erb
```

We are not doing anything to the `file_path` currently. 

**Testing:**
I used postman to test out response codes
 
```
# 200 responses
https://gitlab.com/api/v4/projects/{project.id}/repository/files/src%2Fmorecode.py?ref=main
https://gitlab.com/api/v4/projects/{project.id}/repository/files/src%2Fmorecode%2Epy?ref=main
https://gitlab.com/api/v4/projects/{project.id}/repository/files/README.md?ref=main  
# 404 response
https://gitlab.com/api/v4/projects/{project.id}/repository/files/src/morecode.py?ref=main 

```
