### PR TITLE
test(perf): Improve stability of some performance tests

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -11,6 +11,7 @@ import MarkLine from 'app/components/charts/components/markLine';
 import MarkPoint from 'app/components/charts/components/markPoint';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import DiscoverButton from 'app/components/discoverButton';
+import Placeholder from 'app/components/placeholder';
 import Tag from 'app/components/tag';
 import {FIRE_SVG_PATH} from 'app/icons/iconFire';
 import {t} from 'app/locale';
@@ -335,7 +336,7 @@ class VitalCard extends React.Component<Props, State> {
                   {...zoomRenderProps}
                 />
               ),
-              fixed: 'Web Vitals Histogram',
+              fixed: <Placeholder testId="skeleton-ui" height="200px" />,
             })}
           </Container>
         )}

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -25,6 +25,7 @@ import {
   formatPercentage,
   getDuration,
 } from 'app/utils/formatters';
+import getDynamicText from 'app/utils/getDynamicText';
 import theme from 'app/utils/theme';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
 
@@ -191,7 +192,12 @@ class VitalCard extends React.Component<Props, State> {
             <StyledTag>{t('Fail')}</StyledTag>
           )}
         </SummaryHeading>
-        <StatNumber>{this.getFormattedStatNumber()}</StatNumber>
+        <StatNumber>
+          {getDynamicText({
+            value: this.getFormattedStatNumber(),
+            fixed: '\u2014',
+          })}
+        </StatNumber>
         <Description>{description}</Description>
         <div>
           <DiscoverButton
@@ -311,16 +317,26 @@ class VitalCard extends React.Component<Props, State> {
                 />
               </PercentContainer>
             </Feature>
-            <BarChart
-              series={allSeries}
-              xAxis={xAxis}
-              yAxis={yAxis}
-              colors={colors}
-              onRendered={this.handleRendered}
-              grid={{left: space(3), right: space(3), top: space(3), bottom: space(1.5)}}
-              stacked
-              {...zoomRenderProps}
-            />
+            {getDynamicText({
+              value: (
+                <BarChart
+                  series={allSeries}
+                  xAxis={xAxis}
+                  yAxis={yAxis}
+                  colors={colors}
+                  onRendered={this.handleRendered}
+                  grid={{
+                    left: space(3),
+                    right: space(3),
+                    top: space(3),
+                    bottom: space(1.5),
+                  }}
+                  stacked
+                  {...zoomRenderProps}
+                />
+              ),
+              fixed: 'Web Vitals Histogram',
+            })}
           </Container>
         )}
       </BarChartZoom>

--- a/tests/js/spec/views/performance/trends.spec.jsx
+++ b/tests/js/spec/views/performance/trends.spec.jsx
@@ -386,7 +386,7 @@ describe('Performance > Trends', function () {
         }),
       });
     }
-  });
+  }, 10000);
 
   it('choosing a confidence level changes location', async function () {
     const projects = [TestStubs.Project()];
@@ -414,7 +414,7 @@ describe('Performance > Trends', function () {
         }),
       });
     }
-  });
+  }, 10000);
 
   it('trend functions in location make api calls', async function () {
     const projects = [TestStubs.Project(), TestStubs.Project()];


### PR DESCRIPTION
1. Wrap the vitals histograms in `getDynamicText` to improve flakiness in tests.
2. Increase timeout on trends tests as they take a long time in a suite.