### PR TITLE
ref(stacktrace-link): Remove leading /

### DIFF
--- a/src/sentry/integrations/repositories.py
+++ b/src/sentry/integrations/repositories.py
@@ -30,6 +30,7 @@ class RepositoryMixin(object):
         filepath: file from the stacktrace (string)
         branch: commitsha or default_branch (string)
         """
+        filepath = filepath.lstrip("/")
         try:
             self.get_client().check_file(repo, filepath, branch)
         except ApiError as e:

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -27,8 +27,8 @@ class GitHubAppsClientTest(TestCase):
             integration_id=integration.id,
         )
 
-        install = integration.get_installation(organization_id="123")
-        self.client = install.get_client()
+        self.install = integration.get_installation(organization_id="123")
+        self.client = self.install.get_client()
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
     @responses.activate
@@ -61,7 +61,7 @@ class GitHubAppsClientTest(TestCase):
             content_type="application/json",
         )
 
-        path = "/src/sentry/integrations/github/client.py"
+        path = "src/sentry/integrations/github/client.py"
         version = "master"
         url = "https://api.github.com/repos/{}/contents/{}?ref={}".format(
             self.repo.name, path, version
@@ -84,7 +84,7 @@ class GitHubAppsClientTest(TestCase):
             content_type="application/json",
         )
 
-        path = "/src/santry/integrations/github/client.py"
+        path = "src/santry/integrations/github/client.py"
         version = "master"
         url = u"https://api.github.com/repos/{}/contents/{}?ref={}".format(
             self.repo.name, path, version
@@ -95,3 +95,29 @@ class GitHubAppsClientTest(TestCase):
         with self.assertRaises(ApiError):
             self.client.check_file(self.repo, path, version)
         assert responses.calls[1].response.status_code == 404
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=b"jwt_token_1")
+    @responses.activate
+    def test_get_stacktrace_link(self, get_jwt):
+        responses.add(
+            method=responses.POST,
+            url="https://api.github.com/app/installations/1/access_tokens",
+            body='{"token": "12345token", "expires_at": "2030-01-01T00:00:00Z"}',
+            content_type="application/json",
+        )
+
+        path = "/src/sentry/integrations/github/client.py"
+        version = "master"
+        url = "https://api.github.com/repos/{}/contents/{}?ref={}".format(
+            self.repo.name, path.lstrip("/"), version
+        )
+
+        responses.add(
+            method=responses.HEAD, url=url, json={"text": 200},
+        )
+
+        source_url = self.install.get_stacktrace_link(self.repo, path, "master", version)
+        assert (
+            source_url
+            == "https://github.com/Test-Organization/foo/blob/master/src/sentry/integrations/github/client.py"
+        )

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -156,3 +156,21 @@ class GitlabRefreshAuthTest(GitLabTestCase):
         with self.assertRaises(ApiError):
             self.client.check_file(self.repo, path, ref)
         assert responses.calls[0].response.status_code == 404
+
+    @responses.activate
+    def test_get_stacktrace_link(self):
+        path = "/src/file.py"
+        ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
+        responses.add(
+            responses.HEAD,
+            "https://example.gitlab.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
+                self.gitlab_id, "src%2Ffile.py", ref
+            ),
+            json={"text": 200},
+        )
+
+        source_url = self.installation.get_stacktrace_link(self.repo, path, "master", ref)
+        assert (
+            source_url
+            == "https://example.gitlab.com/example-repo/blob/537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3/src/file.py"
+        )

--- a/tests/sentry/integrations/gitlab/testutils.py
+++ b/tests/sentry/integrations/gitlab/testutils.py
@@ -45,7 +45,7 @@ class GitLabTestCase(APITestCase):
             name=name,
             external_id=u"{}:{}".format(instance, external_id),
             url=url,
-            config={"project_id": external_id},
+            config={"project_id": external_id, "path": "example-repo"},
             provider="integrations:gitlab",
             integration_id=self.integration.id,
         )


### PR DESCRIPTION
A byproduct of the fix in https://github.com/getsentry/sentry/pull/23225 was that in cases where the filepath had a leading `/`, we are now encoding it and getting the following error from GitLab:

```
 “error”: “file_path should be a valid file path”
```

This PR strips any leading slashes: `/src/file.py` will become `src/file.py`. This really only affects GitLab because for GitHub you don't have to encode the filepath and therefore we don't have a problem if a leading `/` is included.
