### PR TITLE
fix(charts) Fix darkmode for charts

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/legend.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/legend.tsx
@@ -21,9 +21,18 @@ export default function Legend(
     type: 'scroll',
     padding: 0,
     formatter,
+    icon: 'circle',
+    itemHeight: 8,
+    itemWidth: 8,
+    itemGap: 12,
+    align: 'left' as const,
     textStyle: {
       color: theme?.textColor,
+      verticalAlign: 'top',
+      fontSize: 11,
+      fontFamily: 'Rubik',
     },
+    inactiveColor: theme?.inactive,
     ...rest,
   };
 }

--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -9,6 +9,7 @@ import {Client} from 'app/api';
 import AreaChart from 'app/components/charts/areaChart';
 import BarChart from 'app/components/charts/barChart';
 import ChartZoom, {ZoomRenderProps} from 'app/components/charts/chartZoom';
+import Legend from 'app/components/charts/components/legend';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LineChart from 'app/components/charts/lineChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
@@ -174,24 +175,14 @@ class Chart extends React.Component<ChartProps, State> {
     }
 
     const legend = showLegend
-      ? {
+      ? Legend({
           right: 16,
           top: 12,
-          icon: 'circle',
-          itemHeight: 8,
-          itemWidth: 8,
-          itemGap: 12,
-          align: 'left' as const,
-          textStyle: {
-            color: theme.textColor,
-            verticalAlign: 'top',
-            fontSize: 11,
-            fontFamily: 'Rubik',
-          },
           data,
           selected: seriesSelection,
+          theme,
           ...(legendOptions ?? {}),
-        }
+        })
       : undefined;
 
     const chartOptions = {
@@ -216,7 +207,7 @@ class Chart extends React.Component<ChartProps, State> {
       },
       yAxis: {
         axisLabel: {
-          color: theme.gray200,
+          color: theme.chartLabel,
           formatter: (value: number) => axisLabelFormatter(value, yAxis),
         },
       },

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -7,6 +7,7 @@ import isEqual from 'lodash/isEqual';
 import {Client} from 'app/api';
 import BarChart from 'app/components/charts/barChart';
 import ChartZoom from 'app/components/charts/chartZoom';
+import Legend from 'app/components/charts/components/legend';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LineChart from 'app/components/charts/lineChart';
 import SimpleTableChart from 'app/components/charts/simpleTableChart';
@@ -315,21 +316,12 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
     const {location, router, selection} = this.props;
     const {start, end, period} = selection.datetime;
 
-    const legend = {
+    const legend = Legend({
       right: 10,
       top: 5,
-      icon: 'circle',
-      itemHeight: 8,
-      itemWidth: 8,
-      itemGap: 12,
-      align: 'left',
       type: 'plain',
-      textStyle: {
-        verticalAlign: 'top',
-        fontSize: 11,
-        fontFamily: 'Rubik',
-      },
       selected: getSeriesSelection(location),
+      theme,
       formatter: (seriesName: string) => {
         const arg = getAggregateArg(seriesName);
         if (arg !== null) {
@@ -340,7 +332,7 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
         }
         return seriesName;
       },
-    };
+    });
 
     const axisField = widget.queries[0]?.fields?.[0] ?? 'count()';
     const chartOptions = {

--- a/src/sentry/static/sentry/app/views/discover/styles.tsx
+++ b/src/sentry/static/sentry/app/views/discover/styles.tsx
@@ -143,7 +143,7 @@ export const SidebarTabs = styled((props: any) => <NavTabs {...props} underlined
 `;
 
 export const PlaceholderText = styled('div')`
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.formPlaceholder};
   font-size: 15px;
 `;
 
@@ -183,7 +183,7 @@ export const AddText = styled('span')`
   margin-left: 4px;
   font-size: 13px;
   line-height: 16px;
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.formPlaceholder};
 `;
 
 const spin = keyframes`
@@ -208,7 +208,7 @@ export const ButtonSpinner = styled('div')`
 `;
 
 export const ResultSummary = styled('div')`
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.formPlaceholder};
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
@@ -240,7 +240,7 @@ export const ChartNote = styled('div')`
 `;
 
 export const SavedQueryAction = styled(Link)`
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.formPlaceholder};
   margin-left: ${space(2)};
   display: flex;
 `;
@@ -270,7 +270,7 @@ export const SavedQueryLink = styled(Link)`
 
 export const SavedQueryUpdated = styled('div')`
   font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.formPlaceholder};
 `;
 
 export const QueryPanelContainer = styled('div')`

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -6,6 +6,7 @@ import {Location, Query} from 'history';
 import {Client} from 'app/api';
 import AreaChart from 'app/components/charts/areaChart';
 import ChartZoom from 'app/components/charts/chartZoom';
+import Legend from 'app/components/charts/components/legend';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
@@ -84,21 +85,12 @@ class DurationChart extends React.Component<Props> {
     const end = this.props.end ? getUtcToLocalDateObject(this.props.end) : null;
     const utc = decodeScalar(router.location.query.utc) !== 'false';
 
-    const legend = {
+    const legend = Legend({
       right: 10,
       top: 0,
-      icon: 'circle',
-      itemHeight: 8,
-      itemWidth: 8,
-      itemGap: 12,
-      align: 'left' as const,
-      textStyle: {
-        verticalAlign: 'top',
-        fontSize: 11,
-        fontFamily: 'Rubik',
-      },
       selected: getSeriesSelection(location),
-    };
+      theme,
+    });
 
     const datetimeSelection = {
       start,

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
@@ -5,6 +5,7 @@ import {Location, Query} from 'history';
 
 import {Client} from 'app/api';
 import ChartZoom from 'app/components/charts/chartZoom';
+import Legend from 'app/components/charts/components/legend';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import LineChart from 'app/components/charts/lineChart';
@@ -90,21 +91,12 @@ class TrendChart extends React.Component<Props> {
     const end = this.props.end ? getUtcToLocalDateObject(this.props.end) : null;
     const utc = decodeScalar(router.location.query.utc) !== 'false';
 
-    const legend = {
+    const legend = Legend({
       right: 10,
       top: 0,
-      icon: 'circle',
-      itemHeight: 8,
-      itemWidth: 8,
-      itemGap: 12,
-      align: 'left' as const,
-      textStyle: {
-        verticalAlign: 'top',
-        fontSize: 11,
-        fontFamily: 'Rubik',
-      },
       selected: getSeriesSelection(location, 'trendsUnselectedSeries'),
-    };
+      theme,
+    });
 
     const datetimeSelection = {
       start,

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 
 import {Client} from 'app/api';
 import ChartZoom from 'app/components/charts/chartZoom';
+import Legend from 'app/components/charts/components/legend';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import LineChart from 'app/components/charts/lineChart';
@@ -87,19 +88,9 @@ class VitalsChart extends React.Component<Props> {
     const end = this.props.end ? getUtcToLocalDateObject(this.props.end) : null;
     const utc = decodeScalar(router.location.query.utc) !== 'false';
 
-    const legend = {
+    const legend = Legend({
       right: 10,
       top: 0,
-      icon: 'circle',
-      itemHeight: 8,
-      itemWidth: 8,
-      itemGap: 12,
-      align: 'left' as const,
-      textStyle: {
-        verticalAlign: 'top',
-        fontSize: 11,
-        fontFamily: 'Rubik',
-      },
       selected: getSeriesSelection(location),
       formatter: seriesName => {
         const arg = getAggregateArg(seriesName);
@@ -111,7 +102,8 @@ class VitalsChart extends React.Component<Props> {
         }
         return seriesName;
       },
-    };
+      theme,
+    });
 
     const datetimeSelection = {
       start,

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -4,6 +4,7 @@ import {WithRouterProps} from 'react-router/lib/withRouter';
 
 import {Client} from 'app/api';
 import ChartZoom from 'app/components/charts/chartZoom';
+import Legend from 'app/components/charts/components/legend';
 import LineChart from 'app/components/charts/lineChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
 import TransitionChart from 'app/components/charts/transitionChart';
@@ -63,7 +64,7 @@ function transformEventStats(data: EventsStatsData, seriesName?: string): Series
 }
 
 function getLegend(trendFunction: string) {
-  const legend = {
+  const legend = Legend({
     right: 10,
     top: 0,
     itemGap: 12,
@@ -73,6 +74,7 @@ function getLegend(trendFunction: string) {
       fontSize: 11,
       fontFamily: 'Rubik',
     },
+    theme,
     data: [
       {
         name: 'Baseline',
@@ -88,7 +90,7 @@ function getLegend(trendFunction: string) {
         icon: 'line',
       },
     ],
-  };
+  });
   return legend;
 }
 

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 
 import {Client} from 'app/api';
 import ChartZoom from 'app/components/charts/chartZoom';
+import Legend from 'app/components/charts/components/legend';
 import MarkLine from 'app/components/charts/components/markLine';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
@@ -86,21 +87,12 @@ class VitalChart extends React.Component<Props> {
 
     const yAxis = [`p75(${vitalName})`];
 
-    const legend = {
+    const legend = Legend({
       right: 10,
       top: 0,
-      icon: 'circle',
-      itemHeight: 8,
-      itemWidth: 8,
-      itemGap: 12,
-      align: 'left' as const,
-      textStyle: {
-        verticalAlign: 'top',
-        fontSize: 11,
-        fontFamily: 'Rubik',
-      },
       selected: getSeriesSelection(location),
-    };
+      theme,
+    });
 
     const datetimeSelection = {
       start,

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -5,6 +5,7 @@ import isEqual from 'lodash/isEqual';
 
 import AreaChart from 'app/components/charts/areaChart';
 import {ZoomRenderProps} from 'app/components/charts/chartZoom';
+import Legend from 'app/components/charts/components/legend';
 import LineChart from 'app/components/charts/lineChart';
 import StackedAreaChart from 'app/components/charts/stackedAreaChart';
 import {getSeriesSelection} from 'app/components/charts/utils';
@@ -201,21 +202,12 @@ class HealthChart extends React.Component<Props> {
 
     const Chart = this.getChart();
 
-    const legend = {
+    const legend = Legend({
       right: 10,
       top: 0,
-      icon: 'circle',
-      itemHeight: 8,
-      itemWidth: 8,
-      itemGap: 12,
-      align: 'left' as const,
-      textStyle: {
-        verticalAlign: 'top',
-        fontSize: 11,
-        fontFamily: 'Rubik',
-      },
       data: timeseriesData.map(d => d.seriesName).reverse(),
       selected: getSeriesSelection(location),
+      theme,
       tooltip: {
         show: true,
         formatter: (params): string => {
@@ -228,7 +220,7 @@ class HealthChart extends React.Component<Props> {
           return ['<div class="tooltip-description">', seriesNameDesc, '</div>'].join('');
         },
       },
-    };
+    });
 
     return (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -210,7 +210,8 @@ class HealthChart extends React.Component<Props> {
       theme,
       tooltip: {
         show: true,
-        formatter: (params): string => {
+        // TODO(ts) tooltip.formatter has incorrect types in echarts 4
+        formatter: (params: any): string => {
           const seriesNameDesc = this.getLegendTooltipDescription(params.name ?? '');
 
           if (!seriesNameDesc) {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -252,16 +252,6 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
     const legend = Legend({
       right: 10,
       top: 0,
-      icon: 'circle',
-      itemHeight: 8,
-      itemWidth: 8,
-      itemGap: 12,
-      align: 'left',
-      textStyle: {
-        verticalAlign: 'top',
-        fontSize: 11,
-        fontFamily: 'Rubik',
-      },
       selected,
     });
 


### PR DESCRIPTION
Use the Legend() factory to create legends where it was not already in use. I also moved some of the common legend attributes up to reduce duplication and ensure consistency. Using the theme aliases fixes poor contrast in dark mode.