### PR TITLE
feat(ui): Make release version link to detail page

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/list/releaseCard.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
+import GlobalSelectionLink from 'app/components/globalSelectionLink';
 import {Panel} from 'app/components/panels';
 import ReleaseStats from 'app/components/releaseStats';
 import TextOverflow from 'app/components/textOverflow';
@@ -13,6 +14,24 @@ import {GlobalSelection, Release} from 'app/types';
 
 import ReleaseHealth from './releaseHealth';
 import {DisplayOption} from './utils';
+
+function getReleaseProjectId(release: Release, selection: GlobalSelection) {
+  // if a release has only one project
+  if (release.projects.length === 1) {
+    return release.projects[0].id;
+  }
+
+  // if only one project is selected in global header and release has it (second condition will prevent false positives like -1)
+  if (
+    selection.projects.length === 1 &&
+    release.projects.map(p => p.id).includes(selection.projects[0])
+  ) {
+    return selection.projects[0];
+  }
+
+  // project selector on release detail page will pick it up
+  return undefined;
+}
 
 type Props = {
   release: Release;
@@ -39,9 +58,18 @@ const ReleaseCard = ({
     <StyledPanel reloading={reloading ? 1 : 0}>
       <ReleaseInfo>
         <ReleaseInfoHeader>
-          <VersionWrapper>
-            <StyledVersion version={version} tooltipRawVersion anchor={false} />
-          </VersionWrapper>
+          <GlobalSelectionLink
+            to={{
+              pathname: `/organizations/${orgSlug}/releases/${encodeURIComponent(
+                version
+              )}/`,
+              query: {project: getReleaseProjectId(release, selection)},
+            }}
+          >
+            <VersionWrapper>
+              <StyledVersion version={version} tooltipRawVersion anchor={false} />
+            </VersionWrapper>
+          </GlobalSelectionLink>
           {commitCount > 0 && <ReleaseStats release={release} withHeading={false} />}
         </ReleaseInfoHeader>
         <ReleaseInfoSubheader>

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/content.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/content.tsx
@@ -221,6 +221,7 @@ const Content = ({
                       orgSlug={orgSlug}
                       project={project}
                       releaseVersion={releaseVersion}
+                      location={location}
                     />
                   </ViewColumn>
                 </Layout>

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/projectLink.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/projectLink.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import {Location} from 'history';
 
 import Button from 'app/components/button';
+import {extractSelectionParameters} from 'app/components/organizations/globalSelectionHeader/utils';
 import {t} from 'app/locale';
 import {ReleaseProject} from 'app/types';
 
@@ -8,16 +10,20 @@ type Props = {
   orgSlug: string;
   releaseVersion: string;
   project: ReleaseProject;
+  location: Location;
 };
 
-const ProjectLink = ({orgSlug, releaseVersion, project}: Props) => (
+const ProjectLink = ({orgSlug, releaseVersion, project, location}: Props) => (
   <Button
     size="xsmall"
     to={{
       pathname: `/organizations/${orgSlug}/releases/${encodeURIComponent(
         releaseVersion
       )}/`,
-      query: {project: project.id},
+      query: {
+        ...extractSelectionParameters(location.query),
+        project: project.id,
+      },
     }}
   >
     {t('View')}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9060071/106150200-5fbc9c00-617b-11eb-80d9-5ea861bfa92b.png)

Each project in a release has its own detail page - this is how we decide:
- if release has only one project then it's easy
- if we have one project selected in global header and it's not `-1` then we know the right one too
- otherwise the project picker on detail page will be presented (or you can click the view button in a release project row)