### PR TITLE
chore(issue_search): Add metric to postgres only search

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -304,6 +304,8 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
         if not end:
             end = now + ALLOWED_FUTURE_DELTA
 
+            metrics.incr("snuba.search.postgres_only")
+
             # This search is for some time window that ends with "now",
             # so if the requested sort is `date` (`last_seen`) and there
             # are no other Snuba-based search predicates, we can simply


### PR DESCRIPTION
I suspect this isn't being hit at all, since from what I can tell `end` is always passed from the
endpoint - it tries to auto calculate it. So we're likely making a bunch of queries to Snuba that
could just be served from Postgres, since we're hitting Postgres in both cases anyway.