### PR TITLE
ref(splunk): Create a SplunkApiClient to reuse error handling code

### DIFF
--- a/src/sentry_plugins/splunk/client.py
+++ b/src/sentry_plugins/splunk/client.py
@@ -1,0 +1,17 @@
+from sentry_plugins.client import ApiClient
+
+
+class SplunkApiClient(ApiClient):
+    plugin_name = "splunk"
+    allow_redirects = False
+
+    def __init__(self, endpoint, token):
+        self.endpoint = endpoint
+        self.token = token
+        super(SplunkApiClient, self).__init__(verify_ssl=False)
+
+    def request(self, data):
+        headers = {"Authorization": "Splunk {}".format(self.token)}
+        return self._request(
+            path=self.endpoint, method="post", data=data, headers=headers, json=True, timeout=5
+        )

--- a/src/sentry_plugins/splunk/client.py
+++ b/src/sentry_plugins/splunk/client.py
@@ -4,6 +4,7 @@ from sentry_plugins.client import ApiClient
 class SplunkApiClient(ApiClient):
     plugin_name = "splunk"
     allow_redirects = False
+    datadog_prefix = "integrations.splunk"
 
     def __init__(self, endpoint, token):
         self.endpoint = endpoint

--- a/src/sentry_plugins/splunk/client.py
+++ b/src/sentry_plugins/splunk/client.py
@@ -9,10 +9,10 @@ class SplunkApiClient(ApiClient):
     def __init__(self, endpoint, token):
         self.endpoint = endpoint
         self.token = token
-        super(SplunkApiClient, self).__init__(verify_ssl=False)
+        super().__init__(verify_ssl=False)
 
     def request(self, data):
-        headers = {"Authorization": "Splunk {}".format(self.token)}
+        headers = {"Authorization": f"Splunk {self.token}"}
         return self._request(
             path=self.endpoint, method="post", data=data, headers=headers, json=True, timeout=5
         )

--- a/src/sentry_plugins/splunk/client.py
+++ b/src/sentry_plugins/splunk/client.py
@@ -14,5 +14,11 @@ class SplunkApiClient(ApiClient):
     def request(self, data):
         headers = {"Authorization": f"Splunk {self.token}"}
         return self._request(
-            path=self.endpoint, method="post", data=data, headers=headers, json=True, timeout=5
+            path=self.endpoint,
+            method="post",
+            data=data,
+            headers=headers,
+            json=True,
+            timeout=5,
+            allow_text=True,
         )

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -17,6 +17,7 @@ For more details on the payload: http://dev.splunk.com/view/event-collector/SP-C
 import logging
 
 from requests.exceptions import ConnectTimeout, ReadTimeout
+import six
 
 from sentry import tagstore
 from sentry.utils import metrics
@@ -39,6 +40,7 @@ Send Sentry events to Splunk.
 """
 
 
+<<<<<<< HEAD
 class SplunkError(Exception):
     def __init__(self, status_code, code=0, text="unknown error"):
         self.status_code = status_code
@@ -93,6 +95,8 @@ class SplunkConfigError(SplunkError):
     KNOWN_CODES = frozenset([7, 10, 11])
 
 
+=======
+>>>>>>> f3385e1034... rm legacy error handling
 class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
     title = "Splunk"
     slug = "splunk"
@@ -266,10 +270,7 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
 
         try:
             # https://docs.splunk.com/Documentation/Splunk/7.2.3/Data/TroubleshootHTTPEventCollector
-            resp = client.request(payload)
-
-            if resp.status_code != 200:
-                raise SplunkError.from_response(resp)
+            client.request(payload)
 
             metrics.incr(
                 "integrations.splunk.forward-event.success",
@@ -288,7 +289,6 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
                     "project_id": event.project_id,
                     "organization_id": event.project.organization_id,
                     "event_type": event.get_event_type(),
-                    "error_code": getattr(exc, "code", None),
                 },
             )
             logger.info(
@@ -301,13 +301,4 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
                 },
             )
 
-            if isinstance(exc, (ConnectTimeout, ReadTimeout)):
-                # If we get a ConnectTimeout or ReadTimeout we don't need to raise an error here.
-                # Just log and return.
-                return False
-
-            if isinstance(exc, SplunkError) and exc.status_code == 403:
-                # 403s are not errors or actionable for us do not re-raise
-                return False
-
-            raise
+            raise exc

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -16,9 +16,6 @@ For more details on the payload: http://dev.splunk.com/view/event-collector/SP-C
 
 import logging
 
-from requests.exceptions import ConnectTimeout, ReadTimeout
-import six
-
 from sentry import tagstore
 from sentry.utils import metrics
 from sentry.utils.hashlib import md5_text
@@ -40,63 +37,6 @@ Send Sentry events to Splunk.
 """
 
 
-<<<<<<< HEAD
-class SplunkError(Exception):
-    def __init__(self, status_code, code=0, text="unknown error"):
-        self.status_code = status_code
-        self.code = code
-        self.text = text
-        super().__init__(text)
-
-    @classmethod
-    def from_response(cls, response):
-        try:
-            body = response.json()
-        except Exception:
-            return cls(
-                status_code=response.status_code, code=0, text="Unable to parse response body"
-            )
-
-        code = body.get("code")
-        if code in SplunkInvalidToken.KNOWN_CODES:
-            cls = SplunkInvalidToken
-        elif code in SplunkServerBusy.KNOWN_CODES:
-            cls = SplunkInvalidToken
-        elif code in SplunkConfigError.KNOWN_CODES:
-            cls = SplunkConfigError
-        return cls(status_code=response.status_code, code=code, text=body.get("text"))
-
-    def __repr__(self):
-        return "<{}: status_code={}, code={}, text={}>".format(
-            type(self).__name__,
-            self.status_code,
-            self.code,
-            self.text,
-        )
-
-
-class SplunkInvalidToken(SplunkError):
-    # 1 - token disabled
-    # 2 - token required (should never happen)
-    # 3 - invalid authorization (should never happen)
-    # 4 - invalid token
-    KNOWN_CODES = frozenset([1, 2, 3, 4])
-
-
-class SplunkServerBusy(SplunkError):
-    # 9 - server is busy
-    KNOWN_CODES = frozenset([9])
-
-
-class SplunkConfigError(SplunkError):
-    # 7 - incorrect index
-    # 10 - data channel missing
-    # 11 - invalid data channel
-    KNOWN_CODES = frozenset([7, 10, 11])
-
-
-=======
->>>>>>> f3385e1034... rm legacy error handling
 class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
     title = "Splunk"
     slug = "splunk"

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -22,7 +22,7 @@ import six
 from sentry import tagstore
 from sentry.utils import metrics
 from sentry.utils.hashlib import md5_text
-
+from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ApiError
 from sentry_plugins.base import CorePluginMixin
 from sentry.plugins.bases.data_forwarding import DataForwardingPlugin
 from sentry_plugins.utils import get_secret_field_config
@@ -300,5 +300,10 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
                     "error": str(exc),
                 },
             )
+
+            if isinstance(exc, (ApiHostError, ApiTimeoutError, ApiError)):
+                # The above errors are already handled by the API client.
+                # Just log and return.
+                return False
 
             raise exc

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -316,4 +316,4 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
                 # 403s are not errors or actionable for us do not re-raise
                 return False
 
-            raise exc
+            raise

--- a/src/sentry_plugins/splunk/plugin.py
+++ b/src/sentry_plugins/splunk/plugin.py
@@ -301,9 +301,19 @@ class SplunkPlugin(CorePluginMixin, DataForwardingPlugin):
                 },
             )
 
-            if isinstance(exc, (ApiHostError, ApiTimeoutError, ApiError)):
+            if isinstance(
+                exc,
+                (
+                    ApiHostError,
+                    ApiTimeoutError,
+                ),
+            ):
                 # The above errors are already handled by the API client.
                 # Just log and return.
+                return False
+
+            if isinstance(exc, ApiError) and exc.status_code == 403:
+                # 403s are not errors or actionable for us do not re-raise
                 return False
 
             raise exc


### PR DESCRIPTION
## Objective:
Fixes SENTRY-K8H

We can reuse request error handling from the ApiClient class. This should gives us better errors for the Splunk plugin.