### PR TITLE
chore: Remove organization_slug as a potential tag

### DIFF
--- a/src/sentry/integrations/jira/issue_hook.py
+++ b/src/sentry/integrations/jira/issue_hook.py
@@ -50,7 +50,7 @@ class JiraIssueHookView(JiraBaseHook):
                 group = Group.objects.get(id=group_link.group_id)
             except (ExternalIssue.DoesNotExist, GroupLink.DoesNotExist, Group.DoesNotExist):
                 return self.get_response({"issue_not_linked": True})
-            scope.set_tag("organization_slug", group.organization.slug)
+            scope.set_tag("organization.slug", group.organization.slug)
 
             # TODO: find more efficient way of getting stats
             def get_serialized_and_stats(stats_period):


### PR DESCRIPTION
- organization_slug should be set as organization.slug, this is to be
  consistent with how we set it across the organization
  - Also one less thing in the autocomplete when you type organization
- Basically I just want to clean this dropdown up:
<img width="293" alt="image" src="https://user-images.githubusercontent.com/4205004/106158903-3cc9c200-6152-11eb-9262-6fb37dea975f.png">
