### PR TITLE
fix(workflow): Fixing owner search bug (and adding test to catch it)

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -134,13 +134,19 @@ def owner_filter(owner, projects):
     organization_id = projects[0].organization_id
     project_ids = [p.id for p in projects]
     if isinstance(owner, Team):
-        return Q(
-            id__in=GroupOwner.objects.filter(
-                team=owner, project_id__in=project_ids, organization_id=organization_id
+        return (
+            Q(
+                id__in=GroupOwner.objects.filter(
+                    Q(group__assignee_set__isnull=True),
+                    team=owner,
+                    project_id__in=project_ids,
+                    organization_id=organization_id,
+                )
+                .values_list("group_id", flat=True)
+                .distinct()
             )
-            .values_list("group_id", flat=True)
-            .distinct()
-        ) | assigned_to_filter(owner, projects)
+            | assigned_to_filter(owner, projects)
+        )
     elif isinstance(owner, User) or (isinstance(owner, list) and owner[0] == "me_or_none"):
         include_none = False
         if isinstance(owner, list) and owner[0] == "me_or_none":

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -890,6 +890,16 @@ class GroupListTest(APITestCase, SnubaTestCase):
             assert int(response.data[2]["id"]) == event2.group.id
             assert int(response.data[3]["id"]) == assigned_event.group.id
 
+            # Assign group to another user and now it shouldn't show up in owner search for this team.
+            GroupAssignee.objects.create(
+                group=event.group,
+                project=event.group.project,
+                user=other_user,
+            )
+            response = self.get_response(sort_by="date", limit=10, query=f"owner:#{self.team.slug}")
+            assert response.status_code == 200
+            assert len(response.data) == 0
+
     def test_aggregate_stats_regression_test(self):
         self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},


### PR DESCRIPTION
Owner search for a team is currently returning issues assigned to others. Adding this filter to the query will remove issues assigned to others from the results.