### PR TITLE
feat(dashboardsv2): Add big number widget to Dashboards

### DIFF
--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -85,7 +85,9 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
     );
   }
 
-  const showAddOverlay = !(displayType === 'world_map' && fields.length === 1);
+  const showAddOverlay = !(
+    ['world_map', 'big_number'].includes(displayType) && fields.length === 1
+  );
 
   return (
     <Field

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -39,13 +39,9 @@ type RenderFunctionBaggage = {
   location: Location;
 };
 
-type FieldFormatterRenderFunction = (
-  field: string,
-  data: EventData,
-  baggage: RenderFunctionBaggage
-) => React.ReactNode;
+type FieldFormatterRenderFunction = (field: string, data: EventData) => React.ReactNode;
 
-export type FieldFormatterRenderFunctionPartial = (
+type FieldFormatterRenderFunctionPartial = (
   data: EventData,
   baggage: RenderFunctionBaggage
 ) => React.ReactNode;
@@ -447,6 +443,29 @@ export function getFieldRenderer(
       return SPECIAL_FUNCTIONS[alias];
     }
   }
+
+  if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {
+    return partial(FIELD_FORMATTERS[fieldType].renderFunc, fieldName);
+  }
+  return partial(FIELD_FORMATTERS.string.renderFunc, fieldName);
+}
+
+type FieldTypeFormatterRenderFunctionPartial = (data: EventData) => React.ReactNode;
+
+/**
+ * Get the field renderer for the named field only based on its type from the given
+ * metadata.
+ *
+ * @param {String} field name
+ * @param {object} metadata mapping.
+ * @returns {Function}
+ */
+export function getFieldFormatter(
+  field: string,
+  meta: MetaType
+): FieldTypeFormatterRenderFunctionPartial {
+  const fieldName = getAggregateAlias(field);
+  const fieldType = meta[fieldName];
 
   if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {
     return partial(FIELD_FORMATTERS[fieldType].renderFunc, fieldName);

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -374,7 +374,7 @@ class Dashboard extends React.Component<Props, State> {
 
     return (
       <LazyLoad key={`${widget.id ?? index}`} once height={240} offset={100}>
-        <WidgetWrapper data-component="widget-wrapper">
+        <WidgetWrapper data-component="widget-wrapper" displayType={widget.displayType}>
           <WidgetCard
             widget={widget}
             isEditing={isEditing}
@@ -422,7 +422,7 @@ class Dashboard extends React.Component<Props, State> {
       <WidgetContainer>
         {widgets.map((widget, i) => this.renderWidget(widget, i))}
         {isEditing && (
-          <WidgetWrapper key="add">
+          <WidgetWrapper key="add" displayType="big_number">
             <AddWidgetWrapper
               key="add"
               data-test-id="widget-add"
@@ -451,10 +451,19 @@ const WidgetContainer = styled('div')`
   }
 `;
 
-const WidgetWrapper = styled('div')`
+const WidgetWrapper = styled('div')<{displayType: Widget['displayType']}>`
   position: relative;
   /* Min-width prevents grid items from stretching the grid */
   min-width: 200px;
+
+  ${p => {
+    switch (p.displayType) {
+      case 'big_number':
+        return 'grid-area: span 1 / span 1;';
+      default:
+        return 'grid-area: span 2 / span 2;';
+    }
+  }};
 `;
 
 const AddWidgetWrapper = styled('a')`

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -442,7 +442,8 @@ export default withApi(withGlobalSelection(Dashboard));
 
 const WidgetContainer = styled('div')`
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(4, 1fr);
+  grid-auto-flow: row dense;
   grid-gap: ${space(2)};
 
   @media (max-width: ${p => p.theme.breakpoints[1]}) {

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -459,8 +459,7 @@ const WidgetWrapper = styled('div')`
 
 const AddWidgetWrapper = styled('a')`
   width: 100%;
-  height: 100%;
-  min-height: 200px;
+  height: 110px;
   border: 2px dashed ${p => p.theme.border};
   border-radius: ${p => p.theme.borderRadius};
   display: flex;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/data.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/data.tsx
@@ -16,6 +16,7 @@ export const DISPLAY_TYPE_CHOICES = [
   {label: t('Line chart'), value: 'line'},
   {label: t('Table results'), value: 'table'},
   {label: t('World Map'), value: 'world_map'},
+  {label: t('Big Number'), value: 'big_number'},
 ];
 
 export const INTERVAL_CHOICES = [

--- a/src/sentry/static/sentry/app/views/dashboardsV2/types.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/types.tsx
@@ -1,4 +1,11 @@
-type DisplayType = 'line' | 'area' | 'stacked_area' | 'bar' | 'table' | 'world_map';
+type DisplayType =
+  | 'line'
+  | 'area'
+  | 'stacked_area'
+  | 'bar'
+  | 'table'
+  | 'world_map'
+  | 'big_number';
 
 export type WidgetQuery = {
   name: string;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -389,7 +389,7 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
     if (widget.displayType === 'big_number') {
       return (
         <TransitionChart loading={loading} reloading={loading}>
-          <TransparentLoadingMask visible={loading} />
+          <LoadingScreen loading={loading} />
           {this.bigNumberComponent({tableResults, loading, errorMessage})}
         </TransitionChart>
       );

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -198,6 +198,7 @@ const StyledPanel = styled(Panel, {
   visibility: ${p => (p.isDragging ? 'hidden' : 'visible')};
   /* If a panel overflows due to a long title stretch its grid sibling */
   height: 100%;
+  min-height: 110px;
 `;
 
 const ToolbarPanel = styled('div')`

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
@@ -160,6 +160,10 @@ class WidgetQueries extends React.Component<Props, State> {
       if (widget.displayType === 'table') {
         url = `/organizations/${organization.slug}/eventsv2/`;
         params.referrer = 'api.dashboards.tablewidget';
+      } else if (widget.displayType === 'big_number') {
+        url = `/organizations/${organization.slug}/eventsv2/`;
+        params.per_page = 1;
+        params.referrer = 'api.dashboards.bignumberwidget';
       } else if (widget.displayType === 'world_map') {
         url = `/organizations/${organization.slug}/events-geo/`;
         delete params.per_page;
@@ -205,7 +209,7 @@ class WidgetQueries extends React.Component<Props, State> {
 
     this.setState({loading: true, errorMessage: undefined});
 
-    if (['table', 'world_map'].includes(widget.displayType)) {
+    if (['table', 'world_map', 'big_number'].includes(widget.displayType)) {
       this.fetchEventData();
     } else {
       this.setState({timeseriesResults: []});


### PR DESCRIPTION
Add Big Number widget to Dashboards. Values for the widget uses the same type-based field formatters as Discover tables; with the exception that the field formatters do not include any field renderers for special aliases/columns.

<img width="1681" alt="Screen Shot 2021-01-28 at 4 59 44 PM" src="https://user-images.githubusercontent.com/139499/106204176-8cc47b00-618a-11eb-8cd3-057a6508abd3.png">

<img width="663" alt="Screen Shot 2021-01-28 at 4 55 44 PM" src="https://user-images.githubusercontent.com/139499/106204171-8c2be480-618a-11eb-83b8-12a0897d9481.png">


https://user-images.githubusercontent.com/139499/106204218-9d74f100-618a-11eb-8e42-d9bfb57ea228.mp4



Grid changes are as follows:

- The grid is split into 4 columns (from 2 columns)
- Bar/Line/Area charts and table now span 2 columns and 2 rows.
- Add button span 1 column and 1 row
- Big number widget span 1 column and 1 row
- Add button span 1 column and 1 row
- Apply `grid-auto-flow: row dense;`, which applies a row-wise dense packing algorithm for the css grid. This should help fill in holes. See: https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-flow

What the grid split looks like: 

https://user-images.githubusercontent.com/139499/106204718-6c48f080-618b-11eb-99d1-91b433695c84.mp4


-------


- Depends on https://github.com/getsentry/sentry/pull/23417