### PR TITLE
fix(aws-lambda): adds exception handler for failing to get account info

### DIFF
--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -189,9 +189,13 @@ class AwsLambdaIntegrationProvider(IntegrationProvider):
         org_client = gen_aws_client(
             account_number, region, aws_external_id, service_name="organizations"
         )
-        account = org_client.describe_account(AccountId=account_number)["Account"]
-
-        integration_name = "{} {}".format(account["Name"], region)
+        try:
+            account = org_client.describe_account(AccountId=account_number)["Account"]
+            account_name = account["Name"]
+            integration_name = f"{account_name} {region}"
+        except org_client.exceptions.AccessDeniedException:
+            # if the customer won't let us access the org name, use the account number instead
+            integration_name = f"{account_number} {region}"
 
         external_id = "{}-{}".format(account_number, region)
 


### PR DESCRIPTION
This PR adds an exception handler when calling `describe_account` if we get a `AccessDeniedException` error. This might happen if the organization has set up permissions that would block Sentry from getting the account name. If this happens, we can just use the account number instead of the account name as the integration name and proceed as usual:

![Screen Shot 2021-01-29 at 2 56 15 PM](https://user-images.githubusercontent.com/8533851/106335680-2ac74c80-6242-11eb-8851-4a4ac60c9fb7.png)


Fixes SENTRY-MQF, SENTRY-MQG