### PR TITLE
fix(discover): Allow search on unknown issue

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -995,12 +995,12 @@ def format_search_filter(term, params):
         # A blank term value means that this is a has filter
         group_ids = to_list(value)
     elif name == ISSUE_ALIAS:
+        operator = term.operator
         if value == "unknown":
             # `unknown` is a special value for when there is no issue associated with the event
             operator = "=" if term.operator == "=" else "!="
             value = ""
         elif value != "" and params and "organization_id" in params:
-            operator = term.operator
             try:
                 group = Group.objects.by_qualified_short_id(params["organization_id"], value)
             except Exception:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -995,14 +995,19 @@ def format_search_filter(term, params):
         # A blank term value means that this is a has filter
         group_ids = to_list(value)
     elif name == ISSUE_ALIAS:
-        if value != "" and params and "organization_id" in params:
+        if value == "unknown":
+            # `unknown` is a special value for when there is no issue associated with the event
+            operator = "=" if term.operator == "=" else "!="
+            value = ""
+        elif value != "" and params and "organization_id" in params:
+            operator = term.operator
             try:
                 group = Group.objects.by_qualified_short_id(params["organization_id"], value)
             except Exception:
                 raise InvalidSearchQuery("Invalid value '{}' for 'issue:' filter".format(value))
             else:
                 value = group.id
-        term = SearchFilter(SearchKey("issue.id"), term.operator, SearchValue(value))
+        term = SearchFilter(SearchKey("issue.id"), operator, SearchValue(value))
         converted_filter = convert_search_filter_to_snuba_query(term)
         conditions.append(converted_filter)
     elif name == RELEASE_ALIAS and params and value == "latest":

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1815,6 +1815,17 @@ class GetSnubaQueryArgsTest(TestCase):
         assert _filter.filter_keys == {}
         assert _filter.group_ids == []
 
+    def test_unknown_issue_filter(self):
+        _filter = get_filter("issue:unknown", {"organization_id": self.organization.id})
+        assert _filter.conditions == [[["isNull", ["issue.id"]], "=", 1]]
+        assert _filter.filter_keys == {}
+        assert _filter.group_ids == []
+
+        _filter = get_filter("!issue:unknown", {"organization_id": self.organization.id})
+        assert _filter.conditions == [["issue.id", "!=", 0]]
+        assert _filter.filter_keys == {}
+        assert _filter.group_ids == []
+
     def test_user_display_filter(self):
         _filter = get_filter(
             "user.display:bill@example.com", {"organization_id": self.organization.id}


### PR DESCRIPTION
When drilling down or using a cell action on an issue column that is unknown,
the generated condition `issue:unknown` does not work as expected as the group
look up fails. This change ensures that this condition works as intended as well
as supports `!issue:unknown`.