### PR TITLE
ref(discover): Ensure consistent ordering in top_events_timeseries query

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -501,7 +501,7 @@ def top_events_timeseries(
             start=snuba_filter.start,
             end=snuba_filter.end,
             rollup=rollup,
-            orderby="time",
+            orderby=["time"] + snuba_filter.groupby,
             groupby=["time"] + snuba_filter.groupby,
             dataset=Dataset.Discover,
             limit=10000,


### PR DESCRIPTION
This helps to ensure that the Snuba query returns consistent results regardless
of which table (events or errors) it is queried from.