### PR TITLE
dev: ignore sentry-flake8 python2 compat errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,11 @@ markers =
 
 [flake8]
 # File filtering is taken care of in pre-commit.
-# TODO(py3): B102 doesn't apply to Python 3. Should be removed from sentry-flake8 in a future release.
-# TODO(py3): B308 doesn't apply to python 3. Should be removed from sentry-flake8 in a future release
+# TODO(joshuarli): Remove the following that don't apply to Python 3 when they're removed in sentry-flake8:
+# B102,B301,B302,B303,B304,B305,B306,B307,B308,B309,B310,B311,B313,B315,B316
 # E203 false positive, see https://github.com/PyCQA/pycodestyle/issues/373
 # W605 false positive until python3.8: https://github.com/PyCQA/pycodestyle/issues/755
-ignore = B102,F999,E203,E501,E128,E124,E402,W503,W504,W605,E731,C901,B007,B306,B009,B010,B308
+ignore = F999,E203,E501,E128,E124,E402,W503,W504,W605,E731,C901,B007,B009,B010,B102,B301,B302,B303,B304,B305,B306,B307,B308,B309,B310,B311,B313,B315,B316
 
 # XXX: E501 is ignored, which disables line length checking.
 # Currently, the black formatter doesn't wrap long strings: https://github.com/psf/black/issues/182#issuecomment-385325274


### PR DESCRIPTION
These error codes are slated to be removed in the next release of sentry-flake8: see https://github.com/getsentry/sentry-flake8/pull/18/. It's good to ignore them preemptively so that we don't regress before the next release (I'd like to get some additional lints in at the same time, which will take some time.)