### PR TITLE
fix(plugins) Silence noise from webhooks/splunk

### DIFF
--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -1,4 +1,5 @@
 import logging
+from requests.exceptions import ReadTimeout, ConnectionError
 import six
 import sentry
 
@@ -121,4 +122,10 @@ class WebHooksPlugin(notify.NotificationPlugin):
         payload = self.get_group_data(group, event, triggering_rules)
         for url in self.get_webhook_urls(group.project):
             # TODO: Use API client with raise_error
-            safe_execute(self.send_webhook, url, payload, _with_transaction=False)
+            safe_execute(
+                self.send_webhook,
+                url,
+                payload,
+                _with_transaction=False,
+                expected_errors=(ReadTimeout, ConnectionError),
+            )

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -304,7 +304,7 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
             )
 
             if isinstance(exc, (ConnectTimeout, ReadTimeout)):
-                # If we get a ReadTimeout we don't need to raise an error here.
+                # If we get a ConnectTimeout or ReadTimeout we don't need to raise an error here.
                 # Just log and return.
                 return False
 

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -17,7 +17,7 @@ For more details on the payload: http://dev.splunk.com/view/event-collector/SP-C
 import logging
 
 import six
-from requests.exceptions import ReadTimeout
+from requests.exceptions import ConnectTimeout, ReadTimeout
 
 from sentry import http, tagstore
 from sentry.utils import metrics
@@ -303,7 +303,7 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
                 },
             )
 
-            if isinstance(exc, ReadTimeout):
+            if isinstance(exc, (ConnectTimeout, ReadTimeout)):
                 # If we get a ReadTimeout we don't need to raise an error here.
                 # Just log and return.
                 return False


### PR DESCRIPTION
When a webhook fails due to timeout or connection errors we can't do anything and recording events only makes sentry harder for us to use internally. A better solution would be to disable the plugin/webhook after repeated failures. This requires a non-trivial amount of thinking and work though.

Refs SENTRY-MER
Refs SENTRY-MHN