### PR TITLE
fix(ui): Move buttonbar css styles to remove comments

### DIFF
--- a/src/sentry/static/sentry/app/components/buttonBar.tsx
+++ b/src/sentry/static/sentry/app/components/buttonBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 
@@ -50,77 +51,77 @@ function ButtonBar({
   );
 }
 
+const MergedStyles = () => css`
+  /* Raised buttons show borders on both sides. Useful to create pill bars */
+  & > .active {
+    z-index: 2;
+  }
+
+  & > .dropdown,
+  & > button,
+  & > a {
+    position: relative;
+
+    /* First button is square on the right side */
+    &:first-child:not(:last-child) {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+
+      & > .dropdown-actor > ${StyledButton} {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+    }
+
+    /* Middle buttons are square */
+    &:not(:last-child):not(:first-child) {
+      border-radius: 0;
+
+      & > .dropdown-actor > ${StyledButton} {
+        border-radius: 0;
+      }
+    }
+
+    /* Middle buttons only need one border so we don't get a double line */
+    &:first-child {
+      & + .dropdown:not(:last-child),
+      & + a:not(:last-child),
+      & + button:not(:last-child) {
+        margin-left: -1px;
+      }
+    }
+
+    /* Middle buttons only need one border so we don't get a double line */
+    &:not(:last-child):not(:first-child) {
+      & + .dropdown,
+      & + button,
+      & + a {
+        margin-left: -1px;
+      }
+    }
+
+    /* Last button is square on the left side */
+    &:last-child:not(:first-child) {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+      margin-left: -1px;
+
+      & > .dropdown-actor > ${StyledButton} {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+        margin-left: -1px;
+      }
+    }
+  }
+`;
+
 const ButtonGrid = styled('div')<{gap: ValidSize; merged: boolean}>`
   display: grid;
   grid-auto-flow: column;
   grid-column-gap: ${p => space(p.gap)};
   align-items: center;
 
-  ${p =>
-    p.merged &&
-    `
-    /* Raised buttons show borders on both sides. Useful to create pill bars */
-    & > .active {
-      z-index: 2;
-    }
-
-    & > .dropdown,
-    & > button,
-    & > a {
-      position: relative;
-
-      /* First button is square on the right side */
-      &:first-child:not(:last-child) {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-
-        & > .dropdown-actor > ${StyledButton} {
-          border-top-right-radius: 0;
-          border-bottom-right-radius: 0;
-        }
-      }
-
-      /* Middle buttons are square */
-      &:not(:last-child):not(:first-child) {
-        border-radius: 0;
-
-        & > .dropdown-actor > ${StyledButton} {
-          border-radius: 0;
-        }
-      }
-
-      /* Middle buttons only need one border so we don't get a double line */
-      &:first-child {
-        & + .dropdown:not(:last-child),
-        & + a:not(:last-child),
-        & + button:not(:last-child) {
-          margin-left: -1px;
-        }
-      }
-
-      /* Middle buttons only need one border so we don't get a double line */
-      &:not(:last-child):not(:first-child) {
-        & + .dropdown,
-        & + button,
-        & + a {
-          margin-left: -1px;
-        }
-      }
-
-      /* Last button is square on the left side */
-      &:last-child:not(:first-child) {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-        margin-left: -1px;
-
-        & > .dropdown-actor > ${StyledButton} {
-          border-top-left-radius: 0;
-          border-bottom-left-radius: 0;
-          margin-left: -1px;
-        }
-      }
-    }
-  `}
+  ${p => p.merged && MergedStyles}
 `;
 
 export default ButtonBar;


### PR DESCRIPTION
Inline css templates are preserved in our production build including newlines and comments. This one was large enough to be moved into its own block.