### PR TITLE
feat(sdk-updates): Add sdk updates list to broadcasts

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/sdkUpdates.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/sdkUpdates.tsx
@@ -1,0 +1,10 @@
+import SdkUpdatesActions from 'app/actions/sdkUpdatesActions';
+import {Client} from 'app/api';
+
+/**
+ * Load SDK Updates for a specific organization
+ */
+export async function loadSdkUpdates(api: Client, orgSlug: string) {
+  const updates = await api.requestPromise(`/organizations/${orgSlug}/sdk-updates/`);
+  SdkUpdatesActions.load(orgSlug, updates);
+}

--- a/src/sentry/static/sentry/app/actions/sdkUpdatesActions.tsx
+++ b/src/sentry/static/sentry/app/actions/sdkUpdatesActions.tsx
@@ -1,0 +1,5 @@
+import Reflux from 'reflux';
+
+const SdkUpdatesActions = Reflux.createActions(['load']);
+
+export default SdkUpdatesActions;

--- a/src/sentry/static/sentry/app/components/events/sdkUpdates/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/sdkUpdates/index.tsx
@@ -5,8 +5,7 @@ import EventDataSection from 'app/components/events/eventDataSection';
 import {IconUpgrade} from 'app/icons';
 import {tct} from 'app/locale';
 import {Event} from 'app/types/event';
-
-import getSuggestion from './getSuggestion';
+import getSdkUpdateSuggestion from 'app/utils/getSdkUpdateSuggestion';
 
 type Props = {
   event: Omit<Event, 'sdkUpdates'> & {
@@ -19,7 +18,7 @@ const SdkUpdates = ({event}: Props) => {
 
   const eventDataSectinContent = sdkUpdates
     .map((sdkUpdate, index) => {
-      const suggestion = getSuggestion({suggestion: sdkUpdate, event});
+      const suggestion = getSdkUpdateSuggestion({suggestion: sdkUpdate, sdk: event.sdk});
 
       if (!suggestion) {
         return null;

--- a/src/sentry/static/sentry/app/components/sidebar/broadcastSdkUpdates.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/broadcastSdkUpdates.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import groupBy from 'lodash/groupBy';
+
+import ProjectBadge from 'app/components/idBadge/projectBadge';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {Project, ProjectSdkUpdates, SDKUpdatesSuggestion} from 'app/types';
+import getSdkUpdateSuggestion from 'app/utils/getSdkUpdateSuggestion';
+import withProjects from 'app/utils/withProjects';
+import withSdkUpdates from 'app/utils/withSdkUpdates';
+
+import Collapsible from '../collapsible';
+import List from '../list';
+import ListItem from '../list/listItem';
+
+import SidebarPanelItem from './sidebarPanelItem';
+
+type Props = {
+  projects: Project[];
+  sdkUpdates?: ProjectSdkUpdates[] | null;
+};
+
+const flattenSuggestions = (list: ProjectSdkUpdates[]) =>
+  list.reduce<SDKUpdatesSuggestion[]>(
+    (suggestions, sdk) => [...suggestions, ...sdk.suggestions],
+    []
+  );
+
+const BroadcastSdkUpdates = ({projects, sdkUpdates}: Props) => {
+  if (!sdkUpdates) {
+    return null;
+  }
+
+  // Are there any updates?
+  if (flattenSuggestions(sdkUpdates).length === 0) {
+    return null;
+  }
+
+  // Group SDK updates by project
+  const items = Object.entries(groupBy(sdkUpdates, 'projectId'));
+
+  return (
+    <SidebarPanelItem
+      hasSeen
+      title={t('Update your SDKs')}
+      message={t(
+        'Seems like your SDKs could use a refresh. We recommend updating these SDKs to make sure you’re getting all the data you need.'
+      )}
+    >
+      <UpdatesList>
+        <Collapsible>
+          {items.map(([projectId, updates]) => {
+            const project = projects.find(p => p.id === projectId);
+            if (project === undefined) {
+              return null;
+            }
+
+            return (
+              <div key={project.id}>
+                <SdkProjectBadge project={project} />
+                <Suggestions>
+                  {updates.map(sdkUpdate => (
+                    <div key={sdkUpdate.sdkName}>
+                      <SdkName>
+                        {sdkUpdate.sdkName}{' '}
+                        <SdkOutdatedVersion>@v{sdkUpdate.sdkVersion}</SdkOutdatedVersion>
+                      </SdkName>
+                      <List>
+                        {sdkUpdate.suggestions.map((suggestion, i) => (
+                          <ListItem key={i}>
+                            {getSdkUpdateSuggestion({
+                              sdk: {
+                                name: sdkUpdate.sdkName,
+                                version: sdkUpdate.sdkVersion,
+                              },
+                              suggestion,
+                              shortStyle: true,
+                            })}
+                          </ListItem>
+                        ))}
+                      </List>
+                    </div>
+                  ))}
+                </Suggestions>
+              </div>
+            );
+          })}
+        </Collapsible>
+      </UpdatesList>
+    </SidebarPanelItem>
+  );
+};
+
+const UpdatesList = styled('div')`
+  margin-top: ${space(3)};
+  display: grid;
+  grid-auto-flow: row;
+  grid-gap: ${space(2)};
+`;
+
+const Suggestions = styled('div')`
+  margin-top: ${space(1)};
+  margin-left: calc(${space(4)} + ${space(0.25)});
+  display: grid;
+  grid-auto-flow: row;
+  grid-gap: ${space(1.5)};
+`;
+
+const SdkProjectBadge = styled(ProjectBadge)`
+  font-size: ${p => p.theme.fontSizeLarge};
+`;
+
+const SdkName = styled('div')`
+  font-family: ${p => p.theme.text.familyMono};
+  font-size: ${p => p.theme.fontSizeSmall};
+  font-weight: bold;
+`;
+
+const SdkOutdatedVersion = styled('span')`
+  color: ${p => p.theme.subText};
+  font-size: ${p => p.theme.fontSizeExtraSmall};
+`;
+
+export default withSdkUpdates(withProjects(BroadcastSdkUpdates));

--- a/src/sentry/static/sentry/app/components/sidebar/broadcasts.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/broadcasts.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {getAllBroadcasts, markBroadcastsAsSeen} from 'app/actionCreators/broadcasts';
 import {Client} from 'app/api';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import BroadcastSdkUpdates from 'app/components/sidebar/broadcastSdkUpdates';
 import SidebarItem from 'app/components/sidebar/sidebarItem';
 import SidebarPanel from 'app/components/sidebar/sidebarPanel';
 import SidebarPanelEmpty from 'app/components/sidebar/sidebarPanelEmpty';
@@ -141,6 +142,7 @@ class Broadcasts extends React.Component<Props, State> {
             title={t("What's new in Sentry")}
             hidePanel={hidePanel}
           >
+            <BroadcastSdkUpdates />
             {loading ? (
               <LoadingIndicator />
             ) : broadcasts.length === 0 ? (

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarPanel.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarPanel.tsx
@@ -68,7 +68,7 @@ const getPositionForOrientation = (
         right: 0;
       `
     : css`
-        width: 320px;
+        width: 360px;
         top: 0;
         left: ${p.collapsed
           ? p.theme.sidebar.collapsedWidth
@@ -97,7 +97,7 @@ const SidebarPanelHeader = styled('div')`
   padding: ${space(3)};
   background: ${p => p.theme.background};
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
-  height: 62px;
+  height: 60px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -105,6 +105,8 @@ const SidebarPanelHeader = styled('div')`
 `;
 
 const SidebarPanelBody = styled('div')<{hasHeader: boolean}>`
+  display: flex;
+  flex-direction: column;
   flex-grow: 1;
   overflow: auto;
 `;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarPanelEmpty.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarPanelEmpty.tsx
@@ -1,12 +1,11 @@
 import styled from '@emotion/styled';
 
 const SidebarPanelEmpty = styled('div')`
+  flex-grow: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   color: ${p => p.theme.gray300};
-  height: 100%;
-  width: 100%;
   padding: 0 60px;
   text-align: center;
 `;

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarPanelItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarPanelItem.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import space from 'app/styles/space';
+
 import {t} from '../../locale';
 import ExternalLink from '../links/externalLink';
 
@@ -11,9 +13,18 @@ type Props = {
   message?: React.ReactNode;
   link?: string;
   cta?: string;
+  children?: React.ReactNode;
 };
 
-const SidebarPanelItem = ({hasSeen, title, image, message, link, cta}: Props) => (
+const SidebarPanelItem = ({
+  hasSeen,
+  title,
+  image,
+  message,
+  link,
+  cta,
+  children,
+}: Props) => (
   <SidebarPanelItemRoot>
     {title && <Title hasSeen={hasSeen}>{title}</Title>}
     {image && (
@@ -22,6 +33,8 @@ const SidebarPanelItem = ({hasSeen, title, image, message, link, cta}: Props) =>
       </ImageBox>
     )}
     {message && <Message>{message}</Message>}
+
+    {children}
 
     {link && (
       <Text>
@@ -35,7 +48,7 @@ export default SidebarPanelItem;
 
 const SidebarPanelItemRoot = styled('div')`
   padding: 15px 20px;
-  line-height: 1.2;
+  line-height: 1.5;
   border-bottom: 1px solid ${p => p.theme.innerBorder};
   background: ${p => p.theme.background};
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
@@ -44,13 +57,13 @@ const SidebarPanelItemRoot = styled('div')`
 
 const ImageBox = styled('div')`
   border: 1px solid #e1e4e5;
-  padding: 15px;
+  padding: ${space(2)};
   border-radius: 2px;
 `;
 
 const Title = styled('div')<Pick<Props, 'hasSeen'>>`
-  font-size: 15px;
-  margin-bottom: 5px;
+  font-size: ${p => p.theme.fontSizeLarge};
+  margin-bottom: ${space(1)};
   color: ${p => p.theme.textColor};
   ${p => !p.hasSeen && 'font-weight: 600;'};
 

--- a/src/sentry/static/sentry/app/stores/sdkUpdatesStore.tsx
+++ b/src/sentry/static/sentry/app/stores/sdkUpdatesStore.tsx
@@ -1,0 +1,44 @@
+import Reflux from 'reflux';
+
+import SdkUpdatesActions from 'app/actions/sdkUpdatesActions';
+import {ProjectSdkUpdates} from 'app/types';
+
+type SdkUpdatesStoreInterface = {
+  onLoadSuccess(orgSlug: string, data: ProjectSdkUpdates[]): void;
+  getUpdates(orgSlug: string): ProjectSdkUpdates[] | undefined;
+  isSdkUpdatesLoaded(orgSlug: string): boolean;
+};
+
+type Internal = {
+  /**
+   * Org slug mapping to SDK updates
+   */
+  orgSdkUpdates: Map<string, ProjectSdkUpdates[]>;
+};
+
+const storeConfig: Reflux.StoreDefinition & SdkUpdatesStoreInterface & Internal = {
+  orgSdkUpdates: new Map(),
+
+  init() {
+    this.listenTo(SdkUpdatesActions.load, this.onLoadSuccess);
+  },
+
+  onLoadSuccess(orgSlug, data) {
+    this.orgSdkUpdates.set(orgSlug, data);
+    this.trigger(this.orgSdkUpdates);
+  },
+
+  getUpdates(orgSlug) {
+    return this.orgSdkUpdates.get(orgSlug);
+  },
+
+  isSdkUpdatesLoaded(orgSlug) {
+    return this.orgSdkUpdates.has(orgSlug);
+  },
+};
+
+type SdkUpdatesStore = Reflux.Store & SdkUpdatesStoreInterface;
+
+const SdkUpdatesStore = Reflux.createStore(storeConfig) as SdkUpdatesStore;
+
+export default SdkUpdatesStore;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -363,6 +363,13 @@ export type SDKUpdatesSuggestion =
   | UpdateSdkSuggestion
   | ChangeSdkSuggestion;
 
+export type ProjectSdkUpdates = {
+  projectId: string;
+  sdkName: string;
+  sdkVersion: string;
+  suggestions: SDKUpdatesSuggestion[];
+};
+
 export type EventsStatsData = [number, {count: number}[]][];
 
 // API response format for a single series

--- a/src/sentry/static/sentry/app/utils/getSdkUpdateSuggestion.tsx
+++ b/src/sentry/static/sentry/app/utils/getSdkUpdateSuggestion.tsx
@@ -7,22 +7,25 @@ import space from 'app/styles/space';
 import {Event} from 'app/types/event';
 
 type Props = {
-  event: Event;
+  sdk: Event['sdk'];
   suggestion: NonNullable<Event['sdkUpdates']>[0];
+  shortStyle?: boolean;
 };
 
-function getSuggestion({event, suggestion}: Props) {
+function getSdkUpdateSuggestion({sdk, suggestion, shortStyle = false}: Props) {
   const getTitleData = () => {
     switch (suggestion.type) {
       case 'updateSdk':
         return {
           href: suggestion?.sdkUrl,
-          content: event?.sdk
-            ? t(
-                'update your SDK from version %s to version %s',
-                event.sdk.version,
-                suggestion.newSdkVersion
-              )
+          content: sdk
+            ? shortStyle
+              ? t('update to version %s', suggestion.newSdkVersion)
+              : t(
+                  'update your SDK from version %s to version %s',
+                  sdk.version,
+                  suggestion.newSdkVersion
+                )
             : t('update your SDK version'),
         };
       case 'changeSdk':
@@ -58,7 +61,7 @@ function getSuggestion({event, suggestion}: Props) {
     return <ExternalLink href={href}>{content}</ExternalLink>;
   };
 
-  const title = getTitle();
+  const title = <React.Fragment>{getTitle()}</React.Fragment>;
 
   if (!suggestion.enables.length) {
     return title;
@@ -66,7 +69,10 @@ function getSuggestion({event, suggestion}: Props) {
 
   const alertContent = suggestion.enables
     .map((subSuggestion, index) => {
-      const subSuggestionContent = getSuggestion({suggestion: subSuggestion, event});
+      const subSuggestionContent = getSdkUpdateSuggestion({
+        suggestion: subSuggestion,
+        sdk,
+      });
       if (!subSuggestionContent) {
         return null;
       }
@@ -84,7 +90,7 @@ function getSuggestion({event, suggestion}: Props) {
   });
 }
 
-export default getSuggestion;
+export default getSdkUpdateSuggestion;
 
 const AlertUl = styled('ul')`
   margin-top: ${space(1)};

--- a/src/sentry/static/sentry/app/utils/withSdkUpdates.tsx
+++ b/src/sentry/static/sentry/app/utils/withSdkUpdates.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import createReactClass from 'create-react-class';
+import Reflux from 'reflux';
+
+import {loadSdkUpdates} from 'app/actionCreators/sdkUpdates';
+import {Client} from 'app/api';
+import SdkUpdatesStore from 'app/stores/sdkUpdatesStore';
+import {Organization, ProjectSdkUpdates} from 'app/types';
+
+import withApi from './withApi';
+import withOrganization from './withOrganization';
+
+type InjectedProps = {
+  /**
+   * List of (Project + SDK)s and potential update suggestions for each.
+   *
+   * Null when updates have not been loaded for this org.
+   */
+  sdkUpdates?: ProjectSdkUpdates[] | null;
+};
+
+type Props = {
+  organization: Organization;
+  /**
+   * Project IDs to limit the updates query to
+   */
+  projectIds?: string[];
+  api: Client;
+};
+
+type State = {
+  sdkUpdates: ProjectSdkUpdates[];
+};
+
+function withSdkUpdates<P extends InjectedProps>(
+  WrappedComponent: React.ComponentType<P>
+) {
+  const ProjectSdkSuggestions = createReactClass<
+    Props & Omit<P, keyof InjectedProps>,
+    State
+  >({
+    mixins: [Reflux.listenTo(SdkUpdatesStore, 'onSdkUpdatesUpdate') as any],
+
+    getInitialState() {
+      return {sdkUpdates: []};
+    },
+
+    componentDidMount() {
+      const orgSlug = this.props.organization.slug;
+      const updates = SdkUpdatesStore.getUpdates(orgSlug);
+
+      // Load SdkUpdates
+      if (updates !== undefined) {
+        this.onSdkUpdatesUpdate();
+        return;
+      }
+
+      loadSdkUpdates(this.props.api, orgSlug);
+    },
+
+    onSdkUpdatesUpdate() {
+      const sdkUpdates = SdkUpdatesStore.getUpdates(this.props.organization.slug) ?? null;
+      this.setState({sdkUpdates});
+    },
+
+    render() {
+      return (
+        <WrappedComponent {...(this.props as P)} sdkUpdates={this.state.sdkUpdates} />
+      );
+    },
+  });
+
+  return withOrganization(withApi(ProjectSdkSuggestions));
+}
+
+export default withSdkUpdates;

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -40,6 +40,10 @@ describe('Sidebar', function () {
       url: `/organizations/${organization.slug}/discover/saved/`,
       body: [],
     });
+    apiMocks.sdkUpdates = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/sdk-updates/`,
+      body: [],
+    });
   });
 
   it('renders', function () {


### PR DESCRIPTION
This is just for broadcasts in the sidebar.

There is another PR that will render the alerts to indicate that there are updates (with a button that will open the sidebar)

This does *not* highlight the sidebar, as there isn't a great way to mark SDK updates as having been seen / acknowledged. So for now we'll rely on the alerts that can be dismissed popping up.