### PR TITLE
build(ci): Fix `getsentry dispatch` when no dependent PR

### DIFF
--- a/.github/workflows/js-getsentry-dispatch.yml
+++ b/.github/workflows/js-getsentry-dispatch.yml
@@ -54,7 +54,7 @@ jobs:
               workflow_id: 'js-build-and-lint.yml',
               ref: 'master',
               inputs: {
-                pull_request: matches && matches[1],
+                pull_request: matches && matches[1] || '',
                 branch,
                 skip: "${{ steps.changes.outputs.frontend != 'true' }}",
                 'sentry-sha': '${{ github.event.pull_request.head.sha }}',


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/getsentry/sentry/pull/23339 -- this causes an error when there is no dependent getsentry PR.