### PR TITLE
fix(integrations): Async Select Field Value

### DIFF
--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -136,12 +136,13 @@ export default class AbstractExternalIssueForm<
     field: IssueConfigField,
     result: {value: string; label: string}[]
   ): void => {
-    const fetchedFieldOptionsCache = result.map(obj => [obj.value, obj.label]);
-    this.setState(prevState => {
-      const newState = cloneDeep(prevState);
-      set(newState, `fetchedFieldOptionsCache[${field.name}]`, fetchedFieldOptionsCache);
-      return newState;
-    });
+    const fetchedFieldOptionsCache = cloneDeep(this.state.fetchedFieldOptionsCache);
+    set(
+      fetchedFieldOptionsCache,
+      field.name,
+      result.map(obj => [obj.value, obj.label])
+    );
+    this.setState({fetchedFieldOptionsCache});
   };
 
   /**

--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import cloneDeep from 'lodash/cloneDeep';
 import debounce from 'lodash/debounce';
-import set from 'lodash/set';
 import * as queryString from 'query-string';
 
 import {ModalRenderProps} from 'app/actionCreators/modal';
@@ -136,13 +134,13 @@ export default class AbstractExternalIssueForm<
     field: IssueConfigField,
     result: {value: string; label: string}[]
   ): void => {
-    const fetchedFieldOptionsCache = cloneDeep(this.state.fetchedFieldOptionsCache);
-    set(
-      fetchedFieldOptionsCache,
-      field.name,
-      result.map(obj => [obj.value, obj.label])
-    );
-    this.setState({fetchedFieldOptionsCache});
+    const {fetchedFieldOptionsCache} = this.state;
+    this.setState({
+      fetchedFieldOptionsCache: {
+        ...fetchedFieldOptionsCache,
+        [field.name]: result.map(obj => [obj.value, obj.label]),
+      },
+    });
   };
 
   /**
@@ -238,12 +236,13 @@ export default class AbstractExternalIssueForm<
 
     const configsFromAPI = (integrationDetails || {})[this.getConfigName()];
     return (configsFromAPI || []).map(field => {
+      const fieldCopy = {...field};
       // Overwrite choices from cache.
       if (fetchedFieldOptionsCache?.hasOwnProperty(field.name)) {
-        field.choices = fetchedFieldOptionsCache[field.name];
+        fieldCopy.choices = fetchedFieldOptionsCache[field.name];
       }
 
-      return field;
+      return fieldCopy;
     });
   };
 

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -8,7 +8,7 @@ import AbstractExternalIssueForm, {
 } from 'app/components/externalIssues/abstractExternalIssueForm';
 import NavTabs from 'app/components/navTabs';
 import {t, tct} from 'app/locale';
-import {Group, Integration, IntegrationExternalIssue, IssueConfigField} from 'app/types';
+import {Group, Integration, IntegrationExternalIssue} from 'app/types';
 import Form from 'app/views/settings/components/forms/form';
 
 const MESSAGES_BY_ACTION = {
@@ -127,9 +127,6 @@ export default class ExternalIssueForm extends AbstractExternalIssueForm<Props, 
   };
 
   renderBody() {
-    const {integrationDetails} = this.state;
-    const config: IssueConfigField[] =
-      (integrationDetails || {})[this.getConfigName()] || [];
-    return this.renderForm(config);
+    return this.renderForm(this.getCleanedFields());
   }
 }

--- a/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/formField/index.tsx
@@ -27,7 +27,7 @@ import {FieldValue} from '../type';
  */
 const getValueFromEvent = (valueOrEvent?: FieldValue | MouseEvent, e?: MouseEvent) => {
   const event = e || valueOrEvent;
-  const value = defined(e) ? valueOrEvent : event && event.target && event.target.value;
+  const value = defined(e) ? valueOrEvent : event?.target?.value;
 
   return {value, event};
 };


### PR DESCRIPTION
Switching off `deprecatedSelectControl` broke the async selects in the `ExternalIssueForm`. This PR move code from the `TickerRuleModal` to the shared abstract base class so that the broken form can correctly update the value of the select.
![Screen Shot 2021-01-28 at 10 15 58 AM](https://user-images.githubusercontent.com/31750075/106180936-d2b11d00-6151-11eb-92de-006253d13bc4.png)