### PR TITLE
ref(images-loaded): Convert location according to the structure

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/features.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/features.tsx
@@ -18,7 +18,10 @@ type Props = {
 };
 
 function Features({download}: Props) {
-  if (download.status !== CandidateDownloadStatus.OK) {
+  if (
+    download.status !== CandidateDownloadStatus.OK &&
+    download.status !== CandidateDownloadStatus.DELETED
+  ) {
     return <NotAvailable />;
   }
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/processings.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/processings.tsx
@@ -19,7 +19,10 @@ type Props = {
 function Processings({candidate}: Props) {
   const items: React.ComponentProps<typeof ProcessingList>['items'] = [];
 
-  if (candidate.download.status !== CandidateDownloadStatus.OK) {
+  if (
+    candidate.download.status !== CandidateDownloadStatus.OK &&
+    candidate.download.status !== CandidateDownloadStatus.DELETED
+  ) {
     return <NotAvailable />;
   }
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -18,7 +18,7 @@ import NotAvailable from '../notAvailable';
 import {getFileName} from '../utils';
 
 import Candidates from './candidates';
-import {INTERNAL_SOURCE} from './utils';
+import {INTERNAL_SOURCE, INTERNAL_SOURCE_LOCATION} from './utils';
 
 type Candidates = Image['candidates'];
 
@@ -88,9 +88,14 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
       return candidates;
     }
 
+    const imageCandidates = candidates.map(candidate => ({
+      ...candidate,
+      location: candidate.location?.split(INTERNAL_SOURCE_LOCATION)[1],
+    }));
+
     // Check for unapplied debug files
     const candidateLocations = new Set(
-      candidates.map(candidate => candidate.location).filter(location => !!location)
+      imageCandidates.map(({location}) => location).filter(location => !!location)
     );
 
     const unAppliedDebugFiles = debugFiles
@@ -99,7 +104,7 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
         download: {
           status: CandidateDownloadStatus.UNAPPLIED,
         },
-        location: debugFile.id,
+        location: `${INTERNAL_SOURCE_LOCATION}${debugFile.id}`,
         source: INTERNAL_SOURCE,
         source_name: debugFile.objectName,
       }));
@@ -107,7 +112,7 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
     // Check for deleted debug files
     const debugFileIds = new Set(debugFiles.map(debugFile => debugFile.id));
 
-    const convertedCandidates = candidates.map(candidate => {
+    const convertedCandidates = imageCandidates.map(candidate => {
       if (
         candidate.source === INTERNAL_SOURCE &&
         candidate.location &&
@@ -117,6 +122,7 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
         return {
           ...candidate,
           download: {
+            ...candidate.download,
             status: CandidateDownloadStatus.DELETED,
           },
         };

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/utils.tsx
@@ -1,1 +1,2 @@
 export const INTERNAL_SOURCE = 'sentry:project';
+export const INTERNAL_SOURCE_LOCATION = 'sentry://project_debug_file/';

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -530,6 +530,7 @@ const StyledPanelTable = styled(PanelTable)<{scrollbarWidth?: number}>`
       ${overflowEllipsis};
       border-bottom: 1px solid ${p => p.theme.border};
       :nth-child(5n) {
+        height: 100%;
         ${p => !p.scrollbarWidth && `display: none`}
       }
     }

--- a/src/sentry/static/sentry/app/types/debugImage.tsx
+++ b/src/sentry/static/sentry/app/types/debugImage.tsx
@@ -44,13 +44,15 @@ type CandidateDownloadOkStatus = {
   details?: string;
 };
 
-type CandidateDownloadNotFoundStatus = {
-  status: CandidateDownloadStatus.NOT_FOUND;
+type CandidateDownloadDeletedStatus = {
+  status: CandidateDownloadStatus.DELETED;
+  features: CandidateFeatures;
   details?: string;
 };
 
-type CandidateDownloadDeletedStatus = {
-  status: CandidateDownloadStatus.DELETED;
+type CandidateDownloadNotFoundStatus = {
+  status: CandidateDownloadStatus.NOT_FOUND;
+  details?: string;
 };
 
 type CandidateDownloadUnAppliedStatus = {


### PR DESCRIPTION
Before the UI was relying on the candidate's location id to display information and as the backend changed the location be a URL the UI started to not display all the information as it should. This PR fixes this issue.

Example:

**Before:**

`"location": "17"`

**Now:**

`"location": "sentry://project_debug_file/17"`