### PR TITLE
fix(dev): Enable line buffering for stdout

### DIFF
--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -292,6 +292,7 @@ def initialize_app(config, skip_service_validation=False):
     if settings.DEBUG:
         # Enable line buffering for stderr, TODO(py3.9) can be removed after py3.9, see bpo-13601
         sys.stderr = os.fdopen(sys.stderr.fileno(), "w", 1)
+        sys.stdout = os.fdopen(sys.stdout.fileno(), "w", 1)
 
     # Just reuse the integration app for Single Org / Self-Hosted as
     # it doesn't make much sense to use 2 separate apps for SSO and


### PR DESCRIPTION
In #22934, @wmak did some digging and discovered a fix to allow errors (stderr) to be printed into the console while the server was running.

Just adding another line here to allow prints to be treated in the same way (stdout).