### PR TITLE
ref(ui): Remove most propTypes

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/access.tsx
+++ b/src/sentry/static/sentry/app/components/acl/access.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import Alert from 'app/components/alert';
 import {IconInfo} from 'app/icons';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Config, Organization, Scope} from 'app/types';
 import {isRenderFunc} from 'app/utils/isRenderFunc';
 import withConfig from 'app/utils/withConfig';
@@ -75,15 +73,6 @@ type Props = {
  * Component to handle access restrictions.
  */
 class Access extends React.Component<Props> {
-  static propTypes: any = {
-    organization: SentryTypes.Organization,
-    access: PropTypes.arrayOf(PropTypes.string),
-    requireAll: PropTypes.bool,
-    isSuperuser: PropTypes.bool,
-    renderNoAccessMessage: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
-    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-  };
-
   static defaultProps = defaultProps;
 
   render() {

--- a/src/sentry/static/sentry/app/components/acl/feature.tsx
+++ b/src/sentry/static/sentry/app/components/acl/feature.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-import SentryTypes from 'app/sentryTypes';
 import HookStore from 'app/stores/hookStore';
 import {Config, Organization, Project} from 'app/types';
 import {FeatureDisabledHooks} from 'app/types/hooks';
@@ -90,17 +88,6 @@ type AllFeatures = {
  * Component to handle feature flags.
  */
 class Feature extends React.Component<Props> {
-  static propTypes = {
-    organization: SentryTypes.Organization,
-    project: SentryTypes.Project,
-    config: SentryTypes.Config.isRequired,
-    features: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
-    requireAll: PropTypes.bool,
-    renderDisabled: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
-    hookName: PropTypes.string as any,
-    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-  };
-
   static defaultProps = {
     renderDisabled: false,
     requireAll: true,

--- a/src/sentry/static/sentry/app/components/activity/item/avatar.tsx
+++ b/src/sentry/static/sentry/app/components/activity/item/avatar.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import UserAvatar from 'app/components/avatar/userAvatar';
 import Placeholder from 'app/components/placeholder';
 import {IconSentry} from 'app/icons';
-import SentryTypes from 'app/sentryTypes';
 import {AvatarUser} from 'app/types';
 
 type Props = {
@@ -38,12 +36,6 @@ function ActivityAvatar({className, type, user, size = 38}: Props) {
     />
   );
 }
-
-ActivityAvatar.propTypes = {
-  user: SentryTypes.User,
-  type: PropTypes.oneOf(['system', 'user']),
-  size: PropTypes.number,
-};
 
 export default ActivityAvatar;
 

--- a/src/sentry/static/sentry/app/components/activity/item/bubble.tsx
+++ b/src/sentry/static/sentry/app/components/activity/item/bubble.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 type Props = {
   backgroundColor?: string;
@@ -44,10 +43,5 @@ const ActivityBubble = styled('div')<Props>`
     top: 13px;
   }
 `;
-
-ActivityBubble.propTypes = {
-  backgroundColor: PropTypes.string,
-  borderColor: PropTypes.string,
-};
 
 export default ActivityBubble;

--- a/src/sentry/static/sentry/app/components/activity/item/index.tsx
+++ b/src/sentry/static/sentry/app/components/activity/item/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
-import PropTypes from 'prop-types';
 
 import DateTime from 'app/components/dateTime';
 import TimeSince from 'app/components/timeSince';
@@ -134,21 +133,6 @@ function ActivityItem({
     </ActivityItemWrapper>
   );
 }
-
-ActivityItem.propTypes = {
-  id: PropTypes.string,
-  date: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
-  author: PropTypes.shape({
-    type: ActivityAvatar.propTypes.type,
-    user: ActivityAvatar.propTypes.user,
-  }),
-  avatarSize: PropTypes.number,
-  hideDate: PropTypes.bool,
-  showTime: PropTypes.bool,
-  header: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-  footer: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-  bubbleProps: PropTypes.shape(ActivityBubble.propTypes as any),
-};
 
 const ActivityItemWrapper = styled('div')`
   display: flex;

--- a/src/sentry/static/sentry/app/components/activity/note/body.tsx
+++ b/src/sentry/static/sentry/app/components/activity/note/body.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import marked from 'app/utils/marked';
 
@@ -15,9 +14,5 @@ const NoteBody = ({className, text}: Props) => (
     dangerouslySetInnerHTML={{__html: marked(text)}}
   />
 );
-
-NoteBody.propTypes = {
-  text: PropTypes.string.isRequired,
-};
 
 export default NoteBody;

--- a/src/sentry/static/sentry/app/components/alert.tsx
+++ b/src/sentry/static/sentry/app/components/alert.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 
 import space from 'app/styles/space';
 
@@ -104,12 +103,6 @@ const Alert = styled(
 )<AlertProps>`
   ${alertStyles}
 `;
-
-Alert.propTypes = {
-  type: PropTypes.oneOf(['muted', 'info', 'warning', 'success', 'error', 'beta']),
-  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  system: PropTypes.bool,
-};
 
 Alert.defaultProps = {
   type: DEFAULT_TYPE,

--- a/src/sentry/static/sentry/app/components/alerts/toastIndicator.tsx
+++ b/src/sentry/static/sentry/app/components/alerts/toastIndicator.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
 import {motion} from 'framer-motion';
-import PropTypes from 'prop-types';
 
 import {Indicator} from 'app/actionCreators/indicator';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -122,15 +121,5 @@ function ToastIndicator({indicator, onDismiss, className, ...props}: Props) {
     </Toast>
   );
 }
-
-ToastIndicator.propTypes = {
-  indicator: PropTypes.shape({
-    type: PropTypes.oneOf(['error', 'success', 'loading', 'undo', '']),
-    id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    message: PropTypes.node,
-    options: PropTypes.object,
-  }),
-  onDismiss: PropTypes.func,
-};
 
 export default ToastIndicator;

--- a/src/sentry/static/sentry/app/components/assigneeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 
 import {assignToActor, assignToUser, clearAssignment} from 'app/actionCreators/group';
@@ -50,17 +49,6 @@ type AssignableTeam = {
 
 const AssigneeSelectorComponent = createReactClass<Props, State>({
   displayName: 'AssigneeSelector',
-
-  propTypes: {
-    id: PropTypes.string.isRequired,
-    size: PropTypes.number,
-    // Either a list of users, or null. If null, members will
-    // be read from the MemberListStore. The prop is useful when the
-    // store contains more/different users than you need to show
-    // in an individual component, eg. Org Issue list
-    memberList: PropTypes.array,
-    disabled: PropTypes.bool,
-  },
 
   contextTypes: {
     organization: SentryTypes.Organization,

--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import createReactClass from 'create-react-class';
 import {Query} from 'history';
-import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 
 import {
@@ -49,18 +48,6 @@ type State = {
  * be shown on the page.
  */
 const GuideAnchor = createReactClass<Props, State>({
-  propTypes: {
-    target: PropTypes.string,
-    position: PropTypes.string,
-    disabled: PropTypes.bool,
-    offset: PropTypes.string,
-    to: PropTypes.shape({
-      pathname: PropTypes.string,
-      query: PropTypes.object,
-      step: PropTypes.number,
-    }),
-  },
-
   mixins: [Reflux.listenTo(GuideStore, 'onGuideStateChange') as any],
 
   getInitialState() {

--- a/src/sentry/static/sentry/app/components/asyncComponent.tsx
+++ b/src/sentry/static/sentry/app/components/asyncComponent.tsx
@@ -63,11 +63,6 @@ export default class AsyncComponent<
   P extends AsyncComponentProps = AsyncComponentProps,
   S extends AsyncComponentState = AsyncComponentState
 > extends React.Component<P, S> {
-  static propTypes: any = {
-    location: PropTypes.object,
-    router: PropTypes.object,
-  };
-
   static contextTypes = {
     router: PropTypes.object,
   };

--- a/src/sentry/static/sentry/app/components/autoSelectText.tsx
+++ b/src/sentry/static/sentry/app/components/autoSelectText.tsx
@@ -1,6 +1,5 @@
 import React, {CSSProperties} from 'react';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 
 import {isRenderFunc} from 'app/utils/isRenderFunc';
 import {selectText} from 'app/utils/selectText';
@@ -26,10 +25,6 @@ type Props = {
 };
 
 class AutoSelectText extends React.Component<Props> {
-  static propTypes = {
-    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
-  };
-
   private el: HTMLElement | undefined;
 
   selectText = () => {

--- a/src/sentry/static/sentry/app/components/avatar/actorAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/actorAvatar.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import * as Sentry from '@sentry/react';
-import PropTypes from 'prop-types';
 
 import TeamAvatar from 'app/components/avatar/teamAvatar';
 import UserAvatar from 'app/components/avatar/userAvatar';
-import SentryTypes from 'app/sentryTypes';
 import MemberListStore from 'app/stores/memberListStore';
 import TeamStore from 'app/stores/teamStore';
 import {Actor} from 'app/types';
@@ -25,16 +23,6 @@ type Props = DefaultProps & {
 };
 
 class ActorAvatar extends React.Component<Props> {
-  static propTypes = {
-    actor: SentryTypes.Actor.isRequired,
-    size: PropTypes.number,
-    default: PropTypes.string,
-    title: PropTypes.string,
-    gravatar: PropTypes.bool,
-    hasTooltip: PropTypes.bool,
-    suggested: PropTypes.bool,
-  };
-
   static defaultProps: DefaultProps = {
     hasTooltip: true,
   };

--- a/src/sentry/static/sentry/app/components/avatar/avatarList.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/avatarList.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import UserAvatar from 'app/components/avatar/userAvatar';
 import Tooltip from 'app/components/tooltip';
-import SentryTypes from 'app/sentryTypes';
 import {AvatarUser} from 'app/types';
 
 const defaultProps = {
@@ -26,15 +24,6 @@ type Props = {
 } & DefaultProps;
 
 export default class AvatarList extends React.Component<Props> {
-  static propTypes = {
-    users: PropTypes.arrayOf(SentryTypes.User).isRequired,
-    avatarSize: PropTypes.number,
-    maxVisibleAvatars: PropTypes.number,
-    renderTooltip: PropTypes.func,
-    tooltipOptions: PropTypes.object,
-    typeMembers: PropTypes.string,
-  };
-
   static defaultProps = defaultProps;
 
   render() {

--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 import * as qs from 'query-string';
 
 import BackgroundAvatar from 'app/components/avatar/backgroundAvatar';
@@ -80,51 +79,6 @@ type State = {
 };
 
 class BaseAvatar extends React.Component<Props, State> {
-  static propTypes = {
-    size: PropTypes.number,
-    /**
-     * This is the size of the remote image to request.
-     */
-    remoteImageSize: PropTypes.oneOf(ALLOWED_SIZES),
-    /**
-     * Default gravatar to display
-     */
-    default: PropTypes.string,
-    /**
-     * Enable to display tooltips.
-     */
-    hasTooltip: PropTypes.bool,
-    /**
-     * The type of avatar being rendered.
-     */
-    type: PropTypes.string,
-    /**
-     * Path to uploaded avatar (differs based on model type)
-     */
-    uploadPath: PropTypes.oneOf([
-      'avatar',
-      'team-avatar',
-      'organization-avatar',
-      'project-avatar',
-    ]),
-    uploadId: PropTypes.string,
-    gravatarId: PropTypes.string,
-    letterId: PropTypes.string,
-    title: PropTypes.string,
-    /**
-     * The content for the tooltip. Requires hasTooltip to display
-     */
-    tooltip: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-    /**
-     * Additional props for the tooltip
-     */
-    tooltipOptions: PropTypes.object,
-    /**
-     * Should avatar be round instead of a square
-     */
-    round: PropTypes.bool,
-  };
-
   static defaultProps = defaultProps;
 
   constructor(props: Props) {

--- a/src/sentry/static/sentry/app/components/avatar/gravatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/gravatar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 import * as qs from 'query-string';
 
 import ConfigStore from 'app/stores/configStore';
@@ -21,13 +20,6 @@ type State = {
 };
 
 class Gravatar extends React.Component<Props, State> {
-  static propTypes = {
-    remoteSize: PropTypes.number,
-    gravatarId: PropTypes.string,
-    placeholder: PropTypes.string,
-    round: PropTypes.bool,
-  };
-
   state = {
     MD5: undefined,
   };

--- a/src/sentry/static/sentry/app/components/avatar/organizationAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/organizationAvatar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import BaseAvatar from 'app/components/avatar/baseAvatar';
-import SentryTypes from 'app/sentryTypes';
 import {OrganizationSummary} from 'app/types';
 import {explodeSlug} from 'app/utils';
 
@@ -10,11 +9,6 @@ type Props = {
 } & Omit<BaseAvatar['props'], 'uploadPath' | 'uploadId'>;
 
 class OrganizationAvatar extends React.Component<Props> {
-  static propTypes = {
-    organization: SentryTypes.Organization.isRequired,
-    ...BaseAvatar.propTypes,
-  };
-
   render() {
     const {organization, ...props} = this.props;
     if (!organization) {

--- a/src/sentry/static/sentry/app/components/avatar/projectAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/projectAvatar.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import BaseAvatar from 'app/components/avatar/baseAvatar';
 import PlatformList from 'app/components/platformList';
 import Tooltip from 'app/components/tooltip';
-import SentryTypes from 'app/sentryTypes';
 import {AvatarProject} from 'app/types';
 
 type Props = {
@@ -12,14 +10,6 @@ type Props = {
 } & BaseAvatar['props'];
 
 class ProjectAvatar extends React.Component<Props> {
-  static propTypes = {
-    project: PropTypes.oneOfType([
-      PropTypes.shape({slug: PropTypes.string}),
-      SentryTypes.Project,
-    ]).isRequired,
-    ...BaseAvatar.propTypes,
-  };
-
   getPlatforms = (project: AvatarProject) => {
     // `platform` is a user selectable option that is performed during the onboarding process. The reason why this
     // is not the default is because there currently is no way to update it. Fallback to this if project does not

--- a/src/sentry/static/sentry/app/components/avatar/teamAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/teamAvatar.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import BaseAvatar from 'app/components/avatar/baseAvatar';
-import SentryTypes from 'app/sentryTypes';
 import {Team} from 'app/types';
 import {explodeSlug} from 'app/utils';
 
@@ -10,11 +9,6 @@ type Props = {
 } & Omit<BaseAvatar['props'], 'uploadPath' | 'uploadId'>;
 
 class TeamAvatar extends React.Component<Props> {
-  static propTypes = {
-    team: SentryTypes.Team,
-    ...BaseAvatar.propTypes,
-  };
-
   render() {
     const {team, ...props} = this.props;
     if (!team) {

--- a/src/sentry/static/sentry/app/components/avatar/userAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/userAvatar.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import BaseAvatar from 'app/components/avatar/baseAvatar';
-import SentryTypes from 'app/sentryTypes';
 import {Actor, AvatarUser} from 'app/types';
 import {userDisplayName} from 'app/utils/formatters';
 import {isRenderFunc} from 'app/utils/isRenderFunc';
@@ -30,13 +28,6 @@ function isActor(maybe: AvatarUser | Actor): maybe is Actor {
 }
 
 class UserAvatar extends React.Component<Props> {
-  static propTypes: any = {
-    user: SentryTypes.User,
-    gravatar: PropTypes.bool,
-    renderTooltip: PropTypes.func,
-    ...BaseAvatar.propTypes,
-  };
-
   static defaultProps = defaultProps;
 
   getType = (user: AvatarUser | Actor, gravatar: boolean | undefined) => {

--- a/src/sentry/static/sentry/app/components/avatarCropper.tsx
+++ b/src/sentry/static/sentry/app/components/avatarCropper.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import Well from 'app/components/well';
@@ -35,13 +34,6 @@ type State = {
 };
 
 class AvatarCropper extends React.Component<Props, State> {
-  static propTypes = {
-    model: PropTypes.object.isRequired,
-    updateDataUrlState: PropTypes.func.isRequired,
-    type: PropTypes.oneOf(['user', 'team', 'organization', 'project']),
-    savedDataUrl: PropTypes.string,
-  };
-
   state: State = {
     file: null,
     objectURL: null,

--- a/src/sentry/static/sentry/app/components/badge.tsx
+++ b/src/sentry/static/sentry/app/components/badge.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import space from 'app/styles/space';
 import theme from 'app/utils/theme';
@@ -37,10 +36,5 @@ const Badge = styled(({priority: _priority, text, ...props}: Props) => (
   position: relative;
   top: -1px;
 `;
-
-Badge.propTypes = {
-  text: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  priority: PropTypes.oneOf(['strong', 'new', 'highlight']),
-} as any;
 
 export default Badge;

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -3,7 +3,6 @@ import {Link} from 'react-router';
 import {css} from '@emotion/core';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import ExternalLink from 'app/components/links/externalLink';
 import Tooltip from 'app/components/tooltip';
@@ -44,61 +43,6 @@ type ButtonProps = Omit<React.HTMLProps<ButtonElement>, keyof Props | 'ref'> & P
 type Url = ButtonProps['to'] | ButtonProps['href'];
 
 class BaseButton extends React.Component<ButtonProps, {}> {
-  static propTypes: any = {
-    priority: PropTypes.oneOf([
-      'default',
-      'primary',
-      'danger',
-      'link',
-      'success',
-      'form',
-    ]),
-    size: PropTypes.oneOf(['zero', 'xsmall', 'small']),
-    disabled: PropTypes.bool,
-    busy: PropTypes.bool,
-    /**
-     * Use this prop if button is a react-router link
-     */
-    to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-    /**
-     * Use this prop if button should use a normal (non-react-router) link
-     */
-    href: PropTypes.string,
-    /**
-     * A react node to use as the icons. Generally pulled from app/icons
-     */
-    icon: PropTypes.node,
-    /**
-     * Tooltip text
-     */
-    title: PropTypes.string,
-    /**
-     * Is an external link? (Will open in new tab)
-     */
-    external: PropTypes.bool,
-    /**
-     * Button with a border
-     */
-    borderless: PropTypes.bool,
-    /**
-     * Text aligment, takes justify-content properties.
-     */
-    align: PropTypes.oneOf(['center', 'left', 'right']),
-    /**
-     * Label for screen-readers (`aria-label`).
-     * `children` will be used by default (only if it is a string), but this property takes priority.
-     */
-    label: PropTypes.string,
-    /**
-     * Passed down to built-in tooltip component
-     */
-    tooltipProps: PropTypes.object,
-
-    onClick: PropTypes.func,
-
-    forwardRef: PropTypes.any,
-  };
-
   static defaultProps: ButtonProps = {
     disabled: false,
     align: 'center',
@@ -199,8 +143,6 @@ const Button = React.forwardRef<ButtonElement, ButtonProps>((props, ref) => (
   <BaseButton forwardRef={ref} {...props} />
 ));
 
-// Some components use Button's propTypes
-Button.propTypes = Button.propTypes;
 Button.displayName = 'Button';
 
 export default Button;

--- a/src/sentry/static/sentry/app/components/charts/chartZoom.tsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import {WithRouterProps} from 'react-router/lib/withRouter';
 import {EChartOption} from 'echarts/lib/echarts';
 import moment from 'moment';
-import PropTypes from 'prop-types';
 
 import {updateDateTime} from 'app/actionCreators/globalSelection';
 import DataZoomInside from 'app/components/charts/components/dataZoomInside';
 import ToolBox from 'app/components/charts/components/toolBox';
-import SentryTypes from 'app/sentryTypes';
 import {DateString} from 'app/types';
 import {
   EChartChartReadyHandler,
@@ -72,30 +70,6 @@ type Props = {
  * generic if need be in the future.
  */
 class ChartZoom extends React.Component<Props> {
-  static propTypes = {
-    router: PropTypes.object,
-    period: PropTypes.string,
-    start: PropTypes.instanceOf(Date),
-    end: PropTypes.instanceOf(Date),
-    utc: PropTypes.bool,
-    disabled: PropTypes.bool,
-
-    xAxis: SentryTypes.EChartsXAxis,
-    /**
-     * If you need the dataZoom control to control more than one chart.
-     * you can provide a list of the axis indexes.
-     */
-    xAxisIndex: PropTypes.arrayOf(PropTypes.number),
-
-    // Callback for when chart has been zoomed
-    onZoom: PropTypes.func,
-    // Callbacks for eCharts events
-    onRestore: PropTypes.func,
-    onChartReady: PropTypes.func,
-    onDataZoom: PropTypes.func,
-    onFinished: PropTypes.func,
-  };
-
   constructor(props) {
     super(props);
 

--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -3,7 +3,6 @@ import {InjectedRouter} from 'react-router/lib/Router';
 import {EChartOption} from 'echarts/lib/echarts';
 import {Query} from 'history';
 import isEqual from 'lodash/isEqual';
-import PropTypes from 'prop-types';
 
 import {Client} from 'app/api';
 import AreaChart from 'app/components/charts/areaChart';
@@ -60,26 +59,6 @@ type State = {
 };
 
 class Chart extends React.Component<ChartProps, State> {
-  static propTypes = {
-    loading: PropTypes.bool,
-    reloading: PropTypes.bool,
-    releaseSeries: PropTypes.array,
-    zoomRenderProps: PropTypes.object,
-    timeseriesData: PropTypes.array,
-    showLegend: PropTypes.bool,
-    previousTimeseriesData: PropTypes.object,
-    currentSeriesName: PropTypes.string,
-    previousSeriesName: PropTypes.string,
-    seriesTransformer: PropTypes.func,
-    showDaily: PropTypes.bool,
-    yAxis: PropTypes.string,
-    stacked: PropTypes.bool,
-    colors: PropTypes.array,
-    disableableSeries: PropTypes.array,
-    legendOptions: PropTypes.object,
-    chartOptions: PropTypes.object,
-  };
-
   state: State = {
     seriesSelection: {},
     forceUpdate: false,
@@ -339,38 +318,6 @@ type ChartDataProps = {
 };
 
 class EventsChart extends React.Component<Props> {
-  static propTypes = {
-    api: PropTypes.object,
-    projects: PropTypes.arrayOf(PropTypes.number),
-    environments: PropTypes.arrayOf(PropTypes.string),
-    period: PropTypes.string,
-    query: PropTypes.string,
-    start: PropTypes.instanceOf(Date),
-    end: PropTypes.instanceOf(Date),
-    utc: PropTypes.bool,
-    router: PropTypes.object,
-    showLegend: PropTypes.bool,
-    yAxis: PropTypes.string,
-    disablePrevious: PropTypes.bool,
-    disableReleases: PropTypes.bool,
-    emphasizeReleases: PropTypes.array,
-    currentSeriesName: PropTypes.string,
-    previousSeriesName: PropTypes.string,
-    seriesTransformer: PropTypes.func,
-    topEvents: PropTypes.number,
-    field: PropTypes.arrayOf(PropTypes.string),
-    showDaily: PropTypes.bool,
-    orderby: PropTypes.string,
-    confirmedQuery: PropTypes.bool,
-    colors: PropTypes.array,
-    preserveReleaseQueryParams: PropTypes.bool,
-    releaseQueryExtras: PropTypes.object,
-    disableableSeries: PropTypes.array,
-    chartHeader: PropTypes.object,
-    legendOptions: PropTypes.object,
-    chartOptions: PropTypes.object,
-  };
-
   render() {
     const {
       api,

--- a/src/sentry/static/sentry/app/components/charts/eventsRequest.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsRequest.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import isEqual from 'lodash/isEqual';
 import omitBy from 'lodash/omitBy';
-import PropTypes from 'prop-types';
 
 import {doEventsRequest} from 'app/actionCreators/events';
 import {addErrorMessage} from 'app/actionCreators/indicator';
@@ -9,7 +8,6 @@ import {Client} from 'app/api';
 import LoadingPanel from 'app/components/charts/loadingPanel';
 import {canIncludePreviousPeriod, isMultiSeriesStats} from 'app/components/charts/utils';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {
   DateString,
   EventsStats,
@@ -156,43 +154,6 @@ const omitIgnoredProps = (props: EventsRequestProps) =>
   omitBy(props, (_value, key) => propNamesToIgnore.includes(key));
 
 class EventsRequest extends React.PureComponent<EventsRequestProps, EventsRequestState> {
-  static propTypes = {
-    api: PropTypes.object.isRequired,
-    organization: SentryTypes.Organization.isRequired,
-    project: PropTypes.arrayOf(PropTypes.number),
-    environment: PropTypes.arrayOf(PropTypes.string),
-    period: PropTypes.string,
-    start: PropTypes.instanceOf(Date),
-    end: PropTypes.instanceOf(Date),
-    interval: PropTypes.string,
-    includePrevious: PropTypes.bool,
-    limit: PropTypes.number,
-    query: PropTypes.string,
-    includeTransformedData: PropTypes.bool,
-
-    /**
-     * Include a dataset transform that will aggregate count values for each
-     * timestamp. Be sure to supply a name to `timeAggregationSeriesName`
-     */
-    includeTimeAggregation: PropTypes.bool,
-
-    /**
-     * Name of series of aggregated timeseries
-     */
-    timeAggregationSeriesName: PropTypes.string,
-    loading: PropTypes.bool,
-    errored: PropTypes.bool,
-    showLoading: PropTypes.bool,
-    currentSeriesName: PropTypes.string,
-    yAxis: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]),
-
-    field: PropTypes.arrayOf(PropTypes.string),
-    topEvents: PropTypes.number,
-    orderby: PropTypes.string,
-
-    confirmedQuery: PropTypes.bool,
-  };
-
   static defaultProps: DefaultProps = {
     period: undefined,
     start: null,

--- a/src/sentry/static/sentry/app/components/charts/percentageAreaChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/percentageAreaChart.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {EChartOption} from 'echarts';
 import moment from 'moment';
-import PropTypes from 'prop-types';
 
 import {Series, SeriesDataUnit} from 'app/types/echarts';
 
@@ -31,13 +30,6 @@ type Props = Omit<ChartProps, 'series'> &
  * See https://exceljet.net/chart-type/100-stacked-bar-chart
  */
 export default class PercentageAreaChart extends React.Component<Props> {
-  static propTypes = {
-    ...BaseChart.propTypes,
-
-    getDataItemName: PropTypes.func,
-    getValue: PropTypes.func,
-  };
-
   static defaultProps: DefaultProps = {
     // TODO(billyvg): Move these into BaseChart? or get rid completely
     getDataItemName: ({name}) => name,

--- a/src/sentry/static/sentry/app/components/charts/pieChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/pieChart.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {EChartOption} from 'echarts';
-import PropTypes from 'prop-types';
 
 import {ReactEchartsRef, Series} from 'app/types/echarts';
 import theme from 'app/utils/theme';
@@ -18,14 +17,6 @@ type Props = Omit<ChartProps, 'series'> & {
 };
 
 class PieChart extends React.Component<Props> {
-  static propTypes = {
-    // We passthrough all props exception `options`
-    ...BaseChart.propTypes,
-
-    // Attempt to select first series in chart (to show in center of PieChart)
-    selectOnRender: PropTypes.bool,
-  };
-
   componentDidMount() {
     const {selectOnRender} = this.props;
 

--- a/src/sentry/static/sentry/app/components/circleIndicator.tsx
+++ b/src/sentry/static/sentry/app/components/circleIndicator.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {Theme} from 'app/utils/theme';
 
@@ -34,12 +33,6 @@ const CircleIndicator = styled('div')<Props>`
   ${getSize};
   ${getBackgroundColor};
 `;
-
-CircleIndicator.propTypes = {
-  enabled: PropTypes.bool.isRequired,
-  size: PropTypes.number.isRequired,
-  color: PropTypes.string,
-};
 
 CircleIndicator.defaultProps = defaultProps;
 

--- a/src/sentry/static/sentry/app/components/clipboard.tsx
+++ b/src/sentry/static/sentry/app/components/clipboard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import Clip from 'clipboard';
-import PropTypes from 'prop-types';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 
@@ -19,20 +18,6 @@ type Props = {
 } & DefaultProps;
 
 class Clipboard extends React.Component<Props> {
-  static propTypes = {
-    value: PropTypes.string,
-    successMessage: PropTypes.string,
-    errorMessage: PropTypes.string,
-    hideMessages: PropTypes.bool,
-
-    /**
-     * Hide component if browser does not support "execCommand"
-     */
-    hideUnsupported: PropTypes.bool,
-    onSuccess: PropTypes.func,
-    onError: PropTypes.func,
-  };
-
   static defaultProps: DefaultProps = {
     hideMessages: false,
     successMessage: 'Copied to clipboard',

--- a/src/sentry/static/sentry/app/components/commitRow.tsx
+++ b/src/sentry/static/sentry/app/components/commitRow.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {openInviteMembersModal} from 'app/actionCreators/modal';
 import UserAvatar from 'app/components/avatar/userAvatar';
@@ -21,11 +20,6 @@ type Props = {
 };
 
 class CommitRow extends React.Component<Props> {
-  static propTypes = {
-    commit: PropTypes.object,
-    customAvatar: PropTypes.node,
-  };
-
   renderMessage(message: Commit['message']): string {
     if (!message) {
       return t('No message provided');

--- a/src/sentry/static/sentry/app/components/count.tsx
+++ b/src/sentry/static/sentry/app/components/count.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {formatAbbreviatedNumber} from 'app/utils/formatters';
 
@@ -17,8 +16,5 @@ function Count(props: Props) {
     </span>
   );
 }
-Count.propTypes = {
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-};
 
 export default Count;

--- a/src/sentry/static/sentry/app/components/customResolutionModal.tsx
+++ b/src/sentry/static/sentry/app/components/customResolutionModal.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {ModalRenderProps} from 'app/actionCreators/modal';
 import Button from 'app/components/button';
@@ -21,12 +20,6 @@ type State = {
 };
 
 class CustomResolutionModal extends React.Component<Props, State> {
-  static propTypes = {
-    onSelected: PropTypes.func.isRequired,
-    orgId: PropTypes.string.isRequired,
-    projectId: PropTypes.string,
-  };
-
   state = {
     version: '',
   };

--- a/src/sentry/static/sentry/app/components/dateTime.tsx
+++ b/src/sentry/static/sentry/app/components/dateTime.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import moment from 'moment-timezone';
-import PropTypes from 'prop-types';
 
 import ConfigStore from 'app/stores/configStore';
 
@@ -19,17 +18,6 @@ type Props = DefaultProps & {
 };
 
 class DateTime extends React.Component<Props> {
-  static propTypes = {
-    date: PropTypes.any.isRequired,
-    dateOnly: PropTypes.bool,
-    timeOnly: PropTypes.bool,
-    shortDate: PropTypes.bool,
-    seconds: PropTypes.bool,
-    timeAndDate: PropTypes.bool,
-    utc: PropTypes.bool,
-    format: PropTypes.string,
-  };
-
   static defaultProps: DefaultProps = {
     seconds: true,
   };

--- a/src/sentry/static/sentry/app/components/deviceName.tsx
+++ b/src/sentry/static/sentry/app/components/deviceName.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {IOSDeviceList} from 'app/types/iOSDeviceList';
 
@@ -27,11 +26,6 @@ type State = {
  * This asynchronously loads the ios-device-list library because of its size
  */
 export default class DeviceName extends React.Component<Props, State> {
-  static propTypes = {
-    value: PropTypes.string,
-    children: PropTypes.func,
-  };
-
   constructor(props) {
     super(props);
 

--- a/src/sentry/static/sentry/app/components/dropdownLink.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownLink.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {css} from '@emotion/core';
 import classNames from 'classnames';
 import {withTheme} from 'emotion-theming';
-import PropTypes from 'prop-types';
 
 import DropdownMenu from 'app/components/dropdownMenu';
 import {IconChevron} from 'app/icons';
@@ -142,17 +141,6 @@ DropdownLink.defaultProps = {
   disabled: false,
   anchorRight: false,
   caret: true,
-};
-
-DropdownLink.propTypes = {
-  ...DropdownMenu.propTypes,
-  title: PropTypes.node,
-  caret: PropTypes.bool,
-  disabled: PropTypes.bool,
-  anchorRight: PropTypes.bool,
-  alwaysRenderMenu: PropTypes.bool,
-  topLevelClasses: PropTypes.string,
-  menuClasses: PropTypes.string,
 };
 
 DropdownLink.displayName = 'DropdownLink';

--- a/src/sentry/static/sentry/app/components/dropdownMenu.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownMenu.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import * as Sentry from '@sentry/react';
-import PropTypes from 'prop-types';
 
 import {MENU_CLOSE_DELAY} from 'app/constants';
 
@@ -100,18 +99,6 @@ type State = {
 };
 
 class DropdownMenu extends React.Component<Props, State> {
-  static propTypes = {
-    onOpen: PropTypes.func,
-    onClose: PropTypes.func,
-    onClickOutside: PropTypes.func,
-    shouldIgnoreClickOutside: PropTypes.func,
-    isOpen: PropTypes.bool,
-    keepMenuOpen: PropTypes.bool,
-    alwaysRenderMenu: PropTypes.bool,
-    closeOnEscape: PropTypes.bool,
-    isNestedDropdown: PropTypes.bool,
-  };
-
   static defaultProps: DefaultProps = {
     keepMenuOpen: false,
     closeOnEscape: true,

--- a/src/sentry/static/sentry/app/components/duration.tsx
+++ b/src/sentry/static/sentry/app/components/duration.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {getDuration, getExactDuration} from 'app/utils/formatters';
 
@@ -17,12 +16,5 @@ const Duration = ({seconds, fixedDigits, abbreviation, exact, ...props}: Props) 
       : getDuration(seconds, fixedDigits, abbreviation)}
   </span>
 );
-
-Duration.propTypes = {
-  seconds: PropTypes.number.isRequired,
-  fixedDigits: PropTypes.number,
-  abbreviation: PropTypes.bool,
-  exact: PropTypes.bool,
-};
 
 export default Duration;

--- a/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
+++ b/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {IconSearch} from 'app/icons';
 import space from 'app/styles/space';
@@ -32,10 +31,6 @@ const EmptyStateWarning = ({
       {children}
     </EmptyStreamWrapper>
   );
-
-EmptyStateWarning.propTypes = {
-  small: PropTypes.bool,
-};
 
 const EmptyStreamWrapper = styled('div')`
   text-align: center;

--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
-import PropTypes from 'prop-types';
 
 import Alert from 'app/components/alert';
 import DetailedError from 'app/components/errors/detailedError';
@@ -35,12 +34,6 @@ function getExclamation() {
 }
 
 class ErrorBoundary extends React.Component<Props, State> {
-  static propTypes = {
-    mini: PropTypes.bool,
-    message: PropTypes.node,
-    customComponent: PropTypes.node,
-  };
-
   static defaultProps: DefaultProps = {
     mini: false,
   };

--- a/src/sentry/static/sentry/app/components/errors/detailedError.tsx
+++ b/src/sentry/static/sentry/app/components/errors/detailedError.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as Sentry from '@sentry/react';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 
 import Button from 'app/components/button';
 import {IconFlag} from 'app/icons';
@@ -36,14 +35,6 @@ function openFeedback(e: React.MouseEvent) {
 }
 
 class DetailedError extends React.Component<Props> {
-  static propTypes = {
-    className: PropTypes.string,
-    onRetry: PropTypes.func,
-    heading: PropTypes.string.isRequired,
-    message: PropTypes.node,
-    hideSupportLinks: PropTypes.bool,
-  };
-
   static defaultProps: DefaultProps = {
     hideSupportLinks: false,
   };

--- a/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryDevice.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryDevice.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import DeviceName from 'app/components/deviceName';
 import AnnotatedText from 'app/components/events/meta/annotatedText';
@@ -86,10 +85,6 @@ const ContextSummaryDevice = ({data}: Props) => {
       )}
     </Item>
   );
-};
-
-ContextSummaryDevice.propTypes = {
-  data: PropTypes.object.isRequired,
 };
 
 export default ContextSummaryDevice;

--- a/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryGPU.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryGPU.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import AnnotatedText from 'app/components/events/meta/annotatedText';
 import {getMeta} from 'app/components/events/meta/metaProxy';
@@ -68,10 +67,6 @@ const ContextSummaryGPU = ({data}: Props) => {
       </TextOverflow>
     </Item>
   );
-};
-
-ContextSummaryGPU.propTypes = {
-  data: PropTypes.object.isRequired,
 };
 
 export default ContextSummaryGPU;

--- a/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryOS.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryOS.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import AnnotatedText from 'app/components/events/meta/annotatedText';
 import {getMeta} from 'app/components/events/meta/metaProxy';
@@ -74,10 +73,6 @@ const ContextSummaryOS = ({data}: Props) => {
       </TextOverflow>
     </Item>
   );
-};
-
-ContextSummaryOS.propTypes = {
-  data: PropTypes.object.isRequired,
 };
 
 export default ContextSummaryOS;

--- a/src/sentry/static/sentry/app/components/events/device.tsx
+++ b/src/sentry/static/sentry/app/components/events/device.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import ContextData from 'app/components/contextData';
 import EventDataSection from 'app/components/events/eventDataSection';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Event} from 'app/types/event';
 
 type Props = {
@@ -56,10 +55,6 @@ const DeviceInterface = ({event}: Props) => {
       </table>
     </EventDataSection>
   );
-};
-
-DeviceInterface.propTypes = {
-  event: SentryTypes.Event.isRequired,
 };
 
 export default DeviceInterface;

--- a/src/sentry/static/sentry/app/components/events/eventAttachments.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventAttachments.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import PropTypes from 'prop-types';
 
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
@@ -37,13 +36,6 @@ type State = {
 };
 
 class EventAttachments extends React.Component<Props, State> {
-  static propTypes: any = {
-    api: PropTypes.object.isRequired,
-    event: PropTypes.object.isRequired,
-    orgId: PropTypes.string.isRequired,
-    projectId: PropTypes.string.isRequired,
-  };
-
   state: State = {
     attachmentList: [],
     expanded: false,

--- a/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventDataSection.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
@@ -29,15 +28,6 @@ type Props = {
 } & DefaultProps;
 
 class EventDataSection extends React.Component<Props> {
-  static propTypes = {
-    title: PropTypes.any,
-    type: PropTypes.string.isRequired,
-    wrapTitle: PropTypes.bool,
-    toggleRaw: PropTypes.func,
-    raw: PropTypes.bool,
-    actions: PropTypes.node,
-  };
-
   static defaultProps = defaultProps;
 
   componentDidMount() {

--- a/src/sentry/static/sentry/app/components/events/eventEntries.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import PropTypes from 'prop-types';
 
 import ErrorBoundary from 'app/components/errorBoundary';
 import EventContexts from 'app/components/events/contexts';
@@ -22,7 +21,6 @@ import EventSdkUpdates from 'app/components/events/sdkUpdates';
 import {DataSection} from 'app/components/events/styles';
 import EventUserFeedback from 'app/components/events/userFeedback';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {Group, Organization, Project, SharedViewOrganization} from 'app/types';
 import {Entry, Event} from 'app/types/event';
@@ -53,24 +51,6 @@ type Props = {
 } & typeof defaultProps;
 
 class EventEntries extends React.Component<Props> {
-  static propTypes = {
-    // Custom shape because shared view doesn't get id.
-    organization: PropTypes.shape({
-      id: PropTypes.string,
-      slug: PropTypes.string.isRequired,
-      features: PropTypes.arrayOf(PropTypes.string),
-    }).isRequired,
-    event: SentryTypes.Event.isRequired,
-
-    group: SentryTypes.Group,
-    project: PropTypes.object.isRequired,
-    // TODO(dcramer): ideally isShare would be replaced with simple permission
-    // checks
-    isShare: PropTypes.bool,
-    showExampleCommit: PropTypes.bool,
-    showTagSummary: PropTypes.bool,
-  };
-
   static defaultProps = defaultProps;
 
   componentDidMount() {

--- a/src/sentry/static/sentry/app/components/events/eventExtraData/eventExtraData.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventExtraData/eventExtraData.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import EventDataSection from 'app/components/events/eventDataSection';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Event} from 'app/types/event';
 
 import EventDataContent from './eventDataContent';
@@ -16,10 +15,6 @@ type State = {
 };
 
 class EventExtraData extends React.Component<Props, State> {
-  static propTypes = {
-    event: SentryTypes.Event.isRequired,
-  };
-
   state: State = {
     raw: false,
   };

--- a/src/sentry/static/sentry/app/components/events/eventMessage.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventMessage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import ErrorLevel from 'app/components/events/errorLevel';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
@@ -35,14 +34,6 @@ const EventMessage = ({
     {annotations}
   </div>
 );
-
-EventMessage.propTypes = {
-  level: PropTypes.oneOf(['error', 'fatal', 'info', 'warning', 'sample']),
-  levelIndicatorSize: PropTypes.string,
-  message: PropTypes.node,
-  annotations: PropTypes.node,
-  className: PropTypes.string,
-};
 
 const StyledEventMessage = styled(EventMessage)`
   display: flex;

--- a/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/assembly.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
@@ -47,13 +46,6 @@ const Assembly = ({name, version, culture, publicKeyToken, filePath}: Props) => 
 );
 
 // TODO(ts): we should be able to delete these after disabling react/prop-types rule in tsx functional components
-Assembly.propTypes = {
-  name: PropTypes.string.isRequired,
-  version: PropTypes.string.isRequired,
-  culture: PropTypes.string.isRequired,
-  publicKeyToken: PropTypes.string.isRequired,
-  filePath: PropTypes.string,
-};
 
 const AssemblyWrapper = styled('div')`
   font-size: 80%;

--- a/src/sentry/static/sentry/app/components/events/interfaces/contextLine.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/contextLine.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 
 import {defined} from 'app/utils';
 
@@ -32,11 +31,6 @@ const ContextLine = function (props: Props) {
       {props.children}
     </li>
   );
-};
-
-ContextLine.propTypes = {
-  line: PropTypes.array.isRequired,
-  isActive: PropTypes.bool,
 };
 
 export default ContextLine;

--- a/src/sentry/static/sentry/app/components/events/interfaces/csp.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/csp.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
@@ -28,10 +27,6 @@ type Props = {
 };
 
 export default class CspInterface extends React.Component<Props> {
-  static propTypes = {
-    data: PropTypes.object.isRequired,
-  };
-
   state = {view: 'report'};
 
   toggleView = value => {

--- a/src/sentry/static/sentry/app/components/events/interfaces/cspContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/cspContent.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import KeyValueList from 'app/components/events/interfaces/keyValueList/keyValueList';
 
@@ -8,10 +7,6 @@ type Props = {
 };
 
 class CSPContent extends React.Component<Props> {
-  static propTypes = {
-    data: PropTypes.object.isRequired,
-  };
-
   render() {
     const {data} = this.props;
     return (

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
@@ -73,15 +72,6 @@ function Candidate({
 }
 
 export default Candidate;
-
-Candidate.propTypes = {
-  candidate: PropTypes.shape({
-    download: PropTypes.shape({
-      status: PropTypes.string.isRequired,
-      features: PropTypes.object,
-    }),
-  }),
-};
 
 const Column = styled('div')`
   display: flex;

--- a/src/sentry/static/sentry/app/components/events/interfaces/generic.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/generic.tsx
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import PropTypes from 'prop-types';
 
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
@@ -30,11 +29,6 @@ type State = {
 } & Pick<Props, 'data'>;
 
 export default class GenericInterface extends Component<Props, State> {
-  static propTypes = {
-    type: PropTypes.string.isRequired,
-    data: PropTypes.object.isRequired,
-  };
-
   state: State = {
     view: 'report',
     data: this.props.data,

--- a/src/sentry/static/sentry/app/components/events/interfaces/imageForBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/imageForBar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import FunctionName from 'app/components/events/interfaces/frame/functionName';
 import {t} from 'app/locale';
@@ -28,11 +27,6 @@ const ImageForBar = ({frame, onShowAllImages}: Props) => {
       </ResetAddressFilterCaption>
     </Wrapper>
   );
-};
-
-ImageForBar.propTypes = {
-  frame: PropTypes.object.isRequired,
-  onShowAllImages: PropTypes.func.isRequired,
 };
 
 const Wrapper = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -8,7 +8,6 @@ import SearchBar from 'app/components/searchBar';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import {IconWarning} from 'app/icons';
 import {t, tn} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {EventTransaction} from 'app/types/event';
@@ -39,11 +38,6 @@ type State = {
 };
 
 class SpansInterface extends React.Component<Props, State> {
-  static propTypes = {
-    event: SentryTypes.Event.isRequired,
-    organization: SentryTypes.Organization.isRequired,
-  };
-
   state: State = {
     searchQuery: undefined,
     parsedTrace: parseTrace(this.props.event),

--- a/src/sentry/static/sentry/app/components/events/packageData.tsx
+++ b/src/sentry/static/sentry/app/components/events/packageData.tsx
@@ -5,7 +5,6 @@ import ErrorBoundary from 'app/components/errorBoundary';
 import EventDataSection from 'app/components/events/eventDataSection';
 import KeyValueList from 'app/components/events/interfaces/keyValueList/keyValueList';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Event} from 'app/types/event';
 
 type Props = {
@@ -13,10 +12,6 @@ type Props = {
 };
 
 class EventPackageData extends React.Component<Props> {
-  static propTypes = {
-    event: SentryTypes.Event.isRequired,
-  };
-
   shouldComponentUpdate(nextProps: Props) {
     return this.props.event.id !== nextProps.event.id;
   }

--- a/src/sentry/static/sentry/app/components/events/userFeedback.tsx
+++ b/src/sentry/static/sentry/app/components/events/userFeedback.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import ActivityAuthor from 'app/components/activity/author';
 import ActivityItem from 'app/components/activity/item';
@@ -8,7 +7,6 @@ import Clipboard from 'app/components/clipboard';
 import Link from 'app/components/links/link';
 import {IconCopy} from 'app/icons';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {UserReport} from 'app/types';
 import {escape, nl2br} from 'app/utils';
@@ -21,13 +19,6 @@ type Props = {
 };
 
 class EventUserFeedback extends React.Component<Props> {
-  static propTypes = {
-    report: SentryTypes.UserReport.isRequired,
-    orgId: PropTypes.string.isRequired,
-    issueId: PropTypes.string.isRequired,
-    className: PropTypes.string,
-  };
-
   getUrl() {
     const {report, orgId, issueId} = this.props;
 

--- a/src/sentry/static/sentry/app/components/eventsTable/eventsTable.tsx
+++ b/src/sentry/static/sentry/app/components/eventsTable/eventsTable.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import EventsTableRow from 'app/components/eventsTable/eventsTableRow';
 import {t} from 'app/locale';
-import CustomPropTypes from 'app/sentryTypes';
 import {Tag} from 'app/types';
 import {Event} from 'app/types/event';
 
@@ -15,14 +13,6 @@ type Props = {
   groupId: string;
 };
 class EventsTable extends React.Component<Props> {
-  static propTypes = {
-    events: PropTypes.arrayOf(CustomPropTypes.Event),
-    tagList: PropTypes.arrayOf(CustomPropTypes.Tag),
-    orgId: PropTypes.string.isRequired,
-    projectId: PropTypes.string.isRequired,
-    groupId: PropTypes.string.isRequired,
-  };
-
   render() {
     const {events, tagList, orgId, projectId, groupId} = this.props;
 

--- a/src/sentry/static/sentry/app/components/fileChange.tsx
+++ b/src/sentry/static/sentry/app/components/fileChange.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import AvatarList from 'app/components/avatar/avatarList';
 import FileIcon from 'app/components/fileIcon';
@@ -26,11 +25,6 @@ const FileChange = ({filename, authors, className}: Props) => (
     </div>
   </FileItem>
 );
-
-FileChange.propTypes = {
-  filename: PropTypes.string.isRequired,
-  authors: PropTypes.array.isRequired,
-};
 
 const FileItem = styled(ListGroupItem)`
   display: flex;

--- a/src/sentry/static/sentry/app/components/fileSize.tsx
+++ b/src/sentry/static/sentry/app/components/fileSize.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {formatBytes} from 'app/utils';
 import getDynamicText from 'app/utils/getDynamicText';
@@ -18,10 +17,5 @@ function FileSize(props: Props) {
     </span>
   );
 }
-
-FileSize.propTypes = {
-  className: PropTypes.string,
-  bytes: PropTypes.number.isRequired,
-};
 
 export default FileSize;

--- a/src/sentry/static/sentry/app/components/forms/apiForm.tsx
+++ b/src/sentry/static/sentry/app/components/forms/apiForm.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {
   addErrorMessage,
@@ -23,16 +22,6 @@ type Props = Form['props'] & {
 
 export default class ApiForm extends Form<Props> {
   api = new Client();
-
-  static propTypes = {
-    ...Form.propTypes,
-    omitDisabled: PropTypes.bool,
-    onSubmit: PropTypes.func,
-    apiMethod: PropTypes.string.isRequired,
-    apiEndpoint: PropTypes.string.isRequired,
-    submitLoadingMessage: PropTypes.string,
-    submitErrorMessage: PropTypes.string,
-  };
 
   static defaultProps = {
     ...Form.defaultProps,

--- a/src/sentry/static/sentry/app/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/components/forms/form.tsx
@@ -47,23 +47,6 @@ class Form<
   Props extends FormProps = FormProps,
   State extends FormClassState = FormClassState
 > extends React.Component<Props, State> {
-  static propTypes = {
-    cancelLabel: PropTypes.string,
-    onCancel: PropTypes.func,
-    onSubmit: PropTypes.func, //actually required but we cannot make it required because it's optional in apiForm
-    onSubmitSuccess: PropTypes.func,
-    onSubmitError: PropTypes.func,
-    submitDisabled: PropTypes.bool,
-    submitLabel: PropTypes.string,
-    footerClass: PropTypes.string,
-    extraButton: PropTypes.element,
-    initialData: PropTypes.object,
-    requireChanges: PropTypes.bool,
-    errorMessage: PropTypes.node,
-    hideErrors: PropTypes.bool,
-    resetOnError: PropTypes.bool,
-  };
-
   static childContextTypes = {
     form: PropTypes.object.isRequired,
   };

--- a/src/sentry/static/sentry/app/components/forms/formField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/formField.tsx
@@ -36,31 +36,6 @@ export default class FormField<
   Props extends FormFieldProps = FormFieldProps,
   State extends FormFieldState = FormFieldState
 > extends React.PureComponent<Props, State> {
-  static propTypes = {
-    name: PropTypes.string.isRequired,
-    /** Inline style */
-    style: PropTypes.object,
-
-    label: PropTypes.node,
-
-    // This is actually used but eslint doesn't parse it correctly
-    // eslint-disable-next-line react/no-unused-prop-types
-    defaultValue: PropTypes.any,
-
-    disabled: PropTypes.bool,
-    disabledReason: PropTypes.string,
-    help: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-    required: PropTypes.bool,
-    hideErrorMessage: PropTypes.bool,
-    className: PropTypes.string,
-
-    // the following should only be used without form context
-    onChange: PropTypes.func,
-    error: PropTypes.string, // eslint-disable-line react/no-unused-prop-types
-    value: PropTypes.any,
-    meta: PropTypes.any, // eslint-disable-line react/no-unused-prop-types
-  };
-
   static contextTypes = {
     form: PropTypes.object,
   };

--- a/src/sentry/static/sentry/app/components/forms/genericField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/genericField.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import BooleanField from 'app/components/forms/booleanField';
 import EmailField from 'app/components/forms/emailField';
@@ -127,14 +126,6 @@ const GenericField = ({
     default:
       return null;
   }
-};
-
-GenericField.propTypes = {
-  config: PropTypes.object.isRequired,
-  formData: PropTypes.object,
-  formErrors: PropTypes.object,
-  formState: PropTypes.string.isRequired,
-  onChange: PropTypes.func,
 };
 
 export default GenericField;

--- a/src/sentry/static/sentry/app/components/forms/multipleCheckboxField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/multipleCheckboxField.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 
 import FormField from 'app/components/forms/formField';
 import Tooltip from 'app/components/tooltip';
@@ -20,12 +19,6 @@ type State = FormField['state'] & {
 };
 
 export default class MultipleCheckboxField extends FormField<Props, State> {
-  static propTypes = {
-    ...FormField.propTypes,
-    hideLabelDivider: PropTypes.bool,
-    choices: PropTypes.array.isRequired,
-  };
-
   onChange = (e: React.ChangeEvent<HTMLInputElement>, _value?: Value) => {
     const value = _value as Value; // Casting here to allow _value to be optional, which it has to be since it's overloaded.
     let allValues = this.state.values;

--- a/src/sentry/static/sentry/app/components/forms/numberField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/numberField.tsx
@@ -1,5 +1,3 @@
-import PropTypes from 'prop-types';
-
 import InputField from 'app/components/forms/inputField';
 
 type Props = {
@@ -8,12 +6,6 @@ type Props = {
 } & InputField['props'];
 
 export default class NumberField extends InputField<Props> {
-  static propTypes = {
-    ...InputField.propTypes,
-    min: PropTypes.number,
-    max: PropTypes.number,
-  };
-
   coerceValue(value) {
     const intValue = parseInt(value, 10);
 

--- a/src/sentry/static/sentry/app/components/forms/passwordField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/passwordField.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {Context} from 'app/components/forms/form';
 import InputField from 'app/components/forms/inputField';
@@ -18,12 +17,6 @@ type State = InputField['state'] & {
 // TODO(dcramer): im not entirely sure this is working correctly with
 // value propagation in all scenarios
 export default class PasswordField extends InputField<Props, State> {
-  static propTypes = {
-    ...InputField.propTypes,
-    hasSavedValue: PropTypes.bool,
-    prefix: PropTypes.string.isRequired,
-  };
-
   static defaultProps = {
     ...InputField.defaultProps,
     hasSavedValue: false,

--- a/src/sentry/static/sentry/app/components/forms/radioBooleanField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/radioBooleanField.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import InputField from 'app/components/forms/inputField';
 import {defined} from 'app/utils';
@@ -11,13 +10,6 @@ type Props = {
 } & InputField['props'];
 
 export default class RadioBooleanField extends InputField<Props> {
-  static propTypes = {
-    ...InputField.propTypes,
-    yesLabel: PropTypes.string.isRequired,
-    noLabel: PropTypes.string.isRequired,
-    yesFirst: PropTypes.bool,
-  };
-
   static defaultProps = {
     ...InputField.defaultProps,
     yesLabel: 'Yes',

--- a/src/sentry/static/sentry/app/components/forms/rangeField.tsx
+++ b/src/sentry/static/sentry/app/components/forms/rangeField.tsx
@@ -1,6 +1,5 @@
 import ReactDOM from 'react-dom';
 import $ from 'jquery';
-import PropTypes from 'prop-types';
 
 import InputField from 'app/components/forms/inputField';
 
@@ -22,15 +21,6 @@ export default class RangeField extends InputField<Props> {
   static formatMinutes = value => {
     value = value / 60;
     return `${value} minute${value !== 1 ? 's' : ''}`;
-  };
-
-  static propTypes = {
-    ...InputField.propTypes,
-    min: PropTypes.number,
-    max: PropTypes.number,
-    step: PropTypes.number,
-    snap: PropTypes.bool,
-    allowedValues: PropTypes.arrayOf(PropTypes.number),
   };
 
   static defaultProps = {

--- a/src/sentry/static/sentry/app/components/forms/selectAsyncField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectAsyncField.jsx
@@ -6,7 +6,8 @@ import SelectField from './selectField';
 
 class SelectAsyncField extends SelectField {
   static propTypes = {
-    ...SelectField.propTypes,
+    // TODO(ts)
+    // ...SelectField.propTypes,
     ...SelectAsyncControl.propTypes,
     /**
      * API endpoint URL
@@ -32,7 +33,8 @@ class SelectAsyncField extends SelectField {
   };
 
   static defaultProps = {
-    ...SelectField.defaultProps,
+    // TODO(ts)
+    // ...SelectField.defaultProps,
     placeholder: 'Start typing to search for an issue',
   };
 

--- a/src/sentry/static/sentry/app/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectField.jsx
@@ -10,7 +10,8 @@ import SelectControl from './selectControl';
 
 export default class SelectField extends FormField {
   static propTypes = {
-    ...FormField.propTypes,
+    // TODO(ts)
+    // ...FormField.propTypes,
     options: SelectControl.propTypes.options,
     choices: SelectControl.propTypes.choices,
     clearable: SelectControl.propTypes.clearable,

--- a/src/sentry/static/sentry/app/components/globalModal.tsx
+++ b/src/sentry/static/sentry/app/components/globalModal.tsx
@@ -51,7 +51,6 @@ class GlobalModal extends React.Component<Props> {
     // Action creator
     closeModal();
 
-    // Read description in propTypes
     if (typeof onClose === 'function') {
       onClose();
     }

--- a/src/sentry/static/sentry/app/components/group/pluginActions.tsx
+++ b/src/sentry/static/sentry/app/components/group/pluginActions.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {ModalRenderProps, openModal} from 'app/actionCreators/modal';
@@ -8,7 +7,6 @@ import IssueSyncListElement from 'app/components/issueSyncListElement';
 import NavTabs from 'app/components/navTabs';
 import {t, tct} from 'app/locale';
 import plugins from 'app/plugins';
-import SentryTypes from 'app/sentryTypes';
 import {Group, Organization, Plugin, Project} from 'app/types';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
@@ -39,14 +37,6 @@ type State = {
 };
 
 class PluginActions extends React.Component<Props, State> {
-  static propTypes: any = {
-    api: PropTypes.object,
-    group: SentryTypes.Group.isRequired,
-    organization: SentryTypes.Organization.isRequired,
-    project: SentryTypes.Project.isRequired,
-    plugin: PropTypes.object.isRequired,
-  };
-
   state: State = {
     issue: null,
     pluginLoading: false,

--- a/src/sentry/static/sentry/app/components/group/seenInfo.tsx
+++ b/src/sentry/static/sentry/app/components/group/seenInfo.tsx
@@ -30,18 +30,6 @@ type Props = {
 };
 
 class SeenInfo extends React.Component<Props> {
-  static propTypes = {
-    orgSlug: PropTypes.string.isRequired,
-    projectSlug: PropTypes.string.isRequired,
-    projectId: PropTypes.string.isRequired,
-    date: PropTypes.any,
-    dateGlobal: PropTypes.any,
-    release: PropTypes.shape({
-      version: PropTypes.string.isRequired,
-    }),
-    environment: PropTypes.string,
-  };
-
   static contextTypes = {
     organization: PropTypes.object,
   };

--- a/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/sentryAppExternalIssueForm.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import {createFilter} from 'react-select';
 import debounce from 'lodash/debounce';
-import PropTypes from 'prop-types';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import ExternalIssueStore from 'app/stores/externalIssueStore';
 import {Group, PlatformExternalIssue, SentryAppInstallation} from 'app/types';
 import {Event} from 'app/types/event';
@@ -54,16 +52,6 @@ type Props = {
 };
 
 export class SentryAppExternalIssueForm extends React.Component<Props, State> {
-  static propTypes: any = {
-    api: PropTypes.object.isRequired,
-    group: SentryTypes.Group.isRequired,
-    sentryAppInstallation: PropTypes.object,
-    appName: PropTypes.string,
-    config: PropTypes.object.isRequired,
-    action: PropTypes.oneOf(['link', 'create']),
-    event: SentryTypes.Event,
-    onSubmitSuccess: PropTypes.func,
-  };
   state: State = {optionsByField: new Map()};
 
   componentDidMount() {

--- a/src/sentry/static/sentry/app/components/group/times.tsx
+++ b/src/sentry/static/sentry/app/components/group/times.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import TimeSince from 'app/components/timeSince';
 import {IconClock} from 'app/icons';
@@ -36,10 +35,6 @@ const Times = ({lastSeen, firstSeen}: Props) => (
     </FlexWrapper>
   </Container>
 );
-Times.propTypes = {
-  lastSeen: PropTypes.string,
-  firstSeen: PropTypes.string,
-};
 
 const Container = styled('div')`
   flex-shrink: 1;

--- a/src/sentry/static/sentry/app/components/hovercard.tsx
+++ b/src/sentry/static/sentry/app/components/hovercard.tsx
@@ -4,7 +4,6 @@ import {Manager, Popper, PopperProps, Reference} from 'react-popper';
 import {keyframes} from '@emotion/core';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 
 import {fadeIn} from 'app/styles/animations';
 import space from 'app/styles/space';
@@ -69,19 +68,6 @@ type State = {
 };
 
 class Hovercard extends React.Component<Props, State> {
-  static propTypes = {
-    displayTimeout: PropTypes.number,
-    className: PropTypes.string,
-    containerClassName: PropTypes.string,
-    header: PropTypes.node,
-    body: PropTypes.node,
-    bodyClassName: PropTypes.string,
-    position: PropTypes.oneOf(VALID_DIRECTIONS),
-    show: PropTypes.bool,
-    tipColor: PropTypes.string,
-    offset: PropTypes.string,
-  };
-
   static defaultProps: DefaultProps = {
     displayTimeout: 100,
     position: 'top',

--- a/src/sentry/static/sentry/app/components/idBadge/memberBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/memberBadge.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
-import PropTypes from 'prop-types';
 
 import UserAvatar from 'app/components/avatar/userAvatar';
 import Link from 'app/components/links/link';
-import SentryTypes from 'app/sentryTypes';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {AvatarUser, Member} from 'app/types';
@@ -71,19 +69,6 @@ const MemberBadge = ({
       </StyledNameAndEmail>
     </StyledUserBadge>
   );
-};
-
-MemberBadge.propTypes = {
-  displayName: PropTypes.node,
-  displayEmail: PropTypes.node,
-  avatarSize: PropTypes.number,
-  /**
-   * This is a Sentry member (not the user object that is a child of the member object)
-   */
-  member: SentryTypes.Member,
-  orgId: PropTypes.string,
-  useLink: PropTypes.bool,
-  hideEmail: PropTypes.bool,
 };
 
 const StyledUserBadge = styled('div')`

--- a/src/sentry/static/sentry/app/components/idBadge/teamBadge/index.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/teamBadge/index.tsx
@@ -3,7 +3,6 @@ import createReactClass from 'create-react-class';
 import isEqual from 'lodash/isEqual';
 import Reflux from 'reflux';
 
-import SentryTypes from 'app/sentryTypes';
 import TeamStore from 'app/stores/teamStore';
 import {Team} from 'app/types';
 
@@ -17,9 +16,6 @@ type ContainerState = {
 
 const TeamBadgeContainer = createReactClass<Props, ContainerState>({
   displayName: 'TeamBadgeContainer',
-  propTypes: {
-    team: SentryTypes.Team.isRequired,
-  },
   mixins: [Reflux.listenTo(TeamStore, 'onTeamStoreUpdate') as any],
   getInitialState() {
     return {

--- a/src/sentry/static/sentry/app/components/idBadge/userBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/userBadge.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import UserAvatar from 'app/components/avatar/userAvatar';
-import SentryTypes from 'app/sentryTypes';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {AvatarUser} from 'app/types';
@@ -46,18 +44,6 @@ const UserBadge = ({
       </StyledNameAndEmail>
     </StyledUserBadge>
   );
-};
-
-UserBadge.propTypes = {
-  displayName: PropTypes.node,
-  displayEmail: PropTypes.node,
-  avatarSize: PropTypes.number,
-  /**
-   * Sometimes we may not have the member object (i.e. the current user, `ConfigStore.get('user')`,
-   * is an user, not a member)
-   */
-  user: SentryTypes.User,
-  hideEmail: PropTypes.bool,
 };
 
 const StyledUserBadge = styled('div')`

--- a/src/sentry/static/sentry/app/components/indicators.tsx
+++ b/src/sentry/static/sentry/app/components/indicators.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 import createReactClass from 'create-react-class';
 import {ThemeProvider} from 'emotion-theming';
 import {AnimatePresence} from 'framer-motion';
-import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 
 import {Indicator, removeIndicator} from 'app/actionCreators/indicator';
@@ -24,18 +23,6 @@ type Props = {
 };
 
 class Indicators extends React.Component<Props> {
-  static propTypes = {
-    className: PropTypes.string,
-    items: PropTypes.arrayOf(
-      PropTypes.shape({
-        type: PropTypes.oneOf(['error', 'success', 'loading', 'undo', '']),
-        id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        message: PropTypes.node,
-        options: PropTypes.object,
-      })
-    ),
-  };
-
   static defaultProps = {
     items: [],
   };

--- a/src/sentry/static/sentry/app/components/inlineSvg.tsx
+++ b/src/sentry/static/sentry/app/components/inlineSvg.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import pickBy from 'lodash/pickBy';
-import PropTypes from 'prop-types';
 
 type Props = {
   src: string;
@@ -35,12 +34,5 @@ const InlineSvg = styled(
 )`
   vertical-align: middle;
 `;
-
-InlineSvg.propTypes = {
-  src: PropTypes.string.isRequired,
-  size: PropTypes.string,
-  width: PropTypes.string,
-  height: PropTypes.string,
-};
 
 export default InlineSvg;

--- a/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
+++ b/src/sentry/static/sentry/app/components/issueSyncListElement.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {ClassNames} from '@emotion/core';
 import styled from '@emotion/styled';
 import capitalize from 'lodash/capitalize';
-import PropTypes from 'prop-types';
 
 import Hovercard from 'app/components/hovercard';
 import {IconAdd, IconClose} from 'app/icons';
@@ -24,18 +23,6 @@ type Props = {
 };
 
 class IssueSyncListElement extends React.Component<Props> {
-  static propTypes = {
-    externalIssueLink: PropTypes.string,
-    externalIssueId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    externalIssueKey: PropTypes.string,
-    externalIssueDisplayName: PropTypes.string,
-    onOpen: PropTypes.func,
-    onClose: PropTypes.func,
-    integrationType: PropTypes.string,
-    hoverCardHeader: PropTypes.node,
-    hoverCardBody: PropTypes.node,
-  };
-
   componentDidUpdate(nextProps) {
     if (
       this.props.showHoverCard !== nextProps.showHoverCard &&

--- a/src/sentry/static/sentry/app/components/issues/compactIssue.tsx
+++ b/src/sentry/static/sentry/app/components/issues/compactIssue.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 
 import {addLoadingMessage, clearIndicators} from 'app/actionCreators/indicator';
@@ -16,7 +15,6 @@ import {PanelItem} from 'app/components/panels';
 import GroupChart from 'app/components/stream/groupChart';
 import {IconChat, IconCheckmark, IconEllipsis, IconMute, IconStar} from 'app/icons';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import GroupStore from 'app/stores/groupStore';
 import space from 'app/styles/space';
 import {Group, LightWeightOrganization} from 'app/types';
@@ -94,16 +92,6 @@ type State = {
 
 const CompactIssue = createReactClass<Props, State>({
   displayName: 'CompactIssue',
-
-  propTypes: {
-    api: PropTypes.object,
-    data: PropTypes.object,
-    id: PropTypes.string,
-    eventId: PropTypes.string,
-    statsPeriod: PropTypes.string,
-    showActions: PropTypes.bool,
-    organization: SentryTypes.Organization.isRequired,
-  },
 
   mixins: [Reflux.listenTo(GroupStore, 'onGroupChange') as any],
 

--- a/src/sentry/static/sentry/app/components/lastCommit.tsx
+++ b/src/sentry/static/sentry/app/components/lastCommit.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import UserAvatar from 'app/components/avatar/userAvatar';
 import TimeSince from 'app/components/timeSince';
@@ -25,11 +24,6 @@ const unknownUser: AvatarUser = {
 };
 
 class LastCommit extends React.Component<Props> {
-  static propTypes = {
-    commit: PropTypes.object.isRequired,
-    headerClass: PropTypes.string,
-  };
-
   renderMessage(message: Commit['message']): string {
     if (!message) {
       return t('No message provided');

--- a/src/sentry/static/sentry/app/components/letterAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/letterAvatar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {imageStyle} from 'app/components/avatar/styles';
 import theme from 'app/utils/theme';
@@ -100,12 +99,6 @@ const LetterAvatar = styled(
 )<Props>`
   ${imageStyle};
 `;
-
-LetterAvatar.propTypes = {
-  identifier: PropTypes.string,
-  displayName: PropTypes.string,
-  round: PropTypes.bool,
-};
 
 LetterAvatar.defaultProps = {
   round: false,

--- a/src/sentry/static/sentry/app/components/links/externalLink.tsx
+++ b/src/sentry/static/sentry/app/components/links/externalLink.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 type AnchorProps = React.HTMLProps<HTMLAnchorElement>;
 
@@ -15,9 +14,5 @@ const ExternalLink = React.forwardRef<HTMLAnchorElement, Props>(function Externa
   const anchorProps = openInNewTab ? {target: '_blank', rel: 'noreferrer noopener'} : {};
   return <a ref={ref} {...anchorProps} {...props} />;
 });
-
-ExternalLink.propTypes = {
-  openInNewTab: PropTypes.bool,
-};
 
 export default ExternalLink;

--- a/src/sentry/static/sentry/app/components/loading/loadingContainer.tsx
+++ b/src/sentry/static/sentry/app/components/loading/loadingContainer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import LoadingIndicator from 'app/components/loadingIndicator';
 import theme from 'app/utils/theme';
@@ -44,12 +43,6 @@ export default function LoadingContainer(props: Props) {
 }
 
 LoadingContainer.defaultProps = defaultProps;
-
-LoadingContainer.propTypes = {
-  isLoading: PropTypes.bool.isRequired,
-  isReloading: PropTypes.bool.isRequired,
-  children: PropTypes.node,
-};
 
 const Container = styled('div')`
   position: relative;

--- a/src/sentry/static/sentry/app/components/loadingError.tsx
+++ b/src/sentry/static/sentry/app/components/loadingError.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Alert from 'app/components/alert';
 import Button from 'app/components/button';
@@ -21,11 +20,6 @@ type Props = DefaultProps & {
  * Renders an Alert box of type "error". Renders a "Retry" button only if a `onRetry` callback is defined.
  */
 class LoadingError extends React.Component<Props> {
-  static propTypes = {
-    onRetry: PropTypes.func,
-    message: PropTypes.string,
-  };
-
   static defaultProps: DefaultProps = {
     message: t('There was an error loading data.'),
   };

--- a/src/sentry/static/sentry/app/components/loadingIndicator.tsx
+++ b/src/sentry/static/sentry/app/components/loadingIndicator.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {withProfiler} from '@sentry/react';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
 
 type Props = {
   overlay?: boolean;
@@ -87,17 +86,6 @@ function LoadingIndicator(props: Props) {
     </div>
   );
 }
-LoadingIndicator.propTypes = {
-  overlay: PropTypes.bool,
-  dark: PropTypes.bool,
-  mini: PropTypes.bool,
-  triangle: PropTypes.bool,
-  finished: PropTypes.bool,
-  relative: PropTypes.bool,
-  hideMessage: PropTypes.bool,
-  size: PropTypes.number,
-  hideSpinner: PropTypes.bool,
-};
 
 export default withProfiler(LoadingIndicator, {
   includeUpdates: false,

--- a/src/sentry/static/sentry/app/components/menuItem.tsx
+++ b/src/sentry/static/sentry/app/components/menuItem.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
-import PropTypes from 'prop-types';
 
 import Link from 'app/components/links/link';
 import space from 'app/styles/space';
@@ -56,21 +55,6 @@ type MenuItemProps = {
 type Props = MenuItemProps & Omit<React.HTMLProps<HTMLLIElement>, keyof MenuItemProps>;
 
 class MenuItem extends React.Component<Props> {
-  static propTypes = {
-    header: PropTypes.bool,
-    divider: PropTypes.bool,
-    title: PropTypes.string,
-    disabled: PropTypes.bool,
-    onSelect: PropTypes.func,
-    eventKey: PropTypes.any,
-    isActive: PropTypes.bool,
-    noAnchor: PropTypes.bool,
-    to: PropTypes.string,
-    href: PropTypes.string,
-    query: PropTypes.object,
-    className: PropTypes.string,
-  };
-
   handleClick = (e: React.MouseEvent): void => {
     const {onSelect, disabled, eventKey} = this.props;
     if (disabled) {

--- a/src/sentry/static/sentry/app/components/modals/sentryAppPublishRequestModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sentryAppPublishRequestModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import intersection from 'lodash/intersection';
-import PropTypes from 'prop-types';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {ModalRenderProps} from 'app/actionCreators/modal';
@@ -62,10 +61,6 @@ type Props = ModalRenderProps & {
 };
 
 export default class SentryAppPublishRequestModal extends React.Component<Props> {
-  static propTypes = {
-    app: PropTypes.object.isRequired,
-  };
-
   form = new PublishRequestFormModel();
 
   get formFields() {

--- a/src/sentry/static/sentry/app/components/modals/sudoModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/sudoModal.tsx
@@ -125,7 +125,6 @@ class SudoModal extends React.Component<Props, State> {
           onSubmitSuccess={this.handleSuccess}
           onSubmitError={this.handleError}
           hideFooter={!user.hasPasswordAuth}
-          hideErrors
           resetOnError
         >
           <StyledInputField

--- a/src/sentry/static/sentry/app/components/narrowLayout.tsx
+++ b/src/sentry/static/sentry/app/components/narrowLayout.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {logout} from 'app/actionCreators/account';
 import {Client} from 'app/api';
@@ -13,11 +12,6 @@ type Props = {
 };
 
 class NarrowLayout extends React.Component<Props> {
-  static propTypes = {
-    showLogout: PropTypes.bool,
-    maxWidth: PropTypes.string,
-  };
-
   UNSAFE_componentWillMount() {
     document.body.classList.add('narrow');
   }

--- a/src/sentry/static/sentry/app/components/navTabs.tsx
+++ b/src/sentry/static/sentry/app/components/navTabs.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import classnames from 'classnames';
-import PropTypes from 'prop-types';
 
 type Props = {
   underlined?: boolean;
@@ -16,9 +15,5 @@ function NavTabs(props: NavProps) {
   });
   return <ul className={mergedClassName} {...tabProps} />;
 }
-
-NavTabs.propTypes = {
-  underlined: PropTypes.bool,
-};
 
 export default NavTabs;

--- a/src/sentry/static/sentry/app/components/noProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/noProjectMessage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 /* TODO: replace with I/O when finished */
 import img from 'sentry-images/spot/hair-on-fire.svg';
@@ -9,7 +8,6 @@ import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import PageHeading from 'app/components/pageHeading';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import ConfigStore from 'app/stores/configStore';
 import space from 'app/styles/space';
 import {LightWeightOrganization, Organization, Project} from 'app/types';
@@ -21,15 +19,6 @@ type Props = {
 };
 
 export default class NoProjectMessage extends React.Component<Props> {
-  static propTypes = {
-    /* if the user has access to any projects, we show whatever
-    children are included. Otherwise we show the message */
-    children: PropTypes.node,
-    organization: SentryTypes.Organization,
-    projects: PropTypes.arrayOf(SentryTypes.Project),
-    loadingProjects: PropTypes.bool,
-  };
-
   render() {
     const {children, organization, projects, loadingProjects} = this.props;
     const orgId = organization.slug;

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {WithRouterProps} from 'react-router/lib/withRouter';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
-import PropTypes from 'prop-types';
 
 import {
   updateDateTime,
@@ -21,7 +20,6 @@ import Tooltip from 'app/components/tooltip';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {IconArrow} from 'app/icons';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {PageContent} from 'app/styles/organization';
 import space from 'app/styles/space';
 import {
@@ -176,47 +174,6 @@ type State = {
 };
 
 class GlobalSelectionHeader extends React.Component<Props, State> {
-  static propTypes: any = {
-    organization: SentryTypes.Organization,
-    router: PropTypes.object,
-    projects: PropTypes.arrayOf(SentryTypes.Project).isRequired,
-
-    memberProjects: PropTypes.arrayOf(SentryTypes.Project).isRequired,
-
-    nonMemberProjects: PropTypes.arrayOf(SentryTypes.Project).isRequired,
-
-    /**
-     * Slugs of projects to display in project selector (this affects the ^^^projects returned from HoC)
-     */
-    specificProjectSlugs: PropTypes.arrayOf(PropTypes.string),
-    disableMultipleProjectSelection: PropTypes.bool,
-    isGlobalSelectionReady: PropTypes.bool,
-    loadingProjects: PropTypes.bool,
-    shouldForceProject: PropTypes.bool,
-    forceProject: SentryTypes.Project,
-    selection: SentryTypes.GlobalSelection,
-    showEnvironmentSelector: PropTypes.bool,
-    showDateSelector: PropTypes.bool,
-    hasCustomRouting: PropTypes.bool,
-    resetParamsOnChange: PropTypes.arrayOf(PropTypes.string),
-    showAbsolute: PropTypes.bool,
-    showRelative: PropTypes.bool,
-    timeRangeHint: PropTypes.string,
-
-    // Callbacks //
-    onChangeProjects: PropTypes.func,
-    onUpdateProjects: PropTypes.func,
-    onChangeEnvironments: PropTypes.func,
-    onUpdateEnvironments: PropTypes.func,
-    onChangeTime: PropTypes.func,
-    onUpdateTime: PropTypes.func,
-
-    showIssueStreamLink: PropTypes.bool,
-    showProjectSettingsLink: PropTypes.bool,
-    lockedMessageSubject: PropTypes.string,
-    projectsFooterMessage: PropTypes.node,
-  };
-
   static defaultProps = defaultProps;
 
   state = {

--- a/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
@@ -3,7 +3,6 @@ import {Link} from 'react-router';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
-import PropTypes from 'prop-types';
 
 import Tooltip from 'app/components/tooltip';
 import {IconChevron, IconClose, IconInfo, IconLock, IconSettings} from 'app/icons';
@@ -29,18 +28,6 @@ type Props = {
   React.HTMLAttributes<HTMLDivElement>;
 
 class HeaderItem extends React.Component<Props> {
-  static propTypes = {
-    icon: PropTypes.element,
-    onClear: PropTypes.func,
-    hasChanges: PropTypes.bool,
-    hasSelected: PropTypes.bool,
-    isOpen: PropTypes.bool,
-    locked: PropTypes.bool,
-    lockedMessage: PropTypes.element,
-    settingsLink: PropTypes.string,
-    hint: PropTypes.string,
-  };
-
   static defaultProps: DefaultProps = {
     allowClear: true,
   };

--- a/src/sentry/static/sentry/app/components/organizations/multipleSelectorSubmitRow.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/multipleSelectorSubmitRow.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Button from 'app/components/button';
 import {t} from 'app/locale';
@@ -19,10 +18,6 @@ const MultipleSelectorSubmitRow = ({onSubmit, disabled = false}: Props) => (
     </SubmitButton>
   </SubmitButtonContainer>
 );
-
-MultipleSelectorSubmitRow.propTypes = {
-  onSubmit: PropTypes.func.isRequired,
-};
 
 const SubmitButtonContainer = styled('div')`
   display: flex;

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/relativeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/relativeSelector.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
 
@@ -24,11 +23,5 @@ const RelativeSelector = ({onClick, selected, relativePeriods}: Props) => (
     ))}
   </React.Fragment>
 );
-
-RelativeSelector.propTypes = {
-  onClick: PropTypes.func,
-  selected: PropTypes.string,
-  relativePeriods: PropTypes.object,
-};
 
 export default RelativeSelector;

--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/selectorItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/dateRange/selectorItem.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import space from 'app/styles/space';
 
@@ -14,12 +13,6 @@ type Props = {
 };
 
 class SelectorItem extends React.PureComponent<Props> {
-  static propTypes = {
-    onClick: PropTypes.func.isRequired,
-    value: PropTypes.string,
-    label: PropTypes.node,
-  };
-
   handleClick = (e: React.MouseEvent) => {
     const {onClick, value} = this.props;
     onClick(value, e);

--- a/src/sentry/static/sentry/app/components/pageHeading.tsx
+++ b/src/sentry/static/sentry/app/components/pageHeading.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import space from 'app/styles/space';
 
@@ -18,11 +17,5 @@ const PageHeading = styled('h1')<Props>`
   margin-bottom: ${p => p.withMargins && space(3)};
   margin-top: ${p => p.withMargins && space(1)};
 `;
-
-PageHeading.propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  withMargins: PropTypes.bool,
-};
 
 export default PageHeading;

--- a/src/sentry/static/sentry/app/components/pagination.tsx
+++ b/src/sentry/static/sentry/app/components/pagination.tsx
@@ -31,13 +31,6 @@ type Props = {
 } & DefaultProps;
 
 class Pagination extends React.Component<Props> {
-  static propTypes = {
-    pageLinks: PropTypes.string,
-    to: PropTypes.string,
-    onCursor: PropTypes.func,
-    className: PropTypes.string,
-  };
-
   static contextTypes = {
     location: PropTypes.object,
   };

--- a/src/sentry/static/sentry/app/components/panels/panel.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import PanelBody from 'app/components/panels/panelBody';
 import PanelHeader from 'app/components/panels/panelHeader';
@@ -36,15 +35,5 @@ const Panel = styled(
   margin-bottom: ${space(3)};
   position: relative;
 `;
-
-Panel.propTypes = {
-  /**
-   * When `title` and `body` are defined, use as children to `<PanelHeader>`
-   * and `<PanelBody>` respectively.
-   */
-  title: PropTypes.node,
-  body: PropTypes.node,
-  dashedBorder: PropTypes.bool,
-};
 
 export default Panel;

--- a/src/sentry/static/sentry/app/components/panels/panelAlert.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelAlert.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Alert from 'app/components/alert';
 import {IconCheckmark, IconClose, IconFlag, IconInfo} from 'app/icons';
@@ -30,10 +29,5 @@ const PanelAlert = styled(({icon, ...props}: Props) => (
     border-radius: 0 0 4px 4px;
   }
 `;
-
-PanelAlert.propTypes = {
-  ...Alert.propTypes,
-  type: PropTypes.oneOf(['info', 'warning', 'success', 'error', 'muted']),
-};
 
 export default PanelAlert;

--- a/src/sentry/static/sentry/app/components/panels/panelBody.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelBody.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 import {Flex} from 'reflexbox'; // eslint-disable-line no-restricted-imports
 
 import space from 'app/styles/space';
@@ -25,11 +24,6 @@ const PanelBody: React.FunctionComponent<Props> = ({
     {...(flexible ? {flexDirection: 'column'} : null)}
   />
 );
-
-PanelBody.propTypes = {
-  flexible: PropTypes.bool,
-  withPadding: PropTypes.bool,
-};
 
 PanelBody.defaultProps = {
   flexible: false,

--- a/src/sentry/static/sentry/app/components/panels/panelHeader.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelHeader.tsx
@@ -1,6 +1,5 @@
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import space from 'app/styles/space';
 
@@ -41,11 +40,5 @@ const PanelHeader = styled('div')<Props>`
   position: relative;
   ${getPadding};
 `;
-
-PanelHeader.propTypes = {
-  disablePadding: PropTypes.bool,
-  hasButtons: PropTypes.bool,
-  lightText: PropTypes.bool,
-};
 
 export default PanelHeader;

--- a/src/sentry/static/sentry/app/components/panels/panelItem.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelItem.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 import {Flex} from 'reflexbox'; // eslint-disable-line no-restricted-imports
 
 const PanelItem = styled(Flex)`
@@ -10,9 +9,6 @@ const PanelItem = styled(Flex)`
   }
 `;
 
-PanelItem.propTypes = {
-  p: PropTypes.number,
-};
 PanelItem.defaultProps = {
   p: 2,
 };

--- a/src/sentry/static/sentry/app/components/placeholder.tsx
+++ b/src/sentry/static/sentry/app/components/placeholder.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import space from 'app/styles/space';
 
@@ -45,12 +44,5 @@ const Placeholder = styled(({className, children, error, testId}: Props) => {
 `;
 
 Placeholder.defaultProps = defaultProps;
-
-Placeholder.propTypes = {
-  shape: PropTypes.oneOf(['rect', 'circle']),
-  width: PropTypes.string,
-  height: PropTypes.string,
-  bottomGutter: PropTypes.number as any,
-};
 
 export default Placeholder;

--- a/src/sentry/static/sentry/app/components/platformList.tsx
+++ b/src/sentry/static/sentry/app/components/platformList.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 import {PlatformIcon} from 'platformicons';
-import PropTypes from 'prop-types';
 
 import Tooltip from 'app/components/tooltip';
 import {PlatformKey} from 'app/data/platformCategories';
@@ -113,10 +112,6 @@ function PlatformList({
 }
 
 export default PlatformList;
-
-PlatformList.propTypes = {
-  platforms: PropTypes.array,
-};
 
 function getOverlapWidth(size: number) {
   return Math.round(size / 4);

--- a/src/sentry/static/sentry/app/components/pluginConfig.tsx
+++ b/src/sentry/static/sentry/app/components/pluginConfig.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
-import PropTypes from 'prop-types';
 
 import {
   addErrorMessage,
@@ -34,15 +33,6 @@ type State = {
 };
 
 class PluginConfig extends React.Component<Props, State> {
-  static propTypes: any = {
-    api: PropTypes.object,
-    organization: PropTypes.object.isRequired,
-    project: PropTypes.object.isRequired,
-    data: PropTypes.object.isRequired,
-    onDisablePlugin: PropTypes.func,
-    enabled: PropTypes.bool,
-  };
-
   static defaultProps = {
     onDisablePlugin: () => {},
   };

--- a/src/sentry/static/sentry/app/components/pluginList.tsx
+++ b/src/sentry/static/sentry/app/components/pluginList.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {disablePlugin, enablePlugin} from 'app/actionCreators/plugins';
 import InactivePlugins from 'app/components/inactivePlugins';
@@ -74,14 +73,6 @@ const PluginList = ({
       />
     </div>
   );
-};
-
-PluginList.propTypes = {
-  organization: PropTypes.object.isRequired,
-  project: PropTypes.object.isRequired,
-  pluginList: PropTypes.array.isRequired,
-  onDisablePlugin: PropTypes.func,
-  onEnablePlugin: PropTypes.func,
 };
 
 export default PluginList;

--- a/src/sentry/static/sentry/app/components/previewFeature.tsx
+++ b/src/sentry/static/sentry/app/components/previewFeature.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import Alert, {Props as AlertProps} from 'app/components/alert';
 import {IconLab} from 'app/icons';
@@ -16,9 +15,5 @@ const PreviewFeature = ({type = 'info'}: Props) => (
     )}
   </Alert>
 );
-
-PreviewFeature.propTypes = {
-  type: PropTypes.oneOf(['success', 'error', 'warning', 'info']),
-};
 
 export default PreviewFeature;

--- a/src/sentry/static/sentry/app/components/projectLabel.tsx
+++ b/src/sentry/static/sentry/app/components/projectLabel.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import {Project as ProjectPropType} from 'app/sentryTypes';
 import {Project} from 'app/types';
 
 type Props = React.HTMLProps<HTMLSpanElement> & {
@@ -8,10 +7,6 @@ type Props = React.HTMLProps<HTMLSpanElement> & {
 };
 
 export default class ProjectLabel extends React.PureComponent<Props> {
-  static propTypes = {
-    project: ProjectPropType.isRequired,
-  };
-
   render() {
     const {project, ...props} = this.props;
 

--- a/src/sentry/static/sentry/app/components/projects/bookmarkStar.tsx
+++ b/src/sentry/static/sentry/app/components/projects/bookmarkStar.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {update} from 'app/actionCreators/projects';
 import {Client} from 'app/api';
 import {IconStar} from 'app/icons';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Organization, Project} from 'app/types';
 import {defined} from 'app/utils';
 import withApi from 'app/utils/withApi';
@@ -62,16 +60,6 @@ const BookmarkStar = ({
       className={className}
     />
   );
-};
-
-BookmarkStar.propTypes = {
-  api: PropTypes.any.isRequired,
-  /* used to override when under local state */
-  isBookmarked: PropTypes.bool,
-  className: PropTypes.string,
-  organization: SentryTypes.Organization.isRequired,
-  project: SentryTypes.Project.isRequired,
-  onToggle: PropTypes.func,
 };
 
 const Star = styled(IconStar, {shouldForwardProp: p => p !== 'isBookmarked'})<{

--- a/src/sentry/static/sentry/app/components/queryCount.tsx
+++ b/src/sentry/static/sentry/app/components/queryCount.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {defined} from 'app/utils';
 
@@ -44,12 +43,6 @@ const QueryCount = ({
       {!hideParens && <span>)</span>}
     </span>
   );
-};
-QueryCount.propTypes = {
-  count: PropTypes.number,
-  max: PropTypes.number,
-  hideIfEmpty: PropTypes.bool,
-  hideParens: PropTypes.bool,
 };
 
 export default QueryCount;

--- a/src/sentry/static/sentry/app/components/releaseStats.tsx
+++ b/src/sentry/static/sentry/app/components/releaseStats.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import AvatarList from 'app/components/avatar/avatarList';
 import {t, tn} from 'app/locale';
@@ -33,10 +32,6 @@ const ReleaseStats = ({release, withHeading = true}: Props) => {
       </span>
     </div>
   );
-};
-
-ReleaseStats.propTypes = {
-  release: PropTypes.object,
 };
 
 const ReleaseSummaryHeading = styled('div')`

--- a/src/sentry/static/sentry/app/components/resolutionBox.tsx
+++ b/src/sentry/static/sentry/app/components/resolutionBox.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import UserAvatar from 'app/components/avatar/userAvatar';
 import CommitLink from 'app/components/commitLink';
@@ -78,11 +77,6 @@ function ResolutionBox({statusDetails, projectId}: Props) {
     </BannerContainer>
   );
 }
-
-ResolutionBox.propTypes = {
-  statusDetails: PropTypes.object.isRequired,
-  projectId: PropTypes.string.isRequired,
-};
 
 const StyledTimeSince = styled(TimeSince)`
   color: ${p => p.theme.gray300};

--- a/src/sentry/static/sentry/app/components/resultGrid.tsx
+++ b/src/sentry/static/sentry/app/components/resultGrid.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {browserHistory} from 'react-router';
 import {Location} from 'history';
-import PropTypes from 'prop-types';
 
 import {Client, RequestOptions} from 'app/api';
 import DropdownLink from 'app/components/dropdownLink';
@@ -91,13 +90,6 @@ type SortByProps = {
 };
 
 class SortBy extends React.Component<SortByProps> {
-  static propTypes = {
-    options: PropTypes.array.isRequired,
-    path: PropTypes.string.isRequired,
-    location: PropTypes.object,
-    value: PropTypes.any,
-  };
-
   getCurrentSortLabel() {
     return this.props.options.find(([value]) => value === this.props.value)?.[1];
   }

--- a/src/sentry/static/sentry/app/components/scoreBar.tsx
+++ b/src/sentry/static/sentry/app/components/scoreBar.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import theme from 'app/utils/theme';
 
@@ -49,18 +48,6 @@ const ScoreBar = ({
       ))}
     </div>
   );
-};
-
-ScoreBar.propTypes = {
-  vertical: PropTypes.bool,
-  score: PropTypes.number.isRequired,
-  /** Array of strings */
-  palette: PropTypes.arrayOf(PropTypes.string),
-  /** Array of classNames whose index maps to score */
-  paletteClassNames: PropTypes.arrayOf(PropTypes.string),
-  size: PropTypes.number,
-  thickness: PropTypes.number,
-  radius: PropTypes.number,
 };
 
 const StyledScoreBar = styled(ScoreBar)`

--- a/src/sentry/static/sentry/app/components/setupWizard.tsx
+++ b/src/sentry/static/sentry/app/components/setupWizard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {Client} from 'app/api';
 import LoadingIndicator from 'app/components/loadingIndicator';
@@ -16,10 +15,6 @@ type State = {
 };
 
 class SetupWizard extends React.Component<Props, State> {
-  static propTypes = {
-    hash: PropTypes.string.isRequired,
-  };
-
   static defaultProps = {
     hash: false,
   };

--- a/src/sentry/static/sentry/app/components/shortId.tsx
+++ b/src/sentry/static/sentry/app/components/shortId.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import AutoSelectText from 'app/components/autoSelectText';
 
@@ -12,11 +11,6 @@ type Props = {
 };
 
 export default class ShortId extends React.Component<Props> {
-  static propTypes = {
-    shortId: PropTypes.string.isRequired,
-    avatar: PropTypes.node,
-  };
-
   render() {
     const {shortId, avatar} = this.props;
 

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarPanelItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarPanelItem.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {t} from '../../locale';
 import ExternalLink from '../links/externalLink';
@@ -31,15 +30,6 @@ const SidebarPanelItem = ({hasSeen, title, image, message, link, cta}: Props) =>
     )}
   </SidebarPanelItemRoot>
 );
-
-SidebarPanelItem.propTypes = {
-  title: PropTypes.string,
-  image: PropTypes.string,
-  message: PropTypes.node,
-  link: PropTypes.string,
-  hasSeen: PropTypes.bool,
-  cta: PropTypes.string,
-};
 
 export default SidebarPanelItem;
 

--- a/src/sentry/static/sentry/app/components/splitDiff.tsx
+++ b/src/sentry/static/sentry/app/components/splitDiff.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import {Change, diffChars, diffLines, diffWords} from 'diff';
-import PropTypes from 'prop-types';
 
 const diffFnMap = {
   chars: diffChars,
@@ -69,12 +68,6 @@ const SplitDiff = ({className, type = 'lines', base, target}: Props) => {
       </SplitBody>
     </SplitTable>
   );
-};
-
-SplitDiff.propTypes = {
-  base: PropTypes.string,
-  target: PropTypes.string,
-  type: PropTypes.oneOf(['lines', 'words', 'chars']),
 };
 
 const SplitTable = styled('table')`

--- a/src/sentry/static/sentry/app/components/stream/groupCheckBox.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupCheckBox.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 
 import Checkbox from 'app/components/checkbox';
@@ -18,11 +17,6 @@ type State = {
 
 const GroupCheckBox = createReactClass<Props, State>({
   displayName: 'GroupCheckBox',
-
-  propTypes: {
-    id: PropTypes.string.isRequired,
-    disabled: PropTypes.bool,
-  },
 
   mixins: [Reflux.listenTo(SelectedGroupStore, 'onSelectedGroupChange') as any],
 

--- a/src/sentry/static/sentry/app/components/stream/processingIssueList.tsx
+++ b/src/sentry/static/sentry/app/components/stream/processingIssueList.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import isEqual from 'lodash/isEqual';
-import PropTypes from 'prop-types';
 
 import {fetchProcessingIssues} from 'app/actionCreators/processingIssues';
 import {Client} from 'app/api';
 import ProcessingIssueHint from 'app/components/stream/processingIssueHint';
-import SentryTypes from 'app/sentryTypes';
 import {Organization, ProcessingIssue} from 'app/types';
 
 const defaultProps = {
@@ -23,12 +21,6 @@ type State = {
 };
 
 class ProcessingIssueList extends React.Component<Props, State> {
-  static propTypes = {
-    organization: SentryTypes.Organization.isRequired,
-    projectIds: PropTypes.array,
-    showProject: PropTypes.bool,
-  };
-
   static defaultProps = defaultProps;
 
   state: State = {

--- a/src/sentry/static/sentry/app/components/subscribeButton.tsx
+++ b/src/sentry/static/sentry/app/components/subscribeButton.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import Button from 'app/components/button';
 import {IconBell} from 'app/icons';
@@ -13,14 +12,6 @@ type Props = {
 };
 
 export default class SubscribeButton extends React.Component<Props> {
-  static propTypes = {
-    isSubscribed: PropTypes.bool,
-    onClick: PropTypes.func.isRequired,
-    disabled: PropTypes.bool,
-    // `Object is possibly 'undefined'` if we try to use Button.propTypes.size
-    size: PropTypes.any,
-  };
-
   render() {
     const {size, isSubscribed, onClick, disabled} = this.props;
     const icon = <IconBell color={isSubscribed ? 'blue300' : undefined} />;

--- a/src/sentry/static/sentry/app/components/tagDistributionMeter.tsx
+++ b/src/sentry/static/sentry/app/components/tagDistributionMeter.tsx
@@ -3,7 +3,6 @@ import {Link} from 'react-router';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {LocationDescriptor} from 'history';
-import PropTypes from 'prop-types';
 
 import {TagSegment} from 'app/actionCreators/events';
 import Tooltip from 'app/components/tooltip';
@@ -36,25 +35,6 @@ type SegmentValue = {
 };
 
 export default class TagDistributionMeter extends React.Component<Props> {
-  static propTypes = {
-    title: PropTypes.string.isRequired,
-    totalValues: PropTypes.number,
-    isLoading: PropTypes.bool,
-    hasError: PropTypes.bool,
-    segments: PropTypes.arrayOf(
-      PropTypes.shape({
-        count: PropTypes.number.isRequired,
-        name: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
-        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.array]),
-        url: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
-      })
-    ).isRequired,
-    renderEmpty: PropTypes.func,
-    renderLoading: PropTypes.func,
-    renderError: PropTypes.func,
-    onTagClick: PropTypes.func,
-  };
-
   static defaultProps: DefaultProps = {
     isLoading: false,
     hasError: false,

--- a/src/sentry/static/sentry/app/components/timeSince.tsx
+++ b/src/sentry/static/sentry/app/components/timeSince.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import isNumber from 'lodash/isNumber';
 import isString from 'lodash/isString';
 import moment from 'moment-timezone';
-import PropTypes from 'prop-types';
 
 import {t} from 'app/locale';
 import ConfigStore from 'app/stores/configStore';
@@ -51,11 +50,6 @@ type State = {
 };
 
 class TimeSince extends React.PureComponent<Props, State> {
-  static propTypes = {
-    date: PropTypes.any.isRequired,
-    suffix: PropTypes.string,
-  };
-
   static defaultProps: DefaultProps = {
     suffix: 'ago',
   };

--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -5,7 +5,6 @@ import styled, {SerializedStyles} from '@emotion/styled';
 import {AnimatePresence, motion, MotionStyle} from 'framer-motion';
 import memoize from 'lodash/memoize';
 import * as PopperJS from 'popper.js';
-import PropTypes from 'prop-types';
 
 import {IS_ACCEPTANCE_TEST} from 'app/constants';
 import {domId} from 'app/utils/domId';
@@ -104,31 +103,6 @@ function computeOriginFromArrow(
 }
 
 class Tooltip extends React.Component<Props, State> {
-  static propTypes = {
-    disabled: PropTypes.bool,
-    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-    position: PropTypes.oneOf([
-      'bottom',
-      'top',
-      'left',
-      'right',
-      'bottom-start',
-      'bottom-end',
-      'top-start',
-      'top-end',
-      'left-start',
-      'left-end',
-      'right-start',
-      'right-end',
-      'auto',
-    ]),
-    popperStyle: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-    containerDisplayMode: PropTypes.string,
-    delay: PropTypes.number,
-    isHoverable: PropTypes.bool,
-    skipWrapper: PropTypes.bool,
-  };
-
   static defaultProps: DefaultProps = {
     position: 'top',
     containerDisplayMode: 'inline-block',

--- a/src/sentry/static/sentry/app/components/truncate.tsx
+++ b/src/sentry/static/sentry/app/components/truncate.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 type DefaultProps = {
   maxLength: number;
@@ -16,12 +15,6 @@ type State = {
 };
 
 class Truncate extends React.Component<Props, State> {
-  static propTypes = {
-    value: PropTypes.string.isRequired,
-    leftTrim: PropTypes.bool,
-    maxLength: PropTypes.number,
-  };
-
   static defaultProps: DefaultProps = {
     maxLength: 50,
     leftTrim: false,

--- a/src/sentry/static/sentry/app/components/u2f/u2finterface.tsx
+++ b/src/sentry/static/sentry/app/components/u2f/u2finterface.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import * as Sentry from '@sentry/react';
-import PropTypes from 'prop-types';
 import u2f from 'u2f-api';
 
 import {t, tct} from 'app/locale';
@@ -25,13 +24,6 @@ type State = {
 };
 
 class U2fInterface extends React.Component<Props, State> {
-  static propTypes = {
-    challengeData: PropTypes.object.isRequired,
-    flowMode: PropTypes.string.isRequired,
-    onTap: PropTypes.func,
-    silentIfUnsupported: PropTypes.bool,
-  };
-
   static defaultProps = {
     silentIfUnsupported: false,
   };

--- a/src/sentry/static/sentry/app/components/u2f/u2fsign.tsx
+++ b/src/sentry/static/sentry/app/components/u2f/u2fsign.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {t} from 'app/locale';
 
@@ -22,11 +21,6 @@ type Props = Omit<InterfaceProps, 'silentIfUnsupported' | 'flowMode'> & {
 };
 
 class U2fSign extends React.Component<Props> {
-  static propTypes = {
-    challengeData: PropTypes.object,
-    displayMode: PropTypes.string,
-  };
-
   static defaultProps = {
     displayMode: 'signin',
   };

--- a/src/sentry/static/sentry/app/components/userMisery.tsx
+++ b/src/sentry/static/sentry/app/components/userMisery.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import ScoreBar from 'app/components/scoreBar';
 import Tooltip from 'app/components/tooltip';
@@ -41,12 +40,5 @@ function UserMisery(props: Props) {
     </Tooltip>
   );
 }
-
-UserMisery.propTypes = {
-  bars: PropTypes.number,
-  miserableUsers: PropTypes.number,
-  totalUsers: PropTypes.number,
-  miseryLimit: PropTypes.number,
-};
 
 export default UserMisery;

--- a/src/sentry/static/sentry/app/components/version.tsx
+++ b/src/sentry/static/sentry/app/components/version.tsx
@@ -3,14 +3,12 @@ import {withRouter} from 'react-router';
 import {WithRouterProps} from 'react-router/lib/withRouter';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Clipboard from 'app/components/clipboard';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
 import Link from 'app/components/links/link';
 import Tooltip from 'app/components/tooltip';
 import {IconCopy} from 'app/icons';
-import SentryTypes from 'app/sentryTypes';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
@@ -151,18 +149,6 @@ const Version = ({
       {renderVersion()}
     </Tooltip>
   );
-};
-
-Version.propTypes = {
-  version: PropTypes.string.isRequired,
-  organization: SentryTypes.Organization.isRequired,
-  anchor: PropTypes.bool,
-  preserveGlobalSelection: PropTypes.bool,
-  tooltipRawVersion: PropTypes.bool,
-  withPackage: PropTypes.bool,
-  projectId: PropTypes.string,
-  truncate: PropTypes.bool,
-  className: PropTypes.string,
 };
 
 // TODO(matej): try to wrap version with this when truncate prop is true (in separate PR)

--- a/src/sentry/static/sentry/app/components/well.tsx
+++ b/src/sentry/static/sentry/app/components/well.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 type Props = {
   hasImage?: boolean;
@@ -20,10 +19,5 @@ const Well = styled('div')<WellProps>`
   border-radius: 3px;
   ${p => p.centered && 'text-align: center'};
 `;
-
-Well.propTypes = {
-  hasImage: PropTypes.bool,
-  centered: PropTypes.bool,
-};
 
 export default Well;

--- a/src/sentry/static/sentry/app/icons/svgIcon.tsx
+++ b/src/sentry/static/sentry/app/icons/svgIcon.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import theme, {Aliases, Color, IconSize} from 'app/utils/theme';
 
@@ -26,12 +25,5 @@ const SvgIcon = React.forwardRef<SVGSVGElement, Props>(function SvgIcon(
     <svg {...props} viewBox={viewBox} fill={color} height={size} width={size} ref={ref} />
   );
 });
-
-SvgIcon.propTypes = {
-  // @ts-expect-error
-  color: PropTypes.string,
-  size: PropTypes.string,
-  viewBox: PropTypes.string,
-};
 
 export default SvgIcon;

--- a/src/sentry/static/sentry/app/plugins/components/issueActions.tsx
+++ b/src/sentry/static/sentry/app/plugins/components/issueActions.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import GroupActions from 'app/actions/groupActions';
 import PluginComponentBase from 'app/components/bases/pluginComponentBase';
@@ -73,12 +72,6 @@ class IssueActions extends PluginComponentBase<Props, State> {
       dependentFieldState: {},
     };
   }
-
-  static propTypes = {
-    plugin: PropTypes.object.isRequired,
-    actionType: PropTypes.oneOf(['unlink', 'link', 'create']).isRequired,
-    onSuccess: PropTypes.func,
-  };
 
   getGroup() {
     return this.props.group;

--- a/src/sentry/static/sentry/app/plugins/components/pluginIcon.tsx
+++ b/src/sentry/static/sentry/app/plugins/components/pluginIcon.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import amixr from 'sentry-images/logos/logo-amixr.svg';
 import asana from 'sentry-images/logos/logo-asana.svg';
@@ -136,11 +135,6 @@ const PluginIcon = styled('div')<Props>`
 PluginIcon.defaultProps = {
   pluginId: '_default',
   size: 20,
-};
-
-PluginIcon.propTypes = {
-  pluginId: PropTypes.string,
-  size: PropTypes.number,
 };
 
 export default PluginIcon;

--- a/src/sentry/static/sentry/app/plugins/components/settings.tsx
+++ b/src/sentry/static/sentry/app/plugins/components/settings.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
-import PropTypes from 'prop-types';
 
 import PluginComponentBase from 'app/components/bases/pluginComponentBase';
 import {Form, FormState} from 'app/components/forms';
@@ -34,12 +33,6 @@ class PluginSettings<
   P extends Props = Props,
   S extends State = State
 > extends PluginComponentBase<P, S> {
-  static propTypes: any = {
-    organization: PropTypes.object.isRequired,
-    project: PropTypes.object.isRequired,
-    plugin: PropTypes.object.isRequired,
-  };
-
   constructor(props: P, context: any) {
     super(props, context);
 

--- a/src/sentry/static/sentry/app/plugins/sessionstack/contexts/sessionstack.tsx
+++ b/src/sentry/static/sentry/app/plugins/sessionstack/contexts/sessionstack.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import $ from 'jquery';
-import PropTypes from 'prop-types';
 
 const ASPECT_RATIO = 16 / 9;
 
@@ -18,10 +17,6 @@ type State = {
 };
 
 class SessionStackContextType extends React.Component<Props, State> {
-  propTypes = {
-    data: PropTypes.object.isRequired,
-  };
-
   state: State = {
     showIframe: false,
   };

--- a/src/sentry/static/sentry/app/utils/projects.tsx
+++ b/src/sentry/static/sentry/app/utils/projects.tsx
@@ -2,11 +2,9 @@ import React from 'react';
 import memoize from 'lodash/memoize';
 import partition from 'lodash/partition';
 import uniqBy from 'lodash/uniqBy';
-import PropTypes from 'prop-types';
 
 import ProjectActions from 'app/actions/projectActions';
 import {Client} from 'app/api';
-import SentryTypes from 'app/sentryTypes';
 import ProjectsStore from 'app/stores/projectsStore';
 import {AvatarProject, Project} from 'app/types';
 import {defined} from 'app/utils';
@@ -125,16 +123,6 @@ type Props = {
  * `Organization` as well as being saved to `ProjectsStore`.
  */
 class Projects extends React.Component<Props, State> {
-  static propTypes: any = {
-    api: PropTypes.object.isRequired,
-    orgId: PropTypes.string.isRequired,
-    projects: PropTypes.arrayOf(SentryTypes.Project).isRequired,
-    slugs: PropTypes.arrayOf(PropTypes.string),
-    limit: PropTypes.number,
-    allProjects: PropTypes.bool,
-    passthroughPlaceholderProject: PropTypes.bool,
-  };
-
   static defaultProps: DefaultProps = {
     passthroughPlaceholderProject: true,
   };

--- a/src/sentry/static/sentry/app/utils/redirect.tsx
+++ b/src/sentry/static/sentry/app/utils/redirect.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import * as ReactRouter from 'react-router';
 import {LocationDescriptor} from 'history';
-import PropTypes from 'prop-types';
 
 type Props = {
   router: ReactRouter.InjectedRouter;
@@ -11,13 +10,6 @@ type Props = {
 // This is react-router v4 <Redirect to="path/" /> component to allow things
 // to be declarative.
 class Redirect extends React.Component<Props> {
-  static propTypes = {
-    router: PropTypes.shape({
-      replace: PropTypes.func.isRequired,
-    }).isRequired,
-    to: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
-  };
-
   componentDidMount() {
     this.props.router.replace(this.props.to);
   }

--- a/src/sentry/static/sentry/app/utils/withLatestContext.tsx
+++ b/src/sentry/static/sentry/app/utils/withLatestContext.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 
-import SentryTypes from 'app/sentryTypes';
 import ConfigStore from 'app/stores/configStore';
 import LatestContextStore from 'app/stores/latestContextStore';
 import {Organization, OrganizationSummary, Project} from 'app/types';
@@ -37,10 +35,6 @@ const withLatestContext = <P extends InjectedLatestContextProps>(
       State
     >({
       displayName: `withLatestContext(${getDisplayName(WrappedComponent)})`,
-      propTypes: {
-        organization: SentryTypes.Organization,
-        organizations: PropTypes.arrayOf(SentryTypes.Organization).isRequired,
-      },
       mixins: [Reflux.connect(LatestContextStore, 'latestContext') as any],
 
       render() {

--- a/src/sentry/static/sentry/app/utils/withPlugins.tsx
+++ b/src/sentry/static/sentry/app/utils/withPlugins.tsx
@@ -3,7 +3,6 @@ import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
 import {fetchPlugins} from 'app/actionCreators/plugins';
-import SentryTypes from 'app/sentryTypes';
 import PluginsStore from 'app/stores/pluginsStore';
 import {Organization, Plugin, Project} from 'app/types';
 import {defined} from 'app/utils';
@@ -31,10 +30,6 @@ const withPlugins = <P extends WithPluginProps>(
     withProject(
       createReactClass<Omit<P, keyof InjectedPluginProps> & WithPluginProps, {}>({
         displayName: `withPlugins(${getDisplayName(WrappedComponent)})`,
-        propTypes: {
-          organization: SentryTypes.Organization.isRequired,
-          project: SentryTypes.Project.isRequired,
-        },
         mixins: [Reflux.connect(PluginsStore, 'store') as any],
 
         componentDidMount() {

--- a/src/sentry/static/sentry/app/utils/withProjects.tsx
+++ b/src/sentry/static/sentry/app/utils/withProjects.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
-import SentryTypes from 'app/sentryTypes';
 import ProjectsStore from 'app/stores/projectsStore';
 import {Project} from 'app/types';
 import getDisplayName from 'app/utils/getDisplayName';
@@ -28,10 +27,6 @@ const withProjects = <P extends InjectedProjectsProps>(
     State
   >({
     displayName: `withProjects(${getDisplayName(WrappedComponent)})`,
-    propTypes: {
-      organization: SentryTypes.Organization,
-      project: SentryTypes.Project,
-    },
     mixins: [Reflux.listenTo(ProjectsStore, 'onProjectUpdate') as any],
     getInitialState() {
       return ProjectsStore.getState();

--- a/src/sentry/static/sentry/app/views/events/searchBar.tsx
+++ b/src/sentry/static/sentry/app/views/events/searchBar.tsx
@@ -5,13 +5,11 @@ import flatten from 'lodash/flatten';
 import isEqual from 'lodash/isEqual';
 import memoize from 'lodash/memoize';
 import omit from 'lodash/omit';
-import PropTypes from 'prop-types';
 
 import {fetchTagValues} from 'app/actionCreators/tags';
 import {Client} from 'app/api';
 import SmartSearchBar from 'app/components/smartSearchBar';
 import {NEGATION_OPERATOR, SEARCH_WILDCARD} from 'app/constants';
-import SentryTypes from 'app/sentryTypes';
 import {Organization, SavedSearchType, TagCollection} from 'app/types';
 import {defined} from 'app/utils';
 import {
@@ -40,15 +38,6 @@ type SearchBarProps = Omit<React.ComponentProps<typeof SmartSearchBar>, 'tags'> 
 };
 
 class SearchBar extends React.PureComponent<SearchBarProps> {
-  static propTypes: any = {
-    api: PropTypes.object,
-    organization: SentryTypes.Organization,
-    tags: PropTypes.objectOf(SentryTypes.Tag),
-    omitTags: PropTypes.arrayOf(PropTypes.string.isRequired),
-    projectIds: PropTypes.arrayOf(PropTypes.number.isRequired),
-    fields: PropTypes.arrayOf(PropTypes.object.isRequired) as any,
-  };
-
   componentDidMount() {
     // Clear memoized data on mount to make tests more consistent.
     this.getEventFieldValues.cache.clear?.();

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {Params} from 'react-router/lib/Router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import PropTypes from 'prop-types';
 
 import Feature from 'app/components/acl/feature';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -21,7 +20,6 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import TagsTable from 'app/components/tagsTable';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import {Event, EventTag} from 'app/types/event';
@@ -38,20 +36,6 @@ import {generateTitle, getExpandedResults} from '../utils';
 
 import LinkedIssue from './linkedIssue';
 
-const slugValidator = function (
-  props: {[key: string]: any},
-  propName: string,
-  componentName: string
-) {
-  const value = props[propName];
-  // Accept slugs that look like:
-  // * project-slug:deadbeef
-  if (value && typeof value === 'string' && !/^(?:[^:]+):(?:[a-f0-9-]+)$/.test(value)) {
-    return new Error(`Invalid value for ${propName} provided to ${componentName}.`);
-  }
-  return null;
-};
-
 type Props = {
   organization: Organization;
   location: Location;
@@ -66,12 +50,6 @@ type State = {
 } & AsyncComponent['state'];
 
 class EventDetailsContent extends AsyncComponent<Props, State> {
-  static propTypes: any = {
-    organization: SentryTypes.Organization.isRequired,
-    eventSlug: slugValidator,
-    location: PropTypes.object.isRequired,
-  };
-
   state: State = {
     // AsyncComponent state
     loading: true,

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/index.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import {Params} from 'react-router/lib/Router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import PropTypes from 'prop-types';
 
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {PageContent} from 'app/styles/organization';
 import {Organization} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
@@ -22,11 +20,6 @@ type Props = {
 };
 
 class EventDetails extends React.Component<Props> {
-  static propTypes: any = {
-    organization: SentryTypes.Organization.isRequired,
-    location: PropTypes.object.isRequired,
-  };
-
   getEventSlug = (): string => {
     const {eventSlug} = this.props.params;
 

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/linkedIssue.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -30,11 +29,6 @@ class LinkedIssue extends AsyncComponent<
   Props & AsyncComponent['props'],
   State & AsyncComponent['state']
 > {
-  static propTypes = {
-    groupId: PropTypes.string.isRequired,
-    eventId: PropTypes.string.isRequired,
-  };
-
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {groupId} = this.props;
     const groupUrl = `/issues/${groupId}/`;

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {PageContent} from 'app/styles/organization';
 import {Organization} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
@@ -13,10 +12,6 @@ type Props = {
 };
 
 class DiscoverContainer extends React.Component<Props> {
-  static propTypes = {
-    organization: SentryTypes.Organization.isRequired,
-  };
-
   renderNoAccess() {
     return (
       <PageContent>

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
-import PropTypes from 'prop-types';
 import {stringify} from 'query-string';
 
 import Feature from 'app/components/acl/feature';
@@ -18,7 +17,6 @@ import SearchBar from 'app/components/searchBar';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import Switch from 'app/components/switch';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import ConfigStore from 'app/stores/configStore';
 import {PageContent} from 'app/styles/organization';
 import space from 'app/styles/space';
@@ -64,12 +62,6 @@ type State = {
 } & AsyncComponent['state'];
 
 class DiscoverLanding extends AsyncComponent<Props, State> {
-  static propTypes: any = {
-    organization: SentryTypes.Organization.isRequired,
-    location: PropTypes.object.isRequired,
-    router: PropTypes.object.isRequired,
-  };
-
   mq = window.matchMedia?.(`(max-width: ${theme.breakpoints[1]})`);
 
   state: State = {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {Location} from 'history';
-import PropTypes from 'prop-types';
 
 import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
@@ -66,9 +65,6 @@ function renderBrowserExportButton(canEdit: boolean, {isLoading, ...props}: Prop
     </Button>
   );
 }
-renderBrowserExportButton.propTypes = {
-  title: PropTypes.string,
-};
 
 function renderAsyncExportButton(canEdit: boolean, props: Props) {
   const {isLoading, location} = props;
@@ -87,9 +83,6 @@ function renderAsyncExportButton(canEdit: boolean, props: Props) {
   );
 }
 // Placate eslint proptype checking
-renderAsyncExportButton.propTypes = {
-  isLoading: PropTypes.bool,
-};
 
 function renderEditButton(canEdit: boolean, props: Props) {
   const onClick = canEdit ? props.onEdit : undefined;
@@ -106,9 +99,6 @@ function renderEditButton(canEdit: boolean, props: Props) {
   );
 }
 // Placate eslint proptype checking
-renderEditButton.propTypes = {
-  onEdit: PropTypes.func,
-};
 
 function renderSummaryButton({onChangeShowTags, showTags}: Props) {
   return (

--- a/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/tags.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {Location, LocationDescriptor} from 'history';
-import PropTypes from 'prop-types';
 
 import {fetchTagFacets, Tag, TagSegment} from 'app/actionCreators/events';
 import {Client} from 'app/api';
@@ -13,7 +12,6 @@ import Placeholder from 'app/components/placeholder';
 import TagDistributionMeter from 'app/components/tagDistributionMeter';
 import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
@@ -38,14 +36,6 @@ type State = {
 };
 
 class Tags extends React.Component<Props, State> {
-  static propTypes: any = {
-    api: PropTypes.object.isRequired,
-    organization: SentryTypes.Organization.isRequired,
-    location: PropTypes.object.isRequired,
-    eventView: PropTypes.object.isRequired,
-    confirmedQuery: PropTypes.bool,
-  };
-
   state: State = {
     loading: true,
     tags: [],

--- a/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
+++ b/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
@@ -148,7 +148,8 @@ const Wrapper = styled('div')`
   padding: 100px 50px 50px 50px;
 `;
 
-const StyledForm = styled(Form)`
+// TODO(ts): Understand why styled is not correctly inheriting props here
+const StyledForm = styled(Form)<Form['props']>`
   margin-top: 10px;
 `;
 

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {InjectedRouter, Link} from 'react-router';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {openModal} from 'app/actionCreators/modal';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
@@ -165,11 +164,6 @@ function IssueListHeader({
 }
 
 export default withProjects(IssueListHeader);
-
-IssueListHeader.propTypes = {
-  projectIds: PropTypes.array.isRequired,
-  projects: PropTypes.array.isRequired,
-};
 
 const StyledLayoutTitle = styled(Layout.Title)`
   margin-top: ${space(0.5)};

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -1066,7 +1066,6 @@ class IssueListOverview extends React.Component<Props, State> {
                     tags={tags}
                     query={query}
                     onQueryChange={this.onIssueListSidebarSearch}
-                    orgId={orgSlug}
                     tagValueLoader={this.tagValueLoader}
                   />
                 )}

--- a/src/sentry/static/sentry/app/views/issueList/searchBar.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/searchBar.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {fetchRecentSearches} from 'app/actionCreators/savedSearches';
 import {Client} from 'app/api';
 import SmartSearchBar from 'app/components/smartSearchBar';
 import {SearchItem} from 'app/components/smartSearchBar/types';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Organization, SavedSearch, SavedSearchType, Tag} from 'app/types';
 import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
@@ -62,12 +60,6 @@ type State = {
 };
 
 class IssueListSearchBar extends React.Component<Props, State> {
-  static propTypes = {
-    savedSearch: SentryTypes.SavedSearch,
-    tagValueLoader: PropTypes.func.isRequired,
-    onSidebarToggle: PropTypes.func,
-  };
-
   state: State = {
     defaultSearchItems: [SEARCH_ITEMS, []],
     recentSearches: [],

--- a/src/sentry/static/sentry/app/views/issueList/sidebar.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/sidebar.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
 import map from 'lodash/map';
-import PropTypes from 'prop-types';
 
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {IconClose} from 'app/icons/iconClose';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {Tag, TagCollection} from 'app/types';
 import {objToQuery, QueryObj, queryToObj} from 'app/utils/stream';
@@ -32,14 +30,6 @@ type State = {
 };
 
 class IssueListSidebar extends React.Component<Props, State> {
-  static propTypes: any = {
-    tags: PropTypes.objectOf(SentryTypes.Tag).isRequired,
-    query: PropTypes.string,
-    onQueryChange: PropTypes.func.isRequired,
-    loading: PropTypes.bool,
-    tagValueLoader: PropTypes.func.isRequired,
-  };
-
   static defaultProps: DefaultProps = {
     tags: {},
     query: '',

--- a/src/sentry/static/sentry/app/views/issueList/sortOptions.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/sortOptions.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import Feature from 'app/components/acl/feature';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
@@ -47,11 +46,6 @@ const IssueListSortOptions = ({onSelect, sort}: Props) => {
       <Feature features={['issue-list-trend-sort']}>{getMenuItem('trend')}</Feature>
     </DropdownControl>
   );
-};
-
-IssueListSortOptions.propTypes = {
-  sort: PropTypes.string.isRequired,
-  onSelect: PropTypes.func.isRequired,
 };
 
 export default IssueListSortOptions;

--- a/src/sentry/static/sentry/app/views/monitors/monitorCheckIns.tsx
+++ b/src/sentry/static/sentry/app/views/monitors/monitorCheckIns.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import AsyncComponent from 'app/components/asyncComponent';
 import Duration from 'app/components/duration';
@@ -27,10 +26,6 @@ type State = {
 } & AsyncComponent['state'];
 
 export default class MonitorCheckIns extends AsyncComponent<Props, State> {
-  static propTypes = {
-    monitor: PropTypes.object.isRequired,
-  };
-
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {monitor} = this.props;
     return [

--- a/src/sentry/static/sentry/app/views/onboarding/createSampleEventButton.tsx
+++ b/src/sentry/static/sentry/app/views/onboarding/createSampleEventButton.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {browserHistory} from 'react-router';
 import * as Sentry from '@sentry/react';
-import PropTypes from 'prop-types';
 
 import {
   addErrorMessage,
@@ -11,7 +10,6 @@ import {
 import {Client} from 'app/api';
 import Button from 'app/components/button';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Organization, Project} from 'app/types';
 import {trackAdhocEvent, trackAnalyticsEvent} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
@@ -53,14 +51,6 @@ async function latestEventAvailable(
 }
 
 class CreateSampleEventButton extends React.Component<Props, State> {
-  static propTypes: any = {
-    api: PropTypes.object,
-    organization: SentryTypes.Organization.isRequired,
-    project: SentryTypes.Project,
-    source: PropTypes.string.isRequired,
-    disabled: PropTypes.bool,
-  };
-
   state = {
     creating: false,
   };

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -4,7 +4,6 @@ import {RouteComponentProps} from 'react-router';
 import {PlainRoute} from 'react-router/lib/Route';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
-import PropTypes from 'prop-types';
 
 import {openSudo} from 'app/actionCreators/modal';
 import {fetchOrganizationDetails} from 'app/actionCreators/organization';
@@ -157,16 +156,6 @@ class OrganizationContext extends React.Component<Props, State> {
       (!detailed || (detailed && organization.projects && organization.teams))
     );
   }
-
-  static propTypes = {
-    api: PropTypes.object,
-    routes: PropTypes.arrayOf(PropTypes.object),
-    includeSidebar: PropTypes.bool,
-    useLastOrganization: PropTypes.bool,
-    organizationsLoading: PropTypes.bool,
-    organizations: PropTypes.arrayOf(SentryTypes.Organization),
-    detailed: PropTypes.bool,
-  } as any;
 
   static childContextTypes = {
     organization: SentryTypes.Organization,

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/shareIssue.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/shareIssue.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import ActionButton from 'app/components/actions/button';
 import AutoSelectText from 'app/components/autoSelectText';
@@ -95,15 +94,6 @@ type Props = {
 };
 
 class ShareIssue extends React.Component<Props> {
-  static propTypes = {
-    loading: PropTypes.bool.isRequired,
-    isShared: PropTypes.bool,
-    shareUrl: PropTypes.string,
-    onToggle: PropTypes.func.isRequired,
-    onReshare: PropTypes.func.isRequired,
-    disabled: PropTypes.bool,
-  };
-
   hasConfirmModal = false;
 
   handleToggleShare = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -3,7 +3,6 @@ import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
-import PropTypes from 'prop-types';
 
 import {fetchSentryAppComponents} from 'app/actionCreators/sentryAppComponents';
 import {Client} from 'app/api';
@@ -15,7 +14,6 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import MutedBox from 'app/components/mutedBox';
 import ReprocessedBox from 'app/components/reprocessedBox';
 import ResolutionBox from 'app/components/resolutionBox';
-import SentryTypes from 'app/sentryTypes';
 import {
   Environment,
   Group,
@@ -58,14 +56,6 @@ type State = {
 };
 
 class GroupEventDetails extends React.Component<Props, State> {
-  static propTypes = {
-    api: PropTypes.object.isRequired,
-    group: SentryTypes.Group.isRequired,
-    project: SentryTypes.Project.isRequired,
-    organization: SentryTypes.Organization.isRequired,
-    environments: PropTypes.arrayOf(SentryTypes.Environment).isRequired,
-  };
-
   state: State = {
     eventNavLinks: '',
     releasesCompletion: null,

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarTraceID/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupSimilarIssues/similarTraceID/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 
 import Body from './body';
@@ -17,10 +16,6 @@ const SimilarTraceID = ({event, ...props}: Props) => {
       <Body traceID={traceID} event={event} {...props} />
     </Wrapper>
   );
-};
-
-SimilarTraceID.propTypes = {
-  event: SentryTypes.Event,
 };
 
 export default SimilarTraceID;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/SplitInstallationIdModal.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/SplitInstallationIdModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {addSuccessMessage} from 'app/actionCreators/indicator';
 import Button from 'app/components/button';
@@ -17,11 +16,6 @@ type Props = {
  * We also have a link for users to click so they can go to Split's website.
  */
 export default class SplitInstallationIdModal extends React.Component<Props> {
-  static propTypes = {
-    installationId: PropTypes.string.isRequired,
-    closeModal: PropTypes.func.isRequired,
-  };
-
   onCopy = async () =>
     //This hack is needed because the normal copying methods with TextCopyInput do not work correctly
     await navigator.clipboard.writeText(this.props.installationId);

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/addIntegration.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import * as queryString from 'query-string';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {IntegrationProvider, IntegrationWithConfig, Organization} from 'app/types';
 import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 
@@ -27,15 +25,6 @@ type Props = {
 };
 
 export default class AddIntegration extends React.Component<Props> {
-  static propTypes = {
-    children: PropTypes.func.isRequired,
-    provider: PropTypes.object.isRequired,
-    onInstall: PropTypes.func.isRequired,
-    integrationId: PropTypes.string,
-    account: PropTypes.string,
-    organization: SentryTypes.Organization,
-  };
-
   componentDidMount() {
     window.addEventListener('message', this.didReceiveMessage);
   }

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationIcon.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import PluginIcon, {DEFAULT_ICON, ICON_PATHS} from 'app/plugins/components/pluginIcon';
 import {Integration} from 'app/types';
@@ -45,10 +44,5 @@ const IntegrationIcon = ({integration, size = 32}: Props) =>
   ) : (
     <PluginIcon size={size} pluginId={integration.provider.key} />
   );
-
-IntegrationIcon.propTypes = {
-  integration: PropTypes.object.isRequired,
-  size: PropTypes.number,
-};
 
 export default IntegrationIcon;

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationItem.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import space from 'app/styles/space';
 import {Integration} from 'app/types';
@@ -14,11 +13,6 @@ type Props = DefaultProps & {
   integration: Integration;
 };
 export default class IntegrationItem extends React.Component<Props> {
-  static propTypes = {
-    integration: PropTypes.object.isRequired,
-    compact: PropTypes.bool,
-  };
-
   static defaultProps: DefaultProps = {
     compact: false,
   };

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationRepos.tsx
@@ -35,9 +35,6 @@ type State = AsyncComponent['state'] & {
 };
 
 export default class IntegrationRepos extends AsyncComponent<Props, State> {
-  static propTypes = {
-    integration: PropTypes.object.isRequired,
-  };
   static contextTypes = {
     organization: PropTypes.object.isRequired,
     router: PropTypes.object,

--- a/src/sentry/static/sentry/app/views/performance/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/index.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {PageContent} from 'app/styles/organization';
 import {Organization} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
@@ -13,10 +12,6 @@ type Props = {
 };
 
 class PerformanceContainer extends React.Component<Props> {
-  static propTypes = {
-    organization: SentryTypes.Organization.isRequired,
-  };
-
   renderNoAccess() {
     return (
       <PageContent>

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {Params} from 'react-router/lib/Router';
 import {Location} from 'history';
-import PropTypes from 'prop-types';
 
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
@@ -17,7 +16,6 @@ import LoadingError from 'app/components/loadingError';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import TagsTable from 'app/components/tagsTable';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Organization, Project} from 'app/types';
 import {Event, EventTag} from 'app/types/event';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
@@ -41,12 +39,6 @@ type State = {
 } & AsyncComponent['state'];
 
 class EventDetailsContent extends AsyncComponent<Props, State> {
-  static propTypes: any = {
-    organization: SentryTypes.Organization.isRequired,
-    eventSlug: PropTypes.string.isRequired,
-    location: PropTypes.object.isRequired,
-  };
-
   state: State = {
     // AsyncComponent state
     loading: true,

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/index.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import {Params} from 'react-router/lib/Router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import PropTypes from 'prop-types';
 
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {PageContent} from 'app/styles/organization';
 import {Organization} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
@@ -21,11 +19,6 @@ type Props = {
 };
 
 class EventDetails extends React.Component<Props> {
-  static propTypes: any = {
-    organization: SentryTypes.Organization.isRequired,
-    location: PropTypes.object.isRequired,
-  };
-
   getEventSlug = (): string => {
     const {eventSlug} = this.props.params;
     return typeof eventSlug === 'string' ? eventSlug.trim() : '';

--- a/src/sentry/static/sentry/app/views/projectDetail/projectTeamAccess.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectTeamAccess.tsx
@@ -8,7 +8,6 @@ import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
 import Placeholder from 'app/components/placeholder';
 import {t, tn} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 
@@ -70,11 +69,6 @@ function ProjectTeamAccess({organization, project}: Props) {
     </Section>
   );
 }
-
-ProjectTeamAccess.propTypes = {
-  organization: SentryTypes.Organization.isRequired,
-  project: SentryTypes.Project,
-};
 
 const Section = styled('section')`
   font-size: ${p => p.theme.fontSizeMedium};

--- a/src/sentry/static/sentry/app/views/projectEventRedirect.tsx
+++ b/src/sentry/static/sentry/app/views/projectEventRedirect.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {RouteComponentProps} from 'react-router';
-import PropTypes from 'prop-types';
 
 import DetailedError from 'app/components/errors/detailedError';
 import {t} from 'app/locale';
@@ -23,10 +22,6 @@ type State = {
  * https://github.com/getsentry/sentry/blob/824c03089907ad22a9282303a5eaca33989ce481/src/sentry/web/urls.py#L578
  */
 class ProjectEventRedirect extends React.Component<Props, State> {
-  static propTypes = {
-    router: PropTypes.object,
-  };
-
   state: State = {
     error: null,
   };

--- a/src/sentry/static/sentry/app/views/projectsDashboard/deploys.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/deploys.tsx
@@ -7,7 +7,6 @@ import TimeSince from 'app/components/timeSince';
 import Version from 'app/components/version';
 import {IconReleases} from 'app/icons';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {Deploy as DeployType, Project} from 'app/types';
 import getDynamicText from 'app/utils/getDynamicText';
@@ -49,10 +48,6 @@ const Deploys = ({project}: Props) => {
   );
 };
 
-Deploys.propTypes = {
-  project: SentryTypes.Project.isRequired,
-};
-
 export default Deploys;
 
 type DeployProps = Props & {
@@ -80,11 +75,6 @@ const Deploy = ({deploy, project}: DeployProps) => (
     </DeployTime>
   </React.Fragment>
 );
-
-Deploy.propTypes = {
-  deploy: SentryTypes.Deploy.isRequired,
-  project: SentryTypes.Project.isRequired,
-};
 
 const NoDeploys = () => (
   <GetStarted>

--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import {withProfiler} from '@sentry/react';
 import flatten from 'lodash/flatten';
 import uniqBy from 'lodash/uniqBy';
-import PropTypes from 'prop-types';
 
 import {Client} from 'app/api';
 import Button from 'app/components/button';
@@ -17,7 +16,6 @@ import PageHeading from 'app/components/pageHeading';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {IconAdd} from 'app/icons';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';
 import space from 'app/styles/space';
 import {Organization, TeamWithProjects} from 'app/types';
@@ -38,13 +36,6 @@ type Props = {
 } & RouteComponentProps<{orgId: string}, {}>;
 
 class Dashboard extends React.Component<Props> {
-  static propTypes = {
-    teams: PropTypes.array,
-    organization: SentryTypes.Organization,
-    loadingTeams: PropTypes.bool,
-    error: PropTypes.instanceOf(Error),
-  };
-
   componentWillUnmount() {
     ProjectsStatsStore.reset();
   }

--- a/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/projectCard.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 
 import {loadStatsForProject} from 'app/actionCreators/projects';
@@ -11,7 +10,6 @@ import Link from 'app/components/links/link';
 import BookmarkStar from 'app/components/projects/bookmarkStar';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {t, tn} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import ProjectsStatsStore from 'app/stores/projectsStatsStore';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
@@ -30,12 +28,6 @@ type Props = {
 };
 
 class ProjectCard extends React.Component<Props> {
-  static propTypes = {
-    organization: SentryTypes.Organization.isRequired,
-    project: SentryTypes.Project.isRequired,
-    hasProjectAccess: PropTypes.bool,
-  };
-
   componentDidMount() {
     const {organization, project, api} = this.props;
 
@@ -153,9 +145,6 @@ type ContainerState = {
 };
 
 const ProjectCardContainer = createReactClass<ContainerProps, ContainerState>({
-  propTypes: {
-    project: SentryTypes.Project,
-  },
   mixins: [Reflux.listenTo(ProjectsStatsStore, 'onProjectStoreUpdate') as any],
   getInitialState(): ContainerState {
     const {project} = this.props;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/teamMembers.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/teamMembers.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import AsyncComponent from 'app/components/asyncComponent';
 import AvatarList from 'app/components/avatar/avatarList';
@@ -15,11 +14,6 @@ type State = AsyncComponent['state'] & {
 };
 
 class TeamMembers extends AsyncComponent<Props, State> {
-  static propTypes = {
-    teamId: PropTypes.string.isRequired,
-    orgId: PropTypes.string.isRequired,
-  };
-
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {orgId, teamId} = this.props;
     return [['members', `/teams/${orgId}/${teamId}/members/`]];

--- a/src/sentry/static/sentry/app/views/projectsDashboard/teamSection.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/teamSection.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import PageHeading from 'app/components/pageHeading';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {Project, Scope, Team} from 'app/types';
 
@@ -41,15 +39,6 @@ const TeamSection = ({team, projects, title, showBorder, orgId, access}: Props) 
       </ProjectCards>
     </TeamSectionWrapper>
   );
-};
-
-TeamSection.propTypes = {
-  team: SentryTypes.Team,
-  orgId: PropTypes.string,
-  showBorder: PropTypes.bool,
-  access: PropTypes.object,
-  title: PropTypes.node,
-  projects: PropTypes.array,
 };
 
 const ProjectCards = styled('div')`

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseActions.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseActions.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {archiveRelease, restoreRelease} from 'app/actionCreators/release';
 import {Client} from 'app/api';
@@ -15,7 +14,6 @@ import TextOverflow from 'app/components/textOverflow';
 import Tooltip from 'app/components/tooltip';
 import {IconEllipsis} from 'app/icons';
 import {t, tct, tn} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {Release, ReleaseMeta} from 'app/types';
 import {formatVersion} from 'app/utils/formatters';
@@ -162,14 +160,6 @@ function ReleaseActions({
     </ButtonBar>
   );
 }
-
-ReleaseActions.propTypes = {
-  orgSlug: PropTypes.string.isRequired,
-  projectSlug: PropTypes.string.isRequired,
-  release: SentryTypes.Release.isRequired,
-  releaseMeta: PropTypes.object.isRequired,
-  refetchData: PropTypes.func.isRequired,
-};
 
 const ActionsButton = styled(Button)`
   width: 40px;

--- a/src/sentry/static/sentry/app/views/routeError.tsx
+++ b/src/sentry/static/sentry/app/views/routeError.tsx
@@ -20,12 +20,6 @@ type Props = WithRouterProps & {
 };
 
 class RouteError extends React.Component<Props> {
-  static propTypes = {
-    disableLogSentry: PropTypes.bool,
-    disableReport: PropTypes.bool,
-    error: PropTypes.instanceOf(Error),
-  };
-
   static contextTypes = {
     organization: PropTypes.object,
     project: PropTypes.object,

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import space from 'app/styles/space';
 import TextBlock from 'app/views/settings/components/text/textBlock';
@@ -55,15 +54,6 @@ const EmptyMessage = styled(
   font-size: ${p =>
     p.size && p.size === 'large' ? p.theme.fontSizeExtraLarge : p.theme.fontSizeLarge};
 `;
-
-EmptyMessage.propTypes = {
-  title: PropTypes.node,
-  description: PropTypes.node,
-  icon: PropTypes.node,
-  action: PropTypes.element,
-  // Currently only the `large` option changes the size - can add more size options as necessary
-  size: PropTypes.oneOf(['large', 'medium']),
-};
 
 const IconWrapper = styled('div')`
   color: ${p => p.theme.gray200};

--- a/src/sentry/static/sentry/app/views/settings/components/forms/choiceMapperField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/choiceMapperField.jsx
@@ -12,11 +12,12 @@ import space from 'app/styles/space';
 import {defined, objectIsEmpty} from 'app/utils';
 import InputField from 'app/views/settings/components/forms/inputField';
 
-const selectControlShape = PropTypes.shape(SelectControl.propTypes);
+const selectControlShape = PropTypes.object;
 
 export default class ChoiceMapper extends React.Component {
   static propTypes = {
-    ...InputField.propTypes,
+    // TODO(ts)
+    // ...InputField.propTypes,
     /**
      * Text used for the 'add row' button.
      */
@@ -24,7 +25,7 @@ export default class ChoiceMapper extends React.Component {
     /**
      * Configuration for the add item dropdown.
      */
-    addDropdown: PropTypes.shape(DropdownAutoComplete.propTypes).isRequired,
+    addDropdown: PropTypes.object.isRequired,
     /**
      * The label to show above the row name selected from the dropdown.
      */

--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/radioGroup.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Radio from 'app/components/radio';
 import space from 'app/styles/space';
@@ -67,15 +66,6 @@ const RadioGroup = <C extends string>({
     ))}
   </Container>
 );
-
-RadioGroup.propTypes = {
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  // TODO(ts): This is causing issues with ts
-  choices: PropTypes.any.isRequired,
-  disabled: PropTypes.bool,
-  label: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-};
 
 const shouldForwardProp = p => !['disabled', 'animate'].includes(p) && isPropValid(p);
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/rangeSlider.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/rangeSlider.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {t} from 'app/locale';
 import space from 'app/styles/space';
@@ -64,56 +63,6 @@ type State = {
 };
 
 class RangeSlider extends React.Component<Props, State> {
-  static propTypes = {
-    name: PropTypes.string.isRequired,
-    /**
-     * min allowed value, not needed if using `allowedValues`
-     */
-    min: PropTypes.number,
-    /**
-     * max allowed value, not needed if using `allowedValues`
-     */
-    max: PropTypes.number,
-    /**
-     * String is a valid type here only for empty string
-     * Otherwise react complains:
-     * "`value` prop on `input` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components."
-     *
-     * And we want this to be a controlled input when value is empty
-     */
-    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    step: PropTypes.number,
-    disabled: PropTypes.bool,
-    onChange: PropTypes.func,
-
-    /**
-     * Render prop for slider's label
-     * Is passed the value as an argument
-     */
-    formatLabel: PropTypes.func,
-
-    /**
-     * Array of allowed values. Make sure `value` is in this list.
-     * THIS NEEDS TO BE SORTED
-     */
-    allowedValues: PropTypes.arrayOf(PropTypes.number),
-
-    /**
-     * Show custom input
-     */
-    showCustomInput: PropTypes.bool,
-
-    // Placeholder for custom input
-    placeholder: PropTypes.string,
-
-    /**
-     * This is called when *any* MouseUp or KeyUp event happens.
-     * Used for "smart" Fields to trigger a "blur" event. `onChange` can
-     * be triggered quite frequently
-     */
-    onBlur: PropTypes.func,
-  };
-
   state: State = {
     sliderValue: this.props.allowedValues
       ? // With `allowedValues` sliderValue will be the index to value in `allowedValues`

--- a/src/sentry/static/sentry/app/views/settings/components/forms/controls/textarea.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/controls/textarea.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import TextareaAutosize from 'react-autosize-textarea';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {inputStyles} from 'app/styles/input';
 
@@ -31,12 +30,6 @@ const TextAreaControl = React.forwardRef(function TextAreaControl(
 });
 
 TextAreaControl.displayName = 'TextAreaControl';
-
-TextAreaControl.propTypes = {
-  autosize: PropTypes.bool,
-  rows: PropTypes.number,
-  monospace: PropTypes.bool,
-};
 
 const propFilter = (p: string) =>
   ['autosize', 'rows', 'maxRows'].includes(p) || isPropValid(p);

--- a/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import {Scope} from 'app/types';
 
@@ -36,58 +35,6 @@ type Props = {
 };
 
 export default class FieldFromConfig extends React.Component<Props> {
-  static propTypes = {
-    field: PropTypes.shape({
-      name: PropTypes.string,
-      type: PropTypes.oneOf([
-        'array',
-        'boolean',
-        'choice',
-        'choice_mapper',
-        'custom',
-        'email',
-        'hidden',
-        'multichoice',
-        'number',
-        'radio',
-        'range',
-        'rich_list',
-        'secret',
-        'select',
-        'separator',
-        'string',
-        'text',
-        'textarea',
-        'url',
-        'table',
-        'project_mapper',
-        'sentry_project_selector',
-      ]),
-      required: PropTypes.bool,
-      multiline: PropTypes.bool,
-      label: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-      placeholder: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-      help: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
-      visible: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
-      disabled: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
-      /**
-       * Function to format the value displayed in the undo toast. May also be
-       * specified as false to disable showing the changed fields in the toast.
-       */
-      formatMessageValue: PropTypes.oneOfType([PropTypes.func, PropTypes.oneOf([false])]),
-      /**
-       * Should show a "return key" icon in input?
-       */
-      showReturnButton: PropTypes.bool,
-      /**
-       * Iff false, disable saveOnBlur for field, instead show a save/cancel button
-       */
-      saveOnBlur: PropTypes.bool,
-      getValue: PropTypes.func,
-      setValue: PropTypes.func,
-    }).isRequired,
-  };
-
   render() {
     const {field, ...otherProps} = this.props;
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -169,7 +169,7 @@ export default class Form extends React.Component<Props> {
     return (
       <form
         onSubmit={this.onSubmit}
-        className={className ?? 'form-stackd'}
+        className={className ?? 'form-stacked'}
         data-test-id={this.props['data-test-id']}
       >
         <div>

--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -62,34 +62,6 @@ type Context = {
 };
 
 export default class Form extends React.Component<Props> {
-  static propTypes: any = {
-    cancelLabel: PropTypes.string,
-    onCancel: PropTypes.func,
-    onSubmit: PropTypes.func,
-    onSubmitSuccess: PropTypes.func,
-    onSubmitError: PropTypes.func,
-    onFieldChange: PropTypes.func,
-    submitDisabled: PropTypes.bool,
-    submitLabel: PropTypes.string,
-    submitPriority: PropTypes.string,
-    footerClass: PropTypes.string,
-    footerStyle: PropTypes.object,
-    extraButton: PropTypes.element,
-    initialData: PropTypes.object,
-    // Require changes before able to submit form
-    requireChanges: PropTypes.bool,
-    // Reset form when there are errors, after submit
-    resetOnError: PropTypes.bool,
-    hideFooter: PropTypes.bool,
-    allowUndo: PropTypes.bool,
-    // Save field on control blur
-    saveOnBlur: PropTypes.bool,
-    model: PropTypes.object,
-    apiMethod: PropTypes.string,
-    apiEndpoint: PropTypes.string,
-    'data-test-id': PropTypes.string,
-  };
-
   static childContextTypes = {
     saveOnBlur: PropTypes.bool.isRequired,
     form: PropTypes.object.isRequired,

--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -64,8 +64,8 @@ type Context = {
 
 export default class Form extends React.Component<Props> {
   static childContextTypes = {
-    saveOnBlur: PropTypes.bool.isRequired,
-    form: PropTypes.object.isRequired,
+    saveOnBlur: PropTypes.bool,
+    form: PropTypes.object,
   };
 
   constructor(props: Props, context: Context) {

--- a/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/form.tsx
@@ -43,6 +43,7 @@ type Props = {
   model?: FormModel;
   // if set to true, preventDefault is not called
   skipPreventDefault?: boolean;
+  additionalFieldProps?: {[key: string]: any};
   'data-test-id'?: string;
 
   onCancel?: (e: React.MouseEvent) => void;
@@ -65,17 +66,6 @@ export default class Form extends React.Component<Props> {
   static childContextTypes = {
     saveOnBlur: PropTypes.bool.isRequired,
     form: PropTypes.object.isRequired,
-  };
-
-  static defaultProps = {
-    cancelLabel: t('Cancel'),
-    submitLabel: t('Save Changes'),
-    submitDisabled: false,
-    submitPriority: 'primary' as 'primary',
-    className: 'form-stacked',
-    requireChanges: false,
-    allowUndo: false,
-    saveOnBlur: false,
   };
 
   constructor(props: Props, context: Context) {
@@ -179,7 +169,7 @@ export default class Form extends React.Component<Props> {
     return (
       <form
         onSubmit={this.onSubmit}
-        className={className}
+        className={className ?? 'form-stackd'}
         data-test-id={this.props['data-test-id']}
       >
         <div>
@@ -203,7 +193,7 @@ export default class Form extends React.Component<Props> {
                       onClick={onCancel}
                       style={{marginLeft: 5}}
                     >
-                      {cancelLabel}
+                      {cancelLabel ?? t('Cancel')}
                     </Button>
                   )}
                 </Observer>
@@ -213,7 +203,7 @@ export default class Form extends React.Component<Props> {
                 {() => (
                   <Button
                     data-test-id="form-submit"
-                    priority={submitPriority}
+                    priority={submitPriority ?? 'primary'}
                     disabled={
                       this.model.isError ||
                       this.model.isSaving ||
@@ -222,7 +212,7 @@ export default class Form extends React.Component<Props> {
                     }
                     type="submit"
                   >
-                    {submitLabel}
+                    {submitLabel ?? t('Save Changes')}
                   </Button>
                 )}
               </Observer>

--- a/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/jsonForm.tsx
@@ -8,7 +8,6 @@ import scrollToElement from 'scroll-to-element';
 import {defined} from 'app/utils';
 import {sanitizeQuerySelector} from 'app/utils/sanitizeQuerySelector';
 
-import FieldFromConfig from './fieldFromConfig';
 import FormPanel from './formPanel';
 import {Field, FieldObject, JsonFormObject} from './type';
 
@@ -44,44 +43,6 @@ type State = {
 };
 
 class JsonForm extends React.Component<Props, State> {
-  static propTypes = {
-    /**
-     * Fields that are grouped by "section"
-     */
-    forms: PropTypes.arrayOf(
-      PropTypes.shape({
-        title: PropTypes.string,
-        fields: PropTypes.arrayOf(
-          PropTypes.oneOfType([PropTypes.func, FieldFromConfig.propTypes.field])
-        ),
-      })
-    ),
-
-    /**
-     * If `forms` is not defined, `title` + `fields` must be required.
-     * Allows more fine grain control of title/fields
-     */
-    fields: PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.func, FieldFromConfig.propTypes.field])
-    ),
-    /**
-     * Panel title if `forms` is not defined
-     */
-    title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-
-    access: PropTypes.object,
-    features: PropTypes.object,
-    renderFooter: PropTypes.func,
-    /**
-     * Renders inside of PanelBody
-     */
-    renderHeader: PropTypes.func,
-    /**
-     * Disables the entire form
-     */
-    disabled: PropTypes.bool,
-  };
-
   static contextTypes = {
     location: PropTypes.object,
   };

--- a/src/sentry/static/sentry/app/views/settings/components/forms/passwordField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/passwordField.jsx
@@ -8,7 +8,8 @@ import InputField from 'app/views/settings/components/forms/inputField';
 // value propagation in all scenarios
 export default class PasswordField extends InputField {
   static propTypes = {
-    ...InputField.propTypes,
+    // TODO(ts)
+    // ...InputField.propTypes,
     hasSavedValue: PropTypes.bool,
     prefix: PropTypes.string,
   };

--- a/src/sentry/static/sentry/app/views/settings/components/forms/richListField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/richListField.jsx
@@ -20,7 +20,7 @@ const RichListProps = {
   /**
    * Configuration for the add item dropdown.
    */
-  addDropdown: PropTypes.shape(DropdownAutoComplete.propTypes).isRequired,
+  addDropdown: PropTypes.object.isRequired,
 
   /**
    * Render function to render an item.
@@ -196,7 +196,8 @@ class RichList extends React.PureComponent {
 
 export default class RichListField extends React.PureComponent {
   static propTypes = {
-    ...InputField.propTypes,
+    // TODO(ts)
+    // ...InputField.propTypes,
     ...RichListProps,
   };
 

--- a/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/selectField.jsx
@@ -16,7 +16,8 @@ const getChoices = props => {
 
 export default class SelectField extends React.Component {
   static propTypes = {
-    ...InputField.propTypes,
+    // TODO(ts)
+    // ...InputField.propTypes,
     choices: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
     options: PropTypes.arrayOf(PropTypes.object),
     allowClear: PropTypes.bool,
@@ -29,7 +30,8 @@ export default class SelectField extends React.Component {
   };
 
   static defaultProps = {
-    ...InputField.defaultProps,
+    // TODO(ts)
+    // ...InputField.propTypes,
     allowClear: false,
     allowEmpty: false,
     placeholder: '--',

--- a/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsBreadcrumb/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import createReactClass from 'create-react-class';
-import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 
 import SettingsBreadcrumbActions from 'app/actions/settingsBreadcrumbActions';
@@ -33,13 +32,6 @@ type Props = {
 };
 
 class SettingsBreadcrumb extends React.Component<Props> {
-  static propTypes = {
-    routes: PropTypes.array,
-    // pathMap maps stringifed routes to a breadcrumb title. This property is
-    // provided by the SettingsBreadcrumbStore.
-    pathMap: PropTypes.object,
-  };
-
   static contextTypes = {
     organization: SentryTypes.Organization,
   };

--- a/src/sentry/static/sentry/app/views/settings/components/teamSelect.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/teamSelect.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
-import PropTypes from 'prop-types';
 
 import {Client} from 'app/api';
 import Button from 'app/components/button';
@@ -197,14 +196,6 @@ const TeamRow = props => {
       </Confirm>
     </TeamPanelItem>
   );
-};
-
-TeamRow.propTypes = {
-  disabled: PropTypes.bool,
-  team: PropTypes.string.isRequired,
-  orgId: PropTypes.string.isRequired,
-  onRemove: PropTypes.func.isRequired,
-  confirmMessage: PropTypes.string,
 };
 
 const TeamDropdownElement = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/organization/organizationSettingsNavigation.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/organizationSettingsNavigation.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
 
-import SentryTypes from 'app/sentryTypes';
 import HookStore from 'app/stores/hookStore';
 import {Organization} from 'app/types';
 import {HookName, Hooks} from 'app/types/hooks';
@@ -22,9 +21,6 @@ type State = {
 
 const OrganizationSettingsNavigation = createReactClass<Props, State>({
   displayName: 'OrganizationSettingsNavigation',
-  propTypes: {
-    organization: SentryTypes.Organization,
-  },
 
   /**
    * TODO(epurkhiser): Becase the settings organization navigation hooks

--- a/src/sentry/static/sentry/app/views/settings/organization/permissionAlert.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organization/permissionAlert.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import Access from 'app/components/acl/access';
 import Alert from 'app/components/alert';
@@ -22,9 +21,5 @@ const PermissionAlert = ({access = ['org:write'], ...props}: Props) => (
     }
   </Access>
 );
-
-PermissionAlert.propTypes = {
-  access: PropTypes.arrayOf(PropTypes.string),
-};
 
 export default PermissionAlert;

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -7,7 +7,6 @@ import Button from 'app/components/button';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {IconAdd} from 'app/icons';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Organization, SentryApp} from 'app/types';
 import routeTitleGen from 'app/utils/routeTitle';
 import withOrganization from 'app/utils/withOrganization';
@@ -25,10 +24,6 @@ type State = AsyncView['state'] & {
 };
 
 class OrganizationDeveloperSettings extends AsyncView<Props, State> {
-  static propTypes = {
-    organization: SentryTypes.Organization.isRequired,
-  };
-
   getTitle() {
     const {orgId} = this.props.params;
     return routeTitleGen(t('Developer Settings'), orgId, false);

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -89,12 +89,6 @@ type State = {
 };
 
 export default class PermissionSelection extends React.Component<Props, State> {
-  static propTypes = {
-    permissions: PropTypes.object.isRequired,
-    onChange: PropTypes.func.isRequired,
-    appPublished: PropTypes.bool,
-  };
-
   static contextTypes = {
     router: PropTypes.object.isRequired,
     form: PropTypes.object,

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/permissionsObserver.tsx
@@ -24,13 +24,6 @@ type State = {
 };
 
 export default class PermissionsObserver extends React.Component<Props, State> {
-  static propTypes = {
-    scopes: PropTypes.arrayOf(PropTypes.string).isRequired,
-    events: PropTypes.arrayOf(PropTypes.string).isRequired,
-    webhookDisabled: PropTypes.bool.isRequired,
-    appPublished: PropTypes.bool.isRequired,
-  };
-
   static contextTypes = {
     router: PropTypes.object.isRequired,
     form: PropTypes.object,

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/resourceSubscriptions.tsx
@@ -23,13 +23,6 @@ type Props = DefaultProps & {
 };
 
 export default class Subscriptions extends React.Component<Props> {
-  static propTypes = {
-    permissions: PropTypes.object.isRequired,
-    events: PropTypes.array.isRequired,
-    onChange: PropTypes.func.isRequired,
-    webhookDisabled: PropTypes.bool.isRequired,
-  };
-
   static contextTypes = {
     router: PropTypes.object.isRequired,
     form: PropTypes.object,

--- a/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationDeveloperSettings/subscriptionBox.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Checkbox from 'app/components/checkbox';
 import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Organization} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
 import {
@@ -28,15 +26,6 @@ type Props = DefaultProps & {
 };
 
 export class SubscriptionBox extends React.Component<Props> {
-  static propTypes: any = {
-    resource: PropTypes.string.isRequired,
-    disabledFromPermissions: PropTypes.bool.isRequired,
-    webhookDisabled: PropTypes.bool.isRequired,
-    checked: PropTypes.bool.isRequired,
-    onChange: PropTypes.func.isRequired,
-    organization: SentryTypes.Organization,
-  };
-
   static defaultProps: DefaultProps = {
     webhookDisabled: false,
   };

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Checkbox from 'app/components/checkbox';
 import Switch from 'app/components/switch';
@@ -130,17 +129,6 @@ const BooleanFilter = ({onChange, value, children}: BooleanFilterProps) => (
     />
   </label>
 );
-
-MembersFilter.propTypes = {
-  roles: PropTypes.arrayOf(PropTypes.object).isRequired as any,
-  query: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-};
-
-BooleanFilter.propTypes = {
-  onChange: PropTypes.func.isRequired,
-  value: PropTypes.oneOf([null, true, false]),
-};
 
 const FilterContainer = styled('div')`
   border-radius: 4px;

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/roleSelect.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteMember/roleSelect.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {Panel, PanelBody, PanelHeader, PanelItem} from 'app/components/panels';
 import Radio from 'app/components/radio';
@@ -24,17 +23,6 @@ type Props = {
 };
 
 class RoleSelect extends React.Component<Props> {
-  static propTypes = {
-    /**
-     * Whether to disable or not using `allowed` prop from API request
-     */
-    enforceAllowed: PropTypes.bool,
-    disabled: PropTypes.bool,
-    selectedRole: PropTypes.string,
-    roleList: PropTypes.array,
-    setRole: PropTypes.func,
-  };
-
   render() {
     const {disabled, enforceAllowed, roleList, selectedRole} = this.props;
 

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
@@ -148,22 +147,6 @@ const InviteRequestRow = ({
       {hookRenderer}
     </InviteModalHook>
   );
-};
-
-InviteRequestRow.propTypes = {
-  inviteRequest: PropTypes.shape({
-    email: PropTypes.string,
-    id: PropTypes.string,
-    inviterName: PropTypes.string,
-    inviteStatus: PropTypes.string,
-    role: PropTypes.string,
-    teams: PropTypes.arrayOf(PropTypes.string),
-  }),
-  onApprove: PropTypes.func,
-  onDeny: PropTypes.func,
-  inviteRequestBusy: PropTypes.object,
-  allRoles: PropTypes.arrayOf(PropTypes.object),
-  allTeams: PropTypes.arrayOf(PropTypes.object),
 };
 
 const JoinRequestIndicator = styled(Tag)`

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersList.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationMembersList.tsx
@@ -13,7 +13,6 @@ import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {MEMBER_ROLES} from 'app/constants';
 import {IconSliders} from 'app/icons';
 import {t, tct} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import ConfigStore from 'app/stores/configStore';
 import space from 'app/styles/space';
 import {Member, MemberRole, Organization} from 'app/types';
@@ -37,10 +36,6 @@ type State = AsyncView['state'] & {
 };
 
 class OrganizationMembersList extends AsyncView<Props, State> {
-  static propTypes = {
-    organization: SentryTypes.Organization,
-  };
-
   getDefaultState() {
     return {
       ...super.getDefaultState(),

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationRequestsView.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/organizationRequestsView.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {RouteComponentProps} from 'react-router';
-import PropTypes from 'prop-types';
 
 import {addErrorMessage, addSuccessMessage} from 'app/actionCreators/indicator';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
@@ -36,14 +35,6 @@ type State = AsyncView['state'] & {
 };
 
 class OrganizationRequestsView extends AsyncView<Props, State> {
-  static propTypes = {
-    requestList: PropTypes.array.isRequired,
-    inviteRequests: PropTypes.array.isRequired,
-    onRemoveInviteRequest: PropTypes.func.isRequired,
-    onRemoveAccessRequest: PropTypes.func.isRequired,
-    showInviteRequests: PropTypes.bool.isRequired,
-  };
-
   static defaultProps: DefaultProps = {
     inviteRequests: [],
   };

--- a/src/sentry/static/sentry/app/views/settings/organizationRepositories/organizationRepositories.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationRepositories/organizationRepositories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {RouteComponentProps} from 'react-router';
-import PropTypes from 'prop-types';
 
 import {Client} from 'app/api';
 import AlertLink from 'app/components/alertLink';
@@ -84,12 +83,6 @@ const OrganizationRepositories = ({itemList, onRepositoryChange, api, params}: P
       )}
     </div>
   );
-};
-
-OrganizationRepositories.propTypes = {
-  itemList: PropTypes.array,
-  api: PropTypes.object,
-  onRepositoryChange: PropTypes.func,
 };
 
 export default OrganizationRepositories;

--- a/src/sentry/static/sentry/app/views/settings/project/permissionAlert.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/permissionAlert.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import Access from 'app/components/acl/access';
 import Alert from 'app/components/alert';
@@ -22,9 +21,5 @@ const PermissionAlert = ({access = ['project:write'], ...props}: Props) => (
     }
   </Access>
 );
-
-PermissionAlert.propTypes = {
-  access: PropTypes.arrayOf(PropTypes.string),
-};
 
 export default PermissionAlert;

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import ProjectActions from 'app/actions/projectActions';
 import Access from 'app/components/acl/access';
@@ -90,12 +89,6 @@ type RowState = {
 };
 
 class LegacyBrowserFilterRow extends React.Component<RowProps, RowState> {
-  static propTypes = {
-    data: PropTypes.object.isRequired,
-    onToggle: PropTypes.func.isRequired,
-    disabled: PropTypes.bool,
-  };
-
   constructor(props) {
     super(props);
     let initialSubfilters;

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/projectFiltersSettings.tsx
@@ -369,7 +369,8 @@ class ProjectFiltersSettings extends AsyncComponent<Props, State> {
 
 export default ProjectFiltersSettings;
 
-const NestedForm = styled(Form)`
+// TODO(ts): Understand why styled is not correctly inheriting props here
+const NestedForm = styled(Form)<Form['props']>`
   flex: 1;
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
@@ -759,7 +759,8 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
 export default withOrganization(IssueRuleEditor);
 
-const StyledForm = styled(Form)`
+// TODO(ts): Understand why styled is not correctly inheriting props here
+const StyledForm = styled(Form)<Form['props']>`
   position: relative;
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/ruleRow.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {Link, RouteComponentProps} from 'react-router';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
@@ -35,11 +34,6 @@ type State = {
 };
 
 class RuleRow extends React.Component<Props, State> {
-  static propTypes: any = {
-    data: PropTypes.object.isRequired,
-    canEdit: PropTypes.bool,
-  };
-
   state = {loading: false, error: false};
 
   renderIssueRule(data: IssueAlertRule) {

--- a/src/sentry/static/sentry/app/views/settings/projectPlugins/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectPlugins/index.tsx
@@ -4,7 +4,6 @@ import {WithRouterProps} from 'react-router/lib/withRouter';
 import {disablePlugin, enablePlugin, fetchPlugins} from 'app/actionCreators/plugins';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Organization, Plugin, Project} from 'app/types';
 import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 import withPlugins from 'app/utils/withPlugins';
@@ -24,12 +23,6 @@ type Props = WithRouterProps<{orgId: string; projectId: string}> & {
 };
 
 class ProjectPluginsContainer extends React.Component<Props> {
-  static propTypes: any = {
-    plugins: SentryTypes.PluginsStore,
-    organization: SentryTypes.Organization,
-    project: SentryTypes.Project,
-  };
-
   componentDidMount() {
     this.fetchData();
   }

--- a/src/sentry/static/sentry/app/views/settings/projectPlugins/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectPlugins/index.tsx
@@ -65,7 +65,6 @@ class ProjectPluginsContainer extends React.Component<Props> {
 
         <ProjectPlugins
           {...this.props}
-          onError={this.fetchData}
           onChange={this.handleChange}
           loading={loading}
           error={error}

--- a/src/sentry/static/sentry/app/views/settings/projectPlugins/projectPluginRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectPlugins/projectPluginRow.tsx
@@ -2,14 +2,12 @@ import React from 'react';
 import {Link, RouteComponentProps} from 'react-router';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
-import PropTypes from 'prop-types';
 
 import Access from 'app/components/acl/access';
 import ExternalLink from 'app/components/links/externalLink';
 import Switch from 'app/components/switch';
 import {t} from 'app/locale';
 import PluginIcon from 'app/plugins/components/pluginIcon';
-import SentryTypes from 'app/sentryTypes';
 import {Organization, Plugin, Project} from 'app/types';
 import getDynamicText from 'app/utils/getDynamicText';
 import {trackIntegrationEvent} from 'app/utils/integrationUtil';
@@ -28,11 +26,6 @@ type Props = {
   Pick<RouteComponentProps<{}, {}>, 'params' | 'routes'>;
 
 class ProjectPluginRow extends React.PureComponent<Props> {
-  static propTypes: any = {
-    ...SentryTypes.Plugin,
-    onChange: PropTypes.func,
-  };
-
   handleChange = () => {
     const {onChange, id, enabled} = this.props;
     onChange(id, !enabled);

--- a/src/sentry/static/sentry/app/views/settings/projectPlugins/projectPlugins.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectPlugins/projectPlugins.tsx
@@ -1,6 +1,5 @@
 import React, {Component} from 'react';
 import {WithRouterProps} from 'react-router';
-import PropTypes from 'prop-types';
 
 import Access from 'app/components/acl/access';
 import Link from 'app/components/links/link';
@@ -13,7 +12,6 @@ import {
   PanelItem,
 } from 'app/components/panels';
 import {t, tct} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {Plugin, Project} from 'app/types';
 import RouteError from 'app/views/routeError';
 
@@ -28,15 +26,6 @@ type Props = {
 } & WithRouterProps<{orgId: string}>;
 
 class ProjectPlugins extends Component<Props> {
-  static propTypes = {
-    plugins: PropTypes.arrayOf(SentryTypes.PluginShape),
-    loading: PropTypes.bool,
-    error: PropTypes.any,
-    onChange: PropTypes.func,
-    onError: PropTypes.func,
-    routes: PropTypes.array,
-  };
-
   render() {
     const {plugins, loading, error, onChange, routes, params, project} = this.props;
     const {orgId} = this.props.params;

--- a/src/sentry/static/sentry/app/views/settings/projectProguard/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectProguard/index.tsx
@@ -3,17 +3,12 @@ import React from 'react';
 import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import {PageContent} from 'app/styles/organization';
 import withOrganization from 'app/utils/withOrganization';
 
 import ProjectProguard from './projectProguard';
 
 class ProjectProguardContainer extends React.Component<ProjectProguard['props']> {
-  static propTypes = {
-    organization: SentryTypes.Organization.isRequired,
-  };
-
   renderNoAccess() {
     return (
       <PageContent>

--- a/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
+++ b/src/sentry/static/sentry/app/views/settings/settingsIndex.tsx
@@ -4,7 +4,6 @@ import {RouteComponentProps} from 'react-router';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
-import PropTypes from 'prop-types';
 
 import {fetchOrganizationDetails} from 'app/actionCreators/organizations';
 import OrganizationAvatar from 'app/components/avatar/organizationAvatar';
@@ -15,7 +14,6 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {IconDocs, IconLock, IconStack, IconSupport} from 'app/icons';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import ConfigStore from 'app/stores/configStore';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {Organization} from 'app/types';
@@ -48,10 +46,6 @@ type Props = {
 } & RouteComponentProps<{}, {}>;
 
 class SettingsIndex extends React.Component<Props> {
-  static propTypes = {
-    organization: SentryTypes.Organization,
-  };
-
   componentDidUpdate(prevProps: Props) {
     const {organization} = this.props;
     if (prevProps.organization === organization) {
@@ -356,14 +350,6 @@ const SupportLinkComponent = <T extends boolean>({
     return <ExternalHomeLink isCentered={isCentered} href={href} {...props} />;
   }
   return <HomeLink to={to} {...props} />;
-};
-
-SupportLinkComponent.propTypes = {
-  isOnPremise: PropTypes.bool,
-  href: PropTypes.string,
-  to: PropTypes.string,
-  isCentered: PropTypes.bool,
-  children: PropTypes.node,
 };
 
 const AvatarContainer = styled('div')`

--- a/src/sentry/static/sentry/app/views/userFeedback/userFeedbackEmpty.tsx
+++ b/src/sentry/static/sentry/app/views/userFeedback/userFeedbackEmpty.tsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
-import PropTypes from 'prop-types';
 
 import Button from 'app/components/button';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import {t} from 'app/locale';
-import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import {trackAdhocEvent, trackAnalyticsEvent} from 'app/utils/analytics';
@@ -23,11 +21,6 @@ type Props = {
 };
 
 class UserFeedbackEmpty extends React.Component<Props> {
-  static propTypes = {
-    organization: SentryTypes.Organization.isRequired,
-    projectIds: PropTypes.arrayOf(PropTypes.string.isRequired),
-  };
-
   componentDidMount() {
     const {organization, projectIds} = this.props;
 

--- a/tests/js/spec/components/avatar/actorAvatar.spec.jsx
+++ b/tests/js/spec/components/avatar/actorAvatar.spec.jsx
@@ -57,8 +57,6 @@ describe('ActorAvatar', function () {
     });
 
     it('should return null when actor type is a unknown', function () {
-      window.console.error = jest.fn();
-
       const avatar = mount(
         <ActorAvatar
           actor={{
@@ -70,10 +68,6 @@ describe('ActorAvatar', function () {
       );
 
       expect(avatar.html()).toBe(null);
-      //proptype warning
-      expect(window.console.error.mock.calls.length).toBeGreaterThan(0);
-
-      window.console.error.mockRestore();
     });
   });
 });

--- a/tests/js/spec/views/onboarding/onboarding.spec.jsx
+++ b/tests/js/spec/views/onboarding/onboarding.spec.jsx
@@ -5,7 +5,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import ProjectsStore from 'app/stores/projectsStore';
-import Onboarding, {stepPropTypes} from 'app/views/onboarding/onboarding';
+import Onboarding from 'app/views/onboarding/onboarding';
 
 const MockStep = ({name, data, active, project, onComplete, onUpadte}) => (
   <div>
@@ -16,8 +16,6 @@ const MockStep = ({name, data, active, project, onComplete, onUpadte}) => (
     <a id="update" href="#" onClick={() => onUpadte(data)} />
   </div>
 );
-
-MockStep.propTypes = stepPropTypes;
 
 const makeMockStep = preFill => p => <MockStep {...preFill} {...p} />;
 


### PR DESCRIPTION
Mostly done using fastmod and then various combinations of tsc, eslint, prettier, rg, and sed.

Focuses primarily on tsx files. Does do some cleanup on jsx files as well though where needed.