### PR TITLE
chore(discover): Improve events error tagging

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -108,14 +108,14 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
             yield
         except discover.InvalidSearchQuery as error:
             message = str(error)
-            sentry_sdk.set_tag("query_error.reason", message)
+            sentry_sdk.set_tag("query.error_reason", message)
             raise ParseError(detail=message)
         except snuba.QueryOutsideRetentionError as error:
-            sentry_sdk.set_tag("query_error.reason", "QueryOutsideRetentionError")
+            sentry_sdk.set_tag("query.error_reason", "QueryOutsideRetentionError")
             raise ParseError(detail=str(error))
         except snuba.QueryIllegalTypeOfArgument:
             message = "Invalid query. Argument to function is wrong type."
-            sentry_sdk.set_tag("query_error.reason", message)
+            sentry_sdk.set_tag("query.error_reason", message)
             raise ParseError(detail=message)
         except snuba.SnubaError as error:
             message = "Internal error. Please try again."
@@ -128,13 +128,13 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                     snuba.QueryTooManySimultaneous,
                 ),
             ):
-                sentry_sdk.set_tag("query_error.reason", "Timeout")
+                sentry_sdk.set_tag("query.error_reason", "Timeout")
                 raise ParseError(
                     detail="Query timeout. Please try again. If the problem persists try a smaller date range or fewer projects."
                 )
             elif isinstance(error, (snuba.UnqualifiedQueryError)):
-                sentry_sdk.set_tag("query_error.reason", error.message)
-                raise ParseError(detail=error.message)
+                sentry_sdk.set_tag("query.error_reason", str(error))
+                raise ParseError(detail=str(error))
             elif isinstance(
                 error,
                 (

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
 import sentry_sdk
-import six
 from django.utils.http import urlquote
 from rest_framework.exceptions import APIException, ParseError
 
@@ -36,7 +35,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         try:
             return get_filter(query, params)
         except InvalidSearchQuery as e:
-            raise ParseError(detail=six.text_type(e))
+            raise ParseError(detail=str(e))
 
     def get_snuba_params(self, request, organization, check_global_views=True):
         with sentry_sdk.start_span(op="discover.endpoint", description="filter_params"):
@@ -76,7 +75,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         try:
             _filter = get_filter(query, params)
         except InvalidSearchQuery as e:
-            raise ParseError(detail=six.text_type(e))
+            raise ParseError(detail=str(e))
 
         snuba_args = {
             "start": _filter.start,
@@ -108,12 +107,12 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         try:
             yield
         except discover.InvalidSearchQuery as error:
-            message = six.text_type(error)
+            message = str(error)
             sentry_sdk.set_tag("query_error.reason", message)
             raise ParseError(detail=message)
         except snuba.QueryOutsideRetentionError as error:
             sentry_sdk.set_tag("query_error.reason", "QueryOutsideRetentionError")
-            raise ParseError(detail=six.text_type(error))
+            raise ParseError(detail=str(error))
         except snuba.QueryIllegalTypeOfArgument:
             message = "Invalid query. Argument to function is wrong type."
             sentry_sdk.set_tag("query_error.reason", message)
@@ -171,7 +170,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
 
         return LINK_HEADER.format(
             uri=base_url,
-            cursor=six.text_type(cursor),
+            cursor=str(cursor),
             name=name,
             has_results="true" if bool(cursor) else "false",
         )
@@ -276,7 +275,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             # that acts as a placeholder.
             if top_events and isinstance(result, dict):
                 results = {}
-                for key, event_result in six.iteritems(result):
+                for key, event_result in result.items():
                     if len(query_columns) > 1:
                         results[key] = self.serialize_multiple_axis(
                             serializer, event_result, columns, query_columns


### PR DESCRIPTION
- This is so we can get better insight as to the breakdown of why the
  events endpoints 400s, While something like Rentention is ignorable, I
  want to see how often we're getting Invalid searchqueries and make
  sure they aren't secretly bugs.