### PR TITLE
ref(ui) Update a handful of select controls

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/tagFilter.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/tagFilter.tsx
@@ -166,17 +166,16 @@ class IssueListTagFilter extends React.Component<Props, State> {
 
         {!tag.isInput && (
           <SelectControl
-            deprecatedSelectControl
             clearable
-            filterOptions={options => options}
             placeholder="--"
             value={this.state.value}
             onChange={this.handleChangeSelect}
             isLoading={this.state.isLoading}
             onInputChange={this.handleChangeSelectInput}
-            onOpen={this.handleOpenMenu}
-            autoload={false}
-            noResultsText={this.state.isLoading ? t('Loading...') : t('No results found')}
+            onFocus={this.handleOpenMenu}
+            noResultsText={
+              this.state.isLoading ? t('Loading\u2026') : t('No results found')
+            }
             options={
               tag.predefined
                 ? tag.values &&

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.tsx
@@ -107,7 +107,6 @@ class CreateProject extends React.Component<Props, State> {
           <FormLabel>{t('Team')}</FormLabel>
           <TeamSelectInput>
             <SelectControl
-              deprecatedSelectControl
               name="select-team"
               clearable={false}
               value={team}

--- a/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -153,7 +153,6 @@ const AccountNotificationsByProject = ({projects, field}: ANBPProps) => {
           {projectFields.map(f => (
             <PanelBodyLineItem key={f.name}>
               <SelectField
-                deprecatedSelectControl
                 defaultValue={f.defaultValue}
                 name={f.name}
                 choices={f.choices}
@@ -190,7 +189,6 @@ const AccountNotificationsByOrganization = ({organizations, field}: ANBOProps) =
       {data.map(f => (
         <PanelBodyLineItem key={f.name}>
           <SelectField
-            deprecatedSelectControl
             defaultValue={f.defaultValue}
             name={f.name}
             choices={f.choices}

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -154,7 +154,6 @@ class KeySettings extends React.Component<Props, State> {
                     </TextCopyInput>
                   </Field>
                   <SelectField
-                    deprecatedSelectControl
                     name="browserSdkVersion"
                     choices={data.browserSdk ? data.browserSdk.choices : []}
                     placeholder={t('4.x')}

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ruleBuilder.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ruleBuilder.tsx
@@ -145,7 +145,6 @@ class RuleBuilder extends React.Component<Props, State> {
         )}
         <BuilderBar>
           <BuilderSelect
-            deprecatedSelectControl
             name="select-type"
             value={type}
             onChange={this.handleTypeChange}

--- a/tests/js/spec/views/issueList/tagFilter.spec.jsx
+++ b/tests/js/spec/views/issueList/tagFilter.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {openMenu, selectByLabel} from 'sentry-test/select-new';
 
 import IssueListTagFilter from 'app/views/issueList/tagFilter';
 
@@ -41,15 +42,12 @@ describe('IssueListTagFilter', function () {
       TestStubs.routerContext()
     );
 
-    wrapper.find('input').simulate('focus');
-    wrapper.find('.Select-control').simulate('mouseDown', {button: 0});
+    openMenu(wrapper, {control: true});
 
     await tick();
     wrapper.update();
 
-    expect(wrapper.find('div.Select-option').prop('children')).toBe('foo');
-
-    wrapper.find('Option').simulate('mouseDown');
+    selectByLabel(wrapper, 'foo', {control: true});
     expect(selectMock).toHaveBeenCalledWith(tag, 'foo');
   });
 
@@ -66,15 +64,12 @@ describe('IssueListTagFilter', function () {
       TestStubs.routerContext()
     );
 
-    wrapper.find('input').simulate('focus');
-    wrapper.find('.Select-control').simulate('mouseDown', {button: 0});
-
+    openMenu(wrapper, {control: true});
     await tick();
     wrapper.update();
 
-    expect(wrapper.find('div.Select-option').prop('children')).toBe('foo');
+    selectByLabel(wrapper, 'foo', {control: true});
 
-    wrapper.find('Option').simulate('mouseDown');
     expect(selectMock).toHaveBeenCalledWith(tag, 'foo');
   });
 });


### PR DESCRIPTION
Update a handful of select controls to the non-deprecated control implementation. These select controls are either static only required a simple change to get working.