### PR TITLE
fix(dashboardsv2): When switching display types, ensure there is a correct number of queries

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -162,11 +162,17 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       set(newState, field, value);
 
       if (field === 'displayType') {
+        let newQueries = prevState.queries;
+
+        if (['table', 'world_map', 'big_number'].includes(value)) {
+          // Some display types may only support at most 1 query.
+          set(newState, 'queries', prevState.queries.slice(0, 1));
+          newQueries = newState.queries;
+        }
+
         if (value === 'table') {
           return newState;
         }
-
-        let newQueries = prevState.queries;
 
         // Filter out non-aggregate fields
         newQueries = newQueries.map(query => {


### PR DESCRIPTION
When switching to a table, a world map, or a big number dashboard widget, we'd need to ensure there are at most one query.

Otherwise, this can lead to weird bugs like this:

<img width="826" alt="Screen Shot 2021-02-01 at 2 17 05 PM" src="https://user-images.githubusercontent.com/139499/106511822-c9e88000-649e-11eb-806a-230c519aa247.png">
