### PR TITLE
feat(workflow): Adding check for OrganizationIntegration

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -23,7 +23,6 @@ from sentry.models import (
     IdentityProvider,
     Integration,
     Organization,
-    OrganizationIntegration,
     Team,
     ReleaseProject,
 )
@@ -500,12 +499,7 @@ def send_incident_alert_notification(action, incident, metric_value):
             organizations=incident.organization,
             status=ObjectStatus.VISIBLE,
         )
-        OrganizationIntegration.objects.get(
-            integration=action.integration_id,
-            organization=incident.organization,
-            status=ObjectStatus.VISIBLE,
-        )
-    except (Integration.DoesNotExist, OrganizationIntegration.DoesNotExist):
+    except Integration.DoesNotExist:
         # Integration removed, but rule is still active.
         return
 


### PR DESCRIPTION
Adding a check here to make sure that the integration still exists before we fire the alert.