### PR TITLE
fix(tsdb): Ensure transactions are excluded from tsdb counts

### DIFF
--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -35,31 +35,38 @@ class SnubaTSDB(BaseTSDB):
     will return empty results for unsupported models.
     """
 
+    # Since transactions are currently (and temporarily) written to Snuba's events storage we need to
+    # include this condition to ensure they are excluded from the query. Once we switch to the
+    # errors storage in Snuba, this can be omitted and transactions will be excluded by default.
+    events_type_condition = ["type", "!=", "transaction"]
+
     # ``non_outcomes_query_settings`` are all the query settings for for non outcomes based TSDB models.
     # Single tenant reads Snuba for these models, and writes to DummyTSDB. It reads and writes to Redis for all the
     # other models.
     non_outcomes_query_settings = {
         TSDBModel.project: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "project_id", None, [["type", "!=", "transaction"]]
+            snuba.Dataset.Events, "project_id", None, [events_type_condition]
         ),
-        TSDBModel.group: SnubaModelQuerySettings(snuba.Dataset.Events, "group_id", None, None),
+        TSDBModel.group: SnubaModelQuerySettings(
+            snuba.Dataset.Events, "group_id", None, [events_type_condition]
+        ),
         TSDBModel.release: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "tags[sentry:release]", None, None
+            snuba.Dataset.Events, "tags[sentry:release]", None, [events_type_condition]
         ),
         TSDBModel.users_affected_by_group: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "group_id", "tags[sentry:user]", None
+            snuba.Dataset.Events, "group_id", "tags[sentry:user]", [events_type_condition]
         ),
         TSDBModel.users_affected_by_project: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "project_id", "tags[sentry:user]", None
+            snuba.Dataset.Events, "project_id", "tags[sentry:user]", [events_type_condition]
         ),
         TSDBModel.frequent_environments_by_group: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "group_id", "environment", None
+            snuba.Dataset.Events, "group_id", "environment", [events_type_condition]
         ),
         TSDBModel.frequent_releases_by_group: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "group_id", "tags[sentry:release]", None
+            snuba.Dataset.Events, "group_id", "tags[sentry:release]", [events_type_condition]
         ),
         TSDBModel.frequent_issues_by_project: SnubaModelQuerySettings(
-            snuba.Dataset.Events, "project_id", "group_id", None
+            snuba.Dataset.Events, "project_id", "group_id", [events_type_condition]
         ),
     }
 

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -1,19 +1,16 @@
 from __future__ import absolute_import
 
-import calendar
 from datetime import datetime, timedelta
 import pytz
-import requests
 import six
 
-from django.conf import settings
 from sentry.utils.compat.mock import patch
 
-from sentry.utils import json
-from sentry.models import GroupHash, GroupRelease, Release
+from sentry.models import Environment, Group, GroupRelease, Release
 from sentry.tsdb.base import TSDBModel
 from sentry.tsdb.snuba import SnubaTSDB
 from sentry.testutils import TestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import iso_format
 from sentry.utils.dates import to_timestamp
 
 
@@ -62,90 +59,78 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
         self.now = datetime.utcnow().replace(
             hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.UTC
         )
-
         self.proj1 = self.create_project()
-        self.proj1env1 = self.create_environment(project=self.proj1, name="test")
-        self.proj1env2 = self.create_environment(project=self.proj1, name="dev")
-        self.proj1env3 = self.create_environment(project=self.proj1, name="staging")
-        self.proj1defaultenv = self.create_environment(project=self.proj1, name="")
+        env1 = "test"
+        env2 = "dev"
+        defaultenv = ""
 
-        self.proj1group1 = self.create_group(self.proj1)
-        self.proj1group2 = self.create_group(self.proj1)
-
-        hash1 = "1" * 32
-        hash2 = "2" * 32
-        GroupHash.objects.create(project=self.proj1, group=self.proj1group1, hash=hash1)
-        GroupHash.objects.create(project=self.proj1, group=self.proj1group2, hash=hash2)
+        release1 = "1" * 10
+        release2 = "2" * 10
 
         self.release1 = Release.objects.create(
-            organization_id=self.organization.id, version="1" * 10, date_added=self.now
+            organization_id=self.organization.id, version=release1, date_added=self.now
         )
         self.release1.add_project(self.proj1)
         self.release2 = Release.objects.create(
-            organization_id=self.organization.id, version="2" * 10, date_added=self.now
+            organization_id=self.organization.id, version=release2, date_added=self.now
         )
         self.release2.add_project(self.proj1)
 
-        self.group1release1 = GroupRelease.objects.create(
-            project_id=self.proj1.id, group_id=self.proj1group1.id, release_id=self.release1.id
-        )
-        self.group1release2 = GroupRelease.objects.create(
-            project_id=self.proj1.id, group_id=self.proj1group1.id, release_id=self.release2.id
-        )
-        self.group2release1 = GroupRelease.objects.create(
-            project_id=self.proj1.id, group_id=self.proj1group2.id, release_id=self.release1.id
-        )
-
-        data = json.dumps(
-            [
-                (
-                    2,
-                    "insert",
-                    {
-                        "event_id": (six.text_type(r) * 32)[:32],
-                        "primary_hash": [hash1, hash2][(r // 600) % 2],  # Switch every 10 mins
-                        "group_id": [self.proj1group1.id, self.proj1group2.id][(r // 600) % 2],
-                        "project_id": self.proj1.id,
-                        "message": "message 1",
-                        "platform": "python",
-                        "datetime": (self.now + timedelta(seconds=r)).strftime(
-                            "%Y-%m-%dT%H:%M:%S.%fZ"
-                        ),
-                        "data": {
-                            "type": "transaction" if r % 1200 == 0 else "error",
-                            "received": calendar.timegm(self.now.timetuple()) + r,
-                            "tags": {
-                                "foo": "bar",
-                                "baz": "quux",
-                                # Switch every 2 hours
-                                "environment": [self.proj1env1.name, None][(r // 7200) % 3],
-                                "sentry:user": u"id:user{}".format(r // 3300),
-                                "sentry:release": six.text_type(r // 3600) * 10,  # 1 per hour
-                            },
-                            "user": {
-                                # change every 55 min so some hours have 1 user, some have 2
-                                "id": u"user{}".format(r // 3300),
-                                "email": u"user{}@sentry.io".format(r),
-                            },
-                        },
+        for r in range(0, 14400, 600):  # Every 10 min for 4 hours
+            self.store_event(
+                data={
+                    "event_id": (six.text_type(r) * 32)[:32],
+                    "message": "message 1",
+                    "platform": "python",
+                    "fingerprint": [["group-1"], ["group-2"]][
+                        (r // 600) % 2
+                    ],  # Switch every 10 mins
+                    "timestamp": iso_format(self.now + timedelta(seconds=r)),
+                    "tags": {
+                        "foo": "bar",
+                        "baz": "quux",
+                        # Switch every 2 hours
+                        "environment": [env1, None][(r // 7200) % 3],
+                        "sentry:user": u"id:user{}".format(r // 3300),
                     },
-                )
-                for r in range(0, 14400, 600)
-            ]
-        )  # Every 10 min for 4 hours
+                    "user": {
+                        # change every 55 min so some hours have 1 user, some have 2
+                        "id": u"user{}".format(r // 3300),
+                        "email": u"user{}@sentry.io".format(r),
+                    },
+                    "release": six.text_type(r // 3600) * 10,  # 1 per hour,
+                },
+                project_id=self.proj1.id,
+            )
 
-        assert (
-            requests.post(settings.SENTRY_SNUBA + "/tests/events/insert", data=data).status_code
-            == 200
+        groups = Group.objects.filter(project=self.proj1).order_by("id")
+        self.proj1group1 = groups[0]
+        self.proj1group2 = groups[1]
+
+        self.env1 = Environment.objects.get(name=env1)
+        self.env2 = self.create_environment(name=env2)  # No events
+        self.defaultenv = Environment.objects.get(name=defaultenv)
+
+        self.group1release1env1 = GroupRelease.objects.get(
+            project_id=self.proj1.id,
+            group_id=self.proj1group1.id,
+            release_id=self.release1.id,
+            environment=env1,
         )
 
-        # snuba trims query windows based on first_seen/last_seen, so these need to be correct-ish
-        self.proj1group1.first_seen = self.now
-        self.proj1group1.last_seen = self.now + timedelta(seconds=14400)
-        self.proj1group1.save()
-        self.proj1group2.first_seen = self.now
-        self.proj1group2.last_seen = self.now + timedelta(seconds=14400)
-        self.proj1group2.save()
+        self.group1release2env1 = GroupRelease.objects.create(
+            project_id=self.proj1.id,
+            group_id=self.proj1group1.id,
+            release_id=self.release2.id,
+            environment=env1,
+        )
+
+        self.group2release1env1 = GroupRelease.objects.get(
+            project_id=self.proj1.id,
+            group_id=self.proj1group2.id,
+            release_id=self.release1.id,
+            environment=env1,
+        )
 
     def test_range_groups(self):
         dts = [self.now + timedelta(hours=i) for i in range(4)]
@@ -203,10 +188,10 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             TSDBModel.project, [self.proj1.id], dts[0], dts[-1], rollup=3600
         ) == {
             self.proj1.id: [
-                (timestamp(dts[0]), 3),
-                (timestamp(dts[1]), 3),
-                (timestamp(dts[2]), 3),
-                (timestamp(dts[3]), 3),
+                (timestamp(dts[0]), 6),
+                (timestamp(dts[1]), 6),
+                (timestamp(dts[2]), 6),
+                (timestamp(dts[3]), 6),
             ]
         }
 
@@ -218,11 +203,11 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             dts[0],
             dts[-1],
             rollup=3600,
-            environment_ids=[self.proj1env1.id],
+            environment_ids=[self.env1.id],
         ) == {
             self.proj1.id: [
-                (timestamp(dts[0]), 3),
-                (timestamp(dts[1]), 3),
+                (timestamp(dts[0]), 6),
+                (timestamp(dts[1]), 6),
                 (timestamp(dts[2]), 0),
                 (timestamp(dts[3]), 0),
             ]
@@ -235,7 +220,7 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             dts[0],
             dts[-1],
             rollup=3600,
-            environment_ids=[self.proj1env2.id],
+            environment_ids=[self.env2.id],
         ) == {
             self.proj1.id: [
                 (timestamp(dts[0]), 0),
@@ -252,13 +237,13 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             dts[0],
             dts[-1],
             rollup=3600,
-            environment_ids=[self.proj1defaultenv.id],
+            environment_ids=[self.defaultenv.id],
         ) == {
             self.proj1.id: [
                 (timestamp(dts[0]), 0),
                 (timestamp(dts[1]), 0),
-                (timestamp(dts[2]), 3),
-                (timestamp(dts[3]), 3),
+                (timestamp(dts[2]), 6),
+                (timestamp(dts[3]), 6),
             ]
         }
 
@@ -268,15 +253,13 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
         dts = [daystart + timedelta(days=i) for i in range(2)]
         assert self.db.get_range(
             TSDBModel.project, [self.proj1.id], dts[0], dts[-1], rollup=86400
-        ) == {self.proj1.id: [(timestamp(dts[0]), 12), (timestamp(dts[1]), 0)]}
+        ) == {self.proj1.id: [(timestamp(dts[0]), 24), (timestamp(dts[1]), 0)]}
 
         # Minutely
         dts = [self.now + timedelta(minutes=i) for i in range(120)]
-        # Expect every 20th minute to have a 1, else 0
-        expected = [
-            (to_timestamp(d), 1 if i % 10 == 0 and i % 20 != 0 else 0) for i, d in enumerate(dts)
-        ]
-        expected[0] = (expected[0][0], 0)
+        # Expect every 10th minute to have a 1, else 0
+        expected = [(to_timestamp(d), 1 if i % 10 == 0 else 0) for i, d in enumerate(dts)]
+
         assert self.db.get_range(
             TSDBModel.project, [self.proj1.id], dts[0], dts[-1], rollup=60
         ) == {self.proj1.id: expected}
@@ -360,7 +343,10 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
             self.now,
             self.now + timedelta(hours=4),
             rollup=3600,
-        ) == {self.proj1.id: [(self.proj1group1.id, 2.0), (self.proj1group2.id, 1.0)]}
+        ) in [
+            {self.proj1.id: [(self.proj1group1.id, 2.0), (self.proj1group2.id, 1.0)]},
+            {self.proj1.id: [(self.proj1group2.id, 2.0), (self.proj1group1.id, 1.0)]},
+        ]  # Both issues equally frequent
 
         assert (
             self.db.get_most_frequent(
@@ -378,24 +364,24 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
         assert self.db.get_frequency_series(
             TSDBModel.frequent_releases_by_group,
             {
-                self.proj1group1.id: (self.group1release1.id, self.group1release2.id),
-                self.proj1group2.id: (self.group2release1.id,),
+                self.proj1group1.id: (self.group1release1env1.id, self.group1release2env1.id),
+                self.proj1group2.id: (self.group2release1env1.id,),
             },
             dts[0],
             dts[-1],
             rollup=3600,
         ) == {
             self.proj1group1.id: [
-                (timestamp(dts[0]), {self.group1release1.id: 0, self.group1release2.id: 0}),
-                (timestamp(dts[1]), {self.group1release1.id: 3, self.group1release2.id: 0}),
-                (timestamp(dts[2]), {self.group1release1.id: 0, self.group1release2.id: 3}),
-                (timestamp(dts[3]), {self.group1release1.id: 0, self.group1release2.id: 0}),
+                (timestamp(dts[0]), {self.group1release1env1.id: 0, self.group1release2env1.id: 0}),
+                (timestamp(dts[1]), {self.group1release1env1.id: 3, self.group1release2env1.id: 0}),
+                (timestamp(dts[2]), {self.group1release1env1.id: 0, self.group1release2env1.id: 3}),
+                (timestamp(dts[3]), {self.group1release1env1.id: 0, self.group1release2env1.id: 0}),
             ],
             self.proj1group2.id: [
-                (timestamp(dts[0]), {self.group2release1.id: 0}),
-                (timestamp(dts[1]), {self.group2release1.id: 3}),
-                (timestamp(dts[2]), {self.group2release1.id: 0}),
-                (timestamp(dts[3]), {self.group2release1.id: 0}),
+                (timestamp(dts[0]), {self.group2release1env1.id: 0}),
+                (timestamp(dts[1]), {self.group2release1env1.id: 3}),
+                (timestamp(dts[2]), {self.group2release1env1.id: 0}),
+                (timestamp(dts[3]), {self.group2release1env1.id: 0}),
             ],
         }
 


### PR DESCRIPTION
Since we are temporarily writing transactions to the same storage
as events in Snuba, we need to ensure that transactions are excluded
from the TSDB aggregates. Once the errors and transactions storages
are separated, this will no longer be required.