### PR TITLE
feat(inbox): Inbox guide with novel steps

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -19,4 +19,5 @@ GUIDES = {
     "issue": {"id": 1, "required_targets": ["issue_title", "exception"]},
     "issue_stream": {"id": 3, "required_targets": ["issue_stream"]},
     "dynamic_counts": {"id": 7, "required_targets": ["dynamic_counts"]},
+    "inbox_guide": {"id": 8, "required_targets": ["inbox_guide"]},
 }

--- a/src/sentry/static/sentry/app/actionCreators/guides.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/guides.tsx
@@ -26,6 +26,10 @@ export function nextStep() {
   GuideActions.nextStep();
 }
 
+export function toStep(step: number) {
+  GuideActions.toStep(step);
+}
+
 export function closeGuide() {
   GuideActions.closeGuide();
 }

--- a/src/sentry/static/sentry/app/actions/guideActions.tsx
+++ b/src/sentry/static/sentry/app/actions/guideActions.tsx
@@ -4,6 +4,7 @@ const GuideActions = Reflux.createActions([
   'closeGuide',
   'fetchSucceeded',
   'nextStep',
+  'toStep',
   'registerAnchor',
   'unregisterAnchor',
 ]);

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -114,5 +114,60 @@ export default function getGuidesContent(): GuidesContent {
         },
       ],
     },
+    {
+      guide: 'inbox_guide',
+      requiredTargets: ['inbox_guide_tab'],
+      steps: [
+        {
+          target: 'inbox_guide_tab',
+          description: t(
+            `For Review lets you focus on new and reopened issues that are
+            assigned to your team.`
+          ),
+          nextText: t(`Take a Look`),
+        },
+        {
+          target: 'inbox_guide_issue',
+          description: t(
+            `These issues give you a lightweight way to review things and ensure
+            that nothing new has happened in the last 7 days.`
+          ),
+          cantDismiss: true,
+        },
+        {
+          target: 'inbox_guide_reason',
+          description: t(
+            `These labels explain why an issue needs attention. When you mark the
+            issue as reviewed, it removes the label and moves the issue to Unresolved.`
+          ),
+          cantDismiss: true,
+        },
+        {
+          target: 'inbox_guide_review',
+          description: t(
+            `Mark as Reviewed lets you get to Inbox Zero so that your team knows
+            which issues need attention.`
+          ),
+          nextText: t(`Wow there's more tutorial, huh?`),
+          cantDismiss: true,
+        },
+        {
+          target: 'inbox_guide_ignore',
+          description: t(
+            `Resolving or ignoring an issue also marks an issue as reviewed.`
+          ),
+          nextText: t(`Next, ugh`),
+          cantDismiss: true,
+        },
+        {
+          target: 'inbox_guide_issue',
+          description: t(
+            `An issue will automatically be reviewed after 7 days so this list never
+            gets too overwhelming.`
+          ),
+          nextText: t(`Got it`),
+        },
+      ],
+    },
   ];
 }

--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import createReactClass from 'create-react-class';
+import {Query} from 'history';
 import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 
@@ -11,6 +12,7 @@ import {
   nextStep,
   recordFinish,
   registerAnchor,
+  toStep,
   unregisterAnchor,
 } from 'app/actionCreators/guides';
 import {Guide} from 'app/components/assistant/types';
@@ -26,6 +28,11 @@ type Props = {
   position?: string;
   disabled?: boolean;
   offset?: string;
+  to?: {
+    pathname: string;
+    query: Query;
+    step: number;
+  };
 };
 
 type State = {
@@ -47,6 +54,11 @@ const GuideAnchor = createReactClass<Props, State>({
     position: PropTypes.string,
     disabled: PropTypes.bool,
     offset: PropTypes.string,
+    to: PropTypes.shape({
+      pathname: PropTypes.string,
+      query: PropTypes.object,
+      step: PropTypes.number,
+    }),
   },
 
   mixins: [Reflux.listenTo(GuideStore, 'onGuideStateChange') as any],
@@ -109,8 +121,12 @@ const GuideAnchor = createReactClass<Props, State>({
   },
 
   handleNextStep(e: React.MouseEvent) {
-    e.stopPropagation();
-    nextStep();
+    if (this.props.to) {
+      toStep(this.props.to.step);
+    } else {
+      e.stopPropagation();
+      nextStep();
+    }
   },
 
   handleDismiss(e: React.MouseEvent) {
@@ -120,6 +136,7 @@ const GuideAnchor = createReactClass<Props, State>({
   },
 
   getHovercardBody() {
+    const {to} = this.props;
     const {currentGuide, step} = this.state;
 
     const totalStepCount = currentGuide.steps.length;
@@ -131,7 +148,7 @@ const GuideAnchor = createReactClass<Props, State>({
     return (
       <GuideContainer>
         <GuideContent>
-          <GuideTitle>{currentStep.title}</GuideTitle>
+          {currentStep.title && <GuideTitle>{currentStep.title}</GuideTitle>}
           <GuideDescription>{currentStep.description}</GuideDescription>
         </GuideContent>
         <GuideAction>
@@ -142,20 +159,23 @@ const GuideAnchor = createReactClass<Props, State>({
                 href="#" // to clear `#assistant` from the url
                 onClick={this.handleFinish}
               >
-                {hasManySteps ? t('Enough Already') : t('Got It')}
+                {currentStep.nextText ||
+                  (hasManySteps ? t('Enough Already') : t('Got It'))}
               </StyledButton>
             ) : (
               <React.Fragment>
-                <DismissButton
-                  priority="primary"
-                  size="small"
-                  href="#" // to clear `#assistant` from the url
-                  onClick={this.handleDismiss}
-                >
-                  {t('Dismiss')}
-                </DismissButton>
-                <StyledButton size="small" onClick={this.handleNextStep}>
-                  {t('Next')}
+                {!currentStep.cantDismiss && (
+                  <DismissButton
+                    priority="primary"
+                    size="small"
+                    href="#" // to clear `#assistant` from the url
+                    onClick={this.handleDismiss}
+                  >
+                    {t('Dismiss')}
+                  </DismissButton>
+                )}
+                <StyledButton size="small" onClick={this.handleNextStep} to={to}>
+                  {currentStep.nextText || t('Next')}
                 </StyledButton>
               </React.Fragment>
             )}

--- a/src/sentry/static/sentry/app/components/assistant/types.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/types.tsx
@@ -1,5 +1,5 @@
 export type GuideStep = {
-  title: string;
+  title?: string;
   /**
    * Step is tied to an anchor target. If the anchor doesn't exist,
    * the step will not be shown. If the anchor exists but is of type
@@ -8,6 +8,8 @@ export type GuideStep = {
    */
   target?: string;
   description: React.ReactNode;
+  nextText?: string;
+  cantDismiss?: boolean;
 };
 
 export type Guide = {

--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
@@ -3,6 +3,7 @@ import {Link, withRouter, WithRouterProps} from 'react-router';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import EventAnnotation from 'app/components/events/eventAnnotation';
 import InboxReason from 'app/components/group/inboxBadges/inboxReason';
 import InboxShortId from 'app/components/group/inboxBadges/shortId';
@@ -23,9 +24,16 @@ type Props = WithRouterProps<{orgId: string}> & {
   data: Event | Group;
   showAssignee?: boolean;
   organization: Organization;
+  hasGuideAnchor?: boolean;
 };
 
-function EventOrGroupExtraDetails({data, showAssignee, params, organization}: Props) {
+function EventOrGroupExtraDetails({
+  data,
+  showAssignee,
+  params,
+  organization,
+  hasGuideAnchor,
+}: Props) {
   const {
     id,
     lastSeen,
@@ -47,7 +55,11 @@ function EventOrGroupExtraDetails({data, showAssignee, params, organization}: Pr
 
   return (
     <GroupExtra hasInbox={hasInbox}>
-      {hasInbox && inbox && <InboxReason inbox={inbox} />}
+      {hasInbox && inbox && (
+        <GuideAnchor target="inbox_guide_reason" disabled={!hasGuideAnchor}>
+          <InboxReason inbox={inbox} />
+        </GuideAnchor>
+      )}
       {shortId &&
         (hasInbox ? (
           <InboxShortId

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -319,9 +319,14 @@ class StreamGroup extends React.Component<Props, State> {
             query={query}
             size="normal"
           />
-          <EventOrGroupExtraDetails organization={organization} data={data} />
+          <EventOrGroupExtraDetails
+            hasGuideAnchor={hasGuideAnchor}
+            organization={organization}
+            data={data}
+          />
         </GroupSummary>
         {hasGuideAnchor && <GuideAnchor target="issue_stream" />}
+        {hasGuideAnchor && <GuideAnchor target="inbox_guide_issue" position="bottom" />}
         {withChart && !displayReprocessingLayout && (
           <ChartWrapper className="hidden-xs hidden-sm">
             {!data.filtered?.stats && !data.stats ? (

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -11,7 +11,7 @@ import {trackAnalyticsEvent} from 'app/utils/analytics';
 
 const guidesContent: GuidesContent = getGuidesContent();
 
-type GuideStoreState = {
+export type GuideStoreState = {
   /**
    * All tooltip guides
    */
@@ -72,6 +72,7 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
     this.listenTo(GuideActions.fetchSucceeded, this.onFetchSucceeded);
     this.listenTo(GuideActions.closeGuide, this.onCloseGuide);
     this.listenTo(GuideActions.nextStep, this.onNextStep);
+    this.listenTo(GuideActions.toStep, this.onToStep);
     this.listenTo(GuideActions.registerAnchor, this.onRegisterAnchor);
     this.listenTo(GuideActions.unregisterAnchor, this.onUnregisterAnchor);
     this.listenTo(OrganizationsActions.setActive, this.onSetActiveOrganization);
@@ -127,6 +128,11 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
 
   onNextStep() {
     this.state.currentStep += 1;
+    this.trigger(this.state);
+  },
+
+  onToStep(step: number) {
+    this.state.currentStep = step;
     this.trigger(this.state);
   },
 
@@ -208,8 +214,13 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
         : null;
 
     this.updatePrevGuide(nextGuide);
+    this.state.currentStep =
+      this.state.currentGuide &&
+      nextGuide &&
+      this.state.currentGuide.guide === nextGuide.guide
+        ? this.state.currentStep
+        : 0;
     this.state.currentGuide = nextGuide;
-    this.state.currentStep = 0;
     this.trigger(this.state);
   },
 };

--- a/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
@@ -6,6 +6,7 @@ import ActionLink from 'app/components/actions/actionLink';
 import ActionButton from 'app/components/actions/button';
 import IgnoreActions from 'app/components/actions/ignore';
 import MenuItemActionLink from 'app/components/actions/menuItemActionLink';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import DropdownLink from 'app/components/dropdownLink';
 import Tooltip from 'app/components/tooltip';
 import {IconEllipsis, IconPause, IconPlay} from 'app/icons';
@@ -36,6 +37,8 @@ type Props = {
   onUpdate: (data?: any) => void;
   selectedProjectSlug?: string;
   hasInbox?: boolean;
+  inboxGuideActiveReview: boolean;
+  inboxGuideActiveIgnore: boolean;
 };
 
 function ActionSet({
@@ -54,6 +57,8 @@ function ActionSet({
   onMerge,
   selectedProjectSlug,
   hasInbox,
+  inboxGuideActiveReview,
+  inboxGuideActiveIgnore,
 }: Props) {
   const numIssues = issues.size;
   const confirm = getConfirm(numIssues, allInQuerySelected, query, queryCount);
@@ -66,13 +71,19 @@ function ActionSet({
   return (
     <Wrapper hasInbox={hasInbox}>
       {hasInbox && (
-        <div className="hidden-sm hidden-xs">
-          <ReviewAction
-            primary={query === Query.FOR_REVIEW || query === Query.FOR_REVIEW_OWNER}
-            disabled={!anySelected}
-            onUpdate={onUpdate}
-          />
-        </div>
+        <GuideAnchor
+          target="inbox_guide_review"
+          disabled={!inboxGuideActiveReview}
+          position="bottom"
+        >
+          <div className="hidden-sm hidden-xs">
+            <ReviewAction
+              primary={query === Query.FOR_REVIEW || query === Query.FOR_REVIEW_OWNER}
+              disabled={!anySelected}
+              onUpdate={onUpdate}
+            />
+          </div>
+        </GuideAnchor>
       )}
       {selectedProjectSlug ? (
         <Projects orgId={orgSlug} slugs={[selectedProjectSlug]}>
@@ -117,13 +128,19 @@ function ActionSet({
         />
       )}
 
-      <IgnoreActions
-        onUpdate={onUpdate}
-        shouldConfirm={onShouldConfirm(ConfirmAction.IGNORE)}
-        confirmMessage={confirm(ConfirmAction.IGNORE, true)}
-        confirmLabel={label('ignore')}
-        disabled={!anySelected}
-      />
+      <GuideAnchor
+        target="inbox_guide_ignore"
+        disabled={!inboxGuideActiveIgnore}
+        position="bottom"
+      >
+        <IgnoreActions
+          onUpdate={onUpdate}
+          shouldConfirm={onShouldConfirm(ConfirmAction.IGNORE)}
+          confirmMessage={confirm(ConfirmAction.IGNORE, true)}
+          confirmLabel={label('ignore')}
+          disabled={!anySelected}
+        />
+      </GuideAnchor>
 
       <div className="hidden-md hidden-sm hidden-xs">
         <ActionLink

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
 import {openModal} from 'app/actionCreators/modal';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import ContextPickerModalContainer from 'app/components/contextPickerModal';
@@ -125,14 +126,24 @@ function IssueListHeader({
                   pathname: `/organizations/${organization.slug}/issues/`,
                 }}
               >
-                {queryName}{' '}
-                {queryCounts[tabQuery] && (
-                  <StyledQueryCount
-                    isTag
-                    count={queryCounts[tabQuery].count}
-                    max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
-                  />
-                )}
+                <GuideAnchor
+                  target={queryName === 'For Review' ? 'inbox_guide_tab' : 'none'}
+                  disabled={queryName !== 'For Review'}
+                  to={{
+                    query: {...router?.location?.query, query: tabQuery},
+                    pathname: `/organizations/${organization.slug}/issues/`,
+                    step: 1,
+                  }}
+                >
+                  {queryName}{' '}
+                  {queryCounts[tabQuery] && (
+                    <StyledQueryCount
+                      isTag
+                      count={queryCounts[tabQuery].count}
+                      max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
+                    />
+                  )}
+                </GuideAnchor>
               </Link>
             </li>
           ))}

--- a/tests/js/spec/components/streamGroup.spec.jsx
+++ b/tests/js/spec/components/streamGroup.spec.jsx
@@ -49,7 +49,7 @@ describe('StreamGroup', function () {
     );
 
     expect(component.find('GuideAnchor').exists()).toBe(true);
-    expect(component.find('GuideAnchor')).toHaveLength(3);
+    expect(component.find('GuideAnchor')).toHaveLength(4);
     expect(component).toSnapshot();
   });
 


### PR DESCRIPTION
This adds an onboarding/guide for inbox for the ea release. A few novel aspects of this guide is:
- Once the guide starts, user can't dismiss until the end.
- Whichever tab user starts in inbox, after step 1, the inbox switches to `For Review` tab
- During the guide for step 4 & 5 that shows hover cards on mark reviewed and ignore actions we show the action set for the issue list
[Designs](https://www.figma.com/file/goZnBcNCwcogcE3sKMYiNB/Handover%3A-For-Review?node-id=4%3A25063)