### PR TITLE
fix: Update DashboardWidgetSerializer to match the schema requirements of the DashboardWidget model

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -76,11 +76,11 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
 class DashboardWidgetSerializer(CamelSnakeSerializer):
     # Is a string because output serializers also make it a string.
     id = serializers.CharField(required=False)
-    title = serializers.CharField(required=False)
+    title = serializers.CharField(required=False, max_length=255)
     display_type = serializers.ChoiceField(
         choices=DashboardWidgetDisplayTypes.as_text_choices(), required=False
     )
-    interval = serializers.CharField(required=False)
+    interval = serializers.CharField(required=False, max_length=10)
     queries = DashboardWidgetQuerySerializer(many=True, required=False)
 
     def validate_display_type(self, display_type):


### PR DESCRIPTION
The app could break if the user sets a dashboard widget title of more than 255 characters. 

We mirror the `DashboardWidgetSerializer` schema requirements to the `DashboardWidget` model:

https://github.com/getsentry/sentry/blob/368af04f25e053271d7a70ddabaccecd9ac74465/src/sentry/models/dashboard_widget.py#L87-L88

Doing so lets the frontend show the validation errors. 

Fixes SENTRY-MK6