### PR TITLE
ref(ui) Update more select controls

### DIFF
--- a/src/sentry/static/sentry/app/components/customIgnoreCountModal.tsx
+++ b/src/sentry/static/sentry/app/components/customIgnoreCountModal.tsx
@@ -4,7 +4,7 @@ import {ModalRenderProps} from 'app/actionCreators/modal';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import {t} from 'app/locale';
-import {ResolutionStatusDetails} from 'app/types';
+import {Choices, ResolutionStatusDetails} from 'app/types';
 import InputField from 'app/views/settings/components/forms/inputField';
 import SelectField from 'app/views/settings/components/forms/selectField';
 
@@ -17,7 +17,7 @@ type Props = ModalRenderProps & {
   countLabel: string;
   countName: CountNames;
   windowName: WindowNames;
-  windowChoices: string[] | [number, string][];
+  windowChoices: Choices;
 };
 
 type State = {
@@ -77,14 +77,13 @@ class CustomIgnoreCountModal extends React.Component<Props, State> {
             placeholder={t('e.g. 100')}
           />
           <SelectField
-            deprecatedSelectControl
             inline={false}
             flexibleControlStateSize
             stacked
             label={t('Time window')}
             value={window}
             name="window"
-            onChange={val => this.handleChange('window' as 'window', val)}
+            onChange={val => this.handleChange('window' as const, val)}
             choices={windowChoices}
             placeholder={t('e.g. per hour')}
             allowClear

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -51,7 +51,7 @@ const InviteRowControl = ({
         deprecatedSelectControl
         data-test-id="select-emails"
         disabled={disabled}
-        placeholder={t('Enter one or more email')}
+        placeholder={t('Enter one or more emails')}
         value={emails}
         options={emails.map(value => ({
           value,
@@ -77,7 +77,6 @@ const InviteRowControl = ({
     </div>
     <div>
       <RoleSelectControl
-        deprecatedSelectControl
         data-test-id="select-role"
         disabled={disabled}
         value={role}
@@ -88,7 +87,6 @@ const InviteRowControl = ({
     </div>
     <div>
       <SelectControl
-        deprecatedSelectControl
         data-test-id="select-teams"
         disabled={disabled}
         placeholder={t('Add to teams...')}

--- a/src/sentry/static/sentry/app/components/roleSelectControl.tsx
+++ b/src/sentry/static/sentry/app/components/roleSelectControl.tsx
@@ -21,44 +21,46 @@ type OptionType = {
   description: string;
 };
 
-const RoleSelector = ({roles, disableUnallowed, ...props}: Props) => (
-  <SelectControl
-    options={roles?.map(
-      (r: MemberRole) =>
-        ({
-          value: r.id,
-          label: r.name,
-          disabled: disableUnallowed && !r.allowed,
-          description: r.desc,
-        } as OptionType)
-    )}
-    components={{
-      Option: ({label, data, ...optionProps}: OptionProps<OptionType>) => (
-        <components.Option label={label} {...(optionProps as any)}>
-          <RoleItem>
-            <h1>{label}</h1>
-            <div>{data.description}</div>
-          </RoleItem>
-        </components.Option>
-      ),
-    }}
-    styles={{
-      control: provided => ({
-        ...provided,
-        borderBottomLeftRadius: theme.borderRadius,
-        borderBottomRightRadius: theme.borderRadius,
-      }),
-      menu: provided => ({
-        ...provided,
-        borderRadius: theme.borderRadius,
-        marginTop: space(0.5),
-        width: '350px',
-        overflow: 'hidden',
-      }),
-    }}
-    {...props}
-  />
-);
+function RoleSelectControl({roles, disableUnallowed, ...props}: Props) {
+  return (
+    <SelectControl
+      options={roles?.map(
+        (r: MemberRole) =>
+          ({
+            value: r.id,
+            label: r.name,
+            disabled: disableUnallowed && !r.allowed,
+            description: r.desc,
+          } as OptionType)
+      )}
+      components={{
+        Option: ({label, data, ...optionProps}: OptionProps<OptionType>) => (
+          <components.Option label={label} {...(optionProps as any)}>
+            <RoleItem>
+              <h1>{label}</h1>
+              <div>{data.description}</div>
+            </RoleItem>
+          </components.Option>
+        ),
+      }}
+      styles={{
+        control: provided => ({
+          ...provided,
+          borderBottomLeftRadius: theme.borderRadius,
+          borderBottomRightRadius: theme.borderRadius,
+        }),
+        menu: provided => ({
+          ...provided,
+          borderRadius: theme.borderRadius,
+          marginTop: space(0.5),
+          width: '350px',
+          overflow: 'hidden',
+        }),
+      }}
+      {...props}
+    />
+  );
+}
 
 const RoleItem = styled('div')`
   display: grid;
@@ -73,4 +75,4 @@ const RoleItem = styled('div')`
   }
 `;
 
-export default RoleSelector;
+export default RoleSelectControl;

--- a/src/sentry/static/sentry/app/components/roleSelectControl.tsx
+++ b/src/sentry/static/sentry/app/components/roleSelectControl.tsx
@@ -1,57 +1,67 @@
 import React from 'react';
+import ReactSelect, {components, OptionProps} from 'react-select';
 import styled from '@emotion/styled';
 
 import SelectControl from 'app/components/forms/selectControl';
 import space from 'app/styles/space';
 import {MemberRole} from 'app/types';
+import theme from 'app/utils/theme';
 
-type Props = SelectControl['props'] & {
+// TODO(ts) Add SelectControl types when it gets them.
+type Props = Omit<React.ComponentProps<typeof ReactSelect>, 'value'> & {
   roles: MemberRole[];
   disableUnallowed: boolean;
+  value?: string;
+};
+
+type OptionType = {
+  label: string;
+  value: string;
+  disabled: boolean;
+  description: string;
 };
 
 const RoleSelector = ({roles, disableUnallowed, ...props}: Props) => (
-  <RoleSelectControl
-    deprecatedSelectControl
+  <SelectControl
     options={
       roles &&
-      roles.map(r => ({
-        value: r.id,
-        label: r.name,
-        disabled: disableUnallowed && !r.allowed,
-      }))
+      roles.map(
+        (r: MemberRole) =>
+          ({
+            value: r.id,
+            label: r.name,
+            disabled: disableUnallowed && !r.allowed,
+            description: r.desc,
+          } as OptionType)
+      )
     }
-    optionRenderer={option => {
-      const {name, desc} = roles.find(r => r.id === option.value)!;
-
-      return (
-        <RoleItem>
-          <h1>{name}</h1>
-          <div>{desc}</div>
-        </RoleItem>
-      );
+    components={{
+      Option: ({label, data, ...optionProps}: OptionProps<OptionType>) => (
+        <components.Option label={label} {...(optionProps as any)}>
+          <RoleItem>
+            <h1>{label}</h1>
+            <div>{data.description}</div>
+          </RoleItem>
+        </components.Option>
+      ),
+    }}
+    styles={{
+      control: provided => ({
+        ...provided,
+        borderBottomLeftRadius: theme.borderRadius,
+        borderBottomRightRadius: theme.borderRadius,
+      }),
+      menu: provided => ({
+        ...provided,
+        borderRadius: theme.borderRadius,
+        marginTop: space(0.5),
+        width: '350px',
+        overflow: 'hidden',
+      }),
     }}
     {...props}
   />
 );
-
-const RoleSelectControl = styled(SelectControl)`
-  .Select-menu-outer {
-    margin-top: ${space(1)};
-    width: 350px;
-    border-radius: 4px;
-    overflow: hidden;
-    box-shadow: 0 0 6px rgba(0, 0, 0, 0.15);
-  }
-
-  &.Select.is-focused.is-open > .Select-control {
-    border-radius: 4px;
-  }
-
-  .Select-option:not(:last-child) {
-    border-bottom: 1px solid ${p => p.theme.innerBorder};
-  }
-`;
 
 const RoleItem = styled('div')`
   display: grid;

--- a/src/sentry/static/sentry/app/components/roleSelectControl.tsx
+++ b/src/sentry/static/sentry/app/components/roleSelectControl.tsx
@@ -23,18 +23,15 @@ type OptionType = {
 
 const RoleSelector = ({roles, disableUnallowed, ...props}: Props) => (
   <SelectControl
-    options={
-      roles &&
-      roles.map(
-        (r: MemberRole) =>
-          ({
-            value: r.id,
-            label: r.name,
-            disabled: disableUnallowed && !r.allowed,
-            description: r.desc,
-          } as OptionType)
-      )
-    }
+    options={roles?.map(
+      (r: MemberRole) =>
+        ({
+          value: r.id,
+          label: r.name,
+          disabled: disableUnallowed && !r.allowed,
+          description: r.desc,
+        } as OptionType)
+    )}
     components={{
       Option: ({label, data, ...optionProps}: OptionProps<OptionType>) => (
         <components.Option label={label} {...(optionProps as any)}>

--- a/src/sentry/static/sentry/app/views/admin/adminQueue.tsx
+++ b/src/sentry/static/sentry/app/views/admin/adminQueue.tsx
@@ -92,12 +92,11 @@ export default class AdminQueue extends AsyncView<{}, State> {
           <div className="m-b-1">
             <label>Show details for task:</label>
             <SelectField
-              deprecatedSelectControl
               name="task"
               onChange={value => this.changeTask(value as string)}
               value={activeTask}
               clearable
-              choices={[''].concat(...taskList).map(t => [t, t])}
+              choices={taskList.map(t => [t, t])}
             />
           </div>
           {activeTask ? (

--- a/src/sentry/static/sentry/app/views/monitors/monitorForm.tsx
+++ b/src/sentry/static/sentry/app/views/monitors/monitorForm.tsx
@@ -207,7 +207,6 @@ class MonitorForm extends Component<Props> {
                               required
                             />
                             <SelectField
-                              deprecatedSelectControl
                               name="config.schedule.interval"
                               label={t('Interval')}
                               disabled={!hasAccess}

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/inviteRequestRow.tsx
@@ -84,9 +84,8 @@ const InviteRequestRow = ({
       />
 
       <TeamSelectControl
-        deprecatedSelectControl
         name="teams"
-        placeholder={t('Add to teams...')}
+        placeholder={t('Add to teams\u2026')}
         onChange={teams => onUpdate({teams: teams.map(team => team.value)})}
         value={inviteRequest.teams}
         options={allTeams.map(({slug}) => ({

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.tsx
@@ -283,6 +283,7 @@ class SelectOwners extends React.Component<Props, State> {
   render() {
     return (
       <MultiSelectControl
+        name="owners"
         filterOption={(option, filterText) =>
           option.data.searchKey.indexOf(filterText) > -1
         }

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {MultiValueProps} from 'react-select';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
@@ -16,6 +17,7 @@ import {t} from 'app/locale';
 import MemberListStore from 'app/stores/memberListStore';
 import ProjectsStore from 'app/stores/projectsStore';
 import TeamStore from 'app/stores/teamStore';
+import space from 'app/styles/space';
 import {Actor, Member, Organization, Project, Team, User} from 'app/types';
 import {buildTeamId, buildUserId} from 'app/utils';
 import withApi from 'app/utils/withApi';
@@ -29,16 +31,11 @@ export type Owner = {
   disabled?: boolean;
 };
 
-type ValueProps = {
-  value: Owner;
-  onRemove: (item: Owner) => void;
-};
-
-function ValueComponent({value, onRemove}: ValueProps) {
+function ValueComponent({data, removeProps}: MultiValueProps<Owner>) {
   return (
-    <a onClick={() => onRemove(value)}>
-      <ActorAvatar actor={value.actor} size={28} />
-    </a>
+    <ValueWrapper onClick={removeProps.onClick}>
+      <ActorAvatar actor={data.actor} size={28} />
+    </ValueWrapper>
   );
 }
 
@@ -278,17 +275,16 @@ class SelectOwners extends React.Component<Props, State> {
               .map(this.createUnmentionableUser)
           : []
       )
-      .then(members => ({
-        options: [...usersInProject, ...teamsInProject, ...teamsNotInProject, ...members],
-      }));
+      .then(members => {
+        return [...usersInProject, ...teamsInProject, ...teamsNotInProject, ...members];
+      });
   };
 
   render() {
     return (
       <MultiSelectControl
-        deprecatedSelectControl
-        filterOptions={(options, filterText) =>
-          options.filter(({searchKey}) => searchKey.indexOf(filterText) > -1)
+        filterOption={(option, filterText) =>
+          option.data.searchKey.indexOf(filterText) > -1
         }
         ref={this.selectRef}
         loadOptions={this.handleLoadOptions}
@@ -297,8 +293,10 @@ class SelectOwners extends React.Component<Props, State> {
         clearable
         disabled={this.props.disabled}
         cache={false}
-        valueComponent={ValueComponent}
         placeholder={t('owners')}
+        components={{
+          MultiValue: ValueComponent,
+        }}
         onInputChange={this.handleInputChange}
         onChange={this.handleChange}
         value={this.props.value}
@@ -322,4 +320,8 @@ const DisabledLabel = styled('div')`
 
 const AddToProjectButton = styled(Button)`
   flex-shrink: 0;
+`;
+
+const ValueWrapper = styled('a')`
+  margin-right: ${space(0.5)};
 `;

--- a/tests/js/sentry-test/select-new.js
+++ b/tests/js/sentry-test/select-new.js
@@ -59,3 +59,12 @@ export async function selectByQuery(wrapper, query, options = {}) {
 
   selectByValue(wrapper, query, options);
 }
+
+export async function selectByValueAsync(wrapper, value, options = {}) {
+  openMenu(wrapper, options);
+
+  await tick();
+  await wrapper.update();
+
+  findOption(wrapper, {value}, options).at(0).simulate('click');
+}

--- a/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
+++ b/tests/js/spec/components/modals/inviteMembersModal.spec.jsx
@@ -52,8 +52,8 @@ describe('InviteMembersModal', function () {
 
     // We have two roles loaded from the members/me endpoint, defaulting to the
     // 'member' role.
-    expect(wrapper.find('RoleSelectControl').props().options).toHaveLength(roles.length);
-    expect(wrapper.find('RoleSelectControl Value').text()).toBe('Member');
+    expect(wrapper.find('RoleSelectControl').props().roles).toHaveLength(roles.length);
+    expect(wrapper.find('RoleSelectControl SingleValue').text()).toBe('Member');
   });
 
   it('renders without organization.access', async function () {

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountGlobalModal} from 'sentry-test/modal';
-import {selectByLabel} from 'sentry-test/select';
+import {selectByLabel} from 'sentry-test/select-new';
 
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import {IssueListActions} from 'app/views/issueList/actions';

--- a/tests/js/spec/views/ownershipInput.spec.jsx
+++ b/tests/js/spec/views/ownershipInput.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
-import {findOption, openMenu} from 'sentry-test/select-new';
+import {selectByValueAsync} from 'sentry-test/select-new';
 
 import MemberListStore from 'app/stores/memberListStore';
 import OwnerInput from 'app/views/settings/project/projectOwnership/ownerInput';
@@ -79,14 +79,7 @@ describe('Project Ownership Input', function () {
     pathInput.simulate('change', {target: {value: 'file.js'}});
 
     // Select the user.
-    let userSelect = wrapper.find('RuleBuilder SelectOwners');
-    openMenu(userSelect, {control: true});
-    await tick();
-    await wrapper.update();
-
-    // Because this menu is async we can't use selectByValue()
-    userSelect = wrapper.find('RuleBuilder SelectOwners');
-    findOption(userSelect, {value: 'user:1'}, {control: true}).at(0).simulate('click');
+    await selectByValueAsync(wrapper, 'user:1', {control: true, name: 'owners'});
     await wrapper.update();
 
     // Add the new rule.

--- a/tests/js/spec/views/ownershipInput.spec.jsx
+++ b/tests/js/spec/views/ownershipInput.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
-import {findOption, openMenu} from 'sentry-test/select';
+import {findOption, openMenu} from 'sentry-test/select-new';
 
 import MemberListStore from 'app/stores/memberListStore';
 import OwnerInput from 'app/views/settings/project/projectOwnership/ownerInput';
@@ -86,14 +86,13 @@ describe('Project Ownership Input', function () {
 
     // Because this menu is async we can't use selectByValue()
     userSelect = wrapper.find('RuleBuilder SelectOwners');
-    findOption(userSelect, {value: 'user:1'}, {control: true})
-      .at(0)
-      .simulate('mouseDown');
+    findOption(userSelect, {value: 'user:1'}, {control: true}).at(0).simulate('click');
     await wrapper.update();
 
     // Add the new rule.
     const button = wrapper.find('RuleBuilder AddButton button');
     button.simulate('click');
+    await wrapper.update();
 
     expect(put).toHaveBeenCalledWith(
       '/projects/org-slug/project-slug/ownership/',

--- a/tests/js/spec/views/ruleBuilder.spec.jsx
+++ b/tests/js/spec/views/ruleBuilder.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {findOption, openMenu, selectByValueAsync} from 'sentry-test/select-new';
 
 import MemberListStore from 'app/stores/memberListStore';
 import ProjectsStore from 'app/stores/projectsStore';
@@ -90,9 +91,9 @@ describe('RuleBuilder', function () {
     add.simulate('click');
     expect(handleAdd).not.toHaveBeenCalled();
 
-    // Simulate select first element via down arrow / enter
-    wrapper.find('SelectOwners .Select-control').simulate('keyDown', {keyCode: 40});
-    wrapper.find('SelectOwners .Select-control').simulate('keyDown', {keyCode: 13});
+    // Select the first item in the list.
+    await selectByValueAsync(wrapper, 'user:1', {name: 'owners', control: true});
+    await wrapper.update();
 
     expect(wrapper.find('Button').prop('disabled')).toBe(false);
     add.simulate('click');
@@ -116,13 +117,10 @@ describe('RuleBuilder', function () {
       TestStubs.routerContext()
     );
 
-    wrapper.find('SelectOwners .Select-input input').simulate('focus');
-
+    // Open the menu so we can do some assertions.
+    openMenu(wrapper, {name: 'owners', control: true});
     await tick();
     wrapper.update();
-
-    // Simulate select first element via down arrow / enter
-    wrapper.find('SelectOwners .Select-control').simulate('keyDown', {keyCode: 40});
 
     // Should have all 4 users/teams listed
     expect(wrapper.find('IdBadge')).toHaveLength(4);
@@ -137,7 +135,9 @@ describe('RuleBuilder', function () {
     expect(wrapper.find('DisabledLabel IdBadge').at(1).prop('user').id).toBe('2');
 
     // Enter to select Jane Bloggs
-    wrapper.find('SelectOwners .Select-control').simulate('keyDown', {keyCode: 13});
+    findOption(wrapper, {value: 'user:1'}, {name: 'owners', control: true})
+      .at(0)
+      .simulate('click');
 
     const ruleCandidate = wrapper.find('RuleCandidate').first();
     ruleCandidate.simulate('click');

--- a/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/inviteRequestRow.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {mountGlobalModal} from 'sentry-test/modal';
-import {selectByValue} from 'sentry-test/select';
+import {selectByValue} from 'sentry-test/select-new';
 
 import InviteRequestRow from 'app/views/settings/organizationMembers/inviteRequestRow';
 

--- a/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
+++ b/tests/js/spec/views/settings/organizationMembers/organizationRequestsView.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {mountGlobalModal} from 'sentry-test/modal';
-import {selectByValue} from 'sentry-test/select';
+import {selectByValue} from 'sentry-test/select-new';
 
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import OrganizationMembersWrapper from 'app/views/settings/organizationMembers/organizationMembersWrapper';


### PR DESCRIPTION
Convert another handful of select controls to react-select v3. There are some minor styling changes made to the RoleSelectControl to align it closer to what our other select controls look like and not have the menu overlap with the adjacent teams select control.