### PR TITLE
feat(dashboards) Add metrics to dashboard operations

### DIFF
--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
@@ -11,6 +11,7 @@ import {IconDelete} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {GlobalSelection, Organization, SavedQuery, SelectValue} from 'app/types';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {Widget, WidgetQuery} from 'app/views/dashboardsV2/types';
 import SearchBar from 'app/views/events/searchBar';
 import {generateFieldOptions} from 'app/views/eventsV2/utils';
@@ -99,6 +100,12 @@ class WidgetQueryForm extends React.Component<Props, State> {
   };
 
   handleSourceChange = (value: string) => {
+    trackAnalyticsEvent({
+      eventKey: 'dashboards2.widget.change_source',
+      eventName: 'Dashboards2: Widget change source',
+      organization_id: parseInt(this.props.organization.id, 10),
+      source: value,
+    });
     this.setState(prevState => {
       return {
         ...prevState,

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -16,6 +16,7 @@ import GlobalSelectionHeader from 'app/components/organizations/globalSelectionH
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -60,6 +61,11 @@ class DashboardDetail extends React.Component<Props, State> {
     if (!dashboard) {
       return;
     }
+    trackAnalyticsEvent({
+      eventKey: 'dashboards2.edit.start',
+      eventName: 'Dashboards2: Edit start',
+      organization_id: parseInt(this.props.organization.id, 10),
+    });
     this.setState({
       dashboardState: 'edit',
       modifiedDashboard: cloneDashboard(dashboard),
@@ -83,6 +89,11 @@ class DashboardDetail extends React.Component<Props, State> {
   };
 
   onCreate = () => {
+    trackAnalyticsEvent({
+      eventKey: 'dashboards2.create.start',
+      eventName: 'Dashboards2: Create start',
+      organization_id: parseInt(this.props.organization.id, 10),
+    });
     this.setState({
       dashboardState: 'create',
       modifiedDashboard: cloneDashboard(EMPTY_DASHBOARD),
@@ -90,6 +101,19 @@ class DashboardDetail extends React.Component<Props, State> {
   };
 
   onCancel = () => {
+    if (this.state.dashboardState === 'create') {
+      trackAnalyticsEvent({
+        eventKey: 'dashboards2.create.cancel',
+        eventName: 'Dashboards2: Create cancel',
+        organization_id: parseInt(this.props.organization.id, 10),
+      });
+    } else if (this.state.dashboardState === 'edit') {
+      trackAnalyticsEvent({
+        eventKey: 'dashboards2.edit.cancel',
+        eventName: 'Dashboards2: Edit cancel',
+        organization_id: parseInt(this.props.organization.id, 10),
+      });
+    }
     this.setState({
       dashboardState: 'view',
       modifiedDashboard: null,
@@ -109,6 +133,11 @@ class DashboardDetail extends React.Component<Props, State> {
         dashboardState: 'pending_delete',
       },
       () => {
+        trackAnalyticsEvent({
+          eventKey: 'dashboards2.delete',
+          eventName: 'Dashboards2: Delete',
+          organization_id: parseInt(this.props.organization.id, 10),
+        });
         deleteDashboard(api, organization.slug, dashboard.id)
           .then(() => {
             addSuccessMessage(t('Dashboard deleted'));
@@ -145,7 +174,11 @@ class DashboardDetail extends React.Component<Props, State> {
           createDashboard(api, organization.slug, modifiedDashboard).then(
             (newDashboard: DashboardDetails) => {
               addSuccessMessage(t('Dashboard created'));
-
+              trackAnalyticsEvent({
+                eventKey: 'dashboards2.create.complete',
+                eventName: 'Dashboards2: Create complete',
+                organization_id: parseInt(organization.id, 10),
+              });
               this.setState({
                 dashboardState: 'view',
                 modifiedDashboard: null,
@@ -178,6 +211,11 @@ class DashboardDetail extends React.Component<Props, State> {
           updateDashboard(api, organization.slug, modifiedDashboard).then(
             (newDashboard: DashboardDetails) => {
               addSuccessMessage(t('Dashboard updated'));
+              trackAnalyticsEvent({
+                eventKey: 'dashboards2.edit.complete',
+                eventName: 'Dashboards2: Edit complete',
+                organization_id: parseInt(organization.id, 10),
+              });
 
               this.setState({
                 dashboardState: 'view',

--- a/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
@@ -11,6 +11,7 @@ import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
 import {Organization} from 'app/types';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 
 import {DashboardDetails, DashboardListItem} from './types';
 
@@ -63,6 +64,12 @@ class OrgDashboards extends AsyncComponent<Props, State> {
 
     if (params.dashboardId) {
       endpoints.push(['selectedDashboard', `${url}${params.dashboardId}/`]);
+      trackAnalyticsEvent({
+        eventKey: 'dashboards2.view',
+        eventName: 'Dashboards2: View dashboard',
+        organization_id: parseInt(this.props.organization.id, 10),
+        dashboard_id: params.dashboardId,
+      });
     }
 
     return endpoints;


### PR DESCRIPTION
Add metrics for create/delete/edit/view operations on dashboards so we can better understand how dashboard edits are aborted and how frequently they are used.

Refs getsentry/reload#187