### PR TITLE
fix(ui) Improve acceptance test placeholders

### DIFF
--- a/src/sentry/static/sentry/app/components/placeholder.tsx
+++ b/src/sentry/static/sentry/app/components/placeholder.tsx
@@ -9,6 +9,7 @@ const defaultProps = {
   bottomGutter: 0 as Parameters<typeof space>[0],
   width: '100%',
   height: '60px',
+  testId: 'loading-placeholder',
 };
 
 type DefaultProps = Readonly<typeof defaultProps>;
@@ -17,12 +18,12 @@ type Props = {
   className?: string;
   children?: React.ReactNode;
   error?: React.ReactNode;
+  testId?: string;
 } & Partial<DefaultProps>;
 
-const Placeholder = styled((props: Props) => {
-  const {className, children, error} = props;
+const Placeholder = styled(({className, children, error, testId}: Props) => {
   return (
-    <div data-test-id="loading-placeholder" className={className}>
+    <div data-test-id={testId} className={className}>
       {error || children}
     </div>
   );

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -391,7 +391,7 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
             value: this.chartComponent({
               series,
             }),
-            fixed: <Placeholder height="200px" />,
+            fixed: <Placeholder height="200px" testId="skeleton-ui" />,
           })}
         </TransitionChart>
       );
@@ -471,7 +471,7 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
                   legend,
                   series,
                 }),
-                fixed: <Placeholder height="200px" />,
+                fixed: <Placeholder height="200px" testId="skeleton-ui" />,
               })}
             </TransitionChart>
           );

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -391,7 +391,7 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
             value: this.chartComponent({
               series,
             }),
-            fixed: 'Widget Chart',
+            fixed: <Placeholder height="200px" />,
           })}
         </TransitionChart>
       );
@@ -471,7 +471,7 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
                   legend,
                   series,
                 }),
-                fixed: 'Widget Chart',
+                fixed: <Placeholder height="200px" />,
               })}
             </TransitionChart>
           );

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -90,7 +90,7 @@ class ResultsChart extends React.Component<ResultsChartProps> {
               confirmedQuery={confirmedQuery}
             />
           ),
-          fixed: <Placeholder height="200px" />,
+          fixed: <Placeholder height="200px" testId="skeleton-ui" />,
         })}
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/resultsChart.tsx
@@ -8,6 +8,7 @@ import {Client} from 'app/api';
 import EventsChart from 'app/components/charts/eventsChart';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel} from 'app/components/panels';
+import Placeholder from 'app/components/placeholder';
 import {Organization} from 'app/types';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
@@ -89,7 +90,7 @@ class ResultsChart extends React.Component<ResultsChartProps> {
               confirmedQuery={confirmedQuery}
             />
           ),
-          fixed: 'events chart',
+          fixed: <Placeholder height="200px" />,
         })}
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -8,6 +8,7 @@ import LoadingPanel from 'app/components/charts/loadingPanel';
 import {getInterval} from 'app/components/charts/utils';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel} from 'app/components/panels';
+import Placeholder from 'app/components/placeholder';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {IconWarning} from 'app/icons';
 import {Organization} from 'app/types';
@@ -114,7 +115,7 @@ class Container extends React.Component<Props> {
                         utc={utc === 'true'}
                       />
                     ),
-                    fixed: 'apdex and throughput charts',
+                    fixed: <Placeholder height="200px" />,
                   })
                 ) : (
                   <LoadingPanel data-test-id="events-request-loading" />

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -115,7 +115,7 @@ class Container extends React.Component<Props> {
                         utc={utc === 'true'}
                       />
                     ),
-                    fixed: <Placeholder height="200px" />,
+                    fixed: <Placeholder height="200px" testId="skeleton-ui" />,
                   })
                 ) : (
                   <LoadingPanel data-test-id="events-request-loading" />

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -13,6 +13,7 @@ import ReleaseSeries from 'app/components/charts/releaseSeries';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getInterval, getSeriesSelection} from 'app/components/charts/utils';
+import Placeholder from 'app/components/placeholder';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
@@ -199,7 +200,7 @@ class DurationChart extends React.Component<Props> {
                               series={[...series, ...releaseSeries]}
                             />
                           ),
-                          fixed: 'Duration Chart',
+                          fixed: <Placeholder height="200px" />,
                         })}
                       </TransitionChart>
                     )}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -200,7 +200,7 @@ class DurationChart extends React.Component<Props> {
                               series={[...series, ...releaseSeries]}
                             />
                           ),
-                          fixed: <Placeholder height="200px" />,
+                          fixed: <Placeholder height="200px" testId="skeleton-ui" />,
                         })}
                       </TransitionChart>
                     )}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
@@ -13,6 +13,7 @@ import ReleaseSeries from 'app/components/charts/releaseSeries';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getInterval, getSeriesSelection} from 'app/components/charts/utils';
+import Placeholder from 'app/components/placeholder';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
@@ -220,7 +221,7 @@ class TrendChart extends React.Component<Props> {
                               series={[...series, ...smoothedSeries, ...releaseSeries]}
                             />
                           ),
-                          fixed: 'Trend Chart',
+                          fixed: <Placeholder height="200px" />,
                         })}
                       </TransitionChart>
                     )}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
@@ -221,7 +221,7 @@ class TrendChart extends React.Component<Props> {
                               series={[...series, ...smoothedSeries, ...releaseSeries]}
                             />
                           ),
-                          fixed: <Placeholder height="200px" />,
+                          fixed: <Placeholder height="200px" testId="skeleton-ui" />,
                         })}
                       </TransitionChart>
                     )}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
@@ -209,7 +209,7 @@ class VitalsChart extends React.Component<Props> {
                               series={[...series, ...releaseSeries]}
                             />
                           ),
-                          fixed: <Placeholder height="200px" />,
+                          fixed: <Placeholder height="200px" testId="skeleton-ui" />,
                         })}
                       </TransitionChart>
                     )}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
@@ -13,6 +13,7 @@ import ReleaseSeries from 'app/components/charts/releaseSeries';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getInterval, getSeriesSelection} from 'app/components/charts/utils';
+import Placeholder from 'app/components/placeholder';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
@@ -208,7 +209,7 @@ class VitalsChart extends React.Component<Props> {
                               series={[...series, ...releaseSeries]}
                             />
                           ),
-                          fixed: 'Web Vitals Chart',
+                          fixed: <Placeholder height="200px" />,
                         })}
                       </TransitionChart>
                     )}


### PR DESCRIPTION
Use properly sized placeholder elements instead of bare text. This more closely approximates how the application would actually render and lets us capture layout issues in visual snapshots.