### PR TITLE
ref: f-stringify tests/

### DIFF
--- a/tests/acceptance/page_objects/global_selection.py
+++ b/tests/acceptance/page_objects/global_selection.py
@@ -30,7 +30,7 @@ class GlobalSelectionPage(BasePage):
         self.browser.click('[data-test-id="global-header-environment-selector"]')
 
     def select_environment(self, environment):
-        environment_path = '//*[text()="{}"]'.format(environment)
+        environment_path = f'//*[text()="{environment}"]'
 
         self.open_project_selector()
         self.browser.wait_until(xpath=environment_path)
@@ -40,7 +40,7 @@ class GlobalSelectionPage(BasePage):
         self.browser.click('[data-test-id="global-header-timerange-selector"]')
 
     def select_date(self, date):
-        date_path = '//*[text()="{}"]'.format(date)
+        date_path = f'//*[text()="{date}"]'
 
         self.open_date_selector()
         self.browser.wait_until(xpath=date_path)

--- a/tests/acceptance/page_objects/global_selection.py
+++ b/tests/acceptance/page_objects/global_selection.py
@@ -18,9 +18,7 @@ class GlobalSelectionPage(BasePage):
         self.browser.click('[data-test-id="global-header-project-selector"]')
 
     def select_project_by_slug(self, slug):
-        project_item_selector = '//*[@data-test-id="badge-display-name" and text()="{}"]'.format(
-            slug
-        )
+        project_item_selector = f'//*[@data-test-id="badge-display-name" and text()="{slug}"]'
 
         self.open_project_selector()
         self.browser.wait_until(xpath=project_item_selector)

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -9,17 +9,15 @@ class IssueDetailsPage(BasePage):
         self.global_selection = GlobalSelectionPage(browser)
 
     def visit_issue(self, org, groupid):
-        self.browser.get("/organizations/{}/issues/{}/".format(org, groupid))
+        self.browser.get(f"/organizations/{org}/issues/{groupid}/")
         self.wait_until_loaded()
 
     def visit_issue_in_environment(self, org, groupid, environment):
-        self.browser.get(
-            "/organizations/{}/issues/{}/?environment={}".format(org, groupid, environment)
-        )
+        self.browser.get(f"/organizations/{org}/issues/{groupid}/?environment={environment}")
         self.browser.wait_until(".group-detail")
 
     def visit_tag_values(self, org, groupid, tag):
-        self.browser.get("/organizations/{}/issues/{}/tags/{}/".format(org, groupid, tag))
+        self.browser.get(f"/organizations/{org}/issues/{groupid}/tags/{tag}/")
         self.browser.wait_until_not(".loading-indicator")
 
     def get_environment(self):
@@ -29,7 +27,7 @@ class IssueDetailsPage(BasePage):
         self.global_selection.go_back_to_issues()
 
     def api_issue_get(self, groupid):
-        return self.client.get("/api/0/issues/{}/".format(groupid))
+        return self.client.get(f"/api/0/issues/{groupid}/")
 
     def go_to_subtab(self, name):
         tabs = self.browser.find_element_by_css_selector(".group-detail .nav-tabs")

--- a/tests/acceptance/page_objects/issue_list.py
+++ b/tests/acceptance/page_objects/issue_list.py
@@ -10,17 +10,17 @@ class IssueListPage(BasePage):
         self.global_selection = GlobalSelectionPage(browser)
 
     def visit_issue_list(self, org, query=""):
-        self.browser.get("/organizations/{}/issues/{}".format(org, query))
+        self.browser.get(f"/organizations/{org}/issues/{query}")
         self.wait_until_loaded()
 
     def wait_for_stream(self):
         self.browser.wait_until('[data-test-id="event-issue-header"]', timeout=20)
 
     def select_issue(self, position):
-        self.browser.click('[data-test-id="group"]:nth-child({})'.format(position))
+        self.browser.click(f'[data-test-id="group"]:nth-child({position})')
 
     def navigate_to_issue(self, position):
-        self.browser.click('[data-test-id="group"]:nth-child({}) a'.format(position))
+        self.browser.click(f'[data-test-id="group"]:nth-child({position}) a')
         self.browser.wait_until(".group-detail")
         self.issue_details = IssueDetailsPage(self.browser, self.client)
 

--- a/tests/acceptance/sentry_plugins/test_amazon_sqs.py
+++ b/tests/acceptance/sentry_plugins/test_amazon_sqs.py
@@ -10,7 +10,7 @@ class AmazonSQSTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/amazon-sqs/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/amazon-sqs/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_asana.py
+++ b/tests/acceptance/sentry_plugins/test_asana.py
@@ -10,7 +10,7 @@ class AsanaTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/asana/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/asana/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_bitbucket.py
+++ b/tests/acceptance/sentry_plugins/test_bitbucket.py
@@ -10,7 +10,7 @@ class BitbucketTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/bitbucket/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/bitbucket/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_clubhouse.py
+++ b/tests/acceptance/sentry_plugins/test_clubhouse.py
@@ -10,7 +10,7 @@ class ClubhouseTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/clubhouse/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/clubhouse/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_github.py
+++ b/tests/acceptance/sentry_plugins/test_github.py
@@ -10,7 +10,7 @@ class GitHubTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/github/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/github/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_gitlab.py
+++ b/tests/acceptance/sentry_plugins/test_gitlab.py
@@ -10,7 +10,7 @@ class GitLabTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/gitlab/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/gitlab/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_jira.py
+++ b/tests/acceptance/sentry_plugins/test_jira.py
@@ -10,7 +10,7 @@ class JIRATest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/jira/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/jira/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_pagerduty.py
+++ b/tests/acceptance/sentry_plugins/test_pagerduty.py
@@ -10,7 +10,7 @@ class PagerDutyTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/pagerduty/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/pagerduty/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_phabricator.py
+++ b/tests/acceptance/sentry_plugins/test_phabricator.py
@@ -10,7 +10,7 @@ class PhabricatorTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/phabricator/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/phabricator/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_pivotal.py
+++ b/tests/acceptance/sentry_plugins/test_pivotal.py
@@ -10,7 +10,7 @@ class PivotalTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/pivotal/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/pivotal/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_pushover.py
+++ b/tests/acceptance/sentry_plugins/test_pushover.py
@@ -10,7 +10,7 @@ class PushoverTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/pushover/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/pushover/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_segment.py
+++ b/tests/acceptance/sentry_plugins/test_segment.py
@@ -10,7 +10,7 @@ class SegmentTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/segment/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/segment/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_sessionstack.py
+++ b/tests/acceptance/sentry_plugins/test_sessionstack.py
@@ -10,7 +10,7 @@ class SessionStackTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/sessionstack/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/sessionstack/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_slack.py
+++ b/tests/acceptance/sentry_plugins/test_slack.py
@@ -10,7 +10,7 @@ class SlackTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/slack/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/slack/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_splunk.py
+++ b/tests/acceptance/sentry_plugins/test_splunk.py
@@ -10,7 +10,7 @@ class SplunkTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/splunk/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/splunk/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_victorops.py
+++ b/tests/acceptance/sentry_plugins/test_victorops.py
@@ -10,7 +10,7 @@ class VictorOpsTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/victorops/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/victorops/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/sentry_plugins/test_vsts.py
+++ b/tests/acceptance/sentry_plugins/test_vsts.py
@@ -10,7 +10,7 @@ class VstsTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/plugins/vsts/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/vsts/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/test_create_project.py
+++ b/tests/acceptance/test_create_project.py
@@ -10,7 +10,7 @@ class CreateProjectTest(AcceptanceTestCase):
         self.org = self.create_organization(name="Rowdy Tiger")
         self.login_as(self.user)
 
-        self.path = "/organizations/{}/projects/new/".format(self.org.slug)
+        self.path = f"/organizations/{self.org.slug}/projects/new/"
 
     @patch("django.db.models.signals.ModelSignal.send")
     def test_simple(self, mock_signal):

--- a/tests/acceptance/test_create_team.py
+++ b/tests/acceptance/test_create_team.py
@@ -11,7 +11,7 @@ class CreateTeamTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/settings/{}/teams/".format(self.org.slug)
+        self.path = f"/settings/{self.org.slug}/teams/"
 
     def test_create(self):
         self.browser.get(self.path)

--- a/tests/acceptance/test_dashboard.py
+++ b/tests/acceptance/test_dashboard.py
@@ -39,7 +39,7 @@ class DashboardTest(AcceptanceTestCase, SnubaTestCase):
         )
 
         self.login_as(self.user)
-        self.path = "/organizations/{}/projects/".format(self.organization.slug)
+        self.path = f"/organizations/{self.organization.slug}/projects/"
 
     def create_sample_event(self):
         self.init_snuba()
@@ -91,7 +91,7 @@ class DashboardTest(AcceptanceTestCase, SnubaTestCase):
         self.browser.wait_until('[data-test-id="toast-success"]')
 
         # Go to projects
-        self.browser.click('[href="/organizations/{}/projects/"]'.format(self.organization.slug))
+        self.browser.click(f'[href="/organizations/{self.organization.slug}/projects/"]')
         self.browser.wait_until_not(".loading-indicator")
 
         assert self.browser.element('[data-test-id="badge-display-name"]').text == "#foo-new-slug"
@@ -101,7 +101,7 @@ class EmptyDashboardTest(AcceptanceTestCase):
     def setUp(self):
         super(EmptyDashboardTest, self).setUp()
         self.login_as(self.user)
-        self.path = "/organizations/{}/projects/".format(self.organization.slug)
+        self.path = f"/organizations/{self.organization.slug}/projects/"
 
     def test_new_dashboard_empty(self):
         self.browser.get(self.path)

--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -59,7 +59,7 @@ class EmailTestCase(AcceptanceTestCase):
             # HTML output is captured as a snapshot
             self.browser.get(self.build_url(url, "html"))
             self.browser.wait_until("#preview")
-            self.browser.snapshot("{} email html".format(name))
+            self.browser.snapshot(f"{name} email html")
 
             # Text output is asserted against static fixture files
             self.browser.get(self.build_url(url, "txt"))

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -39,8 +39,8 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
             self.browser.wait_until_test_id("incident-sparkline")
             self.browser.snapshot("incidents - list")
 
-            details_url = '[href="/organizations/{}/alerts/{}/'.format(
-                self.organization.slug, incident.identifier
+            details_url = (
+                f'[href="/organizations/{self.organization.slug}/alerts/{incident.identifier}/'
             )
             self.browser.wait_until(details_url)
             self.browser.click(details_url)

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -13,7 +13,7 @@ class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
         super(OrganizationIncidentsListTest, self).setUp()
         self.login_as(self.user)
-        self.path = "/organizations/{}/alerts/".format(self.organization.slug)
+        self.path = f"/organizations/{self.organization.slug}/alerts/"
 
     def test_empty_incidents(self):
         with self.feature(FEATURE_NAME):

--- a/tests/acceptance/test_member_list.py
+++ b/tests/acceptance/test_member_list.py
@@ -21,7 +21,7 @@ class ListOrganizationMembersTest(AcceptanceTestCase):
         self.login_as(self.user)
 
     def test_list(self):
-        self.browser.get("/organizations/{}/members/".format(self.org.slug))
+        self.browser.get(f"/organizations/{self.org.slug}/members/")
         self.browser.wait_until_not(".loading-indicator")
         self.browser.snapshot(name="list organization members")
         assert self.browser.element_exists_by_test_id("email-invite")

--- a/tests/acceptance/test_organization_activity.py
+++ b/tests/acceptance/test_organization_activity.py
@@ -14,7 +14,7 @@ class OrganizationActivityTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.group = self.create_group(project=self.project)
         self.login_as(self.user)
-        self.path = "/organizations/{}/activity/".format(self.org.slug)
+        self.path = f"/organizations/{self.org.slug}/activity/"
         self.project.update(first_event=timezone.now())
 
     def test(self):

--- a/tests/acceptance/test_organization_alert_rules.py
+++ b/tests/acceptance/test_organization_alert_rules.py
@@ -10,7 +10,7 @@ class OrganizationAlertRulesListTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
         super(OrganizationAlertRulesListTest, self).setUp()
         self.login_as(self.user)
-        self.path = "/organizations/{}/alerts/rules/".format(self.organization.slug)
+        self.path = f"/organizations/{self.organization.slug}/alerts/rules/"
 
     def test_empty_alert_rules(self):
         with self.feature(FEATURE_NAME):

--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -12,9 +12,7 @@ class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
     def setUp(self):
         super(OrganizationDashboardsAcceptanceTest, self).setUp()
         min_ago = iso_format(before_now(minutes=1))
-        self.default_path = "/organizations/{}/dashboards/default-overview/".format(
-            self.organization.slug
-        )
+        self.default_path = f"/organizations/{self.organization.slug}/dashboards/default-overview/"
         self.store_event(
             data={"event_id": "a" * 32, "message": "oh no", "timestamp": min_ago},
             project_id=self.project.id,

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -14,9 +14,7 @@ class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
         )
 
         self.login_as(self.user)
-        self.org_developer_settings_path = "/settings/{}/developer-settings/".format(
-            self.organization.slug
-        )
+        self.org_developer_settings_path = f"/settings/{self.organization.slug}/developer-settings/"
 
     def load_page(self, url):
         self.browser.get(url)
@@ -65,8 +63,8 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
         )
         self.login_as(self.user)
 
-        self.org_developer_settings_path = "/settings/{}/developer-settings/{}".format(
-            self.org.slug, self.sentry_app.slug
+        self.org_developer_settings_path = (
+            f"/settings/{self.org.slug}/developer-settings/{self.sentry_app.slug}"
         )
 
     def load_page(self, url):

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -94,7 +94,7 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
 
     def test_remove_tokens_internal_app(self):
         internal_app = self.create_internal_integration(name="Internal App", organization=self.org)
-        url = "/settings/{}/developer-settings/{}".format(self.org.slug, internal_app.slug)
+        url = f"/settings/{self.org.slug}/developer-settings/{internal_app.slug}"
 
         self.load_page(url)
 
@@ -107,7 +107,7 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
 
     def test_add_tokens_internal_app(self):
         internal_app = self.create_internal_integration(name="Internal App", organization=self.org)
-        url = "/settings/{}/developer-settings/{}".format(self.org.slug, internal_app.slug)
+        url = f"/settings/{self.org.slug}/developer-settings/{internal_app.slug}"
 
         self.load_page(url)
 

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -48,7 +48,7 @@ class OrganizationDiscoverTest(AcceptanceTestCase, SnubaTestCase):
             },
             project_id=self.project.id,
         )
-        self.path = "/organizations/{}/discover/".format(self.org.slug)
+        self.path = f"/organizations/{self.org.slug}/discover/"
 
     def test_no_access(self):
         with self.feature(

--- a/tests/acceptance/test_organization_document_integration_detailed_view.py
+++ b/tests/acceptance/test_organization_document_integration_detailed_view.py
@@ -11,7 +11,7 @@ class OrganizationDocumentIntegrationDetailView(AcceptanceTestCase):
         self.login_as(self.user)
 
     def load_page(self, slug):
-        url = "/settings/{}/document-integrations/{}/".format(self.organization.slug, slug)
+        url = f"/settings/{self.organization.slug}/document-integrations/{slug}/"
         self.browser.get(url)
         self.browser.wait_until_not(".loading-indicator")
 

--- a/tests/acceptance/test_organization_events.py
+++ b/tests/acceptance/test_organization_events.py
@@ -13,7 +13,7 @@ class OrganizationEventsTest(AcceptanceTestCase):
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
 
         self.login_as(self.user)
-        self.path = "/organizations/{}/events/".format(self.org.slug)
+        self.path = f"/organizations/{self.org.slug}/events/"
 
     def test_no_access(self):
         self.browser.get(self.path)

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -142,8 +142,8 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
 
         self.login_as(self.user)
-        self.landing_path = "/organizations/{}/discover/queries/".format(self.org.slug)
-        self.result_path = "/organizations/{}/discover/results/".format(self.org.slug)
+        self.landing_path = f"/organizations/{self.org.slug}/discover/queries/"
+        self.result_path = f"/organizations/{self.org.slug}/discover/results/"
 
     def wait_until_loaded(self):
         self.browser.wait_until_not(".loading-indicator")
@@ -456,9 +456,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.browser.element('input[name="query_name"]').send_keys(query_name)
             self.browser.element('[aria-label="Save"]').click()
 
-            self.browser.wait_until(
-                'div[name="discover2-query-name"][value="{}"]'.format(query_name)
-            )
+            self.browser.wait_until(f'div[name="discover2-query-name"][value="{query_name}"]')
 
             # Page title should update.
             title_input = self.browser.element('div[name="discover2-query-name"]')
@@ -480,7 +478,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
 
             # Look at the results for our query.
-            self.browser.element('[data-test-id="card-{}"]'.format(query.name)).click()
+            self.browser.element(f'[data-test-id="card-{query.name}"]').click()
             self.wait_until_loaded()
 
             input = self.browser.element('div[name="discover2-query-name"]')
@@ -491,7 +489,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.browser.element("table").click()
 
             new_name = "Custom queryupdated!"
-            new_card_selector = 'div[name="discover2-query-name"][value="{}"]'.format(new_name)
+            new_card_selector = f'div[name="discover2-query-name"][value="{new_name}"]'
             self.browser.wait_until(new_card_selector)
 
         # Assert the name was updated.
@@ -511,7 +509,7 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
 
             # Get the card with the new query
-            card_selector = '[data-test-id="card-{}"]'.format(query.name)
+            card_selector = f'[data-test-id="card-{query.name}"]'
             card = self.browser.element(card_selector)
 
             # Open the context menu
@@ -538,16 +536,16 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
             self.wait_until_loaded()
 
             # Get the card with the new query
-            card_selector = '[data-test-id="card-{}"]'.format(query.name)
+            card_selector = f'[data-test-id="card-{query.name}"]'
             card = self.browser.element(card_selector)
 
             # Open the context menu, and duplicate
             card.find_element_by_css_selector('[data-test-id="context-menu"]').click()
             card.find_element_by_css_selector('[data-test-id="duplicate-query"]').click()
 
-            duplicate_name = "{} copy".format(query.name)
+            duplicate_name = f"{query.name} copy"
             # Wait for new element to show up.
-            self.browser.element('[data-test-id="card-{}"]'.format(duplicate_name))
+            self.browser.element(f'[data-test-id="card-{duplicate_name}"]')
         # Assert the new query exists and has 'copy' added to the name.
         assert DiscoverSavedQuery.objects.filter(name=duplicate_name).exists()
 

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -95,25 +95,23 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         self.create_issues()
         # No project id in URL, selects first project
         self.issues_list.visit_issue_list(self.org.slug)
-        assert "project={}".format(self.project_1.id) in self.browser.current_url
+        assert f"project={self.project_1.id}" in self.browser.current_url
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_1.slug
 
         # Uses project id in URL
-        self.issues_list.visit_issue_list(
-            self.org.slug, query="?project={}".format(self.project_2.id)
-        )
-        assert "project={}".format(self.project_2.id) in self.browser.current_url
+        self.issues_list.visit_issue_list(self.org.slug, query=f"?project={self.project_2.id}")
+        assert f"project={self.project_2.id}" in self.browser.current_url
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_2.slug
 
         # reloads page with no project id in URL, selects first project
         self.issues_list.visit_issue_list(self.org.slug)
-        assert "project={}".format(self.project_1.id) in self.browser.current_url
+        assert f"project={self.project_1.id}" in self.browser.current_url
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_1.slug
 
         # can select a different project
         self.issues_list.global_selection.select_project_by_slug(self.project_3.slug)
         self.issues_list.wait_until_loaded()
-        assert "project={}".format(self.project_3.id) in self.browser.current_url
+        assert f"project={self.project_3.id}" in self.browser.current_url
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
 
         # reloading page with no project id in URL after previously
@@ -122,7 +120,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         # TODO check environment as well
         self.issues_list.visit_issue_list(self.org.slug)
         self.issues_list.wait_until_loaded()
-        assert "project={}".format(self.project_3.id) in self.browser.current_url
+        assert f"project={self.project_3.id}" in self.browser.current_url
 
     def test_global_selection_header_navigates_with_browser_back_button(self):
         """
@@ -143,13 +141,13 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         # selects a different project
         self.issues_list.global_selection.select_project_by_slug(self.project_3.slug)
         self.issues_list.wait_until_loaded()
-        assert "project={}".format(self.project_3.id) in self.browser.current_url
+        assert f"project={self.project_3.id}" in self.browser.current_url
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
 
         # simulate pressing the browser back button
         self.browser.back()
         self.issues_list.wait_until_loaded()
-        assert "project={}".format(self.project_1.id) in self.browser.current_url
+        assert f"project={self.project_1.id}" in self.browser.current_url
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_1.slug
 
     def test_global_selection_header_updates_environment_with_browser_navigation_buttons(self):
@@ -235,25 +233,17 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             self.issues_list.visit_issue_list(self.org.slug)
             assert "project=" not in self.browser.current_url
             assert self.issues_list.global_selection.get_selected_project_slug() == "My Projects"
-            assert (
-                self.browser.get_local_storage_item("global-selection:{}".format(self.org.slug))
-                is None
-            )
+            assert self.browser.get_local_storage_item(f"global-selection:{self.org.slug}") is None
 
             # Uses project id in URL
-            self.issues_list.visit_issue_list(
-                self.org.slug, query="?project={}".format(self.project_2.id)
-            )
-            assert "project={}".format(self.project_2.id) in self.browser.current_url
+            self.issues_list.visit_issue_list(self.org.slug, query=f"?project={self.project_2.id}")
+            assert f"project={self.project_2.id}" in self.browser.current_url
             assert (
                 self.issues_list.global_selection.get_selected_project_slug() == self.project_2.slug
             )
 
             # should not be in local storage
-            assert (
-                self.browser.get_local_storage_item("global-selection:{}".format(self.org.slug))
-                is None
-            )
+            assert self.browser.get_local_storage_item(f"global-selection:{self.org.slug}") is None
 
             # reloads page with no project id in URL, remains "My Projects" because
             # there has been no explicit project selection via UI
@@ -264,7 +254,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             # can select a different project
             self.issues_list.global_selection.select_project_by_slug(self.project_3.slug)
             self.issues_list.wait_until_loaded()
-            assert "project={}".format(self.project_3.id) in self.browser.current_url
+            assert f"project={self.project_3.id}" in self.browser.current_url
             assert (
                 self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
             )
@@ -281,7 +271,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             self.issues_list.visit_issue_list(self.org.slug)
             self.issues_list.wait_until_loaded()
             # TODO check environment as well
-            assert "project={}".format(self.project_3.id) in self.browser.current_url
+            assert f"project={self.project_3.id}" in self.browser.current_url
             assert (
                 self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
             )
@@ -319,7 +309,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             # can select a different project
             self.issues_list.global_selection.select_project_by_slug(self.project_3.slug)
             self.issues_list.wait_until_loaded()
-            assert "project={}".format(self.project_3.id) in self.browser.current_url
+            assert f"project={self.project_3.id}" in self.browser.current_url
             assert (
                 self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
             )
@@ -332,31 +322,29 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         """
         mock_now.return_value = datetime.utcnow().replace(tzinfo=pytz.utc)
         self.create_issues()
-        self.issues_list.visit_issue_list(
-            self.org.slug, query="?project={}".format(self.project_2.id)
-        )
+        self.issues_list.visit_issue_list(self.org.slug, query=f"?project={self.project_2.id}")
         self.issues_list.wait_for_issue()
 
-        assert "project={}".format(self.project_2.id) in self.browser.current_url
+        assert f"project={self.project_2.id}" in self.browser.current_url
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_2.slug
 
         # select the issue
         self.issues_list.navigate_to_issue(1)
 
         # project id should remain in URL
-        assert "project={}".format(self.project_2.id) in self.browser.current_url
+        assert f"project={self.project_2.id}" in self.browser.current_url
 
         # going back to issues list should keep project in URL
         self.issues_list.issue_details.go_back_to_issues()
         self.issues_list.wait_for_issue()
 
         # project id should remain in URL
-        assert "project={}".format(self.project_2.id) in self.browser.current_url
+        assert f"project={self.project_2.id}" in self.browser.current_url
 
         # can select a different project
         self.issues_list.global_selection.select_project_by_slug(self.project_3.slug)
         self.issues_list.wait_until_loaded()
-        assert "project={}".format(self.project_3.id) in self.browser.current_url
+        assert f"project={self.project_3.id}" in self.browser.current_url
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_3.slug
 
     @patch("django.utils.timezone.now")
@@ -371,7 +359,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         self.issue_details.visit_issue_in_environment(self.org.slug, self.issue_2.group.id, "prod")
 
         # Make sure issue's project is in URL and in header
-        assert "project={}".format(self.project_2.id) in self.browser.current_url
+        assert f"project={self.project_2.id}" in self.browser.current_url
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_2.slug
 
         # environment should be in URL and header
@@ -383,7 +371,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
         self.issues_list.wait_for_issue()
 
         # project id should remain in URL
-        assert "project={}".format(self.project_2.id) in self.browser.current_url
+        assert f"project={self.project_2.id}" in self.browser.current_url
         assert "environment=prod" in self.browser.current_url
         assert self.issues_list.global_selection.get_selected_project_slug() == self.project_2.slug
         assert self.issue_details.global_selection.get_selected_environment() == "prod"
@@ -405,7 +393,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             )
 
             # Make sure issue's project is in URL and in header
-            assert "project={}".format(self.project_2.id) in self.browser.current_url
+            assert f"project={self.project_2.id}" in self.browser.current_url
             assert (
                 self.issues_list.global_selection.get_selected_project_slug() == self.project_2.slug
             )
@@ -422,7 +410,7 @@ class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
             self.issues_list.wait_for_issue()
 
             # project id should remain in URL
-            assert "project={}".format(self.project_2.id) in self.browser.current_url
+            assert f"project={self.project_2.id}" in self.browser.current_url
             assert "environment=prod" in self.browser.current_url
             assert (
                 self.issues_list.global_selection.get_selected_project_slug() == self.project_2.slug

--- a/tests/acceptance/test_organization_integration_detail_view.py
+++ b/tests/acceptance/test_organization_integration_detail_view.py
@@ -21,7 +21,7 @@ class OrganizationIntegrationDetailView(AcceptanceTestCase):
         self.login_as(self.user)
 
     def load_page(self, slug, configuration_tab=False):
-        url = "/settings/{}/integrations/{}/".format(self.organization.slug, slug)
+        url = f"/settings/{self.organization.slug}/integrations/{slug}/"
         if configuration_tab:
             url += "?tab=configurations"
         self.browser.get(url)

--- a/tests/acceptance/test_organization_integration_detail_view.py
+++ b/tests/acceptance/test_organization_integration_detail_view.py
@@ -47,9 +47,7 @@ class OrganizationIntegrationDetailView(AcceptanceTestCase):
 
         assert integration
         assert (
-            "/settings/{}/integrations/{}/{}/".format(
-                self.organization.slug, self.provider.key, integration.id
-            )
+            f"/settings/{self.organization.slug}/integrations/{self.provider.key}/{integration.id}/"
             in self.browser.driver.current_url
         )
 

--- a/tests/acceptance/test_organization_integration_directory.py
+++ b/tests/acceptance/test_organization_integration_directory.py
@@ -7,7 +7,7 @@ class OrganizationIntegrationDirectoryTest(AcceptanceTestCase):
         self.login_as(self.user)
 
     def test_all_integrations_list(self):
-        path = "/settings/{}/integrations/".format(self.organization.slug)
+        path = f"/settings/{self.organization.slug}/integrations/"
         self.browser.get(path)
         self.browser.wait_until_not(".loading-indicator")
         self.browser.snapshot("integrations - integration directory")

--- a/tests/acceptance/test_organization_plugin_detail_view.py
+++ b/tests/acceptance/test_organization_plugin_detail_view.py
@@ -20,7 +20,7 @@ class OrganizationPluginDetailedView(AcceptanceTestCase):
         self.login_as(self.user)
 
     def load_page(self, slug, configuration_tab=False):
-        url = "/settings/{}/plugins/{}/".format(self.organization.slug, slug)
+        url = f"/settings/{self.organization.slug}/plugins/{slug}/"
         if configuration_tab:
             url += "?tab=configurations"
         self.browser.get(url)

--- a/tests/acceptance/test_organization_rate_limits.py
+++ b/tests/acceptance/test_organization_rate_limits.py
@@ -13,7 +13,7 @@ class OrganizationRateLimitsTest(AcceptanceTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
-        self.path = "/organizations/{}/rate-limits/".format(self.org.slug)
+        self.path = f"/organizations/{self.org.slug}/rate-limits/"
 
     @patch("sentry.app.quotas.get_maximum_quota", Mock(return_value=(100, 60)))
     def test_with_rate_limits(self):

--- a/tests/acceptance/test_organization_releases.py
+++ b/tests/acceptance/test_organization_releases.py
@@ -17,7 +17,7 @@ class OrganizationReleasesTest(AcceptanceTestCase):
         )
         self.create_project(organization=self.org, teams=[self.team], name="Bengal 3")
         self.login_as(self.user)
-        self.path = "/organizations/{}/releases/".format(self.org.slug)
+        self.path = f"/organizations/{self.org.slug}/releases/"
         self.project.update(first_event=timezone.now())
 
     def test_list(self):

--- a/tests/acceptance/test_organization_security_privacy.py
+++ b/tests/acceptance/test_organization_security_privacy.py
@@ -9,7 +9,7 @@ class OrganizationSecurityAndPrivacyTest(AcceptanceTestCase):
         self.user = self.create_user("owner@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.login_as(self.user)
-        self.path = "/settings/{}/security-and-privacy/".format(self.org.slug)
+        self.path = f"/settings/{self.org.slug}/security-and-privacy/"
 
     def load_organization_helper(self, snapshot_name=None):
         self.browser.wait_until_not(".loading-indicator")

--- a/tests/acceptance/test_organization_sentry_app.py
+++ b/tests/acceptance/test_organization_sentry_app.py
@@ -27,7 +27,7 @@ class OrganizationSentryAppAcceptanceTestCase(AcceptanceTestCase):
 
         self.login_as(self.user)
 
-        self.org_integration_settings_path = "/settings/{}/integrations/".format(self.org.slug)
+        self.org_integration_settings_path = f"/settings/{self.org.slug}/integrations/"
 
         self.provider = mock.Mock()
         self.provider.key = "tesla-app"

--- a/tests/acceptance/test_organization_sentry_app_detailed_view.py
+++ b/tests/acceptance/test_organization_sentry_app_detailed_view.py
@@ -18,7 +18,7 @@ class OrganizationSentryAppDetailedView(AcceptanceTestCase):
         self.login_as(self.user)
 
     def load_page(self, slug):
-        url = "/settings/{}/sentry-apps/{}/".format(self.organization.slug, slug)
+        url = f"/settings/{self.organization.slug}/sentry-apps/{slug}/"
         self.browser.get(url)
         self.browser.wait_until_not(".loading-indicator")
 

--- a/tests/acceptance/test_organization_stats.py
+++ b/tests/acceptance/test_organization_stats.py
@@ -13,7 +13,7 @@ class OrganizationStatsTest(AcceptanceTestCase):
             organization=self.org, teams=[self.team], name="Project Name"
         )
         self.login_as(self.user)
-        self.path = "/organizations/{}/stats/".format(self.org.slug)
+        self.path = f"/organizations/{self.org.slug}/stats/"
 
     def test_simple(self):
         self.project.update(first_event=timezone.now())

--- a/tests/acceptance/test_organization_switch.py
+++ b/tests/acceptance/test_organization_switch.py
@@ -82,4 +82,4 @@ class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
 
     @staticmethod
     def url_creator(page_path, org_slug):
-        return "organizations/{org_id}/{page_path}/".format(org_id=org_slug, page_path=page_path)
+        return f"organizations/{org_slug}/{page_path}/"

--- a/tests/acceptance/test_organization_user_feedback.py
+++ b/tests/acceptance/test_organization_user_feedback.py
@@ -13,7 +13,7 @@ class OrganizationUserFeedbackTest(AcceptanceTestCase):
         )
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
-        self.path = "/organizations/{}/user-feedback/".format(self.org.slug)
+        self.path = f"/organizations/{self.org.slug}/user-feedback/"
         self.project.update(first_event=timezone.now())
 
     def test(self):

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -26,7 +26,7 @@ class PerformanceOverviewTest(AcceptanceTestCase, SnubaTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.group = self.create_group(project=self.project)
         self.login_as(self.user)
-        self.path = "/organizations/{}/performance/".format(self.org.slug)
+        self.path = f"/organizations/{self.org.slug}/performance/"
 
         self.page = BasePage(self.browser)
 

--- a/tests/acceptance/test_performance_trends.py
+++ b/tests/acceptance/test_performance_trends.py
@@ -27,7 +27,7 @@ class PerformanceTrendsTest(AcceptanceTestCase, SnubaTestCase):
             event.update(
                 {
                     "transaction": name,
-                    "event_id": "{:02x}".format(index).rjust(32, "0"),
+                    "event_id": f"{index:02x}".rjust(32, "0"),
                     "start_timestamp": iso_format(before_now(minutes=minutes, seconds=duration)),
                     "timestamp": iso_format(before_now(minutes=minutes)),
                 }

--- a/tests/acceptance/test_project_alert_settings.py
+++ b/tests/acceptance/test_project_alert_settings.py
@@ -40,7 +40,7 @@ class ProjectAlertSettingsTest(AcceptanceTestCase):
         )
 
         self.login_as(self.user)
-        self.path1 = "/settings/{}/projects/{}/alerts/".format(self.org.slug, self.project.slug)
+        self.path1 = f"/settings/{self.org.slug}/projects/{self.project.slug}/alerts/"
 
     def test_settings_load(self):
         self.browser.get(self.path1)

--- a/tests/acceptance/test_project_all_integrations_settings.py
+++ b/tests/acceptance/test_project_all_integrations_settings.py
@@ -13,7 +13,7 @@ class ProjectAllIntegrationsSettingsTest(AcceptanceTestCase):
         self.login_as(self.user)
 
     def test_all_integrations_list(self):
-        path = "/{}/{}/settings/plugins/".format(self.org.slug, self.project.slug)
+        path = f"/{self.org.slug}/{self.project.slug}/settings/plugins/"
         self.browser.get(path)
         self.browser.wait_until_not(".loading-indicator")
         self.browser.snapshot("project settings - all integrations")

--- a/tests/acceptance/test_project_data_forwarding_settings.py
+++ b/tests/acceptance/test_project_data_forwarding_settings.py
@@ -11,7 +11,7 @@ class ProjectDataForwardingSettingsTest(AcceptanceTestCase):
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
 
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/data-forwarding/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/data-forwarding/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/test_project_debug_symbols_settings.py
+++ b/tests/acceptance/test_project_debug_symbols_settings.py
@@ -13,7 +13,7 @@ class ProjectSavedSearchesSettingsTest(AcceptanceTestCase):
         self.login_as(self.user)
 
     def test_saved_searches(self):
-        path = "/{}/{}/settings/debug-symbols/".format(self.org.slug, self.project.slug)
+        path = f"/{self.org.slug}/{self.project.slug}/settings/debug-symbols/"
         self.browser.get(path)
         self.browser.wait_until_not(".loading-indicator")
         self.browser.snapshot("project settings - debug symbols")

--- a/tests/acceptance/test_project_detail.py
+++ b/tests/acceptance/test_project_detail.py
@@ -64,7 +64,7 @@ class ProjectDetailTest(AcceptanceTestCase):
         self.create_release(project=self.project, version="3.3.3")
 
         self.login_as(self.user)
-        self.path = "/organizations/{}/projects/{}/".format(self.org.slug, self.project.slug)
+        self.path = f"/organizations/{self.org.slug}/projects/{self.project.slug}/"
 
     def test_simple(self):
         with self.feature(FEATURE_NAME):

--- a/tests/acceptance/test_project_general_settings.py
+++ b/tests/acceptance/test_project_general_settings.py
@@ -13,7 +13,7 @@ class ProjectGeneralSettingsTest(AcceptanceTestCase):
         self.login_as(self.user)
 
     def test_saved_searches(self):
-        path = "/{}/{}/settings/".format(self.org.slug, self.project.slug)
+        path = f"/{self.org.slug}/{self.project.slug}/settings/"
         self.browser.get(path)
         self.browser.wait_until_not(".loading-indicator")
         self.browser.snapshot("project settings - general settings")
@@ -22,7 +22,7 @@ class ProjectGeneralSettingsTest(AcceptanceTestCase):
         """
         It is only possible to open the menu at mobile widths
         """
-        path = "/{}/{}/settings/".format(self.org.slug, self.project.slug)
+        path = f"/{self.org.slug}/{self.project.slug}/settings/"
 
         with self.browser.mobile_viewport():
             self.browser.get(path)

--- a/tests/acceptance/test_project_keys.py
+++ b/tests/acceptance/test_project_keys.py
@@ -23,7 +23,7 @@ class ProjectKeysTest(AcceptanceTestCase):
         )
 
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/keys/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/keys/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/test_project_keys.py
+++ b/tests/acceptance/test_project_keys.py
@@ -50,9 +50,7 @@ class ProjectKeyDetailsTest(AcceptanceTestCase):
         )
 
         self.login_as(self.user)
-        self.path = "/{}/{}/settings/keys/{}/".format(
-            self.org.slug, self.project.slug, self.pk.public_key
-        )
+        self.path = f"/{self.org.slug}/{self.project.slug}/settings/keys/{self.pk.public_key}/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/test_project_ownership.py
+++ b/tests/acceptance/test_project_ownership.py
@@ -5,9 +5,7 @@ class ProjectOwnershipTest(AcceptanceTestCase):
     def setUp(self):
         super(ProjectOwnershipTest, self).setUp()
         self.login_as(self.user)
-        self.path = "/settings/{}/projects/{}/ownership/".format(
-            self.organization.slug, self.project.slug
-        )
+        self.path = f"/settings/{self.organization.slug}/projects/{self.project.slug}/ownership/"
 
     def test_simple(self):
         self.browser.get(self.path)

--- a/tests/acceptance/test_project_release_tracking_settings.py
+++ b/tests/acceptance/test_project_release_tracking_settings.py
@@ -11,7 +11,7 @@ class ProjectReleaseTrackingSettingsTest(AcceptanceTestCase, SnubaTestCase):
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
 
         self.login_as(self.user)
-        self.path1 = "/{}/{}/settings/release-tracking/".format(self.org.slug, self.project.slug)
+        self.path1 = f"/{self.org.slug}/{self.project.slug}/settings/release-tracking/"
 
     def test_tags_list(self):
         self.store_event(

--- a/tests/acceptance/test_project_releases.py
+++ b/tests/acceptance/test_project_releases.py
@@ -45,9 +45,7 @@ class ProjectReleaseDetailsTest(AcceptanceTestCase):
         self.release = self.create_release(project=self.project, version="1.0")
         self.create_group(first_release=self.release, project=self.project, message="Foo bar")
         self.login_as(self.user)
-        self.path = "/{}/{}/releases/{}/".format(
-            self.org.slug, self.project.slug, self.release.version
-        )
+        self.path = f"/{self.org.slug}/{self.project.slug}/releases/{self.release.version}/"
 
     @pytest.mark.skip(reason="Sentry 9 only")
     def test_release_details_no_commits_no_deploys(self):

--- a/tests/acceptance/test_project_releases.py
+++ b/tests/acceptance/test_project_releases.py
@@ -13,7 +13,7 @@ class ProjectReleasesTest(AcceptanceTestCase):
         self.team = self.create_team(organization=self.org, name="Mariachi Band")
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
-        self.path = "/{}/{}/releases/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/releases/"
 
     @pytest.mark.skip(reason="Sentry 9 only")
     def test_with_releases(self):

--- a/tests/acceptance/test_project_servicehooks.py
+++ b/tests/acceptance/test_project_servicehooks.py
@@ -12,12 +12,8 @@ class ProjectServiceHooksTest(AcceptanceTestCase):
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
 
         self.login_as(self.user)
-        self.list_hooks_path = "/settings/{}/projects/{}/hooks/".format(
-            self.org.slug, self.project.slug
-        )
-        self.new_hook_path = "/settings/{}/projects/{}/hooks/new/".format(
-            self.org.slug, self.project.slug
-        )
+        self.list_hooks_path = f"/settings/{self.org.slug}/projects/{self.project.slug}/hooks/"
+        self.new_hook_path = f"/settings/{self.org.slug}/projects/{self.project.slug}/hooks/new/"
 
     def test_simple(self):
         with self.feature("projects:servicehooks"):
@@ -28,17 +24,15 @@ class ProjectServiceHooksTest(AcceptanceTestCase):
             self.browser.click('[data-test-id="new-service-hook"]')
 
             self.browser.wait_until_not(".loading-indicator")
-            assert self.browser.current_url == "{}{}".format(
-                self.browser.live_server_url, self.new_hook_path
-            )
+            assert self.browser.current_url == f"{self.browser.live_server_url}{self.new_hook_path}"
             self.browser.snapshot("project settings - service hooks - create")
             self.browser.element('input[name="url"]').send_keys("https://example.com/hook")
             # click "Save Changes"
             self.browser.click('form [data-test-id="form-submit"]')
 
             self.browser.wait_until_not(".loading-indicator")
-            assert self.browser.current_url == "{}{}".format(
-                self.browser.live_server_url, self.list_hooks_path
+            assert (
+                self.browser.current_url == f"{self.browser.live_server_url}{self.list_hooks_path}"
             )
             self.browser.snapshot("project settings - service hooks - list with entries")
 
@@ -51,8 +45,6 @@ class ProjectServiceHooksTest(AcceptanceTestCase):
             self.browser.wait_until_not(".loading-indicator")
             assert self.browser.current_url == "{}{}".format(
                 self.browser.live_server_url,
-                "/settings/{}/projects/{}/hooks/{}/".format(
-                    self.org.slug, self.project.slug, hook.guid
-                ),
+                f"/settings/{self.org.slug}/projects/{self.project.slug}/hooks/{hook.guid}/",
             )
             self.browser.snapshot("project settings - service hooks - details")

--- a/tests/acceptance/test_project_tags_settings.py
+++ b/tests/acceptance/test_project_tags_settings.py
@@ -18,7 +18,7 @@ class ProjectTagsSettingsTest(AcceptanceTestCase, SnubaTestCase):
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
 
         self.login_as(self.user)
-        self.path = "/settings/{}/projects/{}/tags/".format(self.org.slug, self.project.slug)
+        self.path = f"/settings/{self.org.slug}/projects/{self.project.slug}/tags/"
 
     @patch("django.utils.timezone.now", return_value=current_time)
     def test_tags_list(self, mock_timezone):

--- a/tests/acceptance/test_project_user_feedback.py
+++ b/tests/acceptance/test_project_user_feedback.py
@@ -13,7 +13,7 @@ class ProjectUserFeedbackTest(AcceptanceTestCase):
         )
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
-        self.path = "/{}/{}/user-feedback/".format(self.org.slug, self.project.slug)
+        self.path = f"/{self.org.slug}/{self.project.slug}/user-feedback/"
         self.project.update(first_event=timezone.now())
 
     def test(self):

--- a/tests/acceptance/test_shared_issue.py
+++ b/tests/acceptance/test_shared_issue.py
@@ -20,7 +20,7 @@ class SharedIssueTest(AcceptanceTestCase):
 
         GroupShare.objects.create(project_id=event.group.project_id, group=event.group)
 
-        self.browser.get("/share/issue/{}/".format(event.group.get_share_id()))
+        self.browser.get(f"/share/issue/{event.group.get_share_id()}/")
         self.browser.wait_until_not(".loading-indicator")
         self.browser.wait_until_test_id("event-entries")
         self.browser.snapshot("shared issue python")

--- a/tests/acceptance/test_teams_list.py
+++ b/tests/acceptance/test_teams_list.py
@@ -13,7 +13,7 @@ class TeamsListTest(AcceptanceTestCase):
         self.create_member(user=self.user, organization=self.org, role="owner", teams=[self.team])
         self.login_as(self.user)
         # this should redirect to /settings/{}/teams/
-        self.path = "/organizations/{}/teams/".format(self.org.slug)
+        self.path = f"/organizations/{self.org.slug}/teams/"
 
     def test_simple(self):
         self.project.update(first_event=timezone.now())

--- a/tests/acceptance/test_transaction_comparison.py
+++ b/tests/acceptance/test_transaction_comparison.py
@@ -33,7 +33,7 @@ class TransactionComparison(AcceptanceTestCase, SnubaTestCase):
         baseline_event = self.store_event(
             data=baseline_event_data, project_id=self.project.id, assert_no_errors=True
         )
-        baseline_event_slug = "{}:{}".format(self.project.slug, baseline_event.event_id)
+        baseline_event_slug = f"{self.project.slug}:{baseline_event.event_id}"
 
         regression_event_data = generate_transaction(trace="b" * 32, span="bc" * 8)
         regression_event_data.update({"event_id": "b" * 32})
@@ -43,7 +43,7 @@ class TransactionComparison(AcceptanceTestCase, SnubaTestCase):
         regression_event = self.store_event(
             data=regression_event_data, project_id=self.project.id, assert_no_errors=True
         )
-        regression_event_slug = "{}:{}".format(self.project.slug, regression_event.event_id)
+        regression_event_slug = f"{self.project.slug}:{regression_event.event_id}"
 
         comparison_page_path = "/organizations/{}/performance/compare/{}/{}/".format(
             self.org.slug, baseline_event_slug, regression_event_slug

--- a/tests/acceptance/test_transaction_comparison.py
+++ b/tests/acceptance/test_transaction_comparison.py
@@ -45,9 +45,7 @@ class TransactionComparison(AcceptanceTestCase, SnubaTestCase):
         )
         regression_event_slug = f"{self.project.slug}:{regression_event.event_id}"
 
-        comparison_page_path = "/organizations/{}/performance/compare/{}/{}/".format(
-            self.org.slug, baseline_event_slug, regression_event_slug
-        )
+        comparison_page_path = f"/organizations/{self.org.slug}/performance/compare/{baseline_event_slug}/{regression_event_slug}/"
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(comparison_page_path)

--- a/tests/apidocs/endpoints/events/test_group_events.py
+++ b/tests/apidocs/endpoints/events/test_group_events.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.test.client import RequestFactory
 
 from sentry.testutils.helpers.datetime import iso_format, before_now
@@ -33,7 +30,7 @@ class ProjectGroupEventBase(APIDocsTestCase):
 class ProjectGroupEventsDocs(ProjectGroupEventBase):
     def setUp(self):
         super(ProjectGroupEventsDocs, self).setUp()
-        self.url = "/api/0/issues/{}/events/".format(self.group_id)
+        self.url = f"/api/0/issues/{self.group_id}/events/"
 
     def test_get(self):
         response = self.client.get(self.url)
@@ -45,7 +42,7 @@ class ProjectGroupEventsDocs(ProjectGroupEventBase):
 class ProjectGroupEventsLatestDocs(ProjectGroupEventBase):
     def setUp(self):
         super(ProjectGroupEventsLatestDocs, self).setUp()
-        self.url = "/api/0/issues/{}/events/latest/".format(self.group_id)
+        self.url = f"/api/0/issues/{self.group_id}/events/latest/"
 
     def test_get(self):
         response = self.client.get(self.url)
@@ -57,7 +54,7 @@ class ProjectGroupEventsLatestDocs(ProjectGroupEventBase):
 class ProjectGroupEventsOldestDocs(ProjectGroupEventBase):
     def setUp(self):
         super(ProjectGroupEventsOldestDocs, self).setUp()
-        self.url = "/api/0/issues/{}/events/oldest/".format(self.group_id)
+        self.url = f"/api/0/issues/{self.group_id}/events/oldest/"
 
     def test_get(self):
         response = self.client.get(self.url)

--- a/tests/apidocs/endpoints/events/test_group_hashes.py
+++ b/tests/apidocs/endpoints/events/test_group_hashes.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.test.client import RequestFactory
 
 from tests.apidocs.util import APIDocsTestCase
@@ -11,7 +8,7 @@ class ProjectGroupHashesDocs(APIDocsTestCase):
         self.create_event("a")
         event = self.create_event("b")
 
-        self.url = "/api/0/issues/{}/hashes/".format(event.group_id)
+        self.url = f"/api/0/issues/{event.group_id}/hashes/"
 
         self.login_as(user=self.user)
 

--- a/tests/apidocs/endpoints/events/test_group_issue_details.py
+++ b/tests/apidocs/endpoints/events/test_group_issue_details.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.test.client import RequestFactory
 
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -27,7 +24,7 @@ class ProjectGroupIssueDetailsDocs(APIDocsTestCase):
         for timestamp in last_release.values():
             event = self.create_event("c", release="1.0a", timestamp=iso_format(timestamp))
 
-        self.url = "/api/0/issues/{}/".format(event.group.id)
+        self.url = f"/api/0/issues/{event.group.id}/"
 
         self.login_as(user=self.user)
 

--- a/tests/apidocs/endpoints/events/test_group_tagkey_values.py
+++ b/tests/apidocs/endpoints/events/test_group_tagkey_values.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.test.client import RequestFactory
 
 from tests.apidocs.util import APIDocsTestCase
@@ -13,7 +10,7 @@ class GroupTagKeyValuesDocs(APIDocsTestCase):
 
         self.login_as(user=self.user)
 
-        self.url = "/api/0/issues/{}/tags/{}/values/".format(event.group_id, key)
+        self.url = f"/api/0/issues/{event.group_id}/tags/{key}/values/"
 
     def test_get(self):
         response = self.client.get(self.url)

--- a/tests/apidocs/endpoints/events/test_project_event_details.py
+++ b/tests/apidocs/endpoints/events/test_project_event_details.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/events/test_project_events.py
+++ b/tests/apidocs/endpoints/events/test_project_events.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/events/test_project_issues.py
+++ b/tests/apidocs/endpoints/events/test_project_issues.py
@@ -8,9 +8,7 @@ class ProjectIssuesDocs(APIDocsTestCase):
         self.create_event("a")
         self.create_event("b")
 
-        self.url = "/api/0/projects/{}/{}/issues/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        self.url = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/issues/"
 
         self.login_as(user=self.user)
 

--- a/tests/apidocs/endpoints/events/test_project_issues.py
+++ b/tests/apidocs/endpoints/events/test_project_issues.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.test.client import RequestFactory
 
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/events/test_project_tagkey_values.py
+++ b/tests/apidocs/endpoints/events/test_project_tagkey_values.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/organizations/test-event-id-lookup.py
+++ b/tests/apidocs/endpoints/organizations/test-event-id-lookup.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/organizations/test-org-details.py
+++ b/tests/apidocs/endpoints/organizations/test-org-details.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/organizations/test-org-index.py
+++ b/tests/apidocs/endpoints/organizations/test-org-index.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/organizations/test-org-projects.py
+++ b/tests/apidocs/endpoints/organizations/test-org-projects.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/organizations/test-org-repos.py
+++ b/tests/apidocs/endpoints/organizations/test-org-repos.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/organizations/test-org-stats.py
+++ b/tests/apidocs/endpoints/organizations/test-org-stats.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/organizations/test-org-users.py
+++ b/tests/apidocs/endpoints/organizations/test-org-users.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/organizations/test-repo-commits.py
+++ b/tests/apidocs/endpoints/organizations/test-repo-commits.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/organizations/test-shortid.py
+++ b/tests/apidocs/endpoints/organizations/test-shortid.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/projects/test-details.py
+++ b/tests/apidocs/endpoints/projects/test-details.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/projects/test-dsyms.py
+++ b/tests/apidocs/endpoints/projects/test-dsyms.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import zipfile
 from six import BytesIO
 

--- a/tests/apidocs/endpoints/projects/test-key-details.py
+++ b/tests/apidocs/endpoints/projects/test-key-details.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/projects/test-keys.py
+++ b/tests/apidocs/endpoints/projects/test-keys.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/projects/test-project-index.py
+++ b/tests/apidocs/endpoints/projects/test-project-index.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/projects/test-project-stats.py
+++ b/tests/apidocs/endpoints/projects/test-project-stats.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/projects/test-service-hook-details.py
+++ b/tests/apidocs/endpoints/projects/test-service-hook-details.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/projects/test-service-hooks.py
+++ b/tests/apidocs/endpoints/projects/test-service-hooks.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/projects/test-tag-values.py
+++ b/tests/apidocs/endpoints/projects/test-tag-values.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/projects/test-user-feedback.py
+++ b/tests/apidocs/endpoints/projects/test-user-feedback.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.test.client import RequestFactory
 from django.utils import timezone
 

--- a/tests/apidocs/endpoints/projects/test-user-feedback.py
+++ b/tests/apidocs/endpoints/projects/test-user-feedback.py
@@ -16,9 +16,7 @@ class ProjectUserFeedbackDocs(APIDocsTestCase):
             event_id=self.event_id,
         )
 
-        self.url = "/api/0/projects/{}/{}/user-feedback/".format(
-            self.organization.slug, self.project.slug
-        )
+        self.url = f"/api/0/projects/{self.organization.slug}/{self.project.slug}/user-feedback/"
 
         self.login_as(user=self.user)
 

--- a/tests/apidocs/endpoints/projects/test-users.py
+++ b/tests/apidocs/endpoints/projects/test-users.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/releases/test_deploys.py
+++ b/tests/apidocs/endpoints/releases/test_deploys.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import datetime
 
 from django.core.urlresolvers import reverse

--- a/tests/apidocs/endpoints/teams/test-by-slug.py
+++ b/tests/apidocs/endpoints/teams/test-by-slug.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/teams/test-index.py
+++ b/tests/apidocs/endpoints/teams/test-index.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/teams/test-projects.py
+++ b/tests/apidocs/endpoints/teams/test-projects.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/apidocs/endpoints/teams/test-stats.py
+++ b/tests/apidocs/endpoints/teams/test-stats.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
 

--- a/tests/fixtures/integrations/__init__.py
+++ b/tests/fixtures/integrations/__init__.py
@@ -1,4 +1,3 @@
-
 import os
 
 FIXTURE_DIRECTORY = os.path.join(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/fixtures/integrations/jira/__init__.py
+++ b/tests/fixtures/integrations/jira/__init__.py
@@ -1,3 +1,2 @@
-
 from .mock import MockJira
 from .stub_client import StubJiraApiClient

--- a/tests/fixtures/integrations/jira/mock.py
+++ b/tests/fixtures/integrations/jira/mock.py
@@ -12,12 +12,12 @@ class MockJira(StubJiraApiClient, MockService):
         :return: list of project objects
         """
         return [{
-            "self": "http://www.example.com/jira/rest/api/2/project/{}".format(project_name),
+            "self": f"http://www.example.com/jira/rest/api/2/project/{project_name}",
             "id": project_name,
             "key": project_name,
             "name": project_name,
             "projectCategory": {
-                "self": "http://www.example.com/jira/rest/api/2/projectCategory/{}".format(project_name),
+                "self": f"http://www.example.com/jira/rest/api/2/projectCategory/{project_name}",
                 "id": project_name,
                 "name": project_name,
                 "description": project_name

--- a/tests/fixtures/integrations/mock_service.py
+++ b/tests/fixtures/integrations/mock_service.py
@@ -71,8 +71,8 @@ class MockService(StubService):
         """
         if self._next_error_code:
             self._next_error_code = None
-            message = message_option or "{} is down".format(self.service_name)
-            raise Exception("{}: {}".format(self._next_error_code, message))
+            message = message_option or f"{self.service_name} is down"
+            raise Exception(f"{self._next_error_code}: {message}")
 
     def _get_project_names(self):
         return self._next_ids.keys()
@@ -97,7 +97,7 @@ class MockService(StubService):
             self._memory[project][name] = data
             return
 
-        path = os.path.join(self._get_project_path(project), "{}.json".format(name))
+        path = os.path.join(self._get_project_path(project), f"{name}.json")
         with open(path, "w") as f:
             f.write(json.dumps(data, sort_keys=True, indent=4))
 
@@ -107,7 +107,7 @@ class MockService(StubService):
                 self._memory[project] = defaultdict()
             return self._memory[project].get(name)
 
-        path = os.path.join(self._get_project_path(project), "{}.json".format(name))
+        path = os.path.join(self._get_project_path(project), f"{name}.json")
         if not os.path.exists(path):
             return None
 

--- a/tests/fixtures/integrations/stub_service.py
+++ b/tests/fixtures/integrations/stub_service.py
@@ -39,7 +39,7 @@ class StubService(object):
         :param name: string
         :return: object
         """
-        cache_key = "{}.{}".format(service_name, name)
+        cache_key = f"{service_name}.{name}"
         cached = StubService.stub_data_cache.get(cache_key)
         if cached:
             data = cached

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -28,12 +28,12 @@ class AuthenticationTest(AuthProviderTestCase):
         self.login_as(user)
 
         paths = (
-            "/api/0/organizations/{}/".format(organization.slug),
-            "/api/0/projects/{}/{}/".format(organization.slug, project.slug),
-            "/api/0/teams/{}/{}/".format(organization.slug, team.slug),
-            "/api/0/issues/{}/".format(group_id),
+            f"/api/0/organizations/{organization.slug}/",
+            f"/api/0/projects/{organization.slug}/{project.slug}/",
+            f"/api/0/teams/{organization.slug}/{team.slug}/",
+            f"/api/0/issues/{group_id}/",
             # this uses the internal API, which once upon a time was broken
-            "/api/0/issues/{}/events/latest/".format(group_id),
+            f"/api/0/issues/{group_id}/events/latest/",
         )
 
         for path in paths:

--- a/tests/integration/test_sso.py
+++ b/tests/integration/test_sso.py
@@ -21,8 +21,8 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         self.login_as(user)
 
-        path = "/{}/".format(organization.slug)
-        redirect_uri = "/auth/login/{}/".format(organization.slug)
+        path = f"/{organization.slug}/"
+        redirect_uri = f"/auth/login/{organization.slug}/"
 
         # we should be redirecting the user to the authentication form as they
         # haven't verified this specific organization

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.utils.compat import mock
 from django.conf import settings
 

--- a/tests/integration/tests.py
+++ b/tests/integration/tests.py
@@ -53,7 +53,7 @@ class DependencyTest(TestCase):
         def callable(package_name):
             if package_name != package:
                 return import_string(package_name)
-            raise ImportError("No module named %s" % (package,))
+            raise ImportError(f"No module named {package}")
 
         return callable
 

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -1,6 +1,3 @@
-# coding: utf-8
-
-
 import os.path
 from base64 import b64encode
 from django.utils.encoding import force_bytes
@@ -16,8 +13,8 @@ from sentry.models import File, Release, ReleaseFile
 # might also want to put this in utils since we pretty much expect the result to be py3 str and not bytes
 BASE64_SOURCEMAP = "data:application/json;base64," + (
     b64encode(
-        '{"version":3,"file":"generated.js","sources":["/test.js"],"names":[],"mappings":"AAAA","sourcesContent":['
-        '"console.log(\\"hello, World!\\")"]}'.encode("utf-8")
+        b'{"version":3,"file":"generated.js","sources":["/test.js"],"names":[],"mappings":"AAAA","sourcesContent":['
+        b'"console.log(\\"hello, World!\\")"]}'
     )
     .decode("utf-8")
     .replace("\n", "")
@@ -430,7 +427,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         )
         f_minified.putfile(open(get_fixture_path("nofiles.js"), "rb"))
         ReleaseFile.objects.create(
-            name="~/{}".format(f_minified.name),
+            name=f"~/{f_minified.name}",
             release=release,
             organization_id=project.organization_id,
             file=f_minified,
@@ -441,7 +438,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         )
         f_sourcemap.putfile(open(get_fixture_path("nofiles.js.map"), "rb"))
         ReleaseFile.objects.create(
-            name="app:///{}".format(f_sourcemap.name),
+            name=f"app:///{f_sourcemap.name}",
             release=release,
             organization_id=project.organization_id,
             file=f_sourcemap,
@@ -603,7 +600,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         # Intentionally omit hostname - use alternate artifact path lookup instead
         # /file1.js vs http://example.com/file1.js
         ReleaseFile.objects.create(
-            name="~/{}?foo=bar".format(f_minified.name),
+            name=f"~/{f_minified.name}?foo=bar",
             release=release,
             organization_id=project.organization_id,
             file=f_minified,
@@ -618,7 +615,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         f1.putfile(open(get_fixture_path("file1.js"), "rb"))
 
         ReleaseFile.objects.create(
-            name="http://example.com/{}".format(f1.name),
+            name=f"http://example.com/{f1.name}",
             release=release,
             organization_id=project.organization_id,
             file=f1,
@@ -632,7 +629,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         )
         f2.putfile(open(get_fixture_path("file2.js"), "rb"))
         ReleaseFile.objects.create(
-            name="http://example.com/{}".format(f2.name),
+            name=f"http://example.com/{f2.name}",
             release=release,
             organization_id=project.organization_id,
             file=f2,
@@ -648,7 +645,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         )
         f2_empty.putfile(open(get_fixture_path("empty.js"), "rb"))
         ReleaseFile.objects.create(
-            name="~/{}".format(f2.name),  # intentionally using f2.name ("file2.js")
+            name=f"~/{f2.name}",  # intentionally using f2.name ("file2.js")
             release=release,
             organization_id=project.organization_id,
             file=f2_empty,
@@ -664,7 +661,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         )
         f_sourcemap.putfile(open(get_fixture_path("file.sourcemap.js"), "rb"))
         ReleaseFile.objects.create(
-            name="http://example.com/{}".format(f_sourcemap.name),
+            name=f"http://example.com/{f_sourcemap.name}",
             release=release,
             organization_id=project.organization_id,
             file=f_sourcemap,
@@ -741,7 +738,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         # Intentionally omit hostname - use alternate artifact path lookup instead
         # /file1.js vs http://example.com/file1.js
         ReleaseFile.objects.create(
-            name="~/{}?foo=bar".format(f_minified.name),
+            name=f"~/{f_minified.name}?foo=bar",
             release=release,
             dist=dist,
             organization_id=project.organization_id,
@@ -757,7 +754,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         f1.putfile(open(get_fixture_path("file1.js"), "rb"))
 
         ReleaseFile.objects.create(
-            name="http://example.com/{}".format(f1.name),
+            name=f"http://example.com/{f1.name}",
             release=release,
             dist=dist,
             organization_id=project.organization_id,
@@ -772,7 +769,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         )
         f2.putfile(open(get_fixture_path("file2.js"), "rb"))
         ReleaseFile.objects.create(
-            name="http://example.com/{}".format(f2.name),
+            name=f"http://example.com/{f2.name}",
             release=release,
             dist=dist,
             organization_id=project.organization_id,
@@ -789,7 +786,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         )
         f2_empty.putfile(open(get_fixture_path("empty.js"), "rb"))
         ReleaseFile.objects.create(
-            name="~/{}".format(f2.name),  # intentionally using f2.name ("file2.js")
+            name=f"~/{f2.name}",  # intentionally using f2.name ("file2.js")
             release=release,
             dist=dist,
             organization_id=project.organization_id,
@@ -806,7 +803,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         )
         f_sourcemap.putfile(open(get_fixture_path("file.sourcemap.js"), "rb"))
         ReleaseFile.objects.create(
-            name="http://example.com/{}".format(f_sourcemap.name),
+            name=f"http://example.com/{f_sourcemap.name}",
             release=release,
             dist=dist,
             organization_id=project.organization_id,
@@ -1130,7 +1127,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         )
         f_minified.putfile(open(get_fixture_path("dist.bundle.js"), "rb"))
         ReleaseFile.objects.create(
-            name="~/{}".format(f_minified.name),
+            name=f"~/{f_minified.name}",
             release=release,
             organization_id=project.organization_id,
             file=f_minified,
@@ -1143,7 +1140,7 @@ class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTest
         )
         f_sourcemap.putfile(open(get_fixture_path("dist.bundle.js.map"), "rb"))
         ReleaseFile.objects.create(
-            name="~/{}".format(f_sourcemap.name),
+            name=f"~/{f_sourcemap.name}",
             release=release,
             organization_id=project.organization_id,
             file=f_sourcemap,

--- a/tests/relay_integration/test_message_filters.py
+++ b/tests/relay_integration/test_message_filters.py
@@ -14,9 +14,7 @@ class FilterTests(RelayStoreHelper, TransactionTestCase):
         return {}
 
     def _set_filter_state(self, flt, state):
-        ProjectOption.objects.set_value(
-            project=self.project, key="filters:{}".format(flt.id), value=state
-        )
+        ProjectOption.objects.set_value(project=self.project, key=f"filters:{flt.id}", value=state)
 
     def test_should_not_filter_simple_messages(self):
         # baseline test (so we know everything works as expected)

--- a/tests/relay_integration/test_sdk.py
+++ b/tests/relay_integration/test_sdk.py
@@ -55,9 +55,7 @@ def test_recursion_breaker(settings, post_event_with_sdk):
         with pytest.raises(ValueError):
             post_event_with_sdk({"message": "internal client test", "event_id": event_id})
 
-    assert_mock_called_once_with_partial(
-        save, settings.SENTRY_PROJECT, cache_key="e:{}:1".format(event_id)
-    )
+    assert_mock_called_once_with_partial(save, settings.SENTRY_PROJECT, cache_key=f"e:{event_id}:1")
 
 
 @pytest.mark.django_db

--- a/tests/sentry/api/bases/test_endpoint.py
+++ b/tests/sentry/api/bases/test_endpoint.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from sentry.utils.compat.mock import Mock
 
 from sentry.testutils import TestCase

--- a/tests/sentry/api/endpoints/test_auth_index.py
+++ b/tests/sentry/api/endpoints/test_auth_index.py
@@ -26,8 +26,7 @@ class AuthLoginEndpointTest(APITestCase):
         user = self.create_user("foo@example.com")
         response = self.client.post(
             self.path,
-            HTTP_AUTHORIZATION=b"Basic "
-            + b64encode("{}:{}".format(user.username, "admin").encode("utf-8")),
+            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{user.username}:admin".encode("utf-8")),
         )
         assert response.status_code == 200
         assert response.data["id"] == six.text_type(user.id)
@@ -36,8 +35,7 @@ class AuthLoginEndpointTest(APITestCase):
         user = self.create_user("foo@example.com")
         response = self.client.post(
             self.path,
-            HTTP_AUTHORIZATION=b"Basic "
-            + b64encode("{}:{}".format(user.username, "foobar").encode("utf-8")),
+            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{user.username}:foobar".encode("utf-8")),
         )
         assert response.status_code == 401
 

--- a/tests/sentry/api/endpoints/test_broadcast_details.py
+++ b/tests/sentry/api/endpoints/test_broadcast_details.py
@@ -11,7 +11,7 @@ class BroadcastDetailsTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        response = self.client.get("/api/0/broadcasts/{}/".format(broadcast1.id))
+        response = self.client.get(f"/api/0/broadcasts/{broadcast1.id}/")
         assert response.status_code == 200
         assert response.data["id"] == six.text_type(broadcast1.id)
 
@@ -25,7 +25,7 @@ class BroadcastUpdateTest(APITestCase):
         self.login_as(user=self.user)
 
         response = self.client.put(
-            "/api/0/broadcasts/{}/".format(broadcast1.id), {"hasSeen": "1", "message": "foobar"}
+            f"/api/0/broadcasts/{broadcast1.id}/", {"hasSeen": "1", "message": "foobar"}
         )
         assert response.status_code == 200
         assert response.data["hasSeen"]
@@ -45,7 +45,7 @@ class BroadcastUpdateTest(APITestCase):
         self.login_as(user=self.user, superuser=True)
 
         response = self.client.put(
-            "/api/0/broadcasts/{}/".format(broadcast1.id), {"hasSeen": "1", "message": "foobar"}
+            f"/api/0/broadcasts/{broadcast1.id}/", {"hasSeen": "1", "message": "foobar"}
         )
         assert response.status_code == 200
         assert response.data["hasSeen"]

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -23,7 +23,7 @@ class ChunkUploadTest(APITestCase):
 
     def test_chunk_parameters(self):
         response = self.client.get(
-            self.url, HTTP_AUTHORIZATION="Bearer {}".format(self.token.token), format="json"
+            self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
         )
 
         endpoint = options.get("system.upload-url-prefix")
@@ -42,7 +42,7 @@ class ChunkUploadTest(APITestCase):
 
         options.set("system.upload-url-prefix", "test")
         response = self.client.get(
-            self.url, HTTP_AUTHORIZATION="Bearer {}".format(self.token.token), format="json"
+            self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
         )
 
         assert response.data["url"] == options.get("system.upload-url-prefix") + self.url
@@ -50,14 +50,14 @@ class ChunkUploadTest(APITestCase):
     def test_large_uploads(self):
         with self.feature("organizations:large-debug-files"):
             response = self.client.get(
-                self.url, HTTP_AUTHORIZATION="Bearer {}".format(self.token.token), format="json"
+                self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
             )
 
         assert response.data["maxFileSize"] == MAX_FILE_SIZE
 
     def test_wrong_api_token(self):
         token = ApiToken.objects.create(user=self.user, scope_list=["org:org"])
-        response = self.client.get(self.url, HTTP_AUTHORIZATION="Bearer {}".format(token.token))
+        response = self.client.get(self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}")
         assert response.status_code == 403, response.content
 
     def test_upload(self):
@@ -71,7 +71,7 @@ class ChunkUploadTest(APITestCase):
         response = self.client.post(
             self.url,
             data={"file": [blob1, blob2]},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
             # this tells drf to select the MultiPartParser. We use that instead of
             # FileUploadParser because we have our own specific file chunking mechanism
             # in the chunk endpoint that has requirements like blob/chunk's filename = checksum.
@@ -87,7 +87,7 @@ class ChunkUploadTest(APITestCase):
 
     def test_empty_upload(self):
         response = self.client.post(
-            self.url, HTTP_AUTHORIZATION="Bearer {}".format(self.token.token), format="multipart"
+            self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="multipart"
         )
         assert response.status_code == 200
 
@@ -105,7 +105,7 @@ class ChunkUploadTest(APITestCase):
         response = self.client.post(
             self.url,
             data={"file": files},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
             format="multipart",
         )
 
@@ -122,7 +122,7 @@ class ChunkUploadTest(APITestCase):
         response = self.client.post(
             self.url,
             data={"file": files},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
             format="multipart",
         )
 
@@ -133,7 +133,7 @@ class ChunkUploadTest(APITestCase):
         response = self.client.post(
             self.url,
             data={"file": files},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
             format="multipart",
         )
         assert response.status_code == 400, response.content
@@ -146,7 +146,7 @@ class ChunkUploadTest(APITestCase):
         response = self.client.post(
             self.url,
             data={"file": files},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
             format="multipart",
         )
 
@@ -160,7 +160,7 @@ class ChunkUploadTest(APITestCase):
         response = self.client.post(
             self.url,
             data={"file": files},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
             format="multipart",
         )
 

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -31,7 +31,7 @@ class DifAssembleEndpoint(APITestCase):
 
     def test_assemble_json_schema(self):
         response = self.client.post(
-            self.url, data={"lol": "test"}, HTTP_AUTHORIZATION="Bearer {}".format(self.token.token)
+            self.url, data={"lol": "test"}, HTTP_AUTHORIZATION=f"Bearer {self.token.token}"
         )
         assert response.status_code == 400, response.content
 
@@ -39,25 +39,25 @@ class DifAssembleEndpoint(APITestCase):
         response = self.client.post(
             self.url,
             data={checksum: "test"},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 400, response.content
 
         response = self.client.post(
-            self.url, data={checksum: {}}, HTTP_AUTHORIZATION="Bearer {}".format(self.token.token)
+            self.url, data={checksum: {}}, HTTP_AUTHORIZATION=f"Bearer {self.token.token}"
         )
         assert response.status_code == 400, response.content
 
         response = self.client.post(
             self.url,
             data={checksum: {"name": "dif", "chunks": []}},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 200, response.content
         assert response.data[checksum]["state"] == ChunkFileState.NOT_FOUND
 
     def test_assemble_check(self):
-        content = "foo bar".encode("utf-8")
+        content = b"foo bar"
         fileobj = ContentFile(content)
         file1 = File.objects.create(name="baz.dSYM", type="default", size=7)
         file1.putfile(fileobj, 3)
@@ -73,7 +73,7 @@ class DifAssembleEndpoint(APITestCase):
         response = self.client.post(
             self.url,
             data={checksum: {"name": "dif", "chunks": checksums}},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
 
         assert response.status_code == 200, response.content
@@ -89,7 +89,7 @@ class DifAssembleEndpoint(APITestCase):
         response = self.client.post(
             self.url,
             data={checksum: {"name": "dif", "chunks": checksums}},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
 
         assert response.status_code == 200, response.content
@@ -112,7 +112,7 @@ class DifAssembleEndpoint(APITestCase):
         response = self.client.post(
             self.url,
             data={checksum: {"name": "dif", "chunks": checksums}},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
 
         assert response.status_code == 200, response.content
@@ -124,7 +124,7 @@ class DifAssembleEndpoint(APITestCase):
         response = self.client.post(
             self.url,
             data={not_found_checksum: {"name": "dif", "chunks": [not_found_checksum]}},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
 
         assert response.status_code == 200, response.content
@@ -133,15 +133,15 @@ class DifAssembleEndpoint(APITestCase):
 
     @patch("sentry.tasks.assemble.assemble_dif")
     def test_assemble(self, mock_assemble_dif):
-        content1 = "foo".encode("utf-8")
+        content1 = b"foo"
         fileobj1 = ContentFile(content1)
         checksum1 = sha1(content1).hexdigest()
 
-        content2 = "bar".encode("utf-8")
+        content2 = b"bar"
         fileobj2 = ContentFile(content2)
         checksum2 = sha1(content2).hexdigest()
 
-        content3 = "baz".encode("utf-8")
+        content3 = b"baz"
         fileobj3 = ContentFile(content3)
         checksum3 = sha1(content3).hexdigest()
 
@@ -158,7 +158,7 @@ class DifAssembleEndpoint(APITestCase):
         response = self.client.post(
             self.url,
             data={total_checksum: {"name": "test", "chunks": [checksum2, checksum1, checksum3]}},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 200, response.content
         assert response.data[total_checksum]["state"] == ChunkFileState.NOT_FOUND
@@ -171,7 +171,7 @@ class DifAssembleEndpoint(APITestCase):
         response = self.client.post(
             self.url,
             data={total_checksum: {"name": "test", "chunks": [checksum2, checksum1, checksum3]}},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 200, response.content
         assert response.data[total_checksum]["state"] == ChunkFileState.CREATED
@@ -211,7 +211,7 @@ class DifAssembleEndpoint(APITestCase):
         response = self.client.post(
             self.url,
             data={total_checksum: {"name": "test.sym", "chunks": chunks}},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
 
         assert response.status_code == 200, response.content
@@ -234,7 +234,7 @@ class DifAssembleEndpoint(APITestCase):
         response = self.client.post(
             self.url,
             data={total_checksum: {"name": "test.sym", "chunks": []}},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -39,9 +39,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
         self.login_as(user=self.user)
 
         self.create_attachment()
-        path = "/api/0/projects/{}/{}/events/{}/attachments/{}/".format(
-            self.organization.slug, self.project.slug, self.event.event_id, self.attachment.id
-        )
+        path = f"/api/0/projects/{self.organization.slug}/{self.project.slug}/events/{self.event.event_id}/attachments/{self.attachment.id}/"
 
         with self.feature("organizations:event-attachments"):
             response = self.client.get(path)
@@ -54,9 +52,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
         self.login_as(user=self.user)
 
         self.create_attachment()
-        path = "/api/0/projects/{}/{}/events/{}/attachments/{}/?download".format(
-            self.organization.slug, self.project.slug, self.event.event_id, self.attachment.id
-        )
+        path = f"/api/0/projects/{self.organization.slug}/{self.project.slug}/events/{self.event.event_id}/attachments/{self.attachment.id}/?download"
 
         with self.feature("organizations:event-attachments"):
             response = self.client.get(path)
@@ -71,9 +67,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
         self.login_as(user=self.user)
 
         self.create_attachment()
-        path = "/api/0/projects/{}/{}/events/{}/attachments/{}/".format(
-            self.organization.slug, self.project.slug, self.event.event_id, self.attachment.id
-        )
+        path = f"/api/0/projects/{self.organization.slug}/{self.project.slug}/events/{self.event.event_id}/attachments/{self.attachment.id}/"
 
         with self.feature("organizations:event-attachments"):
             response = self.client.delete(path)
@@ -86,9 +80,7 @@ class EventAttachmentDetailsPermissionTest(PermissionTestCase, CreateAttachmentM
     def setUp(self):
         super(EventAttachmentDetailsPermissionTest, self).setUp()
         self.create_attachment()
-        self.path = "/api/0/projects/{}/{}/events/{}/attachments/{}/?download".format(
-            self.organization.slug, self.project.slug, self.event.event_id, self.attachment.id
-        )
+        self.path = f"/api/0/projects/{self.organization.slug}/{self.project.slug}/events/{self.event.event_id}/attachments/{self.attachment.id}/?download"
 
     def test_member_can_access_by_default(self):
         with self.feature("organizations:event-attachments"):

--- a/tests/sentry/api/endpoints/test_event_attachments.py
+++ b/tests/sentry/api/endpoints/test_event_attachments.py
@@ -32,9 +32,7 @@ class EventAttachmentsTest(APITestCase):
             name="hello.png",
         )
 
-        path = "/api/0/projects/{}/{}/events/{}/attachments/".format(
-            event1.project.organization.slug, event1.project.slug, event1.event_id
-        )
+        path = f"/api/0/projects/{event1.project.organization.slug}/{event1.project.slug}/events/{event1.event_id}/attachments/"
 
         with self.feature("organizations:event-attachments"):
             response = self.client.get(path)

--- a/tests/sentry/api/endpoints/test_group_attachments.py
+++ b/tests/sentry/api/endpoints/test_group_attachments.py
@@ -25,7 +25,7 @@ class GroupEventAttachmentsTest(APITestCase):
         return self.attachment
 
     def path(self, types=None):
-        path = "/api/0/issues/%s/attachments/" % (self.group.id,)
+        path = f"/api/0/issues/{self.group.id}/attachments/"
 
         query = [("types", t) for t in types or ()]
         if query:

--- a/tests/sentry/api/endpoints/test_group_current_release.py
+++ b/tests/sentry/api/endpoints/test_group_current_release.py
@@ -70,7 +70,7 @@ class GroupCurrentReleaseTest(APITestCase):
         target_group, target_releases = self._set_up_current_release(group_seen_on_latest_release)
 
         self.login_as(user=self.user)
-        url = "/api/0/issues/{}/current-release/".format(target_group.id)
+        url = f"/api/0/issues/{target_group.id}/current-release/"
         response = self.client.get(url, {"environment": environments_to_query}, format="json")
         assert response.status_code == 200
         return response.data["currentRelease"], target_releases

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -52,9 +52,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         group = self.create_group()
         assert group.qualified_short_id
 
-        url = "/api/0/organizations/{}/issues/{}/".format(
-            group.organization.slug, group.qualified_short_id
-        )
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.qualified_short_id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -34,13 +34,13 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         group = self.create_group()
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
         assert response.data["id"] == six.text_type(group.id)
 
-        url = "/api/0/organizations/{}/issues/{}/".format(group.organization.slug, group.id)
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -60,7 +60,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert response.data["id"] == six.text_type(group.id)
 
-        url = "/api/0/issues/{}/".format(group.qualified_short_id)
+        url = f"/api/0/issues/{group.qualified_short_id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 404, response.content
@@ -72,7 +72,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         group = event.group
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.get(url, format="json")
 
@@ -87,7 +87,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         group = event.group
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
@@ -102,16 +102,16 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/".format(group1.id)
+        url = f"/api/0/issues/{group1.id}/"
 
         response = self.client.get(url, format="json")
         assert response.status_code == 404
 
-        url = "/api/0/issues/{}/".format(group2.id)
+        url = f"/api/0/issues/{group2.id}/"
         response = self.client.get(url, format="json")
         assert response.status_code == 404
 
-        url = "/api/0/issues/{}/".format(group3.id)
+        url = f"/api/0/issues/{group3.id}/"
         response = self.client.get(url, format="json")
         assert response.status_code == 404
 
@@ -121,7 +121,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         environment = Environment.get_or_create(group.project, "production")
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         from sentry.api.endpoints.group_details import tsdb
 
@@ -147,7 +147,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             web_url="https://example.com/issues/2",
             display_name="Issue#2",
         )
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
         response = self.client.get(url, format="json")
 
         assert response.data["annotations"] == [
@@ -164,7 +164,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
         response = self.client.get(url, format="json")
 
         assert response.data["annotations"] == ['<a href="https://trello.com/c/134">Trello-134</a>']
@@ -182,7 +182,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
         response = self.client.get(url, format="json")
 
         assert response.data["annotations"] == [
@@ -194,12 +194,12 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         self.login_as(user=superuser, superuser=True)
 
         group = self.create_group()
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
         response = self.client.get(url, format="json")
 
         result = response.data["permalink"]
         assert "http://" in result
-        assert "{}/issues/{}".format(group.organization.slug, group.id) in result
+        assert f"{group.organization.slug}/issues/{group.id}" in result
 
     def test_permalink_sentry_app_installation_token(self):
         project = self.create_project(organization=self.organization, teams=[self.team])
@@ -211,11 +211,11 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         token = internal_app.installations.first().api_token
 
         group = self.create_group(project=project)
-        url = "/api/0/issues/{}/".format(group.id)
-        response = self.client.get(url, HTTP_AUTHORIZATION="Bearer {}".format(token), format="json")
+        url = f"/api/0/issues/{group.id}/"
+        response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}", format="json")
         result = response.data["permalink"]
         assert "http://" in result
-        assert "{}/issues/{}".format(group.organization.slug, group.id) in result
+        assert f"{group.organization.slug}/issues/{group.id}" in result
 
     @patch(
         "sentry.api.helpers.group_index.ratelimiter.is_limited",
@@ -225,7 +225,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
     def test_ratelimit(self, is_limited):
         self.login_as(user=self.user)
         group = self.create_group()
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
         response = self.client.get(url, sort_by="date", limit=1)
         assert response.status_code == 429
 
@@ -236,7 +236,7 @@ class GroupUpdateTest(APITestCase):
 
         group = self.create_group()
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.put(url, data={"status": "resolved"}, format="json")
         assert response.status_code == 200, response.content
@@ -257,7 +257,7 @@ class GroupUpdateTest(APITestCase):
         group = self.create_group(project=project)
         Release.get_or_create(version="abcd", project=project)
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.put(url, data={"status": "resolvedInNextRelease"})
         assert response.status_code == 200, response.content
@@ -272,7 +272,7 @@ class GroupUpdateTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.put(
             url, data={"status": "ignored", "ignoreDuration": 30}, format="json"
@@ -299,7 +299,7 @@ class GroupUpdateTest(APITestCase):
 
         group = self.create_group()
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.put(url, data={"isBookmarked": "1"}, format="json")
 
@@ -317,7 +317,7 @@ class GroupUpdateTest(APITestCase):
 
         group = self.create_group()
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.put(url, data={"assignedTo": self.user.username}, format="json")
 
@@ -351,7 +351,7 @@ class GroupUpdateTest(APITestCase):
 
         group = self.create_group()
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.put(url, data={"assignedTo": self.user.id}, format="json")
 
@@ -387,13 +387,13 @@ class GroupUpdateTest(APITestCase):
         # migrating to DRF 3.x.
         api_key = ApiKey.objects.create(organization=self.organization, scope_list=["event:write"])
         group = self.create_group()
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.put(
             url,
             data={"assignedTo": self.user.id},
             format="json",
-            HTTP_AUTHORIZATION=b"Basic " + b64encode("{}:".format(api_key.key).encode("utf-8")),
+            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{api_key.key}:".encode("utf-8")),
         )
         assert response.status_code == 200, response.content
         assert GroupAssignee.objects.filter(group=group, user=self.user).exists()
@@ -405,11 +405,9 @@ class GroupUpdateTest(APITestCase):
         team = self.create_team(organization=group.project.organization, members=[self.user])
         group.project.add_team(team)
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
-        response = self.client.put(
-            url, data={"assignedTo": "team:{}".format(team.id)}, format="json"
-        )
+        response = self.client.put(url, data={"assignedTo": f"team:{team.id}"}, format="json")
 
         assert response.status_code == 200, response.content
 
@@ -435,11 +433,9 @@ class GroupUpdateTest(APITestCase):
         group = self.create_group()
         team = self.create_team(organization=group.project.organization, members=[self.user])
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
-        response = self.client.put(
-            url, data={"assignedTo": "team:{}".format(team.id)}, format="json"
-        )
+        response = self.client.put(url, data={"assignedTo": f"team:{team.id}"}, format="json")
 
         assert response.status_code == 400, response.content
 
@@ -448,7 +444,7 @@ class GroupUpdateTest(APITestCase):
 
         group = self.create_group()
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.put(url, data={"hasSeen": "1"}, format="json")
 
@@ -468,7 +464,7 @@ class GroupUpdateTest(APITestCase):
 
         group = self.create_group()
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.put(url, data={"hasSeen": "1"}, format="json")
 
@@ -480,7 +476,7 @@ class GroupUpdateTest(APITestCase):
         self.login_as(user=self.user)
         group = self.create_group()
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         resp = self.client.put(url, data={"isSubscribed": "true"})
         assert resp.status_code == 200, resp.content
@@ -500,7 +496,7 @@ class GroupUpdateTest(APITestCase):
 
         group_hash = GroupHash.objects.create(hash="x" * 32, project=group.project, group=group)
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         with self.tasks():
             with self.feature("projects:discard-groups"):
@@ -525,7 +521,7 @@ class GroupUpdateTest(APITestCase):
     def test_ratelimit(self, is_limited):
         self.login_as(user=self.user)
         group = self.create_group()
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
         response = self.client.put(url, sort_by="date", limit=1)
         assert response.status_code == 429
 
@@ -538,7 +534,7 @@ class GroupDeleteTest(APITestCase):
         hash = "x" * 32
         GroupHash.objects.create(project=group.project, hash=hash, group=group)
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.delete(url, format="json")
         assert response.status_code == 202, response.content
@@ -550,7 +546,7 @@ class GroupDeleteTest(APITestCase):
 
         Group.objects.filter(id=group.id).update(status=GroupStatus.UNRESOLVED)
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         with self.tasks():
             response = self.client.delete(url, format="json")
@@ -569,6 +565,6 @@ class GroupDeleteTest(APITestCase):
     def test_ratelimit(self, is_limited):
         self.login_as(user=self.user)
         group = self.create_group()
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
         response = self.client.delete(url, sort_by="date", limit=1)
         assert response.status_code == 429

--- a/tests/sentry/api/endpoints/test_group_events_latest.py
+++ b/tests/sentry/api/endpoints/test_group_events_latest.py
@@ -40,7 +40,7 @@ class GroupEventsLatestEndpointTest(APITestCase, SnubaTestCase):
         )
 
     def test_get_simple(self):
-        url = "/api/0/issues/{}/events/latest/".format(self.event_a.group.id)
+        url = f"/api/0/issues/{self.event_a.group.id}/events/latest/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -49,7 +49,7 @@ class GroupEventsLatestEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["nextEventID"] is None
 
     def test_get_with_environment(self):
-        url = "/api/0/issues/{}/events/latest/".format(self.event_a.group.id)
+        url = f"/api/0/issues/{self.event_a.group.id}/events/latest/"
         response = self.client.get(url, format="json", data={"environment": ["production"]})
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_group_events_oldest.py
+++ b/tests/sentry/api/endpoints/test_group_events_oldest.py
@@ -40,7 +40,7 @@ class GroupEventsOldestEndpointTest(APITestCase, SnubaTestCase):
         )
 
     def test_get_simple(self):
-        url = "/api/0/issues/{}/events/oldest/".format(self.event_a.group.id)
+        url = f"/api/0/issues/{self.event_a.group.id}/events/oldest/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -49,7 +49,7 @@ class GroupEventsOldestEndpointTest(APITestCase, SnubaTestCase):
         assert response.data["nextEventID"] == six.text_type(self.event_b.event_id)
 
     def test_get_with_environment(self):
-        url = "/api/0/issues/{}/events/oldest/".format(self.event_a.group.id)
+        url = f"/api/0/issues/{self.event_a.group.id}/events/oldest/"
         response = self.client.get(url, format="json", data={"environment": ["production"]})
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_group_external_issue_details.py
+++ b/tests/sentry/api/endpoints/test_group_external_issue_details.py
@@ -14,9 +14,7 @@ class GroupExternalIssueDetailsEndpointTest(APITestCase):
             web_url="https://example.com/app/issues/1",
         )
 
-        self.url = "/api/0/issues/{}/external-issues/{}/".format(
-            self.group.id, self.external_issue.id
-        )
+        self.url = f"/api/0/issues/{self.group.id}/external-issues/{self.external_issue.id}/"
 
     def test_deletes_external_issue(self):
         response = self.client.delete(self.url, format="json")

--- a/tests/sentry/api/endpoints/test_group_external_issue_details.py
+++ b/tests/sentry/api/endpoints/test_group_external_issue_details.py
@@ -47,7 +47,7 @@ class GroupExternalIssueDetailsEndpointTest(APITestCase):
             web_url="https://example.com/app/issues/1",
         )
 
-        url = "/api/0/issues/{}/external-issues/{}/".format(group.id, external_issue.id)
+        url = f"/api/0/issues/{group.id}/external-issues/{external_issue.id}/"
 
         response = self.client.delete(url, format="json")
 

--- a/tests/sentry/api/endpoints/test_group_external_issues.py
+++ b/tests/sentry/api/endpoints/test_group_external_issues.py
@@ -18,7 +18,7 @@ class GroupExternalIssuesEndpointTest(APITestCase):
             web_url="https://example.com/app/issues/1",
         )
 
-        url = "/api/0/issues/{}/external-issues/".format(group.id)
+        url = f"/api/0/issues/{group.id}/external-issues/"
         response = self.client.get(url, format="json")
         external_issue = PlatformExternalIssue.objects.first()
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_group_hashes.py
+++ b/tests/sentry/api/endpoints/test_group_hashes.py
@@ -41,7 +41,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
 
         assert new_event.group_id == old_event.group_id
 
-        url = "/api/0/issues/{}/hashes/".format(new_event.group_id)
+        url = f"/api/0/issues/{new_event.group_id}/hashes/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -81,7 +81,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
 
         eventstream.end_merge(state)
 
-        url = "/api/0/issues/{}/hashes/".format(event1.group_id)
+        url = f"/api/0/issues/{event1.group_id}/hashes/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -102,7 +102,7 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
 
         url = "?".join(
             [
-                "/api/0/issues/{}/hashes/".format(group.id),
+                f"/api/0/issues/{group.id}/hashes/",
                 urlencode({"id": [h.hash for h in hashes]}, True),
             ]
         )

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -136,9 +136,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(org, self.user)
 
-        path = "/api/0/issues/{}/integrations/{}/?action=create".format(
-            self.group.id, integration.id
-        )
+        path = f"/api/0/issues/{self.group.id}/integrations/{integration.id}/?action=create"
 
         with self.feature("organizations:integrations-issue-basic"):
             with mock.patch.object(
@@ -155,9 +153,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(org, self.user)
 
-        path = "/api/0/issues/{}/integrations/{}/?action=create".format(
-            self.group.id, integration.id
-        )
+        path = f"/api/0/issues/{self.group.id}/integrations/{integration.id}/?action=create"
 
         with self.feature({"organizations:integrations-issue-basic": False}):
             response = self.client.get(path)
@@ -287,9 +283,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             relationship=GroupLink.Relationship.references,
         )[0]
 
-        path = "/api/0/issues/{}/integrations/{}/?externalIssue={}".format(
-            group.id, integration.id, external_issue.id
-        )
+        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/?externalIssue={external_issue.id}"
 
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.delete(path)
@@ -317,9 +311,7 @@ class GroupIntegrationDetailsTest(APITestCase):
             relationship=GroupLink.Relationship.references,
         )[0]
 
-        path = "/api/0/issues/{}/integrations/{}/?externalIssue={}".format(
-            group.id, integration.id, external_issue.id
-        )
+        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/?externalIssue={external_issue.id}"
 
         with self.feature({"organizations:integrations-issue-basic": False}):
             response = self.client.delete(path)
@@ -353,9 +345,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         org_integration = integration.add_organization(org, self.user)
         org_integration.config = {"project_issue_defaults": {group.project_id: {"project": "2"}}}
         org_integration.save()
-        create_path = "/api/0/issues/{}/integrations/{}/?action=create".format(
-            group.id, integration.id
-        )
+        create_path = f"/api/0/issues/{group.id}/integrations/{integration.id}/?action=create"
         link_path = f"/api/0/issues/{group.id}/integrations/{integration.id}/?action=link"
         project_field = {
             "name": "project",

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -32,7 +32,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(org, self.user)
 
-        path = "/api/0/issues/{}/integrations/{}/?action=link".format(self.group.id, integration.id)
+        path = f"/api/0/issues/{self.group.id}/integrations/{integration.id}/?action=link"
 
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.get(path)
@@ -72,7 +72,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         integration.add_organization(org, self.user)
         group = self.group
 
-        path = "/api/0/issues/{}/integrations/{}/?action=create".format(group.id, integration.id)
+        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/?action=create"
 
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.get(path)
@@ -171,7 +171,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(org, self.user)
 
-        path = "/api/0/issues/{}/integrations/{}/".format(group.id, integration.id)
+        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.put(path, data={"externalIssue": "APP-123"})
 
@@ -206,7 +206,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(org, self.user)
 
-        path = "/api/0/issues/{}/integrations/{}/".format(group.id, integration.id)
+        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
 
         with self.feature({"organizations:integrations-issue-basic": False}):
             response = self.client.put(path, data={"externalIssue": "APP-123"})
@@ -220,7 +220,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(org, self.user)
 
-        path = "/api/0/issues/{}/integrations/{}/".format(group.id, integration.id)
+        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
 
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.post(path, data={})
@@ -261,7 +261,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(org, self.user)
 
-        path = "/api/0/issues/{}/integrations/{}/".format(group.id, integration.id)
+        path = f"/api/0/issues/{group.id}/integrations/{integration.id}/"
 
         with self.feature({"organizations:integrations-issue-basic": False}):
             response = self.client.post(path, data={})
@@ -356,7 +356,7 @@ class GroupIntegrationDetailsTest(APITestCase):
         create_path = "/api/0/issues/{}/integrations/{}/?action=create".format(
             group.id, integration.id
         )
-        link_path = "/api/0/issues/{}/integrations/{}/?action=link".format(group.id, integration.id)
+        link_path = f"/api/0/issues/{group.id}/integrations/{integration.id}/?action=link"
         project_field = {
             "name": "project",
             "label": "Project",

--- a/tests/sentry/api/endpoints/test_group_integrations.py
+++ b/tests/sentry/api/endpoints/test_group_integrations.py
@@ -26,7 +26,7 @@ class GroupIntegrationsTest(APITestCase):
             relationship=GroupLink.Relationship.references,
         )
 
-        path = "/api/0/issues/{}/integrations/".format(group.id)
+        path = f"/api/0/issues/{group.id}/integrations/"
 
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.get(path)
@@ -81,7 +81,7 @@ class GroupIntegrationsTest(APITestCase):
             relationship=GroupLink.Relationship.references,
         )
 
-        path = "/api/0/issues/{}/integrations/".format(group.id)
+        path = f"/api/0/issues/{group.id}/integrations/"
 
         with self.feature({"organizations:integrations-issue-basic": False}):
             response = self.client.get(path)

--- a/tests/sentry/api/endpoints/test_group_notes.py
+++ b/tests/sentry/api/endpoints/test_group_notes.py
@@ -26,7 +26,7 @@ class GroupNoteTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/comments/".format(group.id)
+        url = f"/api/0/issues/{group.id}/comments/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -39,7 +39,7 @@ class GroupNoteCreateTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/comments/".format(group.id)
+        url = f"/api/0/issues/{group.id}/comments/"
 
         response = self.client.post(url, format="json")
         assert response.status_code == 400
@@ -69,7 +69,7 @@ class GroupNoteCreateTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/comments/".format(group.id)
+        url = f"/api/0/issues/{group.id}/comments/"
 
         # mentioning a member that does not exist returns 400
         response = self.client.post(
@@ -116,7 +116,7 @@ class GroupNoteCreateTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/comments/".format(group.id)
+        url = f"/api/0/issues/{group.id}/comments/"
 
         # mentioning a team that does not exist returns 400
         response = self.client.post(
@@ -183,7 +183,7 @@ class GroupNoteCreateTest(APITestCase):
         self.user.save()
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/comments/".format(group.id)
+        url = f"/api/0/issues/{group.id}/comments/"
 
         with self.feature({"organizations:integrations-issue-sync": True}):
             with self.tasks():

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -30,7 +30,7 @@ class GroupNotesDetailsTest(APITestCase):
 
     @fixture
     def url(self):
-        return "/api/0/issues/{}/comments/{}/".format(self.group.id, self.activity.id)
+        return f"/api/0/issues/{self.group.id}/comments/{self.activity.id}/"
 
     def test_delete(self):
         self.login_as(user=self.user)
@@ -81,8 +81,8 @@ class GroupNotesDetailsTest(APITestCase):
                     self.url,
                     format="json",
                     data={
-                        "text": "hi **@{}**".format(self.user.username),
-                        "mentions": ["user:{}".format(self.user.id)],
+                        "text": f"hi **@{self.user.username}**",
+                        "mentions": [f"user:{self.user.id}"],
                     },
                 )
         assert response.status_code == 200, response.content
@@ -92,7 +92,7 @@ class GroupNotesDetailsTest(APITestCase):
         assert activity.group == self.group
         assert activity.data == {
             "external_id": "123",
-            "text": "hi **@{}**".format(self.user.username),
+            "text": f"hi **@{self.user.username}**",
         }
 
     @patch("sentry.integrations.issues.IssueBasicMixin.update_comment")

--- a/tests/sentry/api/endpoints/test_group_participants.py
+++ b/tests/sentry/api/endpoints/test_group_participants.py
@@ -14,7 +14,7 @@ class GroupParticipantsTest(APITestCase):
             user=self.user, group=group, project=group.project, is_active=True
         )
 
-        url = "/api/0/issues/{}/participants/".format(group.id)
+        url = f"/api/0/issues/{group.id}/participants/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_group_stats.py
+++ b/tests/sentry/api/endpoints/test_group_stats.py
@@ -9,7 +9,7 @@ class GroupStatsTest(APITestCase):
         group1 = self.create_group()
         group2 = self.create_group()
 
-        url = "/api/0/issues/{}/stats/".format(group1.id)
+        url = f"/api/0/issues/{group1.id}/stats/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_group_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_details.py
@@ -21,7 +21,7 @@ class GroupTagDetailsTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/tags/{}/".format(group.id, "foo")
+        url = f"/api/0/issues/{group.id}/tags/foo/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert response.data["key"] == six.text_type("foo")

--- a/tests/sentry/api/endpoints/test_group_tagkey_values.py
+++ b/tests/sentry/api/endpoints/test_group_tagkey_values.py
@@ -16,7 +16,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/tags/{}/values/".format(group.id, key)
+        url = f"/api/0/issues/{group.id}/tags/{key}/values/"
 
         response = self.client.get(url)
 
@@ -43,7 +43,7 @@ class GroupTagKeyValuesTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/tags/user/values/".format(group.id)
+        url = f"/api/0/issues/{group.id}/tags/user/values/"
 
         response = self.client.get(url)
 

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -120,7 +120,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
         url = f"/api/0/issues/{event2.group.id}/tags/"
         response = self.client.get(
-            "%s?environment=%s&environment=%s" % (url, env.name, env2.name), format="json"
+            f"{url}?environment={env.name}&environment={env2.name}", format="json"
         )
         assert response.status_code == 200
         assert set([tag["key"] for tag in response.data]) >= set(["biz", "environment", "foo"])

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -34,7 +34,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/issues/{}/tags/".format(event1.group.id)
+        url = f"/api/0/issues/{event1.group.id}/tags/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 4
@@ -53,7 +53,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
         assert len(data[3]["topValues"]) == 1
 
         # Use the key= queryparam to grab results for specific tags
-        url = "/api/0/issues/{}/tags/?key=foo&key=sentry:release".format(event1.group.id)
+        url = f"/api/0/issues/{event1.group.id}/tags/?key=foo&key=sentry:release"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
@@ -70,7 +70,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
     def test_invalid_env(self):
         this_group = self.create_group()
         self.login_as(user=self.user)
-        url = "/api/0/issues/{}/tags/".format(this_group.id)
+        url = f"/api/0/issues/{this_group.id}/tags/"
         response = self.client.get(url, {"environment": "notreal"}, format="json")
         assert response.status_code == 404
 
@@ -86,7 +86,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
         group = event.group
 
         self.login_as(user=self.user)
-        url = "/api/0/issues/{}/tags/".format(group.id)
+        url = f"/api/0/issues/{group.id}/tags/"
         response = self.client.get(url, {"environment": "prod"}, format="json")
         assert response.status_code == 200
         assert len(response.data) == 4
@@ -118,7 +118,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        url = "/api/0/issues/{}/tags/".format(event2.group.id)
+        url = f"/api/0/issues/{event2.group.id}/tags/"
         response = self.client.get(
             "%s?environment=%s&environment=%s" % (url, env.name, env2.name), format="json"
         )

--- a/tests/sentry/api/endpoints/test_group_user_reports.py
+++ b/tests/sentry/api/endpoints/test_group_user_reports.py
@@ -26,7 +26,7 @@ class GroupUserReport(APITestCase, SnubaTestCase):
 
     @fixture
     def path(self):
-        return "/api/0/groups/{}/user-feedback/".format(self.group.id)
+        return f"/api/0/groups/{self.group.id}/user-feedback/"
 
     def create_environment(self, project, name):
         env = Environment.objects.create(

--- a/tests/sentry/api/endpoints/test_index.py
+++ b/tests/sentry/api/endpoints/test_index.py
@@ -30,7 +30,7 @@ class ApiIndexTest(APITestCase):
         key = ApiKey.objects.create(organization=org)
         url = reverse("sentry-api-index")
         response = self.client.get(
-            url, HTTP_AUTHORIZATION=b"Basic " + b64encode("{}:".format(key.key).encode("utf-8"))
+            url, HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{key.key}:".encode("utf-8"))
         )
         assert response.status_code == 200
         assert response.data["version"] == "0"
@@ -40,7 +40,7 @@ class ApiIndexTest(APITestCase):
     def test_token_auth(self):
         token = ApiToken.objects.create(user=self.user)
         url = reverse("sentry-api-index")
-        response = self.client.get(url, HTTP_AUTHORIZATION="Bearer {}".format(token.token))
+        response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token.token}")
         assert response.status_code == 200
         assert response.data["version"] == "0"
         assert response.data["auth"]["scopes"] == token.get_scopes()

--- a/tests/sentry/api/endpoints/test_monitor_checkin_details.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkin_details.py
@@ -27,7 +27,7 @@ class UpdateMonitorCheckInTest(APITestCase):
         self.login_as(user=user)
         with self.feature({"organizations:monitors": True}):
             resp = self.client.put(
-                "/api/0/monitors/{}/checkins/{}/".format(monitor.guid, checkin.guid),
+                f"/api/0/monitors/{monitor.guid}/checkins/{checkin.guid}/",
                 data={"status": "ok"},
             )
 
@@ -62,7 +62,7 @@ class UpdateMonitorCheckInTest(APITestCase):
         self.login_as(user=user)
         with self.feature({"organizations:monitors": True}):
             resp = self.client.put(
-                "/api/0/monitors/{}/checkins/{}/".format(monitor.guid, checkin.guid),
+                f"/api/0/monitors/{monitor.guid}/checkins/{checkin.guid}/",
                 data={"status": "error"},
             )
 

--- a/tests/sentry/api/endpoints/test_monitor_checkins.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkins.py
@@ -26,7 +26,7 @@ class CreateMonitorCheckInTest(APITestCase):
         self.login_as(user=user)
         with self.feature({"organizations:monitors": True}):
             resp = self.client.post(
-                "/api/0/monitors/{}/checkins/".format(monitor.guid), data={"status": "ok"}
+                f"/api/0/monitors/{monitor.guid}/checkins/", data={"status": "ok"}
             )
 
         assert resp.status_code == 201, resp.content
@@ -56,7 +56,7 @@ class CreateMonitorCheckInTest(APITestCase):
         self.login_as(user=user)
         with self.feature({"organizations:monitors": True}):
             resp = self.client.post(
-                "/api/0/monitors/{}/checkins/".format(monitor.guid), data={"status": "error"}
+                f"/api/0/monitors/{monitor.guid}/checkins/", data={"status": "error"}
             )
 
         assert resp.status_code == 201, resp.content
@@ -87,7 +87,7 @@ class CreateMonitorCheckInTest(APITestCase):
         self.login_as(user=user)
         with self.feature({"organizations:monitors": True}):
             resp = self.client.post(
-                "/api/0/monitors/{}/checkins/".format(monitor.guid), data={"status": "error"}
+                f"/api/0/monitors/{monitor.guid}/checkins/", data={"status": "error"}
             )
 
         assert resp.status_code == 201, resp.content
@@ -118,7 +118,7 @@ class CreateMonitorCheckInTest(APITestCase):
         self.login_as(user=user)
         with self.feature({"organizations:monitors": True}):
             resp = self.client.post(
-                "/api/0/monitors/{}/checkins/".format(monitor.guid), data={"status": "error"}
+                f"/api/0/monitors/{monitor.guid}/checkins/", data={"status": "error"}
             )
 
         assert resp.status_code == 404, resp.content
@@ -141,7 +141,7 @@ class CreateMonitorCheckInTest(APITestCase):
         self.login_as(user=user)
         with self.feature({"organizations:monitors": True}):
             resp = self.client.post(
-                "/api/0/monitors/{}/checkins/".format(monitor.guid), data={"status": "error"}
+                f"/api/0/monitors/{monitor.guid}/checkins/", data={"status": "error"}
             )
 
         assert resp.status_code == 404, resp.content
@@ -160,8 +160,8 @@ class CreateMonitorCheckInTest(APITestCase):
 
         with self.feature({"organizations:monitors": True}):
             resp = self.client.post(
-                "/api/0/monitors/{}/checkins/".format(monitor.guid),
-                HTTP_AUTHORIZATION="DSN {}".format(project_key.dsn_public),
+                f"/api/0/monitors/{monitor.guid}/checkins/",
+                HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}",
                 data={"status": "ok"},
             )
 
@@ -187,8 +187,8 @@ class CreateMonitorCheckInTest(APITestCase):
 
         with self.feature({"organizations:monitors": True}):
             resp = self.client.post(
-                "/api/0/monitors/{}/checkins/".format(monitor.guid),
-                HTTP_AUTHORIZATION="DSN {}".format(project_key.dsn_public),
+                f"/api/0/monitors/{monitor.guid}/checkins/",
+                HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}",
                 data={"status": "ok"},
             )
 

--- a/tests/sentry/api/endpoints/test_monitor_details.py
+++ b/tests/sentry/api/endpoints/test_monitor_details.py
@@ -24,7 +24,7 @@ class MonitorDetailsTest(APITestCase):
 
         self.login_as(user=user)
         with self.feature({"organizations:monitors": True}):
-            resp = self.client.get("/api/0/monitors/{}/".format(monitor.guid))
+            resp = self.client.get(f"/api/0/monitors/{monitor.guid}/")
 
         assert resp.status_code == 200, resp.content
         assert resp.data["id"] == six.text_type(monitor.guid)
@@ -45,7 +45,7 @@ class UpdateMonitorTest(APITestCase):
             config={"schedule": "* * * * *", "schedule_type": ScheduleType.CRONTAB},
         )
 
-        self.path = "/api/0/monitors/{}/".format(self.monitor.guid)
+        self.path = f"/api/0/monitors/{self.monitor.guid}/"
 
         self.login_as(user=self.user)
 
@@ -215,7 +215,7 @@ class DeleteMonitorTest(APITestCase):
 
         self.login_as(user=user)
         with self.feature({"organizations:monitors": True}):
-            resp = self.client.delete("/api/0/monitors/{}/".format(monitor.guid))
+            resp = self.client.delete(f"/api/0/monitors/{monitor.guid}/")
 
         assert resp.status_code == 202, resp.content
 

--- a/tests/sentry/api/endpoints/test_organization_activity.py
+++ b/tests/sentry/api/endpoints/test_organization_activity.py
@@ -19,7 +19,7 @@ class OrganizationActivityTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/organizations/{}/activity/".format(org.slug)
+        url = f"/api/0/organizations/{org.slug}/activity/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1

--- a/tests/sentry/api/endpoints/test_organization_config_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_config_integrations.py
@@ -25,9 +25,7 @@ class OrganizationConfigIntegrationsTest(APITestCase):
     def test_provider_key(self):
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user, name="baz")
-        path = "/api/0/organizations/{}/config/integrations/?provider_key=example_server".format(
-            org.slug
-        )
+        path = f"/api/0/organizations/{org.slug}/config/integrations/?provider_key=example_server"
         response = self.client.get(path, format="json")
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -108,7 +108,7 @@ class OrganizationDetailsTest(APITestCase):
         url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
         self.login_as(user=user)
 
-        response = self.client.get("{}?detailed=0".format(url), format="json")
+        response = self.client.get(f"{url}?detailed=0", format="json")
 
         assert "projects" not in response.data
         assert "teams" not in response.data

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -19,7 +19,7 @@ class OrganizationsListTest(APITestCase):
     def test_membership(self):
         org = self.create_organization(owner=self.user)
         self.login_as(user=self.user)
-        response = self.client.get("{}".format(self.path))
+        response = self.client.get(f"{self.path}")
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(org.id)
@@ -27,7 +27,7 @@ class OrganizationsListTest(APITestCase):
     def test_show_all_with_superuser(self):
         org = self.organization
         self.login_as(user=self.create_user(is_superuser=True), superuser=True)
-        response = self.client.get("{}?show=all".format(self.path))
+        response = self.client.get(f"{self.path}?show=all")
         assert response.status_code == 200
         assert len(response.data) == 2
         assert response.data[0]["id"] == six.text_type(org.id)
@@ -35,7 +35,7 @@ class OrganizationsListTest(APITestCase):
     def test_show_all_without_superuser(self):
         self.create_organization(owner=self.user)
         self.login_as(user=self.create_user(is_superuser=False))
-        response = self.client.get("{}?show=all".format(self.path))
+        response = self.client.get(f"{self.path}?show=all")
         assert response.status_code == 200
         assert len(response.data) == 0
 
@@ -51,7 +51,7 @@ class OrganizationsListTest(APITestCase):
         self.create_member(user=self.user, organization=org3, role="owner")
 
         self.login_as(user=self.user)
-        response = self.client.get("{}?owner=1".format(self.path))
+        response = self.client.get(f"{self.path}?owner=1")
         assert response.status_code == 200
         assert len(response.data) == 3
         assert response.data[0]["organization"]["id"] == six.text_type(org.id)
@@ -64,14 +64,14 @@ class OrganizationsListTest(APITestCase):
     def test_status_query(self):
         org = self.create_organization(owner=self.user, status=OrganizationStatus.PENDING_DELETION)
         self.login_as(user=self.user)
-        response = self.client.get("{}?query=status:pending_deletion".format(self.path))
+        response = self.client.get(f"{self.path}?query=status:pending_deletion")
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(org.id)
-        response = self.client.get("{}?query=status:deletion_in_progress".format(self.path))
+        response = self.client.get(f"{self.path}?query=status:deletion_in_progress")
         assert response.status_code == 200
         assert len(response.data) == 0
-        response = self.client.get("{}?query=status:invalid_status".format(self.path))
+        response = self.client.get(f"{self.path}?query=status:invalid_status")
         assert response.status_code == 200
         assert len(response.data) == 0
 
@@ -80,12 +80,12 @@ class OrganizationsListTest(APITestCase):
         self.create_organization(owner=self.user)
         self.login_as(user=self.user)
 
-        response = self.client.get("{}?member=1".format(self.path))
+        response = self.client.get(f"{self.path}?member=1")
         assert response.status_code == 200
         assert len(response.data) == 2
 
         om = OrganizationMember.objects.get(organization=org, user=self.user)
-        response = self.client.get("{}?query=member_id:{}".format(self.path, om.id))
+        response = self.client.get(f"{self.path}?query=member_id:{om.id}")
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(org.id)

--- a/tests/sentry/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_details.py
@@ -34,9 +34,7 @@ class OrganizationIntegrationDetailsTest(APITestCase):
             integration_id=self.integration.id,
         )
 
-        self.path = "/api/0/organizations/{}/integrations/{}/".format(
-            self.org.slug, self.integration.id
-        )
+        self.path = f"/api/0/organizations/{self.org.slug}/integrations/{self.integration.id}/"
 
     def test_simple(self):
         response = self.client.get(self.path, format="json")

--- a/tests/sentry/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repos.py
@@ -11,8 +11,8 @@ class OrganizationIntegrationReposTest(APITestCase):
         self.org = self.create_organization(owner=self.user, name="baz")
         self.integration = Integration.objects.create(provider="github", name="Example")
         self.integration.add_organization(self.org, self.user)
-        self.path = "/api/0/organizations/{}/integrations/{}/repos/".format(
-            self.org.slug, self.integration.id
+        self.path = (
+            f"/api/0/organizations/{self.org.slug}/integrations/{self.integration.id}/repos/"
         )
 
     @patch("sentry.integrations.github.GitHubAppsClient.get_repositories", return_value=[])
@@ -35,9 +35,7 @@ class OrganizationIntegrationReposTest(APITestCase):
     def test_no_repository_method(self):
         integration = Integration.objects.create(provider="example", name="Example")
         integration.add_organization(self.org, self.user)
-        path = "/api/0/organizations/{}/integrations/{}/repos/".format(
-            self.org.slug, integration.id
-        )
+        path = f"/api/0/organizations/{self.org.slug}/integrations/{integration.id}/repos/"
         response = self.client.get(path, format="json")
 
         assert response.status_code == 400

--- a/tests/sentry/api/endpoints/test_organization_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_integrations.py
@@ -14,7 +14,7 @@ class OrganizationIntegrationsListTest(APITestCase):
         self.integration.add_organization(self.org, self.user)
 
     def test_simple(self):
-        path = "/api/0/organizations/{}/integrations/".format(self.org.slug)
+        path = f"/api/0/organizations/{self.org.slug}/integrations/"
 
         response = self.client.get(path, format="json")
 
@@ -24,7 +24,7 @@ class OrganizationIntegrationsListTest(APITestCase):
         assert "configOrganization" in response.data[0]
 
     def test_no_config(self):
-        path = "/api/0/organizations/{}/integrations/?includeConfig=0".format(self.org.slug)
+        path = f"/api/0/organizations/{self.org.slug}/integrations/?includeConfig=0"
 
         response = self.client.get(path, format="json")
         assert response.status_code == 200, response.content
@@ -38,7 +38,7 @@ class OrganizationIntegrationsListTest(APITestCase):
             metadata={"access_token": "xoxa-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
         )
         integration.add_organization(self.org, self.user)
-        path = "/api/0/organizations/{}/integrations/".format(self.org.slug)
+        path = f"/api/0/organizations/{self.org.slug}/integrations/"
 
         response = self.client.get(path, format="json")
         assert response.status_code == 200, response.content
@@ -55,7 +55,7 @@ class OrganizationIntegrationsListTest(APITestCase):
             metadata={"access_token": "xoxa-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
         )
         integration.add_organization(self.org, self.user)
-        path = "/api/0/organizations/{}/integrations/".format(self.org.slug)
+        path = f"/api/0/organizations/{self.org.slug}/integrations/"
 
         response = self.client.get(path, format="json")
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_organization_issues_new.py
+++ b/tests/sentry/api/endpoints/test_organization_issues_new.py
@@ -25,7 +25,7 @@ class OrganizationIssuesNewTest(APITestCase):
 
         self.login_as(user=user)
 
-        url = "/api/0/organizations/{}/issues/new/".format(org.slug)
+        url = f"/api/0/organizations/{org.slug}/issues/new/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert len(response.data) == 2

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -32,9 +32,7 @@ class OrganizationMemberSerializerTest(TestCase):
 
         serializer = OrganizationMemberSerializer(context=context, data=data)
         assert not serializer.is_valid()
-        assert serializer.errors == {
-            "email": ["The user %s is already a member" % (self.user.email,)]
-        }
+        assert serializer.errors == {"email": [f"The user {self.user.email} is already a member"]}
 
     def test_invalid_team_invites(self):
         context = {"organization": self.organization, "allowed_roles": [roles.get("member")]}

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -235,11 +235,11 @@ class OrganizationMemberListTest(APITestCase):
         assert response.data[0]["email"] == self.user_2.email
         assert response.data[1]["email"] == self.owner_user.email
 
-        response = self.client.get(self.url + "?query=email:{}".format(join_request))
+        response = self.client.get(self.url + f"?query=email:{join_request}")
         assert response.status_code == 200
         assert response.data == []
 
-        response = self.client.get(self.url + "?query=email:{}".format(invite_request))
+        response = self.client.get(self.url + f"?query=email:{invite_request}")
         assert response.status_code == 200
         assert response.data == []
 
@@ -273,7 +273,7 @@ class OrganizationMemberListTest(APITestCase):
 
         assert len(mail.outbox) == 1
         assert mail.outbox[0].to == ["foo@example.com"]
-        assert mail.outbox[0].subject == "Join {} in using Sentry".format(self.org.name)
+        assert mail.outbox[0].subject == f"Join {self.org.name} in using Sentry"
 
     def test_existing_user_for_invite(self):
         self.login_as(user=self.owner_user)

--- a/tests/sentry/api/endpoints/test_organization_member_unreleased_commits.py
+++ b/tests/sentry/api/endpoints/test_organization_member_unreleased_commits.py
@@ -56,7 +56,7 @@ class OrganizationMemberUnreleasedCommitsTest(APITestCase):
             project=project, repo=repo, date_added=datetime(2015, 1, 3, tzinfo=timezone.utc)
         )
 
-        path = "/api/0/organizations/{}/members/me/unreleased-commits/".format(org.slug)
+        path = f"/api/0/organizations/{org.slug}/members/me/unreleased-commits/"
 
         self.login_as(user)
 

--- a/tests/sentry/api/endpoints/test_organization_monitors.py
+++ b/tests/sentry/api/endpoints/test_organization_monitors.py
@@ -21,7 +21,7 @@ class ListOrganizationMonitorsTest(APITestCase):
 
     @fixture
     def path(self):
-        return "/api/0/organizations/{}/monitors/".format(self.org.slug)
+        return f"/api/0/organizations/{self.org.slug}/monitors/"
 
     def check_valid_response(self, response, expected_monitors):
         assert response.status_code == 200, response.content
@@ -55,7 +55,7 @@ class CreateOrganizationMonitorTest(APITestCase):
 
     @fixture
     def path(self):
-        return "/api/0/organizations/{}/monitors/".format(self.org.slug)
+        return f"/api/0/organizations/{self.org.slug}/monitors/"
 
     def test_simple(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_organization_plugins.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins.py
@@ -59,7 +59,7 @@ class OrganizationPluginsTest(APITestCase):
             kwargs={"organization_slug": self.projectA.organization.slug},
         )
 
-        url = "{}?plugins=slack".format(url)
+        url = f"{url}?plugins=slack"
         response = self.client.get(url)
 
         assert response.status_code == 200, (response.status_code, response.content)
@@ -77,7 +77,7 @@ class OrganizationPluginsTest(APITestCase):
             kwargs={"organization_slug": self.projectA.organization.slug},
         )
 
-        url = "{}?plugins=nope&plugins=beep&plugins=slack".format(url)
+        url = f"{url}?plugins=nope&plugins=beep&plugins=slack"
         response = self.client.get(url)
 
         assert response.status_code == 200, (response.status_code, response.content)

--- a/tests/sentry/api/endpoints/test_organization_plugins.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins.py
@@ -20,7 +20,7 @@ class OrganizationPluginsTest(APITestCase):
             kwargs={"organization_slug": self.projectA.organization.slug},
         )
 
-        url = "{}?{}".format(url, "plugins=_all")
+        url = f"{url}?plugins=_all"
 
         response = self.client.get(url)
 
@@ -40,7 +40,7 @@ class OrganizationPluginsTest(APITestCase):
             kwargs={"organization_slug": self.projectA.organization.slug},
         )
 
-        url = "{}?{}".format(url, "plugins=slack&plugins=webhooks")
+        url = f"{url}?plugins=slack&plugins=webhooks"
 
         response = self.client.get(url)
 

--- a/tests/sentry/api/endpoints/test_organization_projects.py
+++ b/tests/sentry/api/endpoints/test_organization_projects.py
@@ -9,7 +9,7 @@ from sentry.testutils import APITestCase
 class OrganizationProjectsTest(APITestCase):
     @fixture
     def path(self):
-        return "/api/0/organizations/{}/projects/".format(self.organization.slug)
+        return f"/api/0/organizations/{self.organization.slug}/projects/"
 
     def check_valid_response(self, response, expected_projects):
         assert response.status_code == 200, response.content
@@ -30,29 +30,29 @@ class OrganizationProjectsTest(APITestCase):
 
         projects = [self.create_project(teams=[self.team])]
 
-        response = self.client.get("{}?statsPeriod=24h".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?statsPeriod=24h", format="json")
         self.check_valid_response(response, projects)
         assert "stats" in response.data[0]
 
-        response = self.client.get("{}?statsPeriod=14d".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?statsPeriod=14d", format="json")
         self.check_valid_response(response, projects)
         assert "stats" in response.data[0]
 
-        response = self.client.get("{}?statsPeriod=".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?statsPeriod=", format="json")
         self.check_valid_response(response, projects)
         assert "stats" not in response.data[0]
 
-        response = self.client.get("{}?statsPeriod=48h".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?statsPeriod=48h", format="json")
         assert response.status_code == 400
 
     def test_search(self):
         self.login_as(user=self.user)
         project = self.create_project(teams=[self.team], name="bar", slug="bar")
 
-        response = self.client.get("{}?query=bar".format(self.path))
+        response = self.client.get(f"{self.path}?query=bar")
         self.check_valid_response(response, [project])
 
-        response = self.client.get("{}?query=baz".format(self.path))
+        response = self.client.get(f"{self.path}?query=baz")
         self.check_valid_response(response, [])
 
     def test_search_by_ids(self):
@@ -62,11 +62,11 @@ class OrganizationProjectsTest(APITestCase):
         project_foo = self.create_project(teams=[self.team], name="foo", slug="foo")
         self.create_project(teams=[self.team], name="baz", slug="baz")
 
-        path = "{}?query=id:{}".format(self.path, project_foo.id)
+        path = f"{self.path}?query=id:{project_foo.id}"
         response = self.client.get(path)
         self.check_valid_response(response, [project_foo])
 
-        path = "{}?query=id:{} id:{}".format(self.path, project_bar.id, project_foo.id)
+        path = f"{self.path}?query=id:{project_bar.id} id:{project_foo.id}"
         response = self.client.get(path)
 
         self.check_valid_response(response, [project_bar, project_foo])
@@ -78,11 +78,11 @@ class OrganizationProjectsTest(APITestCase):
         project_foo = self.create_project(teams=[self.team], name="foo", slug="foo")
         self.create_project(teams=[self.team], name="baz", slug="baz")
 
-        path = "{}?query=slug:{}".format(self.path, project_foo.slug)
+        path = f"{self.path}?query=slug:{project_foo.slug}"
         response = self.client.get(path)
         self.check_valid_response(response, [project_foo])
 
-        path = "{}?query=slug:{} slug:{}".format(self.path, project_bar.slug, project_foo.slug)
+        path = f"{self.path}?query=slug:{project_bar.slug} slug:{project_foo.slug}"
         response = self.client.get(path)
 
         self.check_valid_response(response, [project_bar, project_foo])
@@ -91,8 +91,7 @@ class OrganizationProjectsTest(APITestCase):
         self.login_as(user=self.user)
 
         projects = [
-            self.create_project(teams=[self.team], name=i, slug="project-{}".format(i))
-            for i in range(3)
+            self.create_project(teams=[self.team], name=i, slug=f"project-{i}") for i in range(3)
         ]
         projects.sort(key=lambda project: project.slug)
 
@@ -125,11 +124,11 @@ class OrganizationProjectsTest(APITestCase):
         project_bar = self.create_project(teams=[self.team], name="bar", slug="bar")
         project_foo = self.create_project(teams=[other_team], name="foo", slug="foo")
         project_baz = self.create_project(teams=[other_team], name="baz", slug="baz")
-        path = "{}?query=team:{}".format(self.path, self.team.slug)
+        path = f"{self.path}?query=team:{self.team.slug}"
         response = self.client.get(path)
         self.check_valid_response(response, [project_bar])
 
-        path = "{}?query=!team:{}".format(self.path, self.team.slug)
+        path = f"{self.path}?query=!team:{self.team.slug}"
         response = self.client.get(path)
         self.check_valid_response(response, [project_baz, project_foo])
 
@@ -140,7 +139,7 @@ class OrganizationProjectsTest(APITestCase):
 
         response = self.client.get(
             self.path,
-            HTTP_AUTHORIZATION=b"Basic " + b64encode("{}:".format(key.key).encode("utf-8")),
+            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{key.key}:".encode("utf-8")),
         )
         self.check_valid_response(response, [project])
 
@@ -190,7 +189,7 @@ class OrganizationProjectsTest(APITestCase):
 class OrganizationProjectsCountTest(APITestCase):
     @fixture
     def path(self):
-        return "/api/0/organizations/{}/projects-count/".format(self.organization.slug)
+        return f"/api/0/organizations/{self.organization.slug}/projects-count/"
 
     def test_project_count(self):
         self.foo_user = self.create_user("foo@example.com")

--- a/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
@@ -54,7 +54,7 @@ class OrganizationProjectsSentFirstEventEndpointTest(APITestCase):
 
         self.login_as(user=self.foo)
 
-        response = self.client.get("{}?is_member=true".format(self.url))
+        response = self.client.get(f"{self.url}?is_member=true")
         assert response.status_code == 200
 
         assert not response.data["sentFirstEvent"]
@@ -65,7 +65,7 @@ class OrganizationProjectsSentFirstEventEndpointTest(APITestCase):
 
         self.login_as(user=self.foo)
 
-        response = self.client.get("{}?project={}".format(self.url, project.id))
+        response = self.client.get(f"{self.url}?project={project.id}")
         assert response.status_code == 200
 
         assert response.data["sentFirstEvent"]

--- a/tests/sentry/api/endpoints/test_organization_relay_usage.py
+++ b/tests/sentry/api/endpoints/test_organization_relay_usage.py
@@ -66,7 +66,7 @@ class OrganizationRelayHistoryTest(APITestCase):
 
         url = reverse("sentry-api-0-organization-details", args=[self.organization.slug])
         trusted_relays = [
-            {"name": "n_{}".format(idx), "description": "d_{}".format(idx), "publicKey": pk}
+            {"name": f"n_{idx}", "description": f"d_{idx}", "publicKey": pk}
             for idx, pk in enumerate(public_keys)
         ]
 

--- a/tests/sentry/api/endpoints/test_organization_release_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_release_assemble.py
@@ -22,7 +22,7 @@ class OrganizationReleaseAssembleTest(APITestCase):
 
     def test_assemble_json_schema(self):
         response = self.client.post(
-            self.url, data={"lol": "test"}, HTTP_AUTHORIZATION="Bearer {}".format(self.token.token)
+            self.url, data={"lol": "test"}, HTTP_AUTHORIZATION=f"Bearer {self.token.token}"
         )
         assert response.status_code == 400, response.content
 
@@ -30,21 +30,21 @@ class OrganizationReleaseAssembleTest(APITestCase):
         response = self.client.post(
             self.url,
             data={"checksum": "invalid"},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 400, response.content
 
         response = self.client.post(
             self.url,
             data={"checksum": checksum},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 400, response.content
 
         response = self.client.post(
             self.url,
             data={"checksum": checksum, "chunks": []},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.NOT_FOUND
@@ -60,7 +60,7 @@ class OrganizationReleaseAssembleTest(APITestCase):
         response = self.client.post(
             self.url,
             data={"checksum": total_checksum, "chunks": [blob1.checksum]},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
 
         assert response.status_code == 200, response.content
@@ -91,7 +91,7 @@ class OrganizationReleaseAssembleTest(APITestCase):
         response = self.client.post(
             self.url,
             data={"checksum": total_checksum, "chunks": [blob1.checksum]},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
 
         assert response.status_code == 200, response.content
@@ -112,7 +112,7 @@ class OrganizationReleaseAssembleTest(APITestCase):
         response = self.client.post(
             self.url,
             data={"checksum": total_checksum, "chunks": [blob1.checksum]},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
         )
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1460,7 +1460,7 @@ class ReleaseHeadCommitSerializerTest(TestCase):
         super(ReleaseHeadCommitSerializerTest, self).setUp()
         self.repo_name = "repo/name"
         self.commit = "b" * 40
-        self.commit_range = "%s..%s" % ("a" * 40, "b" * 40)
+        self.commit_range = "{}..{}".format("a" * 40, "b" * 40)
         self.prev_commit = "a" * 40
 
     def test_simple(self):
@@ -1533,32 +1533,38 @@ class ReleaseHeadCommitSerializerTest(TestCase):
 
     def test_commit_range_does_not_allow_empty_commits(self):
         serializer = ReleaseHeadCommitSerializer(
-            data={"commit": "%s..%s" % ("", "b" * MAX_COMMIT_LENGTH), "repository": self.repo_name}
+            data={
+                "commit": "{}..{}".format("", "b" * MAX_COMMIT_LENGTH),
+                "repository": self.repo_name,
+            }
         )
         assert not serializer.is_valid()
         serializer = ReleaseHeadCommitSerializer(
-            data={"commit": "%s..%s" % ("a" * MAX_COMMIT_LENGTH, ""), "repository": self.repo_name}
+            data={
+                "commit": "{}..{}".format("a" * MAX_COMMIT_LENGTH, ""),
+                "repository": self.repo_name,
+            }
         )
         assert not serializer.is_valid()
 
     def test_commit_range_limited_by_max_commit_length(self):
         serializer = ReleaseHeadCommitSerializer(
             data={
-                "commit": "%s..%s" % ("a" * MAX_COMMIT_LENGTH, "b" * MAX_COMMIT_LENGTH),
+                "commit": "{}..{}".format("a" * MAX_COMMIT_LENGTH, "b" * MAX_COMMIT_LENGTH),
                 "repository": self.repo_name,
             }
         )
         assert serializer.is_valid()
         serializer = ReleaseHeadCommitSerializer(
             data={
-                "commit": "%s..%s" % ("a" * (MAX_COMMIT_LENGTH + 1), "b" * MAX_COMMIT_LENGTH),
+                "commit": "{}..{}".format("a" * (MAX_COMMIT_LENGTH + 1), "b" * MAX_COMMIT_LENGTH),
                 "repository": self.repo_name,
             }
         )
         assert not serializer.is_valid()
         serializer = ReleaseHeadCommitSerializer(
             data={
-                "commit": "%s..%s" % ("a" * MAX_COMMIT_LENGTH, "b" * (MAX_COMMIT_LENGTH + 1)),
+                "commit": "{}..{}".format("a" * MAX_COMMIT_LENGTH, "b" * (MAX_COMMIT_LENGTH + 1)),
                 "repository": self.repo_name,
             }
         )

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -848,7 +848,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         response = self.client.post(
             url,
             data={"version": "1.2.1", "projects": [project1.slug]},
-            HTTP_AUTHORIZATION=b"Basic " + b64encode("{}:".format(bad_api_key.key).encode("utf-8")),
+            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{bad_api_key.key}:".encode("utf-8")),
         )
         assert response.status_code == 403
 
@@ -857,8 +857,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         response = self.client.post(
             url,
             data={"version": "1.2.1", "projects": [project1.slug]},
-            HTTP_AUTHORIZATION=b"Basic "
-            + b64encode("{}:".format(wrong_org_api_key.key).encode("utf-8")),
+            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{wrong_org_api_key.key}:".encode("utf-8")),
         )
         assert response.status_code == 403
 
@@ -867,8 +866,7 @@ class OrganizationReleaseCreateTest(APITestCase):
         response = self.client.post(
             url,
             data={"version": "1.2.1", "projects": [project1.slug]},
-            HTTP_AUTHORIZATION=b"Basic "
-            + b64encode("{}:".format(good_api_key.key).encode("utf-8")),
+            HTTP_AUTHORIZATION=b"Basic " + b64encode(f"{good_api_key.key}:".encode("utf-8")),
         )
         assert response.status_code == 201, response.content
 
@@ -908,7 +906,7 @@ class OrganizationReleaseCreateTest(APITestCase):
                 ],
                 "projects": [project1.slug],
             },
-            HTTP_AUTHORIZATION="Bearer {}".format(api_token.token),
+            HTTP_AUTHORIZATION=f"Bearer {api_token.token}",
         )
 
         mock_fetch_commits.apply_async.assert_called_with(

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -101,7 +101,7 @@ class MarkInstalledSentryAppInstallationsTest(SentryAppInstallationDetailsTest):
         response = self.client.put(
             self.url,
             data={"status": "installed"},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
             format="json",
         )
         assert response.status_code == 200
@@ -121,7 +121,7 @@ class MarkInstalledSentryAppInstallationsTest(SentryAppInstallationDetailsTest):
         response = self.client.put(
             self.url,
             data={"status": "pending"},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
             format="json",
         )
         assert response.status_code == 400
@@ -143,7 +143,7 @@ class MarkInstalledSentryAppInstallationsTest(SentryAppInstallationDetailsTest):
         response = self.client.put(
             self.url,
             data={"status": "installed"},
-            HTTP_AUTHORIZATION="Bearer {}".format(self.token.token),
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
             format="json",
         )
         assert response.status_code == 403

--- a/tests/sentry/api/endpoints/test_organization_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_stats.py
@@ -32,7 +32,7 @@ class OrganizationStatsTest(APITestCase):
         tsdb.incr(tsdb.models.organization_total_received, org.id, count=3)
 
         url = reverse("sentry-api-0-organization-stats", args=[org.slug])
-        response = self.client.get("{}?resolution=1d".format(url))
+        response = self.client.get(f"{url}?resolution=1d")
 
         assert response.status_code == 200, response.content
         assert response.data[-1][1] == 3, response.data
@@ -41,7 +41,7 @@ class OrganizationStatsTest(APITestCase):
     def test_resolution_invalid(self):
         self.login_as(user=self.user)
         url = reverse("sentry-api-0-organization-stats", args=[self.organization.slug])
-        response = self.client.get("{}?resolution=lol-nope".format(url))
+        response = self.client.get(f"{url}?resolution=lol-nope")
 
         assert response.status_code == 400, response.content
 

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -16,7 +16,7 @@ class OrganizationTeamsListTest(APITestCase):
 
         self.create_member(organization=org, user=user, has_global_access=False, teams=[team1])
 
-        path = "/api/0/organizations/{}/teams/".format(org.slug)
+        path = f"/api/0/organizations/{org.slug}/teams/"
 
         self.login_as(user=user)
 
@@ -38,7 +38,7 @@ class OrganizationTeamsListTest(APITestCase):
 
         self.create_member(organization=org, user=user, has_global_access=False, teams=[team1])
 
-        path = "/api/0/organizations/{}/teams/?is_not_member=1".format(org.slug)
+        path = f"/api/0/organizations/{org.slug}/teams/?is_not_member=1"
 
         self.login_as(user=user)
 
@@ -59,7 +59,7 @@ class OrganizationTeamsListTest(APITestCase):
 
         self.create_member(organization=org, user=user, has_global_access=False, teams=[team1])
 
-        path = "/api/0/organizations/{}/teams/?detailed=0".format(org.slug)
+        path = f"/api/0/organizations/{org.slug}/teams/?detailed=0"
 
         self.login_as(user=user)
 
@@ -79,14 +79,14 @@ class OrganizationTeamsListTest(APITestCase):
 
         self.login_as(user=user)
 
-        path = "/api/0/organizations/{}/teams/?query=bar".format(org.slug)
+        path = f"/api/0/organizations/{org.slug}/teams/?query=bar"
         response = self.client.get(path)
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(team.id)
 
-        path = "/api/0/organizations/{}/teams/?query=baz".format(org.slug)
+        path = f"/api/0/organizations/{org.slug}/teams/?query=baz"
         response = self.client.get(path)
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_organization_user_issues_search.py
+++ b/tests/sentry/api/endpoints/test_organization_user_issues_search.py
@@ -53,7 +53,7 @@ class OrganizationUserIssuesSearchTest(APITestCase, SnubaTestCase):
         self.create_member(user=user, organization=self.org)
         self.login_as(user=user)
 
-        url = "%s?%s" % (self.get_url(), urlencode({"email": "foo@example.com"}))
+        url = "{}?{}".format(self.get_url(), urlencode({"email": "foo@example.com"}))
 
         response = self.client.get(url, format="json")
         assert response.status_code == 200
@@ -68,7 +68,7 @@ class OrganizationUserIssuesSearchTest(APITestCase, SnubaTestCase):
             team=self.team1, organizationmember=member, is_active=True
         )
 
-        url = "%s?%s" % (self.get_url(), urlencode({"email": "foo@example.com"}))
+        url = "{}?{}".format(self.get_url(), urlencode({"email": "foo@example.com"}))
         response = self.client.get(url, format="json")
         # result shouldn't include results from team2/project2 or bar@example.com
         assert response.status_code == 200

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -75,11 +75,11 @@ class ProjectDetailsTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 302
         assert response.data["slug"] == "foobar"
-        assert response.data["detail"]["extra"]["url"] == "/api/0/projects/{}/{}/".format(
-            project.organization.slug,
-            "foobar",
+        assert (
+            response.data["detail"]["extra"]["url"]
+            == f"/api/0/projects/{project.organization.slug}/foobar/"
         )
-        redirect_path = "/api/0/projects/{}/{}/".format(project.organization.slug, "foobar")
+        redirect_path = f"/api/0/projects/{project.organization.slug}/foobar/"
         # XXX: AttributeError: 'Response' object has no attribute 'url'
         # (this is with self.assertRedirects(response, ...))
         assert response["Location"] == redirect_path

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -43,7 +43,7 @@ class ProjectDetailsTest(APITestCase):
         team = self.create_team(organization=org, name="foo", slug="foo")
         project = self.create_project(name="Bar", slug="bar", teams=[team])
         # We want to make sure we don't hit the LegacyProjectRedirect view at all.
-        url = "/api/0/projects/%s/%s/" % (org.slug, project.slug)
+        url = f"/api/0/projects/{org.slug}/{project.slug}/"
         response = self.client.get(url)
         assert response.status_code == 200
         assert response.data["id"] == six.text_type(project.id)
@@ -75,11 +75,11 @@ class ProjectDetailsTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 302
         assert response.data["slug"] == "foobar"
-        assert response.data["detail"]["extra"]["url"] == "/api/0/projects/%s/%s/" % (
+        assert response.data["detail"]["extra"]["url"] == "/api/0/projects/{}/{}/".format(
             project.organization.slug,
             "foobar",
         )
-        redirect_path = "/api/0/projects/%s/%s/" % (project.organization.slug, "foobar")
+        redirect_path = "/api/0/projects/{}/{}/".format(project.organization.slug, "foobar")
         # XXX: AttributeError: 'Response' object has no attribute 'url'
         # (this is with self.assertRedirects(response, ...))
         assert response["Location"] == redirect_path

--- a/tests/sentry/api/endpoints/test_project_filter_details.py
+++ b/tests/sentry/api/endpoints/test_project_filter_details.py
@@ -7,7 +7,7 @@ class ProjectFilterDetailsTest(APITestCase):
         org = self.create_organization(name="baz", slug="1", owner=self.user)
         team = self.create_team(organization=org, name="foo", slug="foo")
         project = self.create_project(name="Bar", slug="bar", teams=[team])
-        url = "/api/0/projects/%s/%s/filters/browser-extensions/" % (org.slug, project.slug)
+        url = f"/api/0/projects/{org.slug}/{project.slug}/filters/browser-extensions/"
 
         project.update_option("filters:browser-extensions", "0")
         response = self.client.put(url, format="json", data={"active": True})

--- a/tests/sentry/api/endpoints/test_project_filters.py
+++ b/tests/sentry/api/endpoints/test_project_filters.py
@@ -7,7 +7,7 @@ class ProjectFiltersTest(APITestCase):
         org = self.create_organization(name="baz", slug="1", owner=self.user)
         team = self.create_team(organization=org, name="foo", slug="foo")
         project = self.create_project(name="Bar", slug="bar", teams=[team])
-        url = "/api/0/projects/%s/%s/filters/" % (org.slug, project.slug)
+        url = f"/api/0/projects/{org.slug}/{project.slug}/filters/"
 
         project.update_option("filters:browser-extension", "0")
         response = self.client.get(url)

--- a/tests/sentry/api/endpoints/test_project_group_stats.py
+++ b/tests/sentry/api/endpoints/test_project_group_stats.py
@@ -13,11 +13,11 @@ class ProjectGroupStatsTest(APITestCase):
         group2 = self.create_group(project=project)
 
         url = f"/api/0/projects/{project.organization.slug}/{project.slug}/issues/stats/"
-        response = self.client.get("%s?id=%s&id=%s" % (url, group1.id, group2.id), format="json")
+        response = self.client.get(f"{url}?id={group1.id}&id={group2.id}", format="json")
 
         tsdb.incr(tsdb.models.group, group1.id, count=3)
 
-        response = self.client.get("%s?id=%s&id=%s" % (url, group1.id, group2.id), format="json")
+        response = self.client.get(f"{url}?id={group1.id}&id={group2.id}", format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2

--- a/tests/sentry/api/endpoints/test_project_group_stats.py
+++ b/tests/sentry/api/endpoints/test_project_group_stats.py
@@ -12,7 +12,7 @@ class ProjectGroupStatsTest(APITestCase):
         group1 = self.create_group(project=project)
         group2 = self.create_group(project=project)
 
-        url = "/api/0/projects/{}/{}/issues/stats/".format(project.organization.slug, project.slug)
+        url = f"/api/0/projects/{project.organization.slug}/{project.slug}/issues/stats/"
         response = self.client.get("%s?id=%s&id=%s" % (url, group1.id, group2.id), format="json")
 
         tsdb.incr(tsdb.models.group, group1.id, count=3)

--- a/tests/sentry/api/endpoints/test_project_index.py
+++ b/tests/sentry/api/endpoints/test_project_index.py
@@ -36,7 +36,7 @@ class ProjectsListTest(APITestCase):
         self.create_project(organization=org2)
 
         self.login_as(user=user, superuser=True)
-        response = self.client.get("{}?show=all".format(self.path))
+        response = self.client.get(f"{self.path}?show=all")
         assert response.status_code == 200
         assert len(response.data) == 2
 
@@ -128,12 +128,12 @@ class ProjectsListTest(APITestCase):
 
         self.login_as(user=user)
 
-        response = self.client.get("{}?query=id:{}".format(self.path, project1.id))
+        response = self.client.get(f"{self.path}?query=id:{project1.id}")
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(project1.id)
 
-        response = self.client.get("{}?query=id:-1".format(self.path))
+        response = self.client.get(f"{self.path}?query=id:-1")
         assert response.status_code == 200
         assert len(response.data) == 0
 
@@ -148,6 +148,6 @@ class ProjectsListTest(APITestCase):
         # there should only be one record created so just grab the first one
         token = SentryAppInstallationToken.objects.first()
         response = self.client.get(
-            "{}".format(self.path), HTTP_AUTHORIZATION="Bearer {}".format(token.api_token.token)
+            f"{self.path}", HTTP_AUTHORIZATION=f"Bearer {token.api_token.token}"
         )
         assert project.name.encode("utf-8") in response.content

--- a/tests/sentry/api/endpoints/test_project_key_stats.py
+++ b/tests/sentry/api/endpoints/test_project_key_stats.py
@@ -10,9 +10,7 @@ class ProjectKeyStatsTest(APITestCase):
         self.project = self.create_project()
         self.key = ProjectKey.objects.create(project=self.project)
         self.login_as(user=self.user)
-        self.path = "/api/0/projects/{}/{}/keys/{}/stats/".format(
-            self.project.organization.slug, self.project.slug, self.key.public_key
-        )
+        self.path = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/keys/{self.key.public_key}/stats/"
 
     def test_simple(self):
         tsdb.incr(tsdb.models.key_total_received, self.key.id, count=3)

--- a/tests/sentry/api/endpoints/test_project_platforms.py
+++ b/tests/sentry/api/endpoints/test_project_platforms.py
@@ -7,7 +7,7 @@ class ProjectPlatformsTest(APITestCase):
         project = self.create_project()
         self.login_as(user=self.user)
         pp1 = ProjectPlatform.objects.create(project_id=project.id, platform="javascript")
-        url = "/api/0/projects/{}/{}/platforms/".format(project.organization.slug, project.slug)
+        url = f"/api/0/projects/{project.organization.slug}/{project.slug}/platforms/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
         assert response.data[0]["platform"] == pp1.platform

--- a/tests/sentry/api/endpoints/test_project_release_token.py
+++ b/tests/sentry/api/endpoints/test_project_release_token.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 
 from sentry.models import ProjectOption

--- a/tests/sentry/api/endpoints/test_project_servicehook_details.py
+++ b/tests/sentry/api/endpoints/test_project_servicehook_details.py
@@ -9,9 +9,7 @@ class ProjectServiceHookDetailsTest(APITestCase):
             project_id=project.id, actor_id=self.user.id, url="http://example.com"
         )[0]
         self.login_as(user=self.user)
-        path = "/api/0/projects/{}/{}/hooks/{}/".format(
-            project.organization.slug, project.slug, hook.guid
-        )
+        path = f"/api/0/projects/{project.organization.slug}/{project.slug}/hooks/{hook.guid}/"
         response = self.client.get(path)
         assert response.status_code == 200
         assert response.data["id"] == hook.guid
@@ -25,9 +23,7 @@ class UpdateProjectServiceHookTest(APITestCase):
         self.hook = ServiceHook.objects.get_or_create(
             project_id=self.project.id, actor_id=self.user.id, url="http://example.com"
         )[0]
-        self.path = "/api/0/projects/{}/{}/hooks/{}/".format(
-            self.project.organization.slug, self.project.slug, self.hook.guid
-        )
+        self.path = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/hooks/{self.hook.guid}/"
 
     def test_simple(self):
         resp = self.client.put(
@@ -48,9 +44,7 @@ class DeleteProjectServiceHookTest(APITestCase):
         self.hook = ServiceHook.objects.get_or_create(
             project_id=self.project.id, actor_id=self.user.id, url="http://example.com"
         )[0]
-        self.path = "/api/0/projects/{}/{}/hooks/{}/".format(
-            self.project.organization.slug, self.project.slug, self.hook.guid
-        )
+        self.path = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/hooks/{self.hook.guid}/"
 
     def test_simple(self):
         resp = self.client.delete(self.path)

--- a/tests/sentry/api/endpoints/test_project_servicehook_stats.py
+++ b/tests/sentry/api/endpoints/test_project_servicehook_stats.py
@@ -10,8 +10,8 @@ class ProjectServiceHookStatsTest(APITestCase):
             project_id=project.id, actor_id=self.user.id, url="http://example.com"
         )[0]
         self.login_as(user=self.user)
-        path = "/api/0/projects/{}/{}/hooks/{}/stats/".format(
-            project.organization.slug, project.slug, hook.guid
+        path = (
+            f"/api/0/projects/{project.organization.slug}/{project.slug}/hooks/{hook.guid}/stats/"
         )
 
         tsdb.incr(tsdb.models.servicehook_fired, hook.id, count=3)

--- a/tests/sentry/api/endpoints/test_project_servicehooks.py
+++ b/tests/sentry/api/endpoints/test_project_servicehooks.py
@@ -9,7 +9,7 @@ class ListProjectServiceHooksTest(APITestCase):
             project_id=project.id, actor_id=self.user.id, url="http://example.com"
         )[0]
         self.login_as(user=self.user)
-        url = "/api/0/projects/{}/{}/hooks/".format(project.organization.slug, project.slug)
+        url = f"/api/0/projects/{project.organization.slug}/{project.slug}/hooks/"
         with self.feature("projects:servicehooks"):
             response = self.client.get(url)
         assert response.status_code == 200

--- a/tests/sentry/api/endpoints/test_project_servicehooks.py
+++ b/tests/sentry/api/endpoints/test_project_servicehooks.py
@@ -22,9 +22,7 @@ class CreateProjectServiceHookTest(APITestCase):
         super(CreateProjectServiceHookTest, self).setUp()
         self.project = self.create_project()
         self.login_as(user=self.user)
-        self.path = "/api/0/projects/{}/{}/hooks/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        self.path = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/hooks/"
 
     def test_simple(self):
         with self.feature("projects:servicehooks"):

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -105,7 +105,7 @@ class ProjectStacktraceLinkTest(APITestCase):
 
     def test_stack_root_mismatch_error(self):
         self.login_as(user=self.user)
-        url = "{}?file={}".format(self.url, "wrong/file/path")
+        url = f"{self.url}?file=wrong/file/path"
 
         response = self.client.get(url)
 

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -62,7 +62,7 @@ class ProjectStacktraceLinkTest(APITestCase):
             "sentry-api-0-project-stacktrace-link",
             kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
         )
-        url = "{}?file={}".format(path, self.filepath)
+        url = f"{path}?file={self.filepath}"
 
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
@@ -74,7 +74,7 @@ class ProjectStacktraceLinkTest(APITestCase):
 
     def test_file_not_found_error(self):
         self.login_as(user=self.user)
-        url = "{}?file={}".format(self.url, self.filepath)
+        url = f"{self.url}?file={self.filepath}"
 
         response = self.client.get(url)
 
@@ -136,7 +136,7 @@ class ProjectStacktraceLinkTest(APITestCase):
 
     def test_config_and_source_url(self):
         self.login_as(user=self.user)
-        url = "{}?file={}".format(self.url, self.filepath)
+        url = f"{self.url}?file={self.filepath}"
 
         with mock.patch.object(
             ExampleIntegration, "get_stacktrace_link", return_value="https://sourceurl.com/"

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -15,7 +15,7 @@ class ProjectTagKeyDetailsTest(APITestCase, SnubaTestCase):
         def make_event(i):
             self.store_event(
                 data={
-                    "tags": {"foo": "val{}".format(i)},
+                    "tags": {"foo": f"val{i}"},
                     "timestamp": iso_format(before_now(seconds=1)),
                 },
                 project_id=project.id,

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -83,7 +83,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
             group_id=group2.id,
         )
 
-        url = "/api/0/projects/{}/{}/user-feedback/".format(project.organization.slug, project.slug)
+        url = f"/api/0/projects/{project.organization.slug}/{project.slug}/user-feedback/"
 
         response = self.client.get(url, format="json")
 
@@ -95,9 +95,9 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
         project = self.create_project()
         project_key = self.create_project_key(project=project)
 
-        url = "/api/0/projects/{}/{}/user-feedback/".format(project.organization.slug, project.slug)
+        url = f"/api/0/projects/{project.organization.slug}/{project.slug}/user-feedback/"
 
-        response = self.client.get(url, HTTP_AUTHORIZATION="DSN {}".format(project_key.dsn_public))
+        response = self.client.get(url, HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}")
 
         assert response.status_code == 401, response.content
 
@@ -115,9 +115,9 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
             group_id=group.id,
         )
 
-        url = "/api/0/projects/{}/{}/user-feedback/".format(project.organization.slug, project.slug)
+        url = f"/api/0/projects/{project.organization.slug}/{project.slug}/user-feedback/"
 
-        response = self.client.get("{}?status=".format(url), format="json")
+        response = self.client.get(f"{url}?status=", format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -210,7 +210,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
 
         response = self.client.post(
             url,
-            HTTP_AUTHORIZATION="DSN {}".format(project_key.dsn_public),
+            HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}",
             data={
                 "event_id": self.event.event_id,
                 "email": "foo@example.com",
@@ -233,7 +233,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
 
         response = self.client.post(
             url,
-            HTTP_AUTHORIZATION="DSN {}".format(project_key.dsn_public),
+            HTTP_AUTHORIZATION=f"DSN {project_key.dsn_public}",
             data={
                 "event_id": uuid4().hex,
                 "email": "foo@example.com",

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -126,8 +126,8 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
     def test_environments(self):
         self.login_as(user=self.user)
 
-        base_url = "/api/0/projects/{}/{}/user-feedback/".format(
-            self.project.organization.slug, self.project.slug
+        base_url = (
+            f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/user-feedback/"
         )
 
         # Specify environment
@@ -179,9 +179,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
     def test_simple(self):
         self.login_as(user=self.user)
 
-        url = "/api/0/projects/{}/{}/user-feedback/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        url = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/user-feedback/"
 
         response = self.client.post(
             url,
@@ -204,9 +202,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
 
     def test_with_dsn_auth(self):
         project_key = self.create_project_key(project=self.project)
-        url = "/api/0/projects/{}/{}/user-feedback/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        url = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/user-feedback/"
 
         response = self.client.post(
             url,
@@ -227,9 +223,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
         project2 = self.create_project()
         project_key = self.create_project_key(project=self.project)
 
-        url = "/api/0/projects/{}/{}/user-feedback/".format(
-            project2.organization.slug, project2.slug
-        )
+        url = f"/api/0/projects/{project2.organization.slug}/{project2.slug}/user-feedback/"
 
         response = self.client.post(
             url,
@@ -256,9 +250,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
             comments="",
         )
 
-        url = "/api/0/projects/{}/{}/user-feedback/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        url = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/user-feedback/"
 
         response = self.client.post(
             url,
@@ -293,9 +285,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
             comments="",
         )
 
-        url = "/api/0/projects/{}/{}/user-feedback/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        url = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/user-feedback/"
 
         response = self.client.post(
             url,
@@ -333,9 +323,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
             date_added=timezone.now() - timedelta(minutes=10),
         )
 
-        url = "/api/0/projects/{}/{}/user-feedback/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        url = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/user-feedback/"
 
         response = self.client.post(
             url,
@@ -352,9 +340,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
     def test_after_event_deadline(self):
         self.login_as(user=self.user)
 
-        url = "/api/0/projects/{}/{}/user-feedback/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        url = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/user-feedback/"
 
         response = self.client.post(
             url,
@@ -371,9 +357,7 @@ class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
     def test_environments(self):
         self.login_as(user=self.user)
 
-        url = "/api/0/projects/{}/{}/user-feedback/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        url = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/user-feedback/"
 
         response = self.client.post(
             url,

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -50,7 +50,7 @@ class ProjectUsersTest(APITestCase):
     def test_empty_search_query(self):
         self.login_as(user=self.user)
 
-        response = self.client.get("{}?query=foo".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?query=foo", format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 0
@@ -58,13 +58,13 @@ class ProjectUsersTest(APITestCase):
     def test_username_search(self):
         self.login_as(user=self.user)
 
-        response = self.client.get("{}?query=username:baz".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?query=username:baz", format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(self.euser2.id)
 
-        response = self.client.get("{}?query=username:ba".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?query=username:ba", format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
@@ -72,15 +72,13 @@ class ProjectUsersTest(APITestCase):
     def test_email_search(self):
         self.login_as(user=self.user)
 
-        response = self.client.get(
-            "{}?query=email:foo@example.com".format(self.path), format="json"
-        )
+        response = self.client.get(f"{self.path}?query=email:foo@example.com", format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(self.euser1.id)
 
-        response = self.client.get("{}?query=email:@example.com".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?query=email:@example.com", format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
@@ -88,13 +86,13 @@ class ProjectUsersTest(APITestCase):
     def test_id_search(self):
         self.login_as(user=self.user)
 
-        response = self.client.get("{}?query=id:1".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?query=id:1", format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(self.euser1.id)
 
-        response = self.client.get("{}?query=id:3".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?query=id:3", format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 0
@@ -102,13 +100,13 @@ class ProjectUsersTest(APITestCase):
     def test_ip_search(self):
         self.login_as(user=self.user)
 
-        response = self.client.get("{}?query=ip:192.168.0.1".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?query=ip:192.168.0.1", format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(self.euser2.id)
 
-        response = self.client.get("{}?query=ip:0".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?query=ip:0", format="json")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2

--- a/tests/sentry/api/endpoints/test_release_deploys.py
+++ b/tests/sentry/api/endpoints/test_release_deploys.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import datetime
 
 from django.core.urlresolvers import reverse

--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -95,7 +95,7 @@ class TestSentryAppAuthorizations(APITestCase):
 
         url = reverse("sentry-api-0-organization-details", args=[self.org.slug])
 
-        response = self.client.get(url, HTTP_AUTHORIZATION="Bearer {}".format(token))
+        response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
 
         assert response.status_code == 200
         assert response.data["id"] == six.text_type(self.org.id)

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
@@ -67,7 +67,7 @@ class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
             "query": "proj",
             "dependentData": json.dumps({"org_id": "A"}),
         }
-        url = "%s?%s" % (self.url, urlencode(query))
+        url = "{}?{}".format(self.url, urlencode(query))
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert response.data == {"choices": [["1234", "Project Name"]]}

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
@@ -30,9 +30,7 @@ class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
         options = [{"label": "Project Name", "value": "1234"}]
         responses.add(
             method=responses.GET,
-            url="https://example.com/get-projects?projectSlug={}&installationId={}&query=proj".format(
-                self.project.slug, self.install.uuid
-            ),
+            url=f"https://example.com/get-projects?projectSlug={self.project.slug}&installationId={self.install.uuid}&query=proj",
             json=options,
             status=200,
             content_type="application/json",

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
@@ -36,9 +36,7 @@ class SentryAppInstallationExternalRequestsEndpointTest(APITestCase):
             content_type="application/json",
             match_querystring=True,
         )
-        url = self.url + "?projectId={}&uri={}&query={}".format(
-            self.project.id, "/get-projects", "proj"
-        )
+        url = self.url + f"?projectId={self.project.id}&uri=/get-projects&query=proj"
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert response.data == {"choices": [["1234", "Project Name"]]}

--- a/tests/sentry/api/endpoints/test_sentry_app_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_requests.py
@@ -154,11 +154,11 @@ class GetSentryAppRequestsTest(SentryAppRequestsTest):
         )
 
         url = reverse("sentry-api-0-sentry-app-requests", args=[self.published_app.slug])
-        response1 = self.client.get("{}?eventType=issue.created".format(url), format="json")
+        response1 = self.client.get(f"{url}?eventType=issue.created", format="json")
         assert response1.status_code == 200
         assert len(response1.data) == 0
 
-        response2 = self.client.get("{}?eventType=issue.assigned".format(url), format="json")
+        response2 = self.client.get(f"{url}?eventType=issue.assigned", format="json")
         assert response2.status_code == 200
         assert len(response2.data) == 1
 
@@ -166,7 +166,7 @@ class GetSentryAppRequestsTest(SentryAppRequestsTest):
         self.login_as(user=self.user)
 
         url = reverse("sentry-api-0-sentry-app-requests", args=[self.published_app.slug])
-        response = self.client.get("{}?eventType=invalid_type".format(url), format="json")
+        response = self.client.get(f"{url}?eventType=invalid_type", format="json")
 
         assert response.status_code == 400
 
@@ -187,7 +187,7 @@ class GetSentryAppRequestsTest(SentryAppRequestsTest):
         )
 
         url = reverse("sentry-api-0-sentry-app-requests", args=[self.published_app.slug])
-        errors_only_response = self.client.get("{}?errorsOnly=true".format(url), format="json")
+        errors_only_response = self.client.get(f"{url}?errorsOnly=true", format="json")
         assert errors_only_response.status_code == 200
         assert len(errors_only_response.data) == 1
 

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -97,7 +97,7 @@ class GetSentryAppsTest(SentryAppsTest):
 
     def test_users_filter_on_internal_apps(self):
         self.login_as(user=self.user)
-        url = "{}?status=internal".format(self.url)
+        url = f"{self.url}?status=internal"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -134,7 +134,7 @@ class GetSentryAppsTest(SentryAppsTest):
         internal_app = self.create_internal_integration(name="Internal Nosee", organization=new_org)
 
         self.login_as(user=self.superuser, superuser=True)
-        url = "{}?status=internal".format(self.url)
+        url = f"{self.url}?status=internal"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -167,7 +167,7 @@ class GetSentryAppsTest(SentryAppsTest):
 
     def test_superuser_filter_on_published(self):
         self.login_as(user=self.superuser, superuser=True)
-        url = "{}?status=published".format(self.url)
+        url = f"{self.url}?status=published"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -203,7 +203,7 @@ class GetSentryAppsTest(SentryAppsTest):
 
     def test_superuser_filter_on_unpublished(self):
         self.login_as(user=self.superuser, superuser=True)
-        url = "{}?status=unpublished".format(self.url)
+        url = f"{self.url}?status=unpublished"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -214,7 +214,7 @@ class GetSentryAppsTest(SentryAppsTest):
 
     def test_user_filter_on_unpublished(self):
         self.login_as(user=self.user)
-        url = "{}?status=unpublished".format(self.url)
+        url = f"{self.url}?status=unpublished"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -250,7 +250,7 @@ class GetSentryAppsTest(SentryAppsTest):
 
     def test_user_filter_on_published(self):
         self.login_as(user=self.user)
-        url = "{}?status=published".format(self.url)
+        url = f"{self.url}?status=published"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
@@ -267,7 +267,7 @@ class GetSentryAppsTest(SentryAppsTest):
             name="Boo Far", organization=self.org, scopes=("project:write",)
         )
         self.login_as(user=user)
-        url = "{}?status=unpublished".format(self.url)
+        url = f"{self.url}?status=unpublished"
         response = self.client.get(url, format="json")
         assert {
             "name": sentry_app.name,
@@ -731,7 +731,7 @@ class PostSentryAppsTest(SentryAppsTest):
     def _post_with_token(self, token, **kwargs):
         body = self._default_body()
         body.update(**kwargs)
-        authorization = "Bearer {}".format(token.token)
+        authorization = f"Bearer {token.token}"
         return self.client.post(
             self.url,
             body,

--- a/tests/sentry/api/endpoints/test_sentry_apps_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps_stats.py
@@ -58,7 +58,7 @@ class SentryAppsStatsTest(APITestCase):
 
         for i in range(15):
             app = self.create_sentry_app(
-                name="Test {}".format(i), organization=self.super_org, published=True
+                name=f"Test {i}", organization=self.super_org, published=True
             )
 
             self.create_sentry_app_installation(slug=app.slug, organization=self.org)

--- a/tests/sentry/api/endpoints/test_setup_wizard.py
+++ b/tests/sentry/api/endpoints/test_setup_wizard.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_shared_group_details.py
+++ b/tests/sentry/api/endpoints/test_shared_group_details.py
@@ -21,7 +21,7 @@ class SharedGroupDetailsTest(APITestCase):
         share_id = group.get_share_id()
         assert share_id is not None
 
-        url = "/api/0/shared/issues/{}/".format(share_id)
+        url = f"/api/0/shared/issues/{share_id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -46,7 +46,7 @@ class SharedGroupDetailsTest(APITestCase):
         share_id = group.get_share_id()
         assert share_id is not None
 
-        url = "/api/0/shared/issues/{}/".format(share_id)
+        url = f"/api/0/shared/issues/{share_id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 404
@@ -62,7 +62,7 @@ class SharedGroupDetailsTest(APITestCase):
         share_id = group.get_share_id()
         assert share_id is not None
 
-        url = "/api/0/shared/issues/{}/".format(share_id)
+        url = f"/api/0/shared/issues/{share_id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content

--- a/tests/sentry/api/endpoints/test_team_groups_new.py
+++ b/tests/sentry/api/endpoints/test_team_groups_new.py
@@ -11,7 +11,7 @@ class TeamGroupsNewTest(APITestCase):
         group2 = self.create_group(checksum="b" * 32, project=project2, times_seen=5)
 
         self.login_as(user=self.user)
-        url = "/api/0/teams/{}/{}/issues/new/".format(self.team.organization.slug, self.team.slug)
+        url = f"/api/0/teams/{self.team.organization.slug}/{self.team.slug}/issues/new/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert len(response.data) == 2

--- a/tests/sentry/api/endpoints/test_team_groups_trending.py
+++ b/tests/sentry/api/endpoints/test_team_groups_trending.py
@@ -12,9 +12,7 @@ class TeamGroupsTrendingTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = "/api/0/teams/{}/{}/issues/trending/".format(
-            self.team.organization.slug, self.team.slug
-        )
+        url = f"/api/0/teams/{self.team.organization.slug}/{self.team.slug}/issues/trending/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert len(response.data) == 2

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -34,7 +34,7 @@ class TeamProjectsListTest(APITestCase):
         team2 = self.create_team(organization=org, name="bar")
         self.create_project(organization=org, teams=[team2])
 
-        path = "/api/0/teams/{}/{}/projects/".format(org.slug, team1.slug)
+        path = f"/api/0/teams/{org.slug}/{team1.slug}/projects/"
 
         self.login_as(user=user)
 
@@ -68,7 +68,7 @@ class TeamProjectsCreateTest(APITestCase):
         org = self.create_organization(owner=user)
         team1 = self.create_team(organization=org, name="foo")
 
-        path = "/api/0/teams/{}/{}/projects/".format(org.slug, team1.slug)
+        path = f"/api/0/teams/{org.slug}/{team1.slug}/projects/"
 
         self.login_as(user=user)
 
@@ -86,7 +86,7 @@ class TeamProjectsCreateTest(APITestCase):
         org = self.create_organization(owner=user)
         team1 = self.create_team(organization=org, name="foo")
 
-        path = "/api/0/teams/{}/{}/projects/".format(org.slug, team1.slug)
+        path = f"/api/0/teams/{org.slug}/{team1.slug}/projects/"
 
         self.login_as(user=user)
 
@@ -105,7 +105,7 @@ class TeamProjectsCreateTest(APITestCase):
         team1 = self.create_team(organization=org, name="foo")
         self.create_project(organization=org, teams=[team1], slug="test-project")
 
-        path = "/api/0/teams/{}/{}/projects/".format(org.slug, team1.slug)
+        path = f"/api/0/teams/{org.slug}/{team1.slug}/projects/"
 
         self.login_as(user=user)
 
@@ -118,7 +118,7 @@ class TeamProjectsCreateTest(APITestCase):
         org = self.create_organization(owner=user)
         team1 = self.create_team(organization=org, name="foo")
 
-        path = "/api/0/teams/{}/{}/projects/".format(org.slug, team1.slug)
+        path = f"/api/0/teams/{org.slug}/{team1.slug}/projects/"
 
         self.login_as(user=user)
 

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -161,7 +161,7 @@ class UserUpdateTest(APITestCase):
 class UserDeleteTest(APITestCase):
     def setUp(self):
         super(UserDeleteTest, self).setUp()
-        self.path = "/api/0/users/{}/".format(self.user.id)
+        self.path = f"/api/0/users/{self.user.id}/"
 
     def test_close_account(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_user_index.py
+++ b/tests/sentry/api/endpoints/test_user_index.py
@@ -30,40 +30,40 @@ class UserListTest(APITestCase):
 
     def test_generic_query(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.get("{}?query=@example.com".format(self.path))
+        response = self.client.get(f"{self.path}?query=@example.com")
         assert response.status_code == 200
         assert len(response.data) == 2
-        response = self.client.get("{}?query=bar".format(self.path))
+        response = self.client.get(f"{self.path}?query=bar")
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(self.superuser.id)
-        response = self.client.get("{}?query=foobar".format(self.path))
+        response = self.client.get(f"{self.path}?query=foobar")
         assert response.status_code == 200
         assert len(response.data) == 0
 
     def test_superuser_query(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.get("{}?query=is:superuser".format(self.path))
+        response = self.client.get(f"{self.path}?query=is:superuser")
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(self.superuser.id)
 
     def test_email_query(self):
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.get("{}?query=email:bar@example.com".format(self.path))
+        response = self.client.get(f"{self.path}?query=email:bar@example.com")
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(self.superuser.id)
-        response = self.client.get("{}?query=email:foobar".format(self.path))
+        response = self.client.get(f"{self.path}?query=email:foobar")
         assert response.status_code == 200
         assert len(response.data) == 0
 
     def test_basic_query(self):
         UserPermission.objects.create(user=self.superuser, permission="broadcasts.admin")
         self.login_as(user=self.superuser, superuser=True)
-        response = self.client.get("{}?query=permission:broadcasts.admin".format(self.path))
+        response = self.client.get(f"{self.path}?query=permission:broadcasts.admin")
         assert response.status_code == 200
         assert len(response.data) == 1
-        response = self.client.get("{}?query=permission:foobar".format(self.path))
+        response = self.client.get(f"{self.path}?query=permission:foobar")
         assert response.status_code == 200
         assert len(response.data) == 0

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -74,7 +74,7 @@ class UpdateGroupsTest(TestCase):
         request = self.make_request(user=self.user, method="GET")
         request.user = self.user
         request.data = {"status": "unresolved"}
-        request.GET = QueryDict(query_string="id={}".format(resolved_group.id))
+        request.GET = QueryDict(query_string=f"id={resolved_group.id}")
 
         search_fn = Mock()
         update_groups(request, [self.project], self.organization.id, search_fn)
@@ -94,7 +94,7 @@ class UpdateGroupsTest(TestCase):
         request = self.make_request(user=self.user, method="GET")
         request.user = self.user
         request.data = {"status": "resolved"}
-        request.GET = QueryDict(query_string="id={}".format(unresolved_group.id))
+        request.GET = QueryDict(query_string=f"id={unresolved_group.id}")
 
         search_fn = Mock()
         update_groups(request, [self.project], self.organization.id, search_fn)
@@ -113,7 +113,7 @@ class UpdateGroupsTest(TestCase):
         request = self.make_request(user=self.user, method="GET")
         request.user = self.user
         request.data = {"status": "ignored"}
-        request.GET = QueryDict(query_string="id={}".format(group.id))
+        request.GET = QueryDict(query_string=f"id={group.id}")
 
         search_fn = Mock()
         update_groups(request, [self.project], self.organization.id, search_fn)
@@ -131,7 +131,7 @@ class UpdateGroupsTest(TestCase):
         request = self.make_request(user=self.user, method="GET")
         request.user = self.user
         request.data = {"status": "unresolved"}
-        request.GET = QueryDict(query_string="id={}".format(group.id))
+        request.GET = QueryDict(query_string=f"id={group.id}")
 
         search_fn = Mock()
         update_groups(request, [self.project], self.organization.id, search_fn)
@@ -150,7 +150,7 @@ class UpdateGroupsTest(TestCase):
             request = self.make_request(user=self.user, method="GET")
             request.user = self.user
             request.data = {"inbox": False}
-            request.GET = QueryDict(query_string="id={}".format(group.id))
+            request.GET = QueryDict(query_string=f"id={group.id}")
 
             search_fn = Mock()
             update_groups(request, [self.project], self.organization.id, search_fn)

--- a/tests/sentry/api/helpers/test_processing_issues.py
+++ b/tests/sentry/api/helpers/test_processing_issues.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from exam import fixture
 
 from sentry.api.helpers.processing_issues import get_processing_issues

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.api.serializers import serialize
 from sentry.models import Activity, PullRequest, Commit, GroupStatus
 from sentry.testutils import TestCase

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/serializers/test_alert_rule_trigger.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger_action.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/serializers/test_app_platform_event.py
+++ b/tests/sentry/api/serializers/test_app_platform_event.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.api.serializers import AppPlatformEvent
 from sentry.testutils import TestCase
 from sentry.utils import json

--- a/tests/sentry/api/serializers/test_base.py
+++ b/tests/sentry/api/serializers/test_base.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.api.serializers import serialize, Serializer
 from sentry.testutils import TestCase
 

--- a/tests/sentry/api/serializers/test_commit.py
+++ b/tests/sentry/api/serializers/test_commit.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from uuid import uuid4
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/serializers/test_commit_filechange.py
+++ b/tests/sentry/api/serializers/test_commit_filechange.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from uuid import uuid4
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/serializers/test_debugfile.py
+++ b/tests/sentry/api/serializers/test_debugfile.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.api.serializers import serialize
 from sentry.testutils import TestCase
 

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 
 from sentry.api.serializers import serialize, SimpleEventSerializer

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.utils.compat import mock
 import six
 

--- a/tests/sentry/api/serializers/test_group_tombstone.py
+++ b/tests/sentry/api/serializers/test_group_tombstone.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.api.serializers import serialize
 from sentry.models import GroupHash, GroupTombstone
 from sentry.testutils import TestCase

--- a/tests/sentry/api/serializers/test_grouptagvalue.py
+++ b/tests/sentry/api/serializers/test_grouptagvalue.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from datetime import datetime
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/serializers/test_incident.py
+++ b/tests/sentry/api/serializers/test_incident.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from datetime import timedelta
 
 import six
@@ -51,7 +48,7 @@ class DetailedIncidentSerializerTest(TestCase):
         serializer = DetailedIncidentSerializer()
         result = serialize(incident, serializer=serializer)
         assert result["alertRule"] == serialize(incident.alert_rule)
-        assert result["discoverQuery"] == "(event.type:error) AND ({})".format(query)
+        assert result["discoverQuery"] == f"(event.type:error) AND ({query})"
 
     def test_error_alert_rule_unicode(self):
         query = "统一码"
@@ -60,7 +57,7 @@ class DetailedIncidentSerializerTest(TestCase):
         serializer = DetailedIncidentSerializer()
         result = serialize(incident, serializer=serializer)
         assert result["alertRule"] == serialize(incident.alert_rule)
-        assert result["discoverQuery"] == "(event.type:error) AND ({})".format(query)
+        assert result["discoverQuery"] == f"(event.type:error) AND ({query})"
 
     def test_transaction_alert_rule(self):
         query = "test query"
@@ -70,4 +67,4 @@ class DetailedIncidentSerializerTest(TestCase):
         serializer = DetailedIncidentSerializer()
         result = serialize(incident, serializer=serializer)
         assert result["alertRule"] == serialize(incident.alert_rule)
-        assert result["discoverQuery"] == "(event.type:transaction) AND ({})".format(query)
+        assert result["discoverQuery"] == f"(event.type:transaction) AND ({query})"

--- a/tests/sentry/api/serializers/test_incident_activity.py
+++ b/tests/sentry/api/serializers/test_incident_activity.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from datetime import datetime, timedelta
 from uuid import uuid4
 

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 
 from django.conf import settings
@@ -54,7 +51,7 @@ class OrganizationSerializerTest(TestCase):
         features.add("organizations:test-feature", OrganizationFeature)
         features.add("organizations:disabled-feature", OrganizationFeature)
         mock_batch.return_value = {
-            "organization:{}".format(organization.id): {
+            f"organization:{organization.id}": {
                 "organizations:test-feature": True,
                 "organizations:disabled-feature": False,
             }

--- a/tests/sentry/api/serializers/test_organization_member.py
+++ b/tests/sentry/api/serializers/test_organization_member.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.api.serializers import OrganizationMemberWithProjectsSerializer, serialize
 from sentry.testutils import TestCase
 

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from datetime import timedelta
 
 import six
@@ -135,7 +132,7 @@ class ProjectSerializerTest(TestCase):
     @mock.patch("sentry.features.batch_has")
     def test_project_batch_has(self, mock_batch):
         mock_batch.return_value = {
-            "project:{}".format(self.project.id): {
+            f"project:{self.project.id}": {
                 "projects:test-feature": True,
                 "projects:disabled-feature": False,
             }

--- a/tests/sentry/api/serializers/test_pull_request.py
+++ b/tests/sentry/api/serializers/test_pull_request.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from uuid import uuid4
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/serializers/test_recent_searches.py
+++ b/tests/sentry/api/serializers/test_recent_searches.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 
 from sentry.utils.compat.mock import patch

--- a/tests/sentry/api/serializers/test_saved_search.py
+++ b/tests/sentry/api/serializers/test_saved_search.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/serializers/test_sentry_app.py
+++ b/tests/sentry/api/serializers/test_sentry_app.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.sentry_app import SentryAppSerializer
 from sentry.testutils import TestCase

--- a/tests/sentry/api/serializers/test_tagvalue.py
+++ b/tests/sentry/api/serializers/test_tagvalue.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from datetime import datetime
 
 from sentry.api.serializers import serialize, UserTagValueSerializer

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/serializers/test_user.py
+++ b/tests/sentry/api/serializers/test_user.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -77,7 +77,7 @@ class TestDSNAuthentication(TestCase):
 
     def test_authenticate(self):
         request = HttpRequest()
-        request.META["HTTP_AUTHORIZATION"] = "DSN {}".format(self.project_key.dsn_public)
+        request.META["HTTP_AUTHORIZATION"] = f"DSN {self.project_key.dsn_public}"
 
         result = self.auth.authenticate(request)
         assert result is not None
@@ -89,7 +89,7 @@ class TestDSNAuthentication(TestCase):
     def test_inactive_key(self):
         self.project_key.update(status=ProjectKeyStatus.INACTIVE)
         request = HttpRequest()
-        request.META["HTTP_AUTHORIZATION"] = "DSN {}".format(self.project_key.dsn_public)
+        request.META["HTTP_AUTHORIZATION"] = f"DSN {self.project_key.dsn_public}"
 
         with pytest.raises(AuthenticationFailed):
             self.auth.authenticate(request)

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1488,9 +1488,7 @@ class ParseBooleanSearchQueryTest(TestCase):
         project3 = self.create_project()
         with self.assertRaisesRegexp(
             InvalidSearchQuery,
-            "Project {} does not exist or is not an actively selected project.".format(
-                project3.slug
-            ),
+            f"Project {project3.slug} does not exist or is not an actively selected project.",
         ):
             get_filter(
                 f"project:{project1.slug} OR project:{project3.slug}",
@@ -1515,9 +1513,7 @@ class ParseBooleanSearchQueryTest(TestCase):
             ),
             (f"issue.id:{group1.id} AND issue.id:{group1.id}", [], [group1.id]),
             (
-                "(issue.id:{} AND issue.id:{}) OR issue.id:{}".format(
-                    group1.id, group2.id, group3.id
-                ),
+                f"(issue.id:{group1.id} AND issue.id:{group2.id}) OR issue.id:{group3.id}",
                 [],
                 [group1.id, group2.id, group3.id],
             ),

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2077,7 +2077,7 @@ class GetSnubaQueryArgsTest(TestCase):
 
     @pytest.mark.xfail(reason="this breaks issue search so needs to be redone")
     def test_trace_id(self):
-        result = get_filter("trace:{}".format("a0fa8803753e40fd8124b21eeb2986b5"))
+        result = get_filter("trace:a0fa8803753e40fd8124b21eeb2986b5")
         assert result.conditions == [["trace", "=", "a0fa8803-753e-40fd-8124-b21eeb2986b5"]]
 
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -662,7 +662,7 @@ class ParseSearchQueryTest(unittest.TestCase):
     def test_boolean_filter(self):
         truthy = ("true", "TRUE", "1")
         for val in truthy:
-            assert parse_search_query("stack.in_app:{}".format(val)) == [
+            assert parse_search_query(f"stack.in_app:{val}") == [
                 SearchFilter(
                     key=SearchKey(name="stack.in_app"),
                     operator="=",
@@ -671,7 +671,7 @@ class ParseSearchQueryTest(unittest.TestCase):
             ]
         falsey = ("false", "FALSE", "0")
         for val in falsey:
-            assert parse_search_query("stack.in_app:{}".format(val)) == [
+            assert parse_search_query(f"stack.in_app:{val}") == [
                 SearchFilter(
                     key=SearchKey(name="stack.in_app"),
                     operator="=",
@@ -1015,12 +1015,12 @@ def _noeq(xy):
 
 # message ("foo bar baz")
 def _m(x):
-    return ["notEquals", [["positionCaseInsensitive", ["message", "'{}'".format(x)]], 0]]
+    return ["notEquals", [["positionCaseInsensitive", ["message", f"'{x}'"]], 0]]
 
 
 # message ("foo bar baz") using operators instead of functions
 def _om(x):
-    return [["positionCaseInsensitive", ["message", "'{}'".format(x)]], "!=", 0]
+    return [["positionCaseInsensitive", ["message", f"'{x}'"]], "!=", 0]
 
 
 # x OR y
@@ -1048,8 +1048,8 @@ class ParseBooleanSearchQueryTest(TestCase):
         super(ParseBooleanSearchQueryTest, self).setUp()
         users = ["foo", "bar", "foobar", "hello", "hi"]
         for u in users:
-            self.__setattr__(u, ["equals", ["user.email", "{}@example.com".format(u)]])
-            self.__setattr__("o{}".format(u), ["user.email", "=", "{}@example.com".format(u)])
+            self.__setattr__(u, ["equals", ["user.email", f"{u}@example.com"]])
+            self.__setattr__(f"o{u}", ["user.email", "=", f"{u}@example.com"])
 
     def test_simple(self):
         result = get_filter("user.email:foo@example.com OR user.email:bar@example.com")
@@ -1427,7 +1427,7 @@ class ParseBooleanSearchQueryTest(TestCase):
         project2 = self.create_project()
         tests = [
             (
-                "project:{} OR project:{}".format(project1.slug, project2.slug),
+                f"project:{project1.slug} OR project:{project2.slug}",
                 [
                     [
                         _or(
@@ -1441,7 +1441,7 @@ class ParseBooleanSearchQueryTest(TestCase):
                 [project1.id, project2.id],
             ),
             (
-                "(project:{} OR project:{}) AND a:b".format(project1.slug, project2.slug),
+                f"(project:{project1.slug} OR project:{project2.slug}) AND a:b",
                 [
                     [
                         _or(
@@ -1456,7 +1456,7 @@ class ParseBooleanSearchQueryTest(TestCase):
                 [project1.id, project2.id],
             ),
             (
-                "(project:{} AND a:b) OR (project:{} AND c:d)".format(project1.slug, project1.slug),
+                f"(project:{project1.slug} AND a:b) OR (project:{project1.slug} AND c:d)",
                 [
                     [
                         _or(
@@ -1493,7 +1493,7 @@ class ParseBooleanSearchQueryTest(TestCase):
             ),
         ):
             get_filter(
-                "project:{} OR project:{}".format(project1.slug, project3.slug),
+                f"project:{project1.slug} OR project:{project3.slug}",
                 params={
                     "organization_id": self.organization.id,
                     "project_id": [project1.id, project2.id],
@@ -1509,11 +1509,11 @@ class ParseBooleanSearchQueryTest(TestCase):
         group3 = self.create_group(project=self.project)
         tests = [
             (
-                "issue.id:{} OR issue.id:{}".format(group1.id, group2.id),
+                f"issue.id:{group1.id} OR issue.id:{group2.id}",
                 [],
                 [group1.id, group2.id],
             ),
-            ("issue.id:{} AND issue.id:{}".format(group1.id, group1.id), [], [group1.id]),
+            (f"issue.id:{group1.id} AND issue.id:{group1.id}", [], [group1.id]),
             (
                 "(issue.id:{} AND issue.id:{}) OR issue.id:{}".format(
                     group1.id, group2.id, group3.id
@@ -1521,16 +1521,16 @@ class ParseBooleanSearchQueryTest(TestCase):
                 [],
                 [group1.id, group2.id, group3.id],
             ),
-            ("issue.id:{} AND a:b".format(group1.id), [_oeq("ab")], [group1.id]),
+            (f"issue.id:{group1.id} AND a:b", [_oeq("ab")], [group1.id]),
             # TODO: Using OR with issue.id is broken. These return incorrect results.
-            ("issue.id:{} OR a:b".format(group1.id), [_oeq("ab")], [group1.id]),
+            (f"issue.id:{group1.id} OR a:b", [_oeq("ab")], [group1.id]),
             (
-                "(issue.id:{} AND a:b) OR issue.id:{}".format(group1.id, group2.id),
+                f"(issue.id:{group1.id} AND a:b) OR issue.id:{group2.id}",
                 [_oeq("ab")],
                 [group1.id, group2.id],
             ),
             (
-                "(issue.id:{} AND a:b) OR c:d".format(group1.id),
+                f"(issue.id:{group1.id} AND a:b) OR c:d",
                 [[_or(_eq("ab"), _eq("cd")), "=", 1]],
                 [group1.id],
             ),
@@ -1594,11 +1594,11 @@ class ParseBooleanSearchQueryTest(TestCase):
 
     def test_or_does_not_match_organization(self):
         result = get_filter(
-            "organization.slug:{}".format(self.organization.slug),
+            f"organization.slug:{self.organization.slug}",
             params={"organization_id": self.organization.id, "project_id": [self.project.id]},
         )
         assert result.conditions == [
-            [["ifNull", ["organization.slug", "''"]], "=", "{}".format(self.organization.slug)]
+            [["ifNull", ["organization.slug", "''"]], "=", f"{self.organization.slug}"]
         ]
 
 
@@ -1703,7 +1703,7 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_escaped_wildcard(self):
         assert get_filter("release:3.1.\\* user.email:\\*@example.com").conditions == [
             [["match", ["release", "'(?i)^3\\.1\\.\\*$'"]], "=", 1],
-            [["match", ["user.email", "'(?i)^\*@example\\.com$'"]], "=", 1],
+            [["match", ["user.email", "'(?i)^\\*@example\\.com$'"]], "=", 1],
         ]
         assert get_filter("release:\\\\\\*").conditions == [
             [["match", ["release", "'(?i)^\\\\\\*$'"]], "=", 1]
@@ -1712,7 +1712,7 @@ class GetSnubaQueryArgsTest(TestCase):
             [["match", ["release", "'(?i)^\\\\.*$'"]], "=", 1]
         ]
         assert get_filter("message:.*?").conditions == [
-            [["match", ["message", "'(?i)\..*\?'"]], "=", 1]
+            [["match", ["message", r"'(?i)\..*\?'"]], "=", 1]
         ]
 
     def test_wildcard_array_field(self):
@@ -1800,7 +1800,7 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_issue_filter(self):
         group = self.create_group(project=self.project)
         _filter = get_filter(
-            "issue:{}".format(group.qualified_short_id), {"organization_id": self.organization.id}
+            f"issue:{group.qualified_short_id}", {"organization_id": self.organization.id}
         )
         assert _filter.conditions == [["issue.id", "=", group.id]]
         assert _filter.filter_keys == {}
@@ -1809,7 +1809,7 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_negated_issue_filter(self):
         group = self.create_group(project=self.project)
         _filter = get_filter(
-            "!issue:{}".format(group.qualified_short_id), {"organization_id": self.organization.id}
+            f"!issue:{group.qualified_short_id}", {"organization_id": self.organization.id}
         )
         assert _filter.conditions == [["issue.id", "!=", group.id]]
         assert _filter.filter_keys == {}
@@ -1900,13 +1900,13 @@ class GetSnubaQueryArgsTest(TestCase):
         p2 = self.create_project(organization=self.organization)
 
         params = {"project_id": [p1.id, p2.id]}
-        _filter = get_filter("project.name:{}".format(p1.slug), params)
+        _filter = get_filter(f"project.name:{p1.slug}", params)
         assert _filter.conditions == [["project_id", "=", p1.id]]
         assert _filter.filter_keys == {"project_id": [p1.id]}
         assert _filter.project_ids == [p1.id]
 
         params = {"project_id": [p1.id, p2.id]}
-        _filter = get_filter("!project.name:{}".format(p1.slug), params)
+        _filter = get_filter(f"!project.name:{p1.slug}", params)
         assert _filter.conditions == [
             [[["isNull", ["project_id"]], "=", 1], ["project_id", "!=", p1.id]]
         ]
@@ -1915,7 +1915,7 @@ class GetSnubaQueryArgsTest(TestCase):
 
         with pytest.raises(InvalidSearchQuery) as err:
             params = {"project_id": []}
-            get_filter("project.name:{}".format(p1.slug), params)
+            get_filter(f"project.name:{p1.slug}", params)
         assert (
             "Invalid query. Project %s does not exist or is not an actively selected project"
             % p1.slug
@@ -1924,7 +1924,7 @@ class GetSnubaQueryArgsTest(TestCase):
 
     def test_transaction_status(self):
         for (key, val) in SPAN_STATUS_CODE_TO_NAME.items():
-            result = get_filter("transaction.status:{}".format(val))
+            result = get_filter(f"transaction.status:{val}")
             assert result.conditions == [["transaction.status", "=", key]]
 
     def test_transaction_status_no_wildcard(self):
@@ -2718,11 +2718,11 @@ class ResolveFieldListTest(unittest.TestCase):
             result = resolve_field_list(fields, eventstore.Filter())
 
             assert result["aggregations"] == [
-                ["quantile(0.5)", snuba_column, "p50_{}".format(column_alias).strip("_")],
-                ["quantile(0.75)", snuba_column, "p75_{}".format(column_alias).strip("_")],
-                ["quantile(0.95)", snuba_column, "p95_{}".format(column_alias).strip("_")],
-                ["quantile(0.99)", snuba_column, "p99_{}".format(column_alias).strip("_")],
-                ["max", snuba_column, "p100_{}".format(column_alias).strip("_")],
+                ["quantile(0.5)", snuba_column, f"p50_{column_alias}".strip("_")],
+                ["quantile(0.75)", snuba_column, f"p75_{column_alias}".strip("_")],
+                ["quantile(0.95)", snuba_column, f"p95_{column_alias}".strip("_")],
+                ["quantile(0.99)", snuba_column, f"p99_{column_alias}".strip("_")],
+                ["max", snuba_column, f"p100_{column_alias}".strip("_")],
             ]
 
     def test_compare_numeric_aggregate(self):
@@ -3081,13 +3081,13 @@ class FunctionTest(unittest.TestCase):
 
     def test_no_optional_not_enough_arguments(self):
         with self.assertRaisesRegexp(
-            InvalidSearchQuery, "fn_wo_optionals\(\): expected 2 argument\(s\)"
+            InvalidSearchQuery, r"fn_wo_optionals\(\): expected 2 argument\(s\)"
         ):
             self.fn_wo_optionals.validate_argument_count("fn_wo_optionals()", ["arg1"])
 
     def test_no_optional_too_may_arguments(self):
         with self.assertRaisesRegexp(
-            InvalidSearchQuery, "fn_wo_optionals\(\): expected 2 argument\(s\)"
+            InvalidSearchQuery, r"fn_wo_optionals\(\): expected 2 argument\(s\)"
         ):
             self.fn_wo_optionals.validate_argument_count(
                 "fn_wo_optionals()", ["arg1", "arg2", "arg3"]
@@ -3100,13 +3100,13 @@ class FunctionTest(unittest.TestCase):
 
     def test_optional_not_enough_arguments(self):
         with self.assertRaisesRegexp(
-            InvalidSearchQuery, "fn_w_optionals\(\): expected at least 1 argument\(s\)"
+            InvalidSearchQuery, r"fn_w_optionals\(\): expected at least 1 argument\(s\)"
         ):
             self.fn_w_optionals.validate_argument_count("fn_w_optionals()", [])
 
     def test_optional_too_many_arguments(self):
         with self.assertRaisesRegexp(
-            InvalidSearchQuery, "fn_w_optionals\(\): expected at most 2 argument\(s\)"
+            InvalidSearchQuery, r"fn_w_optionals\(\): expected at most 2 argument\(s\)"
         ):
             self.fn_w_optionals.validate_argument_count(
                 "fn_w_optionals()", ["arg1", "arg2", "arg3"]

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.utils.compat import mock
 import zlib
 import pytest

--- a/tests/sentry/auth/providers/github/test_client.py
+++ b/tests/sentry/auth/providers/github/test_client.py
@@ -13,9 +13,7 @@ def client():
 
 @responses.activate
 def test_request_sends_access_token(client):
-    responses.add(
-        responses.GET, "https://{0}/".format(API_DOMAIN), json={"status": "SUCCESS"}, status=200
-    )
+    responses.add(responses.GET, f"https://{API_DOMAIN}/", json={"status": "SUCCESS"}, status=200)
     client._request("/")
 
     assert len(responses.calls) == 1

--- a/tests/sentry/buffer/base/tests.py
+++ b/tests/sentry/buffer/base/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.utils.compat import mock
 
 from datetime import timedelta

--- a/tests/sentry/buffer/redis/tests.py
+++ b/tests/sentry/buffer/redis/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 from django.utils.encoding import force_text
 

--- a/tests/sentry/cache/test_redis.py
+++ b/tests/sentry/cache/test_redis.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.cache.redis import RedisCache, ValueTooLarge
 from sentry.testutils import TestCase
 

--- a/tests/sentry/celery/test_app.py
+++ b/tests/sentry/celery/test_app.py
@@ -13,4 +13,4 @@ def test_validate_celerybeat_schedule(name, entry):
     entry = ScheduleEntry(name=name, app=app, **entry)
     assert entry.task in app.tasks
     mod_name = app.tasks[entry.task].__module__
-    assert mod_name in settings.CELERY_IMPORTS, "{} is missing from CELERY_IMPORTS".format(mod_name)
+    assert mod_name in settings.CELERY_IMPORTS, f"{mod_name} is missing from CELERY_IMPORTS"

--- a/tests/sentry/coreapi/test_coreapi.py
+++ b/tests/sentry/coreapi/test_coreapi.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry.interfaces.base import get_interface

--- a/tests/sentry/data/tests.py
+++ b/tests/sentry/data/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import os
 import six
 

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -557,7 +557,7 @@ class AssembleDownloadLargeTest(TestCase, SnubaTestCase):
             event = data.copy()
             event.update(
                 {
-                    "transaction": "/event/{0:03d}/".format(i),
+                    "transaction": f"/event/{i:03d}/",
                     "timestamp": iso_format(before_now(minutes=1, seconds=i)),
                     "start_timestamp": iso_format(before_now(minutes=1, seconds=i + 1)),
                 }

--- a/tests/sentry/db/models/fields/bitfield/test_bitfield.py
+++ b/tests/sentry/db/models/fields/bitfield/test_bitfield.py
@@ -174,7 +174,7 @@ class BitFieldTest(TestCase):
         flags_field = BitFieldTestModel._meta.get_field("flags")
         flags_db_column = flags_field.db_column or flags_field.name
         cursor.execute(
-            "INSERT INTO %s (%s) VALUES (-1)" % (BitFieldTestModel._meta.db_table, flags_db_column)
+            f"INSERT INTO {BitFieldTestModel._meta.db_table} ({flags_db_column}) VALUES (-1)"
         )
         # There should only be the one row we inserted through the cursor.
         instance = BitFieldTestModel.objects.get(flags=-1)

--- a/tests/sentry/db/models/fields/bitfield/test_bitfield.py
+++ b/tests/sentry/db/models/fields/bitfield/test_bitfield.py
@@ -225,7 +225,7 @@ class BitFieldTest(TestCase):
 
         BitFieldTestModel.objects.filter(pk=instance.pk).update(
             flags=bitor(
-                F("flags"), ((~BitFieldTestModel.flags.FLAG_0 | BitFieldTestModel.flags.FLAG_3))
+                F("flags"), (~BitFieldTestModel.flags.FLAG_0 | BitFieldTestModel.flags.FLAG_3)
             )
         )
         instance = BitFieldTestModel.objects.get(pk=instance.pk)

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import pytest
 from sentry.testutils import TestCase
 from sentry.constants import MAX_CULPRIT_LENGTH

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -43,7 +43,7 @@ class RedisBackendTestCase(TestCase):
     def test_truncation(self):
         backend = RedisBackend(capacity=2, truncation_chance=1.0)
 
-        records = [Record("record:{}".format(i), "value", time.time()) for i in xrange(4)]
+        records = [Record(f"record:{i}", "value", time.time()) for i in xrange(4)]
         for record in records:
             backend.add("timeline", record)
 
@@ -88,7 +88,7 @@ class RedisBackendTestCase(TestCase):
 
         # Add 10 items to the timeline.
         for i in xrange(10):
-            backend.add("timeline", Record("record:{}".format(i), "{}".format(i), t + i))
+            backend.add("timeline", Record(f"record:{i}", f"{i}", t + i))
 
         try:
             with backend.digest("timeline", 0) as records:
@@ -101,7 +101,7 @@ class RedisBackendTestCase(TestCase):
         # deleted from Redis or removed from the digest set.) If we add 10 more
         # items, they should be added to the timeline set (not the digest set.)
         for i in xrange(10, 20):
-            backend.add("timeline", Record("record:{}".format(i), "{}".format(i), t + i))
+            backend.add("timeline", Record(f"record:{i}", f"{i}", t + i))
 
         # Maintenance should move the timeline back to the waiting state, ...
         backend.maintenance(time.time())
@@ -112,7 +112,7 @@ class RedisBackendTestCase(TestCase):
         # Only the new records should exist -- the older one should have been
         # trimmed to avoid the digest growing beyond the timeline capacity.
         with backend.digest("timeline", 0) as records:
-            expected_keys = set("record:{}".format(i) for i in xrange(10, 20))
+            expected_keys = set(f"record:{i}" for i in xrange(10, 20))
             assert set(record.key for record in records) == expected_keys
 
     def test_delete(self):
@@ -148,7 +148,7 @@ class RedisBackendTestCase(TestCase):
         n = 8192
         t = time.time()
         for i in xrange(n):
-            backend.add("timeline", Record("record:{}".format(i), "{}".format(i), t))
+            backend.add("timeline", Record(f"record:{i}", f"{i}", t))
 
         with backend.digest("timeline", 0) as records:
             assert len(set(records)) == n

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -117,16 +117,18 @@ class SortRecordsTestCase(TestCase):
 
 class SplitKeyTestCase(TestCase):
     def test_old_style_key(self):
-        assert split_key("mail:p:{}".format(self.project.id)) == (
+        assert split_key(f"mail:p:{self.project.id}") == (
             self.project,
             ActionTargetType.ISSUE_OWNERS,
             None,
         )
 
     def test_new_style_key_no_identifier(self):
-        assert split_key(
-            "mail:p:{}:{}:".format(self.project.id, ActionTargetType.ISSUE_OWNERS.value)
-        ) == (self.project, ActionTargetType.ISSUE_OWNERS, None)
+        assert split_key(f"mail:p:{self.project.id}:{ActionTargetType.ISSUE_OWNERS.value}:") == (
+            self.project,
+            ActionTargetType.ISSUE_OWNERS,
+            None,
+        )
 
     def test_new_style_key_identifier(self):
         identifier = "123"
@@ -139,9 +141,10 @@ class SplitKeyTestCase(TestCase):
 
 class UnsplitKeyTestCase(TestCase):
     def test_no_identifier(self):
-        assert unsplit_key(
-            self.project, ActionTargetType.ISSUE_OWNERS, None
-        ) == "mail:p:{}:{}:".format(self.project.id, ActionTargetType.ISSUE_OWNERS.value)
+        assert (
+            unsplit_key(self.project, ActionTargetType.ISSUE_OWNERS, None)
+            == f"mail:p:{self.project.id}:{ActionTargetType.ISSUE_OWNERS.value}:"
+        )
 
     def test_identifier(self):
         identifier = "123"

--- a/tests/sentry/digests/test_notifications.py
+++ b/tests/sentry/digests/test_notifications.py
@@ -133,9 +133,7 @@ class SplitKeyTestCase(TestCase):
     def test_new_style_key_identifier(self):
         identifier = "123"
         assert split_key(
-            "mail:p:{}:{}:{}".format(
-                self.project.id, ActionTargetType.ISSUE_OWNERS.value, identifier
-            )
+            f"mail:p:{self.project.id}:{ActionTargetType.ISSUE_OWNERS.value}:{identifier}"
         ) == (self.project, ActionTargetType.ISSUE_OWNERS, identifier)
 
 
@@ -148,8 +146,7 @@ class UnsplitKeyTestCase(TestCase):
 
     def test_identifier(self):
         identifier = "123"
-        assert unsplit_key(
-            self.project, ActionTargetType.ISSUE_OWNERS, identifier
-        ) == "mail:p:{}:{}:{}".format(
-            self.project.id, ActionTargetType.ISSUE_OWNERS.value, identifier
+        assert (
+            unsplit_key(self.project, ActionTargetType.ISSUE_OWNERS, identifier)
+            == f"mail:p:{self.project.id}:{ActionTargetType.ISSUE_OWNERS.value}:{identifier}"
         )

--- a/tests/sentry/event_manager/interfaces/test_contexts.py
+++ b/tests/sentry/event_manager/interfaces/test_contexts.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_csp.py
+++ b/tests/sentry/event_manager/interfaces/test_csp.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_debug_meta.py
+++ b/tests/sentry/event_manager/interfaces/test_debug_meta.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_exception.py
+++ b/tests/sentry/event_manager/interfaces/test_exception.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_expectct.py
+++ b/tests/sentry/event_manager/interfaces/test_expectct.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_expectstaple.py
+++ b/tests/sentry/event_manager/interfaces/test_expectstaple.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_frame.py
+++ b/tests/sentry/event_manager/interfaces/test_frame.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_sdk.py
+++ b/tests/sentry/event_manager/interfaces/test_sdk.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_single_exception.py
+++ b/tests/sentry/event_manager/interfaces/test_single_exception.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_spans.py
+++ b/tests/sentry/event_manager/interfaces/test_spans.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_stacktrace.py
+++ b/tests/sentry/event_manager/interfaces/test_stacktrace.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 from sentry.utils.compat import mock
 

--- a/tests/sentry/event_manager/interfaces/test_template.py
+++ b/tests/sentry/event_manager/interfaces/test_template.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_threads.py
+++ b/tests/sentry/event_manager/interfaces/test_threads.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/interfaces/test_user.py
+++ b/tests/sentry/event_manager/interfaces/test_user.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry import eventstore

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -631,16 +631,16 @@ class EventManagerTest(TestCase):
         project = self.create_project(name="foo")
         partial_version_len = MAX_VERSION_LENGTH - 4
         release = Release.objects.create(
-            version="foo-%s" % ("a" * partial_version_len,), organization=project.organization
+            version="foo-{}".format("a" * partial_version_len), organization=project.organization
         )
         release.add_project(project)
 
         event = self.make_release_event("a" * partial_version_len, project.id)
 
         group = event.group
-        assert group.first_release.version == "foo-%s" % ("a" * partial_version_len,)
+        assert group.first_release.version == "foo-{}".format("a" * partial_version_len)
         release_tag = [v for k, v in event.tags if k == "sentry:release"][0]
-        assert release_tag == "foo-%s" % ("a" * partial_version_len,)
+        assert release_tag == "foo-{}".format("a" * partial_version_len)
 
     def test_group_release_no_env(self):
         project_id = 1

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import logging
 from sentry.utils.compat import mock
 import pytest

--- a/tests/sentry/event_manager/test_generate_culprit.py
+++ b/tests/sentry/event_manager/test_generate_culprit.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.constants import MAX_CULPRIT_LENGTH
 from sentry.event_manager import generate_culprit
 from sentry.grouping.utils import hash_from_values

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -27,7 +27,7 @@ def create_topic(partitions=1, replication_factor=1):
         "--zookeeper",
         os.environ["SENTRY_ZOOKEEPER_HOSTS"],
     ]
-    topic = "test-{}".format(uuid.uuid1().hex)
+    topic = f"test-{uuid.uuid1().hex}"
     subprocess.check_call(
         command
         + [
@@ -35,9 +35,9 @@ def create_topic(partitions=1, replication_factor=1):
             "--topic",
             topic,
             "--partitions",
-            "{}".format(partitions),
+            f"{partitions}",
             "--replication-factor",
-            "{}".format(replication_factor),
+            f"{replication_factor}",
         ]
     )
     try:
@@ -47,7 +47,7 @@ def create_topic(partitions=1, replication_factor=1):
 
 
 def test_consumer_start_from_partition_start(requires_kafka):
-    synchronize_commit_group = "consumer-{}".format(uuid.uuid1().hex)
+    synchronize_commit_group = f"consumer-{uuid.uuid1().hex}"
 
     messages_delivered = defaultdict(list)
 
@@ -66,14 +66,14 @@ def test_consumer_start_from_partition_start(requires_kafka):
 
         # Produce some messages into the topic.
         for i in range(3):
-            producer.produce(topic, "{}".format(i).encode("utf8"))
+            producer.produce(topic, f"{i}".encode("utf8"))
 
         assert producer.flush(5) == 0, "producer did not successfully flush queue"
 
         # Create the synchronized consumer.
         consumer = SynchronizedConsumer(
             cluster_name="default",
-            consumer_group="consumer-{}".format(uuid.uuid1().hex),
+            consumer_group=f"consumer-{uuid.uuid1().hex}",
             commit_log_topic=commit_log_topic,
             synchronize_commit_group=synchronize_commit_group,
             initial_offset_reset="earliest",
@@ -133,8 +133,8 @@ def test_consumer_start_from_partition_start(requires_kafka):
 
 
 def test_consumer_start_from_committed_offset(requires_kafka):
-    consumer_group = "consumer-{}".format(uuid.uuid1().hex)
-    synchronize_commit_group = "consumer-{}".format(uuid.uuid1().hex)
+    consumer_group = f"consumer-{uuid.uuid1().hex}"
+    synchronize_commit_group = f"consumer-{uuid.uuid1().hex}"
 
     messages_delivered = defaultdict(list)
 
@@ -153,7 +153,7 @@ def test_consumer_start_from_committed_offset(requires_kafka):
 
         # Produce some messages into the topic.
         for i in range(3):
-            producer.produce(topic, "{}".format(i).encode("utf8"))
+            producer.produce(topic, f"{i}".encode("utf8"))
 
         assert producer.flush(5) == 0, "producer did not successfully flush queue"
 
@@ -234,8 +234,8 @@ def test_consumer_start_from_committed_offset(requires_kafka):
 
 
 def test_consumer_rebalance_from_partition_start(requires_kafka):
-    consumer_group = "consumer-{}".format(uuid.uuid1().hex)
-    synchronize_commit_group = "consumer-{}".format(uuid.uuid1().hex)
+    consumer_group = f"consumer-{uuid.uuid1().hex}"
+    synchronize_commit_group = f"consumer-{uuid.uuid1().hex}"
 
     messages_delivered = defaultdict(list)
 
@@ -254,7 +254,7 @@ def test_consumer_rebalance_from_partition_start(requires_kafka):
 
         # Produce some messages into the topic.
         for i in range(4):
-            producer.produce(topic, "{}".format(i).encode("utf8"), partition=i % 2)
+            producer.produce(topic, f"{i}".encode("utf8"), partition=i % 2)
 
         assert producer.flush(5) == 0, "producer did not successfully flush queue"
 
@@ -354,8 +354,8 @@ def test_consumer_rebalance_from_partition_start(requires_kafka):
 
 
 def test_consumer_rebalance_from_committed_offset(requires_kafka):
-    consumer_group = "consumer-{}".format(uuid.uuid1().hex)
-    synchronize_commit_group = "consumer-{}".format(uuid.uuid1().hex)
+    consumer_group = f"consumer-{uuid.uuid1().hex}"
+    synchronize_commit_group = f"consumer-{uuid.uuid1().hex}"
 
     messages_delivered = defaultdict(list)
 
@@ -374,7 +374,7 @@ def test_consumer_rebalance_from_committed_offset(requires_kafka):
 
         # Produce some messages into the topic.
         for i in range(4):
-            producer.produce(topic, "{}".format(i).encode("utf8"), partition=i % 2)
+            producer.produce(topic, f"{i}".encode("utf8"), partition=i % 2)
 
         assert producer.flush(5) == 0, "producer did not successfully flush queue"
 
@@ -521,8 +521,8 @@ def collect_messages_received(count):
     run=False,
 )
 def test_consumer_rebalance_from_uncommitted_offset(requires_kafka):
-    consumer_group = "consumer-{}".format(uuid.uuid1().hex)
-    synchronize_commit_group = "consumer-{}".format(uuid.uuid1().hex)
+    consumer_group = f"consumer-{uuid.uuid1().hex}"
+    synchronize_commit_group = f"consumer-{uuid.uuid1().hex}"
 
     messages_delivered = defaultdict(list)
 
@@ -541,7 +541,7 @@ def test_consumer_rebalance_from_uncommitted_offset(requires_kafka):
 
         # Produce some messages into the topic.
         for i in range(4):
-            producer.produce(topic, "{}".format(i).encode("utf8"), partition=i % 2)
+            producer.produce(topic, f"{i}".encode("utf8"), partition=i % 2)
 
         assert producer.flush(5) == 0, "producer did not successfully flush queue"
 
@@ -551,7 +551,7 @@ def test_consumer_rebalance_from_uncommitted_offset(requires_kafka):
         }.items():
             producer.produce(
                 commit_log_topic,
-                key="{}:{}:{}".format(topic, partition, synchronize_commit_group).encode("utf8"),
+                key=f"{topic}:{partition}:{synchronize_commit_group}".encode("utf8"),
                 value="{}".format(offset + 1).encode("utf8"),
             )
 

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -105,9 +105,9 @@ def test_consumer_start_from_partition_start(requires_kafka):
         message = messages_delivered[topic][0]
         producer.produce(
             commit_log_topic,
-            key="{}:{}:{}".format(
-                message.topic(), message.partition(), synchronize_commit_group
-            ).encode("utf8"),
+            key=f"{message.topic()}:{message.partition()}:{synchronize_commit_group}".encode(
+                "utf8"
+            ),
             value="{}".format(message.offset() + 1).encode("utf8"),
         )
 
@@ -193,9 +193,9 @@ def test_consumer_start_from_committed_offset(requires_kafka):
         message = messages_delivered[topic][0]
         producer.produce(
             commit_log_topic,
-            key="{}:{}:{}".format(
-                message.topic(), message.partition(), synchronize_commit_group
-            ).encode("utf8"),
+            key=f"{message.topic()}:{message.partition()}:{synchronize_commit_group}".encode(
+                "utf8"
+            ),
             value="{}".format(message.offset() + 1).encode("utf8"),
         )
 
@@ -206,9 +206,9 @@ def test_consumer_start_from_committed_offset(requires_kafka):
         message = messages_delivered[topic][0 + 1]  # second message
         producer.produce(
             commit_log_topic,
-            key="{}:{}:{}".format(
-                message.topic(), message.partition(), synchronize_commit_group
-            ).encode("utf8"),
+            key=f"{message.topic()}:{message.partition()}:{synchronize_commit_group}".encode(
+                "utf8"
+            ),
             value="{}".format(message.offset() + 1).encode("utf8"),
         )
 
@@ -327,9 +327,9 @@ def test_consumer_rebalance_from_partition_start(requires_kafka):
             # Move the committed offset forward for our synchronizing group.
             producer.produce(
                 commit_log_topic,
-                key="{}:{}:{}".format(
-                    expected_message.topic(), expected_message.partition(), synchronize_commit_group
-                ).encode("utf8"),
+                key=f"{expected_message.topic()}:{expected_message.partition()}:{synchronize_commit_group}".encode(
+                    "utf8"
+                ),
                 value="{}".format(expected_message.offset() + 1).encode("utf8"),
             )
 
@@ -458,9 +458,9 @@ def test_consumer_rebalance_from_committed_offset(requires_kafka):
             # Move the committed offset forward for our synchronizing group.
             producer.produce(
                 commit_log_topic,
-                key="{}:{}:{}".format(
-                    expected_message.topic(), expected_message.partition(), synchronize_commit_group
-                ).encode("utf8"),
+                key=f"{expected_message.topic()}:{expected_message.partition()}:{synchronize_commit_group}".encode(
+                    "utf8"
+                ),
                 value="{}".format(expected_message.offset() + 1).encode("utf8"),
             )
 

--- a/tests/sentry/eventstream/kafka/test_protocol.py
+++ b/tests/sentry/eventstream/kafka/test_protocol.py
@@ -55,7 +55,7 @@ def test_get_task_kwargs_for_message_version_1():
     assert kwargs.pop("is_regression") is False
     assert kwargs.pop("is_new_group_environment") is True
 
-    assert not kwargs, "unexpected values remaining: {!r}".format(kwargs)
+    assert not kwargs, f"unexpected values remaining: {kwargs!r}"
 
 
 def test_get_task_kwargs_for_message_version_1_skip_consume():

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.utils.functional import cached_property
 
 import os

--- a/tests/sentry/grouping/test_enhancer.py
+++ b/tests/sentry/grouping/test_enhancer.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 import pytest
 

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from sentry.grouping.fingerprinting import FingerprintingRules, InvalidFingerprintingConfig

--- a/tests/sentry/grouping/test_variants.py
+++ b/tests/sentry/grouping/test_variants.py
@@ -28,18 +28,18 @@ def dump_variant(variant, lines=None, indent=0):
             if isinstance(value, GroupingComponent):
                 _dump_component(value, indent + 1)
             else:
-                lines.append("%s%s" % ("  " * (indent + 1), json.dumps(value)))
+                lines.append("{}{}".format("  " * (indent + 1), json.dumps(value)))
 
-    lines.append("%shash: %s" % ("  " * indent, json.dumps(variant.get_hash())))
+    lines.append("{}hash: {}".format("  " * indent, json.dumps(variant.get_hash())))
     for (key, value) in sorted(variant.__dict__.items()):
         if isinstance(value, GroupingComponent):
-            lines.append("%s%s:" % ("  " * indent, key))
+            lines.append("{}{}:".format("  " * indent, key))
             _dump_component(value, indent + 1)
         elif key == "config":
             # We do not want to dump the config
             continue
         else:
-            lines.append("%s%s: %s" % ("  " * indent, key, json.dumps(value)))
+            lines.append("{}{}: {}".format("  " * indent, key, json.dumps(value)))
 
     return lines
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -370,7 +370,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
             projects=[self.project],
             date_added=before_now(minutes=3).replace(tzinfo=pytz.UTC),
         )
-        self.combined_rules_url = "/api/0/organizations/{0}/combined-rules/".format(self.org.slug)
+        self.combined_rules_url = f"/api/0/organizations/{self.org.slug}/combined-rules/"
 
     def test_invalid_limit(self):
         self.setup_project_and_rules()

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -239,7 +239,7 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
         self.yet_another_alert_rule = self.create_alert_rule(
             projects=self.projects, date_added=before_now(minutes=3).replace(tzinfo=pytz.UTC)
         )
-        self.combined_rules_url = "/api/0/projects/{0}/{1}/combined-rules/".format(
+        self.combined_rules_url = "/api/0/projects/{}/{}/combined-rules/".format(
             self.org.slug, self.project.slug
         )
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -239,8 +239,8 @@ class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestC
         self.yet_another_alert_rule = self.create_alert_rule(
             projects=self.projects, date_added=before_now(minutes=3).replace(tzinfo=pytz.UTC)
         )
-        self.combined_rules_url = "/api/0/projects/{}/{}/combined-rules/".format(
-            self.org.slug, self.project.slug
+        self.combined_rules_url = (
+            f"/api/0/projects/{self.org.slug}/{self.project.slug}/combined-rules/"
         )
 
     def test_invalid_limit(self):

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -419,9 +419,7 @@ class PagerDutyActionHandlerTest(FireTest, TestCase):
 
         assert data["routing_key"] == "pfc73e8cb4s44d519f3d63d45b5q77g9"
         assert data["event_action"] == "trigger"
-        assert data["dedup_key"] == "incident_{}_{}".format(
-            incident.organization_id, incident.identifier
-        )
+        assert data["dedup_key"] == f"incident_{incident.organization_id}_{incident.identifier}"
         assert data["payload"]["summary"] == alert_rule.name
         assert data["payload"]["severity"] == "critical"
         assert data["payload"]["source"] == six.text_type(incident.identifier)

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -428,7 +428,7 @@ class PagerDutyActionHandlerTest(FireTest, TestCase):
         assert data["payload"]["custom_details"] == {
             "details": "1000 events in the last 10 minutes\nFilter: level:error"
         }
-        assert data["links"][0]["text"] == "Critical: {}".format(alert_rule.name)
+        assert data["links"][0]["text"] == f"Critical: {alert_rule.name}"
         assert data["links"][0]["href"] == "http://testserver/organizations/baz/alerts/1/"
 
     @responses.activate

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -465,10 +465,7 @@ class CreateIncidentActivityTest(TestCase, BaseIncidentsTest):
         mentioned_member = self.create_user()
         subscribed_mentioned_member = self.create_user()
         IncidentSubscription.objects.create(incident=incident, user=subscribed_mentioned_member)
-        comment = "hello **@{}** and **@{}**".format(
-            mentioned_member.username,
-            subscribed_mentioned_member.username,
-        )
+        comment = f"hello **@{mentioned_member.username}** and **@{subscribed_mentioned_member.username}**"
         with self.assertChanges(
             lambda: IncidentSubscription.objects.filter(
                 incident=incident, user=mentioned_member

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1819,7 +1819,7 @@ class TriggerActionTest(TestCase):
 
         out = mail.outbox[0]
         assert out.to == [self.user.email]
-        assert out.subject == "[Resolved] {} - {}".format(incident.title, self.project.slug)
+        assert out.subject == f"[Resolved] {incident.title} - {self.project.slug}"
 
     def test_manual_resolve(self):
         incident = self.create_incident(alert_rule=self.rule)
@@ -1839,7 +1839,7 @@ class TriggerActionTest(TestCase):
         assert len(mail.outbox) == 1
         out = mail.outbox[0]
         assert out.to == [self.user.email]
-        assert out.subject == "[Resolved] {} - {}".format(incident.title, self.project.slug)
+        assert out.subject == f"[Resolved] {incident.title} - {self.project.slug}"
 
 
 class TestDeduplicateTriggerActions(unittest.TestCase):

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -465,7 +465,7 @@ class CreateIncidentActivityTest(TestCase, BaseIncidentsTest):
         mentioned_member = self.create_user()
         subscribed_mentioned_member = self.create_user()
         IncidentSubscription.objects.create(incident=incident, user=subscribed_mentioned_member)
-        comment = "hello **@%s** and **@%s**" % (
+        comment = "hello **@{}** and **@{}**".format(
             mentioned_member.username,
             subscribed_mentioned_member.username,
         )

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -84,9 +84,7 @@ class TestGenerateIncidentActivityEmail(BaseIncidentActivityTest, TestCase):
         incident = activity.incident
         recipient = self.create_user()
         message = generate_incident_activity_email(activity, recipient)
-        assert message.subject == "Activity on Alert {} (#{})".format(
-            incident.title, incident.identifier
-        )
+        assert message.subject == f"Activity on Alert {incident.title} (#{incident.identifier})"
         assert message.type == "incident.activity"
         assert message.context == build_activity_context(activity, recipient)
 

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -96,10 +96,9 @@ class TestBuildActivityContext(BaseIncidentActivityTest, TestCase):
         incident = activity.incident
         context = build_activity_context(activity, expected_recipient)
         assert context["user_name"] == expected_username
-        assert context["action"] == "{} on alert {} (#{})".format(
-            expected_action,
-            activity.incident.title,
-            activity.incident.identifier,
+        assert (
+            context["action"]
+            == f"{expected_action} on alert {activity.incident.title} (#{activity.incident.identifier})"
         )
         assert (
             context["link"]

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -96,7 +96,7 @@ class TestBuildActivityContext(BaseIncidentActivityTest, TestCase):
         incident = activity.incident
         context = build_activity_context(activity, expected_recipient)
         assert context["user_name"] == expected_username
-        assert context["action"] == "%s on alert %s (#%s)" % (
+        assert context["action"] == "{} on alert {} (#{})".format(
             expected_action,
             activity.incident.title,
             activity.incident.identifier,

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -30,7 +30,7 @@ def get_test_message(default_project):
         now = datetime.datetime.now()
         # the event id should be 32 digits
         event_id = "{}".format(now.strftime("000000000000%Y%m%d%H%M%S%f"))
-        message_text = "some message {}".format(event_id)
+        message_text = f"some message {event_id}"
         project_id = project.id  # must match the project id set up by the test fixtures
         if type == "transaction":
             event = {

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -51,7 +51,7 @@ def test_deduplication_works(default_project, task_runner, preprocess_event):
 
     (kwargs,) = preprocess_event
     assert kwargs == {
-        "cache_key": "e:{event_id}:{project_id}".format(event_id=event_id, project_id=project_id),
+        "cache_key": f"e:{event_id}:{project_id}",
         "data": payload,
         "event_id": event_id,
         "project": default_project,

--- a/tests/sentry/integrations/bitbucket/test_installed.py
+++ b/tests/sentry/integrations/bitbucket/test_installed.py
@@ -115,7 +115,7 @@ class BitbucketInstalledEndpointTest(APITestCase):
 
         responses.add(
             responses.GET,
-            "https://api.bitbucket.org/2.0/repositories/{}/hooks".format(accessible_repo.name),
+            f"https://api.bitbucket.org/2.0/repositories/{accessible_repo.name}/hooks",
             json={"values": [{"description": "sentry-bitbucket-repo-hook"}]},
         )
 

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -51,9 +51,7 @@ class BitbucketIssueTest(APITestCase):
         repo = "myaccount/myrepo"
         responses.add(
             responses.GET,
-            "https://api.bitbucket.org/2.0/repositories/{repo}/issues/{issue_id}".format(
-                repo=repo, issue_id=issue_id
-            ),
+            f"https://api.bitbucket.org/2.0/repositories/{repo}/issues/{issue_id}",
             json={"id": issue_id, "title": "hello", "content": {"html": "This is the description"}},
         )
 
@@ -73,9 +71,7 @@ class BitbucketIssueTest(APITestCase):
         comment = {"comment": "hello I'm a comment"}
         responses.add(
             responses.POST,
-            "https://api.bitbucket.org/2.0/repositories/{repo}/issues/{issue_id}/comments".format(
-                repo=repo, issue_id=issue_id
-            ),
+            f"https://api.bitbucket.org/2.0/repositories/{repo}/issues/{issue_id}/comments",
             status=201,
             json={"content": {"raw": comment}},
         )

--- a/tests/sentry/integrations/bitbucket/test_issues.py
+++ b/tests/sentry/integrations/bitbucket/test_issues.py
@@ -280,7 +280,7 @@ class BitbucketIssueTest(APITestCase):
 
         responses.add(
             responses.POST,
-            "https://api.bitbucket.org/2.0/repositories/{repo}/issues".format(repo=repo),
+            f"https://api.bitbucket.org/2.0/repositories/{repo}/issues",
             json={"id": id, "title": title, "content": {"html": content}},
         )
         installation = self.integration.get_installation(self.organization.id)

--- a/tests/sentry/integrations/bitbucket/test_repository.py
+++ b/tests/sentry/integrations/bitbucket/test_repository.py
@@ -166,12 +166,12 @@ class BitbucketCreateRepositoryTestCase(IntegrationRepositoryTestCase):
     def add_create_repository_responses(self, repository_config):
         responses.add(
             responses.GET,
-            "%s/2.0/repositories/%s" % (self.base_url, self.repo.name),
+            f"{self.base_url}/2.0/repositories/{self.repo.name}",
             json=repository_config,
         )
         responses.add(
             responses.POST,
-            "%s/2.0/repositories/%s/hooks" % (self.base_url, self.repo.name),
+            f"{self.base_url}/2.0/repositories/{self.repo.name}/hooks",
             json={"uuid": "99"},
         )
 

--- a/tests/sentry/integrations/bitbucket/testutils.py
+++ b/tests/sentry/integrations/bitbucket/testutils.py
@@ -23,7 +23,7 @@ GET_LAST_COMMITS_EXAMPLE = b"""{
 }
 """
 
-COMMIT_DIFF_PATCH = b"""diff --git a/README.md b/README.md
+COMMIT_DIFF_PATCH = br"""diff --git a/README.md b/README.md
 index 89821ce..9e09a8a 100644
 --- a/README.md
 +++ b/README.md

--- a/tests/sentry/integrations/bitbucket_server/test_repository.py
+++ b/tests/sentry/integrations/bitbucket_server/test_repository.py
@@ -175,12 +175,12 @@ class BitbucketServerRepositoryProviderTest(APITestCase):
     def test_build_repository_config(self):
         project = "laurynsentry"
         repo = "helloworld"
-        full_repo_name = "%s/%s" % (project, repo)
+        full_repo_name = f"{project}/{repo}"
 
         webhook_id = 79
         responses.add(
             responses.GET,
-            "https://bitbucket.example.com/rest/api/1.0/projects/%s/repos/%s" % (project, repo),
+            f"https://bitbucket.example.com/rest/api/1.0/projects/{project}/repos/{repo}",
             json=REPO,
         )
         responses.add(

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -61,9 +61,7 @@ class GitHubAppsClientTest(TestCase):
 
         path = "src/sentry/integrations/github/client.py"
         version = "master"
-        url = "https://api.github.com/repos/{}/contents/{}?ref={}".format(
-            self.repo.name, path, version
-        )
+        url = f"https://api.github.com/repos/{self.repo.name}/contents/{path}?ref={version}"
 
         responses.add(
             method=responses.HEAD,
@@ -86,9 +84,7 @@ class GitHubAppsClientTest(TestCase):
 
         path = "src/santry/integrations/github/client.py"
         version = "master"
-        url = "https://api.github.com/repos/{}/contents/{}?ref={}".format(
-            self.repo.name, path, version
-        )
+        url = f"https://api.github.com/repos/{self.repo.name}/contents/{path}?ref={version}"
 
         responses.add(method=responses.HEAD, url=url, status=404)
 

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -41,7 +41,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.POST,
-            self.base_url + "/app/installations/{}/access_tokens".format(self.installation_id),
+            self.base_url + f"/app/installations/{self.installation_id}/access_tokens",
             json={"token": self.access_token, "expires_at": self.expires_at},
         )
 
@@ -58,7 +58,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            self.base_url + "/app/installations/{}".format(self.installation_id),
+            self.base_url + f"/app/installations/{self.installation_id}",
             json={
                 "id": self.installation_id,
                 "app_id": self.app_id,
@@ -253,7 +253,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         default = "master"
         responses.add(
             responses.HEAD,
-            self.base_url + "/repos/{}/contents/{}?ref={}".format(repo.name, path, version),
+            self.base_url + f"/repos/{repo.name}/contents/{path}?ref={version}",
         )
         installation = integration.get_installation(self.organization)
         result = installation.get_stacktrace_link(repo, path, default, version)
@@ -279,7 +279,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
         default = "master"
         responses.add(
             responses.HEAD,
-            self.base_url + "/repos/{}/contents/{}?ref={}".format(repo.name, path, version),
+            self.base_url + f"/repos/{repo.name}/contents/{path}?ref={version}",
             status=404,
         )
         installation = integration.get_installation(self.organization)
@@ -306,12 +306,12 @@ class GitHubIntegrationTest(IntegrationTestCase):
         default = "master"
         responses.add(
             responses.HEAD,
-            self.base_url + "/repos/{}/contents/{}?ref={}".format(repo.name, path, version),
+            self.base_url + f"/repos/{repo.name}/contents/{path}?ref={version}",
             status=404,
         )
         responses.add(
             responses.HEAD,
-            self.base_url + "/repos/{}/contents/{}?ref={}".format(repo.name, path, default),
+            self.base_url + f"/repos/{repo.name}/contents/{path}?ref={default}",
         )
         installation = integration.get_installation(self.organization)
         result = installation.get_stacktrace_link(repo, path, default, version)

--- a/tests/sentry/integrations/github/test_webhooks.py
+++ b/tests/sentry/integrations/github/test_webhooks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import six
 
 from datetime import datetime, timedelta

--- a/tests/sentry/integrations/github/testutils.py
+++ b/tests/sentry/integrations/github/testutils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # we keep this as a raw string as order matters for hmac signing
 PUSH_EVENT_EXAMPLE_INSTALLATION = r"""{
   "ref": "refs/heads/changes",

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -73,7 +73,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.POST,
-            self.base_url + "/app/installations/{}/access_tokens".format(installation_id),
+            self.base_url + f"/app/installations/{installation_id}/access_tokens",
             json={"token": access_token, "expires_at": "3000-01-01T00:00:00Z"},
         )
 
@@ -81,7 +81,7 @@ class GitHubEnterpriseIntegrationTest(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            self.base_url + "/app/installations/{}".format(installation_id),
+            self.base_url + f"/app/installations/{installation_id}",
             json={
                 "id": installation_id,
                 "app_id": app_id,

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import six
 
 from datetime import datetime

--- a/tests/sentry/integrations/github_enterprise/testutils.py
+++ b/tests/sentry/integrations/github_enterprise/testutils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # we keep this as a raw string as order matters for hmac signing
 PUSH_EVENT_EXAMPLE = r"""{
   "ref": "refs/heads/changes",

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -131,9 +131,7 @@ class GitlabRefreshAuthTest(GitLabTestCase):
         ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
         responses.add(
             responses.HEAD,
-            "https://example.gitlab.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
-                self.gitlab_id, "src%2Ffile.py", ref
-            ),
+            f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/src%2Ffile.py?ref={ref}",
             json={"text": 200},
         )
 
@@ -147,9 +145,7 @@ class GitlabRefreshAuthTest(GitLabTestCase):
         ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
         responses.add(
             responses.HEAD,
-            "https://example.gitlab.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
-                self.gitlab_id, "src%2Ffile.py", ref
-            ),
+            f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/src%2Ffile.py?ref={ref}",
             status=404,
         )
         with self.assertRaises(ApiError):
@@ -162,9 +158,7 @@ class GitlabRefreshAuthTest(GitLabTestCase):
         ref = "537f2e94fbc489b2564ca3d6a5f0bd9afa38c3c3"
         responses.add(
             responses.HEAD,
-            "https://example.gitlab.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
-                self.gitlab_id, "src%2Ffile.py", ref
-            ),
+            f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/repository/files/src%2Ffile.py?ref={ref}",
             json={"text": 200},
         )
 

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -203,7 +203,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="Get Sentry / Example Repo",
-            external_id="{}:{}".format(instance, external_id),
+            external_id=f"{instance}:{external_id}",
             url="https://gitlab.example.com/getsentry/projects/example-repo",
             config={"project_id": external_id, "path": "getsentry/example-repo"},
             provider="integrations:gitlab",
@@ -235,7 +235,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="Get Sentry / Example Repo",
-            external_id="{}:{}".format(instance, external_id),
+            external_id=f"{instance}:{external_id}",
             url="https://gitlab.example.com/getsentry/projects/example-repo",
             config={"project_id": external_id, "path": "getsentry/example-repo"},
             provider="integrations:gitlab",
@@ -265,7 +265,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="Get Sentry / Example Repo",
-            external_id="{}:{}".format(instance, external_id),
+            external_id=f"{instance}:{external_id}",
             url="https://gitlab.example.com/getsentry/projects/example-repo",
             config={"project_id": external_id, "path": "getsentry/example-repo"},
             provider="integrations:gitlab",

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -34,7 +34,9 @@ class GitlabIntegrationTest(IntegrationTestCase):
 
     def setUp(self):
         super(GitlabIntegrationTest, self).setUp()
-        self.init_path_without_guide = "%s%s" % (self.init_path, "?completed_installation_guide")
+        self.init_path_without_guide = "{}{}".format(
+            self.init_path, "?completed_installation_guide"
+        )
 
     def assert_setup_flow(self, user_id="user_id_1"):
         resp = self.client.get(self.init_path)

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -34,9 +34,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
 
     def setUp(self):
         super(GitlabIntegrationTest, self).setUp()
-        self.init_path_without_guide = "{}{}".format(
-            self.init_path, "?completed_installation_guide"
-        )
+        self.init_path_without_guide = f"{self.init_path}?completed_installation_guide"
 
     def assert_setup_flow(self, user_id="user_id_1"):
         resp = self.client.get(self.init_path)

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -216,9 +216,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         version = "12345678"
         responses.add(
             responses.HEAD,
-            "https://gitlab.example.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
-                external_id, filepath, version
-            ),
+            f"https://gitlab.example.com/api/v4/projects/{external_id}/repository/files/{filepath}?ref={version}",
         )
         source_url = installation.get_stacktrace_link(repo, "README.md", ref, version)
         assert (
@@ -248,9 +246,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
         version = None
         responses.add(
             responses.HEAD,
-            "https://gitlab.example.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
-                external_id, filepath, ref
-            ),
+            f"https://gitlab.example.com/api/v4/projects/{external_id}/repository/files/{filepath}?ref={ref}",
             status=404,
         )
         source_url = installation.get_stacktrace_link(repo, "README.md", ref, version)
@@ -278,16 +274,12 @@ class GitlabIntegrationTest(IntegrationTestCase):
         version = "12345678"
         responses.add(
             responses.HEAD,
-            "https://gitlab.example.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
-                external_id, filepath, version
-            ),
+            f"https://gitlab.example.com/api/v4/projects/{external_id}/repository/files/{filepath}?ref={version}",
             status=404,
         )
         responses.add(
             responses.HEAD,
-            "https://gitlab.example.com/api/v4/projects/{}/repository/files/{}?ref={}".format(
-                external_id, filepath, ref
-            ),
+            f"https://gitlab.example.com/api/v4/projects/{external_id}/repository/files/{filepath}?ref={ref}",
         )
         source_url = installation.get_stacktrace_link(repo, "README.md", ref, version)
         assert (

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -28,10 +28,10 @@ class GitlabIssuesTest(GitLabTestCase):
     def test_make_external_key(self):
         project_name = "getsentry/sentry"
         issue_iid = "7"
-        external_key = "%s#%s" % (project_name, issue_iid)
+        external_key = f"{project_name}#{issue_iid}"
         domain_name = self.installation.model.metadata["domain_name"]
         data = {"key": external_key}
-        assert self.installation.make_external_key(data) == "%s:%s" % (domain_name, external_key)
+        assert self.installation.make_external_key(data) == f"{domain_name}:{external_key}"
 
     def test_get_issue_url(self):
         issue_id = "example.gitlab.com:project/project#7"
@@ -138,7 +138,7 @@ class GitlabIssuesTest(GitLabTestCase):
         issue_iid = "1"
         project_id = "10"
         project_name = "getsentry/sentry"
-        key = "%s#%s" % (project_name, issue_iid)
+        key = f"{project_name}#{issue_iid}"
         responses.add(
             responses.POST,
             "https://example.gitlab.com/api/v4/projects/%s/issues" % project_id,
@@ -147,7 +147,7 @@ class GitlabIssuesTest(GitLabTestCase):
                 "iid": issue_iid,
                 "title": "hello",
                 "description": "This is the description",
-                "web_url": "https://example.gitlab.com/%s/issues/%s" % (project_name, issue_iid),
+                "web_url": f"https://example.gitlab.com/{project_name}/issues/{issue_iid}",
             },
         )
         responses.add(
@@ -165,7 +165,7 @@ class GitlabIssuesTest(GitLabTestCase):
             "key": key,
             "description": "This is the description",
             "title": "hello",
-            "url": "https://example.gitlab.com/%s/issues/%s" % (project_name, issue_iid),
+            "url": f"https://example.gitlab.com/{project_name}/issues/{issue_iid}",
             "project": project_id,
             "metadata": {"display_name": key},
         }
@@ -175,16 +175,16 @@ class GitlabIssuesTest(GitLabTestCase):
         project_id = "12"
         project_name = "getsentry/sentry"
         issue_iid = "13"
-        key = "%s#%s" % (project_name, issue_iid)
+        key = f"{project_name}#{issue_iid}"
         responses.add(
             responses.GET,
-            "https://example.gitlab.com/api/v4/projects/%s/issues/%s" % (project_id, issue_iid),
+            f"https://example.gitlab.com/api/v4/projects/{project_id}/issues/{issue_iid}",
             json={
                 "id": 18,
                 "iid": issue_iid,
                 "title": "hello",
                 "description": "This is the description",
-                "web_url": "https://example.gitlab.com/%s/issues/%s" % (project_name, issue_iid),
+                "web_url": f"https://example.gitlab.com/{project_name}/issues/{issue_iid}",
             },
         )
         responses.add(
@@ -193,11 +193,11 @@ class GitlabIssuesTest(GitLabTestCase):
             json={"id": project_id, "path_with_namespace": project_name},
         )
 
-        assert self.installation.get_issue(issue_id="%s#%s" % (project_id, issue_iid), data={}) == {
+        assert self.installation.get_issue(issue_id=f"{project_id}#{issue_iid}", data={}) == {
             "key": key,
             "description": "This is the description",
             "title": "hello",
-            "url": "https://example.gitlab.com/%s/issues/%s" % (project_name, issue_iid),
+            "url": f"https://example.gitlab.com/{project_name}/issues/{issue_iid}",
             "project": project_id,
             "metadata": {"display_name": key},
         }

--- a/tests/sentry/integrations/gitlab/test_webhook.py
+++ b/tests/sentry/integrations/gitlab/test_webhook.py
@@ -63,7 +63,7 @@ class WebhookTest(GitLabTestCase):
             self.url,
             data=PUSH_EVENT,
             content_type="application/json",
-            HTTP_X_GITLAB_TOKEN="{}:{}".format(EXTERNAL_ID, "wrong"),
+            HTTP_X_GITLAB_TOKEN=f"{EXTERNAL_ID}:wrong",
             HTTP_X_GITLAB_EVENT="Push Hook",
         )
         assert response.status_code == 400

--- a/tests/sentry/integrations/gitlab/testutils.py
+++ b/tests/sentry/integrations/gitlab/testutils.py
@@ -5,7 +5,7 @@ from sentry.models import Identity, IdentityProvider, Integration, Repository
 
 EXTERNAL_ID = "example.gitlab.com:group-x"
 WEBHOOK_SECRET = "secret-token-value"
-WEBHOOK_TOKEN = "{}:{}".format(EXTERNAL_ID, WEBHOOK_SECRET)
+WEBHOOK_TOKEN = f"{EXTERNAL_ID}:{WEBHOOK_SECRET}"
 
 
 class GitLabTestCase(APITestCase):
@@ -41,7 +41,7 @@ class GitLabTestCase(APITestCase):
         return Repository.objects.create(
             organization_id=organization_id,
             name=name,
-            external_id="{}:{}".format(instance, external_id),
+            external_id=f"{instance}:{external_id}",
             url=url,
             config={"project_id": external_id, "path": "example-repo"},
             provider="integrations:gitlab",

--- a/tests/sentry/integrations/jira/test_issue_hook.py
+++ b/tests/sentry/integrations/jira/test_issue_hook.py
@@ -36,7 +36,7 @@ class JiraIssueHookTest(APITestCase):
             first_release=self.first_release,
         )
         group = self.group
-        self.path = absolute_uri("extensions/jira/issue/{}/".format("APP-123")) + "?xdm_e=base_url"
+        self.path = absolute_uri("extensions/jira/issue/APP-123/") + "?xdm_e=base_url"
 
         self.integration = Integration.objects.create(
             provider="jira",
@@ -94,7 +94,7 @@ class JiraIssueHookTest(APITestCase):
     @patch("sentry.integrations.jira.issue_hook.get_integration_from_request")
     def test_simple_not_linked(self, mock_get_integration_from_request):
         mock_get_integration_from_request.return_value = self.integration
-        path = absolute_uri("extensions/jira/issue/{}/".format("bad-key")) + "?xdm_e=base_url"
+        path = absolute_uri("extensions/jira/issue/bad-key/") + "?xdm_e=base_url"
         response = self.client.get(path)
         assert response.status_code == 200
         assert b"This Sentry issue is not linked to a Jira issue" in response.content

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -40,7 +40,7 @@ class JiraSearchEndpointTest(APITestCase):
 
         path = reverse("sentry-extensions-jira-search", args=[org.slug, self.integration.id])
 
-        resp = self.client.get("%s?field=externalIssue&query=test" % (path,))
+        resp = self.client.get(f"{path}?field=externalIssue&query=test")
         assert resp.status_code == 200
         assert resp.data == [{"label": "(HSP-1) this is a test issue summary", "value": "HSP-1"}]
 
@@ -65,7 +65,7 @@ class JiraSearchEndpointTest(APITestCase):
 
         # queries come through from the front end lowercased, so HSP-1 -> hsp-1
         for field in ("externalIssue", "parent"):
-            resp = self.client.get("%s?field=%s&query=hsp-1" % (path, field))
+            resp = self.client.get(f"{path}?field={field}&query=hsp-1")
             assert resp.status_code == 200
             assert resp.data == [
                 {"label": "(HSP-1) this is a test issue summary", "value": "HSP-1"}
@@ -86,7 +86,7 @@ class JiraSearchEndpointTest(APITestCase):
         path = reverse("sentry-extensions-jira-search", args=[org.slug, self.integration.id])
 
         for field in ("externalIssue", "parent"):
-            resp = self.client.get("%s?field=%s&query=test" % (path, field))
+            resp = self.client.get(f"{path}?field={field}&query=test")
             assert resp.status_code == 400
             assert resp.data == {
                 "detail": "Error Communicating with Jira (HTTP 500): unknown error"
@@ -120,7 +120,7 @@ class JiraSearchEndpointTest(APITestCase):
 
         path = reverse("sentry-extensions-jira-search", args=[org.slug, self.integration.id])
 
-        resp = self.client.get("%s?project=10000&field=assignee&query=bob" % (path,))
+        resp = self.client.get(f"{path}?project=10000&field=assignee&query=bob")
         assert resp.status_code == 200
         assert resp.data == [{"value": "deadbeef123", "label": "Bobby - bob@example.org"}]
 
@@ -144,7 +144,7 @@ class JiraSearchEndpointTest(APITestCase):
 
         path = reverse("sentry-extensions-jira-search", args=[org.slug, self.integration.id])
 
-        resp = self.client.get("%s?project=10000&field=assignee&query=bob" % (path,))
+        resp = self.client.get(f"{path}?project=10000&field=assignee&query=bob")
         assert resp.status_code == 400
 
     @responses.activate
@@ -167,7 +167,7 @@ class JiraSearchEndpointTest(APITestCase):
 
         path = reverse("sentry-extensions-jira-search", args=[org.slug, self.integration.id])
 
-        resp = self.client.get("%s?field=customfield_0123&query=sp" % (path,))
+        resp = self.client.get(f"{path}?field=customfield_0123&query=sp")
         assert resp.status_code == 200
         assert resp.data == [{"label": "Sprint 1 (1)", "value": "1"}]
 
@@ -185,7 +185,7 @@ class JiraSearchEndpointTest(APITestCase):
 
         path = reverse("sentry-extensions-jira-search", args=[org.slug, self.integration.id])
 
-        resp = self.client.get("%s?field=customfield_0123&query=sp" % (path,))
+        resp = self.client.get(f"{path}?field=customfield_0123&query=sp")
         assert resp.status_code == 400
         assert resp.data == {
             "detail": "Unable to fetch autocomplete for customfield_0123 from Jira"

--- a/tests/sentry/integrations/jira_server/test_search.py
+++ b/tests/sentry/integrations/jira_server/test_search.py
@@ -48,7 +48,7 @@ class JiraSearchEndpointTest(APITestCase):
 
         self.login_as(self.user)
         path = reverse("sentry-extensions-jiraserver-search", args=[org.slug, integration.id])
-        resp = self.client.get("%s?field=externalIssue&query=test" % (path,))
+        resp = self.client.get(f"{path}?field=externalIssue&query=test")
 
         assert resp.status_code == 200
         assert resp.data == [{"label": "(HSP-1) this is a test issue summary", "value": "HSP-1"}]
@@ -66,7 +66,7 @@ class JiraSearchEndpointTest(APITestCase):
 
         self.login_as(self.user)
         path = reverse("sentry-extensions-jiraserver-search", args=[org.slug, integration.id])
-        resp = self.client.get("%s?field=externalIssue&query=HSP-1" % (path,))
+        resp = self.client.get(f"{path}?field=externalIssue&query=HSP-1")
 
         assert resp.status_code == 200
         assert resp.data == [{"label": "(HSP-1) this is a test issue summary", "value": "HSP-1"}]
@@ -84,7 +84,7 @@ class JiraSearchEndpointTest(APITestCase):
 
         self.login_as(self.user)
         path = reverse("sentry-extensions-jiraserver-search", args=[org.slug, integration.id])
-        resp = self.client.get("%s?field=externalIssue&query=HSP-1" % (path,))
+        resp = self.client.get(f"{path}?field=externalIssue&query=HSP-1")
 
         assert resp.status_code == 400
 
@@ -93,7 +93,7 @@ class JiraSearchEndpointTest(APITestCase):
         org = self.organization
 
         path = reverse("sentry-extensions-jiraserver-search", args=[org.slug, 99])
-        resp = self.client.get("%s?field=externalIssue&query=HSP-1" % (path,))
+        resp = self.client.get(f"{path}?field=externalIssue&query=HSP-1")
 
         assert resp.status_code == 404
 
@@ -124,7 +124,7 @@ class JiraSearchEndpointTest(APITestCase):
 
         path = reverse("sentry-extensions-jiraserver-search", args=[org.slug, self.integration.id])
 
-        resp = self.client.get("%s?project=10000&field=assignee&query=bob" % (path,))
+        resp = self.client.get(f"{path}?project=10000&field=assignee&query=bob")
         assert resp.status_code == 200
         assert resp.data == [{"value": "bob", "label": "Bobby - bob@example.org (bob)"}]
 
@@ -148,5 +148,5 @@ class JiraSearchEndpointTest(APITestCase):
 
         path = reverse("sentry-extensions-jiraserver-search", args=[org.slug, self.integration.id])
 
-        resp = self.client.get("%s?project=10000&field=assignee&query=bob" % (path,))
+        resp = self.client.get(f"{path}?project=10000&field=assignee&query=bob")
         assert resp.status_code == 400

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -202,7 +202,7 @@ class StatusActionTest(BaseEventTest):
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_assign_to_team(self, verify):
         resp = self.post_webhook(
-            action_type=ACTION_TYPE.ASSIGN, assign_input="team:{}".format(self.team.id)
+            action_type=ACTION_TYPE.ASSIGN, assign_input=f"team:{self.team.id}"
         )
 
         assert resp.status_code == 200, resp.content
@@ -217,10 +217,7 @@ class StatusActionTest(BaseEventTest):
         assert GroupAssignee.objects.filter(group=self.group1, user=self.user).exists()
 
         assert b"Unassign" in responses.calls[0].request.body
-        assert (
-            "Assigned to {}".format(self.user.email).encode("utf-8")
-            in responses.calls[0].request.body
-        )
+        assert f"Assigned to {self.user.email}".encode("utf-8") in responses.calls[0].request.body
 
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
@@ -234,10 +231,7 @@ class StatusActionTest(BaseEventTest):
 
         assert b"Unassign" in responses.calls[0].request.body
         assert "user_conversation_id" in responses.calls[0].request.url
-        assert (
-            "Assigned to {}".format(self.user.email).encode("utf-8")
-            in responses.calls[0].request.body
-        )
+        assert f"Assigned to {self.user.email}".encode("utf-8") in responses.calls[0].request.body
 
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
@@ -251,10 +245,7 @@ class StatusActionTest(BaseEventTest):
 
         assert b"Unassign" in responses.calls[0].request.body
         assert "some_channel_id" in responses.calls[0].request.url
-        assert (
-            "Assigned to {}".format(self.user.email).encode("utf-8")
-            in responses.calls[0].request.body
-        )
+        assert f"Assigned to {self.user.email}".encode("utf-8") in responses.calls[0].request.body
 
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -75,7 +75,7 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
                 integration=integration, organization=self.organization
             )
 
-            integration_url = "organizations/{}/rules/".format(self.organization.slug)
+            integration_url = f"organizations/{self.organization.slug}/rules/"
             assert integration_url in responses.calls[1].request.body.decode("utf-8")
             assert self.organization.name in responses.calls[1].request.body.decode("utf-8")
 

--- a/tests/sentry/integrations/msteams/test_notify_action.py
+++ b/tests/sentry/integrations/msteams/test_notify_action.py
@@ -60,7 +60,7 @@ class MsTeamsNotifyActionTest(RuleTestCase):
         # can't pass the title and title link separately
         # with MS Teams cards.
         title_card = attachments[0]["content"]["body"][0]
-        title_pattern = "\[%s\](.*)" % event.title
+        title_pattern = r"\[%s\](.*)" % event.title
         assert re.match(title_pattern, title_card["text"])
 
     def test_render_label(self):

--- a/tests/sentry/integrations/msteams/test_unlink_identity.py
+++ b/tests/sentry/integrations/msteams/test_unlink_identity.py
@@ -49,9 +49,7 @@ class MsTeamsIntegrationUnlinkIdentityTest(TestCase):
 
         responses.add(
             method=responses.POST,
-            url="https://smba.trafficmanager.net/amer/v3/conversations/{}/activities".format(
-                self.conversation_id
-            ),
+            url=f"https://smba.trafficmanager.net/amer/v3/conversations/{self.conversation_id}/activities",
             status=200,
             json={},
         )

--- a/tests/sentry/integrations/pagerduty/test_integration.py
+++ b/tests/sentry/integrations/pagerduty/test_integration.py
@@ -68,7 +68,7 @@ class PagerDutyIntegrationTest(IntegrationTestCase):
 
     def assert_add_service_flow(self, integration):
         query_param = "?account=%s" % (integration.metadata["domain_name"])
-        init_path_with_account = "%s%s" % (self.init_path, query_param)
+        init_path_with_account = f"{self.init_path}{query_param}"
         resp = self.client.get(init_path_with_account)
         assert resp.status_code == 302
         redirect = urlparse(resp["Location"])

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -125,7 +125,7 @@ class StatusActionTest(BaseEventTest):
         assert resp.status_code == 200, resp.content
         assert self.group1.get_status() == GroupStatus.IGNORED
 
-        expect_status = "*Issue ignored by <@{}>*".format(self.identity.external_id)
+        expect_status = f"*Issue ignored by <@{self.identity.external_id}>*"
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
 
     def test_ignore_issue_with_additional_user_auth(self):
@@ -143,7 +143,7 @@ class StatusActionTest(BaseEventTest):
         assert resp.status_code == 200, resp.content
         assert self.group1.get_status() == GroupStatus.IGNORED
 
-        expect_status = "*Issue ignored by <@{}>*".format(self.identity.external_id)
+        expect_status = f"*Issue ignored by <@{self.identity.external_id}>*"
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
 
     def test_assign_issue(self):
@@ -153,7 +153,7 @@ class StatusActionTest(BaseEventTest):
         # Assign to user
         status_action = {
             "name": "assign",
-            "selected_options": [{"value": "user:{}".format(user2.id)}],
+            "selected_options": [{"value": f"user:{user2.id}"}],
         }
 
         resp = self.post_webhook(action_data=[status_action])
@@ -168,7 +168,7 @@ class StatusActionTest(BaseEventTest):
         # Assign to team
         status_action = {
             "name": "assign",
-            "selected_options": [{"value": "team:{}".format(self.team.id)}],
+            "selected_options": [{"value": f"team:{self.team.id}"}],
         }
 
         resp = self.post_webhook(action_data=[status_action])
@@ -196,7 +196,7 @@ class StatusActionTest(BaseEventTest):
 
         status_action = {
             "name": "assign",
-            "selected_options": [{"value": "user:{}".format(user2.id)}],
+            "selected_options": [{"value": f"user:{user2.id}"}],
         }
 
         resp = self.post_webhook(action_data=[status_action])
@@ -243,7 +243,7 @@ class StatusActionTest(BaseEventTest):
 
         status_action = {
             "name": "assign",
-            "selected_options": [{"value": "user:{}".format(self.user.id)}],
+            "selected_options": [{"value": f"user:{self.user.id}"}],
         }
 
         resp = self.post_webhook(action_data=[status_action])
@@ -307,7 +307,7 @@ class StatusActionTest(BaseEventTest):
 
         update_data = json.loads(responses.calls[1].request.body)
 
-        expect_status = "*Issue resolved by <@{}>*".format(self.identity.external_id)
+        expect_status = f"*Issue resolved by <@{self.identity.external_id}>*"
         assert update_data["text"].endswith(expect_status)
 
     def test_permission_denied(self):

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -161,8 +161,8 @@ class StatusActionTest(BaseEventTest):
         assert resp.status_code == 200, resp.content
         assert GroupAssignee.objects.filter(group=self.group1, user=user2).exists()
 
-        expect_status = "*Issue assigned to {assignee} by <@{assigner}>*".format(
-            assignee=user2.get_display_name(), assigner=self.identity.external_id
+        expect_status = (
+            f"*Issue assigned to {user2.get_display_name()} by <@{self.identity.external_id}>*"
         )
 
         # Assign to team
@@ -176,9 +176,7 @@ class StatusActionTest(BaseEventTest):
         assert resp.status_code == 200, resp.content
         assert GroupAssignee.objects.filter(group=self.group1, team=self.team).exists()
 
-        expect_status = "*Issue assigned to #{team} by <@{assigner}>*".format(
-            team=self.team.slug, assigner=self.identity.external_id
-        )
+        expect_status = f"*Issue assigned to #{self.team.slug} by <@{self.identity.external_id}>*"
 
         assert resp.data["text"].endswith(expect_status), resp.data["text"]
 
@@ -204,8 +202,8 @@ class StatusActionTest(BaseEventTest):
         assert resp.status_code == 200, resp.content
         assert GroupAssignee.objects.filter(group=self.group1, user=user2).exists()
 
-        expect_status = "*Issue assigned to <@{assignee}> by <@{assigner}>*".format(
-            assignee=user2_identity.external_id, assigner=self.identity.external_id
+        expect_status = (
+            f"*Issue assigned to <@{user2_identity.external_id}> by <@{self.identity.external_id}>*"
         )
 
         assert resp.data["text"].endswith(expect_status), resp.data["text"]

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -160,15 +160,10 @@ class LinkSharedEventTest(BaseEventTest):
         data = dict(parse_qsl(responses.calls[0].request.body))
         unfurls = json.loads(data["unfurls"])
         issue_url = f"http://testserver/organizations/{self.org.slug}/issues/{group1.id}/bar/"
-        incident_url = "http://testserver/organizations/{}/incidents/{}/".format(
-            self.org.slug,
-            incident.identifier,
+        incident_url = (
+            f"http://testserver/organizations/{self.org.slug}/incidents/{incident.identifier}/"
         )
-        event_url = "http://testserver/organizations/{}/issues/{}/events/{}/".format(
-            self.org.slug,
-            group3.id,
-            event.event_id,
-        )
+        event_url = f"http://testserver/organizations/{self.org.slug}/issues/{group3.id}/events/{event.event_id}/"
 
         assert unfurls == {
             issue_url: build_group_attachment(group1),

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -159,12 +159,12 @@ class LinkSharedEventTest(BaseEventTest):
         assert resp.status_code == 200, resp.content
         data = dict(parse_qsl(responses.calls[0].request.body))
         unfurls = json.loads(data["unfurls"])
-        issue_url = "http://testserver/organizations/%s/issues/%s/bar/" % (self.org.slug, group1.id)
-        incident_url = "http://testserver/organizations/%s/incidents/%s/" % (
+        issue_url = f"http://testserver/organizations/{self.org.slug}/issues/{group1.id}/bar/"
+        incident_url = "http://testserver/organizations/{}/incidents/{}/".format(
             self.org.slug,
             incident.identifier,
         )
-        event_url = "http://testserver/organizations/%s/issues/%s/events/%s/" % (
+        event_url = "http://testserver/organizations/{}/issues/{}/events/{}/".format(
             self.org.slug,
             group3.id,
             event.event_id,

--- a/tests/sentry/integrations/slack/test_migration_flow.py
+++ b/tests/sentry/integrations/slack/test_migration_flow.py
@@ -43,11 +43,11 @@ class SlackMigrationTest(IntegrationTestCase):
             integration_id=six.text_type(self.integration.id),
             channel_id="XXXXX",
         )
-        self.init_path_verification_results = "%s%s" % (
+        self.init_path_verification_results = "{}{}".format(
             self.setup_path,
             "?show_verification_results",
         )
-        self.init_path_channels = "%s%s" % (self.setup_path, "?start_migration")
+        self.init_path_channels = "{}{}".format(self.setup_path, "?start_migration")
 
     def assert_setup_flow(
         self,

--- a/tests/sentry/integrations/slack/test_migration_flow.py
+++ b/tests/sentry/integrations/slack/test_migration_flow.py
@@ -43,11 +43,8 @@ class SlackMigrationTest(IntegrationTestCase):
             integration_id=six.text_type(self.integration.id),
             channel_id="XXXXX",
         )
-        self.init_path_verification_results = "{}{}".format(
-            self.setup_path,
-            "?show_verification_results",
-        )
-        self.init_path_channels = "{}{}".format(self.setup_path, "?start_migration")
+        self.init_path_verification_results = f"{self.setup_path}?show_verification_results"
+        self.init_path_channels = f"{self.setup_path}?start_migration"
 
     def assert_setup_flow(
         self,

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -373,9 +373,7 @@ class BuildIncidentAttachmentTest(TestCase):
             "fields": [],
             "footer": "BENGAL-ELEPHANT-GIRAFFE-TREE-HOUSE-1",
             "ts": to_timestamp(ts),
-            "title_link": "http://testserver/organizations/rowdy-tiger/issues/{}/events/{}/".format(
-                group.id, event.event_id
-            )
+            "title_link": f"http://testserver/organizations/rowdy-tiger/issues/{group.id}/events/{event.event_id}/"
             + "?referrer=slack",
             "callback_id": '{"issue":' + six.text_type(group.id) + "}",
             "fallback": f"[{self.project.slug}] {event.title}",

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -222,7 +222,7 @@ class BuildIncidentAttachmentTest(TestCase):
                     },
                 )
             ),
-            "text": "{} events in the last 10 minutes\nFilter: level:error".format(metric_value),
+            "text": f"{metric_value} events in the last 10 minutes\nFilter: level:error",
             "fields": [],
             "mrkdwn_in": ["text"],
             "footer_icon": logo_url,
@@ -284,7 +284,7 @@ class BuildIncidentAttachmentTest(TestCase):
             + six.text_type(group.id)
             + "/?referrer=slack",
             "callback_id": '{"issue":' + six.text_type(group.id) + "}",
-            "fallback": "[{}] {}".format(self.project.slug, group.title),
+            "fallback": f"[{self.project.slug}] {group.title}",
             "footer_icon": "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
         }
         event = self.store_event(data={}, project_id=self.project.id)
@@ -331,7 +331,7 @@ class BuildIncidentAttachmentTest(TestCase):
             + six.text_type(group.id)
             + "/?referrer=slack",
             "callback_id": '{"issue":' + six.text_type(group.id) + "}",
-            "fallback": "[{}] {}".format(self.project.slug, event.title),
+            "fallback": f"[{self.project.slug}] {event.title}",
             "footer_icon": "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
         }
 
@@ -378,7 +378,7 @@ class BuildIncidentAttachmentTest(TestCase):
             )
             + "?referrer=slack",
             "callback_id": '{"issue":' + six.text_type(group.id) + "}",
-            "fallback": "[{}] {}".format(self.project.slug, event.title),
+            "fallback": f"[{self.project.slug}] {event.title}",
             "footer_icon": "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
         }
 

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -181,7 +181,7 @@ class BuildIncidentAttachmentTest(TestCase):
         logo_url = absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
         alert_rule = self.create_alert_rule()
         incident = self.create_incident(alert_rule=alert_rule, status=2)
-        title = "{}: {}".format("Resolved", alert_rule.name)
+        title = f"Resolved: {alert_rule.name}"
         assert build_incident_attachment(incident) == {
             "fallback": title,
             "title": title,
@@ -208,7 +208,7 @@ class BuildIncidentAttachmentTest(TestCase):
         logo_url = absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
         alert_rule = self.create_alert_rule()
         incident = self.create_incident(alert_rule=alert_rule, status=2)
-        title = "{}: {}".format("Resolved", alert_rule.name)
+        title = f"Resolved: {alert_rule.name}"
         metric_value = 5000
         assert build_incident_attachment(incident, metric_value=metric_value) == {
             "fallback": title,

--- a/tests/sentry/integrations/test_issues.py
+++ b/tests/sentry/integrations/test_issues.py
@@ -210,7 +210,7 @@ class IssueDefaultTest(TestCase):
         link = self.installation.get_issue_url(self.external_issue.key)
 
         assert self.installation.get_annotations_for_group_list([self.group]) == {
-            self.group.id: ['<a href="%s">%s</a>' % (link, label)]
+            self.group.id: [f'<a href="{link}">{label}</a>']
         }
 
         integration = Integration.objects.create(provider="example", external_id="4444")

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -21,7 +21,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         metric_value = 123
         data = incident_attachment_info(incident, metric_value)
 
-        assert data["title"] == "Resolved: {}".format(alert_rule.name)
+        assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "123 events in the last 10 minutes\nFilter: level:error"
         assert data["ts"] == date_started
@@ -61,7 +61,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
 
         data = incident_attachment_info(incident)
 
-        assert data["title"] == "Resolved: {}".format(alert_rule.name)
+        assert data["title"] == f"Resolved: {alert_rule.name}"
         assert data["status"] == "Resolved"
         assert data["text"] == "4 events in the last 10 minutes\nFilter: level:error"
         assert data["ts"] == date_started

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -477,7 +477,7 @@ class VercelIntegrationTest(IntegrationTestCase):
         assert resp.status_code == 200
         assert (
             absolute_uri(
-                "/settings/%s/integrations/vercel/%s/" % (self.organization.slug, integration.id)
+                f"/settings/{self.organization.slug}/integrations/vercel/{integration.id}/"
             ).encode("utf-8")
             in resp.content
         )

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -109,7 +109,7 @@ class VercelReleasesTest(APITestCase):
                     }
                 ],
             }
-            assert release_request.headers["User-Agent"] == "sentry_vercel/{}".format(VERSION)
+            assert release_request.headers["User-Agent"] == f"sentry_vercel/{VERSION}"
 
     @responses.activate
     def test_no_match(self):
@@ -267,7 +267,7 @@ class VercelReleasesTest(APITestCase):
     @responses.activate
     def test_manual_vercel_deploy(self):
         local_signature = hmac.new(
-            key="vercel-client-secret".encode("utf-8"),
+            key=b"vercel-client-secret",
             msg=DEPLOYMENT_WEBHOOK_NO_COMMITS.encode("utf-8"),
             digestmod=hashlib.sha1,
         ).hexdigest()

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -35,8 +35,9 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         assert responses.calls[-2].request.url == "https://app.vssps.visualstudio.com/oauth2/token"
 
         # Then we request the Projects with the new token
-        assert responses.calls[-1].request.url.split("?")[0] == "{}_apis/projects".format(
-            self.vsts_base_url.lower()
+        assert (
+            responses.calls[-1].request.url.split("?")[0]
+            == f"{self.vsts_base_url.lower()}_apis/projects"
         )
 
         identity = Identity.objects.get(id=identity.id)
@@ -75,8 +76,9 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         assert responses.calls[-2].request.url == "https://app.vssps.visualstudio.com/oauth2/token"
 
         # Then we request the Projects with the new token
-        assert responses.calls[-1].request.url.split("?")[0] == "{}_apis/projects".format(
-            self.vsts_base_url.lower()
+        assert (
+            responses.calls[-1].request.url.split("?")[0]
+            == f"{self.vsts_base_url.lower()}_apis/projects"
         )
 
         identity = Identity.objects.get(id=identity.id)

--- a/tests/sentry/integrations/vsts/test_client.py
+++ b/tests/sentry/integrations/vsts/test_client.py
@@ -101,7 +101,7 @@ class VstsApiClientTest(VstsIntegrationTestCase):
         integration = Integration.objects.get(provider="vsts")
         responses.add_callback(
             responses.GET,
-            "https://{}.visualstudio.com/_apis/projects".format(self.vsts_account_name.lower()),
+            f"https://{self.vsts_account_name.lower()}.visualstudio.com/_apis/projects",
             callback=request_callback,
         )
 

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -106,9 +106,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         Repository.objects.create(
             organization_id=self.organization.id,
             name=self.project_a["name"],
-            url="https://{}.visualstudio.com/_git/{}".format(
-                self.vsts_account_name, self.repo_name
-            ),
+            url=f"https://{self.vsts_account_name}.visualstudio.com/_git/{self.repo_name}",
             provider="visualstudio",
             external_id=self.repo_id,
             config={"name": self.project_a["name"], "project": self.project_a["name"]},
@@ -130,9 +128,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         Repository.objects.create(
             organization_id=self.organization.id,
             name=self.project_a["name"],
-            url="https://{}.visualstudio.com/_git/{}".format(
-                self.vsts_account_name, self.repo_name
-            ),
+            url=f"https://{self.vsts_account_name}.visualstudio.com/_git/{self.repo_name}",
             provider="visualstudio",
             external_id=self.repo_id,
         )
@@ -249,9 +245,7 @@ class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
     def test_create_subscription_forbidden(self, mock_get_scopes):
         responses.replace(
             responses.POST,
-            "https://{}.visualstudio.com/_apis/hooks/subscriptions".format(
-                self.vsts_account_name.lower()
-            ),
+            f"https://{self.vsts_account_name.lower()}.visualstudio.com/_apis/hooks/subscriptions",
             status=403,
             json={
                 "$id": 1,
@@ -284,9 +278,7 @@ class VstsIntegrationProviderBuildIntegrationTest(VstsIntegrationTestCase):
     def test_create_subscription_unauthorized(self, mock_get_scopes):
         responses.replace(
             responses.POST,
-            "https://{}.visualstudio.com/_apis/hooks/subscriptions".format(
-                self.vsts_account_name.lower()
-            ),
+            f"https://{self.vsts_account_name.lower()}.visualstudio.com/_apis/hooks/subscriptions",
             status=401,
             json={
                 "$id": 1,

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -73,7 +73,7 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
         accessible_repo = Repository.objects.create(
             organization_id=self.organization.id,
             name=self.project_a["name"],
-            url="{}/_git/{}".format(self.vsts_base_url, self.repo_name),
+            url=f"{self.vsts_base_url}/_git/{self.repo_name}",
             provider="visualstudio",
             external_id=self.repo_id,
             config={"name": self.project_a["name"], "project": self.project_a["name"]},

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -70,17 +70,13 @@ class VstsIssueBase(TestCase):
     def mock_categories(self, project):
         responses.add(
             responses.GET,
-            "https://fabrikam-fiber-inc.visualstudio.com/{}/_apis/wit/workitemtypecategories".format(
-                project
-            ),
+            f"https://fabrikam-fiber-inc.visualstudio.com/{project}/_apis/wit/workitemtypecategories",
             json={
                 "value": [
                     {
                         "workItemTypes": [
                             {
-                                "url": "https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Bug".format(
-                                    project
-                                ),
+                                "url": f"https://fabrikam-fiber-inc.visualstudio.com/{project}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Bug",
                                 "name": "Bug",
                             }
                         ],
@@ -88,15 +84,11 @@ class VstsIssueBase(TestCase):
                     {
                         "workItemTypes": [
                             {
-                                "url": "https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Bug".format(
-                                    project
-                                ),
+                                "url": f"https://fabrikam-fiber-inc.visualstudio.com/{project}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Bug",
                                 "name": "Issue Bug",
                             },
                             {
-                                "url": "https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Some-Thing.GIssue".format(
-                                    project
-                                ),
+                                "url": f"https://fabrikam-fiber-inc.visualstudio.com/{project}/wit/workItemTypeCategories/Some-Thing.GIssue",
                                 "name": "G Issue",
                             },
                         ],
@@ -104,9 +96,7 @@ class VstsIssueBase(TestCase):
                     {
                         "workItemTypes": [
                             {
-                                "url": "https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Task".format(
-                                    project
-                                ),
+                                "url": f"https://fabrikam-fiber-inc.visualstudio.com/{project}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.Task",
                                 "name": "Task",
                             }
                         ],
@@ -114,9 +104,7 @@ class VstsIssueBase(TestCase):
                     {
                         "workItemTypes": [
                             {
-                                "url": "https://fabrikam-fiber-inc.visualstudio.com/{}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.UserStory".format(
-                                    project
-                                ),
+                                "url": f"https://fabrikam-fiber-inc.visualstudio.com/{project}/wit/workItemTypeCategories/Microsoft.VSTS.WorkItemTypes.UserStory",
                                 "name": "User Story",
                             }
                         ],

--- a/tests/sentry/integrations/vsts/testutils.py
+++ b/tests/sentry/integrations/vsts/testutils.py
@@ -92,7 +92,7 @@ class VstsIntegrationTestCase(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            "https://{}.visualstudio.com/_apis/projects".format(self.vsts_account_name.lower()),
+            f"https://{self.vsts_account_name.lower()}.visualstudio.com/_apis/projects",
             json={"value": [self.project_a, self.project_b], "count": 2},
         )
 
@@ -167,7 +167,7 @@ class VstsIntegrationTestCase(IntegrationTestCase):
     def assert_account_selection(self, response, account_id=None):
         account_id = account_id or self.vsts_account_id
         assert response.status_code == 200
-        assert '<option value="{}"'.format(account_id).encode("utf-8") in response.content
+        assert f'<option value="{account_id}"'.encode("utf-8") in response.content
 
     def assert_installation(self):
         # Initial request to the installation URL for VSTS

--- a/tests/sentry/integrations/vsts/testutils.py
+++ b/tests/sentry/integrations/vsts/testutils.py
@@ -98,17 +98,13 @@ class VstsIntegrationTestCase(IntegrationTestCase):
 
         responses.add(
             responses.POST,
-            "https://{}.visualstudio.com/_apis/hooks/subscriptions".format(
-                self.vsts_account_name.lower()
-            ),
+            f"https://{self.vsts_account_name.lower()}.visualstudio.com/_apis/hooks/subscriptions",
             json=CREATE_SUBSCRIPTION,
         )
 
         responses.add(
             responses.GET,
-            "https://{}.visualstudio.com/_apis/git/repositories".format(
-                self.vsts_account_name.lower()
-            ),
+            f"https://{self.vsts_account_name.lower()}.visualstudio.com/_apis/git/repositories",
             json={
                 "value": [
                     {
@@ -122,9 +118,7 @@ class VstsIntegrationTestCase(IntegrationTestCase):
 
         responses.add(
             responses.GET,
-            "https://{}.visualstudio.com/ProjectA/_apis/git/repositories/ProjectA".format(
-                self.vsts_account_name.lower()
-            ),
+            f"https://{self.vsts_account_name.lower()}.visualstudio.com/ProjectA/_apis/git/repositories/ProjectA",
             json={
                 "repository": {
                     "id": self.repo_id,

--- a/tests/sentry/lang/javascript/test_processor.py
+++ b/tests/sentry/lang/javascript/test_processor.py
@@ -378,7 +378,7 @@ class FetchFileTest(TestCase):
         for i, (header_name_option_value, expected_request_header_name) in enumerate(header_pairs):
             self.project.update_option("sentry:token_header", header_name_option_value)
 
-            url = "http://example.com/{}/".format(i)
+            url = f"http://example.com/{i}/"
             result = fetch_file(url, project=self.project)
 
             assert result.url == url

--- a/tests/sentry/lang/javascript/test_sourcemaps.py
+++ b/tests/sentry/lang/javascript/test_sourcemaps.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from symbolic import SourceMapView, SourceMapTokenMatch
 from unittest import TestCase
 

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core import mail
 from django.utils import timezone
 

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -818,8 +818,9 @@ class MailAdapterHandleSignalTest(BaseMailAdapterTest, TestCase):
         assert "group-header" in msg.alternatives[0][0]
         assert "enhanced privacy" not in msg.body
 
-        assert msg.subject == "[Sentry] {} - New Feedback from Homer Simpson".format(
-            self.group.qualified_short_id
+        assert (
+            msg.subject
+            == f"[Sentry] {self.group.qualified_short_id} - New Feedback from Homer Simpson"
         )
         assert msg.to == [self.user.email]
 
@@ -848,7 +849,8 @@ class MailAdapterHandleSignalTest(BaseMailAdapterTest, TestCase):
         assert "group-header" not in msg.alternatives[0][0]
         assert "enhanced privacy" in msg.body
 
-        assert msg.subject == "[Sentry] {} - New Feedback from Homer Simpson".format(
-            self.group.qualified_short_id
+        assert (
+            msg.subject
+            == f"[Sentry] {self.group.qualified_short_id} - New Feedback from Homer Simpson"
         )
         assert msg.to == [self.user.email]

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from datetime import datetime
 
 import pytz

--- a/tests/sentry/mediators/external_requests/test_select_requester.py
+++ b/tests/sentry/mediators/external_requests/test_select_requester.py
@@ -31,9 +31,7 @@ class TestSelectRequester(TestCase):
         ]
         responses.add(
             method=responses.GET,
-            url="https://example.com/get-issues?installationId={}&projectSlug={}".format(
-                self.install.uuid, self.project.slug
-            ),
+            url=f"https://example.com/get-issues?installationId={self.install.uuid}&projectSlug={self.project.slug}",
             json=options,
             status=200,
             content_type="application/json",
@@ -62,9 +60,7 @@ class TestSelectRequester(TestCase):
         invalid_format = {"value": "12345"}
         responses.add(
             method=responses.GET,
-            url="https://example.com/get-issues?installationId={}&projectSlug={}".format(
-                self.install.uuid, self.project.slug
-            ),
+            url=f"https://example.com/get-issues?installationId={self.install.uuid}&projectSlug={self.project.slug}",
             json=invalid_format,
             status=200,
             content_type="application/json",
@@ -83,9 +79,7 @@ class TestSelectRequester(TestCase):
     def test_500_response(self):
         responses.add(
             method=responses.GET,
-            url="https://example.com/get-issues?installationId={}&projectSlug={}".format(
-                self.install.uuid, self.project.slug
-            ),
+            url=f"https://example.com/get-issues?installationId={self.install.uuid}&projectSlug={self.project.slug}",
             body="Something failed",
             status=500,
         )

--- a/tests/sentry/mediators/sentry_app_components/test_preparer.py
+++ b/tests/sentry/mediators/sentry_app_components/test_preparer.py
@@ -86,8 +86,7 @@ class TestPreparerStacktraceLink(TestCase):
 
         self.preparer.call()
 
-        assert self.component.schema[
-            "url"
-        ] == "https://example.com/redirection?installationId={}&projectSlug={}".format(
-            self.install.uuid, self.project.slug
+        assert (
+            self.component.schema["url"]
+            == f"https://example.com/redirection?installationId={self.install.uuid}&projectSlug={self.project.slug}"
         )

--- a/tests/sentry/models/test_commit.py
+++ b/tests/sentry/models/test_commit.py
@@ -30,7 +30,7 @@ class FindReferencedGroupsTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=group.organization.id,
-            message="Foo Biz\n\Resolved {} {}".format(
+            message="Foo Biz\n\\Resolved {} {}".format(
                 group.qualified_short_id, group2.qualified_short_id
             ),
         )
@@ -44,7 +44,7 @@ class FindReferencedGroupsTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=group.organization.id,
-            message="Foo Biz\n\Close {} {}".format(
+            message="Foo Biz\n\\Close {} {}".format(
                 group.qualified_short_id, group2.qualified_short_id
             ),
         )
@@ -58,7 +58,7 @@ class FindReferencedGroupsTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=group.organization.id,
-            message="Foo Biz\n\nFixes: {}".format(group.qualified_short_id),
+            message=f"Foo Biz\n\nFixes: {group.qualified_short_id}",
         )
 
         groups = commit.find_referenced_groups()

--- a/tests/sentry/models/test_commit.py
+++ b/tests/sentry/models/test_commit.py
@@ -16,9 +16,7 @@ class FindReferencedGroupsTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=group.organization.id,
-            message="Foo Biz\n\nFixes {} {}".format(
-                group.qualified_short_id, group2.qualified_short_id
-            ),
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id} {group2.qualified_short_id}",
         )
 
         groups = commit.find_referenced_groups()
@@ -30,9 +28,7 @@ class FindReferencedGroupsTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=group.organization.id,
-            message="Foo Biz\n\\Resolved {} {}".format(
-                group.qualified_short_id, group2.qualified_short_id
-            ),
+            message=f"Foo Biz\n\\Resolved {group.qualified_short_id} {group2.qualified_short_id}",
         )
 
         groups = commit.find_referenced_groups()
@@ -44,9 +40,7 @@ class FindReferencedGroupsTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=group.organization.id,
-            message="Foo Biz\n\\Close {} {}".format(
-                group.qualified_short_id, group2.qualified_short_id
-            ),
+            message=f"Foo Biz\n\\Close {group.qualified_short_id} {group2.qualified_short_id}",
         )
 
         groups = commit.find_referenced_groups()
@@ -75,9 +69,7 @@ class FindReferencedGroupsTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=group.organization.id,
-            message="Foo Biz\n\nFixes {}, {}".format(
-                group.qualified_short_id, group2.qualified_short_id
-            ),
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id}, {group2.qualified_short_id}",
         )
 
         groups = commit.find_referenced_groups()

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -9,7 +9,7 @@ from sentry.utils.compat import map
 
 class FileBlobTest(TestCase):
     def test_from_file(self):
-        fileobj = ContentFile("foo bar".encode("utf-8"))
+        fileobj = ContentFile(b"foo bar")
 
         my_file1 = FileBlob.from_file(fileobj)
 
@@ -38,7 +38,7 @@ class FileBlobTest(TestCase):
 
 class FileTest(TestCase):
     def test_delete_also_removes_blobs(self):
-        fileobj = ContentFile("foo bar".encode("utf-8"))
+        fileobj = ContentFile(b"foo bar")
         baz_file = File.objects.create(name="baz.js", type="default", size=7)
         baz_file.putfile(fileobj, 3)
 
@@ -51,7 +51,7 @@ class FileTest(TestCase):
         assert FileBlob.objects.count() == 0
 
     def test_delete_does_not_remove_shared_blobs(self):
-        fileobj = ContentFile("foo bar".encode("utf-8"))
+        fileobj = ContentFile(b"foo bar")
         baz_file = File.objects.create(name="baz-v1.js", type="default", size=7)
         baz_file.putfile(fileobj, 3)
         baz_id = baz_file.id
@@ -71,7 +71,7 @@ class FileTest(TestCase):
         assert len(raz_file.blobs.all()) == 3
 
     def test_file_handling(self):
-        fileobj = ContentFile("foo bar".encode("utf-8"))
+        fileobj = ContentFile(b"foo bar")
         file1 = File.objects.create(name="baz.js", type="default", size=7)
         results = file1.putfile(fileobj, 3)
         assert len(results) == 3

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -239,7 +239,5 @@ class GroupTest(TestCase, SnubaTestCase):
             data={"fingerprint": ["group1"], "timestamp": self.min_ago}, project_id=project.id
         )
         group = event.group
-        url = "http://testserver/organizations/{}/issues/{}/events/{}/".format(
-            project.organization.slug, group.id, event.event_id
-        )
+        url = f"http://testserver/organizations/{project.organization.slug}/issues/{group.id}/events/{event.event_id}/"
         assert url == group.get_absolute_url(event_id=event.event_id)

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -208,7 +208,7 @@ class GroupTest(TestCase, SnubaTestCase):
         project = self.create_project()
         group = self.create_group(project=project)
 
-        expect = "{} - {}".format(group.qualified_short_id, group.title)
+        expect = f"{group.qualified_short_id} - {group.title}"
         assert group.get_email_subject() == expect
 
     def test_get_absolute_url(self):

--- a/tests/sentry/models/test_groupmeta.py
+++ b/tests/sentry/models/test_groupmeta.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.models import GroupMeta
 from sentry.testutils import TestCase
 

--- a/tests/sentry/models/test_groupresolution.py
+++ b/tests/sentry/models/test_groupresolution.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from datetime import timedelta
 from django.utils import timezone
 

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -1,6 +1,3 @@
-# coding: utf-8
-
-
 from datetime import timedelta
 from django.core import mail
 from django.utils import timezone

--- a/tests/sentry/models/test_organizationoption.py
+++ b/tests/sentry/models/test_organizationoption.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.models import OrganizationOption
 from sentry.testutils import TestCase
 

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import six
 
 from sentry.models import (

--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.models import Counter
 from sentry.testutils import TestCase
 

--- a/tests/sentry/models/test_projectkey.py
+++ b/tests/sentry/models/test_projectkey.py
@@ -44,10 +44,10 @@ class ProjectKeyTest(TestCase):
     def test_get_dsn_org_subdomain(self):
         with self.feature("organizations:org-subdomains"):
             key = self.model(project_id=1, public_key="abc", secret_key="xyz")
-            host = "o{}.ingest.testserver".format(key.project.organization_id)
+            host = f"o{key.project.organization_id}.ingest.testserver"
 
-            assert key.dsn_private == "http://abc:xyz@{}/1".format(host)
-            assert key.dsn_public == "http://abc@{}/1".format(host)
-            assert key.csp_endpoint == "http://{}/api/1/csp-report/?sentry_key=abc".format(host)
-            assert key.minidump_endpoint == "http://{}/api/1/minidump/?sentry_key=abc".format(host)
-            assert key.unreal_endpoint == "http://{}/api/1/unreal/abc/".format(host)
+            assert key.dsn_private == f"http://abc:xyz@{host}/1"
+            assert key.dsn_public == f"http://abc@{host}/1"
+            assert key.csp_endpoint == f"http://{host}/api/1/csp-report/?sentry_key=abc"
+            assert key.minidump_endpoint == f"http://{host}/api/1/minidump/?sentry_key=abc"
+            assert key.unreal_endpoint == f"http://{host}/api/1/unreal/abc/"

--- a/tests/sentry/models/test_projectoption.py
+++ b/tests/sentry/models/test_projectoption.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.models import ProjectOption
 from sentry.testutils import TestCase
 

--- a/tests/sentry/models/test_projectredirect.py
+++ b/tests/sentry/models/test_projectredirect.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.models import ProjectRedirect
 from sentry.testutils import TestCase
 

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -16,7 +16,7 @@ class FindReferencedGroupsTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=group.organization.id,
-            message="Foo Biz\n\nFixes {}".format(group.qualified_short_id),
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
         )
 
         groups = commit.find_referenced_groups()
@@ -28,7 +28,7 @@ class FindReferencedGroupsTest(TestCase):
             repository_id=repo.id,
             organization_id=group.organization.id,
             title="very cool PR to fix the thing",
-            message="Foo Biz\n\nFixes {}".format(group2.qualified_short_id),
+            message=f"Foo Biz\n\nFixes {group2.qualified_short_id}",
         )
 
         groups = pr.find_referenced_groups()

--- a/tests/sentry/models/test_team.py
+++ b/tests/sentry/models/test_team.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.models import (
     OrganizationMember,
     OrganizationMemberTeam,

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -1,6 +1,3 @@
-# coding: utf-8
-
-
 import pytest
 
 from datetime import timedelta

--- a/tests/sentry/nodestore/django/backend/tests.py
+++ b/tests/sentry/nodestore/django/backend/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 
 from datetime import timedelta

--- a/tests/sentry/options/test_manager.py
+++ b/tests/sentry/options/test_manager.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from exam import fixture, around
 from sentry.utils.compat.mock import patch
 from django.conf import settings

--- a/tests/sentry/options/test_store.py
+++ b/tests/sentry/options/test_store.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from uuid import uuid1
 
 import pytest

--- a/tests/sentry/plugins/bases/issue/tests.py
+++ b/tests/sentry/plugins/bases/issue/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.utils.compat import mock
 
 from social_auth.models import UserSocialAuth

--- a/tests/sentry/plugins/bases/test_issue2.py
+++ b/tests/sentry/plugins/bases/test_issue2.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from social_auth.models import UserSocialAuth
 
 from sentry.models import GroupMeta, User

--- a/tests/sentry/plugins/helpers/tests.py
+++ b/tests/sentry/plugins/helpers/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.utils.compat import mock
 from sentry.plugins.helpers import set_option, unset_option, get_option
 from sentry.testutils import TestCase

--- a/tests/sentry/plugins/sentry_webhooks/test_plugin.py
+++ b/tests/sentry/plugins/sentry_webhooks/test_plugin.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 import responses
 

--- a/tests/sentry/plugins/useragents/tests.py
+++ b/tests/sentry/plugins/useragents/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.testutils import TestCase
 from sentry.plugins.sentry_useragents.models import BrowserPlugin, DevicePlugin, OsPlugin
 from ua_parser.user_agent_parser import Parse

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.utils.compat import mock
 import six
 import time

--- a/tests/sentry/quotas/test_base.py
+++ b/tests/sentry/quotas/test_base.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.constants import DataCategory
 from sentry.models import OrganizationOption, ProjectKey
 from sentry.quotas.base import Quota, QuotaConfig, QuotaScope

--- a/tests/sentry/ratelimits/test_redis.py
+++ b/tests/sentry/ratelimits/test_redis.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.ratelimits.redis import RedisRateLimiter
 from sentry.testutils import TestCase
 

--- a/tests/sentry/receivers/test_core.py
+++ b/tests/sentry/receivers/test_core.py
@@ -1,6 +1,3 @@
-# coding: utf-8
-
-
 from django.apps import apps
 from django.conf import settings
 

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -61,7 +61,7 @@ class ResolvedInCommitTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=group.organization.id,
-            message="Foo Biz\n\nFixes {}".format(group.qualified_short_id),
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
         )
 
         self.assertResolvedFromCommit(group, commit)
@@ -80,7 +80,7 @@ class ResolvedInCommitTest(TestCase):
 
         self.assertNotResolvedFromCommit(group, commit)
 
-        commit.message = "Foo Biz\n\nFixes {}".format(group.qualified_short_id)
+        commit.message = f"Foo Biz\n\nFixes {group.qualified_short_id}"
         commit.save()
 
         self.assertResolvedFromCommit(group, commit)
@@ -95,12 +95,12 @@ class ResolvedInCommitTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=group.organization.id,
-            message="Foo Biz\n\nFixes {}".format(group.qualified_short_id),
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
         )
 
         self.assertResolvedFromCommit(group, commit)
 
-        commit.message = "Foo Bar Biz\n\nFixes {}".format(group.qualified_short_id)
+        commit.message = f"Foo Bar Biz\n\nFixes {group.qualified_short_id}"
         commit.save()
 
         self.assertResolvedFromCommit(group, commit)
@@ -115,7 +115,7 @@ class ResolvedInCommitTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=group.organization.id,
-            message="Foo Biz\n\nFixes {}".format(group.qualified_short_id),
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
         )
 
         self.assertResolvedFromCommit(group, commit)
@@ -133,7 +133,7 @@ class ResolvedInCommitTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             repository_id=repo.id,
             organization_id=self.organization.id,
-            message="Foo Biz\n\nFixes {}-12F".format(self.project.slug.upper()),
+            message=f"Foo Biz\n\nFixes {self.project.slug.upper()}-12F",
         )
 
         assert not GroupLink.objects.filter(
@@ -155,7 +155,7 @@ class ResolvedInCommitTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             organization_id=group.organization.id,
             repository_id=repo.id,
-            message="Foo Biz\n\nFixes {}".format(group.qualified_short_id),
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
             author=CommitAuthor.objects.create(
                 organization_id=group.organization.id, name=user.name, email=user.email
             ),
@@ -190,7 +190,7 @@ class ResolvedInCommitTest(TestCase):
             key=sha1(uuid4().hex.encode("utf-8")).hexdigest(),
             organization_id=group.organization.id,
             repository_id=repo.id,
-            message="Foo Biz\n\nFixes {}".format(group.qualified_short_id),
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
             author=CommitAuthor.objects.create(
                 organization_id=group.organization.id, name=user.name, email=user.email
             ),

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -19,9 +19,7 @@ class TestIssueWorkflowNotifications(APITestCase):
             organization=self.organization, slug=self.sentry_app.slug
         )
 
-        self.url = "/api/0/projects/{}/{}/issues/?id={}".format(
-            self.organization.slug, self.issue.project.slug, self.issue.id
-        )
+        self.url = f"/api/0/projects/{self.organization.slug}/{self.issue.project.slug}/issues/?id={self.issue.id}"
 
         self.login_as(self.user)
 

--- a/tests/sentry/receivers/test_sentry_apps.py
+++ b/tests/sentry/receivers/test_sentry_apps.py
@@ -120,7 +120,7 @@ class TestIssueWorkflowNotifications(APITestCase):
                     "repository": repo.name,
                     "author_email": "foo@example.com",
                     "author_name": "Foo Bar",
-                    "message": "FIXES {}".format(self.issue.qualified_short_id),
+                    "message": f"FIXES {self.issue.qualified_short_id}",
                 }
             ]
         )

--- a/tests/sentry/rules/test_processor.py
+++ b/tests/sentry/rules/test_processor.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from datetime import timedelta
 from django.utils import timezone
 

--- a/tests/sentry/runner/commands/test_createuser.py
+++ b/tests/sentry/runner/commands/test_createuser.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry import roles
 from sentry.testutils import CliTestCase
 from sentry.runner.commands.createuser import createuser

--- a/tests/sentry/runner/commands/test_init.py
+++ b/tests/sentry/runner/commands/test_init.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import os
 import six
 

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -288,7 +288,7 @@ class ParseQueryTest(TestCase):
         assert result == {"assigned_to": self.user, "tags": {}, "query": ""}
 
     def test_assigned_email(self):
-        result = self.parse_query("assigned:%s" % (self.user.email,))
+        result = self.parse_query(f"assigned:{self.user.email}")
         assert result == {"assigned_to": self.user, "tags": {}, "query": ""}
 
     def test_assigned_unknown_user(self):
@@ -316,7 +316,7 @@ class ParseQueryTest(TestCase):
         assert result == {"bookmarked_by": self.user, "tags": {}, "query": ""}
 
     def test_bookmarks_email(self):
-        result = self.parse_query("bookmarks:%s" % (self.user.email,))
+        result = self.parse_query(f"bookmarks:{self.user.email}")
         assert result == {"bookmarked_by": self.user, "tags": {}, "query": ""}
 
     def test_bookmarks_unknown_user(self):
@@ -519,7 +519,7 @@ class ParseQueryTest(TestCase):
         assert result == {"owner": self.user, "tags": {}, "query": ""}
 
     def test_owner_email(self):
-        result = self.parse_query("owner:%s" % (self.user.email,))
+        result = self.parse_query(f"owner:{self.user.email}")
         assert result == {"owner": self.user, "tags": {}, "query": ""}
 
     def test_owner_unknown_user(self):

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -297,12 +297,12 @@ class ParseQueryTest(TestCase):
         assert result["assigned_to"].id == 0
 
     def test_assigned_valid_team(self):
-        result = self.parse_query("assigned:#{}".format(self.team.slug))
+        result = self.parse_query(f"assigned:#{self.team.slug}")
         assert result["assigned_to"] == self.team
 
     def test_assigned_unassociated_team(self):
         team2 = self.create_team(organization=self.organization)
-        result = self.parse_query("assigned:#{}".format(team2.slug))
+        result = self.parse_query(f"assigned:#{team2.slug}")
         assert isinstance(result["assigned_to"], Team)
         assert result["assigned_to"].id == 0
 
@@ -528,12 +528,12 @@ class ParseQueryTest(TestCase):
         assert result["owner"].id == 0
 
     def test_owner_valid_team(self):
-        result = self.parse_query("owner:#{}".format(self.team.slug))
+        result = self.parse_query(f"owner:#{self.team.slug}")
         assert result["owner"] == self.team
 
     def test_owner_unassociated_team(self):
         team2 = self.create_team(organization=self.organization)
-        result = self.parse_query("owner:#{}".format(team2.slug))
+        result = self.parse_query(f"owner:#{team2.slug}")
         assert isinstance(result["owner"], Team)
         assert result["owner"].id == 0
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -238,7 +238,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
         result = discover.query(
             selected_columns=["id", "message"],
-            query="release:{}".format(self.release.version),
+            query=f"release:{self.release.version}",
             params={"project_id": [self.project.id]},
         )
         assert len(result["data"]) == 1
@@ -269,7 +269,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
         result = discover.query(
             selected_columns=["id", "message"],
-            query="environment:{}".format(self.environment.name),
+            query=f"environment:{self.environment.name}",
             params={"project_id": [self.project.id]},
         )
         assert len(result["data"]) == 1
@@ -292,7 +292,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
         result = discover.query(
             selected_columns=["project", "message"],
-            query="project:{} OR project:{}".format(self.project.slug, project2.slug),
+            query=f"project:{self.project.slug} OR project:{project2.slug}",
             params={"project_id": [self.project.id, project2.id]},
             orderby="message",
         )
@@ -377,7 +377,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
             for i in range(ev[1]):
                 data = load_data("transaction")
                 data["timestamp"] = iso_format(before_now(seconds=1))
-                data["transaction"] = "{}-{}".format(val, i)
+                data["transaction"] = f"{val}-{i}"
                 data["message"] = val
                 data["tags"] = {"trek": val}
                 self.store_event(data=data, project_id=self.project.id)
@@ -404,7 +404,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
             for i in range(ev[1]):
                 data = load_data("transaction")
                 data["timestamp"] = iso_format(before_now(seconds=1))
-                data["transaction"] = "{}-{}".format(val, i)
+                data["transaction"] = f"{val}-{i}"
                 data["message"] = val
                 data["tags"] = {"trek": val}
                 self.store_event(data=data, project_id=self.project.id)
@@ -441,7 +441,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
             val = ev[0] * 32
             for i in range(ev[1]):
                 data = load_data("transaction", timestamp=before_now(seconds=3 * t + 1))
-                data["transaction"] = "{}".format(val)
+                data["transaction"] = f"{val}"
                 self.store_event(data=data, project_id=self.project.id)
 
         results = discover.query(
@@ -561,8 +561,8 @@ class QueryTransformTest(TestCase):
                     "transform",
                     [
                         ["toString", ["project_id"]],
-                        ["array", ["'{}'".format(self.project.id)]],
-                        ["array", ["'{}'".format(self.project.slug)]],
+                        ["array", [f"'{self.project.id}'"]],
+                        ["array", [f"'{self.project.slug}'"]],
                         "''",
                     ],
                     "project",
@@ -591,7 +591,7 @@ class QueryTransformTest(TestCase):
         }
         discover.query(
             selected_columns=["title", "project"],
-            query="project:{}".format(project2.slug),
+            query=f"project:{project2.slug}",
             params={"project_id": [self.project.id, project2.id]},
         )
         mock_query.assert_called_with(
@@ -602,8 +602,8 @@ class QueryTransformTest(TestCase):
                     "transform",
                     [
                         ["toString", ["project_id"]],
-                        ["array", ["'{}'".format(project2.id)]],
-                        ["array", ["'{}'".format(project2.slug)]],
+                        ["array", [f"'{project2.id}'"]],
+                        ["array", [f"'{project2.slug}'"]],
                         "''",
                     ],
                     "project",
@@ -632,7 +632,7 @@ class QueryTransformTest(TestCase):
         }
         discover.query(
             selected_columns=["title", "project", "p99()"],
-            query="project:{}".format(project2.slug),
+            query=f"project:{project2.slug}",
             params={"project_id": [self.project.id, project2.id]},
         )
         mock_query.assert_called_with(
@@ -643,8 +643,8 @@ class QueryTransformTest(TestCase):
                     "transform",
                     [
                         ["toString", ["project_id"]],
-                        ["array", ["'{}'".format(project2.id)]],
-                        ["array", ["'{}'".format(project2.slug)]],
+                        ["array", [f"'{project2.id}'"]],
+                        ["array", [f"'{project2.slug}'"]],
                         "''",
                     ],
                     "project",
@@ -1038,7 +1038,7 @@ class QueryTransformTest(TestCase):
             selected_columns=["transaction"],
             conditions=[
                 ["type", "=", "transaction"],
-                [["match", ["email", "'(?i)^.*@sentry\.io$'"]], "=", 1],
+                [["match", ["email", r"'(?i)^.*@sentry\.io$'"]], "=", 1],
                 [["positionCaseInsensitive", ["message", "'recent-searches'"]], "!=", 0],
             ],
             aggregations=[["count", None, "count"]],
@@ -1122,7 +1122,7 @@ class QueryTransformTest(TestCase):
         # project_id condition.
         discover.query(
             selected_columns=["transaction", "transaction.duration"],
-            query="project.name:{}".format(project2.slug),
+            query=f"project.name:{project2.slug}",
             params={"project_id": [self.project.id, project2.id]},
         )
         mock_query.assert_called_with(
@@ -1252,7 +1252,7 @@ class QueryTransformTest(TestCase):
             }
             discover.query(
                 selected_columns=["transaction", "p95()"],
-                query="http.method:GET p95():>{}".format(query_string),
+                query=f"http.method:GET p95():>{query_string}",
                 params={"project_id": [self.project.id], "start": start_time, "end": end_time},
                 use_aggregate_conditions=True,
             )
@@ -1356,7 +1356,7 @@ class QueryTransformTest(TestCase):
             }
             discover.query(
                 selected_columns=["transaction", "avg(transaction.duration)", "max(time)"],
-                query="http.method:GET avg(transaction.duration):>{}".format(query_string),
+                query=f"http.method:GET avg(transaction.duration):>{query_string}",
                 params={"project_id": [self.project.id], "start": start_time, "end": end_time},
                 use_aggregate_conditions=True,
             )
@@ -2277,7 +2277,7 @@ class TimeseriesQueryTest(SnubaTestCase, TestCase):
 
         result = discover.timeseries_query(
             selected_columns=["count()"],
-            query="project:{} OR project:{}".format(self.project.slug, project2.slug),
+            query=f"project:{self.project.slug} OR project:{project2.slug}",
             params={
                 "start": before_now(minutes=5),
                 "end": before_now(seconds=1),
@@ -2333,7 +2333,7 @@ class TimeseriesQueryTest(SnubaTestCase, TestCase):
 
 
 def format_project_event(project_slug, event_id):
-    return "{}:{}".format(project_slug, event_id)
+    return f"{project_slug}:{event_id}"
 
 
 class GetFacetsTest(SnubaTestCase, TestCase):

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -132,7 +132,7 @@ class UpdateSubscriptionInSnubaTest(BaseSnubaTaskTest, TestCase):
     task = update_subscription_in_snuba
 
     def test(self):
-        subscription_id = "1/{}".format(uuid4().hex)
+        subscription_id = f"1/{uuid4().hex}"
         sub = self.create_subscription(
             QuerySubscription.Status.UPDATING, subscription_id=subscription_id
         )
@@ -156,7 +156,7 @@ class DeleteSubscriptionFromSnubaTest(BaseSnubaTaskTest, TestCase):
     task = delete_subscription_from_snuba
 
     def test(self):
-        subscription_id = "1/{}".format(uuid4().hex)
+        subscription_id = f"1/{uuid4().hex}"
         sub = self.create_subscription(
             QuerySubscription.Status.DELETING, subscription_id=subscription_id
         )

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from datetime import timedelta
 from django.utils import timezone
 

--- a/tests/sentry/tasks/process_buffer/tests.py
+++ b/tests/sentry/tasks/process_buffer/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.utils.compat import mock
 
 from sentry.tasks.process_buffer import process_incr, process_pending

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -30,13 +30,13 @@ class BaseAssembleTest(TestCase):
 
 class AssembleDifTest(BaseAssembleTest):
     def test_wrong_dif(self):
-        content1 = "foo".encode("utf-8")
+        content1 = b"foo"
         fileobj1 = ContentFile(content1)
 
-        content2 = "bar".encode("utf-8")
+        content2 = b"bar"
         fileobj2 = ContentFile(content2)
 
-        content3 = "baz".encode("utf-8")
+        content3 = b"baz"
         fileobj3 = ContentFile(content3)
 
         total_checksum = sha1(content2 + content1 + content3).hexdigest()

--- a/tests/sentry/tasks/test_digests.py
+++ b/tests/sentry/tasks/test_digests.py
@@ -26,7 +26,7 @@ class DeliverDigestTest(TestCase):
             data={"timestamp": iso_format(before_now(days=1)), "fingerprint": ["group-2"]},
             project_id=self.project.id,
         )
-        key = "mail:p:{}".format(self.project.id)
+        key = f"mail:p:{self.project.id}"
         backend.add(key, event_to_record(event, [rule]), increment_delay=0, maximum_delay=0)
         backend.add(key, event_to_record(event_2, [rule]), increment_delay=0, maximum_delay=0)
         digests.digest = backend.digest
@@ -36,12 +36,12 @@ class DeliverDigestTest(TestCase):
 
     @patch.object(sentry, "digests")
     def test_old_key(self, digests):
-        self.run_test("mail:p:{}".format(self.project.id), digests)
+        self.run_test(f"mail:p:{self.project.id}", digests)
 
     @patch.object(sentry, "digests")
     def test_new_key(self, digests):
-        self.run_test("mail:p:{}:IssueOwners:".format(self.project.id), digests)
+        self.run_test(f"mail:p:{self.project.id}:IssueOwners:", digests)
 
     @patch.object(sentry, "digests")
     def test_member_key(self, digests):
-        self.run_test("mail:p:{}:Member:{}".format(self.project.id, self.user.id), digests)
+        self.run_test(f"mail:p:{self.project.id}:Member:{self.user.id}", digests)

--- a/tests/sentry/tasks/test_members.py
+++ b/tests/sentry/tasks/test_members.py
@@ -32,5 +32,5 @@ class InviteRequestNotificationTest(TestCase):
         assert mail.outbox[0].to == ["manager@localhost"]
         assert mail.outbox[1].to == ["owner@localhost"]
 
-        expected_subject = "Access request to %s" % (organization.name,)
+        expected_subject = f"Access request to {organization.name}"
         assert mail.outbox[0].subject == expected_subject

--- a/tests/sentry/tasks/test_queues_registered.py
+++ b/tests/sentry/tasks/test_queues_registered.py
@@ -13,7 +13,7 @@ class CeleryQueueRegisteredTest(TestCase):
             if task.name.startswith("celery.") or not hasattr(task, "queue"):
                 continue
             if task.queue not in queue_names:
-                missing_queue_tasks.append(" - Task: {}, Queue: {}".format(task.name, task.queue))
+                missing_queue_tasks.append(f" - Task: {task.name}, Queue: {task.queue}")
 
         assert not missing_queue_tasks, (
             "Found tasks with queues that are undefined. These must be defined in "

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -147,7 +147,7 @@ class TestSendAlertEvent(TestCase):
                             args=[self.organization.slug, group.id, event.event_id],
                         )
                     ),
-                    issue_url=absolute_uri("/api/0/issues/{}/".format(group.id)),
+                    issue_url=absolute_uri(f"/api/0/issues/{group.id}/"),
                 ),
                 "triggered_rule": self.rule.label,
             },

--- a/tests/sentry/tasks/test_servicehooks.py
+++ b/tests/sentry/tasks/test_servicehooks.py
@@ -83,11 +83,11 @@ class TestServiceHooks(TestCase):
 
         process_service_hook(self.hook.id, event)
         body = get_payload_v0(event)
-        assert body["group"]["url"] == "http://testserver/organizations/{}/issues/{}/".format(
-            self.organization.slug, event.group.id
+        assert (
+            body["group"]["url"]
+            == f"http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/"
         )
-        assert body["event"][
-            "url"
-        ] == "http://testserver/organizations/{}/issues/{}/events/{}/".format(
-            self.organization.slug, event.group.id, event.event_id
+        assert (
+            body["event"]["url"]
+            == f"http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/events/{event.event_id}/"
         )

--- a/tests/sentry/templatetags/test_sentry_plugins.py
+++ b/tests/sentry/templatetags/test_sentry_plugins.py
@@ -7,11 +7,11 @@ from sentry.testutils import PluginTestCase
 
 class SamplePlugin(Plugin2):
     def get_actions(self, request, group):
-        return [("Example Action", "http://example.com?id=%s" % (group.id,))]
+        return [("Example Action", f"http://example.com?id={group.id}")]
 
     def get_annotations(self, group):
         return [
-            {"label": "Example Tag", "url": "http://example.com?id=%s" % (group.id,)},
+            {"label": "Example Tag", "url": f"http://example.com?id={group.id}"},
             {"label": "Example Two"},
         ]
 
@@ -35,7 +35,7 @@ class GetActionsTest(PluginTestCase):
         group = self.create_group()
         result = self.TEMPLATE.render(context={"group": group}, request=MagicMock())
 
-        assert "<span>Example Action - http://example.com?id=%s</span>" % (group.id,) in result
+        assert f"<span>Example Action - http://example.com?id={group.id}</span>" in result
 
 
 class GetAnnotationsTest(PluginTestCase):
@@ -54,5 +54,5 @@ class GetAnnotationsTest(PluginTestCase):
         group = self.create_group()
         result = self.TEMPLATE.render(context={"group": group}, request=MagicMock())
 
-        assert "<span>Example Tag - http://example.com?id=%s</span>" % (group.id,) in result
+        assert f"<span>Example Tag - http://example.com?id={group.id}</span>" in result
         assert "<span>Example Two - None</span>" in result

--- a/tests/sentry/test_canonical.py
+++ b/tests/sentry/test_canonical.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import unittest
 
 from collections import OrderedDict

--- a/tests/sentry/test_celery.py
+++ b/tests/sentry/test_celery.py
@@ -6,4 +6,4 @@ def test_import_paths():
         try:
             __import__(path)
         except ImportError:
-            raise AssertionError("Unable to import {} from CELERY_IMPORTS".format(path))
+            raise AssertionError(f"Unable to import {path} from CELERY_IMPORTS")

--- a/tests/sentry/test_datascrubbing.py
+++ b/tests/sentry/test_datascrubbing.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import copy
 import pytest
 

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 import pytz
 

--- a/tests/sentry/utils/hashlib/tests.py
+++ b/tests/sentry/utils/hashlib/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytest
 import six
 
@@ -13,7 +10,7 @@ HASHLIB_VALUES_TESTS = (
     ("seed", True, "1057fb936dc9056388c0b9b48dd0c7df"),
     ("seed", False, "07aae33053c0f3487882d61353780682"),
     ("seed", 42, "d1ce9a19d659ae70a6b76ef6029ae542"),
-    ("seed", six.binary_type("test".encode("utf-8")), "334e3fd2f66966a5c785d825c5f03494"),
+    ("seed", six.binary_type(b"test"), "334e3fd2f66966a5c785d825c5f03494"),
     ("seed", six.text_type("test"), "ce35c0ce0d38976f61a5ca951de74a16"),
     ("seed", (4, 2), "d03b32e798444249d726158594d370f6"),
     ("seed", {six.text_type("test"): 42}, "ca094da15d323155e3954cff7ca373c4"),

--- a/tests/sentry/utils/http/tests.py
+++ b/tests/sentry/utils/http/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.utils.compat import mock
 import unittest
 

--- a/tests/sentry/utils/http/tests.py
+++ b/tests/sentry/utils/http/tests.py
@@ -22,7 +22,7 @@ class AbsoluteUriTest(unittest.TestCase):
         assert absolute_uri() == options.get("system.url-prefix")
 
     def test_with_path(self):
-        assert absolute_uri("/foo/bar") == "%s/foo/bar" % (options.get("system.url-prefix"),)
+        assert absolute_uri("/foo/bar") == "{}/foo/bar".format(options.get("system.url-prefix"))
 
 
 class SameDomainTestCase(unittest.TestCase):

--- a/tests/sentry/utils/json/tests.py
+++ b/tests/sentry/utils/json/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import datetime
 import uuid
 
@@ -33,11 +30,11 @@ class JSONTest(TestCase):
         assert json.dumps(res) == "\"<script>alert('&');</script>\""
         assert (
             json.dumps(res, escape=True).encode("utf-8")
-            == b'"\\u003cscript\\u003ealert(\\u0027\u0026\\u0027);\\u003c/script\\u003e"'
+            == b'"\\u003cscript\\u003ealert(\\u0027\\u0026\\u0027);\\u003c/script\\u003e"'
         )
         assert (
             json.dumps_htmlsafe(res).encode("utf-8")
-            == b'"\\u003cscript\\u003ealert(\\u0027\u0026\\u0027);\\u003c/script\\u003e"'
+            == b'"\\u003cscript\\u003ealert(\\u0027\\u0026\\u0027);\\u003c/script\\u003e"'
         )
 
     def test_inf(self):

--- a/tests/sentry/utils/test_encryption.py
+++ b/tests/sentry/utils/test_encryption.py
@@ -10,7 +10,7 @@ class EncryptionManagerTest(TestCase):
             schemes=(("1", Fernet("J5NxyG0w1OyZEDdEOX0Nyv2upm5H3J35rTEb1jEiVbs=")),)
         )
         value = manager.encrypt("hello world")
-        assert value.startswith("{}1$".format(MARKER))
+        assert value.startswith(f"{MARKER}1$")
         result = manager.decrypt(value)
         assert result == "hello world"
 
@@ -27,7 +27,7 @@ class EncryptionManagerTest(TestCase):
 
         value2 = manager.encrypt("hello world")
         assert value2 != value
-        assert value2.startswith("{}2$".format(MARKER))
+        assert value2.startswith(f"{MARKER}2$")
 
     def test_no_schemes(self):
         manager = EncryptionManager(schemes=())

--- a/tests/sentry/utils/test_glob.py
+++ b/tests/sentry/utils/test_glob.py
@@ -13,7 +13,7 @@ class GlobInput(object):
         return glob_match(self.value, self.pat, **self.kwargs)
 
     def __repr__(self):
-        return "<GlobInput %r>" % (self.__dict__,)
+        return f"<GlobInput {self.__dict__!r}>"
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/utils/test_kafka_config.py
+++ b/tests/sentry/utils/test_kafka_config.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import os
 import pytest
 from django.test import override_settings

--- a/tests/sentry/utils/test_linksign.py
+++ b/tests/sentry/utils/test_linksign.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.test import override_settings
 from django.test.client import RequestFactory
 

--- a/tests/sentry/utils/test_retries.py
+++ b/tests/sentry/utils/test_retries.py
@@ -31,7 +31,7 @@ class TimedRetryPolicyTestCase(TestCase):
         except RetryException as exception:
             assert exception.exception is bomb
         else:
-            self.fail("Expected {!r}!".format(RetryException))
+            self.fail(f"Expected {RetryException!r}!")
 
         assert callable.call_count == 2
 

--- a/tests/sentry/utils/test_types.py
+++ b/tests/sentry/utils/test_types.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.utils.types import InvalidTypeError, Any, Bool, Int, Float, String, Dict, Sequence
 from unittest import TestCase
 

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from sentry.utils.compat import mock
 
 from django.core.urlresolvers import reverse

--- a/tests/sentry/web/frontend/test_auth_oauth2.py
+++ b/tests/sentry/web/frontend/test_auth_oauth2.py
@@ -75,7 +75,7 @@ class AuthOAuth2Test(AuthProviderTestCase):
         urlopen.return_value = MockResponse(headers, json.dumps(auth_data))
 
         query = urlencode({"code": "1234", "state": state})
-        resp = self.client.get("{}?{}".format(self.sso_path, query), **kwargs)
+        resp = self.client.get(f"{self.sso_path}?{query}", **kwargs)
 
         if expect_success:
             assert resp.status_code == 200

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -18,7 +18,7 @@ class ErrorPageEmbedTest(TestCase):
         self.key = self.create_project_key(self.project)
         self.event_id = uuid4().hex
         self.path = reverse("sentry-error-page-embed")
-        self.path_with_qs = "%s?eventId=%s&dsn=%s" % (
+        self.path_with_qs = "{}?eventId={}&dsn={}".format(
             self.path,
             quote(self.event_id),
             quote(self.key.dsn_public),
@@ -47,7 +47,7 @@ class ErrorPageEmbedTest(TestCase):
         assert resp["Content-Type"] == "text/javascript"
 
     def test_missing_eventId(self):
-        path = "%s?dsn=%s" % (self.path, quote(self.key.dsn_public))
+        path = "{}?dsn={}".format(self.path, quote(self.key.dsn_public))
         with self.settings(SENTRY_ALLOW_ORIGIN="*"):
             resp = self.client.get(
                 path, HTTP_REFERER="http://example.com", HTTP_ACCEPT="text/html, text/javascript"
@@ -58,7 +58,7 @@ class ErrorPageEmbedTest(TestCase):
         assert resp.content == b""
 
     def test_missing_dsn(self):
-        path = "%s?eventId=%s" % (self.path, quote(self.event_id))
+        path = "{}?eventId={}".format(self.path, quote(self.event_id))
         with self.settings(SENTRY_ALLOW_ORIGIN="*"):
             resp = self.client.get(
                 path, HTTP_REFERER="http://example.com", HTTP_ACCEPT="text/html, text/javascript"
@@ -110,7 +110,7 @@ class ErrorPageEmbedTest(TestCase):
             )
 
         user_feedback_options_qs = urlencode(user_feedback_options)
-        path_with_qs = "%s?eventId=%s&dsn=%s&%s" % (
+        path_with_qs = "{}?eventId={}&dsn={}&{}".format(
             self.path,
             quote(self.event_id),
             quote(self.key.dsn_public),
@@ -162,7 +162,7 @@ class ErrorPageEmbedTest(TestCase):
 
     def test_submission_invalid_event_id(self):
         self.event_id = "x" * 100
-        path = "%s?eventId=%s&dsn=%s" % (
+        path = "{}?eventId={}&dsn={}".format(
             self.path,
             quote(self.event_id),
             quote(self.key.dsn_public),
@@ -184,7 +184,7 @@ class ErrorPageEmbedEnvironmentTest(TestCase):
         self.project.update_option("sentry:origins", ["example.com"])
         self.key = self.create_project_key(self.project)
         self.event_id = uuid4().hex
-        self.path = "%s?eventId=%s&dsn=%s" % (
+        self.path = "{}?eventId={}&dsn={}".format(
             reverse("sentry-error-page-embed"),
             quote(self.event_id),
             quote(self.key.dsn_public),

--- a/tests/sentry/web/frontend/test_group_event_json.py
+++ b/tests/sentry/web/frontend/test_group_event_json.py
@@ -8,9 +8,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 class GroupEventJsonTest(TestCase):
     @fixture
     def path(self):
-        return "/organizations/{}/issues/{}/events/{}/json/".format(
-            self.organization.slug, self.event.group_id, self.event.event_id
-        )
+        return f"/organizations/{self.organization.slug}/issues/{self.event.group_id}/events/{self.event.event_id}/json/"
 
     def test_does_render(self):
         self.login_as(self.user)

--- a/tests/sentry/web/frontend/test_group_tag_export.py
+++ b/tests/sentry/web/frontend/test_group_tag_export.py
@@ -30,9 +30,7 @@ class GroupTagExportTest(TestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "/{}/{}/issues/{}/tags/{}/export/?environment={}".format(
-            project.organization.slug, project.slug, group.id, key, self.environment.name
-        )
+        url = f"/{project.organization.slug}/{project.slug}/issues/{group.id}/tags/{key}/export/?environment={self.environment.name}"
 
         response = self.client.get(url)
 

--- a/tests/sentry/web/frontend/test_home.py
+++ b/tests/sentry/web/frontend/test_home.py
@@ -38,4 +38,4 @@ class HomeTest(TestCase):
         with self.feature("organizations:create"):
             resp = self.client.get(self.path)
 
-        self.assertRedirects(resp, "/organizations/{}/issues/".format(org.slug))
+        self.assertRedirects(resp, f"/organizations/{org.slug}/issues/")

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -82,7 +82,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?response_type=code&client_id={}".format(self.path, self.application.client_id)
+            f"{self.path}?response_type=code&client_id={self.application.client_id}"
         )
 
         assert resp.status_code == 200
@@ -97,7 +97,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         assert not grant.get_scopes()
 
         assert resp.status_code == 302
-        assert resp["Location"] == "https://example.com?code={}".format(grant.code)
+        assert resp["Location"] == f"https://example.com?code={grant.code}"
 
         authorization = ApiAuthorization.objects.get(user=self.user, application=self.application)
         assert authorization.get_scopes() == grant.get_scopes()
@@ -106,7 +106,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?response_type=code&client_id={}".format(self.path, self.application.client_id)
+            f"{self.path}?response_type=code&client_id={self.application.client_id}"
         )
 
         assert resp.status_code == 200
@@ -146,7 +146,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         # XXX: Compare parsed query strings to avoid ordering differences
         # between py2/3
         assert parse_qs(urlparse(resp["Location"]).query) == parse_qs(
-            "state=foo&code={}".format(grant.code)
+            f"state=foo&code={grant.code}"
         )
 
         assert not ApiToken.objects.filter(user=self.user).exists()
@@ -157,7 +157,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         ApiAuthorization.objects.create(user=self.user, application=self.application)
 
         resp = self.client.get(
-            "{}?response_type=code&client_id={}".format(self.path, self.application.client_id)
+            f"{self.path}?response_type=code&client_id={self.application.client_id}"
         )
 
         grant = ApiGrant.objects.get(user=self.user)
@@ -166,7 +166,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         assert not grant.get_scopes()
 
         assert resp.status_code == 302
-        assert resp["Location"] == "https://example.com?code={}".format(grant.code)
+        assert resp["Location"] == f"https://example.com?code={grant.code}"
 
     def test_approve_flow_force_prompt(self):
         self.login_as(self.user)
@@ -233,7 +233,7 @@ class OAuthAuthorizeCodeTest(TestCase):
 
         assert resp.status_code == 200
         self.assertTemplateUsed("sentry/login.html")
-        assert resp.context["banner"] == "Connect Sentry to {}".format(self.application.name)
+        assert resp.context["banner"] == f"Connect Sentry to {self.application.name}"
 
         resp = self.client.post(
             full_path, {"username": self.user.username, "password": "admin", "op": "login"}
@@ -252,7 +252,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         assert not grant.get_scopes()
 
         assert resp.status_code == 302
-        assert resp["Location"] == "https://example.com?code={}".format(grant.code)
+        assert resp["Location"] == f"https://example.com?code={grant.code}"
 
         authorization = ApiAuthorization.objects.get(user=self.user, application=self.application)
         assert authorization.get_scopes() == grant.get_scopes()
@@ -322,7 +322,7 @@ class OAuthAuthorizeTokenTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?response_type=token&client_id={}".format(self.path, self.application.client_id)
+            f"{self.path}?response_type=token&client_id={self.application.client_id}"
         )
 
         assert resp.status_code == 200
@@ -352,7 +352,7 @@ class OAuthAuthorizeTokenTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?response_type=token&client_id={}".format(self.path, self.application.client_id)
+            f"{self.path}?response_type=token&client_id={self.application.client_id}"
         )
 
         assert resp.status_code == 200

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -20,9 +20,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?redirect_uri={}&client_id={}".format(
-                self.path, "https://example.com", self.application.client_id
-            )
+            f"{self.path}?redirect_uri=https://example.com&client_id={self.application.client_id}"
         )
 
         assert resp.status_code == 400
@@ -33,9 +31,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?response_type=foobar&redirect_uri={}&client_id={}".format(
-                self.path, "https://example.com", self.application.client_id
-            )
+            f"{self.path}?response_type=foobar&redirect_uri=https://example.com&client_id={self.application.client_id}"
         )
 
         assert resp.status_code == 400
@@ -45,9 +41,7 @@ class OAuthAuthorizeCodeTest(TestCase):
     def test_missing_client_id(self):
         self.login_as(self.user)
 
-        resp = self.client.get(
-            "{}?response_type=code&redirect_uri={}".format(self.path, "https://example.com")
-        )
+        resp = self.client.get(f"{self.path}?response_type=code&redirect_uri=https://example.com")
 
         assert resp.status_code == 400
         self.assertTemplateUsed("sentry/oauth-error.html")
@@ -259,9 +253,7 @@ class OAuthAuthorizeTokenTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?redirect_uri={}&client_id={}".format(
-                self.path, "https://example.com", self.application.client_id
-            )
+            f"{self.path}?redirect_uri=https://example.com&client_id={self.application.client_id}"
         )
 
         assert resp.status_code == 400
@@ -272,9 +264,7 @@ class OAuthAuthorizeTokenTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?response_type=foobar&redirect_uri={}&client_id={}".format(
-                self.path, "https://example.com", self.application.client_id
-            )
+            f"{self.path}?response_type=foobar&redirect_uri=https://example.com&client_id={self.application.client_id}"
         )
 
         assert resp.status_code == 400
@@ -284,9 +274,7 @@ class OAuthAuthorizeTokenTest(TestCase):
     def test_missing_client_id(self):
         self.login_as(self.user)
 
-        resp = self.client.get(
-            "{}?response_type=token&redirect_uri={}".format(self.path, "https://example.com")
-        )
+        resp = self.client.get(f"{self.path}?response_type=token&redirect_uri=https://example.com")
 
         assert resp.status_code == 400
         self.assertTemplateUsed("sentry/oauth-error.html")

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -57,9 +57,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?response_type=code&client_id={}&scope=foo".format(
-                self.path, self.application.client_id
-            )
+            f"{self.path}?response_type=code&client_id={self.application.client_id}&scope=foo"
         )
 
         assert resp.status_code == 302
@@ -69,9 +67,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?response_type=code&redirect_uri=https://google.com&client_id={}".format(
-                self.path, self.application.client_id
-            )
+            f"{self.path}?response_type=code&redirect_uri=https://google.com&client_id={self.application.client_id}"
         )
 
         assert resp.status_code == 400
@@ -125,9 +121,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?response_type=code&client_id={}&scope=org%3Aread&state=foo".format(
-                self.path, self.application.client_id
-            )
+            f"{self.path}?response_type=code&client_id={self.application.client_id}&scope=org%3Aread&state=foo"
         )
 
         assert resp.status_code == 200
@@ -174,9 +168,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         ApiAuthorization.objects.create(user=self.user, application=self.application)
 
         resp = self.client.get(
-            "{}?response_type=code&client_id={}&force_prompt=1".format(
-                self.path, self.application.client_id
-            )
+            f"{self.path}?response_type=code&client_id={self.application.client_id}&force_prompt=1"
         )
 
         assert resp.status_code == 200
@@ -191,9 +183,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         )
 
         resp = self.client.get(
-            "{}?response_type=code&client_id={}&scope=org:read".format(
-                self.path, self.application.client_id
-            )
+            f"{self.path}?response_type=code&client_id={self.application.client_id}&scope=org:read"
         )
 
         assert resp.status_code == 200
@@ -211,9 +201,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         ApiAuthorization.objects.create(user=self.user, application=self.application)
 
         resp = self.client.get(
-            "{}?response_type=code&client_id={}&scope=member:read member:admin".format(
-                self.path, self.application.client_id
-            )
+            f"{self.path}?response_type=code&client_id={self.application.client_id}&scope=member:read member:admin"
         )
 
         assert resp.status_code == 200
@@ -225,9 +213,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         ]
 
     def test_unauthenticated_basic_auth(self):
-        full_path = "{}?response_type=code&client_id={}".format(
-            self.path, self.application.client_id
-        )
+        full_path = f"{self.path}?response_type=code&client_id={self.application.client_id}"
 
         resp = self.client.get(full_path)
 
@@ -310,9 +296,7 @@ class OAuthAuthorizeTokenTest(TestCase):
         self.login_as(self.user)
 
         resp = self.client.get(
-            "{}?response_type=token&client_id={}&scope=foo".format(
-                self.path, self.application.client_id
-            )
+            f"{self.path}?response_type=token&client_id={self.application.client_id}&scope=foo"
         )
 
         assert resp.status_code == 302

--- a/tests/sentry/web/frontend/test_organization_integration_setup.py
+++ b/tests/sentry/web/frontend/test_organization_integration_setup.py
@@ -6,7 +6,7 @@ from sentry.testutils import PermissionTestCase, TestCase
 class OrganizationIntegrationSetupPermissionTest(PermissionTestCase):
     def setUp(self):
         super(OrganizationIntegrationSetupPermissionTest, self).setUp()
-        self.path = "/organizations/{}/integrations/example/setup/".format(self.organization.slug)
+        self.path = f"/organizations/{self.organization.slug}/integrations/example/setup/"
 
     # this currently redirects the user
     @pytest.mark.xfail
@@ -24,7 +24,7 @@ class OrganizationIntegrationSetupTest(TestCase):
         super(OrganizationIntegrationSetupTest, self).setUp()
         self.organization = self.create_organization(name="foo", owner=self.user)
         self.login_as(self.user)
-        self.path = "/organizations/{}/integrations/example/setup/".format(self.organization.slug)
+        self.path = f"/organizations/{self.organization.slug}/integrations/example/setup/"
 
     def test_basic_flow(self):
         resp = self.client.get(self.path)

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -26,9 +26,7 @@ class ProjectEventTest(SnubaTestCase, TestCase):
         )
         self.assertRedirects(
             resp,
-            "/organizations/{}/issues/{}/events/{}/".format(
-                self.org.slug, self.event.group_id, self.event.event_id
-            ),
+            f"/organizations/{self.org.slug}/issues/{self.event.group_id}/events/{self.event.event_id}/",
         )
 
     def test_event_not_found(self):

--- a/tests/sentry/web/frontend/test_release_webhook.py
+++ b/tests/sentry/web/frontend/test_release_webhook.py
@@ -23,7 +23,7 @@ class ReleaseWebhookTestBase(TestCase):
     def signature(self):
         return hmac.new(
             key=self.token.encode("utf-8"),
-            msg=("{}-{}".format(self.plugin_id, self.project.id)).encode("utf-8"),
+            msg=(f"{self.plugin_id}-{self.project.id}").encode("utf-8"),
             digestmod=sha256,
         ).hexdigest()
 

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -21,7 +21,7 @@ class SetupWizard(PermissionTestCase):
 
         self.login_as(self.user)
 
-        key = "{}{}".format(SETUP_WIZARD_CACHE_KEY, "abc")
+        key = f"{SETUP_WIZARD_CACHE_KEY}abc"
         default_cache.set(key, "test", 600)
 
         url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "abc"})
@@ -46,7 +46,7 @@ class SetupWizard(PermissionTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
 
-        key = "{}{}".format(SETUP_WIZARD_CACHE_KEY, "abc")
+        key = f"{SETUP_WIZARD_CACHE_KEY}abc"
         default_cache.set(key, "test", 600)
 
         url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "abc"})

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -21,7 +21,7 @@ class SetupWizard(PermissionTestCase):
 
         self.login_as(self.user)
 
-        key = "%s%s" % (SETUP_WIZARD_CACHE_KEY, "abc")
+        key = "{}{}".format(SETUP_WIZARD_CACHE_KEY, "abc")
         default_cache.set(key, "test", 600)
 
         url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "abc"})
@@ -46,7 +46,7 @@ class SetupWizard(PermissionTestCase):
         self.project = self.create_project(organization=self.org, teams=[self.team], name="Bengal")
         self.login_as(self.user)
 
-        key = "%s%s" % (SETUP_WIZARD_CACHE_KEY, "abc")
+        key = "{}{}".format(SETUP_WIZARD_CACHE_KEY, "abc")
         default_cache.set(key, "test", 600)
 
         url = reverse("sentry-project-wizard-fetch", kwargs={"wizard_hash": "abc"})

--- a/tests/sentry/web/generic/tests.py
+++ b/tests/sentry/web/generic/tests.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import TestCase

--- a/tests/sentry_plugins/amazon_sqs/test_plugin.py
+++ b/tests/sentry_plugins/amazon_sqs/test_plugin.py
@@ -117,13 +117,13 @@ class AmazonSQSPluginTest(PluginTestCase):
         self.plugin.set_option("s3_bucket", "my_bucket", self.project)
         event = self.run_test()
         date = event.datetime.strftime("%Y-%m-%d")
-        key = "{}/{}/{}".format(event.project.slug, date, event.event_id)
+        key = f"{event.project.slug}/{date}/{event.event_id}"
 
         mock_client.return_value.send_message.assert_called_once_with(
             QueueUrl="https://sqs-us-east-1.amazonaws.com/12345678/myqueue",
             MessageBody=json.dumps(
                 {
-                    "s3Url": "https://my_bucket.s3-us-east-1.amazonaws.com/{}".format(key),
+                    "s3Url": f"https://my_bucket.s3-us-east-1.amazonaws.com/{key}",
                     "eventID": event.event_id,
                 }
             ),

--- a/tests/sentry_plugins/bitbucket/endpoints/test_webhooks.py
+++ b/tests/sentry_plugins/bitbucket/endpoints/test_webhooks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from datetime import datetime
 from django.utils import timezone
 from sentry.models import Commit, CommitAuthor, Repository
@@ -27,7 +25,7 @@ class WebhookTest(APITestCase):
     def test_get(self):
         project = self.project  # force creation
 
-        url = "/plugins/bitbucket/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/bitbucket/organizations/{project.organization.id}/webhook/"
 
         response = self.client.get(url)
 
@@ -35,7 +33,7 @@ class WebhookTest(APITestCase):
 
     def test_unregistered_event(self):
         project = self.project  # force creation
-        url = "/plugins/bitbucket/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/bitbucket/organizations/{project.organization.id}/webhook/"
 
         response = self.client.post(
             path=url,
@@ -60,7 +58,7 @@ class WebhookTest(APITestCase):
     def test_invalid_signature_ip(self):
         project = self.project  # force creation
 
-        url = "/plugins/bitbucket/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/bitbucket/organizations/{project.organization.id}/webhook/"
 
         response = self.client.post(
             path=url,
@@ -77,7 +75,7 @@ class PushEventWebhookTest(APITestCase):
     def test_simple(self):
         project = self.project  # force creation
 
-        url = "/plugins/bitbucket/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/bitbucket/organizations/{project.organization.id}/webhook/"
 
         Repository.objects.create(
             organization_id=project.organization.id,
@@ -116,7 +114,7 @@ class PushEventWebhookTest(APITestCase):
     def test_anonymous_lookup(self):
         project = self.project  # force creation
 
-        url = "/plugins/bitbucket/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/bitbucket/organizations/{project.organization.id}/webhook/"
 
         Repository.objects.create(
             organization_id=project.organization.id,

--- a/tests/sentry_plugins/github/endpoints/test_webhooks.py
+++ b/tests/sentry_plugins/github/endpoints/test_webhooks.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import six
 
 from datetime import datetime
@@ -30,7 +28,7 @@ class WebhookTest(APITestCase):
     def test_get(self):
         project = self.project  # force creation
 
-        url = "/plugins/github/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/github/organizations/{project.organization.id}/webhook/"
 
         response = self.client.get(url)
 
@@ -38,7 +36,7 @@ class WebhookTest(APITestCase):
 
     def test_unregistered_event(self):
         project = self.project  # force creation
-        url = "/plugins/github/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/github/organizations/{project.organization.id}/webhook/"
 
         secret = "b3002c3e321d4b7880360d397db2ccfd"
 
@@ -60,7 +58,7 @@ class WebhookTest(APITestCase):
     def test_invalid_signature_event(self):
         project = self.project  # force creation
 
-        url = "/plugins/github/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/github/organizations/{project.organization.id}/webhook/"
 
         secret = "2d7565c3537847b789d6995dca8d9f84"
 
@@ -84,7 +82,7 @@ class PushEventWebhookTest(APITestCase):
     def test_simple(self):
         project = self.project  # force creation
 
-        url = "/plugins/github/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/github/organizations/{project.organization.id}/webhook/"
 
         secret = "b3002c3e321d4b7880360d397db2ccfd"
 
@@ -139,7 +137,7 @@ class PushEventWebhookTest(APITestCase):
     def test_anonymous_lookup(self):
         project = self.project  # force creation
 
-        url = "/plugins/github/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/github/organizations/{project.organization.id}/webhook/"
 
         secret = "b3002c3e321d4b7880360d397db2ccfd"
 
@@ -344,7 +342,7 @@ class PullRequestEventWebhook(APITestCase):
     def test_opened(self):
         project = self.project  # force creation
 
-        url = "/plugins/github/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/github/organizations/{project.organization.id}/webhook/"
 
         secret = "b3002c3e321d4b7880360d397db2ccfd"
 
@@ -386,7 +384,7 @@ class PullRequestEventWebhook(APITestCase):
     def test_edited(self):
         project = self.project  # force creation
 
-        url = "/plugins/github/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/github/organizations/{project.organization.id}/webhook/"
 
         secret = "b3002c3e321d4b7880360d397db2ccfd"
 
@@ -426,7 +424,7 @@ class PullRequestEventWebhook(APITestCase):
     def test_closed(self):
         project = self.project  # force creation
 
-        url = "/plugins/github/organizations/{}/webhook/".format(project.organization.id)
+        url = f"/plugins/github/organizations/{project.organization.id}/webhook/"
 
         secret = "b3002c3e321d4b7880360d397db2ccfd"
 

--- a/tests/sentry_plugins/github/test_provider.py
+++ b/tests/sentry_plugins/github/test_provider.py
@@ -82,9 +82,7 @@ class GitHubPluginTest(PluginTestCase):
         assert req_json == {
             "active": True,
             "config": {
-                "url": "http://testserver/plugins/github/organizations/{}/webhook/".format(
-                    organization.id
-                ),
+                "url": f"http://testserver/plugins/github/organizations/{organization.id}/webhook/",
                 "secret": self.provider.get_webhook_secret(organization),
                 "content_type": "json",
             },

--- a/tests/sentry_plugins/pagerduty/test_plugin.py
+++ b/tests/sentry_plugins/pagerduty/test_plugin.py
@@ -77,9 +77,7 @@ class PagerDutyPluginTest(PluginTestCase):
             "contexts": [
                 {
                     "text": "View Sentry Issue Details",
-                    "href": "http://example.com/organizations/baz/issues/{}/?referrer=pagerduty_plugin".format(
-                        group.id
-                    ),
+                    "href": f"http://example.com/organizations/baz/issues/{group.id}/?referrer=pagerduty_plugin",
                     "type": "link",
                 }
             ],
@@ -88,9 +86,7 @@ class PagerDutyPluginTest(PluginTestCase):
             "details": {
                 "project": self.project.name,
                 "release": None,
-                "url": "http://example.com/organizations/baz/issues/{}/?referrer=pagerduty_plugin".format(
-                    group.id
-                ),
+                "url": f"http://example.com/organizations/baz/issues/{group.id}/?referrer=pagerduty_plugin",
                 "culprit": group.culprit,
                 "platform": "python",
                 "event_id": event.event_id,

--- a/tests/sentry_plugins/pushover/test_plugin.py
+++ b/tests/sentry_plugins/pushover/test_plugin.py
@@ -55,9 +55,7 @@ class PushoverPluginTest(PluginTestCase):
             "message": [f"{event.title}\n\nTags: level=warning"],
             "title": ["Bar: Hello world"],
             "url": [
-                "http://example.com/organizations/baz/issues/{}/?referrer=pushover_plugin".format(
-                    group.id
-                )
+                f"http://example.com/organizations/baz/issues/{group.id}/?referrer=pushover_plugin"
             ],
             "url_title": ["Issue Details"],
             "priority": ["0"],
@@ -94,9 +92,7 @@ class PushoverPluginTest(PluginTestCase):
             "message": [f"{event.title}\n\nTags: level=warning"],
             "title": ["Bar: Hello world"],
             "url": [
-                "http://example.com/organizations/baz/issues/{}/?referrer=pushover_plugin".format(
-                    group.id
-                )
+                f"http://example.com/organizations/baz/issues/{group.id}/?referrer=pushover_plugin"
             ],
             "url_title": ["Issue Details"],
             "priority": ["2"],

--- a/tests/sentry_plugins/pushover/test_plugin.py
+++ b/tests/sentry_plugins/pushover/test_plugin.py
@@ -52,7 +52,7 @@ class PushoverPluginTest(PluginTestCase):
         request = responses.calls[0].request
         payload = parse_qs(request.body)
         assert payload == {
-            "message": ["{}\n\nTags: level=warning".format(event.title)],
+            "message": [f"{event.title}\n\nTags: level=warning"],
             "title": ["Bar: Hello world"],
             "url": [
                 "http://example.com/organizations/baz/issues/{}/?referrer=pushover_plugin".format(
@@ -91,7 +91,7 @@ class PushoverPluginTest(PluginTestCase):
         request = responses.calls[0].request
         payload = parse_qs(request.body)
         assert payload == {
-            "message": ["{}\n\nTags: level=warning".format(event.title)],
+            "message": [f"{event.title}\n\nTags: level=warning"],
             "title": ["Bar: Hello world"],
             "url": [
                 "http://example.com/organizations/baz/issues/{}/?referrer=pushover_plugin".format(

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -27,7 +27,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.post(
-                url + "?project={}".format(self.project.id), {"transaction": data["transaction"]}
+                url + f"?project={self.project.id}", {"transaction": data["transaction"]}
             )
         assert response.status_code == 201
 
@@ -39,7 +39,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.post(
-                url + "?project={}".format(self.project.id), {"transaction": data["transaction"]}
+                url + f"?project={self.project.id}", {"transaction": data["transaction"]}
             )
 
         assert response.status_code == 201
@@ -56,7 +56,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.post(
-                url + "?project={}".format(self.project.id), {"transaction": data["transaction"]}
+                url + f"?project={self.project.id}", {"transaction": data["transaction"]}
             )
 
         user = self.create_user()
@@ -66,7 +66,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.post(
-                url + "?project={}".format(self.project.id), {"transaction": data["transaction"]}
+                url + f"?project={self.project.id}", {"transaction": data["transaction"]}
             )
         assert response.status_code == 201
 
@@ -78,12 +78,12 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.post(
-                url + "?project={}".format(self.project.id), {"transaction": data["transaction"]}
+                url + f"?project={self.project.id}", {"transaction": data["transaction"]}
             )
             assert response.status_code == 201
 
             response = self.client.post(
-                url + "?project={}".format(self.project.id), {"transaction": data["transaction"]}
+                url + f"?project={self.project.id}", {"transaction": data["transaction"]}
             )
             assert response.status_code == 204
 
@@ -103,7 +103,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[other_org.slug])
             response = self.client.post(
-                url + "?project={}".format(other_project.id), {"transaction": data["transaction"]}
+                url + f"?project={other_project.id}", {"transaction": data["transaction"]}
             )
 
         assert response.status_code == 403
@@ -115,7 +115,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.post(
-                url + "?project={}&project={}".format(other_project.id, self.project.id),
+                url + f"?project={other_project.id}&project={self.project.id}",
                 {"transaction": data["transaction"]},
             )
 
@@ -126,7 +126,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.post(
-                url + "?project={}".format(self.project.id), {"transaction": "a" * 500}
+                url + f"?project={self.project.id}", {"transaction": "a" * 500}
             )
 
         assert response.status_code == 400
@@ -151,14 +151,12 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.post(
-                url + "?project={}".format(self.project.id), {"transaction": data["transaction"]}
+                url + f"?project={self.project.id}", {"transaction": data["transaction"]}
             )
 
         assert response.status_code == 400
         assert response.data == {
-            "non_field_errors": [
-                "At most {} Key Transactions can be added".format(MAX_KEY_TRANSACTIONS)
-            ]
+            "non_field_errors": [f"At most {MAX_KEY_TRANSACTIONS} Key Transactions can be added"]
         }
 
     def test_is_key_transaction(self):
@@ -209,7 +207,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.delete(
-                url + "?project={}".format(self.project.id),
+                url + f"?project={self.project.id}",
                 {"transaction": event_data["transaction"]},
             )
 
@@ -245,7 +243,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.delete(
-                url + "?project={}".format(self.project.id),
+                url + f"?project={self.project.id}",
                 {"transaction": event_data["transaction"]},
             )
 
@@ -288,7 +286,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.delete(
-                url + "?project={}".format(self.project.id),
+                url + f"?project={self.project.id}",
                 {"transaction": event_data["transaction"]},
             )
         assert response.status_code == 204
@@ -302,7 +300,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.delete(
-                url + "?project={}".format(self.project.id),
+                url + f"?project={self.project.id}",
                 {"transaction": event_data["transaction"]},
             )
 
@@ -317,7 +315,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[other_org.slug])
             response = self.client.delete(
-                url + "?project={}&project={}".format(other_project.id, self.project.id),
+                url + f"?project={other_project.id}&project={self.project.id}",
                 {"transaction": data["transaction"]},
             )
 
@@ -336,13 +334,13 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[self.org.slug])
             response = self.client.delete(
-                url + "?project={}".format(self.project.id),
+                url + f"?project={self.project.id}",
                 {"transaction": data["transaction"] + "0"},
             )
             assert response.status_code == 204
 
             response = self.client.post(
-                url + "?project={}".format(self.project.id), {"transaction": data["transaction"]}
+                url + f"?project={self.project.id}", {"transaction": data["transaction"]}
             )
             assert response.status_code == 201
 
@@ -361,7 +359,7 @@ class KeyTransactionTest(APITestCase, SnubaTestCase):
         with self.feature("organizations:performance-view"):
             url = reverse("sentry-api-0-organization-key-transactions", args=[other_org.slug])
             response = self.client.delete(
-                url + "?project={}".format(other_project.id), {"transaction": data["transaction"]}
+                url + f"?project={other_project.id}", {"transaction": data["transaction"]}
             )
 
         assert response.status_code == 403

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -89,7 +89,7 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
             model = DiscoverSavedQuery.objects.create(
                 organization=self.org,
                 created_by=self.user,
-                name="My query {}".format(i),
+                name=f"My query {i}",
                 query=query,
                 version=1,
             )
@@ -363,7 +363,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
                     "projects": [],
                     "fields": ["title", "count()"],
                     "range": "24h",
-                    "query": "project:{}".format(project.slug),
+                    "query": f"project:{project.slug}",
                     "version": 2,
                 },
             )
@@ -419,7 +419,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
                     "projects": [project.id],
                     "fields": ["title", "count()"],
                     "range": "24h",
-                    "query": "project:{}".format(project.slug),
+                    "query": f"project:{project.slug}",
                     "version": 2,
                 },
             )
@@ -435,7 +435,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
                     "projects": [project.id, project2.id],
                     "fields": ["title", "count()"],
                     "range": "24h",
-                    "query": "project:{} project:{}".format(project.slug, project2.slug),
+                    "query": f"project:{project.slug} project:{project2.slug}",
                     "version": 2,
                 },
             )
@@ -452,7 +452,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
                     "projects": [-1],
                     "fields": ["title", "count()"],
                     "range": "24h",
-                    "query": "project:{} project:{}".format(project.slug, project2.slug),
+                    "query": f"project:{project.slug} project:{project2.slug}",
                     "version": 2,
                 },
             )

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -15,7 +15,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         environment = Environment.get_or_create(group.project, "production")
         environment2 = Environment.get_or_create(group.project, "staging")
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         from sentry.api.endpoints.group_details import tsdb
 
@@ -61,7 +61,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         group = event.group
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -89,7 +89,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         group = event.group
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         with mock.patch(
             "sentry.api.endpoints.group_details.tagstore.get_release_tags"
@@ -116,7 +116,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         group = event.group
 
-        url = "/api/0/issues/{}/".format(group.id)
+        url = f"/api/0/issues/{group.id}/"
 
         response = self.client.get(url, format="json")
         assert response.status_code == 200, response.content
@@ -140,7 +140,7 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             group = event.group
             add_group_to_inbox(group, GroupInboxReason.NEW)
 
-            url = "/api/0/issues/{}/?expand=inbox".format(group.id)
+            url = f"/api/0/issues/{group.id}/?expand=inbox"
 
             response = self.client.get(url, format="json")
             assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_group_details.py
+++ b/tests/snuba/api/endpoints/test_group_details.py
@@ -23,14 +23,14 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             "sentry.api.endpoints.group_details.tsdb.get_range", side_effect=tsdb.get_range
         ) as get_range:
             response = self.client.get(
-                "%s?environment=production&environment=staging" % (url,), format="json"
+                f"{url}?environment=production&environment=staging", format="json"
             )
             assert response.status_code == 200
             assert get_range.call_count == 2
             for args, kwargs in get_range.call_args_list:
                 assert kwargs["environment_ids"] == [environment.id, environment2.id]
 
-        response = self.client.get("%s?environment=invalid" % (url,), format="json")
+        response = self.client.get(f"{url}?environment=invalid", format="json")
         assert response.status_code == 404
 
     def test_with_first_last_release(self):

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -34,7 +34,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             project_id=self.project.id,
         )
 
-        url = "/api/0/issues/{}/events/".format(event_1.group.id)
+        url = f"/api/0/issues/{event_1.group.id}/events/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -63,7 +63,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             },
             project_id=self.project.id,
         )
-        url = "/api/0/issues/{}/events/".format(event_1.group.id)
+        url = f"/api/0/issues/{event_1.group.id}/events/"
         response = self.client.get(url + "?query=foo:baz", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -129,7 +129,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             },
             project_id=self.project.id,
         )
-        url = "/api/0/issues/{}/events/?query={}".format(event_1.group.id, event_1.event_id)
+        url = f"/api/0/issues/{event_1.group.id}/events/?query={event_1.event_id}"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -164,7 +164,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         query_2 = "hello+world"
 
         # Single Word Query
-        url = "/api/0/issues/{}/events/?query={}".format(group.id, query_1)
+        url = f"/api/0/issues/{group.id}/events/?query={query_1}"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -172,7 +172,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         assert response.data[0]["eventID"] == event_1.event_id
 
         # Multiple Word Query
-        url = "/api/0/issues/{}/events/?query={}".format(group.id, query_2)
+        url = f"/api/0/issues/{group.id}/events/?query={query_2}"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -193,7 +193,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             },
             project_id=self.project.id,
         )
-        url = "/api/0/issues/{}/events/?query=release:latest".format(event_1.group.id)
+        url = f"/api/0/issues/{event_1.group.id}/events/?query=release:latest"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -217,7 +217,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         # Asserts that all are in the same group
         (group_id,) = set(e.group.id for e in events.values())
 
-        url = "/api/0/issues/{}/events/".format(group_id)
+        url = f"/api/0/issues/{group_id}/events/"
         response = self.client.get(url + "?environment=production", format="json")
 
         assert response.status_code == 200, response.content
@@ -258,7 +258,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         group = event_2.group
 
         with self.options({"system.event-retention-days": 1}):
-            response = self.client.get("/api/0/issues/{}/events/".format(group.id))
+            response = self.client.get(f"/api/0/issues/{group.id}/events/")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -277,7 +277,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             project_id=self.project.id,
         )
 
-        response = self.client.get("/api/0/issues/{}/events/".format(event.group.id))
+        response = self.client.get(f"/api/0/issues/{event.group.id}/events/")
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -297,9 +297,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         group = event_1.group
         assert group == event_2.group
 
-        response = self.client.get(
-            "/api/0/issues/{}/events/".format(group.id), data={"statsPeriod": "6d"}
-        )
+        response = self.client.get(f"/api/0/issues/{group.id}/events/", data={"statsPeriod": "6d"})
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
@@ -307,9 +305,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             [six.text_type(event_1.event_id), six.text_type(event_2.event_id)]
         )
 
-        response = self.client.get(
-            "/api/0/issues/{}/events/".format(group.id), data={"statsPeriod": "2d"}
-        )
+        response = self.client.get(f"/api/0/issues/{group.id}/events/", data={"statsPeriod": "2d"})
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
@@ -319,9 +315,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
         first_seen = timezone.now() - timedelta(days=5)
         group = self.create_group(first_seen=first_seen)
-        response = self.client.get(
-            "/api/0/issues/{}/events/".format(group.id), data={"statsPeriod": "lol"}
-        )
+        response = self.client.get(f"/api/0/issues/{group.id}/events/", data={"statsPeriod": "lol"})
         assert response.status_code == 400
 
     def test_invalid_query(self):
@@ -329,7 +323,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         first_seen = timezone.now() - timedelta(days=5)
         group = self.create_group(first_seen=first_seen)
         response = self.client.get(
-            "/api/0/issues/{}/events/".format(group.id),
+            f"/api/0/issues/{group.id}/events/",
             data={"statsPeriod": "7d", "query": "foo(bar"},
         )
         assert response.status_code == 400
@@ -357,7 +351,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         )
 
         for event in (event_1, event_2):
-            url = "/api/0/issues/{}/events/".format(event.group.id)
+            url = f"/api/0/issues/{event.group.id}/events/"
             response = self.client.get(url, format="json")
             assert response.status_code == 200, response.content
             assert len(response.data) == 1, response.data

--- a/tests/snuba/api/endpoints/test_group_events_latest.py
+++ b/tests/snuba/api/endpoints/test_group_events_latest.py
@@ -37,21 +37,21 @@ class GroupEventsLatestTest(APITestCase, SnubaTestCase):
         self.group = Group.objects.first()
 
     def test_snuba_no_environment(self):
-        url = "/api/0/issues/{}/events/latest/".format(self.group.id)
+        url = f"/api/0/issues/{self.group.id}/events/latest/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
         assert response.data["id"] == six.text_type(self.event2.event_id)
 
     def test_snuba_environment(self):
-        url = "/api/0/issues/{}/events/latest/".format(self.group.id)
+        url = f"/api/0/issues/{self.group.id}/events/latest/"
         response = self.client.get(url, format="json", data={"environment": ["production"]})
 
         assert response.status_code == 200
         assert response.data["id"] == six.text_type(self.event2.event_id)
 
     def test_simple(self):
-        url = "/api/0/issues/{}/events/latest/".format(self.group.id)
+        url = f"/api/0/issues/{self.group.id}/events/latest/"
         response = self.client.get(url, format="json")
         assert response.status_code == 200
         assert response.data["eventID"] == six.text_type(self.event2.event_id)

--- a/tests/snuba/api/endpoints/test_group_events_oldest.py
+++ b/tests/snuba/api/endpoints/test_group_events_oldest.py
@@ -36,21 +36,21 @@ class GroupEventsOldestTest(APITestCase, SnubaTestCase):
         self.group = Group.objects.first()
 
     def test_snuba_no_environment(self):
-        url = "/api/0/issues/{}/events/oldest/".format(self.group.id)
+        url = f"/api/0/issues/{self.group.id}/events/oldest/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
         assert response.data["id"] == six.text_type(self.event1.event_id)
 
     def test_snuba_environment(self):
-        url = "/api/0/issues/{}/events/oldest/".format(self.group.id)
+        url = f"/api/0/issues/{self.group.id}/events/oldest/"
         response = self.client.get(url, format="json", data={"environment": ["production"]})
 
         assert response.status_code == 200
         assert response.data["id"] == six.text_type(self.event2.event_id)
 
     def test_simple(self):
-        url = "/api/0/issues/{}/events/oldest/".format(self.group.id)
+        url = f"/api/0/issues/{self.group.id}/events/oldest/"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -8,7 +8,7 @@ from sentry.models import Group
 
 
 def format_project_event(project_slug, event_id):
-    return "{}:{}".format(project_slug, event_id)
+    return f"{project_slug}:{event_id}"
 
 
 class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -580,9 +580,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        response = self.client.get(
-            url, {"query": "project_id:{}".format(project.id)}, format="json"
-        )
+        response = self.client.get(url, {"query": f"project_id:{project.id}"}, format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["projectID"] == six.text_type(project.id)

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -178,18 +178,18 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         )
 
         # test bad project id
-        url = "%s?project=abc" % (base_url,)
+        url = f"{base_url}?project=abc"
         response = self.client.get(url, format="json")
         assert response.status_code == 400
 
         # test including project user doesn't have access to
-        url = "%s?project=%s&project=%s" % (base_url, project.id, project3.id)
+        url = f"{base_url}?project={project.id}&project={project3.id}"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 403
 
         # test filtering by project
-        url = "%s?project=%s" % (base_url, project.id)
+        url = f"{base_url}?project={project.id}"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -218,7 +218,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
             "sentry-api-0-organization-events",
             kwargs={"organization_slug": project.organization.slug},
         )
-        url = "%s?statsPeriod=2h" % (url,)
+        url = f"{url}?statsPeriod=2h"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -245,14 +245,14 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         )
 
         # test swapped order of start/end
-        url = "%s?%s" % (
+        url = "{}?{}".format(
             base_url,
             urlencode({"end": iso_format(before_now(hours=2)), "start": iso_format(now)}),
         )
         response = self.client.get(url, format="json")
         assert response.status_code == 400
 
-        url = "%s?%s" % (
+        url = "{}?{}".format(
             base_url,
             urlencode({"start": iso_format(before_now(hours=2)), "end": iso_format(now)}),
         )
@@ -301,7 +301,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         )
 
         # test as part of query param
-        url = "%s?environment=%s" % (base_url, environment.name)
+        url = f"{base_url}?environment={environment.name}"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -309,7 +309,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         self.assert_events_in_response(response, [event_1.event_id, event_2.event_id])
 
         # test multiple as part of query param
-        url = "%s?%s" % (
+        url = "{}?{}".format(
             base_url,
             urlencode((("environment", environment.name), ("environment", environment2.name))),
         )
@@ -322,7 +322,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         )
 
         # test multiple as part of query param with no env
-        url = "%s?%s" % (
+        url = "{}?{}".format(
             base_url,
             urlencode((("environment", environment.name), ("environment", null_env.name))),
         )
@@ -335,7 +335,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         )
 
         # test as part of search
-        url = "%s?query=environment:%s" % (base_url, environment.name)
+        url = f"{base_url}?query=environment:{environment.name}"
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -343,7 +343,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         self.assert_events_in_response(response, [event_1.event_id, event_2.event_id])
 
         # test as part of search - no environment
-        url = '%s?query=environment:""' % (base_url,)
+        url = f'{base_url}?query=environment:""'
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
@@ -351,7 +351,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         self.assert_events_in_response(response, [event_4.event_id])
 
         # test nonexistent environment
-        url = "%s?environment=notanenvironment" % (base_url,)
+        url = f"{base_url}?environment=notanenvironment"
         response = self.client.get(url, format="json")
         assert response.status_code == 404
 
@@ -386,11 +386,11 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
             "sentry-api-0-organization-events", kwargs={"organization_slug": org.slug}
         )
 
-        response = self.client.get("%s?query=fruit:apple" % (base_url,), format="json")
+        response = self.client.get(f"{base_url}?query=fruit:apple", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         self.assert_events_in_response(response, [event_1.event_id])
-        response = self.client.get("%s?query=!fruit:apple" % (base_url,), format="json")
+        response = self.client.get(f"{base_url}?query=!fruit:apple", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         self.assert_events_in_response(response, [event_2.event_id])
@@ -442,26 +442,24 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
             "sentry-api-0-organization-events", kwargs={"organization_slug": org.slug}
         )
 
-        response = self.client.get("%s?query=release:3.1.*" % (base_url,), format="json")
+        response = self.client.get(f"{base_url}?query=release:3.1.*", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         self.assert_events_in_response(response, [event_1.event_id])
 
-        response = self.client.get("%s?query=!release:3.1.*" % (base_url,), format="json")
+        response = self.client.get(f"{base_url}?query=!release:3.1.*", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 3
         self.assert_events_in_response(
             response, [event_2.event_id, event_3.event_id, event_4.event_id]
         )
 
-        response = self.client.get("%s?query=user.email:*@example.com" % (base_url,), format="json")
+        response = self.client.get(f"{base_url}?query=user.email:*@example.com", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         self.assert_events_in_response(response, [event_3.event_id])
 
-        response = self.client.get(
-            "%s?query=!user.email:*@example.com" % (base_url,), format="json"
-        )
+        response = self.client.get(f"{base_url}?query=!user.email:*@example.com", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 3
         self.assert_events_in_response(
@@ -498,24 +496,24 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
             "sentry-api-0-organization-events", kwargs={"organization_slug": org.slug}
         )
 
-        response = self.client.get("%s?query=has:user.email" % (base_url,), format="json")
+        response = self.client.get(f"{base_url}?query=has:user.email", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         self.assert_events_in_response(response, [event_1.event_id])
 
         # test custom tag
-        response = self.client.get("%s?query=has:example_tag" % (base_url,), format="json")
+        response = self.client.get(f"{base_url}?query=has:example_tag", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         self.assert_events_in_response(response, [event_2.event_id])
 
-        response = self.client.get("%s?query=!has:user.email" % (base_url,), format="json")
+        response = self.client.get(f"{base_url}?query=!has:user.email", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         self.assert_events_in_response(response, [event_2.event_id])
 
         # test custom tag
-        response = self.client.get("%s?query=!has:example_tag" % (base_url,), format="json")
+        response = self.client.get(f"{base_url}?query=!has:example_tag", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         self.assert_events_in_response(response, [event_1.event_id])

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -32,7 +32,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
             if facet["key"] == key:
                 actual = facet
                 break
-        assert actual is not None, "Could not find {} facet in {}".format(key, response.data)
+        assert actual is not None, f"Could not find {key} facet in {response.data}"
         assert "topValues" in actual
         key = lambda row: row["name"] if row["name"] is not None else ""
         assert sorted(expected, key=key) == sorted(actual["topValues"], key=key)
@@ -351,7 +351,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
 
         with self.feature(self.feature_list):
             response = self.client.get(
-                self.url, {"query": "project:{}".format(self.project.slug)}, format="json"
+                self.url, {"query": f"project:{self.project.slug}"}, format="json"
             )
 
         assert response.status_code == 200, response.content

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -38,7 +38,7 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
                     data["timestamp"] = iso_format(start)
                     data["start_timestamp"] = iso_format(start - timedelta(seconds=i))
                     value = random.random() * (spec.end - spec.start) + spec.start
-                    data["transaction"] = "/measurement/{}/value/{}".format(measurement, value)
+                    data["transaction"] = f"/measurement/{measurement}/value/{value}"
 
                     data["measurements"] = {measurement: {"value": value}}
                     self.store_event(data, self.project.id)

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -712,7 +712,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         for index, event_data in enumerate(self.event_data):
             data = event_data["data"].copy()
             for i in range(event_data["count"]):
-                data["event_id"] = "{}{}".format(index, i) * 16
+                data["event_id"] = f"{index}{i}" * 16
                 event = self.store_event(data, project_id=event_data["project"].id)
             self.events.append(event)
         self.transaction = self.events[4]
@@ -1368,10 +1368,10 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "interval": "1h",
                     "yAxis": "count()",
                     # the double underscores around the version alias is because of a comma and quote
-                    "orderby": ["-to_other_release__{}__others_current".format(version_alias)],
+                    "orderby": [f"-to_other_release__{version_alias}__others_current"],
                     "field": [
                         "count()",
-                        'to_other(release,"{}",others,current)'.format(version_escaped),
+                        f'to_other(release,"{version_escaped}",others,current)',
                     ],
                     "topEvents": 2,
                 },

--- a/tests/snuba/api/endpoints/test_organization_events_trends.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trends.py
@@ -32,7 +32,7 @@ class OrganizationEventsTrendsBase(APITestCase, SnubaTestCase):
             data["timestamp"] = iso_format(
                 self.day_ago + timedelta(hours=1, minutes=30 + i, seconds=second[i])
             )
-            data["user"] = {"email": "foo{}@example.com".format(i)}
+            data["user"] = {"email": f"foo{i}@example.com"}
             self.store_event(data, project_id=self.project.id)
 
         self.expected_data = {
@@ -706,9 +706,9 @@ class OrganizationEventsTrendsPagingTest(APITestCase, SnubaTestCase):
                     self.day_ago + timedelta(hours=j, minutes=30, seconds=2)
                 )
                 if i < 5:
-                    data["transaction"] = "transaction_1{}".format(i)
+                    data["transaction"] = f"transaction_1{i}"
                 else:
-                    data["transaction"] = "transaction_2{}".format(i)
+                    data["transaction"] = f"transaction_2{i}"
                 self.store_event(data, project_id=self.project.id)
 
     def _parse_links(self, header):

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -279,7 +279,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         query = {
             "field": ["id", "project.id"],
             "project": [project.id],
-            "query": "!project:{}".format(project2.slug),
+            "query": f"!project:{project2.slug}",
         }
         response = self.do_request(query)
         assert response.status_code == 200
@@ -304,7 +304,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         query = {
             "field": ["id", "project.id"],
             "project": [-1],
-            "query": "!project:{}".format(project2.slug),
+            "query": f"!project:{project2.slug}",
         }
         response = self.do_request(query, features=features)
         assert response.status_code == 200
@@ -371,7 +371,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             field = fields[key]
             query = {
                 "field": ["project", "user"],
-                "query": "{}:{}".format(field, value),
+                "query": f"{field}:{value}",
                 "statsPeriod": "14d",
             }
             response = self.do_request(query, features=features)
@@ -770,7 +770,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
         for i in range(6):
             data = load_data("transaction", timestamp=before_now(minutes=1))
-            data["transaction"] = "/failure_rate/{}".format(i)
+            data["transaction"] = f"/failure_rate/{i}"
             data["contexts"]["trace"]["status"] = "unauthenticated"
             self.store_event(data, project_id=project.id)
 
@@ -799,8 +799,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 timestamp=before_now(minutes=(1 + idx)),
                 start_timestamp=before_now(minutes=(1 + idx), milliseconds=event[1]),
             )
-            data["event_id"] = "{}".format(idx) * 32
-            data["transaction"] = "/user_misery/horribilis/{}".format(idx)
+            data["event_id"] = f"{idx}" * 32
+            data["transaction"] = f"/user_misery/horribilis/{idx}"
             data["user"] = {"email": "{}@example.com".format(event[0])}
             self.store_event(data, project_id=project.id)
         query = {"field": ["user_misery(300)"], "query": "event.type:transaction"}
@@ -1447,7 +1447,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         features = {"organizations:discover-basic": True, "organizations:global-views": True}
         query = {
             "field": ["title", "issue.id"],
-            "query": "!issue:{}".format(event1.group.qualified_short_id),
+            "query": f"!issue:{event1.group.qualified_short_id}",
         }
         response = self.do_request(query, features=features)
         assert response.status_code == 200, response.content
@@ -2383,7 +2383,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
         for i in range(6):
             data = load_data("transaction", timestamp=before_now(minutes=1))
-            data["transaction"] = "/failure_count/{}".format(i)
+            data["transaction"] = f"/failure_count/{i}"
             data["contexts"]["trace"]["status"] = "unauthenticated"
             self.store_event(data, project_id=project.id)
 
@@ -2485,10 +2485,10 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
 
         # a value that's a little bigger than the stored fcp
         fcp = int(self.transaction_data["measurements"]["fcp"]["value"] + 1)
-        response = self.do_request({"field": "count_at_least(measurements.fcp, {})".format(fcp)})
+        response = self.do_request({"field": f"count_at_least(measurements.fcp, {fcp})"})
         assert response.status_code == 200
         assert len(response.data["data"]) == 1
-        assert response.data["data"][0]["count_at_least_measurements_fcp_{}".format(fcp)] == 0
+        assert response.data["data"][0][f"count_at_least_measurements_fcp_{fcp}"] == 0
 
     def test_measurements_query(self):
         self.store_event(self.transaction_data, self.project.id)
@@ -2638,12 +2638,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             )
 
         count_unique = "count_unique(measurements.fcp)"
-        self.assert_measurement_condition_with_results(
-            "{}:1".format(count_unique), field=[count_unique]
-        )
-        self.assert_measurement_condition_without_results(
-            "{}:0".format(count_unique), field=[count_unique]
-        )
+        self.assert_measurement_condition_with_results(f"{count_unique}:1", field=[count_unique])
+        self.assert_measurement_condition_without_results(f"{count_unique}:0", field=[count_unique])
 
     def test_compare_numeric_aggregate(self):
         self.store_event(self.transaction_data, self.project.id)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -563,7 +563,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             group = self.store_event(
                 data={
                     "timestamp": iso_format(before_now(days=day)),
-                    "fingerprint": ["group-{}".format(day)],
+                    "fingerprint": [f"group-{day}"],
                 },
                 project_id=self.project.id,
             ).group
@@ -586,15 +586,13 @@ class GroupListTest(APITestCase, SnubaTestCase):
             (self.organization.id, {"project": [self.project.id]}),
         ]
 
-        response = self.get_response(limit=1, query="assigned:{}".format(self.user.email))
+        response = self.get_response(limit=1, query=f"assigned:{self.user.email}")
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(assigned_groups[1].id)
 
         header_links = parse_link_header(response["Link"])
         cursor = [link for link in header_links.values() if link["rel"] == "next"][0]["cursor"]
-        response = self.get_response(
-            limit=1, cursor=cursor, query="assigned:{}".format(self.user.email)
-        )
+        response = self.get_response(limit=1, cursor=cursor, query=f"assigned:{self.user.email}")
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(assigned_groups[0].id)
 
@@ -820,7 +818,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             assert int(response.data[0]["id"]) == event.group.id
 
             response = self.get_response(
-                sort_by="date", limit=10, query="owner:{}".format(other_user.email)
+                sort_by="date", limit=10, query=f"owner:{other_user.email}"
             )
             assert response.status_code == 200
             assert len(response.data) == 1
@@ -829,17 +827,13 @@ class GroupListTest(APITestCase, SnubaTestCase):
             GroupAssignee.objects.create(
                 group=assigned_event.group, project=assigned_event.group.project, user=self.user
             )
-            response = self.get_response(
-                sort_by="date", limit=10, query="owner:{}".format(self.user.email)
-            )
+            response = self.get_response(sort_by="date", limit=10, query=f"owner:{self.user.email}")
             assert response.status_code == 200
             assert len(response.data) == 2
             assert int(response.data[0]["id"]) == event.group.id
             assert int(response.data[1]["id"]) == assigned_event.group.id
 
-            response = self.get_response(
-                sort_by="date", limit=10, query="owner:#{}".format(self.team.slug)
-            )
+            response = self.get_response(sort_by="date", limit=10, query=f"owner:#{self.team.slug}")
             assert response.status_code == 200
             assert len(response.data) == 0
             GroupOwner.objects.create(
@@ -850,9 +844,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
                 team_id=self.team.id,
                 user_id=None,
             )
-            response = self.get_response(
-                sort_by="date", limit=10, query="owner:#{}".format(self.team.slug)
-            )
+            response = self.get_response(sort_by="date", limit=10, query=f"owner:#{self.team.slug}")
             assert response.status_code == 200
             assert len(response.data) == 1
             assert int(response.data[0]["id"]) == event.group.id
@@ -1028,8 +1020,8 @@ class GroupListTest(APITestCase, SnubaTestCase):
             assert int(response.data[0]["id"]) == event.group.id
             assert response.data[0]["owners"] is not None
             assert len(response.data[0]["owners"]) == 2
-            assert response.data[0]["owners"][0]["owner"] == "user:{}".format(self.user.id)
-            assert response.data[0]["owners"][1]["owner"] == "team:{}".format(self.team.id)
+            assert response.data[0]["owners"][0]["owner"] == f"user:{self.user.id}"
+            assert response.data[0]["owners"][1]["owner"] == f"team:{self.team.id}"
             assert (
                 response.data[0]["owners"][0]["type"]
                 == GROUP_OWNER_TYPE[GroupOwnerType.SUSPECT_COMMIT]
@@ -2034,9 +2026,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         group.project.add_team(team)
 
-        response = self.get_valid_response(
-            qs_params={"id": group.id}, assignedTo="team:{}".format(team.id)
-        )
+        response = self.get_valid_response(qs_params={"id": group.id}, assignedTo=f"team:{team.id}")
         assert response.data["assignedTo"]["id"] == six.text_type(team.id)
         assert response.data["assignedTo"]["type"] == "team"
         assert GroupAssignee.objects.filter(group=group, team=team).exists()

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -52,9 +52,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
     @fixture
     def path(self):
-        return "/api/0/projects/{}/{}/issues/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        return f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/issues/"
 
     def test_sort_by_date_with_tag(self):
         # XXX(dcramer): this tests a case where an ambiguous column name existed
@@ -335,9 +333,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
     @fixture
     def path(self):
-        return "/api/0/projects/{}/{}/issues/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        return f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/issues/"
 
     def assertNoResolution(self, group):
         assert not GroupResolution.objects.filter(group=group).exists()
@@ -583,9 +579,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        url = "{url}?id={group1.id}&id={group2.id}&group4={group4.id}".format(
-            url=self.path, group1=group1, group2=group2, group4=group4
-        )
+        url = f"{self.path}?id={group1.id}&id={group2.id}&group4={group4.id}"
         response = self.client.put(url, data={"status": "resolved"}, format="json")
         assert response.status_code == 200
         assert response.data == {"status": "resolved", "statusDetails": {}}
@@ -1014,9 +1008,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        url = "{url}?id={group1.id}&id={group2.id}&group4={group4.id}".format(
-            url=self.path, group1=group1, group2=group2, group4=group4
-        )
+        url = f"{self.path}?id={group1.id}&id={group2.id}&group4={group4.id}"
         response = self.client.put(url, data={"isBookmarked": "true"}, format="json")
         assert response.status_code == 200
         assert response.data == {"isBookmarked": True}
@@ -1048,9 +1040,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         group4 = self.create_group(project=self.create_project(slug="foo"), checksum="b" * 32)
 
         self.login_as(user=self.user)
-        url = "{url}?id={group1.id}&id={group2.id}&group4={group4.id}".format(
-            url=self.path, group1=group1, group2=group2, group4=group4
-        )
+        url = f"{self.path}?id={group1.id}&id={group2.id}&group4={group4.id}"
         response = self.client.put(url, data={"isSubscribed": "true"}, format="json")
         assert response.status_code == 200
         assert response.data == {"isSubscribed": True, "subscriptionDetails": {"reason": "unknown"}}
@@ -1072,9 +1062,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         group2 = self.create_group(checksum="b" * 32)
 
         self.login_as(user=self.user)
-        url = "{url}?id={group1.id}&id={group2.id}".format(
-            url=self.path, group1=group1, group2=group2
-        )
+        url = f"{self.path}?id={group1.id}&id={group2.id}"
         response = self.client.put(url, data={"isPublic": "true"}, format="json")
         assert response.status_code == 200
         assert response.data["isPublic"] is True
@@ -1096,9 +1084,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             assert bool(g.get_share_id())
 
         self.login_as(user=self.user)
-        url = "{url}?id={group1.id}&id={group2.id}".format(
-            url=self.path, group1=group1, group2=group2
-        )
+        url = f"{self.path}?id={group1.id}&id={group2.id}"
         response = self.client.put(url, data={"isPublic": "false"}, format="json")
         assert response.status_code == 200
         assert response.data == {"isPublic": False, "shareId": None}
@@ -1120,9 +1106,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         )
 
         self.login_as(user=self.user)
-        url = "{url}?id={group1.id}&id={group2.id}&group4={group4.id}".format(
-            url=self.path, group1=group1, group2=group2, group4=group4
-        )
+        url = f"{self.path}?id={group1.id}&id={group2.id}&group4={group4.id}"
         response = self.client.put(url, data={"hasSeen": "true"}, format="json")
         assert response.status_code == 200
         assert response.data == {"hasSeen": True}
@@ -1166,9 +1150,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         self.create_group(checksum="d" * 32)
 
         self.login_as(user=self.user)
-        url = "{url}?id={group1.id}&id={group2.id}&id={group3.id}".format(
-            url=self.path, group1=group1, group2=group2, group3=group3
-        )
+        url = f"{self.path}?id={group1.id}&id={group2.id}&id={group3.id}"
         response = self.client.put(url, data={"merge": "1"}, format="json")
         assert response.status_code == 200
         assert response.data["merge"]["parent"] == six.text_type(group2.id)
@@ -1300,9 +1282,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 class GroupDeleteTest(APITestCase, SnubaTestCase):
     @fixture
     def path(self):
-        return "/api/0/projects/{}/{}/issues/".format(
-            self.project.organization.slug, self.project.slug
-        )
+        return f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/issues/"
 
     @patch("sentry.api.helpers.group_index.eventstream")
     @patch("sentry.eventstream")
@@ -1326,9 +1306,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             GroupHash.objects.create(project=g.project, hash=hash, group=g)
 
         self.login_as(user=self.user)
-        url = "{url}?id={group1.id}&id={group2.id}&group4={group4.id}".format(
-            url=self.path, group1=group1, group2=group2, group4=group4
-        )
+        url = f"{self.path}?id={group1.id}&id={group2.id}&group4={group4.id}"
 
         response = self.client.delete(url, format="json")
 

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -274,7 +274,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             data={"release": release.version, "timestamp": iso_format(before_now(seconds=1))},
             project_id=project2.id,
         )
-        url = "%s?query=%s" % (self.path, 'first-release:"%s"' % release.version)
+        url = "{}?query={}".format(self.path, 'first-release:"%s"' % release.version)
         response = self.client.get(url, format="json")
         issues = json.loads(response.content)
         assert response.status_code == 200
@@ -288,7 +288,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             data={"tags": {"sentry:release": version}}, project_id=self.project.id
         )
         group = event.group
-        url = "%s?query=%s" % (self.path, quote('release:"%s"' % version))
+        url = "{}?query={}".format(self.path, quote('release:"%s"' % version))
         response = self.client.get(url, format="json")
         issues = json.loads(response.content)
         assert response.status_code == 200

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -61,9 +61,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         group1 = self.create_group(checksum="a" * 32, last_seen=before_now(seconds=1))
         self.login_as(user=self.user)
 
-        response = self.client.get(
-            "{}?sort_by=date&query=is:unresolved".format(self.path), format="json"
-        )
+        response = self.client.get(f"{self.path}?sort_by=date&query=is:unresolved", format="json")
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(group1.id)
@@ -72,9 +70,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         self.create_group(checksum="a" * 32, last_seen=before_now(seconds=1))
         self.login_as(user=self.user)
 
-        response = self.client.get(
-            "{}?sort_by=date&query=timesSeen:>1k".format(self.path), format="json"
-        )
+        response = self.client.get(f"{self.path}?sort_by=date&query=timesSeen:>1k", format="json")
         assert response.status_code == 400
         assert "could not" in response.data["detail"]
 
@@ -94,7 +90,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             project_id=self.project.id,
         )
         self.login_as(user=self.user)
-        response = self.client.get("{}?sort_by=date&limit=1".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?sort_by=date&limit=1", format="json")
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["id"] == six.text_type(event2.group.id)
@@ -122,16 +118,16 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        response = self.client.get("{}?statsPeriod=24h".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?statsPeriod=24h", format="json")
         assert response.status_code == 200
 
-        response = self.client.get("{}?statsPeriod=14d".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?statsPeriod=14d", format="json")
         assert response.status_code == 200
 
-        response = self.client.get("{}?statsPeriod=".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?statsPeriod=", format="json")
         assert response.status_code == 200
 
-        response = self.client.get("{}?statsPeriod=48h".format(self.path), format="json")
+        response = self.client.get(f"{self.path}?statsPeriod=48h", format="json")
         assert response.status_code == 400
 
     def test_environment(self):
@@ -203,7 +199,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         response = self.client.get(
-            "{}?query={}&environment=test".format(self.path, event.event_id), format="json"
+            f"{self.path}?query={event.event_id}&environment=test", format="json"
         )
         assert response.status_code == 200
         assert len(response.data) == 1
@@ -242,9 +238,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         short_id = group.qualified_short_id
 
         self.login_as(user=self.user)
-        response = self.client.get(
-            "{}?query={}&shortIdLookup=1".format(self.path, short_id), format="json"
-        )
+        response = self.client.get(f"{self.path}?query={short_id}&shortIdLookup=1", format="json")
         assert response.status_code == 200
         assert len(response.data) == 1
 
@@ -262,10 +256,8 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=user)
 
-        path = "/api/0/projects/{}/{}/issues/".format(organization.slug, project2.slug)
-        response = self.client.get(
-            "{}?query={}&shortIdLookup=1".format(path, short_id), format="json"
-        )
+        path = f"/api/0/projects/{organization.slug}/{project2.slug}/issues/"
+        response = self.client.get(f"{path}?query={short_id}&shortIdLookup=1", format="json")
         assert response.status_code == 200
         assert len(response.data) == 0
 
@@ -362,7 +354,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
         response = self.client.put(
-            "{}?status=unresolved".format(self.path), data={"status": "resolved"}, format="json"
+            f"{self.path}?status=unresolved", data={"status": "resolved"}, format="json"
         )
         assert response.status_code == 200, response.data
         assert response.data == {"status": "resolved", "statusDetails": {}}
@@ -402,21 +394,17 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         for i in range(200):
             self.create_group(status=GroupStatus.UNRESOLVED)
 
-        response = self.client.get(
-            "{}?sort_by=date&query=is:unresolved".format(self.path), format="json"
-        )
+        response = self.client.get(f"{self.path}?sort_by=date&query=is:unresolved", format="json")
 
         assert len(response.data) == 100
 
         response = self.client.put(
-            "{}?status=unresolved".format(self.path), data={"status": "resolved"}, format="json"
+            f"{self.path}?status=unresolved", data={"status": "resolved"}, format="json"
         )
         assert response.status_code == 200, response.data
 
         assert response.data == {"status": "resolved", "statusDetails": {}}
-        response = self.client.get(
-            "{}?sort_by=date&query=is:unresolved".format(self.path), format="json"
-        )
+        response = self.client.get(f"{self.path}?sort_by=date&query=is:unresolved", format="json")
 
         assert len(response.data) == 0
 
@@ -453,16 +441,14 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             relationship=GroupLink.Relationship.references,
         )[0]
 
-        response = self.client.get(
-            "{}?sort_by=date&query=is:unresolved".format(self.path), format="json"
-        )
+        response = self.client.get(f"{self.path}?sort_by=date&query=is:unresolved", format="json")
 
         assert len(response.data) == 1
 
         with self.tasks():
             with self.feature({"organizations:integrations-issue-sync": True}):
                 response = self.client.put(
-                    "{}?status=unresolved".format(self.path),
+                    f"{self.path}?status=unresolved",
                     data={"status": "resolved"},
                     format="json",
                 )
@@ -476,9 +462,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
                     external_issue, True, group.project_id
                 )
 
-        response = self.client.get(
-            "{}?sort_by=date&query=is:unresolved".format(self.path), format="json"
-        )
+        response = self.client.get(f"{self.path}?sort_by=date&query=is:unresolved", format="json")
         assert len(response.data) == 0
 
     @patch("sentry.integrations.example.integration.ExampleIntegration.sync_status_outbound")
@@ -514,7 +498,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
 
         with self.tasks():
             with self.feature({"organizations:integrations-issue-sync": True}):
@@ -541,7 +525,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         uo1 = UserOption.objects.create(key="self_assign_issue", value="1", project=None, user=user)
 
         self.login_as(user=user)
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(url, data={"status": "resolved"}, format="json")
 
         assert response.status_code == 200, response.data
@@ -567,7 +551,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(url, data={"status": "resolvedInNextRelease"}, format="json")
         assert response.status_code == 200
         assert response.data["status"] == "resolved"
@@ -634,7 +618,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(
             url,
             data={"status": "resolved", "statusDetails": {"inRelease": "latest"}},
@@ -671,7 +655,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(
             url,
             data={"status": "resolved", "statusDetails": {"inRelease": release.version}},
@@ -706,7 +690,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(
             url,
             data={"status": "resolved", "statusDetails": {"inNextRelease": True}},
@@ -741,7 +725,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(url, data={"status": "resolvedInNextRelease"}, format="json")
         assert response.status_code == 200
         assert response.data["status"] == "resolved"
@@ -771,7 +755,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(
             url,
             data={
@@ -809,7 +793,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(
             url,
             data={
@@ -849,7 +833,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(
             url,
             data={
@@ -871,7 +855,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(url, data={"status": "unresolved"}, format="json")
         assert response.status_code == 200
         assert response.data == {"status": "unresolved", "statusDetails": {}}
@@ -892,7 +876,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(url, data={"status": "unresolved"}, format="json")
         assert response.status_code == 200
         assert response.data == {"status": "unresolved", "statusDetails": {}}
@@ -907,7 +891,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(url, data={"status": "ignored"}, format="json")
 
         assert response.status_code == 200
@@ -925,7 +909,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(
             url, data={"status": "ignored", "ignoreDuration": 30}, format="json"
         )
@@ -956,7 +940,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(
             url, data={"status": "ignored", "ignoreCount": 100}, format="json"
         )
@@ -996,7 +980,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=self.user)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(
             url, data={"status": "ignored", "ignoreUserCount": 10}, format="json"
         )
@@ -1160,7 +1144,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             group1 = self.create_group(checksum="a" * 32, status=GroupStatus.RESOLVED)
             add_group_to_inbox(group1, GroupInboxReason.NEW)
             self.login_as(user=self.user)
-            url = "{url}?id={group1.id}".format(url=self.path, group1=group1)
+            url = f"{self.path}?id={group1.id}"
             response = self.client.put(url, data={"status": "resolved"}, format="json")
             assert "inbox" in response.data
             assert response.data["inbox"] is None
@@ -1210,7 +1194,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         user = self.user
 
         self.login_as(user=user)
-        url = "{url}?id={group1.id}".format(url=self.path, group1=group1)
+        url = f"{self.path}?id={group1.id}"
         response = self.client.put(url, data={"assignedTo": user.username})
 
         assert response.status_code == 200
@@ -1238,7 +1222,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=member)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
+        url = f"{self.path}?id={group.id}"
         response = self.client.put(url, data={"assignedTo": non_member.username}, format="json")
 
         assert response.status_code == 400, response.content
@@ -1254,8 +1238,8 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         group.project.add_team(team)
 
-        url = "{url}?id={group.id}".format(url=self.path, group=group)
-        response = self.client.put(url, data={"assignedTo": "team:{}".format(team.id)})
+        url = f"{self.path}?id={group.id}"
+        response = self.client.put(url, data={"assignedTo": f"team:{team.id}"})
 
         assert response.status_code == 200
         assert response.data["assignedTo"]["id"] == six.text_type(team.id)
@@ -1278,7 +1262,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         user = self.user
 
         self.login_as(user=user)
-        url = "{url}?id={group1.id}".format(url=self.path, group1=group1)
+        url = f"{self.path}?id={group1.id}"
         with self.tasks():
             with self.feature("projects:discard-groups"):
                 response = self.client.put(url, data={"discard": True})
@@ -1305,7 +1289,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
 
         self.login_as(user=user)
 
-        url = "{url}?id={group1.id}".format(url=self.path, group1=group1)
+        url = f"{self.path}?id={group1.id}"
         with self.tasks(), self.feature("projects:discard-groups"):
             response = self.client.put(url, data={"discard": True})
 

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import pytz
 import six
 
@@ -42,7 +39,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         group = self.create_group()
         result = serialize(group, self.user, serializer=GroupSerializerSnuba())
         assert "http://" in result["permalink"]
-        assert "{}/issues/{}".format(group.organization.slug, group.id) in result["permalink"]
+        assert f"{group.organization.slug}/issues/{group.id}" in result["permalink"]
 
     def test_permalink_outside_org(self):
         outside_user = self.create_user()

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1114,11 +1114,11 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         for i in range(400):
             event = self.store_event(
                 data={
-                    "event_id": md5("event {}".format(i).encode("utf-8")).hexdigest(),
-                    "fingerprint": ["put-me-in-group{}".format(i)],
+                    "event_id": md5(f"event {i}".encode("utf-8")).hexdigest(),
+                    "fingerprint": [f"put-me-in-group{i}"],
                     "timestamp": iso_format(self.base_datetime - timedelta(days=21)),
-                    "message": "group {} event".format(i),
-                    "stacktrace": {"frames": [{"module": "module {}".format(i)}]},
+                    "message": f"group {i} event",
+                    "stacktrace": {"frames": [{"module": f"module {i}"}]},
                     "tags": {"match": "{}".format(i % 2)},
                     "environment": "production",
                 },

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1101,7 +1101,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
     def test_search_out_of_range(self):
         the_date = datetime(2000, 1, 1, 0, 0, 0, tzinfo=pytz.utc)
         results = self.make_query(
-            search_filter_query="event.timestamp:>%s event.timestamp:<%s" % (the_date, the_date),
+            search_filter_query=f"event.timestamp:>{the_date} event.timestamp:<{the_date}",
             date_from=the_date,
             date_to=the_date,
         )
@@ -1638,7 +1638,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             try:
                 self.make_query(search_filter_query=query)
             except SnubaError as e:
-                self.fail("Query %s errored. Error info: %s" % (query, e))
+                self.fail(f"Query {query} errored. Error info: {e}")
 
         for key in SENTRY_SNUBA_MAP:
             if key in ["project.id", "issue.id"]:
@@ -1655,6 +1655,6 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 val = "true"
             else:
                 val = "abadcafedeadbeefdeaffeedabadfeed"
-                test_query("!%s:%s" % (key, val))
+                test_query(f"!{key}:{val}")
 
-            test_query("%s:%s" % (key, val))
+            test_query(f"{key}:{val}")

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -43,7 +43,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             get_fingerprint(
                 self.store_event(data={"message": "Hello world"}, project_id=self.project.id)
             )
-            == hashlib.md5("Hello world".encode("utf-8")).hexdigest()
+            == hashlib.md5(b"Hello world").hexdigest()
         )
 
         assert (
@@ -53,7 +53,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
                     project_id=self.project.id,
                 )
             )
-            == hashlib.md5("Not hello world".encode("utf-8")).hexdigest()
+            == hashlib.md5(b"Not hello world").hexdigest()
         )
 
     def test_get_group_creation_attributes(self):

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -94,7 +94,7 @@ class SnubaTSDBTest(TestCase, SnubaTestCase):
                     "user": {
                         # change every 55 min so some hours have 1 user, some have 2
                         "id": "user{}".format(r // 3300),
-                        "email": "user{}@sentry.io".format(r),
+                        "email": f"user{r}@sentry.io",
                     },
                     "release": six.text_type(r // 3600) * 10,  # 1 per hour,
                 },


### PR DESCRIPTION
First piece of https://github.com/getsentry/sentry/pull/23436, where it was decided that single classes of fixes should be applied one at a time, starting with the entirety of `tests/`.

This is using [my own fork of pyupgrade](https://github.com/joshuarli/pyupgrade/tree/joshuarli/individual-fixers) which has some terrible patches to selectively apply some classes of fixes.

I should note, this is relatively conservative, pyupgrade won't attempt to rewrite more complicated `format`s (https://github.com/asottile/pyupgrade/issues/38). I made a few changes to do the following:

- don't bail on multiline
- inline string literals
