### PR TITLE
fix(images-loaded): Handle undefined code_id and debug_id

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImage/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImage/index.tsx
@@ -16,12 +16,15 @@ import Status from './status';
 
 type Props = {
   image: Image & {status: ImageStatus};
-  onOpenImageDetailsModal: (code_id: Image['code_id']) => void;
+  onOpenImageDetailsModal: (
+    code_id: Image['code_id'],
+    debug_id: Image['debug_id']
+  ) => void;
   style?: React.CSSProperties;
 };
 
 function DebugImage({image, onOpenImageDetailsModal, style}: Props) {
-  const {unwind_status, debug_status, code_file, code_id, status} = image;
+  const {unwind_status, debug_status, debug_id, code_file, code_id, status} = image;
 
   const fileName = getFileName(code_file);
   const imageAddress = <Address image={image} />;
@@ -32,7 +35,7 @@ function DebugImage({image, onOpenImageDetailsModal, style}: Props) {
         <Status status={status} />
       </StatusColumn>
       <ImageColumn>
-        <FileName>{fileName}</FileName>
+        {fileName && <FileName>{fileName}</FileName>}
         <ImageAddress>{imageAddress}</ImageAddress>
       </ImageColumn>
       <Column>
@@ -42,14 +45,14 @@ function DebugImage({image, onOpenImageDetailsModal, style}: Props) {
         <Button
           size="xsmall"
           icon={<IconStack size="xs" />}
-          onClick={() => onOpenImageDetailsModal(code_id)}
+          onClick={() => onOpenImageDetailsModal(code_id, debug_id)}
         >
           {t('View')}
         </Button>
         <Button
           size="xsmall"
           icon={<IconStack size="xs" />}
-          onClick={() => onOpenImageDetailsModal(code_id)}
+          onClick={() => onOpenImageDetailsModal(code_id, debug_id)}
           label={t('View')}
         />
       </DebugFilesColumn>

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -26,7 +26,7 @@ type Props = AsyncComponent['props'] &
   ModalRenderProps & {
     projectId: Project['id'];
     organization: Organization;
-    image: Image;
+    image?: Image;
   };
 
 type State = AsyncComponent['state'] & {
@@ -49,6 +49,11 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
     const {organization, projectId, image} = this.props;
+
+    if (!image) {
+      return [['', '']];
+    }
+
     const {debug_id, candidates = []} = image;
     const {builtinSymbolSources} = this.state || {};
 
@@ -82,7 +87,7 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
   getCandidates() {
     const {debugFiles, loading} = this.state;
     const {image} = this.props;
-    const {candidates = []} = image;
+    const {candidates = []} = image ?? {};
 
     if (!debugFiles || loading) {
       return candidates;
@@ -158,13 +163,13 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
     const {Header, Body, Footer, image, organization, projectId} = this.props;
     const {loading, builtinSymbolSources} = this.state;
 
-    const {debug_id, debug_file, code_file, code_id, arch: architecture} = image;
+    const {debug_id, debug_file, code_file, code_id, arch: architecture} = image ?? {};
 
     const candidates = this.getCandidates();
     const baseUrl = this.api.baseUrl;
 
     const title = getFileName(code_file);
-    const imageAddress = <Address image={image} />;
+    const imageAddress = image ? <Address image={image} /> : undefined;
 
     return (
       <React.Fragment>
@@ -179,13 +184,13 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
               <Value coloredBg>{debug_id ?? <NotAvailable />}</Value>
 
               <Label>{t('Debug File')}</Label>
-              <Value>{debug_file}</Value>
+              <Value>{debug_file ?? <NotAvailable />}</Value>
 
               <Label coloredBg>{t('Code ID')}</Label>
-              <Value coloredBg>{code_id}</Value>
+              <Value coloredBg>{code_id ?? <NotAvailable />}</Value>
 
               <Label>{t('Code File')}</Label>
-              <Value>{code_file}</Value>
+              <Value>{code_file ?? <NotAvailable />}</Value>
 
               <Label coloredBg>{t('Architecture')}</Label>
               <Value coloredBg>{architecture ?? <NotAvailable />}</Value>

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -51,7 +51,7 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
     const {organization, projectId, image} = this.props;
 
     if (!image) {
-      return [['', '']];
+      return [];
     }
 
     const {debug_id, candidates = []} = image;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -37,6 +37,7 @@ import layout from './layout';
 import {combineStatus, getFileName, normalizeId} from './utils';
 
 export const PANEL_MAX_HEIGHT = 400;
+const IMAGE_INFO_UNAVAILABLE = '-1';
 
 type DefaultProps = {
   data: {
@@ -203,18 +204,20 @@ class DebugMeta extends React.PureComponent<Props, State> {
   openImageDetailsModal() {
     const {location, organization, projectId, data} = this.props;
     const {query} = location;
-    const {imageId} = query;
 
-    if (!imageId) {
+    const {imageCodeId, imageDebugId} = query;
+
+    if (!imageCodeId && !imageDebugId) {
       return;
     }
 
     const {images} = data;
-    const image = images.find(({code_id}) => code_id === imageId);
-
-    if (!image) {
-      return;
-    }
+    const image =
+      imageCodeId !== IMAGE_INFO_UNAVAILABLE || imageDebugId !== IMAGE_INFO_UNAVAILABLE
+        ? images.find(
+            ({code_id, debug_id}) => code_id === imageCodeId || debug_id === imageDebugId
+          )
+        : undefined;
 
     openModal(
       modalProps => (
@@ -353,12 +356,19 @@ class DebugMeta extends React.PureComponent<Props, State> {
     }));
   };
 
-  handleOpenImageDetailsModal = (code_id: Image['code_id']) => {
+  handleOpenImageDetailsModal = (
+    code_id: Image['code_id'],
+    debug_id: Image['debug_id']
+  ) => {
     const {location, router} = this.props;
 
     router.push({
       ...location,
-      query: {...location.query, imageId: code_id},
+      query: {
+        ...location.query,
+        imageCodeId: code_id ?? IMAGE_INFO_UNAVAILABLE,
+        imageDebugId: debug_id ?? IMAGE_INFO_UNAVAILABLE,
+      },
     });
   };
 
@@ -367,7 +377,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
 
     router.push({
       ...location,
-      query: {...location.query, imageId: undefined},
+      query: {...location.query, imageCodeId: undefined, imageDebugId: undefined},
     });
   };
 
@@ -395,9 +405,9 @@ class DebugMeta extends React.PureComponent<Props, State> {
     const {filteredImagesByFilter: images, panelTableHeight} = this.state;
 
     if (!panelTableHeight) {
-      return images.map(image => (
+      return images.map((image, index) => (
         <DebugImage
-          key={image.debug_file}
+          key={index}
           image={image}
           onOpenImageDetailsModal={this.handleOpenImageDetailsModal}
         />

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/utils.tsx
@@ -24,7 +24,10 @@ export function combineStatus(
   return combined || ImageStatus.UNUSED;
 }
 
-export function getFileName(path: string) {
+export function getFileName(path?: string) {
+  if (!path) {
+    return undefined;
+  }
   const directorySeparator = /^([a-z]:\\|\\\\)/i.test(path) ? '\\' : '/';
   return path.split(directorySeparator).pop();
 }

--- a/src/sentry/static/sentry/app/types/debugImage.tsx
+++ b/src/sentry/static/sentry/app/types/debugImage.tsx
@@ -111,13 +111,13 @@ export enum ImageStatus {
 }
 
 export type Image = {
-  debug_file: string;
-  code_file: string;
-  code_id: string;
   type: string;
-  image_size: number;
   features: ImageFeatures;
   candidates: Array<ImageCandidate>;
+  image_size?: number;
+  debug_file?: string;
+  code_file?: string;
+  code_id?: string;
   debug_id?: string;
   debug_status?: ImageStatus | null;
   unwind_status?: ImageStatus | null;


### PR DESCRIPTION
Previously, the modal of an image was relying on the `code_id` to be opened. Since almost all properties can be undefined, the logic had to be updated.

The UI now displays the modal if imageDebugId or ImageCodeId is present in the URL. If both values are '-1', an empty modal will be shown, otherwise, the image information will be shown according to `debug_id` or `code_id`.