### PR TITLE
fix(perf): Fix landing v2 to only explicitly use hasFeature

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/landing/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/content.tsx
@@ -329,12 +329,10 @@ class LandingContent extends React.Component<Props, State> {
 
     return (
       <div>
-        <Feature
-          organization={organization}
-          features={['performance-landing-v2']}
-          renderDisabled={this.renderLandingV1}
-        >
-          {this.renderLandingV2()}
+        <Feature organization={organization} features={['performance-landing-v2']}>
+          {({hasFeature}) =>
+            hasFeature ? this.renderLandingV2() : this.renderLandingV1()
+          }
         </Feature>
       </div>
     );


### PR DESCRIPTION
### Summary
The `Feature` component allows 'renderDisabled' which will evaluate the childrens render functions. In this instance this calls the tracking code even without the feature on. Going to confirm this fixes the issue then we can look at fixing the disabledRender function for `Feature` to not cause this in the future.