### PR TITLE
fix(ui): Legends in dark mode should be legible

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/legend.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/legend.tsx
@@ -13,12 +13,20 @@ type ChartProps = React.ComponentProps<typeof BaseChart>;
 export default function Legend(
   props: ChartProps['legend'] & {theme?: Theme} = {}
 ): EChartOption.Legend {
-  const {truncate, theme, ...rest} = props ?? {};
+  const {truncate, theme, textStyle, ...rest} = props ?? {};
   const formatter = (value: string) => truncationFormatter(value, truncate ?? 0);
 
-  return {
+  const newTextStyle = {
+    color: theme?.textColor,
+    verticalAlign: 'top',
+    fontSize: 11,
+    fontFamily: 'Rubik',
+    ...textStyle,
+  };
+
+  const legend = {
     show: true,
-    type: 'scroll',
+    type: 'scroll' as const,
     padding: 0,
     formatter,
     icon: 'circle',
@@ -26,13 +34,15 @@ export default function Legend(
     itemWidth: 8,
     itemGap: 12,
     align: 'left' as const,
-    textStyle: {
-      color: theme?.textColor,
-      verticalAlign: 'top',
-      fontSize: 11,
-      fontFamily: 'Rubik',
-    },
+    textStyle: newTextStyle,
     inactiveColor: theme?.inactive,
     ...rest,
   };
+
+  if (theme === undefined) {
+    delete newTextStyle.color;
+    delete legend.inactiveColor;
+  }
+
+  return legend;
 }

--- a/src/sentry/static/sentry/app/components/charts/components/legend.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/legend.tsx
@@ -11,18 +11,10 @@ import {truncationFormatter} from '../utils';
 type ChartProps = React.ComponentProps<typeof BaseChart>;
 
 export default function Legend(
-  props: ChartProps['legend'] & {theme?: Theme} = {}
+  props: ChartProps['legend'] & {theme: Theme}
 ): EChartOption.Legend {
   const {truncate, theme, textStyle, ...rest} = props ?? {};
   const formatter = (value: string) => truncationFormatter(value, truncate ?? 0);
-
-  const newTextStyle = {
-    color: theme?.textColor,
-    verticalAlign: 'top',
-    fontSize: 11,
-    fontFamily: 'Rubik',
-    ...textStyle,
-  };
 
   const legend = {
     show: true,
@@ -34,15 +26,16 @@ export default function Legend(
     itemWidth: 8,
     itemGap: 12,
     align: 'left' as const,
-    textStyle: newTextStyle,
-    inactiveColor: theme?.inactive,
+    textStyle: {
+      color: theme.textColor,
+      verticalAlign: 'top',
+      fontSize: 11,
+      fontFamily: theme.text.family,
+      ...textStyle,
+    },
+    inactiveColor: theme.inactive,
     ...rest,
   };
-
-  if (theme === undefined) {
-    delete newTextStyle.color;
-    delete legend.inactiveColor;
-  }
 
   return legend;
 }

--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -9,7 +9,6 @@ import {Client} from 'app/api';
 import AreaChart from 'app/components/charts/areaChart';
 import BarChart from 'app/components/charts/barChart';
 import ChartZoom, {ZoomRenderProps} from 'app/components/charts/chartZoom';
-import Legend from 'app/components/charts/components/legend';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LineChart from 'app/components/charts/lineChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
@@ -175,13 +174,13 @@ class Chart extends React.Component<ChartProps, State> {
     }
 
     const legend = showLegend
-      ? Legend({
+      ? {
           right: 16,
           top: 12,
           data,
           selected: seriesSelection,
           ...(legendOptions ?? {}),
-        })
+        }
       : undefined;
 
     let series = Array.isArray(releaseSeries)

--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -180,7 +180,6 @@ class Chart extends React.Component<ChartProps, State> {
           top: 12,
           data,
           selected: seriesSelection,
-          theme,
           ...(legendOptions ?? {}),
         })
       : undefined;

--- a/src/sentry/static/sentry/app/components/charts/pieChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/pieChart.tsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types';
 import {ReactEchartsRef, Series} from 'app/types/echarts';
 import theme from 'app/utils/theme';
 
-import Legend from './components/legend';
 import PieSeries from './series/pieSeries';
 import BaseChart from './baseChart';
 
@@ -133,7 +132,7 @@ class PieChart extends React.Component<Props> {
         }}
         {...props}
         options={{
-          legend: Legend({
+          legend: {
             orient: 'vertical',
             align: 'left',
             show: true,
@@ -146,7 +145,7 @@ class PieChart extends React.Component<Props> {
                   ? `(${seriesPercentages[name]}%)`
                   : ''
               }`,
-          }),
+          },
         }}
         series={[
           PieSeries({

--- a/src/sentry/static/sentry/app/components/charts/worldMapChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/worldMapChart.tsx
@@ -134,6 +134,9 @@ class WorldMapChart extends React.Component<Props, State> {
                 color: [theme.purple200, theme.purple300],
               },
               text: ['High', 'Low'],
+              textStyle: {
+                color: theme.textColor,
+              },
 
               // Whether show handles, which can be dragged to adjust "selected range".
               // False because the handles are pretty ugly

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -8,7 +8,6 @@ import {Client} from 'app/api';
 import AreaChart from 'app/components/charts/areaChart';
 import BarChart from 'app/components/charts/barChart';
 import ChartZoom from 'app/components/charts/chartZoom';
-import Legend from 'app/components/charts/components/legend';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LineChart from 'app/components/charts/lineChart';
 import SimpleTableChart from 'app/components/charts/simpleTableChart';
@@ -420,7 +419,7 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
       );
     }
 
-    const legend = Legend({
+    const legend = {
       right: 0,
       top: 3,
       type: 'plain',
@@ -435,7 +434,7 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
         }
         return seriesName;
       },
-    });
+    };
 
     const axisField = widget.queries[0]?.fields?.[0] ?? 'count()';
     const chartOptions = {

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -425,7 +425,6 @@ class WidgetCardVisuals extends React.Component<WidgetCardVisualsProps> {
       top: 3,
       type: 'plain',
       selected: getSeriesSelection(location),
-      theme,
       formatter: (seriesName: string) => {
         const arg = getAggregateArg(seriesName);
         if (arg !== null) {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -6,7 +6,6 @@ import {Location, Query} from 'history';
 import {Client} from 'app/api';
 import AreaChart from 'app/components/charts/areaChart';
 import ChartZoom from 'app/components/charts/chartZoom';
-import Legend from 'app/components/charts/components/legend';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
@@ -86,11 +85,11 @@ class DurationChart extends React.Component<Props> {
     const end = this.props.end ? getUtcToLocalDateObject(this.props.end) : null;
     const utc = decodeScalar(router.location.query.utc) !== 'false';
 
-    const legend = Legend({
+    const legend = {
       right: 10,
       top: 0,
       selected: getSeriesSelection(location),
-    });
+    };
 
     const datetimeSelection = {
       start,

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -90,7 +90,6 @@ class DurationChart extends React.Component<Props> {
       right: 10,
       top: 0,
       selected: getSeriesSelection(location),
-      theme,
     });
 
     const datetimeSelection = {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
@@ -96,7 +96,6 @@ class TrendChart extends React.Component<Props> {
       right: 10,
       top: 0,
       selected: getSeriesSelection(location, 'trendsUnselectedSeries'),
-      theme,
     });
 
     const datetimeSelection = {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
@@ -5,7 +5,6 @@ import {Location, Query} from 'history';
 
 import {Client} from 'app/api';
 import ChartZoom from 'app/components/charts/chartZoom';
-import Legend from 'app/components/charts/components/legend';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import LineChart from 'app/components/charts/lineChart';
@@ -92,11 +91,11 @@ class TrendChart extends React.Component<Props> {
     const end = this.props.end ? getUtcToLocalDateObject(this.props.end) : null;
     const utc = decodeScalar(router.location.query.utc) !== 'false';
 
-    const legend = Legend({
+    const legend = {
       right: 10,
       top: 0,
       selected: getSeriesSelection(location, 'trendsUnselectedSeries'),
-    });
+    };
 
     const datetimeSelection = {
       start,

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
@@ -103,7 +103,6 @@ class VitalsChart extends React.Component<Props> {
         }
         return seriesName;
       },
-      theme,
     });
 
     const datetimeSelection = {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
@@ -5,7 +5,6 @@ import {Location} from 'history';
 
 import {Client} from 'app/api';
 import ChartZoom from 'app/components/charts/chartZoom';
-import Legend from 'app/components/charts/components/legend';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import LineChart from 'app/components/charts/lineChart';
@@ -89,7 +88,7 @@ class VitalsChart extends React.Component<Props> {
     const end = this.props.end ? getUtcToLocalDateObject(this.props.end) : null;
     const utc = decodeScalar(router.location.query.utc) !== 'false';
 
-    const legend = Legend({
+    const legend = {
       right: 10,
       top: 0,
       selected: getSeriesSelection(location),
@@ -103,7 +102,7 @@ class VitalsChart extends React.Component<Props> {
         }
         return seriesName;
       },
-    });
+    };
 
     const datetimeSelection = {
       start,

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -74,7 +74,6 @@ function getLegend(trendFunction: string) {
       fontSize: 11,
       fontFamily: 'Rubik',
     },
-    theme,
     data: [
       {
         name: 'Baseline',

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -68,11 +68,6 @@ function getLegend(trendFunction: string) {
     top: 0,
     itemGap: 12,
     align: 'left' as const,
-    textStyle: {
-      verticalAlign: 'top',
-      fontSize: 11,
-      fontFamily: theme.text.family,
-    },
     data: [
       {
         name: 'Baseline',

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -4,7 +4,6 @@ import {WithRouterProps} from 'react-router/lib/withRouter';
 
 import {Client} from 'app/api';
 import ChartZoom from 'app/components/charts/chartZoom';
-import Legend from 'app/components/charts/components/legend';
 import LineChart from 'app/components/charts/lineChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
 import TransitionChart from 'app/components/charts/transitionChart';
@@ -64,7 +63,7 @@ function transformEventStats(data: EventsStatsData, seriesName?: string): Series
 }
 
 function getLegend(trendFunction: string) {
-  const legend = Legend({
+  return {
     right: 10,
     top: 0,
     itemGap: 12,
@@ -72,7 +71,7 @@ function getLegend(trendFunction: string) {
     textStyle: {
       verticalAlign: 'top',
       fontSize: 11,
-      fontFamily: 'Rubik',
+      fontFamily: theme.text.family,
     },
     data: [
       {
@@ -89,8 +88,7 @@ function getLegend(trendFunction: string) {
         icon: 'line',
       },
     ],
-  });
-  return legend;
+  };
 }
 
 function getIntervalLine(

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
@@ -5,7 +5,6 @@ import {Location} from 'history';
 
 import {Client} from 'app/api';
 import ChartZoom from 'app/components/charts/chartZoom';
-import Legend from 'app/components/charts/components/legend';
 import MarkLine from 'app/components/charts/components/markLine';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
@@ -87,11 +86,11 @@ class VitalChart extends React.Component<Props> {
 
     const yAxis = [`p75(${vitalName})`];
 
-    const legend = Legend({
+    const legend = {
       right: 10,
       top: 0,
       selected: getSeriesSelection(location),
-    });
+    };
 
     const datetimeSelection = {
       start,

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
@@ -91,7 +91,6 @@ class VitalChart extends React.Component<Props> {
       right: 10,
       top: 0,
       selected: getSeriesSelection(location),
-      theme,
     });
 
     const datetimeSelection = {

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -5,7 +5,6 @@ import isEqual from 'lodash/isEqual';
 
 import AreaChart from 'app/components/charts/areaChart';
 import {ZoomRenderProps} from 'app/components/charts/chartZoom';
-import Legend from 'app/components/charts/components/legend';
 import LineChart from 'app/components/charts/lineChart';
 import StackedAreaChart from 'app/components/charts/stackedAreaChart';
 import {getSeriesSelection} from 'app/components/charts/utils';
@@ -202,7 +201,7 @@ class HealthChart extends React.Component<Props> {
 
     const Chart = this.getChart();
 
-    const legend = Legend({
+    const legend = {
       right: 10,
       top: 0,
       data: timeseriesData.map(d => d.seriesName).reverse(),
@@ -220,7 +219,7 @@ class HealthChart extends React.Component<Props> {
           return ['<div class="tooltip-description">', seriesNameDesc, '</div>'].join('');
         },
       },
-    });
+    };
 
     return (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -207,7 +207,6 @@ class HealthChart extends React.Component<Props> {
       top: 0,
       data: timeseriesData.map(d => d.seriesName).reverse(),
       selected: getSeriesSelection(location),
-      theme,
       tooltip: {
         show: true,
         // TODO(ts) tooltip.formatter has incorrect types in echarts 4

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -5,7 +5,6 @@ import debounce from 'lodash/debounce';
 import flatten from 'lodash/flatten';
 
 import Graphic from 'app/components/charts/components/graphic';
-import Legend from 'app/components/charts/components/legend';
 import LineChart, {LineChartSeries} from 'app/components/charts/lineChart';
 import space from 'app/styles/space';
 import {GlobalSelection} from 'app/types';
@@ -249,11 +248,11 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
       },
       {}
     );
-    const legend = Legend({
+    const legend = {
       right: 10,
       top: 0,
       selected,
-    });
+    };
 
     return (
       <LineChart


### PR DESCRIPTION
The imported theme is the light mode theme, so the text colors on the legend
were from the light theme. This changes the default to make sure it's using the
appropriate theme.