### PR TITLE
feat(aws-lambda): adds analytics event for lambda setup

### DIFF
--- a/src/sentry/analytics/events/integration_serverless_setup.py
+++ b/src/sentry/analytics/events/integration_serverless_setup.py
@@ -1,0 +1,16 @@
+from sentry import analytics
+
+
+class IntegrationServerlessSetup(analytics.Event):
+    type = "integrations.serverless_setup"
+
+    attributes = (
+        analytics.Attribute("user_id"),
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("integration"),
+        analytics.Attribute("success_count"),
+        analytics.Attribute("failure_count"),
+    )
+
+
+analytics.register(IntegrationServerlessSetup)

--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -5,7 +5,7 @@ import six
 from botocore.exceptions import ClientError
 from django.utils.translation import ugettext_lazy as _
 
-from sentry import options
+from sentry import options, analytics
 from sentry.api.serializers import serialize
 from sentry.integrations import (
     IntegrationInstallation,
@@ -369,8 +369,18 @@ class AwsLambdaSetupLayerPipelineView(PipelineView):
                     },
                 )
 
+        analytics.record(
+            "integrations.serverless_setup",
+            user_id=request.user.id,
+            organization_id=organization.id,
+            integration="aws_lambda",
+            success_count=success_count,
+            failure_count=len(failures),
+        )
+
         # if we have failures, show them to the user
         # otherwise, finish
+
         if failures:
             return self.render_react_view(
                 request,


### PR DESCRIPTION
This PR adds an analytics event for the number of successes and failures when setting up the AWS Lambda integration.

Merge with: https://github.com/getsentry/etl/pull/606