### PR TITLE
dev(vscode): Remove setting that VS Code removes automatically

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,8 +55,6 @@
 
   "python.linting.pylintEnabled": false,
   "python.linting.flake8Enabled": true,
-  // https://github.com/DonJayamanne/pythonVSCode/issues/992
-  "python.pythonPath": "${workspaceFolder}/.venv/bin/python",
   // test discovery is sluggish and the UI around running
   // tests is often in your way and misclicked
   "python.testing.pytestEnabled": false,


### PR DESCRIPTION
It seems that VS Code automatically determines that this setting is no longer needed and removes it automatically.

You can learn more about it here:
https://github.com/microsoft/vscode-python/wiki/AB-Experiments

<img width="467" alt="image" src="https://user-images.githubusercontent.com/44410/106620437-90b41c80-653f-11eb-9eac-9818cf7a9cfa.png">
