### PR TITLE
test: Fix flaky tsdb backend test

### DIFF
--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -56,7 +56,7 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
         super(SnubaTSDBTest, self).setUp()
 
         self.db = SnubaTSDB()
-        self.now = datetime.utcnow().replace(
+        self.now = (datetime.utcnow() - timedelta(hours=4)).replace(
             hour=0, minute=0, second=0, microsecond=0, tzinfo=pytz.UTC
         )
         self.proj1 = self.create_project()


### PR DESCRIPTION
We need to ensure all of the timestamps are in the past, otherwise this
test will fail in the first 4 hours of each day.