### PR TITLE
fix(chart): Update background colour for world map chart

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.tsx
@@ -124,7 +124,7 @@ class WorldMapChart extends React.Component<Props, State> {
     return (
       <BaseChart
         options={{
-          backgroundColor: theme.backgroundSecondary,
+          backgroundColor: theme.background,
           visualMap: [
             VisualMap({
               left: 'right',


### PR DESCRIPTION
**Before**
<img width="838" alt="Screen Shot 2021-01-22 at 3 11 17 PM" src="https://user-images.githubusercontent.com/139499/105540377-1cb68080-5cc4-11eb-9bcb-e54d65df24f6.png">

**After**

<img width="837" alt="Screen Shot 2021-01-22 at 3 10 56 PM" src="https://user-images.githubusercontent.com/139499/105540381-1d4f1700-5cc4-11eb-9173-8e87175f29aa.png">
