### PR TITLE
fix(ui) Fix collapsing headers in PanelTable

### DIFF
--- a/docs-ui/components/charts.stories.js
+++ b/docs-ui/components/charts.stories.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import {withInfo} from '@storybook/addon-info';
-import {number, boolean, text} from '@storybook/addon-knobs';
+import {boolean, number, text} from '@storybook/addon-knobs';
 
-import LineChart from 'app/components/charts/lineChart';
 import BarChart from 'app/components/charts/barChart';
+import LineChart from 'app/components/charts/lineChart';
 
 export default {
   title: 'DataVisualization/Charts/Playground',

--- a/docs-ui/components/panels.stories.js
+++ b/docs-ui/components/panels.stories.js
@@ -75,10 +75,7 @@ export const _PanelTable = withInfo({
       <div>Panel Item</div>
     </PanelTable>
 
-    <PanelTable
-      // eslint-disable-next-line react/jsx-key
-      headers={['Short', 'Longer heading name', '']}
-    >
+    <PanelTable headers={['Short', 'Longer heading name', '']}>
       <div>One Row</div>
       <div>One Row</div>
       <div>One Row</div>

--- a/docs-ui/components/panels.stories.js
+++ b/docs-ui/components/panels.stories.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import {withInfo} from '@storybook/addon-info';
 
-import {IconTelescope} from 'app/icons';
 import Button from 'app/components/button';
 import {
   Panel,
   PanelAlert,
-  PanelHeader,
   PanelBody,
+  PanelHeader,
   PanelItem,
   PanelTable,
 } from 'app/components/panels';
+import {IconTelescope} from 'app/icons';
 import Field from 'app/views/settings/components/forms/field';
 
 import {_BulkController} from './bulkController.stories';
@@ -60,7 +60,7 @@ export const _PanelTable = withInfo({
   <React.Fragment>
     <PanelTable
       // eslint-disable-next-line react/jsx-key
-      headers={[<div>Header #1</div>, 'Header #2', <div>Custom Header Wooooo</div>]}
+      headers={[<div>Header #1</div>, 'Header #2', <div>Custom Header Wooooo</div>, '']}
     >
       <div>Panel Item with really long content</div>
       <div>Panel Item</div>
@@ -71,6 +71,17 @@ export const _PanelTable = withInfo({
       <div>Panel Item</div>
       <div>Panel Item</div>
       <div>Panel Item</div>
+      <div>Panel Item</div>
+      <div>Panel Item</div>
+    </PanelTable>
+
+    <PanelTable
+      // eslint-disable-next-line react/jsx-key
+      headers={['Short', 'Longer heading name', '']}
+    >
+      <div>One Row</div>
+      <div>One Row</div>
+      <div>One Row</div>
     </PanelTable>
 
     <PanelTable

--- a/docs-ui/components/simpleTableChart.stories.js
+++ b/docs-ui/components/simpleTableChart.stories.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import {withInfo} from '@storybook/addon-info';
+import {text} from '@storybook/addon-knobs';
+
+import SimpleTableChart from 'app/components/charts/simpleTableChart';
+
+export default {
+  title: 'DataVisualization/Charts/SimpleTableChart',
+};
+
+export const _SimpleTableChart = withInfo(
+  'A borderless table that can be used in charts/dashboards'
+)(() => {
+  const organization = {slug: 'org-slug'};
+  const fields = ['title', 'count()'];
+  const metadata = {count: 'string', title: 'string'};
+  const data = [
+    {title: 'An error', count: 100},
+    {title: 'An longer title that goes on a bit', count: 1000},
+  ];
+  const title = text('title', '');
+  return (
+    <div className="section">
+      <h2>Loading State</h2>
+      <SimpleTableChart
+        organization={organization}
+        fields={fields}
+        title={title}
+        metadata={undefined}
+        data={[]}
+        loading
+      />
+      <h2>Filled State</h2>
+      <SimpleTableChart
+        organization={organization}
+        fields={fields}
+        title={title}
+        metadata={metadata}
+        data={data}
+      />
+    </div>
+  );
+});

--- a/src/sentry/static/sentry/app/components/charts/simpleTableChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/simpleTableChart.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import PanelTable from 'app/components/panels/panelTable';
+import PanelTable, {PanelTableHeader} from 'app/components/panels/panelTable';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {TableData, TableDataRow} from 'app/utils/discover/discoverQuery';
@@ -19,6 +19,7 @@ type Props = {
   title: string;
   metadata: TableData['meta'];
   data: TableData['data'];
+  className?: string;
 };
 
 class SimpleTableChart extends React.Component<Props> {
@@ -38,13 +39,14 @@ class SimpleTableChart extends React.Component<Props> {
   }
 
   render() {
-    const {loading, fields, metadata, data, title} = this.props;
+    const {className, loading, fields, metadata, data, title} = this.props;
     const meta = metadata ?? {};
     const columns = decodeColumnOrder(fields.map(field => ({field})));
     return (
       <React.Fragment>
         {title && <h4>{title}</h4>}
         <StyledPanelTable
+          className={className}
           isLoading={loading}
           headers={columns.map((column, index) => {
             const align = fieldAlignment(column.name, column.type, meta);
@@ -68,10 +70,10 @@ const StyledPanelTable = styled(PanelTable)`
   border-right: 0;
   border-bottom: 0;
 
-  /* align height with charts */
-  height: 190px;
-  overflow: scroll;
   margin: ${space(1)} 0 0;
+  ${/* sc-selector */ PanelTableHeader} {
+    height: min-content;
+  }
 `;
 
 type HeadCellProps = {

--- a/src/sentry/static/sentry/app/components/panels/panelTable.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelTable.tsx
@@ -155,7 +155,6 @@ export const PanelTableHeader = styled('div')`
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;
   background: ${p => p.theme.backgroundSecondary};
   line-height: 1;
-  height: min-content;
 `;
 
 export default PanelTable;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -234,6 +234,11 @@ const WidgetTitle = styled(HeaderTitle)`
   width: 100%;
 `;
 
+const StyledSimpleTableChart = styled(SimpleTableChart)`
+  /* align with other card charts */
+  height: 190px;
+`;
+
 type WidgetCardVisualsProps = Pick<ReactRouter.WithRouterProps, 'router'> &
   Pick<
     WidgetQueries['state'],
@@ -288,7 +293,7 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
     return tableResults.map((result, i) => {
       const fields = widget.queries[i]?.fields ?? [];
       return (
-        <SimpleTableChart
+        <StyledSimpleTableChart
           key={`table:${result.title}`}
           location={location}
           fields={fields}


### PR DESCRIPTION
My previous change to PanelTableHeader caused empty header cells to collapse. This reverts that change and add storybook coverage to that scenario and the SimpleTableChart component.