### PR TITLE
fix(symbolication): Use the symbolication duration for timeout

### DIFF
--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -227,6 +227,8 @@ def _do_symbolicate_event(cache_key, start_time, event_id, symbolicate_task, dat
 
     from_reprocessing = symbolicate_task is symbolicate_event_from_reprocessing
 
+    symbolication_start_time = time()
+
     with sentry_sdk.start_span(op="tasks.store.symbolicate_event.symbolication") as span:
         span.set_data("symbolicaton_function", symbolication_function.__name__)
         with metrics.timer(
@@ -248,17 +250,15 @@ def _do_symbolicate_event(cache_key, start_time, event_id, symbolicate_task, dat
                     break
                 except RetrySymbolication as e:
                     if (
-                        start_time
-                        and (time() - start_time) > settings.SYMBOLICATOR_PROCESS_EVENT_WARN_TIMEOUT
-                    ):
+                        time() - symbolication_start_time
+                    ) > settings.SYMBOLICATOR_PROCESS_EVENT_WARN_TIMEOUT:
                         error_logger.warning(
                             "symbolicate.slow",
                             extra={"project_id": project_id, "event_id": event_id},
                         )
                     if (
-                        start_time
-                        and (time() - start_time) > settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT
-                    ):
+                        time() - symbolication_start_time
+                    ) > settings.SYMBOLICATOR_PROCESS_EVENT_HARD_TIMEOUT:
                         # Do not drop event but actually continue with rest of pipeline
                         # (persisting unsymbolicated event)
                         metrics.incr(


### PR DESCRIPTION
Instead of using start_time argument of the task which is filled in by Relay at
the begging of a pipeline, use the time when the symbolication actually started
as a base time for timeouts.

This also better reflects the soft, hard time limits setup for the celery task.