### PR TITLE
ref(reprocessing): Update reprocessing banner message

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupActivity.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupActivity.tsx
@@ -126,7 +126,7 @@ class GroupActivity extends React.Component<Props, State> {
 
   render() {
     const {group, organization} = this.props;
-    const {activity: activities, count} = group;
+    const {activity: activities, count, id: groupId} = group;
     const groupCount = Number(count);
     const mostRecentActivity = getGroupMostRecentActivity(activities);
     const reprocessingStatus = getGroupReprocessingStatus(group, mostRecentActivity);
@@ -150,6 +150,7 @@ class GroupActivity extends React.Component<Props, State> {
             reprocessActivity={mostRecentActivity as GroupActivityReprocess}
             groupCount={groupCount}
             orgSlug={organization.slug}
+            groupId={groupId}
           />
         )}
         <div className="row">

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -223,7 +223,7 @@ class GroupEventDetails extends React.Component<Props, State> {
 
     // reprocessing
     const hasReprocessingV2Feature = organization.features?.includes('reprocessing-v2');
-    const {activity: activities, count} = group;
+    const {activity: activities, count, id: groupId} = group;
     const groupCount = Number(count);
     const mostRecentActivity = getGroupMostRecentActivity(activities);
     const reprocessStatus = getGroupReprocessingStatus(group, mostRecentActivity);
@@ -264,6 +264,7 @@ class GroupEventDetails extends React.Component<Props, State> {
                     <ReprocessedBox
                       reprocessActivity={mostRecentActivity as GroupActivityReprocess}
                       groupCount={groupCount}
+                      groupId={groupId}
                       orgSlug={organization.slug}
                     />
                   )}


### PR DESCRIPTION
**Description:**

When a reprocessed event ends in the same group, the reprocessing banner (in green) doesn't display a very clear message. This PR fixes this issue by updating the message.

![reprocess-loop](https://user-images.githubusercontent.com/29228205/106022952-a4d2c680-60c6-11eb-85d2-bfb7f24279db.gif)

