### PR TITLE
fix(perf): Make sure to pass start/end to chartZoom

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -482,7 +482,14 @@ class EventsChart extends React.Component<Props> {
     }
 
     return (
-      <ChartZoom router={router} period={period} utc={utc} {...props}>
+      <ChartZoom
+        router={router}
+        period={period}
+        start={start}
+        end={end}
+        utc={utc}
+        {...props}
+      >
         {zoomRenderProps => (
           <EventsRequest
             {...props}

--- a/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/chart.tsx
@@ -5,6 +5,7 @@ import min from 'lodash/min';
 
 import AreaChart from 'app/components/charts/areaChart';
 import ChartZoom from 'app/components/charts/chartZoom';
+import {DateString} from 'app/types';
 import {Series} from 'app/types/echarts';
 import {axisLabelFormatter, tooltipFormatter} from 'app/utils/discover/charts';
 import {aggregateOutputType} from 'app/utils/discover/fields';
@@ -14,6 +15,8 @@ type Props = {
   data: Series[];
   router: ReactRouter.InjectedRouter;
   statsPeriod: string | undefined;
+  start: DateString;
+  end: DateString;
   utc: boolean;
   height?: number;
   grid?: AreaChart['props']['grid'];
@@ -55,6 +58,8 @@ class Chart extends React.Component<Props> {
       data,
       router,
       statsPeriod,
+      start,
+      end,
       utc,
       loading,
       height,
@@ -169,6 +174,8 @@ class Chart extends React.Component<Props> {
       <ChartZoom
         router={router}
         period={statsPeriod}
+        start={start}
+        end={end}
         utc={utc}
         xAxisIndex={disableMultiAxis ? undefined : [0, 1]}
       >

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -48,10 +48,10 @@ class Container extends React.Component<Props> {
     const globalSelection = eventView.getGlobalSelection();
     const start = globalSelection.datetime.start
       ? getUtcToLocalDateObject(globalSelection.datetime.start)
-      : undefined;
+      : null;
     const end = globalSelection.datetime.end
       ? getUtcToLocalDateObject(globalSelection.datetime.end)
-      : undefined;
+      : null;
 
     const {utc} = getParams(location.query);
     const axisOptions = this.getChartParameters();
@@ -68,8 +68,8 @@ class Container extends React.Component<Props> {
           end={end}
           interval={getInterval(
             {
-              start: start || null,
-              end: end || null,
+              start,
+              end,
               period: globalSelection.datetime.period,
             },
             true
@@ -112,6 +112,8 @@ class Container extends React.Component<Props> {
                         loading={loading || reloading}
                         router={router}
                         statsPeriod={globalSelection.datetime.period}
+                        start={start}
+                        end={end}
                         utc={utc === 'true'}
                       />
                     ),

--- a/src/sentry/static/sentry/app/views/performance/landing/chart/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/chart/durationChart.tsx
@@ -50,11 +50,11 @@ function DurationChart(props: Props) {
   const globalSelection = eventView.getGlobalSelection();
   const start = globalSelection.datetime.start
     ? getUtcToLocalDateObject(globalSelection.datetime.start)
-    : undefined;
+    : null;
 
   const end = globalSelection.datetime.end
     ? getUtcToLocalDateObject(globalSelection.datetime.end)
-    : undefined;
+    : null;
 
   const {utc} = getParams(location.query);
 
@@ -69,8 +69,8 @@ function DurationChart(props: Props) {
       end={end}
       interval={getInterval(
         {
-          start: start || null,
-          end: end || null,
+          start,
+          end,
           period: globalSelection.datetime.period,
         },
         true
@@ -117,6 +117,8 @@ function DurationChart(props: Props) {
                         loading={loading || reloading}
                         router={router}
                         statsPeriod={globalSelection.datetime.period}
+                        start={start}
+                        end={end}
                         utc={utc === 'true'}
                         grid={{
                           left: space(3),

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -134,7 +134,7 @@ class DurationChart extends React.Component<Props> {
             )}
           />
         </HeaderTitleLegend>
-        <ChartZoom router={router} period={statsPeriod}>
+        <ChartZoom router={router} period={statsPeriod} start={start} end={end} utc={utc}>
           {zoomRenderProps => (
             <EventsRequest
               api={api}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
@@ -172,7 +172,14 @@ function SidebarCharts({api, eventView, organization, router}: Props) {
         />
       </ChartTitle>
 
-      <ChartZoom router={router} period={statsPeriod} xAxisIndex={[0, 1, 2]}>
+      <ChartZoom
+        router={router}
+        period={statsPeriod}
+        start={start}
+        end={end}
+        utc={utc}
+        xAxisIndex={[0, 1, 2]}
+      >
         {zoomRenderProps => (
           <EventsRequest
             api={api}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
@@ -148,7 +148,7 @@ class VitalsChart extends React.Component<Props> {
             )}
           />
         </HeaderTitleLegend>
-        <ChartZoom router={router} period={statsPeriod}>
+        <ChartZoom router={router} period={statsPeriod} start={start} end={end} utc={utc}>
           {zoomRenderProps => (
             <EventsRequest
               api={api}

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -312,7 +312,7 @@ class Chart extends React.Component<Props> {
     };
 
     return (
-      <ChartZoom router={router} period={statsPeriod}>
+      <ChartZoom router={router} period={statsPeriod} start={start} end={end} utc={utc}>
         {zoomRenderProps => {
           const smoothedSeries = smoothedResults
             ? smoothedResults.map(values => {

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
@@ -189,7 +189,13 @@ class VitalChart extends React.Component<Props> {
               title={t(`The durations shown should fall under the vital threshold.`)}
             />
           </HeaderTitleLegend>
-          <ChartZoom router={router} period={statsPeriod}>
+          <ChartZoom
+            router={router}
+            period={statsPeriod}
+            start={start}
+            end={end}
+            utc={utc}
+          >
             {zoomRenderProps => (
               <EventsRequest
                 api={api}


### PR DESCRIPTION
Not all charts are passing start/end to chartZoom. This causes a problem when
using an absolute date range where the x axis formatter is not using the date
format when it should.

# Screenshot

## Before

![image](https://user-images.githubusercontent.com/10239353/106200382-e164f780-6184-11eb-8226-14e8b227eaaf.png)

## After

![image](https://user-images.githubusercontent.com/10239353/106200334-d01beb00-6184-11eb-8a44-6fda74a9d9d8.png)