### PR TITLE
ref(sdk): Temporarily remove parent sampling

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1033,7 +1033,7 @@ SENTRY_FRONTEND_WHITELIST_URLS = None
 SENTRY_FRONTEND_APM_SAMPLING = 0
 
 # sample rate for transactions in the backend
-SENTRY_BACKEND_APM_SAMPLING = 0
+SENTRY_BACKEND_APM_SAMPLING = 0.2
 
 # Sample rate for symbolicate_event task transactions
 SENTRY_SYMBOLICATE_EVENT_APM_SAMPLING = 0

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -131,8 +131,6 @@ def _override_on_full_queue(transport, metric_name):
 
 
 def traces_sampler(sampling_context):
-    if options.get("transaction-events.force-disable-internal-project"):
-        return 0.0
     # Resolve the url, and see if we want to set our own sampling
     if "wsgi_environ" in sampling_context:
         try:

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -131,10 +131,6 @@ def _override_on_full_queue(transport, metric_name):
 
 
 def traces_sampler(sampling_context):
-    # If there's already a sampling decision, just use that
-    if sampling_context["parent_sampled"] is not None:
-        return sampling_context["parent_sampled"]
-
     # Resolve the url, and see if we want to set our own sampling
     if "wsgi_environ" in sampling_context:
         try:

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -131,6 +131,8 @@ def _override_on_full_queue(transport, metric_name):
 
 
 def traces_sampler(sampling_context):
+    if options.get("transaction-events.force-disable-internal-project"):
+        return 0.0
     # Resolve the url, and see if we want to set our own sampling
     if "wsgi_environ" in sampling_context:
         try:


### PR DESCRIPTION
### Summary
This will test the effects of parent sampling on event ingestion. Will pair it with getsentry change for conf. Going to run it for a short period (likely tomorrow) then revert.