### PR TITLE
fix(discover): Top results indicator should only be on first page

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -10,6 +10,7 @@ import {metric} from 'app/utils/analytics';
 import {TableData} from 'app/utils/discover/discoverQuery';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import Measurements from 'app/utils/measurements/measurements';
+import parseLinkHeader from 'app/utils/parseLinkHeader';
 import withApi from 'app/utils/withApi';
 import withTags from 'app/utils/withTags';
 
@@ -150,6 +151,10 @@ class Table extends React.PureComponent<TableProps, TableState> {
     const {pageLinks, tableData, isLoading, error} = this.state;
     const tagKeys = Object.values(tags).map(({key}) => key);
 
+    const isFirstPage = pageLinks
+      ? parseLinkHeader(pageLinks).previous.results === false
+      : false;
+
     return (
       <Container>
         <Measurements>
@@ -159,6 +164,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
               <TableView
                 {...this.props}
                 isLoading={isLoading}
+                isFirstPage={isFirstPage}
                 error={error}
                 eventView={eventView}
                 tableData={tableData}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -43,6 +43,7 @@ export type TableViewProps = {
   isLoading: boolean;
   error: string | null;
 
+  isFirstPage: boolean;
   eventView: EventView;
   tableData: TableData | null | undefined;
   tagKeys: null | string[];
@@ -199,7 +200,7 @@ class TableView extends React.Component<TableViewProps> {
     rowIndex: number,
     columnIndex: number
   ): React.ReactNode => {
-    const {eventView, location, organization, tableData} = this.props;
+    const {isFirstPage, eventView, location, organization, tableData} = this.props;
 
     if (!tableData || !tableData.meta) {
       return dataRow[column.key];
@@ -236,7 +237,7 @@ class TableView extends React.Component<TableViewProps> {
 
     return (
       <React.Fragment>
-        {isTopEvents && rowIndex < TOP_N && columnIndex === 0 ? (
+        {isFirstPage && isTopEvents && rowIndex < TOP_N && columnIndex === 0 ? (
           <TopResultsIndicator count={count} index={rowIndex} />
         ) : null}
         <CellAction


### PR DESCRIPTION
When paginating the table in discover, only the table is paginated and not the
chart. This means that when using a top 5 mode chart, if the user goes on to the
second page, none of the results on the table is in the graph. In this case, the
top 5 indicator should not be visible.