### PR TITLE
feat(ui): Limit issues on release detail, swap Open buttons

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/issues.tsx
@@ -82,6 +82,8 @@ class Issues extends React.Component<Props, State> {
       pathname: `/organizations/${orgId}/issues/`,
       query: {
         ...queryParams,
+        limit: undefined,
+        cursor: undefined,
         query: stringifyQueryObject(query),
       },
     };
@@ -92,7 +94,7 @@ class Issues extends React.Component<Props, State> {
     const {issuesType} = this.state;
     const queryParams = {
       ...pick(location.query, [...Object.values(URL_PARAM), 'cursor']),
-      limit: 50,
+      limit: 10,
       sort: 'new',
     };
 
@@ -206,6 +208,10 @@ class Issues extends React.Component<Props, State> {
           </DropdownControl>
 
           <OpenInButtonBar gap={1}>
+            <Button to={this.getIssuesUrl()} size="small" data-test-id="issues-button">
+              {t('Open in Issues')}
+            </Button>
+
             <Feature features={['discover-basic']}>
               <DiscoverButton
                 to={this.getDiscoverUrl()}
@@ -215,10 +221,6 @@ class Issues extends React.Component<Props, State> {
                 {t('Open in Discover')}
               </DiscoverButton>
             </Feature>
-
-            <Button to={this.getIssuesUrl()} size="small" data-test-id="issues-button">
-              {t('Open in Issues')}
-            </Button>
           </OpenInButtonBar>
         </ControlsWrapper>
         <TableWrapper data-test-id="release-wrapper">

--- a/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
+++ b/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
@@ -27,20 +27,20 @@ describe('Release Issues', function () {
     });
 
     newIssuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.orgId}/issues/?limit=50&query=first-release%3A1.0.0&sort=new`,
+      url: `/organizations/${props.orgId}/issues/?limit=10&query=first-release%3A1.0.0&sort=new`,
       body: [],
     });
     resolvedIssuesEndpoint = MockApiClient.addMockResponse({
-      url: '/organizations/org/releases/1.0.0/resolved/?limit=50&query=&sort=new',
+      url: '/organizations/org/releases/1.0.0/resolved/?limit=10&query=&sort=new',
       body: [],
     });
     unhandledIssuesEndpoint = MockApiClient.addMockResponse({
       url:
-        '/organizations/org/issues/?limit=50&query=release%3A1.0.0%20error.handled%3A0&sort=new',
+        '/organizations/org/issues/?limit=10&query=release%3A1.0.0%20error.handled%3A0&sort=new',
       body: [],
     });
     allIssuesEndpoint = MockApiClient.addMockResponse({
-      url: '/organizations/org/issues/?limit=50&query=release%3A1.0.0&sort=new',
+      url: '/organizations/org/issues/?limit=10&query=release%3A1.0.0&sort=new',
       body: [],
     });
   });
@@ -146,25 +146,25 @@ describe('Release Issues', function () {
 
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
-      query: {limit: 50, sort: 'new', query: 'firstRelease:1.0.0'},
+      query: {sort: 'new', query: 'firstRelease:1.0.0'},
     });
 
     filterIssues(wrapper, 'resolved');
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
-      query: {limit: 50, sort: 'new', query: 'release:1.0.0'},
+      query: {sort: 'new', query: 'release:1.0.0'},
     });
 
     filterIssues(wrapper, 'unhandled');
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
-      query: {limit: 50, sort: 'new', query: 'release:1.0.0 error.handled:0'},
+      query: {sort: 'new', query: 'release:1.0.0 error.handled:0'},
     });
 
     filterIssues(wrapper, 'all');
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
-      query: {limit: 50, sort: 'new', query: 'release:1.0.0'},
+      query: {sort: 'new', query: 'release:1.0.0'},
     });
   });
 });


### PR DESCRIPTION
Changing the limit of displayed issues to 10.
50 was way too much for the release detail page (there's always pagination a the ability to open in Issues).

Also changing the order of `Open in Issues` and `Open in Discover` buttons to be more consistent. 
![Screenshot 2021-02-02 at 10 05 38](https://user-images.githubusercontent.com/9060071/106577152-4da57980-653e-11eb-8a64-28022736a68d.png)


