### PR TITLE
ref(slack): Datadog metrics on shared links

### DIFF
--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -166,12 +166,10 @@ class SlackEventEndpoint(Endpoint):
         parsed_issues = defaultdict(dict)
         event_id_by_url = {}
         for item in data["links"]:
-            try:
-                metrics.incr(
-                    "slack.link_shared", sample_rate=1.0,
-                )
-            except Exception as e:
-                logger.error("slack.parse-link-error", extra={"error": six.text_type(e)})
+            metrics.incr(
+                "slack.link_shared",
+                sample_rate=1.0,
+            )
             event_type, instance_id, event_id = self._parse_url(item["url"])
             if not instance_id:
                 continue

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -2,8 +2,6 @@ import re
 import six
 from collections import defaultdict
 
-import sentry_sdk
-
 from django.db.models import Q
 
 from sentry import eventstore
@@ -12,11 +10,11 @@ from sentry.incidents.models import Incident
 from sentry.models import Group, Project
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.web.decorators import transaction_start
-from sentry.utils import json
+from sentry.utils import json, metrics
 
 from .client import SlackClient
 from .requests import SlackEventRequest, SlackRequestError
-from .utils import build_group_attachment, build_incident_attachment, parse_link, logger
+from .utils import build_group_attachment, build_incident_attachment, logger
 
 # XXX(dcramer): this could be more tightly bound to our configured domain,
 # but slack limits what we can unfurl anyways so its probably safe
@@ -165,53 +163,52 @@ class SlackEventEndpoint(Endpoint):
         return self.respond()
 
     def on_link_shared(self, request, integration, token, data):
-        with sentry_sdk.start_transaction(
-            op="slack.link_shared", name="SlackLinkShared", sampled=1.0
-        ) as span:
-            parsed_issues = defaultdict(dict)
-            event_id_by_url = {}
-            for item in data["links"]:
-                try:
-                    span.set_tag("link", parse_link(item["url"]))
-                except Exception as e:
-                    logger.error("slack.parse-link-error", extra={"error": six.text_type(e)})
-                event_type, instance_id, event_id = self._parse_url(item["url"])
-                if not instance_id:
-                    continue
-                # note that because we store the url by the issue,
-                # we will only unfurl one link per issue even if there are
-                # multiple links to different events
-                parsed_issues[event_type][instance_id] = item["url"]
-                event_id_by_url[item["url"]] = event_id
-
-            if not parsed_issues:
-                return
-
-            results = {}
-            for event_type, instance_map in parsed_issues.items():
-                results.update(
-                    self.event_handlers[event_type](integration, instance_map, event_id_by_url)
-                )
-
-            if not results:
-                return
-
-            access_token = self._get_access_token(integration)
-
-            payload = {
-                "token": access_token,
-                "channel": data["channel"],
-                "ts": data["message_ts"],
-                "unfurls": json.dumps(results),
-            }
-
-            client = SlackClient()
+        parsed_issues = defaultdict(dict)
+        event_id_by_url = {}
+        for item in data["links"]:
             try:
-                client.post("/chat.unfurl", data=payload)
-            except ApiError as e:
-                logger.error("slack.event.unfurl-error", extra={"error": six.text_type(e)})
+                metrics.incr(
+                    "slack.link_shared", sample_rate=1.0,
+                )
+            except Exception as e:
+                logger.error("slack.parse-link-error", extra={"error": six.text_type(e)})
+            event_type, instance_id, event_id = self._parse_url(item["url"])
+            if not instance_id:
+                continue
+            # note that because we store the url by the issue,
+            # we will only unfurl one link per issue even if there are
+            # multiple links to different events
+            parsed_issues[event_type][instance_id] = item["url"]
+            event_id_by_url[item["url"]] = event_id
 
-            return self.respond()
+        if not parsed_issues:
+            return
+
+        results = {}
+        for event_type, instance_map in parsed_issues.items():
+            results.update(
+                self.event_handlers[event_type](integration, instance_map, event_id_by_url)
+            )
+
+        if not results:
+            return
+
+        access_token = self._get_access_token(integration)
+
+        payload = {
+            "token": access_token,
+            "channel": data["channel"],
+            "ts": data["message_ts"],
+            "unfurls": json.dumps(results),
+        }
+
+        client = SlackClient()
+        try:
+            client.post("/chat.unfurl", data=payload)
+        except ApiError as e:
+            logger.error("slack.event.unfurl-error", extra={"error": six.text_type(e)})
+
+        return self.respond()
 
     # TODO(dcramer): implement app_uninstalled and tokens_revoked
     @transaction_start("SlackEventEndpoint")


### PR DESCRIPTION
Until we figure out what to do/if we can do anything about Slack `link_shared` events being blocked because of [the web crawler filter in Relay](https://github.com/getsentry/relay/blob/master/relay-filter/src/web_crawlers.rs), we'll simply gather data on how many links are shared in Slack before either putting this back in Sentry or sending it to Kibana.