### PR TITLE
fix(dashboards) Fix duplicate reloads on zoom

### DIFF
--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -50,7 +50,7 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
     event.preventDefault();
 
     const newFields = [...fields];
-    newFields.splice(fieldIndex, fieldIndex + 1);
+    newFields.splice(fieldIndex, 1);
     onChange(newFields);
   }
 

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/utils.tsx
@@ -1,5 +1,6 @@
 import {Location} from 'history';
 import identity from 'lodash/identity';
+import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
 
@@ -86,4 +87,33 @@ export function getDefaultSelection(): GlobalSelection {
       utc: typeof utc !== 'undefined' ? utc === 'true' : null,
     },
   };
+}
+
+/**
+ * Compare the non-utc values of two selections.
+ * Useful when re-fetching data based on globalselection changing.
+ *
+ * utc is not compared as there is a problem somewhere in the selection
+ * data flow that results in it being undefined | null | boolean instead of null | boolean.
+ * The additional undefined state makes this function just as unreliable as isEqual(selection, other)
+ */
+export function isSelectionEqual(
+  selection: GlobalSelection,
+  other: GlobalSelection
+): boolean {
+  if (
+    !isEqual(selection.projects, other.projects) ||
+    !isEqual(selection.environments, other.environments)
+  ) {
+    return false;
+  }
+  // Use string comparison as we aren't interested in the identity of the datetimes.
+  if (
+    selection.datetime.period !== other.datetime.period ||
+    selection.datetime.start?.toString() !== other.datetime.start?.toString() ||
+    selection.datetime.end?.toString() !== other.datetime.end?.toString()
+  ) {
+    return false;
+  }
+  return true;
 }

--- a/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
@@ -212,12 +212,12 @@ class GenericDiscoverQuery<T, P> extends React.Component<Props<T, P>, State<T>> 
   }
 }
 
-type RequestParameters = Partial<EventQuery & LocationQuery>;
+export type DiscoverQueryRequestParams = Partial<EventQuery & LocationQuery>;
 
 export async function doDiscoverQuery<T>(
   api: Client,
   url: string,
-  params: RequestParameters
+  params: DiscoverQueryRequestParams
 ): Promise<[T, string | undefined, JQueryXHR | undefined]> {
   return api.requestPromise(url, {
     method: 'GET',

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -18,6 +18,7 @@ import {getSeriesSelection} from 'app/components/charts/utils';
 import WorldMapChart from 'app/components/charts/worldMapChart';
 import ErrorBoundary from 'app/components/errorBoundary';
 import LoadingIndicator from 'app/components/loadingIndicator';
+import {isSelectionEqual} from 'app/components/organizations/globalSelectionHeader/utils';
 import {Panel} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
 import {IconDelete, IconEdit, IconGrabbable, IconWarning} from 'app/icons';
@@ -63,7 +64,7 @@ class WidgetCard extends React.Component<Props> {
   shouldComponentUpdate(nextProps: Props): boolean {
     if (
       !isEqual(nextProps.widget, this.props.widget) ||
-      !isEqual(nextProps.selection, this.props.selection) ||
+      !isSelectionEqual(nextProps.selection, this.props.selection) ||
       this.props.isEditing !== nextProps.isEditing ||
       this.props.isDragging !== nextProps.isDragging ||
       this.props.hideToolbar !== nextProps.hideToolbar

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
@@ -8,6 +8,7 @@ import {
   getInterval,
   isMultiSeriesStats,
 } from 'app/components/charts/utils';
+import {isSelectionEqual} from 'app/components/organizations/globalSelectionHeader/utils';
 import {t} from 'app/locale';
 import {
   EventsStats,
@@ -19,7 +20,10 @@ import {Series} from 'app/types/echarts';
 import {getUtcDateString, parsePeriodToHours} from 'app/utils/dates';
 import {TableData} from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
-import {doDiscoverQuery} from 'app/utils/discover/genericDiscoverQuery';
+import {
+  DiscoverQueryRequestParams,
+  doDiscoverQuery,
+} from 'app/utils/discover/genericDiscoverQuery';
 
 import {Widget, WidgetQuery} from './types';
 
@@ -120,7 +124,7 @@ class WidgetQueries extends React.Component<Props, State> {
       !isEqual(widget.interval, prevProps.widget.interval) ||
       !isEqual(widget.queries, prevProps.widget.queries) ||
       !isEqual(widget.displayType, prevProps.widget.displayType) ||
-      !isEqual(selection, prevProps.selection)
+      !isSelectionEqual(selection, prevProps.selection)
     ) {
       this.fetchData();
     }
@@ -149,8 +153,8 @@ class WidgetQueries extends React.Component<Props, State> {
         end: end ? getUtcDateString(end) : undefined,
       });
 
-      let url;
-      const params: any = {
+      let url: string = '';
+      const params: DiscoverQueryRequestParams = {
         per_page: 5,
       };
       if (widget.displayType === 'table') {

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -223,7 +223,7 @@ class IssueListOverview extends React.Component<Props, State> {
     // If any important url parameter changed or saved search changed
     // reload data.
     if (
-      !isEqual(prevProps.selection, this.props.selection) ||
+      selectionChanged ||
       prevQuery.cursor !== newQuery.cursor ||
       prevQuery.sort !== newQuery.sort ||
       prevQuery.query !== newQuery.query ||

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import * as Sentry from '@sentry/react';
 import {withTheme} from 'emotion-theming';
-import isEqual from 'lodash/isEqual';
 
 import {fetchTotalCount} from 'app/actionCreators/events';
 import EventsChart from 'app/components/charts/eventsChart';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import {isSelectionEqual} from 'app/components/organizations/globalSelectionHeader/utils';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {t} from 'app/locale';
 import {GlobalSelection} from 'app/types';
@@ -32,7 +32,7 @@ class ProjectBaseEventsChart extends React.Component<Props> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (!isEqual(this.props.selection, prevProps.selection)) {
+    if (!isSelectionEqual(this.props.selection, prevProps.selection)) {
       this.fetchTotalCount();
     }
   }

--- a/tests/js/spec/components/organizations/utils.spec.jsx
+++ b/tests/js/spec/components/organizations/utils.spec.jsx
@@ -1,0 +1,78 @@
+import {isSelectionEqual} from 'app/components/organizations/globalSelectionHeader/utils';
+
+describe('isSelectionEqual', function () {
+  const base = {
+    projects: [1, 2],
+    environments: ['prod'],
+    datetime: {
+      period: '14d',
+      start: new Date(2021, 0, 28, 12, 13, 14),
+      end: new Date(2021, 0, 28, 23, 59, 59),
+      utc: null,
+    },
+  };
+
+  it('compares projects', function () {
+    let changed = {...base, projects: [1]};
+    expect(isSelectionEqual(base, changed)).toBe(false);
+
+    changed = {...base, projects: []};
+    expect(isSelectionEqual(base, changed)).toBe(false);
+
+    changed = {...base, projects: [2, 3, 4]};
+    expect(isSelectionEqual(base, changed)).toBe(false);
+  });
+
+  it('compares environments', function () {
+    let changed = {...base, environments: ['staging']};
+    expect(isSelectionEqual(base, changed)).toBe(false);
+
+    changed = {...base, projects: []};
+    expect(isSelectionEqual(base, changed)).toBe(false);
+
+    changed = {...base, projects: ['prod', 'staging']};
+    expect(isSelectionEqual(base, changed)).toBe(false);
+  });
+
+  it('compares period', function () {
+    const changed = {...base};
+    changed.datetime.period = '7d';
+    expect(isSelectionEqual(base, changed)).toBe(true);
+  });
+
+  it('compares start/end safely', function () {
+    // Same datetime but different object.
+    const changed = {
+      ...base,
+      datetime: {...base.datetime, start: null, end: null},
+    };
+    expect(isSelectionEqual(base, changed)).toBe(false);
+  });
+
+  it('compares start/end as value', function () {
+    // Same datetime but different object.
+    let changed = {
+      ...base,
+      datetime: {...base.datetime, start: new Date(2021, 0, 28, 12, 13, 14)},
+    };
+    expect(isSelectionEqual(base, changed)).toBe(true);
+
+    changed = {
+      ...base,
+      datetime: {...base.datetime, end: new Date(2021, 0, 28, 23, 59, 59)},
+    };
+    expect(isSelectionEqual(base, changed)).toBe(true);
+
+    changed = {
+      ...base,
+      datetime: {...base.datetime, end: new Date(2021, 0, 28, 1, 1, 1)},
+    };
+    expect(isSelectionEqual(base, changed)).toBe(false);
+
+    changed = {
+      ...base,
+      datetime: {...base.datetime, start: new Date(2021, 0, 28, 1, 1, 1)},
+    };
+    expect(isSelectionEqual(base, changed)).toBe(false);
+  });
+});


### PR DESCRIPTION
The global selection header was updating multiple times and the changing utc value was causing additional data fetches. I added a new utility function as I suspect we will have more of these problems in the future.

When auditing `isEqual.*selection` I found a bit of duplicate code in issue list, and a usage in project details that could be updated.

I also fixed a bad splice() when widget series are removed.