### PR TITLE
fix(dashboards): Filter out irrelevant data when querying for events by geo.country_code

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -153,7 +153,7 @@ class OrganizationEventsGeoEndpoint(OrganizationEventsV2EndpointBase):
         def data_fn(offset, limit):
             return discover.query(
                 selected_columns=["geo.country_code", maybe_aggregate],
-                query=request.GET.get("query"),
+                query=f"{request.GET.get('query', '')} has:geo.country_code",
                 params=params,
                 offset=offset,
                 limit=limit,

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -374,9 +374,11 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
 
         return {
           title: tableResult.title ?? '',
-          data: data.map(row => {
-            return {name: row['geo.country_code'] ?? '', value: row[preAggregate]};
-          }),
+          data: data
+            .filter(row => row['geo.country_code'])
+            .map(row => {
+              return {name: row['geo.country_code'], value: row[preAggregate]};
+            }),
         };
       };
 

--- a/tests/snuba/api/endpoints/test_organization_events_geo.py
+++ b/tests/snuba/api/endpoints/test_organization_events_geo.py
@@ -80,17 +80,25 @@ class OrganizationEventsGeoEndpointTest(APITestCase, SnubaTestCase):
 
         response = self.do_request(query)
         assert response.status_code == 200, response.data
-        assert len(response.data["data"]) == 2
-        assert response.data["data"] == [
-            {"count": 1, "geo.country_code": None},
-            {"count": 1, "geo.country_code": "CA"},
-        ]
+        assert len(response.data["data"]) == 1
+        assert response.data["data"] == [{"count": 1, "geo.country_code": "CA"}]
         # Expect no pagination
         assert "Link" not in response
 
     def test_only_use_last_field(self):
         self.store_event(
-            data={"event_id": "a" * 32, "environment": "staging", "timestamp": self.min_ago},
+            data={
+                "event_id": "a" * 32,
+                "environment": "staging",
+                "timestamp": self.min_ago,
+                "user": {
+                    "email": "foo@example.com",
+                    "id": "123",
+                    "ip_address": "127.0.0.1",
+                    "username": "foo",
+                    "geo": {"country_code": "CA", "region": "Canada"},
+                },
+            },
             project_id=self.project.id,
         )
 
@@ -103,6 +111,4 @@ class OrganizationEventsGeoEndpointTest(APITestCase, SnubaTestCase):
         response = self.do_request(query)
         assert response.status_code == 200, response.data
         assert len(response.data["data"]) == 1
-        assert response.data["data"] == [
-            {"count": 1, "geo.country_code": None},
-        ]
+        assert response.data["data"] == [{"count": 1, "geo.country_code": "CA"}]


### PR DESCRIPTION
- Filter events that have no `geo.country_code` values on the frontend
- Hardcode `has:geo.country_code` into the query 