### PR TITLE
feat(ui): Add stability chart to project detail

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/errorPanel.tsx
+++ b/src/sentry/static/sentry/app/components/charts/errorPanel.tsx
@@ -12,6 +12,7 @@ const ErrorPanel = styled('div')<{height?: string}>`
   position: relative;
   border-color: transparent;
   margin-bottom: 0;
+  color: ${p => p.theme.gray300};
 `;
 
 export default ErrorPanel;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1942,3 +1942,13 @@ export type ServerlessFunction = {
  * File storage service options for debug files
  */
 export type DebugFileSource = 'http' | 's3' | 'gcs';
+
+export type SessionApiResponse = {
+  query: string;
+  intervals: string[];
+  groups: {
+    by: Record<string, string>;
+    totals: Record<string, number>;
+    series: Record<string, number[]>;
+  }[];
+};

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import {InjectedRouter} from 'react-router/lib/Router';
+import {withTheme} from 'emotion-theming';
+
+import {Client} from 'app/api';
+import ChartZoom, {ZoomRenderProps} from 'app/components/charts/chartZoom';
+import ErrorPanel from 'app/components/charts/errorPanel';
+import LineChart from 'app/components/charts/lineChart';
+import ReleaseSeries from 'app/components/charts/releaseSeries';
+import TransitionChart from 'app/components/charts/transitionChart';
+import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
+import QuestionTooltip from 'app/components/questionTooltip';
+import {IconWarning} from 'app/icons';
+import {t} from 'app/locale';
+import {GlobalSelection, Organization} from 'app/types';
+import {Series} from 'app/types/echarts';
+import getDynamicText from 'app/utils/getDynamicText';
+import {Theme} from 'app/utils/theme';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
+import {HeaderTitleLegend} from 'app/views/performance/styles';
+import {displayCrashFreePercent} from 'app/views/releases/utils';
+import {
+  getSessionTermDescription,
+  SessionTerm,
+} from 'app/views/releases/utils/sessionTerm';
+
+import SessionsRequest from './sessionsRequest';
+
+type Props = {
+  router: InjectedRouter;
+  selection: GlobalSelection;
+  api: Client;
+  organization: Organization;
+  theme: Theme;
+  onTotalValuesChange: (value: number | null) => void;
+};
+
+class ProjectStabilityChart extends React.Component<Props> {
+  render() {
+    const {theme} = this.props;
+
+    const {organization, router, selection, api, onTotalValuesChange} = this.props;
+    const {projects, environments, datetime} = selection;
+    const {start, end, period, utc} = datetime;
+
+    return getDynamicText({
+      value: (
+        <ChartZoom router={router} period={period} start={start} end={end} utc={utc}>
+          {zoomRenderProps => (
+            <SessionsRequest api={api} selection={selection} organization={organization}>
+              {({
+                errored,
+                loading,
+                reloading,
+                timeseriesData,
+                previousTimeseriesData,
+                totalSessions,
+              }) => (
+                <ReleaseSeries
+                  utc={utc}
+                  period={period}
+                  start={start}
+                  end={end}
+                  projects={projects}
+                  environments={environments}
+                >
+                  {({releaseSeries}) => {
+                    if (errored) {
+                      return (
+                        <ErrorPanel>
+                          <IconWarning color="gray300" size="lg" />
+                        </ErrorPanel>
+                      );
+                    }
+
+                    if (totalSessions === 0) {
+                      return <ErrorPanel>{t('There are no session data')}</ErrorPanel>;
+                    }
+
+                    onTotalValuesChange(totalSessions);
+
+                    return (
+                      <TransitionChart loading={loading} reloading={reloading}>
+                        <TransparentLoadingMask visible={reloading} />
+
+                        <HeaderTitleLegend>
+                          {t('Stability')}
+                          <QuestionTooltip
+                            size="sm"
+                            position="top"
+                            title={getSessionTermDescription(SessionTerm.STABILITY, null)}
+                          />
+                        </HeaderTitleLegend>
+
+                        <Chart
+                          theme={theme}
+                          zoomRenderProps={zoomRenderProps}
+                          reloading={reloading}
+                          timeSeries={timeseriesData}
+                          previousTimeSeries={
+                            previousTimeseriesData ? [previousTimeseriesData] : undefined
+                          }
+                          releaseSeries={releaseSeries}
+                        />
+                      </TransitionChart>
+                    );
+                  }}
+                </ReleaseSeries>
+              )}
+            </SessionsRequest>
+          )}
+        </ChartZoom>
+      ),
+      fixed: t('Stability Chart'),
+    });
+  }
+}
+
+type ChartProps = {
+  theme: Theme;
+  zoomRenderProps: ZoomRenderProps;
+  reloading: boolean;
+  timeSeries: Series[];
+  releaseSeries: Series[];
+  previousTimeSeries?: Series[];
+};
+
+class Chart extends React.Component<ChartProps> {
+  shouldComponentUpdate(nextProps: ChartProps) {
+    if (
+      nextProps.releaseSeries !== this.props.releaseSeries &&
+      !nextProps.reloading &&
+      !this.props.reloading
+    ) {
+      return true;
+    }
+
+    if (this.props.reloading && !nextProps.reloading) {
+      return true;
+    }
+
+    return false;
+  }
+
+  get legend() {
+    const {theme} = this.props;
+
+    return {
+      right: 10,
+      top: 0,
+      icon: 'circle',
+      itemHeight: 8,
+      itemWidth: 8,
+      itemGap: 12,
+      align: 'left' as const,
+      textStyle: {
+        color: theme.textColor,
+        verticalAlign: 'top',
+        fontSize: 11,
+        fontFamily: 'Rubik',
+      },
+    };
+  }
+
+  get chartOptions() {
+    const {theme} = this.props;
+
+    return {
+      colors: [theme.green300, theme.purple200],
+      grid: {left: '10px', right: '10px', top: '40px', bottom: '0px'},
+      seriesOptions: {
+        showSymbol: false,
+      },
+      tooltip: {
+        trigger: 'axis' as const,
+        truncate: 80,
+        valueFormatter: (value: number) => displayCrashFreePercent(value, 0, 3),
+      },
+      yAxis: {
+        axisLabel: {
+          color: theme.gray200,
+          formatter: (value: number) => `${value.toFixed(value === 100 ? 0 : 2)}%`,
+        },
+        scale: true,
+        max: 100,
+      },
+    };
+  }
+
+  render() {
+    const {zoomRenderProps, timeSeries, previousTimeSeries, releaseSeries} = this.props;
+
+    return (
+      <LineChart
+        {...zoomRenderProps}
+        {...this.chartOptions}
+        legend={this.legend}
+        series={
+          Array.isArray(releaseSeries) ? [...timeSeries, ...releaseSeries] : timeSeries
+        }
+        previousPeriod={previousTimeSeries}
+      />
+    );
+  }
+}
+
+export default withGlobalSelection(withTheme(ProjectStabilityChart));

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
@@ -46,76 +46,89 @@ function ProjectStabilityChart({
   const {projects, environments, datetime} = selection;
   const {start, end, period, utc} = datetime;
 
-  return getDynamicText({
-    value: (
-      <ChartZoom router={router} period={period} start={start} end={end} utc={utc}>
-        {zoomRenderProps => (
-          <SessionsRequest api={api} selection={selection} organization={organization}>
-            {({
-              errored,
-              loading,
-              reloading,
-              timeseriesData,
-              previousTimeseriesData,
-              totalSessions,
-            }) => (
-              <ReleaseSeries
-                utc={utc}
-                period={period}
-                start={start}
-                end={end}
-                projects={projects}
-                environments={environments}
+  return (
+    <React.Fragment>
+      {getDynamicText({
+        value: (
+          <ChartZoom router={router} period={period} start={start} end={end} utc={utc}>
+            {zoomRenderProps => (
+              <SessionsRequest
+                api={api}
+                selection={selection}
+                organization={organization}
               >
-                {({releaseSeries}) => {
-                  if (errored) {
-                    return (
-                      <ErrorPanel>
-                        <IconWarning color="gray300" size="lg" />
-                      </ErrorPanel>
-                    );
-                  }
+                {({
+                  errored,
+                  loading,
+                  reloading,
+                  timeseriesData,
+                  previousTimeseriesData,
+                  totalSessions,
+                }) => (
+                  <ReleaseSeries
+                    utc={utc}
+                    period={period}
+                    start={start}
+                    end={end}
+                    projects={projects}
+                    environments={environments}
+                  >
+                    {({releaseSeries}) => {
+                      if (errored) {
+                        return (
+                          <ErrorPanel>
+                            <IconWarning color="gray300" size="lg" />
+                          </ErrorPanel>
+                        );
+                      }
 
-                  if (totalSessions === 0) {
-                    return <ErrorPanel>{t('There are no session data')}</ErrorPanel>;
-                  }
+                      if (totalSessions === 0) {
+                        return <ErrorPanel>{t('There are no session data')}</ErrorPanel>;
+                      }
 
-                  onTotalValuesChange(totalSessions);
+                      onTotalValuesChange(totalSessions);
 
-                  return (
-                    <TransitionChart loading={loading} reloading={reloading}>
-                      <TransparentLoadingMask visible={reloading} />
+                      return (
+                        <TransitionChart loading={loading} reloading={reloading}>
+                          <TransparentLoadingMask visible={reloading} />
 
-                      <HeaderTitleLegend>
-                        {t('Stability')}
-                        <QuestionTooltip
-                          size="sm"
-                          position="top"
-                          title={getSessionTermDescription(SessionTerm.STABILITY, null)}
-                        />
-                      </HeaderTitleLegend>
+                          <HeaderTitleLegend>
+                            {t('Stability')}
+                            <QuestionTooltip
+                              size="sm"
+                              position="top"
+                              title={getSessionTermDescription(
+                                SessionTerm.STABILITY,
+                                null
+                              )}
+                            />
+                          </HeaderTitleLegend>
 
-                      <Chart
-                        theme={theme}
-                        zoomRenderProps={zoomRenderProps}
-                        reloading={reloading}
-                        timeSeries={timeseriesData}
-                        previousTimeSeries={
-                          previousTimeseriesData ? [previousTimeseriesData] : undefined
-                        }
-                        releaseSeries={releaseSeries}
-                      />
-                    </TransitionChart>
-                  );
-                }}
-              </ReleaseSeries>
+                          <Chart
+                            theme={theme}
+                            zoomRenderProps={zoomRenderProps}
+                            reloading={reloading}
+                            timeSeries={timeseriesData}
+                            previousTimeSeries={
+                              previousTimeseriesData
+                                ? [previousTimeseriesData]
+                                : undefined
+                            }
+                            releaseSeries={releaseSeries}
+                          />
+                        </TransitionChart>
+                      );
+                    }}
+                  </ReleaseSeries>
+                )}
+              </SessionsRequest>
             )}
-          </SessionsRequest>
-        )}
-      </ChartZoom>
-    ),
-    fixed: t('Stability Chart'),
-  });
+          </ChartZoom>
+        ),
+        fixed: t('Stability Chart'),
+      })}
+    </React.Fragment>
+  );
 }
 
 type ChartProps = {

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
@@ -172,7 +172,7 @@ class Chart extends React.Component<ChartProps> {
         color: theme.textColor,
         verticalAlign: 'top',
         fontSize: 11,
-        fontFamily: 'Rubik',
+        fontFamily: theme.text.family,
       },
     };
   }

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
@@ -35,85 +35,87 @@ type Props = {
   onTotalValuesChange: (value: number | null) => void;
 };
 
-class ProjectStabilityChart extends React.Component<Props> {
-  render() {
-    const {theme} = this.props;
+function ProjectStabilityChart({
+  theme,
+  organization,
+  router,
+  selection,
+  api,
+  onTotalValuesChange,
+}: Props) {
+  const {projects, environments, datetime} = selection;
+  const {start, end, period, utc} = datetime;
 
-    const {organization, router, selection, api, onTotalValuesChange} = this.props;
-    const {projects, environments, datetime} = selection;
-    const {start, end, period, utc} = datetime;
-
-    return getDynamicText({
-      value: (
-        <ChartZoom router={router} period={period} start={start} end={end} utc={utc}>
-          {zoomRenderProps => (
-            <SessionsRequest api={api} selection={selection} organization={organization}>
-              {({
-                errored,
-                loading,
-                reloading,
-                timeseriesData,
-                previousTimeseriesData,
-                totalSessions,
-              }) => (
-                <ReleaseSeries
-                  utc={utc}
-                  period={period}
-                  start={start}
-                  end={end}
-                  projects={projects}
-                  environments={environments}
-                >
-                  {({releaseSeries}) => {
-                    if (errored) {
-                      return (
-                        <ErrorPanel>
-                          <IconWarning color="gray300" size="lg" />
-                        </ErrorPanel>
-                      );
-                    }
-
-                    if (totalSessions === 0) {
-                      return <ErrorPanel>{t('There are no session data')}</ErrorPanel>;
-                    }
-
-                    onTotalValuesChange(totalSessions);
-
+  return getDynamicText({
+    value: (
+      <ChartZoom router={router} period={period} start={start} end={end} utc={utc}>
+        {zoomRenderProps => (
+          <SessionsRequest api={api} selection={selection} organization={organization}>
+            {({
+              errored,
+              loading,
+              reloading,
+              timeseriesData,
+              previousTimeseriesData,
+              totalSessions,
+            }) => (
+              <ReleaseSeries
+                utc={utc}
+                period={period}
+                start={start}
+                end={end}
+                projects={projects}
+                environments={environments}
+              >
+                {({releaseSeries}) => {
+                  if (errored) {
                     return (
-                      <TransitionChart loading={loading} reloading={reloading}>
-                        <TransparentLoadingMask visible={reloading} />
-
-                        <HeaderTitleLegend>
-                          {t('Stability')}
-                          <QuestionTooltip
-                            size="sm"
-                            position="top"
-                            title={getSessionTermDescription(SessionTerm.STABILITY, null)}
-                          />
-                        </HeaderTitleLegend>
-
-                        <Chart
-                          theme={theme}
-                          zoomRenderProps={zoomRenderProps}
-                          reloading={reloading}
-                          timeSeries={timeseriesData}
-                          previousTimeSeries={
-                            previousTimeseriesData ? [previousTimeseriesData] : undefined
-                          }
-                          releaseSeries={releaseSeries}
-                        />
-                      </TransitionChart>
+                      <ErrorPanel>
+                        <IconWarning color="gray300" size="lg" />
+                      </ErrorPanel>
                     );
-                  }}
-                </ReleaseSeries>
-              )}
-            </SessionsRequest>
-          )}
-        </ChartZoom>
-      ),
-      fixed: t('Stability Chart'),
-    });
-  }
+                  }
+
+                  if (totalSessions === 0) {
+                    return <ErrorPanel>{t('There are no session data')}</ErrorPanel>;
+                  }
+
+                  onTotalValuesChange(totalSessions);
+
+                  return (
+                    <TransitionChart loading={loading} reloading={reloading}>
+                      <TransparentLoadingMask visible={reloading} />
+
+                      <HeaderTitleLegend>
+                        {t('Stability')}
+                        <QuestionTooltip
+                          size="sm"
+                          position="top"
+                          title={getSessionTermDescription(SessionTerm.STABILITY, null)}
+                        />
+                      </HeaderTitleLegend>
+
+                      <Chart
+                        theme={theme}
+                        zoomRenderProps={zoomRenderProps}
+                        reloading={reloading}
+                        timeSeries={timeseriesData}
+                        previousTimeSeries={
+                          previousTimeseriesData ? [previousTimeseriesData] : undefined
+                        }
+                        releaseSeries={releaseSeries}
+                      />
+                    </TransitionChart>
+                  );
+                }}
+              </ReleaseSeries>
+            )}
+          </SessionsRequest>
+        )}
+      </ChartZoom>
+    ),
+    fixed: t('Stability Chart'),
+  });
 }
 
 type ChartProps = {

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/sessionsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/sessionsRequest.tsx
@@ -1,0 +1,284 @@
+import React from 'react';
+import isEqual from 'lodash/isEqual';
+import omit from 'lodash/omit';
+
+import {addErrorMessage} from 'app/actionCreators/indicator';
+import {Client} from 'app/api';
+import {
+  DateTimeObject,
+  getDiffInMinutes,
+  SIXTY_DAYS,
+  THIRTY_DAYS,
+} from 'app/components/charts/utils';
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import {t} from 'app/locale';
+import {GlobalSelection, Organization, SessionApiResponse} from 'app/types';
+import {Series} from 'app/types/echarts';
+import {percent} from 'app/utils';
+import {getPeriod} from 'app/utils/getPeriod';
+import {getCrashFreePercent} from 'app/views/releases/utils';
+
+import {shouldFetchPreviousPeriod} from '../utils';
+
+const omitIgnoredProps = (props: Props) =>
+  omit(props, ['api', 'organization', 'children', 'selection.datetime.utc']);
+
+function getInterval(datetimeObj: DateTimeObject) {
+  const diffInMinutes = getDiffInMinutes(datetimeObj);
+
+  if (diffInMinutes >= SIXTY_DAYS) {
+    // Greater than or equal to 60 days
+    return '1d';
+  }
+
+  if (diffInMinutes >= THIRTY_DAYS) {
+    // Greater than or equal to 30 days
+    return '4h';
+  }
+
+  return '1h';
+}
+
+type ReleaseStatsRequestRenderProps = {
+  loading: boolean;
+  reloading: boolean;
+  errored: boolean;
+  timeseriesData: Series[];
+  previousTimeseriesData: Series | null;
+  totalSessions: number | null;
+};
+
+type Props = {
+  api: Client;
+  organization: Organization;
+  selection: GlobalSelection;
+  children: (renderProps: ReleaseStatsRequestRenderProps) => React.ReactNode;
+};
+
+type State = {
+  reloading: boolean;
+  errored: boolean;
+  timeseriesData: Series[] | null;
+  previousTimeseriesData: Series | null;
+  totalSessions: number | null;
+};
+
+class SessionsRequest extends React.Component<Props, State> {
+  state: State = {
+    reloading: false,
+    errored: false,
+    timeseriesData: null,
+    previousTimeseriesData: null,
+    totalSessions: null,
+  };
+
+  componentDidMount() {
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (!isEqual(omitIgnoredProps(this.props), omitIgnoredProps(prevProps))) {
+      this.fetchData();
+    }
+  }
+
+  componentWillUnmount() {
+    this.unmounting = true;
+  }
+
+  private unmounting: boolean = false;
+
+  fetchData = async () => {
+    const {api, selection} = this.props;
+    const shouldFetchWithPrevious = shouldFetchPreviousPeriod(selection.datetime);
+
+    this.setState(state => ({
+      reloading: state.timeseriesData !== null,
+      errored: false,
+    }));
+
+    try {
+      const response: SessionApiResponse = await api.requestPromise(this.path, {
+        query: this.queryParams({shouldFetchWithPrevious}),
+      });
+
+      const {
+        timeseriesData,
+        previousTimeseriesData,
+        totalSessions,
+      } = this.transformData(response, {fetchedWithPrevious: shouldFetchWithPrevious});
+
+      if (this.unmounting) {
+        return;
+      }
+
+      this.setState({
+        reloading: false,
+        timeseriesData,
+        previousTimeseriesData,
+        totalSessions,
+      });
+    } catch {
+      addErrorMessage(t('Error loading chart data'));
+      this.setState({
+        errored: true,
+        reloading: false,
+        timeseriesData: null,
+        previousTimeseriesData: null,
+        totalSessions: null,
+      });
+    }
+  };
+
+  get path() {
+    const {organization} = this.props;
+
+    return `/organizations/${organization.slug}/sessions/`;
+  }
+
+  queryParams({shouldFetchWithPrevious = false}) {
+    const {selection} = this.props;
+    const {datetime, projects, environments: environment} = selection;
+
+    const baseParams = {
+      field: 'sum(session)',
+      groupBy: 'session.status',
+      interval: getInterval(datetime),
+      project: projects[0],
+      environment,
+    };
+
+    if (!shouldFetchWithPrevious) {
+      return {
+        ...baseParams,
+        ...getParams(datetime),
+      };
+    }
+
+    const {period} = selection.datetime;
+    const doubledPeriod = getPeriod(
+      {period, start: undefined, end: undefined},
+      {shouldDoublePeriod: true}
+    ).statsPeriod;
+
+    return {
+      ...baseParams,
+      statsPeriod: doubledPeriod,
+    };
+  }
+
+  transformData(
+    responseData: SessionApiResponse,
+    {fetchedWithPrevious = false}
+  ): {
+    timeseriesData: Series[];
+    previousTimeseriesData: Series | null;
+    totalSessions: number;
+  } {
+    // Take the floor just in case, but data should always be divisible by 2
+    const dataMiddleIndex = Math.floor(responseData.intervals.length / 2);
+
+    // calculate the total number of sessions for this period (exclude previous if there)
+    const totalSessions = responseData.groups.reduce(
+      (acc, group) =>
+        acc +
+        group.series['sum(session)']
+          .slice(fetchedWithPrevious ? dataMiddleIndex : 0)
+          .reduce((value, groupAcc) => groupAcc + value, 0),
+      0
+    );
+
+    // TODO(project-details): refactor this to avoid duplication as we add more session charts
+    const timeseriesData = [
+      {
+        seriesName: t('This Period'),
+        data: responseData.intervals
+          .slice(fetchedWithPrevious ? dataMiddleIndex : 0)
+          .map((interval, i) => {
+            const totalIntervalSessions = responseData.groups.reduce(
+              (acc, group) =>
+                acc +
+                group.series['sum(session)'].slice(
+                  fetchedWithPrevious ? dataMiddleIndex : 0
+                )[i],
+              0
+            );
+
+            const intervalCrashedSessions =
+              responseData.groups
+                .find(group => group.by['session.status'] === 'crashed')
+                ?.series['sum(session)'].slice(fetchedWithPrevious ? dataMiddleIndex : 0)[
+                i
+              ] ?? 0;
+
+            const crashedSessionsPercent = percent(
+              intervalCrashedSessions,
+              totalIntervalSessions
+            );
+
+            return {
+              name: interval,
+              value: getCrashFreePercent(100 - crashedSessionsPercent),
+            };
+          }),
+      },
+    ];
+
+    const previousTimeseriesData = fetchedWithPrevious
+      ? {
+          seriesName: t('Previous Period'),
+          data: responseData.intervals.slice(0, dataMiddleIndex).map((_interval, i) => {
+            const totalIntervalSessions = responseData.groups.reduce(
+              (acc, group) =>
+                acc + group.series['sum(session)'].slice(0, dataMiddleIndex)[i],
+              0
+            );
+
+            const intervalCrashedSessions =
+              responseData.groups
+                .find(group => group.by['session.status'] === 'crashed')
+                ?.series['sum(session)'].slice(0, dataMiddleIndex)[i] ?? 0;
+
+            const crashedSessionsPercent = percent(
+              intervalCrashedSessions,
+              totalIntervalSessions
+            );
+
+            return {
+              name: responseData.intervals[i + dataMiddleIndex],
+              value: getCrashFreePercent(100 - crashedSessionsPercent),
+            };
+          }),
+        }
+      : null;
+
+    return {
+      totalSessions,
+      timeseriesData,
+      previousTimeseriesData,
+    };
+  }
+
+  render() {
+    const {children} = this.props;
+    const {
+      timeseriesData,
+      reloading,
+      errored,
+      totalSessions,
+      previousTimeseriesData,
+    } = this.state;
+    const loading = timeseriesData === null;
+
+    return children({
+      loading,
+      reloading,
+      errored,
+      totalSessions,
+      previousTimeseriesData,
+      timeseriesData: timeseriesData ?? [],
+    });
+  }
+}
+
+export default SessionsRequest;

--- a/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
@@ -25,6 +25,7 @@ import {getTermHelp} from '../performance/data';
 import {ChartContainer} from '../performance/styles';
 
 import ProjectBaseEventsChart from './charts/projectBaseEventsChart';
+import ProjectStabilityChart from './charts/projectStabilityChart';
 
 enum DisplayModes {
   APDEX = 'apdex',
@@ -32,10 +33,11 @@ enum DisplayModes {
   TPM = 'tpm',
   ERRORS = 'errors',
   TRANSACTIONS = 'transactions',
+  STABILITY = 'stability',
 }
 
 const DISPLAY_URL_KEY = ['display1', 'display2'];
-const DEFAULT_DISPLAY_MODES = [DisplayModes.APDEX, DisplayModes.FAILURE_RATE];
+const DEFAULT_DISPLAY_MODES = [DisplayModes.STABILITY, DisplayModes.APDEX];
 
 type Props = {
   api: Client;
@@ -130,6 +132,11 @@ class ProjectCharts extends React.Component<Props, State> {
           !hasPerformance,
         tooltip: hasPerformance ? undefined : noPerformanceTooltip,
       },
+      {
+        value: DisplayModes.STABILITY,
+        label: t('Stability'),
+        disabled: this.otherActiveDisplayModes.includes(DisplayModes.STABILITY),
+      },
     ];
   }
 
@@ -137,6 +144,8 @@ class ProjectCharts extends React.Component<Props, State> {
     switch (this.displayMode) {
       case DisplayModes.ERRORS:
         return t('Total Errors');
+      case DisplayModes.STABILITY:
+        return t('Total Sessions');
       case DisplayModes.APDEX:
       case DisplayModes.FAILURE_RATE:
       case DisplayModes.TPM:
@@ -163,7 +172,9 @@ class ProjectCharts extends React.Component<Props, State> {
   };
 
   handleTotalValuesChange = (value: number | null) => {
-    this.setState({totalValues: value});
+    if (value !== this.state.totalValues) {
+      this.setState({totalValues: value});
+    }
   };
 
   render() {
@@ -243,6 +254,14 @@ class ProjectCharts extends React.Component<Props, State> {
               onTotalValuesChange={this.handleTotalValuesChange}
               colors={[theme.gray200, theme.purple200]}
               showDaily
+            />
+          )}
+          {displayMode === DisplayModes.STABILITY && (
+            <ProjectStabilityChart
+              router={router}
+              api={api}
+              organization={organization}
+              onTotalValuesChange={this.handleTotalValuesChange}
             />
           )}
         </ChartContainer>

--- a/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -6,24 +6,18 @@ import {getParams} from 'app/components/organizations/globalSelectionHeader/getP
 import ScoreCard from 'app/components/scoreCard';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {t} from 'app/locale';
-import {GlobalSelection, Organization} from 'app/types';
+import {GlobalSelection, Organization, SessionApiResponse} from 'app/types';
 import {defined, percent} from 'app/utils';
 import {formatAbbreviatedNumber} from 'app/utils/formatters';
 import {getPeriod} from 'app/utils/getPeriod';
 import {displayCrashFreePercent, getCrashFreePercent} from 'app/views/releases/utils';
+import {
+  getSessionTermDescription,
+  SessionTerm,
+} from 'app/views/releases/utils/sessionTerm';
 
 import MissingReleasesButtons from '../missingFeatureButtons/missingReleasesButtons';
 import {shouldFetchPreviousPeriod} from '../utils';
-
-type SessionApiResponse = {
-  query: string;
-  intervals: string[];
-  groups: {
-    by: Record<string, string>;
-    totals: Record<string, number>;
-    series: Record<string, number[]>;
-  }[];
-};
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;
@@ -132,7 +126,7 @@ class ProjectStabilityScoreCard extends AsyncComponent<Props, State> {
   }
 
   get cardHelp() {
-    return t('Stability score is the percentage of crash free sessions.');
+    return getSessionTermDescription(SessionTerm.STABILITY, null);
   }
 
   get score() {

--- a/src/sentry/static/sentry/app/views/releases/utils/sessionTerm.tsx
+++ b/src/sentry/static/sentry/app/views/releases/utils/sessionTerm.tsx
@@ -10,6 +10,7 @@ export enum SessionTerm {
   HEALTHY = 'healthy',
   ERRORED = 'errored',
   UNHANDLED = 'unhandled',
+  STABILITY = 'stability',
 }
 
 export const sessionTerm = {
@@ -28,6 +29,7 @@ export const commonTermsDescription = {
   [SessionTerm.CRASHES]: t('Number of sessions with a crashed state'),
   [SessionTerm.CRASH_FREE_USERS]: t('Number of unique users with non-crashed sessions'),
   [SessionTerm.CRASH_FREE_SESSIONS]: t('Number of non-crashed sessions'),
+  [SessionTerm.STABILITY]: t('Stability is the percentage of crash free sessions.'),
 };
 
 // This should never be used directly (except in tests)


### PR DESCRIPTION
This is the first chart ever that takes data from the brand new sessions API.

Once we start adding more session charts and things become more clear, I'll start extracting more functions to reusable bits to make working with sessions API easier.

![image](https://user-images.githubusercontent.com/9060071/105741680-e3d41100-5f3a-11eb-86d2-b4ef801b0f86.png)

Project detail is still behind an internal feature flag.