### PR TITLE
fix(perf): Fix loading state of graphs for landing v2

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -157,7 +157,7 @@ class Chart extends React.Component<Props> {
     };
 
     if (loading) {
-      return <AreaChart series={[]} {...areaChartProps} />;
+      return <AreaChart height={height} series={[]} {...areaChartProps} />;
     }
     const series = data.map((values, i: number) => ({
       ...values,

--- a/src/sentry/static/sentry/app/views/performance/landing/chart/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/chart/durationChart.tsx
@@ -7,14 +7,17 @@ import {Location} from 'history';
 import {Client} from 'app/api';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
+import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getInterval} from 'app/components/charts/utils';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import Placeholder from 'app/components/placeholder';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {IconWarning} from 'app/icons';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import EventView from 'app/utils/discover/eventView';
+import getDynamicText from 'app/utils/getDynamicText';
 import withApi from 'app/utils/withApi';
 
 import Chart from '../../charts/chart';
@@ -97,21 +100,29 @@ function DurationChart(props: Props) {
             </DoubleHeaderContainer>
             {results && (
               <ChartContainer>
-                <Chart
-                  height={250}
-                  data={results}
-                  loading={loading || reloading}
-                  router={router}
-                  statsPeriod={globalSelection.datetime.period}
-                  utc={utc === 'true'}
-                  grid={{
-                    left: space(3),
-                    right: space(3),
-                    top: space(3),
-                    bottom: space(1.5),
-                  }}
-                  disableMultiAxis
-                />
+                <MaskContainer>
+                  <TransparentLoadingMask visible={loading} />
+                  {getDynamicText({
+                    value: (
+                      <Chart
+                        height={250}
+                        data={results}
+                        loading={loading || reloading}
+                        router={router}
+                        statsPeriod={globalSelection.datetime.period}
+                        utc={utc === 'true'}
+                        grid={{
+                          left: space(3),
+                          right: space(3),
+                          top: space(3),
+                          bottom: loading || reloading ? space(4) : space(1.5),
+                        }}
+                        disableMultiAxis
+                      />
+                    ),
+                    fixed: <Placeholder height="250px" testId="skeleton-ui" />,
+                  })}
+                </MaskContainer>
               </ChartContainer>
             )}
           </div>
@@ -123,6 +134,9 @@ function DurationChart(props: Props) {
 
 const ChartContainer = styled('div')`
   padding-top: ${space(1)};
+`;
+const MaskContainer = styled('div')`
+  position: relative;
 `;
 
 export default withRouter(withApi(DurationChart));

--- a/src/sentry/static/sentry/app/views/performance/landing/display/doubleAxisDisplay.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/display/doubleAxisDisplay.tsx
@@ -89,6 +89,7 @@ const DoubleChartContainer = styled('div')`
   grid-template-columns: 1fr 1fr;
   grid-gap: ${space(3)};
   background-color: ${p => p.theme.background};
+  min-height: 282px;
 `;
 
 const Footer = withApi(_Footer);


### PR DESCRIPTION
### Summary
This touches up the loading state for the landing v2 graphs. The loading state was using loading panel and had a separate color than the background, in addition to being off center. This isn't perfect, but the level of visual noise when loading is a lot lower.

### Other
- Added dynamic text for acceptance.