### PR TITLE
feat(metric_alerts): Metric chart coloring

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -30,6 +30,7 @@ import {
   TimeWindow,
 } from 'app/views/settings/incidentRules/types';
 
+import {Incident} from '../../types';
 import {DATA_SOURCE_LABELS, getIncidentRuleMetricPreset} from '../../utils';
 
 import MetricChart from './metricChart';
@@ -38,6 +39,7 @@ import RelatedIssues from './relatedIssues';
 type Props = {
   api: Client;
   rule?: IncidentRule;
+  incidents?: Incident[];
   organization: Organization;
   location: Location;
 } & RouteComponentProps<{orgId: string}, {}>;
@@ -200,6 +202,7 @@ export default class DetailsBody extends React.Component<Props> {
     const {
       api,
       rule,
+      incidents,
       organization,
       params: {orgId},
     } = this.props;
@@ -238,7 +241,7 @@ export default class DetailsBody extends React.Component<Props> {
                       environment={environment ? [environment] : undefined}
                       project={(projects as Project[]).map(project => Number(project.id))}
                       // TODO(davidenwang): allow interval to be changed for larger time periods
-                      interval="5m"
+                      interval="60s"
                       period={timePeriod.value}
                       yAxis={aggregate}
                       includePrevious={false}
@@ -246,7 +249,7 @@ export default class DetailsBody extends React.Component<Props> {
                     >
                       {({loading, timeseriesData}) =>
                         !loading && timeseriesData ? (
-                          <MetricChart data={timeseriesData} />
+                          <MetricChart data={timeseriesData} incidents={incidents} />
                         ) : (
                           <Placeholder height="200px" />
                         )

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -57,7 +57,7 @@ class AlertRuleDetails extends React.Component<Props, State> {
   };
 
   render() {
-    const {rule, hasError} = this.state;
+    const {rule, incidents, hasError} = this.state;
     const {params, organization} = this.props;
 
     return (
@@ -68,7 +68,7 @@ class AlertRuleDetails extends React.Component<Props, State> {
             params={params}
             rule={rule}
           />
-          <DetailsBody {...this.props} rule={rule} />
+          <DetailsBody {...this.props} rule={rule} incidents={incidents} />
         </Feature>
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -1,14 +1,83 @@
 import React from 'react';
+import moment from 'moment';
 
+import MarkLine from 'app/components/charts/components/markLine';
 import LineChart from 'app/components/charts/lineChart';
 import space from 'app/styles/space';
 import {Series} from 'app/types/echarts';
+import theme from 'app/utils/theme';
+
+import {Incident} from '../../types';
 
 type Props = {
   data: Series[];
+  incidents?: Incident[];
 };
 
-const MetricChart = ({data}: Props) => {
+const MetricChart = ({data, incidents}: Props) => {
+  // Iterate through incidents to add markers to chart
+  let incidentLines;
+  let criticalAreas;
+  const dataArr = data[0].data;
+  const firstPoint = dataArr[0].name;
+  const lastPoint = dataArr[dataArr.length - 1].name;
+  const resolvedArea = {
+    seriesName: 'Critical Area',
+    type: 'line',
+    markLine: MarkLine({
+      silent: true,
+      lineStyle: {color: theme.green300, type: 'solid', width: 4},
+      data: [[{coord: [firstPoint, 0]}, {coord: [lastPoint, 0]}] as any],
+    }),
+    data: [],
+  };
+  if (incidents) {
+    criticalAreas = incidents.map(incident => {
+      const detectTime = moment(incident.dateDetected).valueOf();
+      let resolveTime;
+      if (incident.dateClosed) {
+        resolveTime = moment(incident.dateClosed).valueOf();
+      } else {
+        resolveTime = lastPoint;
+      }
+      const line = [{coord: [detectTime, 0]}, {coord: [resolveTime, 0]}];
+      return {
+        seriesName: 'Critical Area',
+        type: 'line',
+        markLine: MarkLine({
+          silent: true,
+          lineStyle: {color: theme.red300, type: 'solid', width: 4},
+          data: [line as any],
+        }),
+        data: [],
+      };
+    });
+    incidentLines = incidents.map(incident => {
+      const detectTime = moment(incident.dateDetected).valueOf();
+      return {
+        seriesName: 'Incident Line',
+        type: 'line',
+        markLine: MarkLine({
+          silent: true,
+          lineStyle: {color: theme.red300, type: 'solid'},
+          data: [
+            {
+              xAxis: detectTime,
+            } as any,
+          ],
+          label: {
+            show: true,
+            position: 'insideEndTop',
+            formatter: 'CRITICAL',
+            color: theme.red300,
+            fontSize: 10,
+          } as any,
+        }),
+        data: [],
+      };
+    });
+  }
+
   return (
     <LineChart
       isGroupedByDate
@@ -19,7 +88,7 @@ const MetricChart = ({data}: Props) => {
         top: space(2),
         bottom: 0,
       }}
-      series={data}
+      series={[...data, resolvedArea, ...incidentLines, ...criticalAreas]}
     />
   );
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9372512/105564439-f3532000-5cd6-11eb-8bb6-b46e02668892.png)

Super rough draft of metric alert coloring, handing off to @taylangocmen.

Summary of what I've accomplished:
- Have metric chart ingest incident data
- Use the start and end times of each incident to calculate red areas and critical lines

What needs to done:
- Clean up the echarts code (can probably get away with not making a separate series per incident, but adding more data to the markline)
- Perhaps my incident examples are bad but they frequently fire and then immediately resolve so there is no clear red area. Not sure if there is much to do there
- Add warning similar to how critical was done
- Collapse labels? (^above picture shows `Critical` overlapping each other)