### PR TITLE
ref: pre-emptively fix new flake8 lints

### DIFF
--- a/src/sentry/api/endpoints/sentry_app_interaction.py
+++ b/src/sentry/api/endpoints/sentry_app_interaction.py
@@ -72,8 +72,7 @@ class SentryAppInteractionEndpoint(SentryAppBaseEndpoint, StatsMixin):
             if component_type is None or component_type not in COMPONENT_TYPES:
                 return Response(
                     {
-                        "detail": "The field componentType is required and must be one of %s"
-                        % (COMPONENT_TYPES)
+                        "detail": f"The field componentType is required and must be one of {COMPONENT_TYPES}"
                     },
                     status=400,
                 )

--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -25,7 +25,6 @@ class BulkDeleteQuery(object):
                 "{} < '{}'::timestamptz".format(
                     quote_name(self.dtfield),
                     (timezone.now() - timedelta(days=self.days)).isoformat(),
-                    self.days,
                 )
             )
         if self.project_id:

--- a/src/sentry/identity/base.py
+++ b/src/sentry/identity/base.py
@@ -16,7 +16,7 @@ class Provider(PipelineProvider):
 
     def __init__(self, **config):
         self.config = config
-        self.logger = logging.getLogger("sentry.identity.%s".format(self.key))
+        self.logger = logging.getLogger(f"sentry.identity.{self.key}")
 
     def build_identity(self, state):
         """

--- a/src/sentry/integrations/cloudflare/webhook.py
+++ b/src/sentry/integrations/cloudflare/webhook.py
@@ -224,7 +224,7 @@ class CloudflareWebhookEndpoint(Endpoint):
             return Response(status=400)
 
         if not self.verify(payload, key, signature):
-            logger.error("cloudflare.webhook.invalid-signature".format(event), extra=logging_data)
+            logger.error("cloudflare.webhook.invalid-signature", extra=logging_data)
             return Response(status=400)
 
         if event == "option-change:account":

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -334,6 +334,7 @@ class User(BaseModel, AbstractBaseUser):
 # HACK(dcramer): last_login needs nullable for Django 1.8
 User._meta.get_field("last_login").null = True
 
+
 # When a user logs out, we want to always log them out of all
 # sessions and refresh their nonce.
 @receiver(user_logged_out, sender=User)

--- a/src/sentry/utils/batching_kafka_consumer.py
+++ b/src/sentry/utils/batching_kafka_consumer.py
@@ -35,9 +35,7 @@ def wait_for_topics(admin_client, topics, timeout=10):
         while True:
             if time.time() > start + timeout:
                 raise RuntimeError(
-                    "Timeout when waiting for Kafka topic '%s' to become available, last error: %s".format(
-                        topic, last_error
-                    )
+                    f"Timeout when waiting for Kafka topic '{topic}' to become available, last error: {last_error}"
                 )
 
             result = admin_client.list_topics(topic=topic)

--- a/src/sentry/utils/distutils/commands/build_assets.py
+++ b/src/sentry/utils/distutils/commands/build_assets.py
@@ -59,7 +59,7 @@ class BuildAssetsCommand(BaseBuildCommand):
             version = None
             build = None
         else:
-            log.info("pulled version information from 'sentry' module".format(sentry.__file__))
+            log.info("pulled version information from 'sentry' module")
             version = self.distribution.get_version()
             build = sentry.__build__
         finally:

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
@@ -79,12 +79,10 @@ class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
         self.login_as(user=self.user)
         responses.add(
             method=responses.GET,
-            url="https://example.com/get-projects?installationId={}".format(
-                self.project.slug, self.install.uuid
-            ),
+            url=f"https://example.com/get-projects?installationId={self.project.slug}",
             status=500,
             content_type="application/json",
         )
-        url = self.url + "?uri={}".format(self.project.id, "/get-projects")
+        url = self.url + f"?uri={self.project.id}"
         response = self.client.get(url, format="json")
         assert response.status_code == 400

--- a/tests/sentry/api/endpoints/test_sentry_app_interaction.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_interaction.py
@@ -98,12 +98,14 @@ class PostSentryAppInteractionTest(SentryAppInteractionTest):
             self.owned_url, body, headers={"Content-Type": "application/json"}
         )
         assert response.status_code == 400
-        assert response.data[
-            "detail"
-        ] == "The field componentType is required and must be one of %s" % [
+        component_types = [
             "stacktrace-link",
             "issue-link",
         ]
+        assert (
+            response.data["detail"]
+            == f"The field componentType is required and must be one of {component_types}"
+        )
 
     def test_incorrect_component_type(self):
         self.login_as(self.user)
@@ -112,12 +114,14 @@ class PostSentryAppInteractionTest(SentryAppInteractionTest):
             self.owned_url, body, headers={"Content-Type": "application/json"}
         )
         assert response.status_code == 400
-        assert response.data[
-            "detail"
-        ] == "The field componentType is required and must be one of %s" % [
+        component_types = [
             "stacktrace-link",
             "issue-link",
         ]
+        assert (
+            response.data["detail"]
+            == f"The field componentType is required and must be one of {component_types}"
+        )
 
     def test_allows_logged_in_user_who_doesnt_own_app(self):
         self.login_as(self.user)

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -29,8 +29,8 @@ class WebhookTest(APITestCase):
         assert response.status_code == 405
 
     def test_unregistered_event(self):
-        project = self.project  # force creation
-        url = "/extensions/github/webhook/".format(project.organization.id)
+        project = self.project  # noqa force creation
+        url = "/extensions/github/webhook/"
 
         secret = "b3002c3e321d4b7880360d397db2ccfd"
 

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -41,8 +41,8 @@ class WebhookTest(APITestCase):
         assert response.status_code == 400
 
     def test_unregistered_event(self):
-        project = self.project  # force creation
-        url = "/extensions/github-enterprise/webhook/".format(project.organization.id)
+        project = self.project  # noqa force creation
+        url = "/extensions/github-enterprise/webhook/"
 
         response = self.client.post(
             path=url,


### PR DESCRIPTION
These issues are caught with flake8 3.8.x which is slated to be upgraded to in the next release of sentry-flake8 which includes https://github.com/getsentry/sentry-flake8/pull/18/.

I thought it'd just be nice to fix them all now.

```
src/sentry/db/deletion.py:25:17: F523 '...'.format(...) has unused arguments at position(s): 2
src/sentry/integrations/cloudflare/webhook.py:227:26: F523 '...'.format(...) has unused arguments at position(s): 0
src/sentry/utils/distutils/commands/build_assets.py:62:22: F523 '...'.format(...) has unused arguments at position(s): 0
src/sentry/models/user.py:339:1: E302 expected 2 blank lines, found 1
tests/sentry/integrations/github/test_webhooks.py:33:15: F523 '...'.format(...) has unused arguments at position(s): 0
tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py:82:17: F523 '...'.format(...) has unused arguments at position(s): 1
tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py:88:26: F523 '...'.format(...) has unused arguments at position(s): 1
tests/sentry/integrations/github_enterprise/test_webhooks.py:45:15: F523 '...'.format(...) has unused arguments at position(s): 0
src/sentry/identity/base.py:19:41: F523 '...'.format(...) has unused arguments at position(s): 0
tests/sentry/api/endpoints/test_sentry_app_interaction.py:103:14: F507 '...' % ... has 1 placeholder(s) but 2 substitution(s)
tests/sentry/api/endpoints/test_sentry_app_interaction.py:117:14: F507 '...' % ... has 1 placeholder(s) but 2 substitution(s)
src/sentry/utils/batching_kafka_consumer.py:38:21: F523 '...'.format(...) has unused arguments at position(s): 0, 1
```