### PR TITLE
fix(perf): Landing V2 eventView should respect default display

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -380,9 +380,12 @@ function generateFrontendNavigationPerformanceEventView(
 }
 
 export function generatePerformanceEventView(organization, location, projects) {
-  const display = organization.features.includes('performance-landing-v2')
-    ? getCurrentLandingDisplay(location, projects)
-    : undefined;
+  const eventView = generateGenericPerformanceEventView(organization, location);
+  if (!organization.features.includes('performance-landing-v2')) {
+    return eventView;
+  }
+
+  const display = getCurrentLandingDisplay(location, projects, eventView);
   switch (display?.field) {
     case LandingDisplayField.FRONTEND_PAGELOAD:
       return generateFrontendPageloadPerformanceEventView(organization, location);
@@ -390,7 +393,7 @@ export function generatePerformanceEventView(organization, location, projects) {
       return generateFrontendNavigationPerformanceEventView(organization, location);
     case LandingDisplayField.BACKEND:
     default:
-      return generateGenericPerformanceEventView(organization, location);
+      return eventView;
   }
 }
 


### PR DESCRIPTION
The eventView is generated prior to the default display. This causes a
discrepancy on the landing page where the UI is tailored for the project
platform but the eventView used is for the all display.