### PR TITLE
fix(perf): Remove extra empty bins

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -877,6 +877,11 @@ def find_histogram_params(num_buckets, min_value, max_value, multiplier):
     if start_offset + num_buckets * bucket_size <= scaled_max:
         bucket_size = nice_int(bucket_size + 1)
 
+    # compute the bin for max value and adjust the number of buckets accordingly
+    # to minimize unnecessary empty bins at the tail
+    last_bin = int((scaled_max - start_offset) / bucket_size) * bucket_size + start_offset
+    num_buckets = (last_bin - start_offset) // bucket_size + 1
+
     return HistogramParams(num_buckets, bucket_size, start_offset, multiplier)
 
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1665,14 +1665,14 @@ class QueryTransformTest(TestCase):
         assert discover.find_histogram_params(1, 1, None, 100) == (1, 1, 100, 100)
 
         assert discover.find_histogram_params(10, 0, 9, 1) == (10, 1, 0, 1)
-        assert discover.find_histogram_params(10, 0, 10, 1) == (10, 2, 0, 1)
+        assert discover.find_histogram_params(10, 0, 10, 1) == (6, 2, 0, 1)
         assert discover.find_histogram_params(10, 0, 99, 1) == (10, 10, 0, 1)
-        assert discover.find_histogram_params(10, 0, 100, 1) == (10, 20, 0, 1)
+        assert discover.find_histogram_params(10, 0, 100, 1) == (6, 20, 0, 1)
         assert discover.find_histogram_params(5, 10, 19, 10) == (5, 20, 100, 10)
         assert discover.find_histogram_params(5, 10, 19.9, 10) == (5, 20, 100, 10)
-        assert discover.find_histogram_params(10, 10, 20, 1) == (10, 2, 10, 1)
-        assert discover.find_histogram_params(10, 10, 20, 10) == (10, 20, 100, 10)
-        assert discover.find_histogram_params(10, 10, 20, 100) == (10, 120, 1000, 100)
+        assert discover.find_histogram_params(10, 10, 20, 1) == (6, 2, 10, 1)
+        assert discover.find_histogram_params(10, 10, 20, 10) == (6, 20, 100, 10)
+        assert discover.find_histogram_params(10, 10, 20, 100) == (9, 120, 1000, 100)
 
     def test_normalize_histogram_results_empty(self):
         results = {

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -609,8 +609,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             (10, 15, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
             (15, 20, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
             (20, 25, [("measurements.bar", 1), ("measurements.baz", 1), ("measurements.foo", 1)]),
-            (25, 30, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (30, 35, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
         ]
         assert response.data == self.as_response_data(expected)
 
@@ -635,8 +633,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             (10, 15, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
             (15, 20, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
             (20, 25, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (25, 30, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (30, 35, [("measurements.bar", 1), ("measurements.baz", 1), ("measurements.foo", 1)]),
         ]
         assert response.data == self.as_response_data(expected)
 
@@ -681,7 +677,7 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
     def test_histogram_exclude_outliers_data_filter(self):
         specs = [
-            (0, 1, [("measurements.foo", 4)]),
+            (0, 0, [("measurements.foo", 4)]),
             (4000, 4001, [("measurements.foo", 1)]),
         ]
         self.populate_measurements(specs)
@@ -697,10 +693,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         expected = [
             (0, 1, [("measurements.foo", 4)]),
-            (1, 1, [("measurements.foo", 0)]),
-            (2, 2, [("measurements.foo", 0)]),
-            (3, 3, [("measurements.foo", 0)]),
-            (4, 4, [("measurements.foo", 0)]),
         ]
         assert response.data == self.as_response_data(expected)
 
@@ -781,14 +773,6 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
         assert response.data == self.as_response_data(expected)
 
     def test_histogram_outlier_filtering_with_no_rows(self):
-        specs = [
-            (0, 1, [("transaction.duration", 0)]),
-            (1, 2, [("transaction.duration", 0)]),
-            (2, 3, [("transaction.duration", 0)]),
-            (3, 4, [("transaction.duration", 0)]),
-            (4, 5, [("transaction.duration", 0)]),
-        ]
-
         query = {
             "project": [self.project.id],
             "field": ["transaction.duration"],
@@ -798,5 +782,7 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200
-        expected = specs
+        expected = [
+            (0, 1, [("transaction.duration", 0)]),
+        ]
         assert response.data == self.as_response_data(expected)


### PR DESCRIPTION
Today, the histogram endpoint guarantees the specified number of bins will be
returned. Because of the other guarantees that the min/max can be predefined and
we want to use "nice" numbers, this means we can end up in situations where the
trailing N bins are all zeros. This can appear awkward when rendered. This
change relaxes the guarantee on the specified number of bins and treats it as
the maximum number of bins. The resulting histogram will only contain bins that
range from the min to the max. Because the max can be determined by the outlier
filtering, there can still be some zeros, but they should still appear
reasonable.