### PR TITLE
fix(ui): rename 'More' dropdown to 'Saved Searches'

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
@@ -38,7 +38,7 @@ function SavedSearchTab({
           <StyledQueryCount isTag count={queryCount} max={1000} />
         </React.Fragment>
       ) : (
-        t('More')
+        t('Saved Searches')
       )}
     </TitleWrapper>
   );


### PR DESCRIPTION
## Before

<img width="501" alt="Screen Shot 2021-01-28 at 9 57 02 AM" src="https://user-images.githubusercontent.com/1900676/106178918-2ff79f00-614f-11eb-893c-d78b399386d1.png">

## After

<img width="617" alt="Screen Shot 2021-01-28 at 9 56 50 AM" src="https://user-images.githubusercontent.com/1900676/106178935-3423bc80-614f-11eb-895c-39f93cc87765.png">
