### PR TITLE
feat(inbox): Revised two step inbox guide

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -18,6 +18,6 @@
 GUIDES = {
     "issue": {"id": 1, "required_targets": ["issue_title", "exception"]},
     "issue_stream": {"id": 3, "required_targets": ["issue_stream"]},
-    "dynamic_counts": {"id": 7, "required_targets": ["dynamic_counts"]},
     "inbox_guide": {"id": 8, "required_targets": ["inbox_guide"]},
+    "for_review_guide": {"id": 9, "required_targets": ["for_review_guide_tab"]},
 }

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -103,6 +103,7 @@ export default function getGuidesContent(): GuidesContent {
     {
       guide: 'inbox_guide',
       requiredTargets: ['inbox_guide_tab'],
+      dateThreshold: new Date(2021, 1, 26),
       steps: [
         {
           target: 'inbox_guide_tab',

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -101,20 +101,6 @@ export default function getGuidesContent(): GuidesContent {
       ],
     },
     {
-      guide: 'dynamic_counts',
-      requiredTargets: ['dynamic_counts'],
-      steps: [
-        {
-          title: t('These counts have changed'),
-          target: 'dynamic_counts',
-          description: t(
-            `These numbers and the bar chart now respect the time selected and any search
-            filters you've applied. You can hover to see the totals.`
-          ),
-        },
-      ],
-    },
-    {
       guide: 'inbox_guide',
       requiredTargets: ['inbox_guide_tab'],
       steps: [
@@ -124,46 +110,48 @@ export default function getGuidesContent(): GuidesContent {
             `For Review lets you focus on new and reopened issues that are
             assigned to your team.`
           ),
+          dismissText: t(`Later`),
           nextText: t(`Take a Look`),
         },
+      ],
+    },
+    {
+      guide: 'for_review_guide',
+      requiredTargets: ['for_review_guide_tab'],
+      steps: [
         {
-          target: 'inbox_guide_issue',
+          target: 'for_review_guide_tab',
           description: t(
-            `These issues give you a lightweight way to review things and ensure
-            that nothing new has happened in the last 7 days.`
+            `For Review is a list of Unresolved issues that are new or have
+            reopened in the last 7 days.`
           ),
           cantDismiss: true,
         },
         {
           target: 'inbox_guide_reason',
-          description: t(
-            `These labels explain why an issue needs attention. When you mark the
-            issue as reviewed, it removes the label and moves the issue to Unresolved.`
-          ),
+          description: t(`These labels explain why an issue needs review.`),
           cantDismiss: true,
         },
         {
           target: 'inbox_guide_review',
           description: t(
-            `Mark as Reviewed lets you get to Inbox Zero so that your team knows
-            which issues need attention.`
+            `When you mark an issue reviewed, it removes the label from the
+            issue and removes the issue from this list.`
           ),
           nextText: t(`Wow there's more tutorial, huh?`),
           cantDismiss: true,
         },
         {
           target: 'inbox_guide_ignore',
-          description: t(
-            `Resolving or ignoring an issue also marks an issue as reviewed.`
-          ),
+          description: t(`Resolving or ignoring an issue implicitly marks it reviewed.`),
           nextText: t(`Next, ugh`),
           cantDismiss: true,
         },
         {
           target: 'inbox_guide_issue',
           description: t(
-            `An issue will automatically be reviewed after 7 days so this list never
-            gets too overwhelming.`
+            `If you don’t take action for 7 days on an issue that needs
+            review, Sentry automatically marks it reviewed.`
           ),
           nextText: t(`Got it`),
         },

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -115,7 +115,11 @@ export default function getGuidesContent(): GuidesContent {
     },
     {
       guide: 'for_review_guide',
-      requiredTargets: ['for_review_guide_tab'],
+      requiredTargets: [
+        'for_review_guide_tab',
+        'inbox_guide_reason',
+        'inbox_guide_issue',
+      ],
       steps: [
         {
           target: 'for_review_guide_tab',

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -112,6 +112,7 @@ export default function getGuidesContent(): GuidesContent {
           ),
           dismissText: t(`Later`),
           nextText: t(`Take a Look`),
+          hasNextGuide: true,
         },
       ],
     },

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -106,10 +106,7 @@ export default function getGuidesContent(): GuidesContent {
       steps: [
         {
           target: 'inbox_guide_tab',
-          description: t(
-            `For Review lets you focus on new and reopened issues that are
-            assigned to your team.`
-          ),
+          description: t(`We’ve made some changes to help you focus on what’s new.`),
           dismissText: t(`Later`),
           nextText: t(`Take a Look`),
           hasNextGuide: true,
@@ -123,8 +120,7 @@ export default function getGuidesContent(): GuidesContent {
         {
           target: 'for_review_guide_tab',
           description: t(
-            `For Review is a list of Unresolved issues that are new or have
-            reopened in the last 7 days.`
+            `This is a list of Unresolved issues that are new or reopened in the last 7 days.`
           ),
           cantDismiss: true,
         },
@@ -136,25 +132,24 @@ export default function getGuidesContent(): GuidesContent {
         {
           target: 'inbox_guide_review',
           description: t(
-            `When you mark an issue reviewed, it removes the label from the
-            issue and removes the issue from this list.`
+            `Mark Reviewed removes the issue from this list and also removes the label.`
           ),
-          nextText: t(`Wow there's more tutorial, huh?`),
+          nextText: t(`When does this end?`),
           cantDismiss: true,
         },
         {
           target: 'inbox_guide_ignore',
-          description: t(`Resolving or ignoring an issue implicitly marks it reviewed.`),
-          nextText: t(`Next, ugh`),
+          description: t(`Resolving or ignoring an issue also marks it reviewed.`),
+          nextText: t(`Seriously, there's more?`),
           cantDismiss: true,
         },
         {
           target: 'inbox_guide_issue',
           description: t(
-            `If you don’t take action for 7 days on an issue that needs
-            review, Sentry automatically marks it reviewed.`
+            `Everything is automatically reviewed after seven days, preventing
+            issues from piling up and you from losing your damn mind.`
           ),
-          nextText: t(`Got it`),
+          nextText: t(`Make It Stop Already`),
         },
       ],
     },

--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
@@ -11,7 +11,6 @@ import {
   nextStep,
   recordFinish,
   registerAnchor,
-  toStep,
   unregisterAnchor,
 } from 'app/actionCreators/guides';
 import {Guide} from 'app/components/assistant/types';
@@ -30,7 +29,6 @@ type Props = {
   to?: {
     pathname: string;
     query: Query;
-    step: number;
   };
 };
 
@@ -108,12 +106,8 @@ const GuideAnchor = createReactClass<Props, State>({
   },
 
   handleNextStep(e: React.MouseEvent) {
-    if (this.props.to) {
-      toStep(this.props.to.step);
-    } else {
-      e.stopPropagation();
-      nextStep();
-    }
+    e.stopPropagation();
+    nextStep();
   },
 
   handleDismiss(e: React.MouseEvent) {
@@ -144,6 +138,7 @@ const GuideAnchor = createReactClass<Props, State>({
               <StyledButton
                 size="small"
                 href="#" // to clear `#assistant` from the url
+                to={to}
                 onClick={this.handleFinish}
               >
                 {currentStep.nextText ||
@@ -156,9 +151,10 @@ const GuideAnchor = createReactClass<Props, State>({
                     priority="primary"
                     size="small"
                     href="#" // to clear `#assistant` from the url
+                    to={to}
                     onClick={this.handleDismiss}
                   >
-                    {t('Dismiss')}
+                    {currentStep.dismissText || t('Dismiss')}
                   </DismissButton>
                 )}
                 <StyledButton size="small" onClick={this.handleNextStep} to={to}>

--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
@@ -135,15 +135,26 @@ const GuideAnchor = createReactClass<Props, State>({
         <GuideAction>
           <div>
             {lastStep ? (
-              <StyledButton
-                size="small"
-                href="#" // to clear `#assistant` from the url
-                to={to}
-                onClick={this.handleFinish}
-              >
-                {currentStep.nextText ||
-                  (hasManySteps ? t('Enough Already') : t('Got It'))}
-              </StyledButton>
+              <React.Fragment>
+                {currentStep.hasNextGuide && (
+                  <DismissButton
+                    size="small"
+                    href="#" // to clear `#assistant` from the url
+                    onClick={this.handleFinish}
+                  >
+                    {currentStep.dismissText || t('Dismiss')}
+                  </DismissButton>
+                )}
+                <StyledButton
+                  size="small"
+                  href="#" // to clear `#assistant` from the url
+                  to={to}
+                  onClick={this.handleFinish}
+                >
+                  {currentStep.nextText ||
+                    (hasManySteps ? t('Enough Already') : t('Got It'))}
+                </StyledButton>
+              </React.Fragment>
             ) : (
               <React.Fragment>
                 {!currentStep.cantDismiss && (

--- a/src/sentry/static/sentry/app/components/assistant/types.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/types.tsx
@@ -17,6 +17,7 @@ export type GuideStep = {
 export type Guide = {
   guide: string;
   requiredTargets: string[];
+  dateThreshold?: Date;
   steps: GuideStep[];
   seen: boolean;
 };
@@ -28,6 +29,7 @@ export type GuidesContent = {
    * guide to be shown regardless.
    */
   requiredTargets: string[];
+  dateThreshold?: Date;
   steps: GuideStep[];
 }[];
 

--- a/src/sentry/static/sentry/app/components/assistant/types.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/types.tsx
@@ -11,6 +11,7 @@ export type GuideStep = {
   nextText?: string;
   dismissText?: string;
   cantDismiss?: boolean;
+  hasNextGuide?: boolean;
 };
 
 export type Guide = {

--- a/src/sentry/static/sentry/app/components/assistant/types.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/types.tsx
@@ -9,6 +9,7 @@ export type GuideStep = {
   target?: string;
   description: React.ReactNode;
   nextText?: string;
+  dismissText?: string;
   cantDismiss?: boolean;
 };
 

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -194,10 +194,10 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
     const userDateJoined = new Date(user?.dateJoined);
 
     if (!forceShow) {
-      guideOptions = guideOptions.filter(({guide, seen}) =>
+      guideOptions = guideOptions.filter(({/*guide, */ seen}) =>
         seen
           ? false
-          : user?.isSuperuser || guide === 'dynamic_counts'
+          : user?.isSuperuser // || guide === 'dynamic_counts'
           ? true
           : userDateJoined > assistantThreshold
       );

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -194,9 +194,18 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
     const userDateJoined = new Date(user?.dateJoined);
 
     if (!forceShow) {
-      guideOptions = guideOptions.filter(({seen}) =>
-        seen ? false : user?.isSuperuser ? true : userDateJoined > assistantThreshold
-      );
+      guideOptions = guideOptions.filter(({seen, dateThreshold}) => {
+        if (seen) {
+          return false;
+        } else if (user?.isSuperuser) {
+          return true;
+        } else if (dateThreshold) {
+          // Don't show the guide to users who've joined after the date threshold
+          return userDateJoined < dateThreshold;
+        } else {
+          return userDateJoined > assistantThreshold;
+        }
+      });
     }
 
     const nextGuide =

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -194,12 +194,8 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
     const userDateJoined = new Date(user?.dateJoined);
 
     if (!forceShow) {
-      guideOptions = guideOptions.filter(({/*guide, */ seen}) =>
-        seen
-          ? false
-          : user?.isSuperuser // || guide === 'dynamic_counts'
-          ? true
-          : userDateJoined > assistantThreshold
+      guideOptions = guideOptions.filter(({seen}) =>
+        seen ? false : user?.isSuperuser ? true : userDateJoined > assistantThreshold
       );
     }
 

--- a/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
@@ -121,11 +121,13 @@ class IssueListActions extends React.Component<Props, State> {
 
   handleGuideStateChange(data: GuideStoreState) {
     const {hasInbox} = this.props;
-    const inboxGuideActive = !!(hasInbox && data.currentGuide?.guide === 'inbox_guide');
+    const inboxGuideActive = !!(
+      hasInbox && data.currentGuide?.guide === 'for_review_guide'
+    );
     this.setState({
       inboxGuideActive,
-      inboxGuideActiveReview: inboxGuideActive && data.currentStep === 3,
-      inboxGuideActiveIgnore: inboxGuideActive && data.currentStep === 4,
+      inboxGuideActiveReview: inboxGuideActive && data.currentStep === 2,
+      inboxGuideActiveIgnore: inboxGuideActive && data.currentStep === 3,
     });
   }
 

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -80,35 +80,40 @@ function IssueListHeader({
       </BorderlessHeader>
       <TabLayoutHeader>
         <Layout.HeaderNavTabs underlined>
-          {visibleTabs.map(([tabQuery, {name: queryName}]) => (
-            <li key={tabQuery} className={query === tabQuery ? 'active' : ''}>
-              <Link
-                to={{
-                  query: {...queryParms, query: tabQuery},
-                  pathname: `/organizations/${organization.slug}/issues/`,
-                }}
-              >
-                <GuideAnchor
-                  target={queryName === 'For Review' ? 'inbox_guide_tab' : 'none'}
-                  disabled={queryName !== 'For Review'}
-                  to={{
-                    query: {...router?.location?.query, query: tabQuery},
-                    pathname: `/organizations/${organization.slug}/issues/`,
-                    step: 1,
-                  }}
-                >
-                  {queryName}{' '}
-                  {queryCounts[tabQuery] && (
-                    <StyledQueryCount
-                      isTag
-                      count={queryCounts[tabQuery].count}
-                      max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
-                    />
-                  )}
-                </GuideAnchor>
-              </Link>
-            </li>
-          ))}
+          {visibleTabs.map(([tabQuery, {name: queryName}]) => {
+            const inboxGuideStepOne = queryName === 'For Review' && query !== tabQuery;
+            const inboxGuideStepTwo = queryName === 'For Review' && query === tabQuery;
+            const to = {
+              query: {...queryParms, query: tabQuery},
+              pathname: `/organizations/${organization.slug}/issues/`,
+            };
+
+            return (
+              <li key={tabQuery} className={query === tabQuery ? 'active' : ''}>
+                <Link to={to}>
+                  <GuideAnchor
+                    target={inboxGuideStepOne ? 'inbox_guide_tab' : 'none'}
+                    disabled={!inboxGuideStepOne}
+                    to={to}
+                  >
+                    <GuideAnchor
+                      target={inboxGuideStepTwo ? 'for_review_guide_tab' : 'none'}
+                      disabled={!inboxGuideStepTwo}
+                    >
+                      {queryName}{' '}
+                      {queryCounts[tabQuery] && (
+                        <StyledQueryCount
+                          isTag
+                          count={queryCounts[tabQuery].count}
+                          max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
+                        />
+                      )}
+                    </GuideAnchor>
+                  </GuideAnchor>
+                </Link>
+              </li>
+            );
+          })}
           <SavedSearchTab
             organization={organization}
             query={query}


### PR DESCRIPTION
This removes the dynamic counts guide and makes the inbox guide the default guide for forcing assistant. It also splits the guide into two steps as described in the Jira card.

See the [Jira card](https://getsentry.atlassian.net/browse/WOR-472) for specs