### PR TITLE
ref(dynamic-sampling): Add actions in the dropdown items

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/actionLink.tsx
+++ b/src/sentry/static/sentry/app/components/actions/actionLink.tsx
@@ -7,7 +7,10 @@ import ConfirmableAction from './confirmableAction';
 
 type ConfirmableActionProps = React.ComponentProps<typeof ConfirmableAction>;
 
-type Props = Omit<ConfirmableActionProps, 'onConfirm' | 'confirmText' | 'children'> & {
+type Props = Omit<
+  ConfirmableActionProps,
+  'onConfirm' | 'confirmText' | 'children' | 'stopPropagation' | 'priority'
+> & {
   title: string;
   onAction?: () => void;
   children?: React.ReactNode;
@@ -15,6 +18,7 @@ type Props = Omit<ConfirmableActionProps, 'onConfirm' | 'confirmText' | 'childre
   disabled?: boolean;
   className?: string;
   shouldConfirm?: boolean;
+  confirmPriority?: ConfirmableActionProps['priority'];
   confirmLabel?: string;
 } & Partial<React.ComponentProps<typeof ActionButton>>;
 
@@ -28,6 +32,7 @@ export default function ActionLink({
   disabled,
   children,
   shouldConfirm,
+  confirmPriority,
   ...props
 }: Props) {
   const action = (
@@ -47,10 +52,12 @@ export default function ActionLink({
     return (
       <ConfirmableAction
         shouldConfirm={shouldConfirm}
+        priority={confirmPriority}
         disabled={disabled}
         message={message}
         confirmText={confirmLabel}
         onConfirm={onAction}
+        stopPropagation={disabled}
       >
         {action}
       </ConfirmableAction>

--- a/src/sentry/static/sentry/app/components/actions/confirmableAction.tsx
+++ b/src/sentry/static/sentry/app/components/actions/confirmableAction.tsx
@@ -6,7 +6,7 @@ type ConfirmProps = React.ComponentProps<typeof Confirm>;
 type Props = {
   children: React.ReactNode | ConfirmProps['children'];
   shouldConfirm?: boolean;
-} & Partial<Pick<ConfirmProps, 'confirmText'>> &
+} & Partial<Pick<ConfirmProps, 'confirmText' | 'priority' | 'stopPropagation'>> &
   Pick<ConfirmProps, 'message' | 'disabled' | 'confirmText' | 'onConfirm'>;
 
 export default function ConfirmableAction({shouldConfirm, children, ...props}: Props) {

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/rule/actions.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/rule/actions.tsx
@@ -4,9 +4,21 @@ import styled from '@emotion/styled';
 import MenuItemActionLink from 'app/components/actions/menuItemActionLink';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
+import Confirm from 'app/components/confirm';
 import DropdownLink from 'app/components/dropdownLink';
+import Tooltip from 'app/components/tooltip';
 import {IconDelete, IconDownload, IconEdit, IconEllipsis} from 'app/icons';
 import {t} from 'app/locale';
+
+const deleteRuleConfirmMessage = t(
+  'Are you sure you wish to delete this dynamic sampling rule?'
+);
+
+const deleteRuleMessage = t(
+  'You do not have permission to delete dynamic sampling rules.'
+);
+
+const editRuleMessage = t('You do not have permission to edit dynamic sampling rules.');
 
 type Props = {
   disabled: boolean;
@@ -24,14 +36,21 @@ function Actions({disabled, onEditRule, onDeleteRule}: Props) {
           onClick={onEditRule}
           icon={<IconEdit />}
           disabled={disabled}
+          title={disabled ? editRuleMessage : undefined}
         />
-        <Button
-          label={t('Delete Rule')}
-          size="small"
-          onClick={onDeleteRule}
-          icon={<IconDelete />}
+        <Confirm
+          priority="danger"
+          message={deleteRuleConfirmMessage}
+          onConfirm={onDeleteRule}
           disabled={disabled}
-        />
+        >
+          <Button
+            label={t('Delete Rule')}
+            size="small"
+            icon={<IconDelete />}
+            title={disabled ? deleteRuleMessage : undefined}
+          />
+        </Confirm>
       </StyledButtonbar>
       <StyledDropdownLink
         caret={false}
@@ -44,15 +63,39 @@ function Actions({disabled, onEditRule, onDeleteRule}: Props) {
           shouldConfirm={false}
           icon={<IconDownload size="xs" />}
           title={t('Edit')}
+          onClick={
+            !disabled
+              ? onEditRule
+              : event => {
+                  event?.stopPropagation();
+                }
+          }
+          disabled={disabled}
         >
-          {t('Edit')}
+          <Tooltip
+            disabled={!disabled}
+            title={editRuleMessage}
+            containerDisplayMode="block"
+          >
+            {t('Edit')}
+          </Tooltip>
         </MenuItemActionLink>
         <MenuItemActionLink
-          shouldConfirm={false}
+          onAction={onDeleteRule}
+          message={deleteRuleConfirmMessage}
           icon={<IconDownload size="xs" />}
           title={t('Delete')}
+          disabled={disabled}
+          priority="danger"
+          shouldConfirm
         >
-          {t('Delete')}
+          <Tooltip
+            disabled={!disabled}
+            title={deleteRuleMessage}
+            containerDisplayMode="block"
+          >
+            {t('Delete')}
+          </Tooltip>
         </MenuItemActionLink>
       </StyledDropdownLink>
     </React.Fragment>
@@ -65,7 +108,6 @@ const StyledButtonbar = styled(ButtonBar)`
   justify-content: flex-end;
   flex: 1;
   display: none;
-
   @media (min-width: ${p => p.theme.breakpoints[2]}) {
     display: flex;
   }
@@ -75,7 +117,6 @@ const StyledDropdownLink = styled(DropdownLink)`
   display: flex;
   align-items: center;
   transition: none;
-
   @media (min-width: ${p => p.theme.breakpoints[2]}) {
     display: none;
   }


### PR DESCRIPTION
Add actions in the dropdown items and tooltips below:

![image](https://user-images.githubusercontent.com/29228205/106272043-b0420100-6230-11eb-8b96-14aae8744aec.png)
![image](https://user-images.githubusercontent.com/29228205/106272050-b46e1e80-6230-11eb-8eb1-7f6d443cece3.png)
![image](https://user-images.githubusercontent.com/29228205/106272214-fb5c1400-6230-11eb-97b6-6ffa33fb100d.png)
![image](https://user-images.githubusercontent.com/29228205/106272243-04e57c00-6231-11eb-9bfd-b593e0e44633.png)
