### PR TITLE
ui(perf): Consolidate empty states on transaction summary

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 
 import {fetchTagFacets, Tag, TagSegment} from 'app/actionCreators/events';
 import {Client} from 'app/api';
+import ErrorPanel from 'app/components/charts/errorPanel';
 import {SectionHeading} from 'app/components/charts/styles';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import Placeholder from 'app/components/placeholder';
@@ -153,16 +154,17 @@ class Tags extends React.Component<Props, State> {
       return this.renderPlaceholders();
     }
     if (error) {
-      return <EmptyStateWarning small />;
+      return (
+        <ErrorPanel height="132px">
+          <IconWarning color="gray300" size="lg" />
+        </ErrorPanel>
+      );
     }
     if (tags.length > 0) {
       return tags.map(tag => this.renderTag(tag));
     } else {
       return (
-        <StyledError>
-          <StyledIconWarning color="gray300" size="lg" />
-          {t('No tags found')}
-        </StyledError>
+        <StyledEmptyStateWarning small>{t('No tags found')}</StyledEmptyStateWarning>
       );
     }
   };
@@ -177,14 +179,9 @@ class Tags extends React.Component<Props, State> {
   }
 }
 
-const StyledError = styled('div')`
-  color: ${p => p.theme.gray300};
-  display: flex;
-  align-items: center;
-`;
-
-const StyledIconWarning = styled(IconWarning)`
-  margin-right: ${space(1)};
+const StyledEmptyStateWarning = styled(EmptyStateWarning)`
+  height: 132px;
+  padding: 54px 15%;
 `;
 
 const StyledPlaceholder = styled(Placeholder)`

--- a/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
@@ -292,7 +292,7 @@ export function VitalBar(props: VitalBarProps) {
   }
 
   const emptyState = showStates ? (
-    <EmptyStateWarning small>{t('No data available')}</EmptyStateWarning>
+    <EmptyVitalBar small>{t('No vitals available')}</EmptyVitalBar>
   ) : null;
 
   if (!data) {
@@ -339,6 +339,11 @@ export function VitalBar(props: VitalBarProps) {
     </React.Fragment>
   );
 }
+
+const EmptyVitalBar = styled(EmptyStateWarning)`
+  height: 48px;
+  padding: ${space(1.5)} 15%;
+`;
 
 type VitalCardProps = {
   title: string;

--- a/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
@@ -292,7 +292,7 @@ export function VitalBar(props: VitalBarProps) {
   }
 
   const emptyState = showStates ? (
-    <EmptyVitalBar small>{t('No vitals available')}</EmptyVitalBar>
+    <EmptyVitalBar small>{t('No vitals found')}</EmptyVitalBar>
   ) : null;
 
   if (!data) {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -83,10 +83,12 @@ class RelatedIssues extends React.Component<Props> {
     return (
       <Panel>
         <PanelBody>
-          <EmptyStateWarning small withIcon={false}>
-            {tct('No new issues for this transaction for the [timePeriod].', {
-              timePeriod: displayedPeriod,
-            })}
+          <EmptyStateWarning>
+            <p>
+              {tct('No new issues for this transaction for the [timePeriod].', {
+                timePeriod: displayedPeriod,
+              })}
+            </p>
           </EmptyStateWarning>
         </PanelBody>
       </Panel>

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
@@ -191,7 +191,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
             {({results, errored, loading, reloading}) => {
               if (errored) {
                 return (
-                  <ErrorPanel>
+                  <ErrorPanel height="580px">
                     <IconWarning color="gray300" size="lg" />
                   </ErrorPanel>
                 );
@@ -205,7 +205,7 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
                 : [];
 
               return (
-                <TransitionChart loading={loading} reloading={reloading} height="550px">
+                <TransitionChart loading={loading} reloading={reloading} height="580px">
                   <TransparentLoadingMask visible={reloading} />
                   <LineChart {...zoomRenderProps} {...chartOptions} series={series} />
                 </TransitionChart>

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/statusBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/statusBreakdown.tsx
@@ -47,17 +47,21 @@ function StatusBreakdown({eventView, location, organization}: Props) {
       >
         {({isLoading, error, tableData}) => {
           if (isLoading) {
-            return <Placeholder height="125px" />;
+            return <Placeholder height="124px" />;
           }
           if (error) {
             return (
-              <ErrorPanel height="125px">
+              <ErrorPanel height="124px">
                 <IconWarning color="gray300" size="lg" />
               </ErrorPanel>
             );
           }
           if (!tableData || tableData.data.length === 0) {
-            return <EmptyStateWarning small>{t('No data available')}</EmptyStateWarning>;
+            return (
+              <EmptyStatusBreakdown small>
+                {t('No statuses available')}
+              </EmptyStatusBreakdown>
+            );
           }
           const points = tableData.data.map(row => ({
             label: String(row['transaction.status']),
@@ -69,6 +73,11 @@ function StatusBreakdown({eventView, location, organization}: Props) {
     </Container>
   );
 }
+
+const EmptyStatusBreakdown = styled(EmptyStateWarning)`
+  height: 124px;
+  padding: 50px 15%;
+`;
 
 export default StatusBreakdown;
 

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/statusBreakdown.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/statusBreakdown.tsx
@@ -58,9 +58,7 @@ function StatusBreakdown({eventView, location, organization}: Props) {
           }
           if (!tableData || tableData.data.length === 0) {
             return (
-              <EmptyStatusBreakdown small>
-                {t('No statuses available')}
-              </EmptyStatusBreakdown>
+              <EmptyStatusBreakdown small>{t('No statuses found')}</EmptyStatusBreakdown>
             );
           }
           const points = tableData.data.map(row => ({


### PR DESCRIPTION
The empty states on the transaction summary page have varying styles. This
change attempts to consolidate some of them to have the same styles.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/105427980-6186dc80-5c1c-11eb-9873-32164281290f.png)

## After

![image](https://user-images.githubusercontent.com/10239353/105428130-b62a5780-5c1c-11eb-8991-acf101df7405.png)