### PR TITLE
fix(workflow): Disable always render for stats dropdown

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -343,7 +343,7 @@ class StreamGroup extends React.Component<Props, State> {
               {!defined(primaryCount) ? (
                 <Placeholder height="18px" />
               ) : (
-                <DropdownMenu isNestedDropdown>
+                <DropdownMenu isNestedDropdown alwaysRenderMenu={false}>
                   {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
                     const topLevelCx = classNames('dropdown', {
                       'anchor-middle': true,

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -406,7 +406,7 @@ class StreamGroup extends React.Component<Props, State> {
               {!defined(primaryUserCount) ? (
                 <Placeholder height="18px" />
               ) : (
-                <DropdownMenu isNestedDropdown>
+                <DropdownMenu isNestedDropdown alwaysRenderMenu={false}>
                   {({isOpen, getRootProps, getActorProps, getMenuProps}) => {
                     const topLevelCx = classNames('dropdown', {
                       'anchor-middle': true,

--- a/src/sentry/static/sentry/app/views/issueList/sortOptions.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/sortOptions.tsx
@@ -38,11 +38,7 @@ const IssueListSortOptions = ({onSelect, sort}: Props) => {
   );
 
   return (
-    <DropdownControl
-      buttonProps={{prefix: t('Sort by')}}
-      label={getSortLabel(sortKey)}
-      alwaysRenderMenu={false}
-    >
+    <DropdownControl buttonProps={{prefix: t('Sort by')}} label={getSortLabel(sortKey)}>
       {getMenuItem('priority')}
       {getMenuItem('date')}
       {getMenuItem('new')}

--- a/src/sentry/static/sentry/app/views/issueList/sortOptions.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/sortOptions.tsx
@@ -38,7 +38,11 @@ const IssueListSortOptions = ({onSelect, sort}: Props) => {
   );
 
   return (
-    <DropdownControl buttonProps={{prefix: t('Sort by')}} label={getSortLabel(sortKey)}>
+    <DropdownControl
+      buttonProps={{prefix: t('Sort by')}}
+      label={getSortLabel(sortKey)}
+      alwaysRenderMenu={false}
+    >
       {getMenuItem('priority')}
       {getMenuItem('date')}
       {getMenuItem('new')}


### PR DESCRIPTION
These components do not need to render until hover saving time to change detect and reducing dom elements. Probably cannot measure impact, but it's something. Each row has 2 dropdown menus with 13 elements each, 25 issues * 23 elements is 650 dom elements

We render about 4000 elements on a full issue details page load.