### PR TITLE
fix(ui): react-select input color in dark mode

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -141,6 +141,10 @@ const SelectControl = props => {
       ...provided,
       alignItems: 'center',
     }),
+    input: provided => ({
+      ...provided,
+      color: theme.formText,
+    }),
     singleValue: provided => ({
       ...provided,
       color: theme.formText,


### PR DESCRIPTION
The input color for react-select is not using the correct form color, making it
illegible in dark mode. This ensures that it is using the correct form color.

# Screenshots

## Before

![Screen Shot 2021-02-02 at 3 55 52 PM](https://user-images.githubusercontent.com/10239353/106661818-a8a39480-656f-11eb-90c8-33eeac7804ed.png)

## After

![Screen Shot 2021-02-02 at 3 57 50 PM](https://user-images.githubusercontent.com/10239353/106661826-aa6d5800-656f-11eb-92c5-3c0ef02c2990.png)