### PR TITLE
feat(ui): adds initialCounterValue prop

### DIFF
--- a/src/sentry/static/sentry/app/components/list/index.tsx
+++ b/src/sentry/static/sentry/app/components/list/index.tsx
@@ -9,36 +9,45 @@ type Props = {
   children: Array<React.ReactElement>;
   symbol?: keyof typeof listSymbol | React.ReactElement;
   className?: string;
+  initialCounterValue?: number;
 };
 
-const List = styled(({children, className, symbol, ...props}: Props) => {
-  const getWrapperComponent = () => {
-    switch (symbol) {
-      case 'numeric':
-      case 'colored-numeric':
-        return 'ol';
-      default:
-        return 'ul';
-    }
-  };
+const List = styled(
+  ({
+    children,
+    className,
+    symbol,
+    initialCounterValue: _initialCounterValue,
+    ...props
+  }: Props) => {
+    const getWrapperComponent = () => {
+      switch (symbol) {
+        case 'numeric':
+        case 'colored-numeric':
+          return 'ol';
+        default:
+          return 'ul';
+      }
+    };
 
-  const Wrapper = getWrapperComponent();
+    const Wrapper = getWrapperComponent();
 
-  return (
-    <Wrapper className={className} {...props}>
-      {!symbol || typeof symbol === 'string'
-        ? children
-        : React.Children.map(children, child => {
-            if (!React.isValidElement(child)) {
-              return child;
-            }
-            return React.cloneElement(child as React.ReactElement, {
-              symbol,
-            });
-          })}
-    </Wrapper>
-  );
-})`
+    return (
+      <Wrapper className={className} {...props}>
+        {!symbol || typeof symbol === 'string'
+          ? children
+          : React.Children.map(children, child => {
+              if (!React.isValidElement(child)) {
+                return child;
+              }
+              return React.cloneElement(child as React.ReactElement, {
+                symbol,
+              });
+            })}
+      </Wrapper>
+    );
+  }
+)`
   margin: 0;
   padding: 0;
   list-style: none;
@@ -47,7 +56,7 @@ const List = styled(({children, className, symbol, ...props}: Props) => {
   ${p =>
     typeof p.symbol === 'string' &&
     listSymbol[p.symbol] &&
-    getListSymbolStyle(p.theme, p.symbol)}
+    getListSymbolStyle(p.theme, p.symbol, p.initialCounterValue)}
 `;
 
 export default List;

--- a/src/sentry/static/sentry/app/components/list/utils.tsx
+++ b/src/sentry/static/sentry/app/components/list/utils.tsx
@@ -24,7 +24,15 @@ const bulletStyle = (theme: Theme) => css`
   }
 `;
 
-const numericStyle = (theme: Theme, isSolid = false) => css`
+type Options = {
+  isSolid?: boolean;
+  initialCounterValue?: number;
+};
+
+const numericStyle = (
+  theme: Theme,
+  {isSolid = false, initialCounterValue = 0}: Options
+) => css`
   ${commonSymbolStyle}
   & > li:before {
     counter-increment: numberedList;
@@ -51,7 +59,7 @@ const numericStyle = (theme: Theme, isSolid = false) => css`
           border: 1px solid ${theme.gray500};
         `}
   }
-  counter-reset: numberedList;
+  counter-reset: numberedList ${initialCounterValue};
 `;
 
 export const listSymbol = {
@@ -60,12 +68,16 @@ export const listSymbol = {
   bullet: 'bullet',
 };
 
-export function getListSymbolStyle(theme: Theme, symbol: keyof typeof listSymbol) {
+export function getListSymbolStyle(
+  theme: Theme,
+  symbol: keyof typeof listSymbol,
+  initialCounterValue?: number
+) {
   switch (symbol) {
     case 'numeric':
-      return numericStyle(theme);
+      return numericStyle(theme, {initialCounterValue});
     case 'colored-numeric':
-      return numericStyle(theme, true);
+      return numericStyle(theme, {isSolid: true, initialCounterValue});
     default:
       return bulletStyle(theme);
   }

--- a/src/sentry/static/sentry/app/components/list/utils.tsx
+++ b/src/sentry/static/sentry/app/components/list/utils.tsx
@@ -26,6 +26,7 @@ const bulletStyle = (theme: Theme) => css`
 
 type Options = {
   isSolid?: boolean;
+  //setting initialCounterValue to 0 means the first visible step is 1
   initialCounterValue?: number;
 };
 


### PR DESCRIPTION
This PR adds an `initialCounterValue` prop to the List component. This prop sets the initial counter value for list items. This is needed for instructions that are rendered in multiple views. PR using this: https://github.com/getsentry/sentry/pull/23298