### PR TITLE
fix(ui): Platform sorting done according to name(#23410)

### DIFF
--- a/src/sentry/static/sentry/app/components/platformPicker.tsx
+++ b/src/sentry/static/sentry/app/components/platformPicker.tsx
@@ -59,7 +59,7 @@ class PlatformPicker extends React.Component<Props, State> {
 
     const filtered = platforms
       .filter(this.state.filter ? subsetMatch : categoryMatch)
-      .sort((a, b) => a.id.localeCompare(b.id));
+      .sort((a, b) => a.name.localeCompare(b.name));
 
     return this.props.showOther ? filtered : filtered.filter(({id}) => id !== 'other');
   }

--- a/tests/js/spec/views/projectInstall/createProject.spec.jsx
+++ b/tests/js/spec/views/projectInstall/createProject.spec.jsx
@@ -85,11 +85,11 @@ describe('CreateProject', function () {
 
     let node = wrapper.find('PlatformCard').first();
     node.simulate('click');
-    expect(wrapper.find('ProjectNameInput input').props().value).toBe('iOS');
+    expect(wrapper.find('ProjectNameInput input').props().value).toBe('.NET');
 
     node = wrapper.find('PlatformCard').last();
     node.simulate('click');
-    expect(wrapper.find('ProjectNameInput input').props().value).toBe('Rails');
+    expect(wrapper.find('ProjectNameInput input').props().value).toBe('Vue');
 
     //but not replace it when project name is something else:
     wrapper.setState({projectName: 'another'});


### PR DESCRIPTION
* Hi @EvanPurkhiser My first pr here, I tried to sort platforms according to name instead of id to resolve issue https://github.com/getsentry/sentry/issues/23410. 

* This include a change in `should fill in project name if its empty when platform is chosen` test in `createProject.spec.jsx` due to sorting order change

* New sorting screenshots according to `platform.name`:

![image](https://user-images.githubusercontent.com/32355782/106511186-f0c7a600-64e0-11eb-9c0c-bfd263852f79.png)
![image](https://user-images.githubusercontent.com/32355782/106511267-118ffb80-64e1-11eb-86ac-6b92ee6c1cd3.png)
