### PR TITLE
ref(pyupgrade): class-related refactors for tests/

### DIFF
--- a/tests/acceptance/page_objects/base.py
+++ b/tests/acceptance/page_objects/base.py
@@ -1,4 +1,4 @@
-class BasePage(object):
+class BasePage:
     """Base class for PageObjects"""
 
     def __init__(self, browser):
@@ -12,7 +12,7 @@ class BasePage(object):
         self.browser.wait_until_not(".loading-indicator")
 
 
-class BaseElement(object):
+class BaseElement:
     def __init__(self, element):
         self.element = element
 

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -4,7 +4,7 @@ from .global_selection import GlobalSelectionPage
 
 class IssueDetailsPage(BasePage):
     def __init__(self, browser, client):
-        super(IssueDetailsPage, self).__init__(browser)
+        super().__init__(browser)
         self.client = client
         self.global_selection = GlobalSelectionPage(browser)
 

--- a/tests/acceptance/page_objects/issue_list.py
+++ b/tests/acceptance/page_objects/issue_list.py
@@ -5,7 +5,7 @@ from .issue_details import IssueDetailsPage
 
 class IssueListPage(BasePage):
     def __init__(self, browser, client):
-        super(IssueListPage, self).__init__(browser)
+        super().__init__(browser)
         self.client = client
         self.global_selection = GlobalSelectionPage(browser)
 

--- a/tests/acceptance/page_objects/organization_integration_settings.py
+++ b/tests/acceptance/page_objects/organization_integration_settings.py
@@ -6,7 +6,7 @@ class ExampleIntegrationSetupWindowElement(ModalElement):
     submit_button_selector = '[type="submit"]'
 
     def __init__(self, *args, **kwargs):
-        super(ExampleIntegrationSetupWindowElement, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.name = self.element.find_element_by_name("name")
         continue_button_element = self.element.find_element_by_css_selector(
             self.submit_button_selector

--- a/tests/acceptance/sentry_plugins/test_amazon_sqs.py
+++ b/tests/acceptance/sentry_plugins/test_amazon_sqs.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class AmazonSQSTest(AcceptanceTestCase):
     def setUp(self):
-        super(AmazonSQSTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_asana.py
+++ b/tests/acceptance/sentry_plugins/test_asana.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class AsanaTest(AcceptanceTestCase):
     def setUp(self):
-        super(AsanaTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_bitbucket.py
+++ b/tests/acceptance/sentry_plugins/test_bitbucket.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class BitbucketTest(AcceptanceTestCase):
     def setUp(self):
-        super(BitbucketTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_clubhouse.py
+++ b/tests/acceptance/sentry_plugins/test_clubhouse.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ClubhouseTest(AcceptanceTestCase):
     def setUp(self):
-        super(ClubhouseTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_github.py
+++ b/tests/acceptance/sentry_plugins/test_github.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class GitHubTest(AcceptanceTestCase):
     def setUp(self):
-        super(GitHubTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_gitlab.py
+++ b/tests/acceptance/sentry_plugins/test_gitlab.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class GitLabTest(AcceptanceTestCase):
     def setUp(self):
-        super(GitLabTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_jira.py
+++ b/tests/acceptance/sentry_plugins/test_jira.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class JIRATest(AcceptanceTestCase):
     def setUp(self):
-        super(JIRATest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_pagerduty.py
+++ b/tests/acceptance/sentry_plugins/test_pagerduty.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class PagerDutyTest(AcceptanceTestCase):
     def setUp(self):
-        super(PagerDutyTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_phabricator.py
+++ b/tests/acceptance/sentry_plugins/test_phabricator.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class PhabricatorTest(AcceptanceTestCase):
     def setUp(self):
-        super(PhabricatorTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_pivotal.py
+++ b/tests/acceptance/sentry_plugins/test_pivotal.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class PivotalTest(AcceptanceTestCase):
     def setUp(self):
-        super(PivotalTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_pushover.py
+++ b/tests/acceptance/sentry_plugins/test_pushover.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class PushoverTest(AcceptanceTestCase):
     def setUp(self):
-        super(PushoverTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_segment.py
+++ b/tests/acceptance/sentry_plugins/test_segment.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class SegmentTest(AcceptanceTestCase):
     def setUp(self):
-        super(SegmentTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_sessionstack.py
+++ b/tests/acceptance/sentry_plugins/test_sessionstack.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class SessionStackTest(AcceptanceTestCase):
     def setUp(self):
-        super(SessionStackTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_slack.py
+++ b/tests/acceptance/sentry_plugins/test_slack.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class SlackTest(AcceptanceTestCase):
     def setUp(self):
-        super(SlackTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_splunk.py
+++ b/tests/acceptance/sentry_plugins/test_splunk.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class SplunkTest(AcceptanceTestCase):
     def setUp(self):
-        super(SplunkTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_victorops.py
+++ b/tests/acceptance/sentry_plugins/test_victorops.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class VictorOpsTest(AcceptanceTestCase):
     def setUp(self):
-        super(VictorOpsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/sentry_plugins/test_vsts.py
+++ b/tests/acceptance/sentry_plugins/test_vsts.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class VstsTest(AcceptanceTestCase):
     def setUp(self):
-        super(VstsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_accept_organization_invite.py
+++ b/tests/acceptance/test_accept_organization_invite.py
@@ -6,7 +6,7 @@ from sentry.models import Organization, AuthProvider
 
 class AcceptOrganizationInviteTest(AcceptanceTestCase):
     def setUp(self):
-        super(AcceptOrganizationInviteTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_account_settings.py
+++ b/tests/acceptance/test_account_settings.py
@@ -5,7 +5,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class AccountSettingsTest(AcceptanceTestCase):
     def setUp(self):
-        super(AccountSettingsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger Rowdy Tiger Rowdy Tiger", owner=None)
         self.team = self.create_team(

--- a/tests/acceptance/test_api.py
+++ b/tests/acceptance/test_api.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ApiTokensTest(AcceptanceTestCase):
     def setUp(self):
-        super(ApiTokensTest, self).setUp()
+        super().setUp()
         self.user = self.create_user(email="foo@example.com", name="User Name")
         self.login_as(self.user)
         self.path = "/api/"
@@ -24,7 +24,7 @@ class ApiTokensTest(AcceptanceTestCase):
 
 class ApiApplicationTest(AcceptanceTestCase):
     def setUp(self):
-        super(ApiApplicationTest, self).setUp()
+        super().setUp()
         self.user = self.create_user(email="foo@example.com", name="User Name")
         self.login_as(self.user)
         self.path = "/api/applications/"

--- a/tests/acceptance/test_create_organization.py
+++ b/tests/acceptance/test_create_organization.py
@@ -5,7 +5,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class CreateOrganizationTest(AcceptanceTestCase):
     def setUp(self):
-        super(CreateOrganizationTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.login_as(self.user)
 

--- a/tests/acceptance/test_create_project.py
+++ b/tests/acceptance/test_create_project.py
@@ -5,7 +5,7 @@ from sentry.utils.compat.mock import patch
 
 class CreateProjectTest(AcceptanceTestCase):
     def setUp(self):
-        super(CreateProjectTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger")
         self.login_as(self.user)

--- a/tests/acceptance/test_create_team.py
+++ b/tests/acceptance/test_create_team.py
@@ -4,7 +4,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class CreateTeamTest(AcceptanceTestCase):
     def setUp(self):
-        super(CreateTeamTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_dashboard.py
+++ b/tests/acceptance/test_dashboard.py
@@ -17,7 +17,7 @@ from datetime import datetime
 
 class DashboardTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(DashboardTest, self).setUp()
+        super().setUp()
         release = Release.objects.create(organization_id=self.organization.id, version="1")
 
         environment = Environment.objects.create(
@@ -99,7 +99,7 @@ class DashboardTest(AcceptanceTestCase, SnubaTestCase):
 
 class EmptyDashboardTest(AcceptanceTestCase):
     def setUp(self):
-        super(EmptyDashboardTest, self).setUp()
+        super().setUp()
         self.login_as(self.user)
         self.path = f"/organizations/{self.organization.slug}/projects/"
 

--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -47,7 +47,7 @@ def read_txt_email_fixture(name):
 
 class EmailTestCase(AcceptanceTestCase):
     def setUp(self):
-        super(EmailTestCase, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.login_as(self.user)
 

--- a/tests/acceptance/test_incidents.py
+++ b/tests/acceptance/test_incidents.py
@@ -11,7 +11,7 @@ event_time = before_now(days=3).replace(tzinfo=pytz.utc)
 
 class OrganizationIncidentsListTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationIncidentsListTest, self).setUp()
+        super().setUp()
         self.login_as(self.user)
         self.path = f"/organizations/{self.organization.slug}/alerts/"
 

--- a/tests/acceptance/test_issue_details.py
+++ b/tests/acceptance/test_issue_details.py
@@ -13,7 +13,7 @@ now = datetime.utcnow().replace(tzinfo=pytz.utc)
 
 class IssueDetailsTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(IssueDetailsTest, self).setUp()
+        super().setUp()
         patcher = patch("django.utils.timezone.now", return_value=now)
         patcher.start()
         self.addCleanup(patcher.stop)

--- a/tests/acceptance/test_issue_details_workflow.py
+++ b/tests/acceptance/test_issue_details_workflow.py
@@ -8,7 +8,7 @@ from tests.acceptance.page_objects.issue_details import IssueDetailsPage
 
 class IssueDetailsWorkflowTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(IssueDetailsWorkflowTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(

--- a/tests/acceptance/test_issue_tag_values.py
+++ b/tests/acceptance/test_issue_tag_values.py
@@ -6,7 +6,7 @@ from tests.acceptance.page_objects.issue_details import IssueDetailsPage
 
 class IssueTagValuesTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(IssueTagValuesTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_member_list.py
+++ b/tests/acceptance/test_member_list.py
@@ -4,7 +4,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ListOrganizationMembersTest(AcceptanceTestCase):
     def setUp(self):
-        super(ListOrganizationMembersTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_new_settings.py
+++ b/tests/acceptance/test_new_settings.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class NewSettingsTest(AcceptanceTestCase):
     def setUp(self):
-        super(NewSettingsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user(
             name="A Very Very Very Very Long Username", email="foo@example.com"
         )

--- a/tests/acceptance/test_oauth_authorize.py
+++ b/tests/acceptance/test_oauth_authorize.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class OAuthAuthorizeTest(AcceptanceTestCase):
     def setUp(self):
-        super(OAuthAuthorizeTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com", is_superuser=True)
         self.login_as(self.user)
 

--- a/tests/acceptance/test_onboarding.py
+++ b/tests/acceptance/test_onboarding.py
@@ -8,7 +8,7 @@ from sentry.utils.retries import TimedRetryPolicy
 
 class OrganizationOnboardingTest(AcceptanceTestCase):
     def setUp(self):
-        super(OrganizationOnboardingTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_organization_activity.py
+++ b/tests/acceptance/test_organization_activity.py
@@ -6,7 +6,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class OrganizationActivityTest(AcceptanceTestCase):
     def setUp(self):
-        super(OrganizationActivityTest, self).setUp()
+        super().setUp()
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(
             organization=self.org, name="Mariachi Band", members=[self.user]

--- a/tests/acceptance/test_organization_alert_rules.py
+++ b/tests/acceptance/test_organization_alert_rules.py
@@ -8,7 +8,7 @@ FEATURE_NAME = ["organizations:incidents"]
 
 class OrganizationAlertRulesListTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationAlertRulesListTest, self).setUp()
+        super().setUp()
         self.login_as(self.user)
         self.path = f"/organizations/{self.organization.slug}/alerts/rules/"
 

--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -10,7 +10,7 @@ FEATURE_NAMES = [
 
 class OrganizationDashboardsAcceptanceTest(AcceptanceTestCase):
     def setUp(self):
-        super(OrganizationDashboardsAcceptanceTest, self).setUp()
+        super().setUp()
         min_ago = iso_format(before_now(minutes=1))
         self.default_path = f"/organizations/{self.organization.slug}/dashboards/default-overview/"
         self.store_event(

--- a/tests/acceptance/test_organization_developer_settings.py
+++ b/tests/acceptance/test_organization_developer_settings.py
@@ -7,7 +7,7 @@ class OrganizationDeveloperSettingsNewAcceptanceTest(AcceptanceTestCase):
     """
 
     def setUp(self):
-        super(OrganizationDeveloperSettingsNewAcceptanceTest, self).setUp()
+        super().setUp()
         self.team = self.create_team(organization=self.organization, name="Tesla Motors")
         self.project = self.create_project(
             organization=self.organization, teams=[self.team], name="Model S"
@@ -51,7 +51,7 @@ class OrganizationDeveloperSettingsEditAcceptanceTest(AcceptanceTestCase):
     """
 
     def setUp(self):
-        super(OrganizationDeveloperSettingsEditAcceptanceTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Tesla", owner=self.user)
         self.team = self.create_team(organization=self.org, name="Tesla Motors")

--- a/tests/acceptance/test_organization_discover.py
+++ b/tests/acceptance/test_organization_discover.py
@@ -7,7 +7,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 class OrganizationDiscoverTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationDiscoverTest, self).setUp()
+        super().setUp()
 
         self.login_as(user=self.user, superuser=False)
 

--- a/tests/acceptance/test_organization_document_integration_detailed_view.py
+++ b/tests/acceptance/test_organization_document_integration_detailed_view.py
@@ -7,7 +7,7 @@ class OrganizationDocumentIntegrationDetailView(AcceptanceTestCase):
     """
 
     def setUp(self):
-        super(OrganizationDocumentIntegrationDetailView, self).setUp()
+        super().setUp()
         self.login_as(self.user)
 
     def load_page(self, slug):

--- a/tests/acceptance/test_organization_events.py
+++ b/tests/acceptance/test_organization_events.py
@@ -5,7 +5,7 @@ FEATURE_NAME = "organizations:events"
 
 class OrganizationEventsTest(AcceptanceTestCase):
     def setUp(self):
-        super(OrganizationEventsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=None, name="Rowdy Tiger")
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -133,7 +133,7 @@ def generate_transaction(trace=None, span=None):
 
 class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsV2Test, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com", is_superuser=True)
         self.org = self.create_organization(name="Rowdy Tiger")
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_organization_global_selection_header.py
+++ b/tests/acceptance/test_organization_global_selection_header.py
@@ -16,7 +16,7 @@ event_time = before_now(days=3).replace(tzinfo=pytz.utc)
 
 class OrganizationGlobalHeaderTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationGlobalHeaderTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -15,7 +15,7 @@ event_time = before_now(days=3).replace(tzinfo=pytz.utc)
 
 class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationGroupIndexTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(

--- a/tests/acceptance/test_organization_integration_detail_view.py
+++ b/tests/acceptance/test_organization_integration_detail_view.py
@@ -16,7 +16,7 @@ class OrganizationIntegrationDetailView(AcceptanceTestCase):
     """
 
     def setUp(self):
-        super(OrganizationIntegrationDetailView, self).setUp()
+        super().setUp()
         features.add("organizations:integrations-feature_flag_integration", OrganizationFeature)
         self.login_as(self.user)
 

--- a/tests/acceptance/test_organization_integration_directory.py
+++ b/tests/acceptance/test_organization_integration_directory.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class OrganizationIntegrationDirectoryTest(AcceptanceTestCase):
     def setUp(self):
-        super(OrganizationIntegrationDirectoryTest, self).setUp()
+        super().setUp()
         self.login_as(self.user)
 
     def test_all_integrations_list(self):

--- a/tests/acceptance/test_organization_plugin_detail_view.py
+++ b/tests/acceptance/test_organization_plugin_detail_view.py
@@ -13,7 +13,7 @@ class OrganizationPluginDetailedView(AcceptanceTestCase):
         return OpsGeniePlugin()
 
     def setUp(self):
-        super(OrganizationPluginDetailedView, self).setUp()
+        super().setUp()
         # need at least two projects
         self.project = self.create_project(organization=self.organization, name="Back end")
         self.create_project(organization=self.organization, name="Front End")

--- a/tests/acceptance/test_organization_rate_limits.py
+++ b/tests/acceptance/test_organization_rate_limits.py
@@ -6,7 +6,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class OrganizationRateLimitsTest(AcceptanceTestCase):
     def setUp(self):
-        super(OrganizationRateLimitsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_organization_releases.py
+++ b/tests/acceptance/test_organization_releases.py
@@ -5,7 +5,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class OrganizationReleasesTest(AcceptanceTestCase):
     def setUp(self):
-        super(OrganizationReleasesTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(

--- a/tests/acceptance/test_organization_security_privacy.py
+++ b/tests/acceptance/test_organization_security_privacy.py
@@ -5,7 +5,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class OrganizationSecurityAndPrivacyTest(AcceptanceTestCase):
     def setUp(self):
-        super(OrganizationSecurityAndPrivacyTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("owner@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.login_as(self.user)

--- a/tests/acceptance/test_organization_sentry_app.py
+++ b/tests/acceptance/test_organization_sentry_app.py
@@ -14,7 +14,7 @@ class OrganizationSentryAppAcceptanceTestCase(AcceptanceTestCase):
     """
 
     def setUp(self):
-        super(OrganizationSentryAppAcceptanceTestCase, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Tesla", owner=None)
         self.team = self.create_team(organization=self.org, name="Tesla Motors")

--- a/tests/acceptance/test_organization_sentry_app_detailed_view.py
+++ b/tests/acceptance/test_organization_sentry_app_detailed_view.py
@@ -7,7 +7,7 @@ from tests.acceptance.page_objects.organization_integration_settings import (
 
 class OrganizationSentryAppDetailedView(AcceptanceTestCase):
     def setUp(self):
-        super(OrganizationSentryAppDetailedView, self).setUp()
+        super().setUp()
         self.create_project(organization=self.organization)
         self.sentry_app = self.create_sentry_app(
             organization=self.organization,

--- a/tests/acceptance/test_organization_stats.py
+++ b/tests/acceptance/test_organization_stats.py
@@ -5,7 +5,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class OrganizationStatsTest(AcceptanceTestCase):
     def setUp(self):
-        super(OrganizationStatsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Org Name")
         self.team = self.create_team(name="Team Name", organization=self.org, members=[self.user])

--- a/tests/acceptance/test_organization_switch.py
+++ b/tests/acceptance/test_organization_switch.py
@@ -5,7 +5,7 @@ from sentry.utils.retries import TimedRetryPolicy
 
 class OrganizationSwitchTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationSwitchTest, self).setUp()
+        super().setUp()
 
         self.primary_projects = [
             self.create_project(organization=self.organization, teams=[self.team], name=name)

--- a/tests/acceptance/test_organization_user_feedback.py
+++ b/tests/acceptance/test_organization_user_feedback.py
@@ -5,7 +5,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class OrganizationUserFeedbackTest(AcceptanceTestCase):
     def setUp(self):
-        super(OrganizationUserFeedbackTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -18,7 +18,7 @@ FEATURE_NAMES = (
 
 class PerformanceOverviewTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(PerformanceOverviewTest, self).setUp()
+        super().setUp()
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(
             organization=self.org, name="Mariachi Band", members=[self.user]

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -22,7 +22,7 @@ def make_event(event_data):
 
 class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(PerformanceSummaryTest, self).setUp()
+        super().setUp()
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(
             organization=self.org, name="Mariachi Band", members=[self.user]

--- a/tests/acceptance/test_performance_trends.py
+++ b/tests/acceptance/test_performance_trends.py
@@ -35,7 +35,7 @@ class PerformanceTrendsTest(AcceptanceTestCase, SnubaTestCase):
             self.store_event(data=event, project_id=self.project.id)
 
     def setUp(self):
-        super(PerformanceTrendsTest, self).setUp()
+        super().setUp()
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(
             organization=self.org, name="Mariachi Band", members=[self.user]

--- a/tests/acceptance/test_performance_vital_detail.py
+++ b/tests/acceptance/test_performance_vital_detail.py
@@ -19,7 +19,7 @@ FEATURE_NAMES = (
 
 class PerformanceVitalDetailsTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(PerformanceVitalDetailsTest, self).setUp()
+        super().setUp()
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(
             organization=self.org, name="Mariachi Band", members=[self.user]

--- a/tests/acceptance/test_project_alert_settings.py
+++ b/tests/acceptance/test_project_alert_settings.py
@@ -4,7 +4,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ProjectAlertSettingsTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectAlertSettingsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_project_all_integrations_settings.py
+++ b/tests/acceptance/test_project_all_integrations_settings.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ProjectAllIntegrationsSettingsTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectAllIntegrationsSettingsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_project_data_forwarding_settings.py
+++ b/tests/acceptance/test_project_data_forwarding_settings.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ProjectDataForwardingSettingsTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectDataForwardingSettingsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_project_debug_symbols_settings.py
+++ b/tests/acceptance/test_project_debug_symbols_settings.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ProjectSavedSearchesSettingsTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectSavedSearchesSettingsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_project_detail.py
+++ b/tests/acceptance/test_project_detail.py
@@ -8,7 +8,7 @@ FEATURE_NAME = ["organizations:incidents", "organizations:project-detail"]
 
 class ProjectDetailTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectDetailTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
 

--- a/tests/acceptance/test_project_general_settings.py
+++ b/tests/acceptance/test_project_general_settings.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ProjectGeneralSettingsTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectGeneralSettingsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_project_keys.py
+++ b/tests/acceptance/test_project_keys.py
@@ -7,7 +7,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ProjectKeysTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectKeysTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")
@@ -34,7 +34,7 @@ class ProjectKeysTest(AcceptanceTestCase):
 
 class ProjectKeyDetailsTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectKeyDetailsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_project_ownership.py
+++ b/tests/acceptance/test_project_ownership.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ProjectOwnershipTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectOwnershipTest, self).setUp()
+        super().setUp()
         self.login_as(self.user)
         self.path = f"/settings/{self.organization.slug}/projects/{self.project.slug}/ownership/"
 

--- a/tests/acceptance/test_project_release_tracking_settings.py
+++ b/tests/acceptance/test_project_release_tracking_settings.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase, SnubaTestCase
 
 class ProjectReleaseTrackingSettingsTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(ProjectReleaseTrackingSettingsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_project_releases.py
+++ b/tests/acceptance/test_project_releases.py
@@ -7,7 +7,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ProjectReleasesTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectReleasesTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(organization=self.org, name="Mariachi Band")
@@ -35,7 +35,7 @@ class ProjectReleasesTest(AcceptanceTestCase):
 
 class ProjectReleaseDetailsTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectReleaseDetailsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_project_servicehooks.py
+++ b/tests/acceptance/test_project_servicehooks.py
@@ -4,7 +4,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ProjectServiceHooksTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectServiceHooksTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_project_similar_issues.py
+++ b/tests/acceptance/test_project_similar_issues.py
@@ -7,7 +7,7 @@ from sentry.utils.samples import create_sample_event
 
 class ProjectIssuesGroupingTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectIssuesGroupingTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.org.flags.early_adopter = True

--- a/tests/acceptance/test_project_tags_settings.py
+++ b/tests/acceptance/test_project_tags_settings.py
@@ -10,7 +10,7 @@ current_time = datetime.utcnow().replace(tzinfo=pytz.utc)
 
 class ProjectTagsSettingsTest(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(ProjectTagsSettingsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_project_user_feedback.py
+++ b/tests/acceptance/test_project_user_feedback.py
@@ -5,7 +5,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class ProjectUserFeedbackTest(AcceptanceTestCase):
     def setUp(self):
-        super(ProjectUserFeedbackTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(

--- a/tests/acceptance/test_shared_issue.py
+++ b/tests/acceptance/test_shared_issue.py
@@ -6,7 +6,7 @@ from sentry.utils.samples import load_data
 
 class SharedIssueTest(AcceptanceTestCase):
     def setUp(self):
-        super(SharedIssueTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(owner=self.user, name="Rowdy Tiger")
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_sidebar.py
+++ b/tests/acceptance/test_sidebar.py
@@ -3,7 +3,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class SidebarTest(AcceptanceTestCase):
     def setUp(self):
-        super(SidebarTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.login_as(self.user)
         self.create_organization(name="Foo Foo Foo Foo Foo Foo Foo", owner=self.user)

--- a/tests/acceptance/test_teams_list.py
+++ b/tests/acceptance/test_teams_list.py
@@ -5,7 +5,7 @@ from sentry.testutils import AcceptanceTestCase
 
 class TeamsListTest(AcceptanceTestCase):
     def setUp(self):
-        super(TeamsListTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/acceptance/test_transaction_comparison.py
+++ b/tests/acceptance/test_transaction_comparison.py
@@ -12,7 +12,7 @@ FEATURE_NAMES = ["organizations:performance-view"]
 
 class TransactionComparison(AcceptanceTestCase, SnubaTestCase):
     def setUp(self):
-        super(TransactionComparison, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com", is_superuser=True)
         self.org = self.create_organization(name="Rowdy Tiger")
         self.team = self.create_team(organization=self.org, name="Mariachi Band")

--- a/tests/apidocs/endpoints/events/test_group_events.py
+++ b/tests/apidocs/endpoints/events/test_group_events.py
@@ -29,7 +29,7 @@ class ProjectGroupEventBase(APIDocsTestCase):
 
 class ProjectGroupEventsDocs(ProjectGroupEventBase):
     def setUp(self):
-        super(ProjectGroupEventsDocs, self).setUp()
+        super().setUp()
         self.url = f"/api/0/issues/{self.group_id}/events/"
 
     def test_get(self):
@@ -41,7 +41,7 @@ class ProjectGroupEventsDocs(ProjectGroupEventBase):
 
 class ProjectGroupEventsLatestDocs(ProjectGroupEventBase):
     def setUp(self):
-        super(ProjectGroupEventsLatestDocs, self).setUp()
+        super().setUp()
         self.url = f"/api/0/issues/{self.group_id}/events/latest/"
 
     def test_get(self):
@@ -53,7 +53,7 @@ class ProjectGroupEventsLatestDocs(ProjectGroupEventBase):
 
 class ProjectGroupEventsOldestDocs(ProjectGroupEventBase):
     def setUp(self):
-        super(ProjectGroupEventsOldestDocs, self).setUp()
+        super().setUp()
         self.url = f"/api/0/issues/{self.group_id}/events/oldest/"
 
     def test_get(self):

--- a/tests/apidocs/endpoints/releases/test_project_issues_solved_in_release.py
+++ b/tests/apidocs/endpoints/releases/test_project_issues_solved_in_release.py
@@ -12,7 +12,7 @@ class ProjectIssuesResolvedInReleaseEndpointTest(APIDocsTestCase):
     method = "get"
 
     def setUp(self):
-        super(ProjectIssuesResolvedInReleaseEndpointTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization()
         self.team = self.create_team(organization=self.org)

--- a/tests/fixtures/integrations/jira/mock.py
+++ b/tests/fixtures/integrations/jira/mock.py
@@ -53,7 +53,7 @@ class MockJira(StubJiraApiClient, MockService):
             return createmeta
 
         # Fallback to stub data
-        return super(MockJira, self).get_create_meta_for_project(project)
+        return super().get_create_meta_for_project(project)
 
     def create_issue(self, raw_form_data):
         """

--- a/tests/fixtures/integrations/mock_service.py
+++ b/tests/fixtures/integrations/mock_service.py
@@ -21,7 +21,7 @@ class MockService(StubService):
         """
         Initialize the mock instance. Wipe the previous instance's data if it exists.
         """
-        super(MockService, self).__init__()
+        super().__init__()
         self.mode = mode
         self._next_error_code = None
         self._next_ids = defaultdict(lambda: 0)

--- a/tests/fixtures/integrations/stub_service.py
+++ b/tests/fixtures/integrations/stub_service.py
@@ -5,7 +5,7 @@ from sentry.utils import json
 from tests.fixtures.integrations import FIXTURE_DIRECTORY
 
 
-class StubService(object):
+class StubService:
     """
     A stub is a service that replicates the functionality of a real software
     system by returning valid data without actually implementing any business

--- a/tests/relay_integration/lang/javascript/test_plugin.py
+++ b/tests/relay_integration/lang/javascript/test_plugin.py
@@ -30,7 +30,7 @@ def load_fixture(name):
 
 class JavascriptIntegrationTest(RelayStoreHelper, SnubaTestCase, TransactionTestCase):
     def setUp(self):
-        super(JavascriptIntegrationTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
 
     def test_adds_contexts_without_device(self):

--- a/tests/sentry/analytics/test_base.py
+++ b/tests/sentry/analytics/test_base.py
@@ -5,7 +5,7 @@ from sentry.testutils import TestCase
 class DummyAnalytics(Analytics):
     def __init__(self):
         self.events = []
-        super(DummyAnalytics, self).__init__()
+        super().__init__()
 
     def record_event(self, event):
         self.events.append(event)

--- a/tests/sentry/analytics/test_event.py
+++ b/tests/sentry/analytics/test_event.py
@@ -17,14 +17,14 @@ class ExampleEvent(Event):
     )
 
 
-class DummyType(object):
+class DummyType:
     key = "value"
 
 
 class EventTest(TestCase):
     @patch("sentry.analytics.event.uuid1")
     def test_simple(self, mock_uuid1):
-        class uuid(object):
+        class uuid:
             bytes = b"\x00\x01\x02"
 
         mock_uuid1.return_value = uuid

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -16,7 +16,7 @@ from sentry.models import ApiKey, Organization
 from sentry.testutils import TestCase
 
 
-class MockSuperUser(object):
+class MockSuperUser:
     @property
     def is_active(self):
         return True

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -25,7 +25,7 @@ class MockSuperUser(object):
 class OrganizationPermissionBase(TestCase):
     def setUp(self):
         self.org = self.create_organization()
-        super(OrganizationPermissionBase, self).setUp()
+        super().setUp()
 
     def has_object_perm(self, method, obj, auth=None, user=None, is_superuser=None):
         perm = OrganizationPermission()

--- a/tests/sentry/api/bases/test_project.py
+++ b/tests/sentry/api/bases/test_project.py
@@ -8,7 +8,7 @@ class ProjectPermissionBase(TestCase):
         self.org = self.create_organization()
         self.team = self.create_team(organization=self.org)
         self.project = self.create_project(organization=self.org)
-        super(ProjectPermissionBase, self).setUp()
+        super().setUp()
 
     def has_object_perm(self, method, obj, auth=None, user=None, is_superuser=None):
         perm = ProjectPermission()
@@ -144,7 +144,7 @@ class ProjectPermissionTest(ProjectPermissionBase):
 
 class ProjectPermissionNoJoinLeaveTest(ProjectPermissionBase):
     def setUp(self):
-        super(ProjectPermissionNoJoinLeaveTest, self).setUp()
+        super().setUp()
         self.org = self.create_organization()
         self.org.flags.allow_joinleave = False
         self.org.save()

--- a/tests/sentry/api/bases/test_team.py
+++ b/tests/sentry/api/bases/test_team.py
@@ -7,7 +7,7 @@ class TeamPermissionBase(TestCase):
     def setUp(self):
         self.org = self.create_organization(flags=0)
         self.team = self.create_team(organization=self.org)
-        super(TeamPermissionBase, self).setUp()
+        super().setUp()
 
     def has_object_perm(self, method, obj, auth=None, user=None, is_superuser=None):
         perm = TeamPermission()

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -18,7 +18,7 @@ from sentry.testutils import TestCase
 
 class AcceptInviteTest(TestCase):
     def setUp(self):
-        super(AcceptInviteTest, self).setUp()
+        super().setUp()
         self.organization = self.create_organization(owner=self.create_user("foo@example.com"))
         self.user = self.create_user("bar@example.com")
 

--- a/tests/sentry/api/endpoints/test_accept_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_accept_project_transfer.py
@@ -9,7 +9,7 @@ from sentry.testutils import APITestCase, PermissionTestCase
 
 class AcceptTransferProjectPermissionTest(PermissionTestCase):
     def setUp(self):
-        super(AcceptTransferProjectPermissionTest, self).setUp()
+        super().setUp()
         self.project = self.create_project(teams=[self.team])
         self.path = reverse("sentry-api-0-accept-project-transfer")
 
@@ -19,7 +19,7 @@ class AcceptTransferProjectPermissionTest(PermissionTestCase):
 
 class AcceptTransferProjectTest(APITestCase):
     def setUp(self):
-        super(AcceptTransferProjectTest, self).setUp()
+        super().setUp()
         self.owner = self.create_user(email="example@example.com", is_superuser=False)
         self.from_organization = self.create_organization(owner=self.owner)
         self.to_organization = self.create_organization(owner=self.owner)

--- a/tests/sentry/api/endpoints/test_assistant.py
+++ b/tests/sentry/api/endpoints/test_assistant.py
@@ -11,7 +11,7 @@ from sentry.testutils import APITestCase
 
 class AssistantActivityTest(APITestCase):
     def setUp(self):
-        super(AssistantActivityTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
         self.path = reverse("sentry-api-0-assistant")
         self.guides = manager.all()
@@ -55,7 +55,7 @@ class AssistantActivityV2Test(APITestCase):
         return manager.all()
 
     def setUp(self):
-        super(AssistantActivityV2Test, self).setUp()
+        super().setUp()
         self.create_organization(owner=self.user)
         self.login_as(user=self.user)
 
@@ -95,7 +95,7 @@ class AssistantActivityV2UpdateTest(APITestCase):
         return manager.all()
 
     def setUp(self):
-        super(AssistantActivityV2UpdateTest, self).setUp()
+        super().setUp()
         self.create_organization(owner=self.user)
         self.login_as(user=self.user)
 

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -5,7 +5,7 @@ from sentry.testutils import APITestCase, PermissionTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 
 
-class CreateAttachmentMixin(object):
+class CreateAttachmentMixin:
     def create_attachment(self):
         self.project = self.create_project()
         self.release = self.create_release(self.project, self.user)

--- a/tests/sentry/api/endpoints/test_event_attachment_details.py
+++ b/tests/sentry/api/endpoints/test_event_attachment_details.py
@@ -78,7 +78,7 @@ class EventAttachmentDetailsTest(APITestCase, CreateAttachmentMixin):
 
 class EventAttachmentDetailsPermissionTest(PermissionTestCase, CreateAttachmentMixin):
     def setUp(self):
-        super(EventAttachmentDetailsPermissionTest, self).setUp()
+        super().setUp()
         self.create_attachment()
         self.path = f"/api/0/projects/{self.organization.slug}/{self.project.slug}/events/{self.event.event_id}/attachments/{self.attachment.id}/?download"
 

--- a/tests/sentry/api/endpoints/test_group_events_latest.py
+++ b/tests/sentry/api/endpoints/test_group_events_latest.py
@@ -4,7 +4,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 
 class GroupEventsLatestEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(GroupEventsLatestEndpointTest, self).setUp()
+        super().setUp()
 
         self.login_as(user=self.user)
         project = self.create_project()

--- a/tests/sentry/api/endpoints/test_group_events_oldest.py
+++ b/tests/sentry/api/endpoints/test_group_events_oldest.py
@@ -4,7 +4,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 
 class GroupEventsOldestEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(GroupEventsOldestEndpointTest, self).setUp()
+        super().setUp()
 
         self.login_as(user=self.user)
         project = self.create_project()

--- a/tests/sentry/api/endpoints/test_group_integration_details.py
+++ b/tests/sentry/api/endpoints/test_group_integration_details.py
@@ -12,7 +12,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 class GroupIntegrationDetailsTest(APITestCase):
     def setUp(self):
-        super(GroupIntegrationDetailsTest, self).setUp()
+        super().setUp()
         self.min_ago = before_now(minutes=1)
         self.event = self.store_event(
             data={

--- a/tests/sentry/api/endpoints/test_group_notes_details.py
+++ b/tests/sentry/api/endpoints/test_group_notes_details.py
@@ -9,7 +9,7 @@ from sentry.testutils import APITestCase
 
 class GroupNotesDetailsTest(APITestCase):
     def setUp(self):
-        super(GroupNotesDetailsTest, self).setUp()
+        super().setUp()
         self.activity.data["external_id"] = "123"
         self.activity.save()
         self.integration = Integration.objects.create(

--- a/tests/sentry/api/endpoints/test_group_user_reports.py
+++ b/tests/sentry/api/endpoints/test_group_user_reports.py
@@ -7,7 +7,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 
 class GroupUserReport(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(GroupUserReport, self).setUp()
+        super().setUp()
         self.project = self.create_project()
         self.env1 = self.create_environment(self.project, "production")
         self.env2 = self.create_environment(self.project, "staging")

--- a/tests/sentry/api/endpoints/test_organization_auth_provider_details.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_provider_details.py
@@ -5,7 +5,7 @@ from sentry.testutils import PermissionTestCase
 
 class OrganizationAuthProviderPermissionTest(PermissionTestCase):
     def setUp(self):
-        super(OrganizationAuthProviderPermissionTest, self).setUp()
+        super().setUp()
         self.path = reverse(
             "sentry-api-0-organization-auth-provider", args=[self.organization.slug]
         )

--- a/tests/sentry/api/endpoints/test_organization_auth_providers.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_providers.py
@@ -5,7 +5,7 @@ from sentry.testutils import APITestCase, PermissionTestCase
 
 class OrganizationAuthProvidersPermissionTest(PermissionTestCase):
     def setUp(self):
-        super(OrganizationAuthProvidersPermissionTest, self).setUp()
+        super().setUp()
         self.path = reverse(
             "sentry-api-0-organization-auth-providers", args=[self.organization.slug]
         )

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -12,7 +12,7 @@ from sentry.utils.compat import zip
 
 class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):
     def setUp(self):
-        super(OrganizationDashboardDetailsTestCase, self).setUp()
+        super().setUp()
         self.widget_1 = DashboardWidget.objects.create(
             dashboard=self.dashboard,
             order=0,
@@ -131,7 +131,7 @@ class OrganizationDashboardDetailsDeleteTest(OrganizationDashboardDetailsTestCas
 
 class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
     def setUp(self):
-        super(OrganizationDashboardDetailsPutTest, self).setUp()
+        super().setUp()
         self.create_user_member_role()
         self.widget_3 = DashboardWidget.objects.create(
             dashboard=self.dashboard,

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -7,7 +7,7 @@ from sentry.testutils import OrganizationDashboardWidgetTestCase
 
 class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
     def setUp(self):
-        super(OrganizationDashboardsTest, self).setUp()
+        super().setUp()
         self.login_as(self.user)
         self.url = reverse(
             "sentry-api-0-organization-dashboards",

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -690,7 +690,7 @@ class OrganizationDeleteTest(APITestCase):
     @patch("sentry.api.endpoints.organization_details.uuid4")
     @patch("sentry.api.endpoints.organization_details.delete_organization")
     def test_can_remove_as_owner(self, mock_delete_organization, mock_uuid4):
-        class uuid(object):
+        class uuid:
             hex = "abc123"
 
         mock_uuid4.return_value = uuid

--- a/tests/sentry/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_details.py
@@ -10,7 +10,7 @@ from sentry.testutils import APITestCase
 
 class OrganizationIntegrationDetailsTest(APITestCase):
     def setUp(self):
-        super(OrganizationIntegrationDetailsTest, self).setUp()
+        super().setUp()
 
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user, name="baz")

--- a/tests/sentry/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repos.py
@@ -5,7 +5,7 @@ from sentry.testutils import APITestCase
 
 class OrganizationIntegrationReposTest(APITestCase):
     def setUp(self):
-        super(OrganizationIntegrationReposTest, self).setUp()
+        super().setUp()
 
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user, name="baz")

--- a/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_config_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_config_details.py
@@ -7,7 +7,7 @@ from sentry.testutils import APITestCase
 
 class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
     def setUp(self):
-        super(OrganizationIntegrationRepositoryProjectPathConfigTest, self).setUp()
+        super().setUp()
 
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user, name="baz")

--- a/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
@@ -6,7 +6,7 @@ from sentry.testutils import APITestCase
 
 class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
     def setUp(self):
-        super(OrganizationIntegrationRepositoryProjectPathConfigTest, self).setUp()
+        super().setUp()
 
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user, name="baz")

--- a/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
@@ -15,7 +15,7 @@ class AbstractServerlessTest(APITestCase):
     endpoint = "sentry-api-0-organization-integration-serverless-functions"
 
     def setUp(self):
-        super(AbstractServerlessTest, self).setUp()
+        super().setUp()
         self.project = self.create_project(organization=self.organization)
         self.integration = Integration.objects.create(
             provider="aws_lambda",
@@ -31,9 +31,7 @@ class AbstractServerlessTest(APITestCase):
         self.login_as(self.user)
 
     def get_response(self, **kwargs):
-        return super(AbstractServerlessTest, self).get_response(
-            self.organization.slug, self.integration.id, **kwargs
-        )
+        return super().get_response(self.organization.slug, self.integration.id, **kwargs)
 
     @property
     def sentry_dsn(self):

--- a/tests/sentry/api/endpoints/test_organization_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_integrations.py
@@ -5,7 +5,7 @@ from sentry.testutils.helpers import with_feature
 
 class OrganizationIntegrationsListTest(APITestCase):
     def setUp(self):
-        super(OrganizationIntegrationsListTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user, name="baz")
         self.integration = Integration.objects.create(provider="example", name="Example")

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -11,7 +11,7 @@ class OrganizationJoinRequestTest(APITestCase):
     method = "post"
 
     def setUp(self):
-        super(OrganizationJoinRequestTest, self).setUp()
+        super().setUp()
         self.email = "test@example.com"
         self.org = self.create_organization(owner=self.user)
 

--- a/tests/sentry/api/endpoints/test_organization_pinned_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_pinned_searches.py
@@ -18,9 +18,7 @@ class CreateOrganizationPinnedSearchTest(APITestCase):
         return user
 
     def get_response(self, *args, **params):
-        return super(CreateOrganizationPinnedSearchTest, self).get_response(
-            *((self.organization.slug,) + args), **params
-        )
+        return super().get_response(*((self.organization.slug,) + args), **params)
 
     def test(self):
         self.login_as(self.member)
@@ -118,9 +116,7 @@ class DeleteOrganizationPinnedSearchTest(APITestCase):
         return user
 
     def get_response(self, *args, **params):
-        return super(DeleteOrganizationPinnedSearchTest, self).get_response(
-            *((self.organization.slug,) + args), **params
-        )
+        return super().get_response(*((self.organization.slug,) + args), **params)
 
     def test(self):
         saved_search = SavedSearch.objects.create(

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -594,7 +594,7 @@ class ReleaseDeleteTest(APITestCase):
 
 class ReleaseSerializerTest(unittest.TestCase):
     def setUp(self):
-        super(ReleaseSerializerTest, self).setUp()
+        super().setUp()
         self.repo_name = "repo/name"
         self.repo2_name = "repo2/name"
         self.commits = [{"id": "a" * 40}, {"id": "b" * 40}]

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -950,7 +950,7 @@ class OrganizationReleaseCreateTest(APITestCase):
 
 class OrganizationReleaseCommitRangesTest(SetRefsTestCase):
     def setUp(self):
-        super(OrganizationReleaseCommitRangesTest, self).setUp()
+        super().setUp()
         self.url = reverse(
             "sentry-api-0-organization-releases", kwargs={"organization_slug": self.org.slug}
         )
@@ -1311,7 +1311,7 @@ class OrganizationReleaseCreateCommitPatch(ReleaseCommitPatchTest):
 
 class ReleaseSerializerWithProjectsTest(TestCase):
     def setUp(self):
-        super(ReleaseSerializerWithProjectsTest, self).setUp()
+        super().setUp()
         self.version = "1234567890"
         self.repo_name = "repo/name"
         self.repo2_name = "repo2/name"
@@ -1457,7 +1457,7 @@ class ReleaseSerializerWithProjectsTest(TestCase):
 
 class ReleaseHeadCommitSerializerTest(TestCase):
     def setUp(self):
-        super(ReleaseHeadCommitSerializerTest, self).setUp()
+        super().setUp()
         self.repo_name = "repo/name"
         self.commit = "b" * 40
         self.commit_range = "{}..{}".format("a" * 40, "b" * 40)

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -11,7 +11,7 @@ from sentry.testutils import APITestCase
 
 class OrganizationRepositoriesListTest(APITestCase):
     def setUp(self):
-        super(OrganizationRepositoriesListTest, self).setUp()
+        super().setUp()
 
         self.org = self.create_organization(owner=self.user, name="baz")
         self.url = reverse("sentry-api-0-organization-repositories", args=[self.org.slug])
@@ -199,7 +199,7 @@ class OrganizationRepositoriesCreateTest(APITestCase):
 
 class OrganizationIntegrationRepositoriesCreateTest(APITestCase):
     def setUp(self):
-        super(OrganizationIntegrationRepositoriesCreateTest, self).setUp()
+        super().setUp()
         self.org = self.create_organization(owner=self.user, name="baz")
         self.integration = Integration.objects.create(provider="example")
         self.integration.add_organization(self.org, self.user)

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -11,7 +11,7 @@ class OrganizationRepositoryDeleteTest(APITestCase):
     def setUp(self):
         super().setUp()
 
-        class mock_uuid(object):
+        class mock_uuid:
             hex = "1234567"
 
         self.mock_uuid = mock_uuid

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -9,7 +9,7 @@ from sentry.testutils import APITestCase
 
 class OrganizationRepositoryDeleteTest(APITestCase):
     def setUp(self):
-        super(OrganizationRepositoryDeleteTest, self).setUp()
+        super().setUp()
 
         class mock_uuid(object):
             hex = "1234567"

--- a/tests/sentry/api/endpoints/test_organization_search_details.py
+++ b/tests/sentry/api/endpoints/test_organization_search_details.py
@@ -18,9 +18,7 @@ class DeleteOrganizationSearchTest(APITestCase):
         return user
 
     def get_response(self, *args, **params):
-        return super(DeleteOrganizationSearchTest, self).get_response(
-            *((self.organization.slug,) + args), **params
-        )
+        return super().get_response(*((self.organization.slug,) + args), **params)
 
     def test_owner_can_delete_org_searches(self):
         search = SavedSearch.objects.create(organization=self.organization, name="foo", query="")

--- a/tests/sentry/api/endpoints/test_organization_searches.py
+++ b/tests/sentry/api/endpoints/test_organization_searches.py
@@ -15,7 +15,7 @@ class OrgLevelOrganizationSearchesListTest(APITestCase):
         return self.create_user("test@test.com")
 
     def get_response(self, *args, **params):
-        return super(OrgLevelOrganizationSearchesListTest, self).get_response(*args, **params)
+        return super().get_response(*args, **params)
 
     def create_base_data(self):
         # Depending on test we run migrations in Django 1.8. This causes

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -85,7 +85,7 @@ class DeleteSentryAppInstallationDetailsTest(SentryAppInstallationDetailsTest):
 
 class MarkInstalledSentryAppInstallationsTest(SentryAppInstallationDetailsTest):
     def setUp(self):
-        super(MarkInstalledSentryAppInstallationsTest, self).setUp()
+        super().setUp()
         self.token = GrantExchanger.run(
             install=self.installation,
             code=self.installation.api_grant.code,

--- a/tests/sentry/api/endpoints/test_organization_user_issues.py
+++ b/tests/sentry/api/endpoints/test_organization_user_issues.py
@@ -7,7 +7,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 class OrganizationUserIssuesTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationUserIssuesTest, self).setUp()
+        super().setUp()
         self.org = self.create_organization()
         self.org.flags.allow_joinleave = False
         self.org.save()

--- a/tests/sentry/api/endpoints/test_organization_user_issues_search.py
+++ b/tests/sentry/api/endpoints/test_organization_user_issues_search.py
@@ -9,7 +9,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 class OrganizationUserIssuesSearchTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationUserIssuesSearchTest, self).setUp()
+        super().setUp()
         self.org = self.create_organization(owner=None)
         self.org.flags.allow_joinleave = False
         self.org.save()

--- a/tests/sentry/api/endpoints/test_organization_user_reports.py
+++ b/tests/sentry/api/endpoints/test_organization_user_reports.py
@@ -11,7 +11,7 @@ class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
     method = "get"
 
     def setUp(self):
-        super(OrganizationUserReportListTest, self).setUp()
+        super().setUp()
         self.user = self.create_user("test@test.com")
         self.login_as(user=self.user)
         self.org = self.create_organization()

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -792,7 +792,7 @@ class ProjectDeleteTest(APITestCase):
     @mock.patch("sentry.api.endpoints.project_details.uuid4")
     @mock.patch("sentry.api.endpoints.project_details.delete_project")
     def test_simple(self, mock_delete_project, mock_uuid4_project, mock_uuid4_mixin):
-        class uuid(object):
+        class uuid:
             hex = "abc123"
 
         mock_uuid4_mixin.return_value = uuid

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -140,7 +140,7 @@ class ProjectDetailsTest(APITestCase):
 
 class ProjectUpdateTest(APITestCase):
     def setUp(self):
-        super(ProjectUpdateTest, self).setUp()
+        super().setUp()
         self.path = reverse(
             "sentry-api-0-project-details",
             kwargs={
@@ -600,7 +600,7 @@ class ProjectUpdateTest(APITestCase):
 
 class CopyProjectSettingsTest(APITestCase):
     def setUp(self):
-        super(CopyProjectSettingsTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
 
         self.options_dict = {

--- a/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
+++ b/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
@@ -12,7 +12,7 @@ class ProjectIssuesResolvedInReleaseEndpointTest(APITestCase):
     method = "get"
 
     def setUp(self):
-        super(ProjectIssuesResolvedInReleaseEndpointTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization()
         self.team = self.create_team(organization=self.org)

--- a/tests/sentry/api/endpoints/test_project_release_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_details.py
@@ -214,7 +214,7 @@ class ReleaseDeleteTest(APITestCase):
 
 class ReleaseSerializerTest(unittest.TestCase):
     def setUp(self):
-        super(ReleaseSerializerTest, self).setUp()
+        super().setUp()
         self.commits = [{"id": "a" * 40}, {"id": "b" * 40}]
         self.ref = "master"
         self.url = "https://example.com"

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -600,7 +600,7 @@ class ProjectReleaseCreateCommitPatch(ReleaseCommitPatchTest):
 
 class ReleaseSerializerTest(TestCase):
     def setUp(self):
-        super(ReleaseSerializerTest, self).setUp()
+        super().setUp()
         self.version = "1234567890"
         self.repo_name = "repo/name"
         self.repo2_name = "repo2/name"

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -26,7 +26,7 @@ class BaseStacktraceLinkTest(APITestCase):
 
 class ProjectStacktraceLinkGithubTest(BaseStacktraceLinkTest):
     def setUp(self):
-        super(ProjectStacktraceLinkGithubTest, self).setUp()
+        super().setUp()
         self.integration = Integration.objects.create(
             provider="github",
             name="getsentry",
@@ -135,7 +135,7 @@ class ProjectStacktraceLinkGithubTest(BaseStacktraceLinkTest):
 
 class ProjectStacktraceLinkGitlabTest(BaseStacktraceLinkTest):
     def setUp(self):
-        super(ProjectStacktraceLinkGitlabTest, self).setUp()
+        super().setUp()
 
         self.integration = Integration.objects.create(
             provider="gitlab",

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -13,7 +13,7 @@ class ProjectRuleConfigurationTest(APITestCase):
     endpoint = "sentry-api-0-project-rules-configuration"
 
     def setUp(self):
-        super(ProjectRuleConfigurationTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
 
     def test_simple(self):

--- a/tests/sentry/api/endpoints/test_project_servicehook_details.py
+++ b/tests/sentry/api/endpoints/test_project_servicehook_details.py
@@ -17,7 +17,7 @@ class ProjectServiceHookDetailsTest(APITestCase):
 
 class UpdateProjectServiceHookTest(APITestCase):
     def setUp(self):
-        super(UpdateProjectServiceHookTest, self).setUp()
+        super().setUp()
         self.project = self.create_project()
         self.login_as(user=self.user)
         self.hook = ServiceHook.objects.get_or_create(
@@ -38,7 +38,7 @@ class UpdateProjectServiceHookTest(APITestCase):
 
 class DeleteProjectServiceHookTest(APITestCase):
     def setUp(self):
-        super(DeleteProjectServiceHookTest, self).setUp()
+        super().setUp()
         self.project = self.create_project()
         self.login_as(user=self.user)
         self.hook = ServiceHook.objects.get_or_create(

--- a/tests/sentry/api/endpoints/test_project_servicehooks.py
+++ b/tests/sentry/api/endpoints/test_project_servicehooks.py
@@ -19,7 +19,7 @@ class ListProjectServiceHooksTest(APITestCase):
 
 class CreateProjectServiceHookTest(APITestCase):
     def setUp(self):
-        super(CreateProjectServiceHookTest, self).setUp()
+        super().setUp()
         self.project = self.create_project()
         self.login_as(user=self.user)
         self.path = f"/api/0/projects/{self.project.organization.slug}/{self.project.slug}/hooks/"

--- a/tests/sentry/api/endpoints/test_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_project_transfer.py
@@ -24,7 +24,7 @@ class ProjectTransferTest(APITestCase):
 
     @mock.patch("sentry.api.endpoints.project_details.uuid4")
     def test_transfer_project(self, mock_uuid4):
-        class uuid(object):
+        class uuid:
             hex = "abc123"
 
         mock_uuid4.return_value = uuid
@@ -50,7 +50,7 @@ class ProjectTransferTest(APITestCase):
 
     @mock.patch("sentry.api.endpoints.project_details.uuid4")
     def test_transfer_project_to_invalid_user(self, mock_uuid4):
-        class uuid(object):
+        class uuid:
             hex = "abc123"
 
         mock_uuid4.return_value = uuid

--- a/tests/sentry/api/endpoints/test_project_user_details.py
+++ b/tests/sentry/api/endpoints/test_project_user_details.py
@@ -6,7 +6,7 @@ from sentry.testutils import APITestCase
 
 class ProjectUserDetailsTest(APITestCase):
     def setUp(self):
-        super(ProjectUserDetailsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization(owner=None)
         self.team = self.create_team(organization=self.org)

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -10,7 +10,7 @@ from sentry.utils.compat import map
 
 class ProjectUserReportListTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(ProjectUserReportListTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
         self.environment = self.create_environment(project=self.project, name="production")
         self.event = self.store_event(
@@ -156,7 +156,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
 class CreateProjectUserReportTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(CreateProjectUserReportTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
         self.hour_ago = iso_format(before_now(minutes=60))
 

--- a/tests/sentry/api/endpoints/test_project_user_stats.py
+++ b/tests/sentry/api/endpoints/test_project_user_stats.py
@@ -8,7 +8,7 @@ from sentry.testutils import APITestCase
 
 class ProjectUserDetailsTest(APITestCase):
     def setUp(self):
-        super(ProjectUserDetailsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization(owner=None)
         self.team = self.create_team(organization=self.org)

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -7,7 +7,7 @@ from sentry.utils.compat import map
 
 class ProjectUsersTest(APITestCase):
     def setUp(self):
-        super(ProjectUsersTest, self).setUp()
+        super().setUp()
 
         self.project = self.create_project()
         self.euser1 = EventUser.objects.create(

--- a/tests/sentry/api/endpoints/test_prompts_activity.py
+++ b/tests/sentry/api/endpoints/test_prompts_activity.py
@@ -5,7 +5,7 @@ from sentry.testutils import APITestCase
 
 class PromptsActivityTest(APITestCase):
     def setUp(self):
-        super(PromptsActivityTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user, name="baz")
         # self.project = self.create_project(

--- a/tests/sentry/api/endpoints/test_relay_publickeys.py
+++ b/tests/sentry/api/endpoints/test_relay_publickeys.py
@@ -23,7 +23,7 @@ def disable_internal_networks():
 
 class RelayPublicKeysConfigTest(APITestCase):
     def setUp(self):
-        super(RelayPublicKeysConfigTest, self).setUp()
+        super().setUp()
 
         self.key_pair = generate_key_pair()
 

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -13,7 +13,7 @@ from sentry_relay import generate_key_pair
 
 class RelayRegisterTest(APITestCase):
     def setUp(self):
-        super(RelayRegisterTest, self).setUp()
+        super().setUp()
 
         self.key_pair = generate_key_pair()
 

--- a/tests/sentry/api/endpoints/test_team_details.py
+++ b/tests/sentry/api/endpoints/test_team_details.py
@@ -81,7 +81,7 @@ class TeamDeleteTest(APITestCase):
         """Admins can remove teams of which they're a part"""
 
         # mock the transaction_id when mock_delete_team is called
-        class uuid(object):
+        class uuid:
             hex = "abc123"
 
         mock_uuid4.return_value = uuid
@@ -113,7 +113,7 @@ class TeamDeleteTest(APITestCase):
         open membership is on."""
 
         # mock the transaction_id when mock_delete_team is called
-        class uuid(object):
+        class uuid:
             hex = "abc123"
 
         mock_uuid4.return_value = uuid

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -158,7 +158,7 @@ class UserUpdateTest(APITestCase):
 
 class UserDeleteTest(APITestCase):
     def setUp(self):
-        super(UserDeleteTest, self).setUp()
+        super().setUp()
         self.path = f"/api/0/users/{self.user.id}/"
 
     def test_close_account(self):

--- a/tests/sentry/api/endpoints/test_user_emails.py
+++ b/tests/sentry/api/endpoints/test_user_emails.py
@@ -6,7 +6,7 @@ from sentry.testutils import APITestCase
 
 class UserEmailsTest(APITestCase):
     def setUp(self):
-        super(UserEmailsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user(email="foo@example.com")
         self.login_as(user=self.user)
         self.url = reverse("sentry-api-0-user-emails", kwargs={"user_id": self.user.id})

--- a/tests/sentry/api/endpoints/test_user_index.py
+++ b/tests/sentry/api/endpoints/test_user_index.py
@@ -11,7 +11,7 @@ class UserListTest(APITestCase):
         return reverse("sentry-api-0-user-index")
 
     def setUp(self):
-        super(UserListTest, self).setUp()
+        super().setUp()
         self.superuser = self.create_user("bar@example.com", is_superuser=True)
         self.normal_user = self.create_user("foo@example.com", is_superuser=False)
 

--- a/tests/sentry/api/endpoints/test_user_ips.py
+++ b/tests/sentry/api/endpoints/test_user_ips.py
@@ -7,7 +7,7 @@ from sentry.testutils import APITestCase
 
 class UserEmailsTest(APITestCase):
     def setUp(self):
-        super(UserEmailsTest, self).setUp()
+        super().setUp()
         self.user = self.create_user(email="foo@example.com")
         self.login_as(user=self.user)
         self.url = "/api/0/users/me/ips/"

--- a/tests/sentry/api/serializers/test_alert_rule.py
+++ b/tests/sentry/api/serializers/test_alert_rule.py
@@ -10,7 +10,7 @@ from sentry.snuba.models import SnubaQueryEventType
 from sentry.testutils import TestCase, APITestCase
 
 
-class BaseAlertRuleSerializerTest(object):
+class BaseAlertRuleSerializerTest:
     def assert_alert_rule_serialized(self, alert_rule, result, skip_dates=False):
         alert_rule_projects = sorted(
             AlertRule.objects.filter(id=alert_rule.id).values_list(

--- a/tests/sentry/api/serializers/test_alert_rule_trigger.py
+++ b/tests/sentry/api/serializers/test_alert_rule_trigger.py
@@ -4,7 +4,7 @@ from sentry.incidents.logic import create_alert_rule_trigger
 from sentry.testutils import TestCase
 
 
-class BaseAlertRuleTriggerSerializerTest(object):
+class BaseAlertRuleTriggerSerializerTest:
     def assert_alert_rule_trigger_serialized(self, trigger, result):
         assert result["id"] == str(trigger.id)
         assert result["alertRuleId"] == str(trigger.alert_rule_id)

--- a/tests/sentry/api/serializers/test_base.py
+++ b/tests/sentry/api/serializers/test_base.py
@@ -2,7 +2,7 @@ from sentry.api.serializers import serialize, Serializer
 from sentry.testutils import TestCase
 
 
-class Foo(object):
+class Foo:
     pass
 
 

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -30,7 +30,7 @@ from sentry.utils.compat import mock
 
 class ProjectSerializerTest(TestCase):
     def setUp(self):
-        super(ProjectSerializerTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.organization = self.create_organization()
         self.team = self.create_team(organization=self.organization)
@@ -213,7 +213,7 @@ class ProjectWithTeamSerializerTest(TestCase):
 
 class ProjectSummarySerializerTest(SnubaTestCase, TestCase):
     def setUp(self):
-        super(ProjectSummarySerializerTest, self).setUp()
+        super().setUp()
         self.date = datetime.datetime(2018, 1, 12, 3, 8, 25, tzinfo=timezone.utc)
         self.user = self.create_user(username="foo")
         self.organization = self.create_organization(owner=self.user)

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -10,7 +10,7 @@ from sentry.testutils import TestCase
 
 class TestClientIdSecretAuthentication(TestCase):
     def setUp(self):
-        super(TestClientIdSecretAuthentication, self).setUp()
+        super().setUp()
 
         self.auth = ClientIdSecretAuthentication()
         self.org = self.create_organization(owner=self.user)
@@ -68,7 +68,7 @@ class TestClientIdSecretAuthentication(TestCase):
 
 class TestDSNAuthentication(TestCase):
     def setUp(self):
-        super(TestDSNAuthentication, self).setUp()
+        super().setUp()
 
         self.auth = DSNAuthentication()
         self.org = self.create_organization(owner=self.user)

--- a/tests/sentry/api/test_base.py
+++ b/tests/sentry/api/test_base.py
@@ -58,7 +58,7 @@ class EndpointTest(APITestCase):
 
 class PaginateTest(APITestCase):
     def setUp(self):
-        super(PaginateTest, self).setUp()
+        super().setUp()
         self.request = HttpRequest()
         self.request.method = "GET"
         self.view = DummyPaginationEndpoint().as_view()
@@ -85,7 +85,7 @@ class PaginateTest(APITestCase):
 
 class EndpointJSONBodyTest(APITestCase):
     def setUp(self):
-        super(EndpointJSONBodyTest, self).setUp()
+        super().setUp()
 
         self.request = HttpRequest()
         self.request.method = "GET"

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1044,7 +1044,7 @@ def _oc(op, val):
 
 class ParseBooleanSearchQueryTest(TestCase):
     def setUp(self):
-        super(ParseBooleanSearchQueryTest, self).setUp()
+        super().setUp()
         users = ["foo", "bar", "foobar", "hello", "hi"]
         for u in users:
             self.__setattr__(u, ["equals", ["user.email", f"{u}@example.com"]])

--- a/tests/sentry/api/test_invite_helper.py
+++ b/tests/sentry/api/test_invite_helper.py
@@ -8,7 +8,7 @@ from sentry.utils.compat.mock import patch
 
 class ApiInviteHelperTest(TestCase):
     def setUp(self):
-        super(ApiInviteHelperTest, self).setUp()
+        super().setUp()
         self.org = self.create_organization(name="Rowdy Tiger", owner=None)
         self.team = self.create_team(organization=self.org, name="Mariachi Band")
         self.user = self.create_user("foo@example.com")

--- a/tests/sentry/attachments/test_base.py
+++ b/tests/sentry/attachments/test_base.py
@@ -3,7 +3,7 @@ import copy
 from sentry.attachments.base import CachedAttachment, BaseAttachmentCache
 
 
-class InMemoryCache(object):
+class InMemoryCache:
     """
     In-memory mock cache that roughly works like Django cache. Extended with
     internal assertions to ensure correct use of `raw`.

--- a/tests/sentry/attachments/test_redis.py
+++ b/tests/sentry/attachments/test_redis.py
@@ -9,7 +9,7 @@ from sentry.utils.imports import import_string
 KEY_FMT = "c:1:%s"
 
 
-class FakeClient(object):
+class FakeClient:
     def __init__(self):
         self.data = {}
 
@@ -24,7 +24,7 @@ def mock_client():
 
 @pytest.fixture(params=["rb", "rediscluster"])
 def mocked_attachment_cache(request, mock_client):
-    class RbCluster(object):
+    class RbCluster:
         def get_routing_client(self):
             return mock_client
 

--- a/tests/sentry/auth/providers/google/test_provider.py
+++ b/tests/sentry/auth/providers/google/test_provider.py
@@ -12,7 +12,7 @@ class GoogleOAuth2ProviderTest(TestCase):
         self.org = self.create_organization(owner=self.user)
         self.user = self.create_user("foo@example.com")
         self.auth_provider = AuthProvider.objects.create(provider="google", organization=self.org)
-        super(GoogleOAuth2ProviderTest, self).setUp()
+        super().setUp()
 
     def test_refresh_identity_without_refresh_token(self):
         auth_identity = AuthIdentity.objects.create(

--- a/tests/sentry/auth/providers/test_oauth2.py
+++ b/tests/sentry/auth/providers/test_oauth2.py
@@ -11,7 +11,7 @@ class OAuth2ProviderTest(TestCase):
     def setUp(self):
         self.org = self.create_organization(owner=self.user)
         self.user = self.create_user("foo@example.com")
-        super(OAuth2ProviderTest, self).setUp()
+        super().setUp()
 
     @fixture
     def auth_provider(self):

--- a/tests/sentry/auth/providers/test_saml2.py
+++ b/tests/sentry/auth/providers/test_saml2.py
@@ -26,7 +26,7 @@ class SAML2ProviderTest(TestCase):
         self.org = self.create_organization()
         self.auth_provider = AuthProvider.objects.create(provider="saml2", organization=self.org)
         self.provider = SAML2Provider(key=self.auth_provider.provider)
-        super(SAML2ProviderTest, self).setUp()
+        super().setUp()
 
     def test_build_config_adds_attributes(self):
         config = self.provider.build_config({})
@@ -82,7 +82,7 @@ class SAML2ACSViewTest(TestCase):
         self.provider = SAML2Provider(key=self.auth_provider.provider)
         self.provider.config = dummy_provider_config
         self.auth_provider.get_provider = mock.MagicMock(return_value=self.provider)
-        super(SAML2ACSViewTest, self).setUp()
+        super().setUp()
 
         request = self.make_request(user=None)
         request.META = {

--- a/tests/sentry/auth/test_access.py
+++ b/tests/sentry/auth/test_access.py
@@ -225,7 +225,7 @@ class FromUserTest(TestCase):
 
 class FromSentryAppTest(TestCase):
     def setUp(self):
-        super(FromSentryAppTest, self).setUp()
+        super().setUp()
 
         # Partner's normal Sentry account.
         self.user = self.create_user("integration@example.com")

--- a/tests/sentry/auth/test_superuser.py
+++ b/tests/sentry/auth/test_superuser.py
@@ -28,7 +28,7 @@ UNSET = object()
 
 class SuperuserTestCase(TestCase):
     def setUp(self):
-        super(SuperuserTestCase, self).setUp()
+        super().setUp()
         self.current_datetime = timezone.now()
         self.default_token = "abcdefghjiklmnog"
 

--- a/tests/sentry/data/tests.py
+++ b/tests/sentry/data/tests.py
@@ -20,7 +20,7 @@ class DataGenerator(type):
 
             test_func.__name__ = func_name
             attrs[func_name] = test_func
-        return super(DataGenerator, cls).__new__(cls, name, bases, attrs)
+        return super().__new__(cls, name, bases, attrs)
 
 
 class DataTestCase(TestCase, metaclass=DataGenerator):

--- a/tests/sentry/data_export/processors/test_discover.py
+++ b/tests/sentry/data_export/processors/test_discover.py
@@ -5,7 +5,7 @@ from sentry.testutils import TestCase, SnubaTestCase
 
 class DiscoverProcessorTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(DiscoverProcessorTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization(owner=self.user)
         self.project1 = self.create_project(organization=self.org)

--- a/tests/sentry/data_export/processors/test_issues_by_tag.py
+++ b/tests/sentry/data_export/processors/test_issues_by_tag.py
@@ -19,7 +19,7 @@ class IssuesByTagProcessorTest(TestCase, SnubaTestCase):
     ]
 
     def setUp(self):
-        super(IssuesByTagProcessorTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.org)

--- a/tests/sentry/data_export/test_models.py
+++ b/tests/sentry/data_export/test_models.py
@@ -17,7 +17,7 @@ class ExportedDataTest(TestCase):
     TEST_STRING = b"A bunch of test data..."
 
     def setUp(self):
-        super(ExportedDataTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.organization = self.create_organization()
         self.data_export = ExportedData.objects.create(

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -27,7 +27,7 @@ from sentry.utils.snuba import (
 
 class AssembleDownloadTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(AssembleDownloadTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization()
         self.project = self.create_project(organization=self.org)
@@ -548,7 +548,7 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
 
 class AssembleDownloadLargeTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(AssembleDownloadLargeTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization()
         self.project = self.create_project()

--- a/tests/sentry/db/test_mixin.py
+++ b/tests/sentry/db/test_mixin.py
@@ -6,7 +6,7 @@ from sentry.testutils import TestCase
 
 class RenamePendingDeleteTest(TestCase):
     def setUp(self):
-        super(RenamePendingDeleteTest, self).setUp()
+        super().setUp()
         self.repository = Repository.objects.create(
             organization_id=self.organization.id,
             name="example/name",

--- a/tests/sentry/deletions/test_group.py
+++ b/tests/sentry/deletions/test_group.py
@@ -21,7 +21,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 class DeleteGroupTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(DeleteGroupTest, self).setUp()
+        super().setUp()
         self.event_id = "a" * 32
         self.event_id2 = "b" * 32
         self.event_id3 = "c" * 32

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -149,7 +149,7 @@ class UtilitiesHelpersTestCase(TestCase, SnubaTestCase):
 
 class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
     def setUp(self):
-        super(GetPersonalizedDigestsTestCase, self).setUp()
+        super().setUp()
         self.user1 = self.create_user()
         self.user2 = self.create_user()
         self.user3 = self.create_user()

--- a/tests/sentry/discover/test_models.py
+++ b/tests/sentry/discover/test_models.py
@@ -4,7 +4,7 @@ from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
 
 class DiscoverSavedQueryTest(TestCase):
     def setUp(self):
-        super(DiscoverSavedQueryTest, self).setUp()
+        super().setUp()
         self.org = self.create_organization()
         self.project_ids = [
             self.create_project(organization=self.org).id,

--- a/tests/sentry/discover/test_utils.py
+++ b/tests/sentry/discover/test_utils.py
@@ -5,7 +5,7 @@ from sentry.discover.utils import transform_aliases_and_query
 
 class TransformAliasesAndQueryTest(SnubaTestCase, TestCase):
     def setUp(self):
-        super(TransformAliasesAndQueryTest, self).setUp()
+        super().setUp()
         self.environment = self.create_environment(self.project, name="prod")
         self.release = self.create_release(self.project, version="first-release")
 

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -8,7 +8,7 @@ from sentry.utils.samples import load_data
 
 class SnubaEventStorageTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(SnubaEventStorageTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
         self.two_min_ago = iso_format(before_now(minutes=2))
         self.project1 = self.create_project()

--- a/tests/sentry/eventstore/test_base.py
+++ b/tests/sentry/eventstore/test_base.py
@@ -42,7 +42,7 @@ class EventStorageTest(TestCase):
 
 class ServiceDelegationTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(ServiceDelegationTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
         self.two_min_ago = iso_format(before_now(minutes=2))
         self.project = self.create_project()

--- a/tests/sentry/grouping/__init__.py
+++ b/tests/sentry/grouping/__init__.py
@@ -17,7 +17,7 @@ from sentry.grouping.api import apply_server_fingerprinting
 _grouping_fixture_path = os.path.join(os.path.dirname(__file__), "grouping_inputs")
 
 
-class GroupingInput(object):
+class GroupingInput:
     def __init__(self, filename):
         self.filename = filename
 
@@ -66,7 +66,7 @@ def with_grouping_input(name):
 _fingerprint_fixture_path = os.path.join(os.path.dirname(__file__), "fingerprint_inputs")
 
 
-class FingerprintInput(object):
+class FingerprintInput:
     def __init__(self, filename):
         self.filename = filename
 

--- a/tests/sentry/identity/test_oauth2.py
+++ b/tests/sentry/identity/test_oauth2.py
@@ -15,10 +15,10 @@ class OAuth2CallbackViewTest(TestCase):
         self.org = self.create_organization(owner=self.user)
         self.user = self.create_user("foo@example.com")
         sentry.identity.register(DummyProvider)
-        super(OAuth2CallbackViewTest, self).setUp()
+        super().setUp()
 
     def tearDown(self):
-        super(OAuth2CallbackViewTest, self).tearDown()
+        super().tearDown()
         sentry.identity.unregister(DummyProvider)
 
     @fixture

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_available_action_index.py
@@ -24,7 +24,7 @@ class OrganizationAlertRuleAvailableActionIndexEndpointTest(APITestCase):
     pagerduty = AlertRuleTriggerAction.get_registered_type(AlertRuleTriggerAction.Type.PAGERDUTY)
 
     def setUp(self):
-        super(OrganizationAlertRuleAvailableActionIndexEndpointTest, self).setUp()
+        super().setUp()
         self.login_as(self.user)
 
     def install_new_sentry_app(self, name, **kwargs):

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -15,7 +15,7 @@ from sentry.utils import json
 from tests.sentry.api.serializers.test_alert_rule import BaseAlertRuleSerializerTest
 
 
-class AlertRuleBase(object):
+class AlertRuleBase:
     @fixture
     def organization(self):
         return self.create_organization()

--- a/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_comment_details.py
@@ -4,7 +4,7 @@ from sentry.incidents.models import IncidentActivity, IncidentActivityType
 from sentry.testutils import APITestCase
 
 
-class BaseIncidentCommentDetailsTest(object):
+class BaseIncidentCommentDetailsTest:
     endpoint = "sentry-api-0-organization-incident-comment-details"
 
     def setUp(self):

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -69,7 +69,7 @@ class OrganizationIncidentUpdateStatusTest(BaseIncidentDetailsTest, APITestCase)
 
     def get_valid_response(self, *args, **params):
         params.setdefault("status", IncidentStatus.CLOSED.value)
-        return super(OrganizationIncidentUpdateStatusTest, self).get_valid_response(*args, **params)
+        return super().get_valid_response(*args, **params)
 
     def test_simple(self):
         incident = self.create_incident()

--- a/tests/sentry/incidents/endpoints/test_organization_incident_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_details.py
@@ -9,7 +9,7 @@ from sentry.incidents.models import Incident, IncidentActivity, IncidentStatus
 from sentry.testutils import APITestCase
 
 
-class BaseIncidentDetailsTest(object):
+class BaseIncidentDetailsTest:
     endpoint = "sentry-api-0-organization-incident-details"
 
     def setUp(self):

--- a/tests/sentry/incidents/endpoints/test_organization_incident_stats.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_stats.py
@@ -15,7 +15,7 @@ class OrganizationIncidentDetailsTest(SnubaTestCase, APITestCase):
     endpoint = "sentry-api-0-organization-incident-stats"
 
     def setUp(self):
-        super(OrganizationIncidentDetailsTest, self).setUp()
+        super().setUp()
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
 

--- a/tests/sentry/incidents/endpoints/test_organization_incident_subscription_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_subscription_index.py
@@ -5,7 +5,7 @@ from sentry.incidents.models import IncidentSubscription
 from sentry.testutils import APITestCase
 
 
-class BaseOrganizationSubscriptionEndpointTest(object):
+class BaseOrganizationSubscriptionEndpointTest:
     endpoint = "sentry-api-0-organization-incident-subscription-index"
 
     @fixture

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -7,7 +7,7 @@ from sentry.models import Integration
 from sentry.testutils import APITestCase
 
 
-class AlertRuleDetailsBase(object):
+class AlertRuleDetailsBase:
     endpoint = "sentry-api-0-project-alert-rule-details"
 
     @fixture
@@ -198,7 +198,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
     def test_kicks_off_slack_async_job(
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
     ):
-        class uuid(object):
+        class uuid:
             hex = "abc123"
 
         mock_uuid4.return_value = uuid

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -145,7 +145,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
     def test_kicks_off_slack_async_job(
         self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
     ):
-        class uuid(object):
+        class uuid:
             hex = "abc123"
 
         mock_uuid4.return_value = uuid

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -67,7 +67,7 @@ class TestAlertRuleSerializer(TestCase):
         return {"organization": self.organization, "access": self.access}
 
     def Any(self, cls):
-        class Any(object):
+        class Any:
             def __eq__(self, other):
                 return isinstance(other, cls)
 

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -147,7 +147,7 @@ class EmailActionHandlerGenerateEmailContextTest(TestCase):
         ).get("environment")
 
 
-class FireTest(object):
+class FireTest:
     def run_test(self, incident, method):
         raise NotImplementedError
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1231,7 +1231,7 @@ class GetTriggersForAlertRuleTest(TestCase):
         assert get_triggers_for_alert_rule(alert_rule).get() == trigger
 
 
-class BaseAlertRuleTriggerActionTest(object):
+class BaseAlertRuleTriggerActionTest:
     @fixture
     def alert_rule(self):
         return self.create_alert_rule()

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -452,7 +452,7 @@ class AlertRuleTriggerActionTargetTest(TestCase):
         assert trigger.target == email
 
 
-class AlertRuleTriggerActionActivateTest(object):
+class AlertRuleTriggerActionActivateTest:
     method = None
 
     def setUp(self):

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -45,7 +45,7 @@ class ProcessUpdateTest(TestCase):
     metrics = patcher("sentry.incidents.subscription_processor.metrics")
 
     def setUp(self):
-        super(ProcessUpdateTest, self).setUp()
+        super().setUp()
         self.old_handlers = AlertRuleTriggerAction._type_registrations
         AlertRuleTriggerAction._type_registrations = {}
         self.email_action_handler = Mock()
@@ -56,7 +56,7 @@ class ProcessUpdateTest(TestCase):
         self._run_tasks.__enter__()
 
     def tearDown(self):
-        super(ProcessUpdateTest, self).tearDown()
+        super().tearDown()
         AlertRuleTriggerAction._type_registrations = self.old_handlers
         self._run_tasks.__exit__(None, None, None)
 

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -32,7 +32,7 @@ from sentry.testutils import TestCase
 from sentry.utils.http import absolute_uri
 
 
-class BaseIncidentActivityTest(object):
+class BaseIncidentActivityTest:
     @property
     def incident(self):
         return self.create_incident(title="hello")

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -30,7 +30,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
     provider = AwsLambdaIntegrationProvider
 
     def setUp(self):
-        super(AwsLambdaIntegrationTest, self).setUp()
+        super().setUp()
         self.projectA = self.create_project(organization=self.organization, slug="projA")
         self.projectB = self.create_project(organization=self.organization, slug="projB")
 

--- a/tests/sentry/integrations/bitbucket/test_installed.py
+++ b/tests/sentry/integrations/bitbucket/test_installed.py
@@ -65,7 +65,7 @@ class BitbucketInstalledEndpointTest(APITestCase):
 
     def tearDown(self):
         unregister_mock_plugins()
-        super(BitbucketInstalledEndpointTest, self).tearDown()
+        super().tearDown()
 
     def test_default_permissions(self):
         # Permissions must be empty so that it will be accessible to bitbucket.

--- a/tests/sentry/integrations/bitbucket/test_repository.py
+++ b/tests/sentry/integrations/bitbucket/test_repository.py
@@ -13,7 +13,7 @@ from .testutils import COMPARE_COMMITS_EXAMPLE, COMMIT_DIFF_PATCH, REPO
 
 class BitbucketRepositoryProviderTest(TestCase):
     def setUp(self):
-        super(BitbucketRepositoryProviderTest, self).setUp()
+        super().setUp()
         self.base_url = "https://api.bitbucket.org"
         self.shared_secret = "234567890"
         self.subject = "connect:1234567"
@@ -137,7 +137,7 @@ class BitbucketCreateRepositoryTestCase(IntegrationRepositoryTestCase):
     provider_name = "integrations:bitbucket"
 
     def setUp(self):
-        super(BitbucketCreateRepositoryTestCase, self).setUp()
+        super().setUp()
         self.base_url = "https://api.bitbucket.org"
         self.shared_secret = "234567890"
         self.subject = "connect:1234567"

--- a/tests/sentry/integrations/bitbucket/test_webhook.py
+++ b/tests/sentry/integrations/bitbucket/test_webhook.py
@@ -28,7 +28,7 @@ class UtilityFunctionTest(TestCase):
 
 class WebhookTest(APITestCase):
     def setUp(self):
-        super(WebhookTest, self).setUp()
+        super().setUp()
         project = self.project  # force creation
         self.url = "/extensions/bitbucket/organizations/%s/webhook/" % project.organization_id
 
@@ -71,7 +71,7 @@ class WebhookTest(APITestCase):
 
 class PushEventWebhookTest(APITestCase):
     def setUp(self):
-        super(PushEventWebhookTest, self).setUp()
+        super().setUp()
         project = self.project  # force creation
         self.url = "/extensions/bitbucket/organizations/%s/webhook/" % project.organization.id
 

--- a/tests/sentry/integrations/cloudflare/test_webhook.py
+++ b/tests/sentry/integrations/cloudflare/test_webhook.py
@@ -11,7 +11,7 @@ UNSET = object()
 
 class BaseWebhookTest(TestCase):
     def setUp(self):
-        super(BaseWebhookTest, self).setUp()
+        super().setUp()
         self.user = self.create_user(is_superuser=False)
         self.org = self.create_organization(owner=None)
         self.team = self.create_team(organization=self.org)

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -18,7 +18,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
     base_url = "https://api.github.com"
 
     def setUp(self):
-        super(GitHubIntegrationTest, self).setUp()
+        super().setUp()
 
         self.installation_id = "install_1"
         self.user_id = "user_1"
@@ -31,7 +31,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
     def tearDown(self):
         unregister_mock_plugins()
-        super(GitHubIntegrationTest, self).tearDown()
+        super().tearDown()
 
     def _stub_github(self):
         responses.reset()

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -26,12 +26,12 @@ def stub_installation_token():
 
 class GitHubAppsProviderTest(PluginTestCase):
     def setUp(self):
-        super(GitHubAppsProviderTest, self).setUp()
+        super().setUp()
         self.organization = self.create_organization()
         self.integration = Integration.objects.create(provider="github", external_id="654321")
 
     def tearDown(self):
-        super(GitHubAppsProviderTest, self).tearDown()
+        super().tearDown()
         responses.reset()
 
     @fixture

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -27,7 +27,7 @@ class GithubSearchTest(APITestCase):
         )
 
     def setUp(self):
-        super(GithubSearchTest, self).setUp()
+        super().setUp()
         self.integration = self.create_integration()
         identity = Identity.objects.create(
             idp=IdentityProvider.objects.create(type=self.provider, config={}),

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -12,7 +12,7 @@ class GitlabRefreshAuthTest(GitLabTestCase):
     get_user_should_succeed = True
 
     def setUp(self):
-        super(GitlabRefreshAuthTest, self).setUp()
+        super().setUp()
         self.client = self.installation.get_client()
         self.request_data = {"id": "user_id"}
         self.request_url = "https://example.gitlab.com/api/v4/user"

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -32,7 +32,7 @@ class GitlabIntegrationTest(IntegrationTestCase):
     default_group_id = 4
 
     def setUp(self):
-        super(GitlabIntegrationTest, self).setUp()
+        super().setUp()
         self.init_path_without_guide = f"{self.init_path}?completed_installation_guide"
 
     def assert_setup_flow(self, user_id="user_id_1"):

--- a/tests/sentry/integrations/gitlab/test_issues.py
+++ b/tests/sentry/integrations/gitlab/test_issues.py
@@ -11,7 +11,7 @@ from .testutils import GitLabTestCase
 
 class GitlabIssuesTest(GitLabTestCase):
     def setUp(self):
-        super(GitlabIssuesTest, self).setUp()
+        super().setUp()
         min_ago = iso_format(before_now(minutes=1))
         event = self.store_event(
             data={

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -18,7 +18,7 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
     provider_name = "integrations:gitlab"
 
     def setUp(self):
-        super(GitLabRepositoryProviderTest, self).setUp()
+        super().setUp()
         self.integration = Integration.objects.create(
             provider="gitlab",
             name="Example GitLab",
@@ -54,7 +54,7 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         return GitlabRepositoryProvider("gitlab")
 
     def tearDown(self):
-        super(GitLabRepositoryProviderTest, self).tearDown()
+        super().tearDown()
         responses.reset()
 
     def add_create_repository_responses(self, repository_config):

--- a/tests/sentry/integrations/gitlab/test_search.py
+++ b/tests/sentry/integrations/gitlab/test_search.py
@@ -12,7 +12,7 @@ class GitlabSearchTest(GitLabTestCase):
     provider = "gitlab"
 
     def setUp(self):
-        super(GitlabSearchTest, self).setUp()
+        super().setUp()
         self.url = reverse(
             "sentry-extensions-gitlab-search",
             kwargs={

--- a/tests/sentry/integrations/jira/test_client.py
+++ b/tests/sentry/integrations/jira/test_client.py
@@ -9,7 +9,7 @@ from sentry.utils.compat import mock
 
 class StubJiraCloud(JiraCloud):
     def request_hook(self, *args, **kwargs):
-        r = super(StubJiraCloud, self).request_hook(*args, **kwargs)
+        r = super().request_hook(*args, **kwargs)
         r["params"]["jwt"] = "my-jwt-token"
         return r
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -46,7 +46,7 @@ class JiraIntegrationTest(APITestCase):
         return integration
 
     def setUp(self):
-        super(JiraIntegrationTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
         self.login_as(self.user)
 
@@ -851,7 +851,7 @@ class JiraInstallationTest(IntegrationTestCase):
     provider = JiraIntegrationProvider
 
     def setUp(self):
-        super(JiraInstallationTest, self).setUp()
+        super().setUp()
         self.metadata = {
             "oauth_client_id": "oauth-client-id",
             "shared_secret": "a-super-secret-key-from-atlassian",

--- a/tests/sentry/integrations/jira/test_issue_hook.py
+++ b/tests/sentry/integrations/jira/test_issue_hook.py
@@ -16,7 +16,7 @@ CLICK_TO_FINISH = b"Click to Finish Installation"
 
 class JiraIssueHookTest(APITestCase):
     def setUp(self):
-        super(JiraIssueHookTest, self).setUp()
+        super().setUp()
         self.first_seen = datetime(2015, 8, 13, 3, 8, 25, tzinfo=timezone.utc)
         self.last_seen = datetime(2016, 1, 13, 3, 8, 25, tzinfo=timezone.utc)
         self.first_release = self.create_release(

--- a/tests/sentry/integrations/jira/test_ui_hook.py
+++ b/tests/sentry/integrations/jira/test_ui_hook.py
@@ -14,7 +14,7 @@ CLICK_TO_FINISH = b"Finish Installation in Sentry"
 
 class JiraUiHookViewTestCase(APITestCase):
     def setUp(self):
-        super(JiraUiHookViewTestCase, self).setUp()
+        super().setUp()
         self.path = absolute_uri("extensions/jira/ui-hook/") + "?xdm_e=base_url"
 
         self.user.name = "Sentry Admin"
@@ -45,7 +45,7 @@ class JiraUiHookViewErrorsTest(JiraUiHookViewTestCase):
 
 class JiraUiHookViewTest(JiraUiHookViewTestCase):
     def setUp(self):
-        super(JiraUiHookViewTest, self).setUp()
+        super().setUp()
         self.login_as(self.user)
 
     def assert_no_errors(self, response):

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -27,7 +27,7 @@ from sentry.integrations.msteams.link_identity import build_linking_url
 
 class BaseEventTest(APITestCase):
     def setUp(self):
-        super(BaseEventTest, self).setUp()
+        super().setUp()
         self.user = self.create_user(is_superuser=False)
         owner = self.create_user()
         self.org = self.create_organization(owner=owner)

--- a/tests/sentry/integrations/msteams/test_integration.py
+++ b/tests/sentry/integrations/msteams/test_integration.py
@@ -17,7 +17,7 @@ class MsTeamsIntegrationTest(IntegrationTestCase):
     provider = MsTeamsIntegrationProvider
 
     def setUp(self):
-        super(MsTeamsIntegrationTest, self).setUp()
+        super().setUp()
         self.start_time = 1594768808
         self.pipeline_state = {
             "team_id": team_id,

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -29,7 +29,7 @@ kid = "Su-pdZys9LJGhDVgah3UjfPouuc"
 
 class MsTeamsWebhookTest(APITestCase):
     def setUp(self):
-        super(MsTeamsWebhookTest, self).setUp()
+        super().setUp()
 
         responses.add(
             responses.GET,

--- a/tests/sentry/integrations/pagerduty/test_integration.py
+++ b/tests/sentry/integrations/pagerduty/test_integration.py
@@ -16,7 +16,7 @@ class PagerDutyIntegrationTest(IntegrationTestCase):
     base_url = "https://app.pagerduty.com"
 
     def setUp(self):
-        super(PagerDutyIntegrationTest, self).setUp()
+        super().setUp()
         self.app_id = "app_1"
         self.account_slug = "test-app"
         self._stub_pagerduty()

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -26,7 +26,7 @@ from sentry.integrations.slack.unlink_identity import build_unlinking_url
 
 class BaseEventTest(APITestCase):
     def setUp(self):
-        super(BaseEventTest, self).setUp()
+        super().setUp()
         self.user = self.create_user(is_superuser=False)
         self.org = self.create_organization(owner=None)
         self.team = self.create_team(organization=self.org, members=[self.user])

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -69,7 +69,7 @@ MESSAGE_IM_BOT_EVENT = """{
 
 class BaseEventTest(APITestCase):
     def setUp(self):
-        super(BaseEventTest, self).setUp()
+        super().setUp()
         self.user = self.create_user(is_superuser=False)
         self.org = self.create_organization(owner=None)
         self.integration = Integration.objects.create(

--- a/tests/sentry/integrations/slack/test_migration_flow.py
+++ b/tests/sentry/integrations/slack/test_migration_flow.py
@@ -21,7 +21,7 @@ class SlackMigrationTest(IntegrationTestCase):
     provider = SlackIntegrationProvider
 
     def setUp(self):
-        super(SlackMigrationTest, self).setUp()
+        super().setUp()
         self.team = self.create_team(
             organization=self.organization, name="Go Team", members=[self.user]
         )

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -20,7 +20,7 @@ from sentry.integrations.slack.requests import (
 
 class SlackRequestTest(TestCase):
     def setUp(self):
-        super(SlackRequestTest, self).setUp()
+        super().setUp()
 
         self.request = mock.Mock()
         self.request.data = {
@@ -92,7 +92,7 @@ class SlackRequestTest(TestCase):
 
 class SlackEventRequestTest(TestCase):
     def setUp(self):
-        super(SlackEventRequestTest, self).setUp()
+        super().setUp()
 
         self.request = mock.Mock()
         self.request.data = {
@@ -201,7 +201,7 @@ class SlackEventRequestTest(TestCase):
 
 class SlackActionRequestTest(TestCase):
     def setUp(self):
-        super(SlackActionRequestTest, self).setUp()
+        super().setUp()
 
         self.request = mock.Mock()
         self.request.data = {

--- a/tests/sentry/integrations/test_client.py
+++ b/tests/sentry/integrations/test_client.py
@@ -122,7 +122,7 @@ class OAuthProvider(OAuth2Provider):
 
 class OAuth2ApiClient(ApiClient, OAuth2RefreshMixin):
     def __init__(self, identity, *args, **kwargs):
-        super(OAuth2ApiClient, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.identity = identity
 
 

--- a/tests/sentry/integrations/test_migrate.py
+++ b/tests/sentry/integrations/test_migrate.py
@@ -15,7 +15,7 @@ plugins.register(ExamplePlugin)
 
 class MigratorTest(TestCase):
     def setUp(self):
-        super(MigratorTest, self).setUp()
+        super().setUp()
 
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)

--- a/tests/sentry/integrations/test_pipeline.py
+++ b/tests/sentry/integrations/test_pipeline.py
@@ -28,12 +28,12 @@ class FinishPipelineTestCase(IntegrationTestCase):
     provider = ExampleIntegrationProvider
 
     def setUp(self):
-        super(FinishPipelineTestCase, self).setUp()
+        super().setUp()
         self.external_id = "dummy_id-123"
         self.provider.needs_default_identity = False
 
     def tearDown(self):
-        super(FinishPipelineTestCase, self).tearDown()
+        super().tearDown()
 
     def test_with_data(self, *args):
         data = {
@@ -324,11 +324,11 @@ class GitlabFinishPipelineTest(IntegrationTestCase):
     provider = GitlabIntegrationProvider
 
     def setUp(self):
-        super(GitlabFinishPipelineTest, self).setUp()
+        super().setUp()
         self.external_id = "dummy_id-123"
 
     def tearDown(self):
-        super(GitlabFinishPipelineTest, self).tearDown()
+        super().tearDown()
 
     def test_different_user_same_external_id(self, *args):
         new_user = self.create_user()

--- a/tests/sentry/integrations/test_ticket_rules.py
+++ b/tests/sentry/integrations/test_ticket_rules.py
@@ -26,7 +26,7 @@ class JiraTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
         return self.mock_jira
 
     def setUp(self):
-        super(JiraTicketRulesTestCase, self).setUp()
+        super().setUp()
         self.project_name = "Jira Cloud"
         self.integration = Integration.objects.create(
             provider="jira",

--- a/tests/sentry/integrations/vercel/test_webhook.py
+++ b/tests/sentry/integrations/vercel/test_webhook.py
@@ -43,7 +43,7 @@ class SignatureVercelTest(APITestCase):
 
 class VercelReleasesTest(APITestCase):
     def setUp(self):
-        super(VercelReleasesTest, self).setUp()
+        super().setUp()
         self.project = self.create_project(organization=self.organization)
         self.integration = Integration.objects.create(
             provider="vercel",

--- a/tests/sentry/integrations/vsts/test_integration.py
+++ b/tests/sentry/integrations/vsts/test_integration.py
@@ -29,12 +29,12 @@ class VstsIntegrationProviderTest(VstsIntegrationTestCase):
     # Test data setup in ``VstsIntegrationTestCase``
 
     def setUp(self):
-        super(VstsIntegrationProviderTest, self).setUp()
+        super().setUp()
         register_mock_plugins()
 
     def tearDown(self):
         unregister_mock_plugins()
-        super(VstsIntegrationProviderTest, self).tearDown()
+        super().tearDown()
 
     def test_basic_flow(self):
         self.assert_installation()

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -406,7 +406,7 @@ class VstsIssueSyncTest(VstsIssueBase):
 
 class VstsIssueFormTest(VstsIssueBase):
     def setUp(self):
-        super(VstsIssueFormTest, self).setUp()
+        super().setUp()
         responses.add(
             responses.GET,
             "https://fabrikam-fiber-inc.visualstudio.com/_apis/projects",

--- a/tests/sentry/integrations/vsts/test_repository.py
+++ b/tests/sentry/integrations/vsts/test_repository.py
@@ -124,7 +124,7 @@ class AzureDevOpsRepositoryProviderTest(IntegrationRepositoryTestCase):
     provider_name = "integrations:vsts"
 
     def setUp(self):
-        super(AzureDevOpsRepositoryProviderTest, self).setUp()
+        super().setUp()
         self.base_url = "https://visualstudio.com/"
         self.vsts_external_id = "654321"
         self.integration = Integration.objects.create(
@@ -169,7 +169,7 @@ class AzureDevOpsRepositoryProviderTest(IntegrationRepositoryTestCase):
         return VstsRepositoryProvider("integrations:vsts")
 
     def tearDown(self):
-        super(AzureDevOpsRepositoryProviderTest, self).tearDown()
+        super().tearDown()
         responses.reset()
 
     def add_create_repository_responses(self, repository_config):

--- a/tests/sentry/integrations/vsts/testutils.py
+++ b/tests/sentry/integrations/vsts/testutils.py
@@ -10,7 +10,7 @@ class VstsIntegrationTestCase(IntegrationTestCase):
     provider = VstsIntegrationProvider
 
     def setUp(self):
-        super(VstsIntegrationTestCase, self).setUp()
+        super().setUp()
 
         self.access_token = "9d646e20-7a62-4bcc-abc0-cb2d4d075e36"
         self.refresh_token = "32004633-a3c0-4616-9aa0-a40632adac77"

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -21,7 +21,7 @@ from sentry.testutils import TestCase
 
 class ReleaseTestCase(TestCase):
     def setUp(self):
-        super(ReleaseTestCase, self).setUp()
+        super().setUp()
         self.user = self.create_user("foo@example.com")
 
         assert UserEmail.objects.filter(user=self.user, email=self.user.email).update(

--- a/tests/sentry/mail/test_actions.py
+++ b/tests/sentry/mail/test_actions.py
@@ -14,7 +14,7 @@ class NotifyEmailFormTest(TestCase):
     TARGET_IDENTIFIER_KEY = "targetIdentifier"
 
     def setUp(self):
-        super(NotifyEmailFormTest, self).setUp()
+        super().setUp()
         self.user = self.create_user(email="foo@example.com", is_active=True)
         self.user2 = self.create_user(email="baz@example.com", is_active=True)
         self.inactive_user = self.create_user(email="totallynotabot@149.com", is_active=False)

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -36,7 +36,7 @@ from sentry.utils.compat import mock
 from sentry.utils.email import MessageBuilder
 
 
-class BaseMailAdapterTest(object):
+class BaseMailAdapterTest:
     @fixture
     def adapter(self):
         return mail_adapter

--- a/tests/sentry/mediators/external_issues/test_issue_link_creator.py
+++ b/tests/sentry/mediators/external_issues/test_issue_link_creator.py
@@ -8,7 +8,7 @@ from sentry.testutils import TestCase
 
 class TestIssueLinkCreator(TestCase):
     def setUp(self):
-        super(TestIssueLinkCreator, self).setUp()
+        super().setUp()
 
         self.user = self.create_user(name="foo")
         self.org = self.create_organization(owner=self.user)

--- a/tests/sentry/mediators/external_requests/test_issue_link_requester.py
+++ b/tests/sentry/mediators/external_requests/test_issue_link_requester.py
@@ -9,7 +9,7 @@ from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 
 class TestIssueLinkRequester(TestCase):
     def setUp(self):
-        super(TestIssueLinkRequester, self).setUp()
+        super().setUp()
 
         self.user = self.create_user(name="foo")
         self.org = self.create_organization(owner=self.user)

--- a/tests/sentry/mediators/external_requests/test_select_requester.py
+++ b/tests/sentry/mediators/external_requests/test_select_requester.py
@@ -9,7 +9,7 @@ from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 
 class TestSelectRequester(TestCase):
     def setUp(self):
-        super(TestSelectRequester, self).setUp()
+        super().setUp()
 
         self.user = self.create_user(name="foo")
         self.org = self.create_organization(owner=self.user)

--- a/tests/sentry/mediators/sentry_app_components/test_preparer.py
+++ b/tests/sentry/mediators/sentry_app_components/test_preparer.py
@@ -6,7 +6,7 @@ from sentry.testutils import TestCase
 
 class TestPreparerIssueLink(TestCase):
     def setUp(self):
-        super(TestPreparerIssueLink, self).setUp()
+        super().setUp()
 
         self.sentry_app = self.create_sentry_app(
             schema={"elements": [self.create_issue_link_schema()]}
@@ -66,7 +66,7 @@ class TestPreparerIssueLink(TestCase):
 
 class TestPreparerStacktraceLink(TestCase):
     def setUp(self):
-        super(TestPreparerStacktraceLink, self).setUp()
+        super().setUp()
 
         self.sentry_app = self.create_sentry_app(
             schema={"elements": [{"type": "stacktrace-link", "uri": "/redirection"}]}

--- a/tests/sentry/mediators/sentry_app_installation_tokens/test_creator.py
+++ b/tests/sentry/mediators/sentry_app_installation_tokens/test_creator.py
@@ -16,7 +16,7 @@ class TestCreatorBase(TestCase):
 
 class TestCreatorInternal(TestCreatorBase):
     def setUp(self):
-        super(TestCreatorInternal, self).setUp()
+        super().setUp()
 
         # will create the installation and the first token
         self.sentry_app = self.create_internal_integration(
@@ -91,7 +91,7 @@ class TestCreatorInternal(TestCreatorBase):
 
 class TestCreatorExternal(TestCreatorBase):
     def setUp(self):
-        super(TestCreatorExternal, self).setUp()
+        super().setUp()
 
         self.sentry_app = self.create_sentry_app(
             name="external_app", organization=self.org, scopes=("org:write", "team:admin")

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -29,7 +29,7 @@ class DictContaining(object):
 
 class TestInstallationNotifier(TestCase):
     def setUp(self):
-        super(TestInstallationNotifier, self).setUp()
+        super().setUp()
 
         self.user = self.create_user(name="foo")
         self.org = self.create_organization(owner=self.user)

--- a/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
+++ b/tests/sentry/mediators/sentry_app_installations/test_installation_notifier.py
@@ -19,7 +19,7 @@ MockResponse = namedtuple(
 MockResponseInstance = MockResponse({}, {}, True, 200, raiseStatusFalse)
 
 
-class DictContaining(object):
+class DictContaining:
     def __init__(self, *keys):
         self.keys = keys
 

--- a/tests/sentry/mediators/test_mediator.py
+++ b/tests/sentry/mediators/test_mediator.py
@@ -9,7 +9,7 @@ from sentry.testutils import TestCase
 from sentry.testutils.helpers.faux import faux
 
 
-class Double(object):
+class Double:
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)

--- a/tests/sentry/mediators/test_param.py
+++ b/tests/sentry/mediators/test_param.py
@@ -27,7 +27,7 @@ class TestParam(TestCase):
         assert user.validate(None, "user", User())
 
     def test_setup(self):
-        class Target(object):
+        class Target:
             name = 1
 
         name = Param((str,))
@@ -47,7 +47,7 @@ class TestParam(TestCase):
         assert name.default(None) == "Steve"
 
     def test_default_referencing_instance(self):
-        class Target(object):
+        class Target:
             user = {"name": "Pete"}
 
         target = Target()

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -18,7 +18,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 class GroupTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(GroupTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
         self.two_min_ago = iso_format(before_now(minutes=2))
         self.just_over_one_min_ago = iso_format(before_now(seconds=61))

--- a/tests/sentry/models/test_groupresolution.py
+++ b/tests/sentry/models/test_groupresolution.py
@@ -7,7 +7,7 @@ from sentry.testutils import TestCase
 
 class GroupResolutionTest(TestCase):
     def setUp(self):
-        super(GroupResolutionTest, self).setUp()
+        super().setUp()
         self.old_release = self.create_release(version="a", project=self.project)
         self.old_release.update(date_added=timezone.now() - timedelta(minutes=30))
         self.new_release = self.create_release(version="b", project=self.project)

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -199,7 +199,7 @@ class ProjectTest(TestCase):
 
 class CopyProjectSettingsTest(TestCase):
     def setUp(self):
-        super(CopyProjectSettingsTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
 
         self.options_dict = {

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -10,7 +10,7 @@ class ProjectOwnershipTestCase(TestCase):
     def tearDown(self):
         cache.delete(ProjectOwnership.get_cache_key(self.project.id))
 
-        super(ProjectOwnershipTestCase, self).tearDown()
+        super().tearDown()
 
     def assert_ownership_equals(self, o1, o2):
         assert sorted(o1[0]) == sorted(o2[0]) and sorted(o1[1]) == sorted(o2[1])

--- a/tests/sentry/models/test_release.py
+++ b/tests/sentry/models/test_release.py
@@ -536,7 +536,7 @@ class SetCommitsTestCase(TestCase):
 
 class SetRefsTest(SetRefsTestCase):
     def setUp(self):
-        super(SetRefsTest, self).setUp()
+        super().setUp()
         self.release = Release.objects.create(version="abcdabc", organization=self.org)
         self.release.add_project(self.project)
 

--- a/tests/sentry/nodestore/bigtable/backend/tests.py
+++ b/tests/sentry/nodestore/bigtable/backend/tests.py
@@ -6,12 +6,12 @@ from sentry.utils.compat import mock
 
 
 class MockedBigtableNodeStorage(BigtableNodeStorage):
-    class Cell(object):
+    class Cell:
         def __init__(self, value, timestamp):
             self.value = value
             self.timestamp = timestamp
 
-    class Row(object):
+    class Row:
         def __init__(self, connection, row_key):
             self.row_key = row_key.encode("utf8")
             self.connection = connection
@@ -33,7 +33,7 @@ class MockedBigtableNodeStorage(BigtableNodeStorage):
         def cells(self):
             return {"x": dict(self.connection._table.get(self.row_key) or ())}
 
-    class Connection(object):
+    class Connection:
         def __init__(self):
             self._table = {}
 

--- a/tests/sentry/plugins/bases/test_issue2.py
+++ b/tests/sentry/plugins/bases/test_issue2.py
@@ -74,7 +74,7 @@ class GetAuthForUserTest(TestCase):
 
 class IssuePlugin2GroupActionTest(TestCase):
     def setUp(self):
-        super(IssuePlugin2GroupActionTest, self).setUp()
+        super().setUp()
         self.project = self.create_project()
         self.plugin_instance = plugins.get(slug="issuetrackingplugin2")
         min_ago = iso_format(before_now(minutes=1))

--- a/tests/sentry/receivers/test_featureadoption.py
+++ b/tests/sentry/receivers/test_featureadoption.py
@@ -24,7 +24,7 @@ from sentry.testutils import SnubaTestCase, TestCase
 
 class FeatureAdoptionTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(FeatureAdoptionTest, self).setUp()
+        super().setUp()
         self.now = timezone.now()
         self.owner = self.create_user()
         self.organization = self.create_organization(owner=self.owner)

--- a/tests/sentry/receivers/test_signals.py
+++ b/tests/sentry/receivers/test_signals.py
@@ -8,7 +8,7 @@ from sentry.utils.compat.mock import patch
 
 class SignalsTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(SignalsTest, self).setUp()
+        super().setUp()
         self.now = timezone.now()
         self.owner = self.create_user()
         self.organization = self.create_organization(owner=self.owner)

--- a/tests/sentry/rules/conditions/test_event_frequency.py
+++ b/tests/sentry/rules/conditions/test_event_frequency.py
@@ -13,7 +13,7 @@ from sentry.rules.conditions.event_frequency import (
 from sentry.testutils.cases import RuleTestCase
 
 
-class FrequencyConditionMixin(object):
+class FrequencyConditionMixin:
     def increment(self, event, count, timestamp=None):
         raise NotImplementedError
 

--- a/tests/sentry/runner/test_initializer.py
+++ b/tests/sentry/runner/test_initializer.py
@@ -6,7 +6,7 @@ from sentry.runner.initializer import bootstrap_options, apply_legacy_settings
 
 @pytest.fixture
 def settings():
-    class Settings(object):
+    class Settings:
         pass
 
     s = Settings()

--- a/tests/sentry/similarity/backends/base.py
+++ b/tests/sentry/similarity/backends/base.py
@@ -1,7 +1,7 @@
 import abc
 
 
-class MinHashIndexBackendTestMixin(object):
+class MinHashIndexBackendTestMixin:
     __meta__ = abc.ABCMeta
 
     @abc.abstractproperty

--- a/tests/sentry/similarity/test_encoder.py
+++ b/tests/sentry/similarity/test_encoder.py
@@ -32,7 +32,7 @@ def test_builtin_types():
 
 
 def test_custom_types():
-    class Widget(object):
+    class Widget:
         def __init__(self, color):
             self.color = color
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -13,7 +13,7 @@ from sentry.utils.snuba import Dataset
 
 class QueryIntegrationTest(SnubaTestCase, TestCase):
     def setUp(self):
-        super(QueryIntegrationTest, self).setUp()
+        super().setUp()
         self.environment = self.create_environment(self.project, name="prod")
         self.release = self.create_release(self.project, version="first-release")
 
@@ -2118,7 +2118,7 @@ class QueryTransformTest(TestCase):
 
 class TimeseriesQueryTest(SnubaTestCase, TestCase):
     def setUp(self):
-        super(TimeseriesQueryTest, self).setUp()
+        super().setUp()
 
         self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
 
@@ -2336,7 +2336,7 @@ def format_project_event(project_slug, event_id):
 
 class GetFacetsTest(SnubaTestCase, TestCase):
     def setUp(self):
-        super(GetFacetsTest, self).setUp()
+        super().setUp()
 
         self.project = self.create_project()
         self.min_ago = before_now(minutes=1)

--- a/tests/sentry/snuba/test_query_subscription_consumer.py
+++ b/tests/sentry/snuba/test_query_subscription_consumer.py
@@ -21,7 +21,7 @@ from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscrip
 from sentry.testutils.cases import TestCase
 
 
-class BaseQuerySubscriptionTest(object):
+class BaseQuerySubscriptionTest:
     @fixture
     def consumer(self):
         return QuerySubscriptionConsumer("hello")

--- a/tests/sentry/snuba/test_tasks.py
+++ b/tests/sentry/snuba/test_tasks.py
@@ -21,7 +21,7 @@ from sentry.utils import json
 from sentry.testutils import TestCase
 
 
-class BaseSnubaTaskTest(object, metaclass=abc.ABCMeta):
+class BaseSnubaTaskTest(metaclass=abc.ABCMeta):
     metrics = patcher("sentry.snuba.tasks.metrics")
 
     status_translations = {

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -22,7 +22,7 @@ from sentry.tasks.post_process import post_process_group
 from sentry.utils.compat.mock import Mock, patch, ANY
 
 
-class EventMatcher(object):
+class EventMatcher:
     def __init__(self, expected, group=None):
         self.expected = expected
         self.expected_group = group

--- a/tests/sentry/tasks/test_assemble.py
+++ b/tests/sentry/tasks/test_assemble.py
@@ -179,7 +179,7 @@ class AssembleDifTest(BaseAssembleTest):
 
 class AssembleArtifactsTest(BaseAssembleTest):
     def setUp(self):
-        super(AssembleArtifactsTest, self).setUp()
+        super().setUp()
         self.release = self.create_release(version="my-unique-release.1")
 
     def test_artifacts(self):

--- a/tests/sentry/tasks/test_auth.py
+++ b/tests/sentry/tasks/test_auth.py
@@ -7,7 +7,7 @@ from sentry.tasks.auth import email_missing_links, email_unlink_notifications
 
 class EmailMissingLinksTest(TestCase):
     def setUp(self):
-        super(EmailMissingLinksTest, self).setUp()
+        super().setUp()
         self.user = self.create_user(email="bar@example.com")
         self.organization = self.create_organization(name="Test")
         self.provider = AuthProvider.objects.create(

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -60,7 +60,7 @@ MockResponseWithHeadersInstance = MockResponse(
 )
 
 
-class DictContaining(object):
+class DictContaining:
     def __init__(self, *args, **kwargs):
         if len(args) == 1 and isinstance(args[0], dict):
             self.args = []

--- a/tests/sentry/tasks/test_servicehooks.py
+++ b/tests/sentry/tasks/test_servicehooks.py
@@ -9,7 +9,7 @@ from sentry.testutils.helpers.faux import faux
 from sentry.utils import json
 
 
-class DictContaining(object):
+class DictContaining:
     def __init__(self, *keys):
         self.keys = keys
 
@@ -17,7 +17,7 @@ class DictContaining(object):
         return all([k in other.keys() for k in self.keys])
 
 
-class Any(object):
+class Any:
     def __eq__(self, other):
         return True
 

--- a/tests/sentry/tsdb/test_snuba.py
+++ b/tests/sentry/tsdb/test_snuba.py
@@ -23,7 +23,7 @@ def floor_to_10s_epoch(value):
 
 class SnubaTSDBTest(OutcomesSnubaTest):
     def setUp(self):
-        super(SnubaTSDBTest, self).setUp()
+        super().setUp()
         self.db = SnubaTSDB()
 
         # Set up the times

--- a/tests/sentry/utils/audit/tests.py
+++ b/tests/sentry/utils/audit/tests.py
@@ -15,7 +15,7 @@ from sentry.utils.audit import create_audit_entry
 username = "hello" * 20
 
 
-class FakeHttpRequest(object):
+class FakeHttpRequest:
     def __init__(self, user):
         self.user = user
         self.META = {"REMOTE_ADDR": "127.0.0.1"}

--- a/tests/sentry/utils/test_committers.py
+++ b/tests/sentry/utils/test_committers.py
@@ -128,7 +128,7 @@ class GetFramePathsTestCase(unittest.TestCase):
 
 class GetCommitFileChangesTestCase(CommitTestCase):
     def setUp(self):
-        super(GetCommitFileChangesTestCase, self).setUp()
+        super().setUp()
         file_change_1 = self.create_commitfilechange(filename="hello/app.py", type="A")
         file_change_2 = self.create_commitfilechange(filename="hello/templates/app.html", type="A")
         file_change_3 = self.create_commitfilechange(filename="hello/app.py", type="M")
@@ -215,7 +215,7 @@ class GetPreviousReleasesTestCase(TestCase):
 
 class GetEventFileCommitters(CommitTestCase):
     def setUp(self):
-        super(GetEventFileCommitters, self).setUp()
+        super().setUp()
         self.release = self.create_release(project=self.project, version="v12")
         self.group = self.create_group(
             project=self.project, message="Kaboom!", first_release=self.release
@@ -448,7 +448,7 @@ class GetEventFileCommitters(CommitTestCase):
 
 class DedupeCommits(CommitTestCase):
     def setUp(self):
-        super(DedupeCommits, self).setUp()
+        super().setUp()
 
     def test_dedupe_with_same_commit(self):
         commit = self.create_commit().__dict__

--- a/tests/sentry/utils/test_glob.py
+++ b/tests/sentry/utils/test_glob.py
@@ -3,7 +3,7 @@ import pytest
 from sentry.utils.glob import glob_match
 
 
-class GlobInput(object):
+class GlobInput:
     def __init__(self, value, pat, **kwargs):
         self.value = value
         self.pat = pat

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -78,13 +78,13 @@ class SafeExecuteTest(TestCase):
         assert safe_execute(simple, 1) is None
 
     def test_with_instance_method(self):
-        class Foo(object):
+        class Foo:
             def simple(self, a):
                 return a
 
         assert safe_execute(Foo().simple, 1) == 1
 
-        class Foo(object):
+        class Foo:
             def simple(self, a):
                 raise Exception()
 

--- a/tests/sentry/utils/test_urllib3_timeout.py
+++ b/tests/sentry/utils/test_urllib3_timeout.py
@@ -10,7 +10,7 @@ from sentry.utils.snuba import RetrySkipTimeout
 class FakeConnectionPool(HTTPConnectionPool):
     def __init__(self, connection, **kwargs):
         self.connection = connection
-        super(FakeConnectionPool, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def _new_conn(self):
         return self.connection

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -246,7 +246,7 @@ class AuthLoginNewsletterTest(TestCase):
         return reverse("sentry-login")
 
     def setUp(self):
-        super(AuthLoginNewsletterTest, self).setUp()
+        super().setUp()
 
         def disable_newsletter():
             newsletter.backend.disable()

--- a/tests/sentry/web/frontend/test_auth_oauth2.py
+++ b/tests/sentry/web/frontend/test_auth_oauth2.py
@@ -44,7 +44,7 @@ class AuthOAuth2Test(AuthProviderTestCase):
         self.auth_provider = AuthProvider.objects.create(
             provider=self.provider_name, organization=self.org
         )
-        super(AuthOAuth2Test, self).setUp()
+        super().setUp()
 
     @fixture
     def login_path(self):

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -70,13 +70,13 @@ class AuthSAML2Test(AuthProviderTestCase):
 
         settings.SENTRY_OPTIONS.update({"system.url-prefix": "http://testserver.com"})
 
-        super(AuthSAML2Test, self).setUp()
+        super().setUp()
 
     def tearDown(self):
         # restore url-prefix config
         settings.SENTRY_OPTIONS.update({"system.url-prefix": self.url_prefix})
 
-        super(AuthSAML2Test, self).tearDown()
+        super().tearDown()
 
     @fixture
     def login_path(self):

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -12,7 +12,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 @override_settings(ROOT_URLCONF="sentry.conf.urls")
 class ErrorPageEmbedTest(TestCase):
     def setUp(self):
-        super(ErrorPageEmbedTest, self).setUp()
+        super().setUp()
         self.project = self.create_project()
         self.project.update_option("sentry:origins", ["example.com"])
         self.key = self.create_project_key(self.project)

--- a/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
+++ b/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
@@ -10,7 +10,7 @@ body_plain = "foo bar"
 
 class TestMailgunInboundWebhookView(TestCase):
     def setUp(self):
-        super(TestMailgunInboundWebhookView, self).setUp()
+        super().setUp()
         self.event = self.store_event(data={"event_id": "a" * 32}, project_id=self.project.id)
         self.mailto = group_id_to_email(self.group.pk)
 

--- a/tests/sentry/web/frontend/test_oauth_authorize.py
+++ b/tests/sentry/web/frontend/test_oauth_authorize.py
@@ -11,7 +11,7 @@ class OAuthAuthorizeCodeTest(TestCase):
         return "/oauth/authorize/"
 
     def setUp(self):
-        super(OAuthAuthorizeCodeTest, self).setUp()
+        super().setUp()
         self.application = ApiApplication.objects.create(
             owner=self.user, redirect_uris="https://example.com"
         )
@@ -244,7 +244,7 @@ class OAuthAuthorizeTokenTest(TestCase):
         return "/oauth/authorize/"
 
     def setUp(self):
-        super(OAuthAuthorizeTokenTest, self).setUp()
+        super().setUp()
         self.application = ApiApplication.objects.create(
             owner=self.user, redirect_uris="https://example.com"
         )

--- a/tests/sentry/web/frontend/test_oauth_token.py
+++ b/tests/sentry/web/frontend/test_oauth_token.py
@@ -41,7 +41,7 @@ class OAuthTokenCodeTest(TestCase):
         return "/oauth/token/"
 
     def setUp(self):
-        super(OAuthTokenCodeTest, self).setUp()
+        super().setUp()
         self.application = ApiApplication.objects.create(
             owner=self.user, redirect_uris="https://example.com"
         )
@@ -145,7 +145,7 @@ class OAuthTokenRefreshTokenTest(TestCase):
         return "/oauth/token/"
 
     def setUp(self):
-        super(OAuthTokenRefreshTokenTest, self).setUp()
+        super().setUp()
         self.application = ApiApplication.objects.create(
             owner=self.user, redirect_uris="https://example.com"
         )

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -17,7 +17,7 @@ from sentry.testutils import AuthProviderTestCase, PermissionTestCase
 
 class OrganizationAuthSettingsPermissionTest(PermissionTestCase):
     def setUp(self):
-        super(OrganizationAuthSettingsPermissionTest, self).setUp()
+        super().setUp()
         self.auth_provider = AuthProvider.objects.create(
             organization=self.organization, provider="dummy"
         )

--- a/tests/sentry/web/frontend/test_organization_integration_setup.py
+++ b/tests/sentry/web/frontend/test_organization_integration_setup.py
@@ -5,7 +5,7 @@ from sentry.testutils import PermissionTestCase, TestCase
 
 class OrganizationIntegrationSetupPermissionTest(PermissionTestCase):
     def setUp(self):
-        super(OrganizationIntegrationSetupPermissionTest, self).setUp()
+        super().setUp()
         self.path = f"/organizations/{self.organization.slug}/integrations/example/setup/"
 
     # this currently redirects the user
@@ -21,7 +21,7 @@ class OrganizationIntegrationSetupPermissionTest(PermissionTestCase):
 
 class OrganizationIntegrationSetupTest(TestCase):
     def setUp(self):
-        super(OrganizationIntegrationSetupTest, self).setUp()
+        super().setUp()
         self.organization = self.create_organization(name="foo", owner=self.user)
         self.login_as(self.user)
         self.path = f"/organizations/{self.organization.slug}/integrations/example/setup/"

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -5,7 +5,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 class ProjectEventTest(SnubaTestCase, TestCase):
     def setUp(self):
-        super(ProjectEventTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.login_as(self.user)
         self.org = self.create_organization()

--- a/tests/sentry/web/frontend/test_release_webhook.py
+++ b/tests/sentry/web/frontend/test_release_webhook.py
@@ -12,7 +12,7 @@ from sentry.utils import json
 
 class ReleaseWebhookTestBase(TestCase):
     def setUp(self):
-        super(ReleaseWebhookTestBase, self).setUp()
+        super().setUp()
         self.organization = self.create_organization()
         self.team = self.create_team(organization=self.organization)
         self.project = self.create_project(teams=[self.team])
@@ -41,7 +41,7 @@ class ReleaseWebhookTestBase(TestCase):
 
 class ReleaseWebhookTest(ReleaseWebhookTestBase):
     def setUp(self):
-        super(ReleaseWebhookTest, self).setUp()
+        super().setUp()
         self.plugin_id = "dummy"
 
     def test_no_token(self):
@@ -93,7 +93,7 @@ class ReleaseWebhookTest(ReleaseWebhookTestBase):
 
 class BuiltinReleaseWebhookTest(ReleaseWebhookTestBase):
     def setUp(self):
-        super(BuiltinReleaseWebhookTest, self).setUp()
+        super().setUp()
         self.plugin_id = "builtin"
 
     def test_invalid_params(self):

--- a/tests/sentry/web/frontend/test_restore_organization.py
+++ b/tests/sentry/web/frontend/test_restore_organization.py
@@ -6,7 +6,7 @@ from sentry.testutils import TestCase, PermissionTestCase
 
 class RestoreOrganizationPermissionTest(PermissionTestCase):
     def setUp(self):
-        super(RestoreOrganizationPermissionTest, self).setUp()
+        super().setUp()
         self.organization = self.create_organization(
             name="foo", owner=self.user, status=OrganizationStatus.PENDING_DELETION
         )
@@ -24,7 +24,7 @@ class RestoreOrganizationPermissionTest(PermissionTestCase):
 
 class RemoveOrganizationTest(TestCase):
     def setUp(self):
-        super(RemoveOrganizationTest, self).setUp()
+        super().setUp()
 
         self.organization = self.create_organization(
             name="foo", owner=self.user, status=OrganizationStatus.PENDING_DELETION

--- a/tests/sentry/web/frontend/test_unsubscribe_notifications.py
+++ b/tests/sentry/web/frontend/test_unsubscribe_notifications.py
@@ -4,7 +4,7 @@ from sentry.testutils import TestCase
 from sentry.utils.linksign import generate_signed_link
 
 
-class UnsubscribeNotificationsBaseTest(object):
+class UnsubscribeNotificationsBaseTest:
     def create_instance(self):
         raise NotImplementedError()
 

--- a/tests/sentry_plugins/amazon_sqs/test_plugin.py
+++ b/tests/sentry_plugins/amazon_sqs/test_plugin.py
@@ -98,7 +98,7 @@ class AmazonSQSPluginTest(PluginTestCase):
     @patch("uuid.uuid4")
     @patch("boto3.client")
     def test_pass_message_group_id(self, mock_client, mock_uuid):
-        class uuid(object):
+        class uuid:
             hex = "some-uuid"
 
         mock_uuid.return_value = uuid

--- a/tests/sentry_plugins/victorops/test_plugin.py
+++ b/tests/sentry_plugins/victorops/test_plugin.py
@@ -14,7 +14,7 @@ SUCCESS = """{
 }"""
 
 
-class UnicodeTestInterface(object):
+class UnicodeTestInterface:
     def __init__(self, title, body):
         self.title = title
         self.body = body

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -8,7 +8,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 class KeyTransactionTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(KeyTransactionTest, self).setUp()
+        super().setUp()
 
         self.login_as(user=self.user, superuser=False)
 

--- a/tests/snuba/api/endpoints/test_discover_query.py
+++ b/tests/snuba/api/endpoints/test_discover_query.py
@@ -9,7 +9,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 
 class DiscoverQueryTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(DiscoverQueryTest, self).setUp()
+        super().setUp()
 
         self.now = datetime.now()
         self.one_second_ago = iso_format(before_now(seconds=1))

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -7,7 +7,7 @@ from sentry.testutils.helpers.datetime import before_now
 
 class DiscoverSavedQueryBase(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(DiscoverSavedQueryBase, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
         self.projects = [
@@ -29,7 +29,7 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
     feature_name = "organizations:discover"
 
     def setUp(self):
-        super(DiscoverSavedQueriesTest, self).setUp()
+        super().setUp()
         self.url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
 
     def test_get(self):
@@ -256,7 +256,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
     feature_name = "organizations:discover-query"
 
     def setUp(self):
-        super(DiscoverSavedQueriesVersion2Test, self).setUp()
+        super().setUp()
         self.url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
 
     def test_post_invalid_conditions(self):

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -8,7 +8,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
     feature_name = "organizations:discover"
 
     def setUp(self):
-        super(DiscoverSavedQueryDetailTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
         self.org_without_access = self.create_organization()

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -9,7 +9,7 @@ from sentry.utils.compat import map
 
 class GroupEventsTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(GroupEventsTest, self).setUp()
+        super().setUp()
         self.min_ago = before_now(minutes=1)
 
     def test_simple(self):

--- a/tests/snuba/api/endpoints/test_group_events_latest.py
+++ b/tests/snuba/api/endpoints/test_group_events_latest.py
@@ -5,7 +5,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 class GroupEventsLatestTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(GroupEventsLatestTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
 
         project = self.create_project()

--- a/tests/snuba/api/endpoints/test_group_events_oldest.py
+++ b/tests/snuba/api/endpoints/test_group_events_oldest.py
@@ -5,7 +5,7 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 
 class GroupEventsOldestTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(GroupEventsOldestTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
 
         project = self.create_project()

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -13,7 +13,7 @@ def format_project_event(project_slug, event_id):
 
 class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventDetailsEndpointTest, self).setUp()
+        super().setUp()
         min_ago = iso_format(before_now(minutes=1))
         two_min_ago = iso_format(before_now(minutes=2))
         three_min_ago = iso_format(before_now(minutes=3))

--- a/tests/snuba/api/endpoints/test_organization_eventid.py
+++ b/tests/snuba/api/endpoints/test_organization_eventid.py
@@ -7,7 +7,7 @@ from sentry.utils.compat.mock import patch
 
 class EventIdLookupEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(EventIdLookupEndpointTest, self).setUp()
+        super().setUp()
         min_ago = iso_format(before_now(minutes=1))
         self.org = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.org)

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -10,7 +10,7 @@ from sentry.utils.compat import map
 
 class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsEndpointTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
         self.day_ago = iso_format(before_now(days=1))
 

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -14,7 +14,7 @@ class OrganizationEventsFacetsEndpointTest(SnubaTestCase, APITestCase):
     feature_list = ("organizations:discover-basic", "organizations:global-views")
 
     def setUp(self):
-        super(OrganizationEventsFacetsEndpointTest, self).setUp()
+        super().setUp()
         self.min_ago = before_now(minutes=1).replace(microsecond=0)
         self.day_ago = before_now(days=1).replace(microsecond=0)
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_events_geo.py
+++ b/tests/snuba/api/endpoints/test_organization_events_geo.py
@@ -6,7 +6,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 
 class OrganizationEventsGeoEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsGeoEndpointTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
 
     def do_request(self, query, features=None):

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -19,7 +19,7 @@ HistogramSpec = namedtuple("HistogramSpec", ["start", "end", "fields"])
 
 class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsHistogramEndpointTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
         self.data = load_data("transaction")
 

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -10,7 +10,7 @@ from sentry.utils.compat import mock
 
 class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsMetaEndpoint, self).setUp()
+        super().setUp()
         self.min_ago = before_now(minutes=1)
         self.login_as(user=self.user)
         self.project = self.create_project()
@@ -172,7 +172,7 @@ class OrganizationEventsMetaEndpoint(APITestCase, SnubaTestCase):
 
 class OrganizationEventBaselineEndpoint(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventBaselineEndpoint, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
         self.project = self.create_project()
         self.prototype = {
@@ -315,7 +315,7 @@ class OrganizationEventBaselineEndpoint(APITestCase, SnubaTestCase):
 
 class OrganizationEventsRelatedIssuesEndpoint(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsRelatedIssuesEndpoint, self).setUp()
+        super().setUp()
 
     def test_find_related_issue(self):
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -14,7 +14,7 @@ from sentry.utils.samples import load_data
 
 class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsStatsEndpointTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
         self.authed_user = self.user
 
@@ -631,7 +631,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
 
 class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsStatsTopNEvents, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
 
         self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)

--- a/tests/snuba/api/endpoints/test_organization_events_trends.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trends.py
@@ -13,7 +13,7 @@ from sentry.api.endpoints.organization_events_trends import OrganizationEventsTr
 
 class OrganizationEventsTrendsBase(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsTrendsBase, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
 
         self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
@@ -48,7 +48,7 @@ class OrganizationEventsTrendsBase(APITestCase, SnubaTestCase):
 
 class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
     def setUp(self):
-        super(OrganizationEventsTrendsEndpointTest, self).setUp()
+        super().setUp()
         self.url = reverse(
             "sentry-api-0-organization-events-trends",
             kwargs={"organization_slug": self.project.organization.slug},
@@ -347,7 +347,7 @@ class OrganizationEventsTrendsEndpointTest(OrganizationEventsTrendsBase):
 
 class OrganizationEventsTrendsStatsEndpointTest(OrganizationEventsTrendsBase):
     def setUp(self):
-        super(OrganizationEventsTrendsStatsEndpointTest, self).setUp()
+        super().setUp()
         self.url = reverse(
             "sentry-api-0-organization-events-trends-stats",
             kwargs={"organization_slug": self.project.organization.slug},
@@ -684,7 +684,7 @@ class OrganizationEventsTrendsStatsEndpointTest(OrganizationEventsTrendsBase):
 
 class OrganizationEventsTrendsPagingTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsTrendsPagingTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
         self.url = reverse(
             "sentry-api-0-organization-events-trends-stats",

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -16,7 +16,7 @@ from sentry.utils.snuba import RateLimitExceeded, QueryIllegalTypeOfArgument, Qu
 
 class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsV2EndpointTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
         self.two_min_ago = iso_format(before_now(minutes=2))
         self.transaction_data = load_data("transaction", timestamp=before_now(minutes=1))

--- a/tests/snuba/api/endpoints/test_organization_events_vitals.py
+++ b/tests/snuba/api/endpoints/test_organization_events_vitals.py
@@ -10,7 +10,7 @@ from sentry.utils.samples import load_data
 
 class OrganizationEventsVitalsEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationEventsVitalsEndpointTest, self).setUp()
+        super().setUp()
         self.start = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
         self.end = self.start + timedelta(hours=6)
 
@@ -25,7 +25,7 @@ class OrganizationEventsVitalsEndpointTest(APITestCase, SnubaTestCase):
             for vital, value in measurements.items():
                 data["measurements"][vital]["value"] = value
 
-        return super(OrganizationEventsVitalsEndpointTest, self).store_event(
+        return super().store_event(
             data.copy(),
             project_id=self.project.id,
         )

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -1950,7 +1950,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         eventstream_state = object()
         mock_eventstream.start_merge = Mock(return_value=eventstream_state)
 
-        class uuid(object):
+        class uuid:
             hex = "abc123"
 
         mock_uuid4.return_value = uuid

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -46,7 +46,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-group-index"
 
     def setUp(self):
-        super(GroupListTest, self).setUp()
+        super().setUp()
         self.min_ago = before_now(minutes=1)
 
     def _parse_links(self, header):
@@ -62,7 +62,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             org = self.project.organization.slug
         else:
             org = args[0]
-        return super(GroupListTest, self).get_response(org, **kwargs)
+        return super().get_response(org, **kwargs)
 
     def test_sort_by_date_with_tag(self):
         # XXX(dcramer): this tests a case where an ambiguous column name existed
@@ -1173,7 +1173,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
     method = "put"
 
     def setUp(self):
-        super(GroupUpdateTest, self).setUp()
+        super().setUp()
         self.min_ago = timezone.now() - timedelta(minutes=1)
 
     def get_response(self, *args, **kwargs):
@@ -1181,7 +1181,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
             org = self.project.organization.slug
         else:
             org = args[0]
-        return super(GroupUpdateTest, self).get_response(org, **kwargs)
+        return super().get_response(org, **kwargs)
 
     def assertNoResolution(self, group):
         assert not GroupResolution.objects.filter(group=group).exists()
@@ -2108,7 +2108,7 @@ class GroupDeleteTest(APITestCase, SnubaTestCase):
             org = self.project.organization.slug
         else:
             org = args[0]
-        return super(GroupDeleteTest, self).get_response(org, **kwargs)
+        return super().get_response(org, **kwargs)
 
     @patch("sentry.api.helpers.group_index.eventstream")
     @patch("sentry.eventstream")

--- a/tests/snuba/api/endpoints/test_organization_group_index_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index_stats.py
@@ -9,7 +9,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-group-index-stats"
 
     def setUp(self):
-        super(GroupListTest, self).setUp()
+        super().setUp()
         self.min_ago = before_now(minutes=1)
 
     def _parse_links(self, header):
@@ -25,7 +25,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             org = self.project.organization.slug
         else:
             org = args[0]
-        return super(GroupListTest, self).get_response(org, **kwargs)
+        return super().get_response(org, **kwargs)
 
     def test_simple(self):
         self.store_event(

--- a/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
+++ b/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
@@ -12,7 +12,7 @@ class OrganizationIssuesResolvedInReleaseEndpointTest(APITestCase, SnubaTestCase
     method = "get"
 
     def setUp(self):
-        super(OrganizationIssuesResolvedInReleaseEndpointTest, self).setUp()
+        super().setUp()
         self.user = self.create_user()
         self.org = self.create_organization()
         self.team = self.create_team(organization=self.org)

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -22,7 +22,7 @@ def result_sorted(result):
 
 class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationSessionsEndpointTest, self).setUp()
+        super().setUp()
         self.setup_fixture()
 
     def setup_fixture(self):

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -11,7 +11,7 @@ class OrganizationTagKeyTestCase(APITestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-tagkey-values"
 
     def setUp(self):
-        super(OrganizationTagKeyTestCase, self).setUp()
+        super().setUp()
         self.min_ago = before_now(minutes=1)
         self.day_ago = before_now(days=1)
         user = self.create_user()
@@ -21,7 +21,7 @@ class OrganizationTagKeyTestCase(APITestCase, SnubaTestCase):
         self.login_as(user=user)
 
     def get_response(self, key, **kwargs):
-        return super(OrganizationTagKeyTestCase, self).get_response(self.org.slug, key, **kwargs)
+        return super().get_response(self.org.slug, key, **kwargs)
 
     def run_test(self, key, expected, **kwargs):
         response = self.get_valid_response(key, **kwargs)
@@ -262,7 +262,7 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
 
 class TransactionTagKeyValues(OrganizationTagKeyTestCase):
     def setUp(self):
-        super(TransactionTagKeyValues, self).setUp()
+        super().setUp()
         data = load_data("transaction", timestamp=before_now(minutes=1))
         self.store_event(data, project_id=self.project.id)
         self.transaction = data.copy()
@@ -286,7 +286,7 @@ class TransactionTagKeyValues(OrganizationTagKeyTestCase):
         qs_params = kwargs.get("qs_params", {})
         qs_params["includeTransactions"] = "1"
         kwargs["qs_params"] = qs_params
-        super(TransactionTagKeyValues, self).run_test(key, expected, **kwargs)
+        super().run_test(key, expected, **kwargs)
 
     def test_status(self):
         self.run_test("transaction.status", expected=[("unknown", 1), ("ok", 1)])

--- a/tests/snuba/api/endpoints/test_organization_tags.py
+++ b/tests/snuba/api/endpoints/test_organization_tags.py
@@ -7,7 +7,7 @@ from sentry.utils.compat import mock
 
 class OrganizationTagsTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(OrganizationTagsTest, self).setUp()
+        super().setUp()
         self.min_ago = iso_format(before_now(minutes=1))
 
     def test_simple(self):

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -5,7 +5,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 
 class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(ProjectEventDetailsTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
         project = self.create_project()
 
@@ -116,7 +116,7 @@ class ProjectEventDetailsTest(APITestCase, SnubaTestCase):
 
 class ProjectEventJsonEndpointTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(ProjectEventJsonEndpointTest, self).setUp()
+        super().setUp()
         self.login_as(user=self.user)
         self.event_id = "c" * 32
         self.fingerprint = ["group_2"]

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -1139,7 +1139,7 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         eventstream_state = object()
         mock_eventstream.start_merge = Mock(return_value=eventstream_state)
 
-        class uuid(object):
+        class uuid:
             hex = "abc123"
 
         mock_uuid4.return_value = uuid

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -38,7 +38,7 @@ from sentry.utils import json
 
 class GroupListTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(GroupListTest, self).setUp()
+        super().setUp()
         self.min_ago = before_now(minutes=1)
 
     def _parse_links(self, header):
@@ -327,7 +327,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
 class GroupUpdateTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(GroupUpdateTest, self).setUp()
+        super().setUp()
         self.min_ago = timezone.now() - timedelta(minutes=1)
 
     @fixture

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -29,7 +29,7 @@ from sentry.utils.compat.mock import patch
 
 class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
     def setUp(self):
-        super(GroupSerializerSnubaTest, self).setUp()
+        super().setUp()
         self.min_ago = before_now(minutes=1)
         self.day_ago = before_now(days=1)
         self.week_ago = before_now(days=7)

--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -12,7 +12,7 @@ from sentry.utils import snuba, json
 
 class SnubaEventStreamTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(SnubaEventStreamTest, self).setUp()
+        super().setUp()
 
         self.kafka_eventstream = KafkaEventStream()
         self.kafka_eventstream.producer = Mock()

--- a/tests/snuba/incidents/test_tasks.py
+++ b/tests/snuba/incidents/test_tasks.py
@@ -30,7 +30,7 @@ from sentry.testutils import TestCase
 @freeze_time()
 class HandleSnubaQueryUpdateTest(TestCase):
     def setUp(self):
-        super(HandleSnubaQueryUpdateTest, self).setUp()
+        super().setUp()
         self.override_settings_cm = override_settings(
             KAFKA_TOPICS={self.topic: {"cluster": "default", "topic": self.topic}}
         )
@@ -38,7 +38,7 @@ class HandleSnubaQueryUpdateTest(TestCase):
         self.orig_registry = deepcopy(subscriber_registry)
 
     def tearDown(self):
-        super(HandleSnubaQueryUpdateTest, self).tearDown()
+        super().tearDown()
         self.override_settings_cm.__exit__(None, None, None)
         subscriber_registry.clear()
         subscriber_registry.update(self.orig_registry)

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -982,7 +982,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         query_mock.return_value = {"data": [], "totals": {"total": 0}}
 
         def Any(cls):
-            class Any(object):
+            class Any:
                 def __eq__(self, other):
                     return isinstance(other, cls)
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -37,7 +37,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         return EventsDatasetSnubaSearchBackend()
 
     def setUp(self):
-        super(EventsSnubaSearchTest, self).setUp()
+        super().setUp()
         self.base_datetime = (datetime.utcnow() - timedelta(days=3)).replace(tzinfo=pytz.utc)
 
         event1_timestamp = iso_format(self.base_datetime - timedelta(days=21))
@@ -122,7 +122,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         }
 
     def store_event(self, data, *args, **kwargs):
-        event = super(EventsSnubaSearchTest, self).store_event(data, *args, **kwargs)
+        event = super().store_event(data, *args, **kwargs)
         environment_name = data.get("environment")
         if environment_name:
             GroupEnvironment.objects.filter(

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -25,7 +25,7 @@ def make_24h_stats(ts):
 
 class SnubaSessionsTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(SnubaSessionsTest, self).setUp()
+        super().setUp()
         self.received = time.time()
         self.session_started = time.time() // 60 * 60
         self.session_release = "foo@1.0.0"

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -67,7 +67,7 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
         return Producer(conf)
 
     def setUp(self):
-        super(QuerySubscriptionConsumerTest, self).setUp()
+        super().setUp()
         self.override_settings_cm = override_settings(
             KAFKA_TOPICS={self.topic: {"cluster": "default", "topic": self.topic}}
         )
@@ -75,7 +75,7 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
         self.orig_registry = deepcopy(subscriber_registry)
 
     def tearDown(self):
-        super(QuerySubscriptionConsumerTest, self).tearDown()
+        super().tearDown()
         self.override_settings_cm.__exit__(None, None, None)
         subscriber_registry.clear()
         subscriber_registry.update(self.orig_registry)

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -17,7 +17,7 @@ from sentry.testutils.helpers.datetime import iso_format
 
 class TagStorageTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(TagStorageTest, self).setUp()
+        super().setUp()
 
         self.ts = SnubaTagStorage()
 

--- a/tests/snuba/tsdb/test_tsdb_backend.py
+++ b/tests/snuba/tsdb/test_tsdb_backend.py
@@ -50,7 +50,7 @@ def has_shape(data, shape, allow_empty=False):
 
 class SnubaTSDBTest(TestCase, SnubaTestCase):
     def setUp(self):
-        super(SnubaTSDBTest, self).setUp()
+        super().setUp()
 
         self.db = SnubaTSDB()
         self.now = (datetime.utcnow() - timedelta(hours=4)).replace(


### PR DESCRIPTION
This is using my own pyupgrade fork to apply these two classes of fixes: https://github.com/asottile/pyupgrade#super-calls, https://github.com/asottile/pyupgrade#new-style-classes

After this, there isn't that many pyupgrade sweeping changes left (after dict, set literals) and I can just apply the rest of them for manual review.