### PR TITLE
fix(ui): Broken URL to add custom tags

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectTags.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectTags.tsx
@@ -89,7 +89,7 @@ class ProjectTags extends AsyncView<Props, State> {
               <EmptyMessage>
                 {tct('There are no tags, [link:learn how to add tags]', {
                   link: (
-                    <ExternalLink href="https://docs.sentry.io/enriching-error-data/additional-data/" />
+                    <ExternalLink href="https://docs.sentry.io/product/sentry-basics/guides/enrich-data/" />
                   ),
                 })}
               </EmptyMessage>


### PR DESCRIPTION
I've updated link to https://docs.sentry.io/product/sentry-basics/guides/enrich-data/

The current link is broken: 