### PR TITLE
feat(aws-lambda): adds external id input

### DIFF
--- a/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaCloudformation.tsx
+++ b/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaCloudformation.tsx
@@ -135,6 +135,7 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
   };
 
   handleChangeExternalId = (awsExternalId: string) => {
+    awsExternalId = awsExternalId.trim();
     window.localStorage.setItem(ID_NAME, awsExternalId);
     this.setState({awsExternalId});
   };

--- a/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaCloudformation.tsx
+++ b/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaCloudformation.tsx
@@ -42,6 +42,7 @@ type Props = {
 };
 
 type State = {
+  awsExternalId?: string;
   accountNumber?: string;
   region?: string;
   accountNumberError?: string;
@@ -52,6 +53,7 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
   state: State = {
     accountNumber: this.props.accountNumber,
     region: this.props.region,
+    awsExternalId: getAwsExternalId(),
   };
 
   componentDidMount() {
@@ -64,7 +66,7 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
 
   get initialData() {
     const {region, accountNumber} = this.props;
-    const awsExternalId = getAwsExternalId();
+    const {awsExternalId} = this.state;
     return {
       awsExternalId,
       region,
@@ -76,7 +78,7 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
     // generarate the cloudformation URL using the params we get from the server
     // and the external id we generate
     const {baseCloudformationUrl, templateUrl, stackName} = this.props;
-    const awsExternalId = getAwsExternalId();
+    const {awsExternalId} = this.state;
     const query = qs.stringify({
       templateURL: templateUrl,
       stackName,
@@ -132,14 +134,25 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
     this.setState({region});
   };
 
+  handleChangeExternalId = (awsExternalId: string) => {
+    window.localStorage.setItem(ID_NAME, awsExternalId);
+    this.setState({awsExternalId});
+  };
+
   get formValid() {
-    const {accountNumber, region} = this.state;
-    return !!region && testAccountNumber(accountNumber || '');
+    const {accountNumber, region, awsExternalId} = this.state;
+    return !!region && testAccountNumber(accountNumber || '') && !!awsExternalId;
   }
 
   render = () => {
     const {initialStepNumber} = this.props;
-    const {accountNumber, region, accountNumberError, submitting} = this.state;
+    const {
+      accountNumber,
+      region,
+      accountNumberError,
+      submitting,
+      awsExternalId,
+    } = this.state;
     return (
       <React.Fragment>
         <HeaderWithHelp docsUrl="https://docs.sentry.io/product/integrations/aws_lambda/" />
@@ -173,6 +186,15 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
               inline={false}
               stacked
               label={t('AWS Region')}
+            />
+            <TextField
+              name="awsExternalId"
+              value={awsExternalId}
+              onChange={this.handleChangeExternalId}
+              inline={false}
+              stacked
+              error={awsExternalId ? '' : t('External ID Required')}
+              label={t('External ID')}
             />
           </ListItem>
         </StyledList>


### PR DESCRIPTION
If two different users try to set up the AWS Lambda integration on different regions, it will fail because the external ID doesn't match. This PR adds an input for the external ID so you can copy it from an existing CloudFormation stack. The input field has the default value of an external ID that we generate.

![Screen Shot 2021-01-25 at 7 21 29 PM](https://user-images.githubusercontent.com/8533851/105796037-c6a34080-5f42-11eb-9f68-edf49b5eac8c.png)
