### PR TITLE
fix(api): Fix `ProjectProcessingIssuesFixEndpoint.permission_denied` signature

### DIFF
--- a/src/sentry/api/endpoints/project_processingissues.py
+++ b/src/sentry/api/endpoints/project_processingissues.py
@@ -58,7 +58,7 @@ class ProjectProcessingIssuesFixEndpoint(ProjectEndpoint):
         resp["Content-Type"] = "text/plain"
         return resp
 
-    def permission_denied(self, request):
+    def permission_denied(self, request, message=None):
         resp = render_to_response("sentry/reprocessing-script.sh", {"token": None})
         resp["Content-Type"] = "text/plain"
         return resp


### PR DESCRIPTION
This was likely broken during our upgrade of DRF, only noticed it now due to an error in sentry.

Fixes SENTRY-GA6