### PR TITLE
feat(dashboard) Add Errors by Country widget to the default dashboard

### DIFF
--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -125,6 +125,17 @@ PREBUILT_DASHBOARDS = {
                         },
                     ],
                 },
+                {
+                    "title": "Errors by Country",
+                    "displayType": "world_map",
+                    "queries": [
+                        {
+                            "name": "Error counts",
+                            "conditions": "event.type:error has:geo.country_code",
+                            "fields": ["count()"],
+                        }
+                    ],
+                },
             ],
         }
     ]


### PR DESCRIPTION
Adding this to match the widget as offered in Dashboards v1.

<img width="840" alt="Screen Shot 2021-01-26 at 5 51 51 PM" src="https://user-images.githubusercontent.com/139499/105916714-632b1880-5fff-11eb-98db-4b7a92162ba5.png">
