### PR TITLE
fix(ado): Handle agile workflow

### DIFF
--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -16,7 +16,7 @@ class VstsIssueSync(IssueSyncMixin):
     conf_key = slug
 
     issue_fields = frozenset(["id", "title", "url"])
-    done_categories = frozenset(["Resolved", "Completed"])
+    done_categories = frozenset(["Resolved", "Completed", "Closed"])
 
     def get_persisted_default_config_fields(self):
         return ["project", "work_item_type"]
@@ -241,7 +241,6 @@ class VstsIssueSync(IssueSyncMixin):
     def sync_status_outbound(self, external_issue, is_resolved, project_id, **kwargs):
         client = self.get_client()
         work_item = client.get_work_item(self.instance, external_issue.key)
-
         # For some reason, vsts doesn't include the project id
         # in the work item response.
         # TODO(jess): figure out if there's a better way to do this
@@ -293,11 +292,7 @@ class VstsIssueSync(IssueSyncMixin):
 
     def should_unresolve(self, data):
         done_states = self.get_done_states(data["project"])
-        return (
-            data["old_state"] in done_states
-            or data["old_state"] is None
-            and not data["new_state"] in done_states
-        )
+        return not data["new_state"] in done_states or data["old_state"] is None
 
     def should_resolve(self, data):
         done_states = self.get_done_states(data["project"])
@@ -313,7 +308,6 @@ class VstsIssueSync(IssueSyncMixin):
                 extra={"integration_id": self.model.id, "exception": err},
             )
             return []
-
         done_states = [
             state["name"] for state in all_states if state["category"] in self.done_categories
         ]

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -403,6 +403,13 @@ class VstsIssueSyncTest(VstsIssueBase):
         assert should_unresolve is True
 
     @responses.activate
+    def test_should_not_unresolve_resolved_to_closed(self):
+        should_unresolve = self.integration.should_unresolve(
+            {"project": self.project_id_with_states, "old_state": "Resolved", "new_state": "Closed"}
+        )
+        assert should_unresolve is False
+
+    @responses.activate
     def test_should_unresolve_new(self):
         should_unresolve = self.integration.should_unresolve(
             {"project": self.project_id_with_states, "old_state": None, "new_state": "New"}


### PR DESCRIPTION
If using an [agile workflow](https://docs.microsoft.com/en-us/azure/devops/boards/work-items/workflow-and-state-categories?view=azure-devops&tabs=agile-process#workflow-states) an issue's state can change from "resolved" to "closed" and the desired behavior when the 'Sync Azure DevOps Status to Sentry' setting is enabled is to have the Sentry issue remain resolved, but we would flip the status of the Sentry issue if the previous state was resolved.

To anyone trying to reproduce this themselves now or in the future, to enable the Agile workflow go to Organization settings > Boards > Process > Select the "..." next to Agile > Select "set as default process". Then create a new project (it might be possible to change the workflow of an existing project but I couldn't figure this out), under Boards select Backlogs and create the work item there. If you create the work item from the "work items" view under Boards, you will not have all of "new, active, resolved, and closed" but rather only "new" and "resolved" statuses.