### PR TITLE
fix(email): Add sendgrid categories with correct serialization

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -14,6 +14,7 @@ from sentry.incidents.models import (
     IncidentTrigger,
     INCIDENT_STATUS,
 )
+from sentry.utils import json
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri
 
@@ -87,7 +88,7 @@ class EmailActionHandler(ActionHandler):
             html_template=u"sentry/emails/incidents/trigger.html",
             type="incident.alert_rule_{}".format(display.lower()),
             context=context,
-            headers={"category": "metric_alert_email"},
+            headers={"X-SMTPAPI": json.dumps({"category": "metric_alert_email"})},
         )
 
 

--- a/src/sentry/mail/activity/base.py
+++ b/src/sentry/mail/activity/base.py
@@ -12,6 +12,7 @@ from sentry.models import (
     UserAvatar,
     UserOption,
 )
+from sentry.utils import json
 from sentry.utils.assets import get_asset_url
 from sentry.utils.avatar import get_email_avatar
 from sentry.utils.email import MessageBuilder, group_id_to_email
@@ -133,7 +134,10 @@ class ActivityEmail(object):
         project = self.project
         group = self.group
 
-        headers = {"X-Sentry-Project": project.slug}
+        headers = {
+            "X-Sentry-Project": project.slug,
+            "X-SMTPAPI": json.dumps({"category": self.get_category()}),
+        }
 
         if group:
             headers.update(
@@ -141,7 +145,6 @@ class ActivityEmail(object):
                     "X-Sentry-Logger": group.logger,
                     "X-Sentry-Logger-Level": group.get_level_display(),
                     "X-Sentry-Reply-To": group_id_to_email(group.id),
-                    "category": self.get_category(),
                 }
             )
 

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -28,7 +28,7 @@ from sentry.models import (
 from sentry.plugins.base.structs import Notification
 from sentry.plugins.base import plugins
 from sentry.tasks.digests import deliver_digest
-from sentry.utils import metrics
+from sentry.utils import metrics, json
 from sentry.utils.cache import cache
 from sentry.utils.committers import get_serialized_event_file_committers
 from sentry.utils.email import group_id_to_email, MessageBuilder
@@ -363,7 +363,7 @@ class MailAdapter(object):
             "X-Sentry-Logger-Level": group.get_level_display(),
             "X-Sentry-Project": project.slug,
             "X-Sentry-Reply-To": group_id_to_email(group.id),
-            "category": "issue_alert_email",
+            "X-SMTPAPI": json.dumps({"category": "issue_alert_email"}),
         }
 
         for user_id in self.get_send_to(
@@ -444,7 +444,7 @@ class MailAdapter(object):
 
             headers = {
                 "X-Sentry-Project": project.slug,
-                "category": "digest_email",
+                "X-SMTPAPI": json.dumps({"category": "digest_email"}),
             }
 
             group = six.next(iter(counts))
@@ -520,7 +520,7 @@ class MailAdapter(object):
 
         headers = {
             "X-Sentry-Project": project.slug,
-            "category": "user_report_email",
+            "X-SMTPAPI": json.dumps({"category": "user_report_email"}),
         }
 
         # TODO(dcramer): this is copypasta'd from activity notifications

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -545,7 +545,7 @@ def build_message(timestamp, duration, organization, user, reports):
             "report": to_context(organization, interval, reports),
             "user": user,
         },
-        headers={"category": "organization_report_email"},
+        headers={"X-SMTPAPI": json.dumps({"category": "organization_report_email"})},
     )
 
     message.add_users((user.id,))


### PR DESCRIPTION
Following up on the failure of https://github.com/getsentry/sentry/pull/22677, @iProgramStuff and I did some investigation to discover that we had to encode the headers as json before sending them through our mail pipeline and through sendgrid. This PR just properly encodes the category headers so that we can view email analytics in sendgrid.