### PR TITLE
ref(ts) Refine feature/hook types

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/feature.tsx
+++ b/src/sentry/static/sentry/app/components/acl/feature.tsx
@@ -45,9 +45,7 @@ type Props = {
    * passed to `children` if a func is provided there, will be used here,
    * additionally `children` will also be passed.
    */
-  renderDisabled?:
-    | ((props: FeatureRenderProps & Pick<Props, 'children'>) => React.ReactNode)
-    | boolean;
+  renderDisabled?: boolean | RenderDisabledFn;
   /**
    * Specify the key to use for hookstore functionality.
    *
@@ -69,16 +67,34 @@ type Props = {
   project?: Project;
 };
 
-type ChildrenRenderFn = (
-  props: FeatureRenderProps & Pick<Props, 'renderDisabled'>
-) => React.ReactNode;
-
+/**
+ * Common props passed to children and disabled render handlers.
+ */
 type FeatureRenderProps = {
   organization: Organization;
   features: string[];
   hasFeature: boolean;
   project?: Project;
 };
+
+/**
+ * When a feature is disabled the caller of Feature may provide a `renderDisabled`
+ * prop. This prop can be overriden by getsentry via hooks. Often getsentry will
+ * call the original children function  but override the `renderDisabled`
+ * with another function/component.
+ */
+type RenderDisabledProps = FeatureRenderProps & {
+  children: React.ReactNode | ChildrenRenderFn;
+  renderDisabled?: (props: FeatureRenderProps) => React.ReactNode;
+};
+
+export type RenderDisabledFn = (props: RenderDisabledProps) => React.ReactNode;
+
+type ChildRenderProps = FeatureRenderProps & {
+  renderDisabled?: undefined | boolean | RenderDisabledFn;
+};
+
+export type ChildrenRenderFn = (props: ChildRenderProps) => React.ReactNode;
 
 type AllFeatures = {
   configFeatures: string[];

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -1,6 +1,6 @@
 import {Route} from 'react-router';
 
-import FeatureDisabled from 'app/components/acl/featureDisabled';
+import {ChildrenRenderFn} from 'app/components/acl/feature';
 import DateRange from 'app/components/organizations/timeRangeSelector/dateRange';
 import SelectorItems from 'app/components/organizations/timeRangeSelector/dateRange/selectorItems';
 import SidebarItem from 'app/components/sidebar/sidebarItem';
@@ -165,7 +165,7 @@ type OrganizationHeaderComponentHook = (org: Organization) => React.ReactNode;
 /**
  * A FeatureDisabledHook returns a react element when a feature is not enabled.
  */
-type FeatureDisabledHook = (opts: {
+export type FeatureDisabledHook = (opts: {
   /**
    * The organization that is associated to this feature.
    */
@@ -179,7 +179,11 @@ type FeatureDisabledHook = (opts: {
    */
   hasFeature: boolean;
 
-  children: FeatureDisabled['props']['children'];
+  /**
+   * Children can either be a node, or a function that accepts a renderDisabled prop containing
+   * a function/component to render when the feature is not enabled.
+   */
+  children: React.ReactNode | ChildrenRenderFn;
 
   /**
    * The project that is associated to this feature.

--- a/src/sentry/static/sentry/app/types/hooks.ts
+++ b/src/sentry/static/sentry/app/types/hooks.ts
@@ -165,7 +165,7 @@ type OrganizationHeaderComponentHook = (org: Organization) => React.ReactNode;
 /**
  * A FeatureDisabledHook returns a react element when a feature is not enabled.
  */
-export type FeatureDisabledHook = (opts: {
+type FeatureDisabledHook = (opts: {
   /**
    * The organization that is associated to this feature.
    */


### PR DESCRIPTION
I was attempting to convert over some of the disabled feature hooks to typescript and the existing types made progress hard as they don't account for the various states that `children` and `renderDisabled` can be in. With these types I was able to convert the DisableRateLimit feature handler to typescript.