### PR TITLE
ref(sdk): Revert sampling change

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1033,7 +1033,7 @@ SENTRY_FRONTEND_WHITELIST_URLS = None
 SENTRY_FRONTEND_APM_SAMPLING = 0
 
 # sample rate for transactions in the backend
-SENTRY_BACKEND_APM_SAMPLING = 0.2
+SENTRY_BACKEND_APM_SAMPLING = 0
 
 # Sample rate for symbolicate_event task transactions
 SENTRY_SYMBOLICATE_EVENT_APM_SAMPLING = 0

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -131,6 +131,10 @@ def _override_on_full_queue(transport, metric_name):
 
 
 def traces_sampler(sampling_context):
+    # If there's already a sampling decision, just use that
+    if sampling_context["parent_sampled"] is not None:
+        return sampling_context["parent_sampled"]
+
     # Resolve the url, and see if we want to set our own sampling
     if "wsgi_environ" in sampling_context:
         try:


### PR DESCRIPTION
This reverts #23235 to once again use parent sampling.