### PR TITLE
chore(performance): Rename statsPeriod tag to query.period

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/utils.tsx
@@ -59,7 +59,7 @@ export function addRoutePerformanceContext(selection: GlobalSelection) {
   );
   const seconds = Math.floor(days * 86400);
 
-  transaction?.setTag('statsPeriod', seconds.toString());
+  transaction?.setTag('query.period', seconds.toString());
 }
 
 export function getTransactionName(location: Location): string | undefined {


### PR DESCRIPTION
- This is so that this tag is consistent between js + python, renaming
  this to `query.period`