### PR TITLE
fix(perf): Fix eventview to use 'add' for extra conditions

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -858,7 +858,7 @@ class EventView {
 
     if (this.query) {
       if (this.additionalConditions) {
-        queryParts.push(this.getQueryWithOverrides());
+        queryParts.push(this.getQueryWithAdditionalConditions());
       } else {
         queryParts.push(this.query);
       }
@@ -945,7 +945,7 @@ class EventView {
         field: [...new Set(fields)],
         sort,
         per_page: DEFAULT_PER_PAGE,
-        query: this.getQueryWithOverrides(),
+        query: this.getQueryWithAdditionalConditions(),
       }
     ) as EventQuery & LocationQuery;
 
@@ -1093,14 +1093,14 @@ class EventView {
     return DisplayModes.DEFAULT;
   }
 
-  getQueryWithOverrides() {
+  getQueryWithAdditionalConditions() {
     const {query} = this;
     if (!this.additionalConditions) {
       return query;
     }
     const conditions = tokenizeSearch(query);
     Object.entries(this.additionalConditions.tagValues).forEach(([tag, tagValues]) => {
-      conditions.setTagValues(tag, tagValues);
+      conditions.addTagValues(tag, tagValues);
     });
     return stringifyQueryObject(conditions);
   }

--- a/src/sentry/static/sentry/app/views/performance/landing/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/content.tsx
@@ -204,7 +204,7 @@ class LandingContent extends React.Component<Props, State> {
           organization={organization}
           location={location}
           setError={setError}
-          summaryConditions={eventView.getQueryWithOverrides()}
+          summaryConditions={eventView.getQueryWithAdditionalConditions()}
           columnTitles={columnTitles}
         />
       </React.Fragment>
@@ -240,7 +240,7 @@ class LandingContent extends React.Component<Props, State> {
           organization={organization}
           location={location}
           setError={setError}
-          summaryConditions={eventView.getQueryWithOverrides()}
+          summaryConditions={eventView.getQueryWithAdditionalConditions()}
           columnTitles={columnTitles}
         />
       </React.Fragment>
@@ -264,7 +264,7 @@ class LandingContent extends React.Component<Props, State> {
           organization={organization}
           location={location}
           setError={setError}
-          summaryConditions={eventView.getQueryWithOverrides()}
+          summaryConditions={eventView.getQueryWithAdditionalConditions()}
         />
       </React.Fragment>
     );

--- a/tests/js/spec/views/performance/data.spec.jsx
+++ b/tests/js/spec/views/performance/data.spec.jsx
@@ -12,7 +12,7 @@ describe('generatePerformanceEventView()', function () {
     expect(result.name).toEqual('Performance');
     expect(result.fields.length).toBeGreaterThanOrEqual(7);
     expect(result.query).toEqual('transaction.duration:<15m');
-    expect(result.getQueryWithOverrides()).toEqual(
+    expect(result.getQueryWithAdditionalConditions()).toEqual(
       'transaction.duration:<15m event.type:transaction'
     );
     expect(result.sorts).toEqual([{kind: 'desc', field: 'tpm'}]);
@@ -60,7 +60,7 @@ describe('generatePerformanceEventView()', function () {
       },
     });
     expect(result.query).toEqual(expect.stringContaining('transaction:*things.update*'));
-    expect(result.getQueryWithOverrides()).toEqual(
+    expect(result.getQueryWithAdditionalConditions()).toEqual(
       expect.stringContaining('event.type:transaction')
     );
   });
@@ -72,7 +72,7 @@ describe('generatePerformanceEventView()', function () {
       },
     });
     expect(result.query).toEqual(expect.stringContaining('transaction:*things.update*'));
-    expect(result.getQueryWithOverrides()).toEqual(
+    expect(result.getQueryWithAdditionalConditions()).toEqual(
       expect.stringContaining('event.type:transaction')
     );
     expect(result.query).toEqual(expect.not.stringContaining('transaction:thing.gone'));
@@ -86,7 +86,7 @@ describe('generatePerformanceEventView()', function () {
     });
     expect(result.query).toEqual(expect.stringContaining('key:value'));
     expect(result.query).toEqual(expect.stringContaining('tag:value'));
-    expect(result.getQueryWithOverrides()).toEqual(
+    expect(result.getQueryWithAdditionalConditions()).toEqual(
       expect.stringContaining('event.type:transaction')
     );
   });


### PR DESCRIPTION
### Summary
The additional conditions were still using an override behavior, I forgot to switch this to be 'add' which was causing bugs when you had a conflicting tag.