### PR TITLE
fix(dashboards) Improve rendering of edit icons

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -87,12 +87,14 @@ class WidgetCard extends React.Component<Props> {
     return (
       <ToolbarPanel>
         <IconContainer data-component="icon-container">
-          <StyledIconGrabbable
-            color="gray500"
-            size="md"
-            onMouseDown={event => startWidgetDrag(event)}
-            onTouchStart={event => startWidgetDrag(event)}
-          />
+          <IconClick>
+            <StyledIconGrabbable
+              color="gray500"
+              size="md"
+              onMouseDown={event => startWidgetDrag(event)}
+              onTouchStart={event => startWidgetDrag(event)}
+            />
+          </IconClick>
           <IconClick
             data-test-id="widget-edit"
             onClick={() => {
@@ -212,13 +214,14 @@ const IconContainer = styled('div')`
   > * + * {
     margin-left: 50px;
   }
-
-  svg {
-    background: ${p => p.theme.background};
-  }
 `;
 
 const IconClick = styled('div')`
+  background: ${p => p.theme.background};
+  padding: ${space(0.5)};
+  border-radius: ${p => p.theme.borderRadius};
+  line-height: 0.9;
+
   &:hover {
     cursor: pointer;
   }


### PR DESCRIPTION
Add padding and border radius to make the widget icons look better.

![Screen Shot 2021-01-28 at 1 27 51 PM](https://user-images.githubusercontent.com/24086/106182550-fdf53580-616c-11eb-8341-6bfa60220a88.png)
