### PR TITLE
fix(ui): Rename switch to switchButton

### DIFF
--- a/src/sentry/static/sentry/app/components/switch.tsx
+++ b/src/sentry/static/sentry/app/components/switch.tsx
@@ -1,4 +1,0 @@
-// TODO(scttcper): Temporary fix until getsentry is switched over
-import Switch from './switchButton';
-
-export default Switch;

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/legacyBrowsersField/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/legacyBrowsersField/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import BulkController from 'app/components/bulkController';
 import {PanelTable} from 'app/components/panels';
-import Switch from 'app/components/switch';
+import Switch from 'app/components/switchButton';
 
 import {LEGACY_BROWSER_LIST} from '../utils';
 

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/legacyBrowsersField/legacyBrowser.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/legacyBrowsersField/legacyBrowser.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
-import Switch from 'app/components/switch';
+import Switch from 'app/components/switchButton';
 import space from 'app/styles/space';
 
 import {LEGACY_BROWSER_LIST} from '../utils';


### PR DESCRIPTION
Cleanup from storybook 6, missed a few renames and cleanup the re-export file.