### PR TITLE
test: Upgrade "freezegun" to 1.1.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 docker>=3.7.0,<3.8.0
 exam>=0.5.1
-freezegun==0.3.11
+freezegun==1.1.0
 honcho>=1.0.0,<1.1.0
 openapi-core @ https://github.com/getsentry/openapi-core/archive/master.zip#egg=openapi-core
 pytest==4.6.5


### PR DESCRIPTION
This should fix `AttributeError: module 'time' has no attribute 'clock'` errors when running tests with Python 3.8 (failure here: https://github.com/getsentry/sentry/pull/23218/checks?check_run_id=1743837400)

Changelog: https://github.com/spulec/freezegun/blob/master/CHANGELOG
Note: version 1.0.0 dropped Python 2 support.

Fixes #23242 