### PR TITLE
ref(perf): Reduce api calls on vitals tab

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -29,14 +29,15 @@ import {
 import getDynamicText from 'app/utils/getDynamicText';
 import theme from 'app/utils/theme';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import {VitalData} from 'app/views/performance/vitalDetail/vitalsCardsDiscoverQuery';
 
+import {VitalBar} from '../landing/vitalsCards';
 import {
   VitalState,
   vitalStateColors,
   webVitalMeh,
   webVitalPoor,
 } from '../vitalDetail/utils';
-import VitalInfo from '../vitalDetail/vitalInfo';
 
 import {NUM_BUCKETS, PERCENTILE} from './constants';
 import {Card, CardSectionHeading, CardSummary, Description, StatNumber} from './styles';
@@ -50,8 +51,7 @@ type Props = {
   error: boolean;
   vital: WebVital;
   vitalDetails: Vital;
-  summary: number | null;
-  failureRate: number;
+  summaryData: VitalData | null;
   chartData: HistogramData[];
   colors: [string];
   eventView: EventView;
@@ -130,8 +130,21 @@ class VitalCard extends React.Component<Props, State> {
     });
   };
 
+  get summary() {
+    const {summaryData} = this.props;
+    return summaryData?.p75 ?? null;
+  }
+
+  get failureRate() {
+    const {summaryData} = this.props;
+    const numerator = summaryData?.poor ?? 0;
+    const denominator = summaryData?.total ?? 0;
+    return denominator <= 0 ? 0 : numerator / denominator;
+  }
+
   getFormattedStatNumber() {
-    const {summary, vitalDetails: vital} = this.props;
+    const {vitalDetails: vital} = this.props;
+    const summary = this.summary;
     const {type} = vital;
 
     return summary === null
@@ -142,15 +155,8 @@ class VitalCard extends React.Component<Props, State> {
   }
 
   renderSummary() {
-    const {
-      summary,
-      vitalDetails: vital,
-      colors,
-      eventView,
-      organization,
-      min,
-      max,
-    } = this.props;
+    const {vitalDetails: vital, colors, eventView, organization, min, max} = this.props;
+    const summary = this.summary;
     const {slug, name, description, failureThreshold} = vital;
 
     const column = `measurements.${slug}`;
@@ -244,13 +250,12 @@ class VitalCard extends React.Component<Props, State> {
   renderHistogram() {
     const {
       location,
-      organization,
       isLoading,
+      summaryData,
       error,
       colors,
       vital,
       vitalDetails,
-      eventView,
       precision = 0,
     } = this.props;
     const {slug} = vitalDetails;
@@ -291,6 +296,9 @@ class VitalCard extends React.Component<Props, State> {
       }
     }
 
+    const vitalData =
+      !isLoading && !error && summaryData !== null ? {[vital]: summaryData} : {};
+
     return (
       <BarChartZoom
         minZoomWidth={10 ** -precision * NUM_BUCKETS}
@@ -306,15 +314,14 @@ class VitalCard extends React.Component<Props, State> {
             <TransparentLoadingMask visible={isLoading} />
             <Feature features={['organizations:performance-vitals-overview']}>
               <PercentContainer>
-                <VitalInfo
-                  eventView={eventView}
-                  organization={organization}
-                  location={location}
+                <VitalBar
+                  isLoading={isLoading}
+                  data={vitalData}
                   vital={vital}
-                  hideBar
-                  hideStates
-                  hideVitalPercentNames
-                  hideDurationDetail
+                  showBar={false}
+                  showStates={false}
+                  showVitalPercentNames={false}
+                  showDurationDetail={false}
                 />
               </PercentContainer>
             </Feature>
@@ -417,7 +424,8 @@ class VitalCard extends React.Component<Props, State> {
   }
 
   getBaselineSeries() {
-    const {chartData, summary} = this.props;
+    const {chartData} = this.props;
+    const summary = this.summary;
     if (summary === null || this.state.refPixelRect === null) {
       return null;
     }
@@ -489,7 +497,8 @@ class VitalCard extends React.Component<Props, State> {
   }
 
   getFailureSeries() {
-    const {chartData, vitalDetails: vital, failureRate} = this.props;
+    const {chartData, vitalDetails: vital} = this.props;
+    const failureRate = this.failureRate;
     const {failureThreshold, type} = vital;
     if (this.state.refDataRect === null || this.state.refPixelRect === null) {
       return null;

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalsPanel.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalsPanel.tsx
@@ -3,13 +3,14 @@ import {Location} from 'history';
 
 import {Panel} from 'app/components/panels';
 import {Organization} from 'app/types';
-import DiscoverQuery, {TableData} from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
-import {getAggregateAlias, WebVital} from 'app/utils/discover/fields';
-import {GenericChildrenProps} from 'app/utils/discover/genericDiscoverQuery';
+import {WebVital} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
+import VitalsCardDiscoverQuery, {
+  VitalData,
+} from 'app/views/performance/vitalDetail/vitalsCardsDiscoverQuery';
 
-import {NUM_BUCKETS, PERCENTILE, VITAL_GROUPS, WEB_VITAL_DETAILS} from './constants';
+import {NUM_BUCKETS, VITAL_GROUPS, WEB_VITAL_DETAILS} from './constants';
 import HistogramQuery from './histogramQuery';
 import {DataFilter, HistogramData, VitalGroup} from './types';
 import VitalCard from './vitalCard';
@@ -26,8 +27,7 @@ class VitalsPanel extends React.Component<Props> {
     vital: WebVital,
     isLoading: boolean,
     error: boolean,
-    summary: number | null,
-    failureRate: number,
+    data: VitalData | null,
     histogram: HistogramData[],
     color: [string],
     min?: number,
@@ -62,8 +62,7 @@ class VitalsPanel extends React.Component<Props> {
               error={errored}
               vital={vital}
               vitalDetails={vitalDetails}
-              summary={summary}
-              failureRate={failureRate}
+              summaryData={data}
               chartData={chartData}
               colors={color}
               eventView={eventView}
@@ -78,7 +77,7 @@ class VitalsPanel extends React.Component<Props> {
     );
   }
 
-  renderVitalGroup(group: VitalGroup, summaryResults: GenericChildrenProps<TableData>) {
+  renderVitalGroup(group: VitalGroup, summaryResults) {
     const {location, organization, eventView, dataFilter} = this.props;
     const {vitals, colors, min, max, precision} = group;
 
@@ -118,22 +117,8 @@ class VitalsPanel extends React.Component<Props> {
           return (
             <React.Fragment>
               {vitals.map((vital, index) => {
-                const details = WEB_VITAL_DETAILS[vital];
-                const data = summaryResults.tableData?.data?.[0];
-
-                const percentileAlias = getAggregateAlias(
-                  `percentile(${vital}, ${PERCENTILE})`
-                );
-                const summary = (data?.[percentileAlias] ?? null) as number | null;
-
-                const countAlias = getAggregateAlias(`count_at_least(${vital}, 0)`);
-                const failedAlias = getAggregateAlias(
-                  `count_at_least(${vital}, ${details.failureThreshold})`
-                );
-                const numerator = (data?.[failedAlias] ?? 0) as number;
-                const denominator = (data?.[countAlias] ?? 0) as number;
-                const failureRate = denominator <= 0 ? 0 : numerator / denominator;
-
+                const data = summaryResults?.vitalsData?.[vital] ?? null;
+                const histogram = multiHistogramResults.histograms?.[vital] ?? [];
                 const {start, end} = bounds[vital] ?? {};
 
                 return (
@@ -142,9 +127,8 @@ class VitalsPanel extends React.Component<Props> {
                       vital,
                       isLoading,
                       error,
-                      summary,
-                      failureRate,
-                      multiHistogramResults.histograms?.[vital] ?? [],
+                      data,
+                      histogram,
                       [colors[index]],
                       parseBound(start, precision),
                       parseBound(end, precision),
@@ -163,14 +147,17 @@ class VitalsPanel extends React.Component<Props> {
   render() {
     const {location, organization, eventView} = this.props;
 
+    const allVitals = VITAL_GROUPS.reduce((keys: WebVital[], {vitals}) => {
+      return keys.concat(vitals);
+    }, []);
+
     return (
       <Panel>
-        <DiscoverQuery
-          location={location}
-          orgSlug={organization.slug}
+        <VitalsCardDiscoverQuery
           eventView={eventView}
-          limit={1}
-          noPagination
+          orgSlug={organization.slug}
+          location={location}
+          vitals={allVitals}
         >
           {results => (
             <React.Fragment>
@@ -181,7 +168,7 @@ class VitalsPanel extends React.Component<Props> {
               ))}
             </React.Fragment>
           )}
-        </DiscoverQuery>
+        </VitalsCardDiscoverQuery>
       </Panel>
     );
   }

--- a/tests/js/spec/views/performance/transactionVitals.spec.jsx
+++ b/tests/js/spec/views/performance/transactionVitals.spec.jsx
@@ -80,24 +80,13 @@ describe('Performance > Web Vitals', function () {
     });
     // Mock baseline measurements
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/eventsv2/',
+      url: '/organizations/org-slug/events-vitals/',
       body: {
-        meta: {
-          percentile_measurements_fp_0_75: 'duration',
-          percentile_measurements_fcp_0_75: 'duration',
-          percentile_measurements_lcp_0_75: 'duration',
-          percentile_measurements_fid_0_75: 'duration',
-          percentile_measurements_cls_0_75: 'number',
-        },
-        data: [
-          {
-            percentile_measurements_fp_0_75: 4567,
-            percentile_measurements_fcp_0_75: 1456,
-            percentile_measurements_lcp_0_75: 1342,
-            percentile_measurements_fid_0_75: 987,
-            percentile_measurements_cls_0_75: 0.02,
-          },
-        ],
+        'measurements.fp': {poor: 1, meh: 2, good: 3, total: 6, p75: 4567},
+        'measurements.fcp': {poor: 1, meh: 2, good: 3, total: 6, p75: 1456},
+        'measurements.lcp': {poor: 1, meh: 2, good: 3, total: 6, p75: 1342},
+        'measurements.fid': {poor: 1, meh: 2, good: 3, total: 6, p75: 987},
+        'measurements.cls': {poor: 1, meh: 2, good: 3, total: 6, p75: 0.02},
       },
     });
 


### PR DESCRIPTION
The vitals tab current makes 1 api call to eventsv2 for the p75 and 5 api calls
to events-vitals for each of the breakdowns. The events-vitals endpoint is
capable of returning all the necessary values in one query. This change
consolidates all these api calls into just 1.