### PR TITLE
ref(api): Rename promptsactivity -> prompts-activity

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -460,10 +460,16 @@ urlpatterns = [
         name="sentry-api-0-api-authorizations",
     ),
     url(r"^api-tokens/$", ApiTokensEndpoint.as_view(), name="sentry-api-0-api-tokens"),
+    # TODO: Remove after deploy
     url(
         r"^promptsactivity/$",
         PromptsActivityEndpoint.as_view(),
         name="sentry-api-0-promptsactivity",
+    ),
+    url(
+        r"^prompts-activity/$",
+        PromptsActivityEndpoint.as_view(),
+        name="sentry-api-0-prompts-activity",
     ),
     # Auth
     url(

--- a/src/sentry/static/sentry/app/actionCreators/prompts.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/prompts.tsx
@@ -20,7 +20,7 @@ type PromptsUpdateParams = {
  * Update the status of a prompt
  */
 export function promptsUpdate(api: Client, params: PromptsUpdateParams) {
-  return api.requestPromise('/promptsactivity/', {
+  return api.requestPromise('/prompts-activity/', {
     method: 'PUT',
     data: {
       organization_id: params.organizationId,
@@ -63,7 +63,9 @@ export async function promptsCheck(api: Client, params: PromptCheckParams) {
     ...(params.projectId === undefined ? {} : {project_id: params.projectId}),
   };
 
-  const response: PromptResponse = await api.requestPromise('/promptsactivity/', {query});
+  const response: PromptResponse = await api.requestPromise('/prompts-activity/', {
+    query,
+  });
   const data = response?.data;
 
   if (!data) {

--- a/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
+++ b/tests/js/spec/components/events/eventCauseEmpty.spec.jsx
@@ -26,12 +26,12 @@ describe('EventCauseEmpty', function () {
     });
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/promptsactivity/',
+      url: '/prompts-activity/',
       body: {},
     });
     putMock = MockApiClient.addMockResponse({
       method: 'PUT',
-      url: '/promptsactivity/',
+      url: '/prompts-activity/',
     });
   });
 
@@ -69,7 +69,7 @@ describe('EventCauseEmpty', function () {
     await wrapper.update();
 
     expect(putMock).toHaveBeenCalledWith(
-      '/promptsactivity/',
+      '/prompts-activity/',
       expect.objectContaining({
         method: 'PUT',
         data: {
@@ -97,7 +97,7 @@ describe('EventCauseEmpty', function () {
 
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/promptsactivity/',
+      url: '/prompts-activity/',
       body: {data: {snoozed_ts}},
     });
 
@@ -117,7 +117,7 @@ describe('EventCauseEmpty', function () {
 
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/promptsactivity/',
+      url: '/prompts-activity/',
       body: {data: {snoozed_ts}},
     });
 
@@ -147,7 +147,7 @@ describe('EventCauseEmpty', function () {
     await wrapper.update();
 
     expect(putMock).toHaveBeenCalledWith(
-      '/promptsactivity/',
+      '/prompts-activity/',
       expect.objectContaining({
         method: 'PUT',
         data: {
@@ -173,7 +173,7 @@ describe('EventCauseEmpty', function () {
   it('does not render when dismissed', async function () {
     MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/promptsactivity/',
+      url: '/prompts-activity/',
       body: {data: {dismissed_ts: moment().unix()}},
     });
 

--- a/tests/js/spec/views/alerts/list/index.spec.jsx
+++ b/tests/js/spec/views/alerts/list/index.spec.jsx
@@ -126,11 +126,11 @@ describe('IncidentsList', function () {
       body: [],
     });
     const promptsMock = MockApiClient.addMockResponse({
-      url: '/promptsactivity/',
+      url: '/prompts-activity/',
       body: {data: {dismissed_ts: null}},
     });
     const promptsUpdateMock = MockApiClient.addMockResponse({
-      url: '/promptsactivity/',
+      url: '/prompts-activity/',
       method: 'PUT',
     });
 
@@ -157,7 +157,7 @@ describe('IncidentsList', function () {
       body: [],
     });
     const promptsMock = MockApiClient.addMockResponse({
-      url: '/promptsactivity/',
+      url: '/prompts-activity/',
       body: {data: {dismissed_ts: Math.floor(Date.now() / 1000)}},
     });
 
@@ -185,7 +185,7 @@ describe('IncidentsList', function () {
       body: [{id: 1}],
     });
     const promptsMock = MockApiClient.addMockResponse({
-      url: '/promptsactivity/',
+      url: '/prompts-activity/',
       body: {data: {dismissed_ts: Math.floor(Date.now() / 1000)}},
     });
 

--- a/tests/js/spec/views/organizationGroupDetails/groupEventDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventDetails.spec.jsx
@@ -65,7 +65,7 @@ describe('groupEventDetails', () => {
     });
 
     MockApiClient.addMockResponse({
-      url: '/promptsactivity/',
+      url: '/prompts-activity/',
       body: promptsActivity,
     });
 

--- a/tests/sentry/api/endpoints/test_prompts_activity.py
+++ b/tests/sentry/api/endpoints/test_prompts_activity.py
@@ -18,7 +18,7 @@ class PromptsActivityTest(APITestCase):
         self.project = self.create_project(
             organization=self.org, teams=[self.team], name="Bengal-Elephant-Giraffe-Tree-House"
         )
-        self.path = reverse("sentry-api-0-promptsactivity")
+        self.path = reverse("sentry-api-0-prompts-activity")
 
     def test_invalid_feature(self):
         # Invalid feature prompt name


### PR DESCRIPTION
This has been bothering me for a long time.

This is an internal endpoint for hiding 'prompts', such as the 'enable suspect commits' nag.