### PR TITLE
chore(dx): Remove useless else in snuba.discover

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -210,9 +210,9 @@ def query(
     """
     if not selected_columns:
         raise InvalidSearchQuery("No columns selected")
-    else:
-        # We clobber this value throughout this code, so copy the value
-        selected_columns = selected_columns[:]
+
+    # We clobber this value throughout this code, so copy the value
+    selected_columns = selected_columns[:]
 
     with sentry_sdk.start_span(
         op="discover.discover", description="query.filter_transform"


### PR DESCRIPTION
Just casually found this in my unstaged changes