### PR TITLE
feat(perf): Enable outlier filtering on latency histogram

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
@@ -218,7 +218,7 @@ class LatencyChart extends React.Component<Props, State> {
           numBuckets={NUM_BUCKETS}
           fields={['transaction.duration']}
           min={min}
-          dataFilter="all"
+          dataFilter="exclude_outliers"
         >
           {({histograms, isLoading, error}) => {
             if (isLoading) {


### PR DESCRIPTION
This turns on the outlier filtering capabilities of the histogram endpoint.
There is currently no UI to disable the outlier filtering but the resulting
histogram is often more useful than the existing histogram.