### PR TITLE
feat(sidebar): Control open sidebar panels via a mobx store

### DIFF
--- a/src/sentry/static/sentry/app/stores/sidebarPanelStore.tsx
+++ b/src/sentry/static/sentry/app/stores/sidebarPanelStore.tsx
@@ -1,0 +1,23 @@
+import {action, observable} from 'mobx';
+
+import {SidebarPanelKey} from 'app/components/sidebar/types';
+
+class SidebarPanelStore {
+  @observable
+  activePanel: SidebarPanelKey | '' = '';
+
+  @action
+  activatePanel(panel: SidebarPanelKey) {
+    this.activePanel = this.activePanel === panel ? '' : panel;
+    console.log('TEST');
+  }
+
+  @action
+  hidePanel() {
+    this.activePanel = '';
+  }
+}
+
+const sidebarPanelStore = new SidebarPanelStore();
+
+export default sidebarPanelStore;


### PR DESCRIPTION
I need to control the state of what sidebar panel is displyaed for a new feature where available SDK updates are shown in the Broadcasts panel. (see https://github.com/getsentry/sentry/pull/23408)

This is definitely a RFC since we haven't used mobx yet for anything outside of forms, so this is a PoC for using mobx for other things

I am fine if this gets -1'd, and can implement with reflux for now. (though it becomes a bit harder to reactively add and remove the click-outside handlers