### PR TITLE
fix(dashboardsv2): Add max_length for Dashboard titles

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -111,7 +111,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer):
 class DashboardDetailsSerializer(CamelSnakeSerializer):
     # Is a string because output serializers also make it a string.
     id = serializers.CharField(required=False)
-    title = serializers.CharField(required=False)
+    title = serializers.CharField(required=False, max_length=255)
     widgets = DashboardWidgetSerializer(many=True, required=False)
 
     validate_id = validate_id
@@ -257,4 +257,4 @@ class DashboardDetailsSerializer(CamelSnakeSerializer):
 
 
 class DashboardSerializer(DashboardDetailsSerializer):
-    title = serializers.CharField(required=True)
+    title = serializers.CharField(required=True, max_length=255)


### PR DESCRIPTION
Adding the `max_length` for Dashboard titles on Dashboard serializer to match: https://github.com/getsentry/sentry/blob/b18d4f4ce5cc507f31efb7eef1349a687dd6631e/src/sentry/models/dashboard.py#L14

On the frontend app, we already trim the Dashboard title to length of 255 characters before sending it; so there's no path to break the app. But adding this requirement here on the API endpoint. 