### PR TITLE
fix(dashboards) Add a background to svg icons

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -210,6 +210,10 @@ const IconContainer = styled('div')`
   > * + * {
     margin-left: 50px;
   }
+
+  svg {
+    background: ${p => p.theme.background};
+  }
 `;
 
 const IconClick = styled('div')`


### PR DESCRIPTION
This should help improve readability as the icons will have a solid background.

![Screen Shot 2021-01-26 at 1 38 25 PM](https://user-images.githubusercontent.com/24086/105897551-51894700-5fe6-11eb-8884-be811fe5164a.png)
