### PR TITLE
build(ci): Add support for `getsentry` dependency for CI

### DIFF
--- a/.github/workflows/js-getsentry-dispatch.yml
+++ b/.github/workflows/js-getsentry-dispatch.yml
@@ -14,9 +14,7 @@ jobs:
     name: frontend dispatch
     runs-on: ubuntu-16.04
     steps:
-      # This workflow only uses `.github/file-filters.yml`, so we do not need to checkout
-      # the head ref from potential forked repo. Instead, we are ok with the base branch
-      # (i.e. getsentry master)
+      # Need to checkout just for `github/file-filters.yml`
       - uses: actions/checkout@v2
 
       - name: Check for frontend file changes
@@ -33,19 +31,32 @@ jobs:
           app_id: ${{ secrets.SENTRY_INTERNAL_APP_ID }}
           private_key: ${{ secrets.SENTRY_INTERNAL_APP_PRIVATE_KEY }}
 
-      # Notify getsentry only if there were frontend files changed
       - name: Dispatch getsentry frontend tests
         uses: actions/github-script@v3
         with:
           github-token: ${{ steps.getsentry.outputs.token }}
           script: |
+            // Check for getsentry PR dependency
+            const body = context.payload.pull_request.body;
+
+            // Logs convert the full PR URL into a shortened link, but we need to match against the full URL
+            const matches = body && body.match(/requires.*getsentry\/getsentry\/pull\/(\d+)/im);
+            const pr = matches && await github.pulls.get({
+              owner: 'getsentry',
+              repo: 'getsentry',
+              pull_number: matches[1],
+            });
+            const branch = pr ? pr.data.head.ref : '';
+
             github.actions.createWorkflowDispatch({
               owner: 'getsentry',
               repo: 'getsentry',
               workflow_id: 'js-build-and-lint.yml',
               ref: 'master',
               inputs: {
-                'skip': "${{ steps.changes.outputs.frontend != 'true' }}",
+                pull_request: matches && matches[1],
+                branch,
+                skip: "${{ steps.changes.outputs.frontend != 'true' }}",
                 'sentry-sha': '${{ github.event.pull_request.head.sha }}',
               }
             })


### PR DESCRIPTION
This adds support for parsing `Requires <getsentry PR URL>` and testing against said PR/branch.

See https://github.com/getsentry/getsentry/pull/5004 for more information


