### PR TITLE
build(ci): Increase the number of `acceptance` job instances to 4

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -76,7 +76,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        instance: [0, 1, 2]
+        instance: [0, 1, 2, 3]
 
     env:
       VISUAL_SNAPSHOT_ENABLE: 1


### PR DESCRIPTION
This increases the number of `acceptance` job instances from 3 -> 4. Previously, instance #1 was occasionally hitting the 20 minute time limit due to long running test suites (issue details and events v2). Since we have removed py2 workflows, lets bump up the number of `acceptance` instances.

This reduces the longest acceptance test from ~20 minutes --> ~15 minutes.