### PR TITLE
ref(slack): Gather metrics on shared links in Kibana

### DIFF
--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -10,11 +10,11 @@ from sentry.incidents.models import Incident
 from sentry.models import Group, Project
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.web.decorators import transaction_start
-from sentry.utils import json, metrics
+from sentry.utils import json
 
 from .client import SlackClient
 from .requests import SlackEventRequest, SlackRequestError
-from .utils import build_group_attachment, build_incident_attachment, logger
+from .utils import build_group_attachment, build_incident_attachment, parse_link, logger
 
 # XXX(dcramer): this could be more tightly bound to our configured domain,
 # but slack limits what we can unfurl anyways so its probably safe
@@ -166,10 +166,12 @@ class SlackEventEndpoint(Endpoint):
         parsed_issues = defaultdict(dict)
         event_id_by_url = {}
         for item in data["links"]:
-            metrics.incr(
-                "slack.link_shared",
-                sample_rate=1.0,
-            )
+            try:
+                logger.info(
+                    "slack.link-shared", extra={"slack_shared_link": parse_link(item["url"])}
+                )
+            except Exception as e:
+                logger.error("slack.parse-link-error", extra={"error": six.text_type(e)})
             event_type, instance_id, event_id = self._parse_url(item["url"])
             if not instance_id:
                 continue

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -167,6 +167,7 @@ class SlackEventEndpoint(Endpoint):
         event_id_by_url = {}
         for item in data["links"]:
             try:
+                # we're logging to Kibana because the Slackbot is filtered in Relay
                 logger.info(
                     "slack.link-shared", extra={"slack_shared_link": parse_link(item["url"])}
                 )


### PR DESCRIPTION
Now that we have gathered the number of links shared in Slack in the [previous PR](https://github.com/getsentry/sentry/pull/23306) and know it's a reasonable amount to send to Kibana, we can start actually sending the parsed links to get an idea of what people are sharing.

There's a longer conversation about putting this in Sentry that's currently blocked due to the Slack bot being on the web crawler filter list, so this may be temporary but we still want to get started.