### PR TITLE
fix(group-stats): Ensure group stats counts always exclude transactions

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -852,12 +852,13 @@ class GroupSerializerSnuba(GroupSerializerBase):
         filters = {"project_id": project_ids, "group_id": group_ids}
         if self.environment_ids:
             filters["environment"] = self.environment_ids
+
         result = snuba.aliased_query(
             dataset=snuba.Dataset.Events,
             start=start,
             end=end,
             groupby=["group_id"],
-            conditions=conditions,
+            conditions=[*(conditions or []), ["type", "!=", "transaction"]],
             filter_keys=filters,
             aggregations=aggregations,
             referrer="serializers.GroupSerializerSnuba._execute_seen_stats_query",


### PR DESCRIPTION
Since transactions are being written to events storage currently, we need
to add a condition to ensure they are never included in group counts.

This can be removed in the future when errors and transaction storages
are fully separated.