### PR TITLE
fix(asana): Handle auth failure

### DIFF
--- a/src/sentry_plugins/asana/plugin.py
+++ b/src/sentry_plugins/asana/plugin.py
@@ -207,8 +207,12 @@ class AsanaPlugin(CorePluginMixin, IssuePlugin2):
         try:
             workspaces = client.get_workspaces()
         except HTTPError as e:
-            if e.response.status_code == 400:
+            if (
+                e.response.status_code == 400
+                and e.response.url == "https://app.asana.com/-/oauth_token"
+            ):
                 raise PluginIdentityRequired(ERR_BEARER_EXPIRED)
+            raise
         workspace_choices = self.get_workspace_choices(workspaces)
         workspace = self.get_option("workspace", kwargs["project"])
         # check to make sure the current user has access to the workspace

--- a/src/sentry_plugins/client.py
+++ b/src/sentry_plugins/client.py
@@ -1,4 +1,3 @@
-from sentry.exceptions import PluginIdentityRequired
 from sentry.shared_integrations.client import BaseApiClient, BaseInternalApiClient
 from sentry.shared_integrations.exceptions import ApiUnauthorized
 
@@ -51,10 +50,6 @@ class AuthApiClient(ApiClient):
                 raise
             if not self.auth:
                 raise
-            if self.auth.provider == "asana" and exc.code == 401:
-                raise PluginIdentityRequired(
-                    "Authorization failed. Disconnect identity and reconfigure."
-                )
 
         # refresh token
         self.logger.info(

--- a/src/sentry_plugins/client.py
+++ b/src/sentry_plugins/client.py
@@ -39,6 +39,7 @@ class AuthApiClient(ApiClient):
     def _request(self, method, path, **kwargs):
         headers = kwargs.setdefault("headers", {})
         headers.setdefault("Accept", "application/json, application/xml")
+
         # TODO(dcramer): we could proactively refresh the token if we knew
         # about expires
         kwargs = self.ensure_auth(**kwargs)


### PR DESCRIPTION
If the authorization header's value is bad for any reason, requests to Asana's API return a 401 ApiUnauthorized and then we attempt to refresh the auth, which results in `HTTPError: 400 Client Error: Bad Request for url: https://app.asana.com/-/oauth_token`. For the 401 they do provide a little more if you print out the exception: "The bearer token has expired. If you have a refresh token, please use it to request a new bearer token, otherwise allow the user to re-authenticate."

I was able to reproduce the customer's issue by creating an Asana workspace, configuring it in my Sentry project, leaving the workspace, and attempting to load the Asana configuration page in Sentry (the page crashes entirely).

I wanted to be able to provide an actionable error message to the user.
<img width="557" alt="Screen Shot 2021-01-27 at 5 12 51 PM" src="https://user-images.githubusercontent.com/29959063/106075637-e497af00-60c2-11eb-8470-cdf320114b9c.png">


Fixes [ISSUE-1088](https://getsentry.atlassian.net/browse/ISSUE-1088)