### PR TITLE
ref(sidebar): Use Store to control panel state

### DIFF
--- a/src/sentry/static/sentry/app/actions/sidebarPanelActions.tsx
+++ b/src/sentry/static/sentry/app/actions/sidebarPanelActions.tsx
@@ -1,0 +1,3 @@
+import Reflux from 'reflux';
+
+export default Reflux.createActions(['activatePanel', 'togglePanel', 'hidePanel']);

--- a/src/sentry/static/sentry/app/stores/sidebarPanelStore.tsx
+++ b/src/sentry/static/sentry/app/stores/sidebarPanelStore.tsx
@@ -1,0 +1,53 @@
+import Reflux from 'reflux';
+
+import {SidebarPanelKey} from 'app/components/sidebar/types';
+
+import SidebarPanelActions from '../actions/sidebarPanelActions';
+
+type SidebarPanelStoreInterface = {
+  activePanel: SidebarPanelKey | '';
+
+  onActivatePanel(panel: SidebarPanelKey): void;
+  onTogglePanel(panel: SidebarPanelKey): void;
+  onHidePanel(): void;
+};
+
+const sidebarPanelStoreConfig: Reflux.StoreDefinition & SidebarPanelStoreInterface = {
+  activePanel: '',
+
+  init() {
+    this.listenTo(SidebarPanelActions.activatePanel, this.onActivatePanel);
+    this.listenTo(SidebarPanelActions.hidePanel, this.onHidePanel);
+    this.listenTo(SidebarPanelActions.togglePanel, this.onTogglePanel);
+  },
+
+  onActivatePanel(panel: SidebarPanelKey) {
+    this.activePanel = panel;
+    this.trigger(this.activePanel);
+  },
+
+  onTogglePanel(panel: SidebarPanelKey) {
+    if (this.activePanel === panel) {
+      this.onHidePanel();
+    } else {
+      this.onActivatePanel(panel);
+    }
+  },
+
+  onHidePanel() {
+    this.activePanel = '';
+    this.trigger(this.activePanel);
+  },
+};
+
+type SidebarPanelStore = Reflux.Store & SidebarPanelStoreInterface;
+
+/**
+ * This store is used to hold local user preferences
+ * Side-effects (like reading/writing to cookies) are done in associated actionCreators
+ */
+const SidebarPanelStore = Reflux.createStore(
+  sidebarPanelStoreConfig
+) as SidebarPanelStore;
+
+export default SidebarPanelStore;


### PR DESCRIPTION
I am doing this so that I may open the 'broadcasts' panel, which now displays SDK update notifications