### PR TITLE
feat(wizard): add xamarin to mobile

### DIFF
--- a/src/sentry/static/sentry/app/data/platformCategories.tsx
+++ b/src/sentry/static/sentry/app/data/platformCategories.tsx
@@ -49,6 +49,7 @@ const mobile = [
   'flutter',
   'dart-flutter',
   'unity',
+  'dotnet-xamarin',
 ] as const;
 
 export const backend = [


### PR DESCRIPTION
The wizard is there but without a category:

![image](https://user-images.githubusercontent.com/1633368/106072229-cbe4c480-60d5-11eb-8bff-0da2d29c5c52.png)
