### PR TITLE
fix(integrations): Ignore integrations with deleted accounts

### DIFF
--- a/src/sentry/api/endpoints/organization_sentry_apps.py
+++ b/src/sentry/api/endpoints/organization_sentry_apps.py
@@ -7,7 +7,7 @@ from sentry.models import SentryApp
 class OrganizationSentryAppsEndpoint(OrganizationEndpoint):
     @add_integration_platform_metric_tag
     def get(self, request, organization):
-        queryset = SentryApp.objects.filter(owner=organization)
+        queryset = SentryApp.objects.filter(owner=organization, application__isnull=False)
 
         return self.paginate(
             request=request,


### PR DESCRIPTION
Fixes #23290.

The stacktrace was like the following:
```py
Traceback (most recent call last):
   File "/usr/local/lib/python3.6/site-packages/sentry/api/base.py", line 122, in handle_exception
     response = super(Endpoint, self).handle_exception(exc)
   File "/usr/local/lib/python3.6/site-packages/rest_framework/views.py", line 449, in handle_exception
     self.raise_uncaught_exception(exc)
   File "/usr/local/lib/python3.6/site-packages/sentry/api/base.py", line 235, in dispatch
     response = handler(request, *args, **kwargs)
   File "/usr/local/lib/python3.6/site-packages/sentry/api/bases/sentryapps.py", line 57, in wrapped
     return func(self, *args, **kwargs)
   File "/usr/local/lib/python3.6/site-packages/sentry/api/endpoints/organization_sentry_apps.py", line 17, in get
     on_results=lambda x: serialize(x, request.user, access=request.access),
   File "/usr/local/lib/python3.6/site-packages/sentry/api/base.py", line 331, in paginate
     results = on_results(cursor_result.results)
   File "/usr/local/lib/python3.6/site-packages/sentry/api/endpoints/organization_sentry_apps.py", line 17, in <lambda>
     on_results=lambda x: serialize(x, request.user, access=request.access),
   File "/usr/local/lib/python3.6/site-packages/sentry/api/serializers/base.py", line 43, in serialize
     return [serializer(o, attrs=attrs.get(o, {}), user=user, **kwargs) for o in objects]
   File "/usr/local/lib/python3.6/site-packages/sentry/api/serializers/base.py", line 43, in <listcomp>
     return [serializer(o, attrs=attrs.get(o, {}), user=user, **kwargs) for o in objects]
   File "/usr/local/lib/python3.6/site-packages/sentry/api/serializers/base.py", line 58, in __call__
     return self.serialize(obj, attrs, user, **kwargs)
   File "/usr/local/lib/python3.6/site-packages/sentry/api/serializers/models/sentry_app.py", line 29, in serialize
     "allowedOrigins": obj.application.get_allowed_origins(),
 AttributeError: 'NoneType' object has no attribute 'get_allowed_origins'
```