### PR TITLE
fix(discover): Handle random whitespace in functions

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -154,7 +154,7 @@ has_filter           = negation? "has" sep (search_key / search_value)
 is_filter            = negation? "is" sep search_value
 tag_filter           = negation? "tags[" search_key "]" sep search_value
 
-aggregate_key        = key space? open_paren function_arg* closed_paren
+aggregate_key        = key open_paren function_arg* closed_paren
 search_key           = key / quoted_key
 search_value         = quoted_value / value
 value                = ~r"[^()\s]*"

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -154,7 +154,7 @@ has_filter           = negation? "has" sep (search_key / search_value)
 is_filter            = negation? "is" sep search_value
 tag_filter           = negation? "tags[" search_key "]" sep search_value
 
-aggregate_key        = key space? open_paren space? function_arg* space? closed_paren
+aggregate_key        = key space? open_paren function_arg* closed_paren
 search_key           = key / quoted_key
 search_value         = quoted_value / value
 value                = ~r"[^()\s]*"
@@ -675,6 +675,7 @@ class SearchVisitor(NodeVisitor):
         children = self.flatten(children)
         children = self.remove_optional_nodes(children)
         children = self.remove_space(children)
+
         if len(children) == 3:
             (function_name, open_paren, close_paren) = children
             args = ""

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2023,6 +2023,15 @@ class GetSnubaQueryArgsTest(TestCase):
         result = get_filter("percentile(transaction.duration, 0.75):>100")
         assert result.having == [["percentile_transaction_duration_0_75", ">", 100]]
 
+    def test_function_arguments_with_spaces(self):
+        result = get_filter("percentile(     transaction.duration,     0.75   ):>100")
+        assert result.having == [["percentile_transaction_duration_0_75", ">", 100]]
+
+        result = get_filter(
+            "epm(       ):>100", {"start": before_now(minutes=5), "end": before_now()}
+        )
+        assert result.having == [["epm", ">", 100]]
+
     def test_function_with_float_arguments(self):
         result = get_filter("apdex(300):>0.5")
         assert result.having == [["apdex_300", ">", 0.5]]

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2027,6 +2027,14 @@ class GetSnubaQueryArgsTest(TestCase):
         result = get_filter("percentile(     transaction.duration,     0.75   ):>100")
         assert result.having == [["percentile_transaction_duration_0_75", ">", 100]]
 
+        result = get_filter("percentile    (transaction.duration, 0.75):>100")
+        assert result.conditions == [
+            _om("percentile"),
+            _om("transaction.duration, 0.75"),
+            _om(":>100"),
+        ]
+        assert result.having == []
+
         result = get_filter(
             "epm(       ):>100", {"start": before_now(minutes=5), "end": before_now()}
         )


### PR DESCRIPTION
- This fixes a bug where the function_arg rule already handles extra
  spaces, and because the space rule was repeated twice it wasn't being
  handled correctly.
- Fixes SENTRY-MM3