### PR TITLE
feat(sentry apps): Add external issue creator

### DIFF
--- a/src/sentry/mediators/external_issues/__init__.py
+++ b/src/sentry/mediators/external_issues/__init__.py
@@ -1,2 +1,3 @@
 from .issue_link_creator import IssueLinkCreator  # NOQA
+from .creator import Creator  # NOQA
 from .destroyer import Destroyer  # NOQA

--- a/src/sentry/mediators/external_issues/creator.py
+++ b/src/sentry/mediators/external_issues/creator.py
@@ -1,0 +1,27 @@
+import six
+
+from sentry.mediators import Mediator, Param
+from sentry.models import PlatformExternalIssue
+from sentry.utils.html import escape
+
+
+class Creator(Mediator):
+    install = Param("sentry.models.SentryAppInstallation")
+    group = Param("sentry.models.Group")
+    web_url = Param(six.string_types)
+    project = Param(six.string_types)
+    identifier = Param(six.string_types)
+
+    def call(self):
+        self._create_external_issue()
+        return self.external_issue
+
+    def _create_external_issue(self):
+        display_name = "{}#{}".format(escape(self.project), escape(self.identifier))
+        self.external_issue = PlatformExternalIssue.objects.create(
+            group_id=self.group.id,
+            project_id=self.group.project_id,
+            service_type=self.install.sentry_app.slug,
+            display_name=display_name,
+            web_url=self.web_url,
+        )

--- a/src/sentry/mediators/external_issues/issue_link_creator.py
+++ b/src/sentry/mediators/external_issues/issue_link_creator.py
@@ -38,7 +38,7 @@ class IssueLinkCreator(Mediator):
             install=self.install,
             group=self.group,
             web_url=self.response["webUrl"],
-            project=self.group.project.slug,
+            project=self.response["project"],
             identifier=self.response["identifier"],
         )
 

--- a/src/sentry/mediators/external_issues/issue_link_creator.py
+++ b/src/sentry/mediators/external_issues/issue_link_creator.py
@@ -1,10 +1,8 @@
 import six
 
 from sentry.coreapi import APIUnauthorized
-from sentry.mediators import Mediator, Param, external_requests
-from sentry.models import PlatformExternalIssue
+from sentry.mediators import Mediator, Param, external_requests, external_issues
 from sentry.utils.cache import memoize
-from sentry.utils.html import escape
 
 
 class IssueLinkCreator(Mediator):
@@ -35,23 +33,13 @@ class IssueLinkCreator(Mediator):
             action=self.action,
         )
 
-    def _format_response_data(self):
-        web_url = self.response["webUrl"]
-
-        display_name = "{}#{}".format(
-            escape(self.response["project"]), escape(self.response["identifier"])
-        )
-
-        return [web_url, display_name]
-
     def _create_external_issue(self):
-        web_url, display_name = self._format_response_data()
-        self.external_issue = PlatformExternalIssue.objects.create(
-            group_id=self.group.id,
-            project_id=self.group.project_id,
-            service_type=self.sentry_app.slug,
-            display_name=display_name,
-            web_url=web_url,
+        self.external_issue = external_issues.Creator.run(
+            install=self.install,
+            group=self.group,
+            web_url=self.response["webUrl"],
+            project=self.group.project.slug,
+            identifier=self.response["identifier"],
         )
 
     @memoize

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_issues.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_issues.py
@@ -39,7 +39,7 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
             method=responses.POST,
             url="https://example.com/create-issues",
             json={
-                "project": self.project.slug,
+                "project": "ProjectName",
                 "webUrl": "https://example.com/project/issue-id",
                 "identifier": "issue-1",
             },
@@ -55,7 +55,7 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
             "id": six.text_type(external_issue.id),
             "groupId": six.text_type(self.group.id),
             "serviceType": self.sentry_app.slug,
-            "displayName": "{}#issue-1".format(self.project.slug),
+            "displayName": "ProjectName#issue-1",
             "webUrl": "https://example.com/project/issue-id",
         }
 

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_issues.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_issues.py
@@ -39,7 +39,7 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
             method=responses.POST,
             url="https://example.com/create-issues",
             json={
-                "project": "ProjectName",
+                "project": self.project.slug,
                 "webUrl": "https://example.com/project/issue-id",
                 "identifier": "issue-1",
             },
@@ -55,7 +55,7 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
             "id": six.text_type(external_issue.id),
             "groupId": six.text_type(self.group.id),
             "serviceType": self.sentry_app.slug,
-            "displayName": "ProjectName#issue-1",
+            "displayName": "{}#issue-1".format(self.project.slug),
             "webUrl": "https://example.com/project/issue-id",
         }
 

--- a/tests/sentry/mediators/external_issues/test_creator.py
+++ b/tests/sentry/mediators/external_issues/test_creator.py
@@ -35,3 +35,4 @@ class TestCreator(TestCase):
         assert external_issue.project_id == self.group.project.id
         assert external_issue.web_url == "https://example.com/project/issue-id"
         assert external_issue.display_name == "Projectname#issue-1"
+        assert external_issue.service_type == self.sentry_app.slug

--- a/tests/sentry/mediators/external_issues/test_creator.py
+++ b/tests/sentry/mediators/external_issues/test_creator.py
@@ -1,5 +1,3 @@
-import responses
-
 from sentry.mediators.external_issues import Creator
 from sentry.models import PlatformExternalIssue
 from sentry.testutils import TestCase
@@ -22,20 +20,7 @@ class TestCreator(TestCase):
             slug="foo", organization=self.org, user=self.user
         )
 
-    @responses.activate
     def test_creates_platform_external_issue(self):
-        responses.add(
-            method=responses.POST,
-            url="https://example.com/link-issue",
-            json={
-                "project": "Projectname",
-                "webUrl": "https://example.com/project/issue-id",
-                "identifier": "issue-1",
-            },
-            status=200,
-            content_type="application/json",
-        )
-
         result = Creator.run(
             install=self.install,
             group=self.group,

--- a/tests/sentry/mediators/external_issues/test_creator.py
+++ b/tests/sentry/mediators/external_issues/test_creator.py
@@ -28,7 +28,7 @@ class TestCreator(TestCase):
             method=responses.POST,
             url="https://example.com/link-issue",
             json={
-                "project": self.project.slug,
+                "project": "Projectname",
                 "webUrl": "https://example.com/project/issue-id",
                 "identifier": "issue-1",
             },
@@ -40,7 +40,7 @@ class TestCreator(TestCase):
             install=self.install,
             group=self.group,
             web_url="https://example.com/project/issue-id",
-            project=self.project.slug,
+            project="Projectname",
             identifier="issue-1",
         )
 
@@ -49,4 +49,4 @@ class TestCreator(TestCase):
         assert external_issue.group_id == self.group.id
         assert external_issue.project_id == self.group.project.id
         assert external_issue.web_url == "https://example.com/project/issue-id"
-        assert external_issue.display_name == "boop#issue-1"
+        assert external_issue.display_name == "Projectname#issue-1"

--- a/tests/sentry/mediators/external_issues/test_issue_link_creator.py
+++ b/tests/sentry/mediators/external_issues/test_issue_link_creator.py
@@ -31,7 +31,7 @@ class TestIssueLinkCreator(TestCase):
             method=responses.POST,
             url="https://example.com/link-issue",
             json={
-                "project": self.project.slug,
+                "project": "Projectname",
                 "webUrl": "https://example.com/project/issue-id",
                 "identifier": "issue-1",
             },
@@ -53,7 +53,7 @@ class TestIssueLinkCreator(TestCase):
         assert external_issue.group_id == self.group.id
         assert external_issue.project_id == self.group.project.id
         assert external_issue.web_url == "https://example.com/project/issue-id"
-        assert external_issue.display_name == "boop#issue-1"
+        assert external_issue.display_name == "Projectname#issue-1"
 
     def test_invalid_action(self):
         with self.assertRaises(APIUnauthorized):


### PR DESCRIPTION
We're going to make a new external issues endpoint, so to make creating a `PlatformExternalIssue` more reusable, pull it into its own mediator. The `IssueLinkCreator` now uses it, and it will be used in the new endpoint as well. 