### PR TITLE
fix(ui): Fix endless spinner on deleted event page

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -139,7 +139,7 @@ class GroupDetails extends React.Component<Props, State> {
     } catch (err) {
       // This is an expected error, capture to Sentry so that it is not considered as an unhandled error
       Sentry.captureException(err);
-      this.setState({eventError: true, loading: false});
+      this.setState({eventError: true, loading: false, loadingEvent: false});
     }
   }
 


### PR DESCRIPTION
If an event from a group was deleted (retention), right now you get an endless spinner.
This PR fixes that.