### PR TITLE
fix(aws-lambda): adds organization to analytics events

### DIFF
--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -247,6 +247,7 @@ class AwsLambdaCloudFormationPipelineView(PipelineView):
         curr_step = 0 if pipeline.fetch_state("skipped_project_select") else 1
 
         def render_response(error=None):
+            serialized_organization = serialize(pipeline.organization, request.user)
             template_url = options.get("aws-lambda.cloudformation-url")
             context = {
                 "baseCloudformationUrl": "https://console.aws.amazon.com/cloudformation/home#/stacks/create/review",
@@ -257,6 +258,7 @@ class AwsLambdaCloudFormationPipelineView(PipelineView):
                 "region": pipeline.fetch_state("region"),
                 "error": error,
                 "initialStepNumber": curr_step,
+                "organization": serialized_organization,
             }
             return self.render_react_view(request, "awsLambdaCloudformation", context)
 

--- a/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaCloudformation.tsx
+++ b/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaCloudformation.tsx
@@ -8,6 +8,7 @@ import ExternalLink from 'app/components/links/externalLink';
 import List from 'app/components/list';
 import ListItem from 'app/components/list/listItem';
 import {t} from 'app/locale';
+import {Organization} from 'app/types';
 import {uniqueId} from 'app/utils/guid';
 import {trackIntegrationEvent} from 'app/utils/integrationUtil';
 import SelectField from 'app/views/settings/components/forms/selectField';
@@ -37,6 +38,7 @@ type Props = {
   stackName: string;
   regionList: string[];
   initialStepNumber: number;
+  organization: Organization;
   accountNumber?: string;
   region?: string;
   error?: string;
@@ -151,24 +153,28 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
 
   //debounce so we don't send a request on every input change
   debouncedTrackValueChanged = debounce((fieldName: string) => {
-    //TODO: add org to trackIntegrationEvent call
-    trackIntegrationEvent({
-      eventKey: 'integrations.installation_input_value_changed',
-      eventName: 'Integrations: Installation Input Value Changed',
-      integration: 'aws_lambda',
-      integration_type: 'first_party',
-      field_name: fieldName,
-    });
+    trackIntegrationEvent(
+      {
+        eventKey: 'integrations.installation_input_value_changed',
+        eventName: 'Integrations: Installation Input Value Changed',
+        integration: 'aws_lambda',
+        integration_type: 'first_party',
+        field_name: fieldName,
+      },
+      this.props.organization
+    );
   }, 200);
 
   trackOpenCloudFormation = () => {
-    //TODO: add org to trackIntegrationEvent call
-    trackIntegrationEvent({
-      eventKey: 'integrations.cloudformation_link_clicked',
-      eventName: 'Integrations: CloudFormation Link Clicked',
-      integration: 'aws_lambda',
-      integration_type: 'first_party',
-    });
+    trackIntegrationEvent(
+      {
+        eventKey: 'integrations.cloudformation_link_clicked',
+        eventName: 'Integrations: CloudFormation Link Clicked',
+        integration: 'aws_lambda',
+        integration_type: 'first_party',
+      },
+      this.props.organization
+    );
   };
 
   render = () => {

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -67,6 +67,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
                 "accountNumber": None,
                 "error": None,
                 "initialStepNumber": 1,
+                "organization": serialize(self.organization),
             },
         )
 
@@ -99,6 +100,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
                 "accountNumber": account_number,
                 "error": "Please validate the Cloudformation stack was created successfully",
                 "initialStepNumber": 1,
+                "organization": serialize(self.organization),
             },
         )
 


### PR DESCRIPTION
[Getsentry does not send events without an org_id to Amplitude](https://github.com/getsentry/getsentry/blob/master/static/getsentry/gsApp/utils/trackAmplitudeEvent.tsx#L28-L34) so we need to pass in the organization for all front end events. A future PR will fix the typing on `trackIntegrationEvent` but for now I'm just fixing it for the `AwsLambdaCloudformation` view.