### PR TITLE
fix(discover): Has message filter is backwards

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -817,6 +817,9 @@ def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
             # message. Strip off here
             value = search_filter.value.value[1:-1]
             return [["match", ["message", "'(?i){}'".format(value)]], search_filter.operator, 1]
+        elif value == "":
+            operator = "=" if search_filter.operator == "=" else "!="
+            return [["equals", ["message", "{}".format(value)]], operator, 1]
         else:
             # https://clickhouse.yandex/docs/en/query_language/functions/string_search_functions/#position-haystack-needle
             # positionCaseInsensitive returns 0 if not found and an index of 1 or more if found

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1754,6 +1754,12 @@ class GetSnubaQueryArgsTest(TestCase):
         assert has_issue_filter.group_ids == []
         assert has_issue_filter.conditions == [[["isNull", ["issue.id"]], "=", 1]]
 
+    def test_message_empty(self):
+        assert get_filter("has:message").conditions == [[["equals", ["message", ""]], "!=", 1]]
+        assert get_filter("!has:message").conditions == [[["equals", ["message", ""]], "=", 1]]
+        assert get_filter('message:""').conditions == [[["equals", ["message", ""]], "=", 1]]
+        assert get_filter('!message:""').conditions == [[["equals", ["message", ""]], "!=", 1]]
+
     def test_message_negative(self):
         assert get_filter('!message:"post_process.process_error HTTPError 403"').conditions == [
             [


### PR DESCRIPTION
The has filter on message is currently using Clickhouses's
positionCaseInsensitive which causes backwards results when searching against
the empty string. This changes special cases the empty string to use equals.