### PR TITLE
feat(code-path-mapping): Allow forward slashes for branch names

### DIFF
--- a/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
+++ b/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
@@ -24,10 +24,12 @@ class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
     stack_root = gen_path_regex_field()
     source_root = gen_path_regex_field()
     default_branch = serializers.RegexField(
-        r"^[\w-]+$",
+        r"^[(\w)\/-]+$",
         required=True,
         error_messages={
-            "invalid": _("Branch name may only have letters, numbers, underscores, and dashes")
+            "invalid": _(
+                "Branch name may only have letters, numbers, underscores, forward slashes and dashes"
+            )
         },
     )
 

--- a/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
+++ b/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
@@ -24,11 +24,11 @@ class RepositoryProjectPathConfigSerializer(CamelSnakeModelSerializer):
     stack_root = gen_path_regex_field()
     source_root = gen_path_regex_field()
     default_branch = serializers.RegexField(
-        r"^[(\w)\/-]+$",
+        r"^(^(?![\/]))([\w\/-]+)(?<![\/])$",
         required=True,
         error_messages={
             "invalid": _(
-                "Branch name may only have letters, numbers, underscores, forward slashes and dashes"
+                "Branch name may only have letters, numbers, underscores, forward slashes and dashes. Branch name may not start or end with a forward slash."
             )
         },
     )

--- a/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
@@ -183,6 +183,28 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
         assert response.status_code == 400
         assert response.data == {
             "defaultBranch": [
-                "Branch name may only have letters, numbers, underscores, and dashes"
+                "Branch name may only have letters, numbers, underscores, forward slashes and dashes. Branch name may not start or end with a forward slash."
+            ],
+        }
+
+    def test_forward_slash_in_branch(self):
+        response = self.make_post({"defaultBranch": "prod/deploy-branch"})
+        assert response.status_code == 201, response.content
+
+    def test_leading_forward_slash_in_branch_conflict(self):
+        response = self.make_post({"defaultBranch": "/prod/deploy-branch"})
+        assert response.status_code == 400
+        assert response.data == {
+            "defaultBranch": [
+                "Branch name may only have letters, numbers, underscores, forward slashes and dashes. Branch name may not start or end with a forward slash."
+            ],
+        }
+
+    def test_ending_forward_slash_in_branch_conflict(self):
+        response = self.make_post({"defaultBranch": "prod/deploy-branch/"})
+        assert response.status_code == 400
+        assert response.data == {
+            "defaultBranch": [
+                "Branch name may only have letters, numbers, underscores, forward slashes and dashes. Branch name may not start or end with a forward slash."
             ],
         }


### PR DESCRIPTION
## Objective:
We want to support branches with forward slashes when configuring Code Mappings.

## UI:

<img width="631" alt="Screen Shot 2021-01-27 at 11 33 37 AM" src="https://user-images.githubusercontent.com/10491193/106043949-f150de80-6093-11eb-8a2b-d5f290a60771.png">
<img width="1439" alt="Screen Shot 2021-01-27 at 11 32 38 AM" src="https://user-images.githubusercontent.com/10491193/106043969-f6ae2900-6093-11eb-9306-26c011f11641.png">
