### PR TITLE
[WIP]: Updated slack linked shared transactions

### DIFF
--- a/src/sentry/integrations/slack/urls.py
+++ b/src/sentry/integrations/slack/urls.py
@@ -8,8 +8,8 @@ from .link_identity import SlackLinkIdentityView
 from .unlink_identity import SlackUnlinkIdentityView
 
 urlpatterns = [
-    url(r"^action/$", SlackActionEndpoint.as_view()),
-    url(r"^event/$", SlackEventEndpoint.as_view()),
+    url(r"^action/$", SlackActionEndpoint.as_view(), name="sentry-integration-slack-action",),
+    url(r"^event/$", SlackEventEndpoint.as_view(), name="sentry-integration-slack-event",),
     url(
         r"^link-identity/(?P<signed_params>[^\/]+)/$",
         SlackLinkIdentityView.as_view(),

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -27,6 +27,8 @@ UNSAFE_FILES = (
 # URLs that should always be sampled
 SAMPLED_URL_NAMES = {
     "sentry-api-0-organization-releases",
+    "sentry-integration-slack-event",
+    "sentry-integration-slack-action",
 }
 
 UNSAFE_TAG = "_unsafe"


### PR DESCRIPTION
Instead of using `start_transaction`, utilize the `traces_sampler` and then create subsequent spans. Since span tags aren't searchable yet, can use the `scope.set_tag` so that we can have results like :

> <img width="1178" alt="Screen Shot 2021-01-22 at 3 34 20 PM" src="https://user-images.githubusercontent.com/15368179/105559986-7d938800-5cc7-11eb-9481-da34a72f61d8.png">

Example of viewing the span itself, the tag `link` is still there and is the same value as the `slack_shared_link` but it's not in the top level search
> <img width="879" alt="Screen Shot 2021-01-22 at 3 35 03 PM" src="https://user-images.githubusercontent.com/15368179/105559982-7bc9c480-5cc7-11eb-8a11-9417514f992e.png">
