### PR TITLE
ref(ui): Change decodeList to decodeScalar on health chart

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -16,7 +16,7 @@ import {defined} from 'app/utils';
 import {getUtcDateString} from 'app/utils/dates';
 import {axisDuration} from 'app/utils/discover/charts';
 import {getExactDuration} from 'app/utils/formatters';
-import {decodeList} from 'app/utils/queryString';
+import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 import {HeaderTitleLegend} from 'app/views/performance/styles';
 
@@ -74,7 +74,7 @@ class HealthChart extends React.Component<Props> {
     const otherAreasThanHealthyArePositive = timeseriesData
       .filter(s => s.seriesName !== sessionTerm.healthy)
       .some(s => s.data.some(d => d.value > 0));
-    const alreadySomethingUnselected = !!decodeList(location.query.unselectedSeries);
+    const alreadySomethingUnselected = !!decodeScalar(location.query.unselectedSeries);
 
     return (
       shouldRecalculateVisibleSeries &&


### PR DESCRIPTION
The implementation of `decodeList` changed recently to always return truthy value: https://github.com/getsentry/sentry/pull/23198

Swapping this for decodeScalar which can still return falsy value and as we don't need the actual list (a single value is enough).