### PR TITLE
feat(dashboardsv2): Show landing drop zone

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -130,7 +130,7 @@ class WidgetCard extends React.Component<Props> {
       >
         <div
           style={{
-            backgroundColor: isDragging ? theme.border : undefined,
+            backgroundColor: isDragging ? theme.innerBorder : undefined,
             borderRadius: isDragging ? theme.borderRadius : undefined,
           }}
         >

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -128,36 +128,43 @@ class WidgetCard extends React.Component<Props> {
       <ErrorBoundary
         customComponent={<ErrorCard>{t('Error loading widget data')}</ErrorCard>}
       >
-        <StyledPanel isDragging={isDragging}>
-          <WidgetTitle>{widget.title}</WidgetTitle>
-          <WidgetQueries
-            api={api}
-            organization={organization}
-            widget={widget}
-            selection={selection}
-          >
-            {({tableResults, timeseriesResults, errorMessage, loading}) => {
-              return (
-                <React.Fragment>
-                  {typeof renderErrorMessage === 'function'
-                    ? renderErrorMessage(errorMessage)
-                    : null}
-                  <WidgetCardVisuals
-                    timeseriesResults={timeseriesResults}
-                    tableResults={tableResults}
-                    errorMessage={errorMessage}
-                    loading={loading}
-                    location={location}
-                    widget={widget}
-                    selection={selection}
-                    router={router}
-                  />
-                  {this.renderToolbar()}
-                </React.Fragment>
-              );
-            }}
-          </WidgetQueries>
-        </StyledPanel>
+        <div
+          style={{
+            backgroundColor: isDragging ? theme.border : undefined,
+            borderRadius: isDragging ? theme.borderRadius : undefined,
+          }}
+        >
+          <StyledPanel isDragging={isDragging}>
+            <WidgetTitle>{widget.title}</WidgetTitle>
+            <WidgetQueries
+              api={api}
+              organization={organization}
+              widget={widget}
+              selection={selection}
+            >
+              {({tableResults, timeseriesResults, errorMessage, loading}) => {
+                return (
+                  <React.Fragment>
+                    {typeof renderErrorMessage === 'function'
+                      ? renderErrorMessage(errorMessage)
+                      : null}
+                    <WidgetCardVisuals
+                      timeseriesResults={timeseriesResults}
+                      tableResults={tableResults}
+                      errorMessage={errorMessage}
+                      loading={loading}
+                      location={location}
+                      widget={widget}
+                      selection={selection}
+                      router={router}
+                    />
+                    {this.renderToolbar()}
+                  </React.Fragment>
+                );
+              }}
+            </WidgetQueries>
+          </StyledPanel>
+        </div>
       </ErrorBoundary>
     );
   }


### PR DESCRIPTION
It'll be helpful to know where the widget will land into during a drag. This will be useful for when the Big Number widget is introduced since it is a differently sized widget.

https://user-images.githubusercontent.com/139499/106176922-e1a1ca80-6165-11eb-8a15-f0a6279e2bfe.mp4

