### PR TITLE
fix(integrations): Content Security Policy missing xdm_e

### DIFF
--- a/src/sentry/integrations/jira/base_hook.py
+++ b/src/sentry/integrations/jira/base_hook.py
@@ -7,11 +7,13 @@ from sentry import options
 class JiraBaseHook(View):
     def get_response(self, context):
         context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
-        res = render_to_response(self.html_file, context, self.request)
+        response = render_to_response(self.html_file, context, self.request)
         # COOP blocks the Jira glance view links from opening
-        res["Cross-Origin-Opener-Policy"] = "same-origin-allow-popups"
-        res["Content-Security-Policy"] = "frame-ancestors 'self' %s %s" % (
-            self.request.GET["xdm_e"],
+        response["Cross-Origin-Opener-Policy"] = "same-origin-allow-popups"
+        sources = [
+            self.request.GET.get("xdm_e"),
             options.get("system.url-prefix"),
-        )
-        return res
+        ]
+        sources_string = " ".join([s for s in sources if s])  # Filter out None
+        response["Content-Security-Policy"] = "frame-ancestors 'self' %s" % sources_string
+        return response


### PR DESCRIPTION
[SENTRY-MEA](https://sentry.io/organizations/sentry/issues/2166955328/) 
Use a `.get()` in order to guard against a missing value. This error is only occurring a few times but just patching it up to be safe.