### PR TITLE
feat(ui): .NET stack trace improvements

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
-import {IconReturn} from 'app/icons/iconReturn';
+import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
@@ -18,7 +18,6 @@ interface Props {
 
 const Assembly = ({name, version, culture, publicKeyToken, filePath}: Props) => (
   <AssemblyWrapper>
-    <StyledIconReturn />
     <AssemblyInfo>
       <Caption>Assembly:</Caption>
       {name || '-'}
@@ -39,7 +38,9 @@ const Assembly = ({name, version, culture, publicKeyToken, filePath}: Props) => 
     {filePath && (
       <FilePathInfo>
         <Caption>{t('Path')}:</Caption>
-        <TextCopyInput rtl>{filePath}</TextCopyInput>
+        <Tooltip title={filePath}>
+          <TextCopyInput rtl>{filePath}</TextCopyInput>
+        </Tooltip>
       </FilePathInfo>
     )}
   </AssemblyWrapper>
@@ -61,14 +62,7 @@ const AssemblyWrapper = styled('div')`
   color: ${p => p.theme.textColor};
   text-align: center;
   position: relative;
-  padding: 0 ${space(3)} 0 50px;
-`;
-
-const StyledIconReturn = styled(IconReturn)`
-  transform: scaleX(-1);
-  position: absolute;
-  top: 4px;
-  left: 25px;
+  padding: 0 ${space(3)} 0 ${space(3)};
 `;
 
 const AssemblyInfo = styled('div')`
@@ -86,7 +80,8 @@ const FilePathInfo = styled('div')`
   align-items: center;
   margin-bottom: 5px;
   input {
-    width: 250px;
+    width: 300px;
+    height: 20px;
     padding-top: 0;
     padding-bottom: 0;
     line-height: 1.5;

--- a/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
@@ -93,8 +93,8 @@ const FilePathInfo = styled('div')`
     padding: 2px 5px;
   }
   svg {
-    width: 0.9em;
-    height: 0.9em;
+    width: 11px;
+    height: 11px;
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/defaultTitle/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/defaultTitle/index.tsx
@@ -13,7 +13,7 @@ import {Frame, Meta, PlatformType} from 'app/types';
 import {defined, isUrl} from 'app/utils';
 
 import FunctionName from '../functionName';
-import {getPlatform, isCsharp, trimPackage} from '../utils';
+import {getPlatform, isDotnet, trimPackage} from '../utils';
 
 import OriginalSourceInfo from './originalSourceInfo';
 
@@ -79,7 +79,7 @@ const DefaultTitle = ({frame, platform}: Props) => {
     const shouldPrioritizeModuleName = framePlatform === 'java';
 
     // we do not want to show path in title on csharp platform
-    const pathName = isCsharp(framePlatform)
+    const pathName = isDotnet(framePlatform)
       ? undefined
       : getPathName(shouldPrioritizeModuleName);
     const enablePathTooltip = defined(frame.absPath) && frame.absPath !== pathName?.value;
@@ -146,7 +146,7 @@ const DefaultTitle = ({frame, platform}: Props) => {
     );
   }
 
-  if (defined(frame.package) && !isCsharp(framePlatform)) {
+  if (defined(frame.package) && !isDotnet(framePlatform)) {
     title.push(
       <span className="within" key="within">
         {` ${t('within')} `}

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/defaultTitle/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/defaultTitle/index.tsx
@@ -13,7 +13,7 @@ import {Frame, Meta, PlatformType} from 'app/types';
 import {defined, isUrl} from 'app/utils';
 
 import FunctionName from '../functionName';
-import {getPlatform, trimPackage} from '../utils';
+import {getPlatform, isCsharp, trimPackage} from '../utils';
 
 import OriginalSourceInfo from './originalSourceInfo';
 
@@ -76,10 +76,12 @@ const DefaultTitle = ({frame, platform}: Props) => {
   // localized correctly
   if (defined(frame.filename || frame.module)) {
     // prioritize module name for Java as filename is often only basename
-    const shouldPrioritizeModuleName =
-      framePlatform === 'java' || framePlatform === 'csharp';
+    const shouldPrioritizeModuleName = framePlatform === 'java';
 
-    const pathName = getPathName(shouldPrioritizeModuleName);
+    // we do not want to show path in title on csharp platform
+    const pathName = isCsharp(framePlatform)
+      ? undefined
+      : getPathName(shouldPrioritizeModuleName);
     const enablePathTooltip = defined(frame.absPath) && frame.absPath !== pathName?.value;
 
     if (pathName) {
@@ -97,7 +99,7 @@ const DefaultTitle = ({frame, platform}: Props) => {
 
     // in case we prioritized the module name but we also have a filename info
     // we want to show a litle (?) icon that on hover shows the actual filename
-    if (shouldPrioritizeModuleName && frame.filename && framePlatform !== 'csharp') {
+    if (shouldPrioritizeModuleName && frame.filename) {
       title.push(
         <Tooltip key={frame.filename} title={frame.filename}>
           <a className="in-at real-filename">
@@ -115,7 +117,7 @@ const DefaultTitle = ({frame, platform}: Props) => {
       );
     }
 
-    if (defined(frame.function) || defined(frame.rawFunction)) {
+    if ((defined(frame.function) || defined(frame.rawFunction)) && defined(pathName)) {
       title.push(
         <span className="in-at" key="in">
           {` ${t('in')} `}
@@ -144,7 +146,7 @@ const DefaultTitle = ({frame, platform}: Props) => {
     );
   }
 
-  if (defined(frame.package) && framePlatform !== 'csharp') {
+  if (defined(frame.package) && !isCsharp(framePlatform)) {
     title.push(
       <span className="within" key="within">
         {` ${t('within')} `}

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
@@ -30,7 +30,7 @@ import withSentryAppComponents from 'app/utils/withSentryAppComponents';
 import Context from './context';
 import DefaultTitle from './defaultTitle';
 import Symbol, {FunctionNameToggleIcon} from './symbol';
-import {getPlatform} from './utils';
+import {getPlatform, isCsharp} from './utils';
 
 type Props = {
   data: Frame;
@@ -118,7 +118,7 @@ export class Line extends React.Component<Props, State> {
   }
 
   hasAssembly() {
-    return this.getPlatform() === 'csharp' && defined(this.props.data.package);
+    return isCsharp(this.getPlatform()) && defined(this.props.data.package);
   }
 
   isExpandable() {
@@ -199,7 +199,7 @@ export class Line extends React.Component<Props, State> {
       <ToggleContextButtonWrapper>
         <ToggleContextButton
           className="btn-toggle"
-          css={this.getPlatform() === 'csharp' && {display: 'block !important'}} // remove important once we get rid of css files
+          css={isCsharp(this.getPlatform()) && {display: 'block !important'}} // remove important once we get rid of css files
           title={t('Toggle Context')}
           onClick={this.toggleContext}
         >

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
@@ -30,7 +30,7 @@ import withSentryAppComponents from 'app/utils/withSentryAppComponents';
 import Context from './context';
 import DefaultTitle from './defaultTitle';
 import Symbol, {FunctionNameToggleIcon} from './symbol';
-import {getPlatform, isCsharp} from './utils';
+import {getPlatform, isDotnet} from './utils';
 
 type Props = {
   data: Frame;
@@ -118,7 +118,7 @@ export class Line extends React.Component<Props, State> {
   }
 
   hasAssembly() {
-    return isCsharp(this.getPlatform()) && defined(this.props.data.package);
+    return isDotnet(this.getPlatform()) && defined(this.props.data.package);
   }
 
   isExpandable() {
@@ -199,7 +199,7 @@ export class Line extends React.Component<Props, State> {
       <ToggleContextButtonWrapper>
         <ToggleContextButton
           className="btn-toggle"
-          css={isCsharp(this.getPlatform()) && {display: 'block !important'}} // remove important once we get rid of css files
+          css={isDotnet(this.getPlatform()) && {display: 'block !important'}} // remove important once we get rid of css files
           title={t('Toggle Context')}
           onClick={this.toggleContext}
         >

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/utils.tsx
@@ -62,3 +62,7 @@ export function getFrameHint(frame: Frame) {
 
   return [null, null];
 }
+
+export function isCsharp(platform: string) {
+  return platform === 'csharp';
+}

--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/utils.tsx
@@ -63,6 +63,7 @@ export function getFrameHint(frame: Frame) {
   return [null, null];
 }
 
-export function isCsharp(platform: string) {
+export function isDotnet(platform: string) {
+  // csharp platform represents .NET and can be F#, VB or any language targeting CLS (the Common Language Specification)
   return platform === 'csharp';
 }

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
@@ -3,7 +3,11 @@ import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
 
 import Line from 'app/components/events/interfaces/frame/line';
-import {getImageRange, parseAddress} from 'app/components/events/interfaces/utils';
+import {
+  getImageRange,
+  parseAddress,
+  stackTracePlatformIcon,
+} from 'app/components/events/interfaces/utils';
 import {t} from 'app/locale';
 import {Frame, PlatformType} from 'app/types';
 import {Event} from 'app/types/event';
@@ -250,7 +254,7 @@ export default class StacktraceContent extends React.Component<Props, State> {
     return (
       <Wrapper className={className}>
         <StyledPlatformIcon
-          platform={platform}
+          platform={stackTracePlatformIcon(platform, data.frames)}
           size="20px"
           style={{borderRadius: '3px 0 0 3px'}}
         />

--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.tsx
@@ -1,10 +1,14 @@
 import * as Sentry from '@sentry/react';
+import compact from 'lodash/compact';
 import isString from 'lodash/isString';
+import uniq from 'lodash/uniq';
 import * as qs from 'query-string';
 
 import {FILTER_MASK} from 'app/constants';
+import {Frame, PlatformType} from 'app/types';
 import {EntryRequest} from 'app/types/event';
 import {defined} from 'app/utils';
+import {fileExtensionToPlatform, getFileExtension} from 'app/utils/fileExtension';
 
 import {DebugImage} from './debugMeta/types';
 
@@ -188,4 +192,18 @@ export function parseAssembly(assembly: string | null) {
   }
 
   return {name, version, culture, publicKeyToken};
+}
+
+export function stackTracePlatformIcon(platform: PlatformType, frames: Frame[]) {
+  const fileExtensions = uniq(
+    compact(frames.map(frame => getFileExtension(frame.filename ?? '')))
+  );
+
+  if (fileExtensions.length === 1) {
+    const newPlatform = fileExtensionToPlatform(fileExtensions[0]);
+
+    return newPlatform ?? platform;
+  }
+
+  return platform;
 }

--- a/src/sentry/static/sentry/app/components/fileIcon.tsx
+++ b/src/sentry/static/sentry/app/components/fileIcon.tsx
@@ -1,31 +1,8 @@
 import React from 'react';
 
 import {IconFile} from 'app/icons';
+import {fileExtensionToPlatform, getFileExtension} from 'app/utils/fileExtension';
 import theme from 'app/utils/theme';
-
-const FILE_EXTENSION_TO_ICON = {
-  jsx: 'react',
-  tsx: 'react',
-  js: 'javascript',
-  ts: 'javascript',
-  php: 'php',
-  py: 'python',
-  vue: 'vue',
-  go: 'go',
-  java: 'java',
-  perl: 'perl',
-  rb: 'ruby',
-  rs: 'rust',
-  rlib: 'rust',
-  swift: 'swift',
-  h: 'apple',
-  m: 'apple',
-  mm: 'apple',
-  M: 'apple',
-  cs: 'csharp',
-  ex: 'elixir',
-  exs: 'elixir',
-};
 
 type Props = {
   fileName: string;
@@ -34,8 +11,8 @@ type Props = {
 };
 
 const FileIcon = ({fileName, size: providedSize = 'sm', className}: Props) => {
-  const fileExtension = fileName.split('.').pop();
-  const iconName = fileExtension ? FILE_EXTENSION_TO_ICON[fileExtension] : null;
+  const fileExtension = getFileExtension(fileName);
+  const iconName = fileExtension ? fileExtensionToPlatform(fileExtension) : null;
   const size = theme.iconSizes[providedSize] ?? providedSize;
 
   if (!iconName) {

--- a/src/sentry/static/sentry/app/utils/fileExtension.tsx
+++ b/src/sentry/static/sentry/app/utils/fileExtension.tsx
@@ -1,0 +1,39 @@
+const FILE_EXTENSION_TO_PLATFORM = {
+  jsx: 'react',
+  tsx: 'react',
+  js: 'javascript',
+  ts: 'javascript',
+  php: 'php',
+  py: 'python',
+  vue: 'vue',
+  go: 'go',
+  java: 'java',
+  perl: 'perl',
+  rb: 'ruby',
+  rs: 'rust',
+  rlib: 'rust',
+  swift: 'swift',
+  h: 'apple',
+  m: 'apple',
+  mm: 'apple',
+  M: 'apple',
+  cs: 'csharp',
+  ex: 'elixir',
+  exs: 'elixir',
+  fs: 'fsharp',
+};
+
+/**
+ * Takes in path (/Users/test/sentry/something.jsx) and returns file extension (jsx)
+ */
+export function getFileExtension(fileName: string): string | undefined {
+  // this won't work for something like .spec.jsx
+  return fileName.split('.').pop();
+}
+
+/**
+ * Takes in file extension and returns a platform string that can be passed into platformicons
+ */
+export function fileExtensionToPlatform(fileExtension: string): string | undefined {
+  return FILE_EXTENSION_TO_PLATFORM[fileExtension];
+}


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/9060071/105858580-c317c400-5feb-11eb-935e-a615d62ae93b.png)

### After
![image](https://user-images.githubusercontent.com/9060071/105858497-aed3c700-5feb-11eb-87a5-c98412477edc.png)

- hide pathname in title
- fix regression of path input
- add tooltip with full path to path input
- remove IconReturn
- create a mapping function for stack trace platform icon