### PR TITLE
ref(pyupgrade): set and dict literals for tests/

### DIFF
--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -164,7 +164,7 @@ class GetProjectIdsTest(BaseOrganizationEndpointTest):
             self.org,
             include_all_accessible=include_all_accessible,
         )
-        assert set([p.id for p in expected_projects]) == set(p.id for p in result)
+        assert {p.id for p in expected_projects} == {p.id for p in result}
 
     def test_no_ids_no_teams(self):
         # Should get nothing if not part of the org
@@ -267,7 +267,7 @@ class GetEnvironmentsTest(BaseOrganizationEndpointTest):
         if env_names:
             request_args["environment"] = env_names
         result = self.endpoint.get_environments(self.build_request(**request_args), self.org)
-        assert set([e.name for e in expected_envs]) == set([e.name for e in result])
+        assert {e.name for e in expected_envs} == {e.name for e in result}
 
     def test_no_params(self):
         self.run_test([])
@@ -323,11 +323,11 @@ class GetFilterParamsTest(BaseOrganizationEndpointTest):
             date_filter_optional=date_filter_optional,
         )
 
-        assert set([p.id for p in expected_projects]) == set(result["project_id"])
+        assert {p.id for p in expected_projects} == set(result["project_id"])
         assert expected_start == result["start"]
         assert expected_end == result["end"]
         if expected_envs:
-            assert set([e.name for e in expected_envs]) == set(result["environment"])
+            assert {e.name for e in expected_envs} == set(result["environment"])
         else:
             assert "environment" not in result
 

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -129,7 +129,7 @@ class DifAssembleEndpoint(APITestCase):
 
         assert response.status_code == 200, response.content
         assert response.data[not_found_checksum]["state"] == ChunkFileState.NOT_FOUND
-        assert set(response.data[not_found_checksum]["missingChunks"]) == set([not_found_checksum])
+        assert set(response.data[not_found_checksum]["missingChunks"]) == {not_found_checksum}
 
     @patch("sentry.tasks.assemble.assemble_dif")
     def test_assemble(self, mock_assemble_dif):

--- a/tests/sentry/api/endpoints/test_group_tags.py
+++ b/tests/sentry/api/endpoints/test_group_tags.py
@@ -62,7 +62,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
 
         assert data[0]["key"] == "foo"
         assert len(data[0]["topValues"]) == 2
-        assert set(v["value"] for v in data[0]["topValues"]) == set(["bar", "quux"])
+        assert {v["value"] for v in data[0]["topValues"]} == {"bar", "quux"}
 
         assert data[1]["key"] == "release"
         assert len(data[1]["topValues"]) == 1
@@ -90,9 +90,7 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, {"environment": "prod"}, format="json")
         assert response.status_code == 200
         assert len(response.data) == 4
-        assert set([tag["key"] for tag in response.data]) == set(
-            ["foo", "biz", "environment", "level"]
-        )
+        assert {tag["key"] for tag in response.data} == {"foo", "biz", "environment", "level"}
 
     def test_multi_env(self):
         min_ago = before_now(minutes=1)
@@ -123,4 +121,4 @@ class GroupTagsTest(APITestCase, SnubaTestCase):
             f"{url}?environment={env.name}&environment={env2.name}", format="json"
         )
         assert response.status_code == 200
-        assert set([tag["key"] for tag in response.data]) >= set(["biz", "environment", "foo"])
+        assert {tag["key"] for tag in response.data} >= {"biz", "environment", "foo"}

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -727,7 +727,7 @@ class OrganizationDeleteTest(APITestCase):
 
         # Make sure we've emailed all owners
         assert len(mail.outbox) == len(owners)
-        owner_emails = set(o.email for o in owners)
+        owner_emails = {o.email for o in owners}
         for msg in mail.outbox:
             assert "Deletion" in msg.subject
             assert len(msg.to) == 1

--- a/tests/sentry/api/endpoints/test_organization_release_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_release_assemble.py
@@ -65,7 +65,7 @@ class OrganizationReleaseAssembleTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert response.data["state"] == ChunkFileState.CREATED
-        assert set(response.data["missingChunks"]) == set([])
+        assert set(response.data["missingChunks"]) == set()
 
         mock_assemble_artifacts.apply_async.assert_called_once_with(
             kwargs={

--- a/tests/sentry/api/endpoints/test_organization_user_issues_search.py
+++ b/tests/sentry/api/endpoints/test_organization_user_issues_search.py
@@ -84,6 +84,7 @@ class OrganizationUserIssuesSearchTest(APITestCase, SnubaTestCase):
         # now result should include results from team2/project2
         assert response.status_code == 200
         assert len(response.data) == 2
-        assert set([r["project"]["slug"] for r in response.data]) == set(
-            [self.project1.slug, self.project2.slug]
-        )
+        assert {r["project"]["slug"] for r in response.data} == {
+            self.project1.slug,
+            self.project2.slug,
+        }

--- a/tests/sentry/api/endpoints/test_organization_user_reports.py
+++ b/tests/sentry/api/endpoints/test_organization_user_reports.py
@@ -68,8 +68,8 @@ class OrganizationUserReportListTest(APITestCase, SnubaTestCase):
         response = self.get_response(self.project_1.organization.slug, **params)
 
         assert response.status_code == 200, response.content
-        result_ids = set(report["id"] for report in response.data)
-        assert result_ids == set(str(report.id) for report in expected)
+        result_ids = {report["id"] for report in response.data}
+        assert result_ids == {str(report.id) for report in expected}
 
     def test_no_filters(self):
         self.run_test([self.report_1, self.report_2])

--- a/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
+++ b/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
@@ -55,7 +55,7 @@ class ProjectIssuesResolvedInReleaseEndpointTest(APITestCase):
         response = self.get_valid_response(self.org.slug, self.project.slug, self.release.version)
         assert len(response.data) == len(expected_groups)
         expected = set(map(str, [g.id for g in expected_groups]))
-        assert set([item["id"] for item in response.data]) == expected
+        assert {item["id"] for item in response.data} == expected
 
     def test_shows_issues_from_groupresolution(self):
         """

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -146,7 +146,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert set([report["eventID"] for report in response.data]) == set(["a" * 32, "b" * 32])
+        assert {report["eventID"] for report in response.data} == {"a" * 32, "b" * 32}
 
         # Invalid environment
         response = self.client.get(base_url + "?environment=invalid_env")

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -109,7 +109,7 @@ def test_internal_relays_should_receive_minimal_configs_if_they_do_not_explicitl
 
     # Sweeping assertion that we do not have any snake_case in that config.
     # Might need refining.
-    assert not set(x for x in _get_all_keys(result) if "-" in x or "_" in x)
+    assert not {x for x in _get_all_keys(result) if "-" in x or "_" in x}
 
     cfg = safe.get_path(result, "configs", str(default_project.id))
     assert safe.get_path(cfg, "config", "filterSettings") is None
@@ -126,7 +126,7 @@ def test_internal_relays_should_receive_full_configs(
 
     # Sweeping assertion that we do not have any snake_case in that config.
     # Might need refining.
-    assert not set(x for x in _get_all_keys(result) if "-" in x or "_" in x)
+    assert not {x for x in _get_all_keys(result) if "-" in x or "_" in x}
 
     cfg = safe.get_path(result, "configs", str(default_project.id))
     assert safe.get_path(cfg, "disabled") is False

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -108,7 +108,7 @@ def test_internal_relays_should_receive_minimal_configs_if_they_do_not_explicitl
 
     # Sweeping assertion that we do not have any snake_case in that config.
     # Might need refining.
-    assert not set(x for x in _get_all_keys(result) if "-" in x or "_" in x)
+    assert not {x for x in _get_all_keys(result) if "-" in x or "_" in x}
 
     cfg = safe.get_path(result, "configs", str(default_projectkey.public_key))
     assert safe.get_path(cfg, "config", "filterSettings") is None
@@ -125,7 +125,7 @@ def test_internal_relays_should_receive_full_configs(
 
     # Sweeping assertion that we do not have any snake_case in that config.
     # Might need refining.
-    assert not set(x for x in _get_all_keys(result) if "-" in x or "_" in x)
+    assert not {x for x in _get_all_keys(result) if "-" in x or "_" in x}
 
     cfg = safe.get_path(result, "configs", default_projectkey.public_key)
     assert safe.get_path(cfg, "disabled") is False

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -148,7 +148,7 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.data["name"] == "NewName"
         assert response.data["slug"] == slug
         assert response.data["scopes"] == ["event:read"]
-        assert response.data["events"] == set(["issue"])
+        assert response.data["events"] == {"issue"}
         assert response.data["uuid"] == self.unpublished_app.uuid
         assert response.data["webhookUrl"] == "https://newurl.com"
 

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -56,7 +56,7 @@ class GetSentryAppsTest(SentryAppsTest):
         self.login_as(user=self.superuser, superuser=True)
 
         response = self.client.get(self.url, format="json")
-        response_uuids = set(o["uuid"] for o in response.data)
+        response_uuids = {o["uuid"] for o in response.data}
 
         assert response.status_code == 200
         assert self.published_app.uuid in response_uuids
@@ -121,7 +121,7 @@ class GetSentryAppsTest(SentryAppsTest):
             "featureData": [],
         } in json.loads(response.content)
 
-        response_uuids = set(o["uuid"] for o in response.data)
+        response_uuids = {o["uuid"] for o in response.data}
         assert self.published_app.uuid not in response_uuids
         assert self.unpublished_app.uuid not in response_uuids
         assert self.unowned_unpublished_app.uuid not in response_uuids
@@ -158,7 +158,7 @@ class GetSentryAppsTest(SentryAppsTest):
             "featureData": [],
         } in json.loads(response.content)
 
-        response_uuids = set(o["uuid"] for o in response.data)
+        response_uuids = {o["uuid"] for o in response.data}
         assert internal_app.uuid in response_uuids
         assert self.published_app.uuid not in response_uuids
         assert self.unpublished_app.uuid not in response_uuids
@@ -196,7 +196,7 @@ class GetSentryAppsTest(SentryAppsTest):
             ],
         } in json.loads(response.content)
 
-        response_uuids = set(o["uuid"] for o in response.data)
+        response_uuids = {o["uuid"] for o in response.data}
         assert self.unpublished_app.uuid not in response_uuids
         assert self.unowned_unpublished_app.uuid not in response_uuids
 
@@ -206,7 +206,7 @@ class GetSentryAppsTest(SentryAppsTest):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
-        response_uuids = set(o["uuid"] for o in response.data)
+        response_uuids = {o["uuid"] for o in response.data}
         assert self.unpublished_app.uuid in response_uuids
         assert self.unowned_unpublished_app.uuid in response_uuids
         assert self.published_app.uuid not in response_uuids
@@ -243,7 +243,7 @@ class GetSentryAppsTest(SentryAppsTest):
             ],
         } in json.loads(response.content)
 
-        response_uuids = set(o["uuid"] for o in response.data)
+        response_uuids = {o["uuid"] for o in response.data}
         assert self.published_app.uuid not in response_uuids
         assert self.unowned_unpublished_app.uuid not in response_uuids
 
@@ -253,7 +253,7 @@ class GetSentryAppsTest(SentryAppsTest):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200
-        response_uuids = set(o["uuid"] for o in response.data)
+        response_uuids = {o["uuid"] for o in response.data}
         assert self.published_app.uuid in response_uuids
         assert self.unpublished_app not in response_uuids
         assert self.unowned_unpublished_app.uuid not in response_uuids

--- a/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
+++ b/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
@@ -270,21 +270,21 @@ class UserNotificationFineTuningTest(APITestCase):
 
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
-        ) == set([self.org.id, self.org2.id])
+        ) == {self.org.id, self.org2.id}
 
         update = {}
         update[self.org.id] = 1
         resp = self.client.put(url, data=update)
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
-        ) == set([self.org2.id])
+        ) == {self.org2.id}
 
         update = {}
         update[self.org.id] = 0
         resp = self.client.put(url, data=update)
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
-        ) == set([self.org.id, self.org2.id])
+        ) == {self.org.id, self.org2.id}
 
     def test_enable_weekly_reports_from_default_setting(self):
         url = reverse(
@@ -299,9 +299,10 @@ class UserNotificationFineTuningTest(APITestCase):
         resp = self.client.put(url, data=update)
         assert resp.status_code == 204
 
-        assert set(
-            UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
-        ) == set([])
+        assert (
+            set(UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value)
+            == set()
+        )
 
         # can disable
         update = {}
@@ -309,15 +310,16 @@ class UserNotificationFineTuningTest(APITestCase):
         resp = self.client.put(url, data=update)
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
-        ) == set([self.org.id])
+        ) == {self.org.id}
 
         # re-enable
         update = {}
         update[self.org.id] = 1
         resp = self.client.put(url, data=update)
-        assert set(
-            UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
-        ) == set([])
+        assert (
+            set(UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value)
+            == set()
+        )
 
     def test_permissions(self):
         new_user = self.create_user(email="b@example.com")

--- a/tests/sentry/api/serializers/rest_framework/test_mentions.py
+++ b/tests/sentry/api/serializers/rest_framework/test_mentions.py
@@ -8,14 +8,14 @@ class ExtractUserIdsFromMentionsTest(TestCase):
     def test_users(self):
         actor = Actor(self.user.id, User)
         result = extract_user_ids_from_mentions(self.organization.id, [actor])
-        assert result["users"] == set([self.user.id])
+        assert result["users"] == {self.user.id}
         assert result["team_users"] == set()
 
         other_user = self.create_user()
         result = extract_user_ids_from_mentions(
             self.organization.id, [actor, Actor(other_user.id, User)]
         )
-        assert result["users"] == set([self.user.id, other_user.id])
+        assert result["users"] == {self.user.id, other_user.id}
         assert result["team_users"] == set()
 
     def test_teams(self):
@@ -26,11 +26,11 @@ class ExtractUserIdsFromMentionsTest(TestCase):
         actor = Actor(self.team.id, Team)
         result = extract_user_ids_from_mentions(self.organization.id, [actor])
         assert result["users"] == set()
-        assert result["team_users"] == set([self.user.id, member_user.id])
+        assert result["team_users"] == {self.user.id, member_user.id}
 
         # Explicitly mentioned users shouldn't be included in team_users
         result = extract_user_ids_from_mentions(
             self.organization.id, [Actor(member_user.id, User), actor]
         )
-        assert result["users"] == set([member_user.id])
-        assert result["team_users"] == set([self.user.id])
+        assert result["users"] == {member_user.id}
+        assert result["team_users"] == {self.user.id}

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -179,12 +179,12 @@ class ProjectSerializerTest(TestCase):
         def api_form(flag):
             return flag[len("projects:") :]
 
-        flags_to_find = set(api_form(f) for f in [early_flag, red_flag, blue_flag])
+        flags_to_find = {api_form(f) for f in [early_flag, red_flag, blue_flag]}
 
         def assert_has_features(project, expected_features):
             serialized = serialize(project)
-            actual_features = set(f for f in serialized["features"] if f in flags_to_find)
-            assert actual_features == set(api_form(f) for f in expected_features)
+            actual_features = {f for f in serialized["features"] if f in flags_to_find}
+            assert actual_features == {api_form(f) for f in expected_features}
 
         assert_has_features(early_red, [early_flag, red_flag])
         assert_has_features(early_blue, [early_flag, blue_flag])
@@ -483,19 +483,21 @@ class BulkFetchProjectLatestReleases(TestCase):
 
     def test_multi_mixed_releases(self):
         release = self.create_release(self.project)
-        assert set(bulk_fetch_project_latest_releases([self.project, self.other_project])) == set(
-            [release]
-        )
+        assert set(bulk_fetch_project_latest_releases([self.project, self.other_project])) == {
+            release
+        }
 
     def test_multi_releases(self):
         release = self.create_release(
             self.project, date_added=timezone.now() - timedelta(minutes=5)
         )
         other_project_release = self.create_release(self.other_project)
-        assert set(bulk_fetch_project_latest_releases([self.project, self.other_project])) == set(
-            [release, other_project_release]
-        )
+        assert set(bulk_fetch_project_latest_releases([self.project, self.other_project])) == {
+            release,
+            other_project_release,
+        }
         release_2 = self.create_release(self.project)
-        assert set(bulk_fetch_project_latest_releases([self.project, self.other_project])) == set(
-            [release_2, other_project_release]
-        )
+        assert set(bulk_fetch_project_latest_releases([self.project, self.other_project])) == {
+            release_2,
+            other_project_release,
+        }

--- a/tests/sentry/db/test_deletion.py
+++ b/tests/sentry/db/test_deletion.py
@@ -37,7 +37,7 @@ class BulkDeleteQueryTest(TestCase):
 class BulkDeleteQueryIteratorTestCase(TransactionTestCase):
     def test_iteration(self):
         target_project = self.project
-        expected_group_ids = set([self.create_group().id for i in range(2)])
+        expected_group_ids = {self.create_group().id for i in range(2)}
 
         other_project = self.create_project()
         self.create_group(other_project)

--- a/tests/sentry/digests/backends/test_redis.py
+++ b/tests/sentry/digests/backends/test_redis.py
@@ -25,14 +25,14 @@ class RedisBackendTestCase(TestCase):
         assert set(backend.schedule(time.time())) == set()
 
         with backend.digest("timeline", 0) as records:
-            assert set(records) == set([record_1, record_2])
+            assert set(records) == {record_1, record_2}
 
         # The schedule should now contain the timeline.
-        assert set(entry.key for entry in backend.schedule(time.time())) == set(["timeline"])
+        assert {entry.key for entry in backend.schedule(time.time())} == {"timeline"}
 
         # We didn't add any new records so there's nothing to do here.
         with backend.digest("timeline", 0) as records:
-            assert set(records) == set([])
+            assert set(records) == set()
 
         # There's nothing to move between sets since the timeline contents no
         # longer exist at this point.
@@ -72,12 +72,12 @@ class RedisBackendTestCase(TestCase):
         backend.add("timeline", record_2)
 
         # The schedule should now contain the timeline.
-        assert set(entry.key for entry in backend.schedule(time.time())) == set(["timeline"])
+        assert {entry.key for entry in backend.schedule(time.time())} == {"timeline"}
 
         # The existing and new record should be there because the timeline
         # contents were merged back into the digest.
         with backend.digest("timeline", 0) as records:
-            assert set(records) == set([record_1, record_2])
+            assert set(records) == {record_1, record_2}
 
     def test_maintenance_failure_recovery_with_capacity(self):
         backend = RedisBackend(capacity=10, truncation_chance=0.0)
@@ -105,13 +105,13 @@ class RedisBackendTestCase(TestCase):
         backend.maintenance(time.time())
 
         # The schedule should now contain the timeline.
-        assert set(entry.key for entry in backend.schedule(time.time())) == set(["timeline"])
+        assert {entry.key for entry in backend.schedule(time.time())} == {"timeline"}
 
         # Only the new records should exist -- the older one should have been
         # trimmed to avoid the digest growing beyond the timeline capacity.
         with backend.digest("timeline", 0) as records:
-            expected_keys = set(f"record:{i}" for i in range(10, 20))
-            assert set(record.key for record in records) == expected_keys
+            expected_keys = {f"record:{i}" for i in range(10, 20)}
+            assert {record.key for record in records} == expected_keys
 
     def test_delete(self):
         backend = RedisBackend()
@@ -120,7 +120,7 @@ class RedisBackendTestCase(TestCase):
 
         with pytest.raises(InvalidState):
             with backend.digest("timeline", 0) as records:
-                assert set(records) == set([])
+                assert set(records) == set()
 
         assert set(backend.schedule(time.time())) == set()
         assert len(backend._get_connection("timeline").keys("d:*")) == 0
@@ -138,7 +138,7 @@ class RedisBackendTestCase(TestCase):
         # The existing and new record should be there because the timeline
         # contents were merged back into the digest.
         with backend.digest("timeline", 0) as records:
-            assert set(records) == set([record_2])
+            assert set(records) == {record_2}
 
     def test_large_digest(self):
         backend = RedisBackend()

--- a/tests/sentry/digests/test_utilities.py
+++ b/tests/sentry/digests/test_utilities.py
@@ -66,9 +66,9 @@ class UtilitiesHelpersTestCase(TestCase, SnubaTestCase):
         )
 
         events.pop(0)  # remove event with same group
-        assert set([e.event_id for e in get_event_from_groups_in_digest(digest)]) == set(
-            [e.event_id for e in events]
-        )
+        assert {e.event_id for e in get_event_from_groups_in_digest(digest)} == {
+            e.event_id for e in events
+        }
 
     def test_team_actors_to_user_ids(self):
         team1 = self.create_team()
@@ -97,8 +97,8 @@ class UtilitiesHelpersTestCase(TestCase, SnubaTestCase):
         user_ids = [user.id for user in users]
 
         assert team_actors_to_user_ids(team_actors, user_ids) == {
-            team1.id: set([users[0].id, users[1].id, users[2].id, users[3].id]),
-            team2.id: set([users[3].id, users[4].id, users[5].id]),
+            team1.id: {users[0].id, users[1].id, users[2].id, users[3].id},
+            team2.id: {users[3].id, users[4].id, users[5].id},
         }
 
     def test_convert_actors_to_user_set(self):
@@ -115,23 +115,19 @@ class UtilitiesHelpersTestCase(TestCase, SnubaTestCase):
         self.create_member(user=user3, organization=self.organization, teams=[team1, team2])
         self.create_member(user=user4, organization=self.organization, teams=[])
 
-        team1_events = set(
-            [
-                self.create_event(self.project.id),
-                self.create_event(self.project.id),
-                self.create_event(self.project.id),
-                self.create_event(self.project.id),
-            ]
-        )
-        team2_events = set(
-            [
-                self.create_event(self.project.id),
-                self.create_event(self.project.id),
-                self.create_event(self.project.id),
-                self.create_event(self.project.id),
-            ]
-        )
-        user4_events = set([self.create_event(self.project.id), self.create_event(self.project.id)])
+        team1_events = {
+            self.create_event(self.project.id),
+            self.create_event(self.project.id),
+            self.create_event(self.project.id),
+            self.create_event(self.project.id),
+        }
+        team2_events = {
+            self.create_event(self.project.id),
+            self.create_event(self.project.id),
+            self.create_event(self.project.id),
+            self.create_event(self.project.id),
+        }
+        user4_events = {self.create_event(self.project.id), self.create_event(self.project.id)}
         events_by_actor = {
             Actor(team1.id, Team): team1_events,
             Actor(team2.id, Team): team2_events,
@@ -239,9 +235,9 @@ class GetPersonalizedDigestsTestCase(TestCase, SnubaTestCase):
             target_type, project.id, digest, user_ids
         ):
             assert user_id in expected_result
-            assert set([e.event_id for e in get_event_from_groups_in_digest(user_digest)]) == set(
-                [e.event_id for e in expected_result[user_id]]
-            )
+            assert {e.event_id for e in get_event_from_groups_in_digest(user_digest)} == {
+                e.event_id for e in expected_result[user_id]
+            }
             result_user_ids.append(user_id)
 
         assert sorted(expected_result.keys()) == sorted(result_user_ids)

--- a/tests/sentry/eventstream/kafka/test_consumer.py
+++ b/tests/sentry/eventstream/kafka/test_consumer.py
@@ -93,7 +93,7 @@ def test_consumer_start_from_partition_start(requires_kafka):
                 break
 
         assert len(assignments_received) == 1, "expected to receive partition assignment"
-        assert set((i.topic, i.partition) for i in assignments_received[0]) == set([(topic, 0)])
+        assert {(i.topic, i.partition) for i in assignments_received[0]} == {(topic, 0)}
 
         # TODO: Make sure that all partitions remain paused.
 
@@ -184,7 +184,7 @@ def test_consumer_start_from_committed_offset(requires_kafka):
                 break
 
         assert len(assignments_received) == 1, "expected to receive partition assignment"
-        assert set((i.topic, i.partition) for i in assignments_received[0]) == set([(topic, 0)])
+        assert {(i.topic, i.partition) for i in assignments_received[0]} == {(topic, 0)}
 
         # TODO: Make sure that all partitions are paused on assignment.
 
@@ -281,9 +281,10 @@ def test_consumer_rebalance_from_partition_start(requires_kafka):
         assert (
             len(assignments_received[consumer_a]) == 1
         ), "expected to receive partition assignment"
-        assert set((i.topic, i.partition) for i in assignments_received[consumer_a][0]) == set(
-            [(topic, 0), (topic, 1)]
-        )
+        assert {(i.topic, i.partition) for i in assignments_received[consumer_a][0]} == {
+            (topic, 0),
+            (topic, 1),
+        }
 
         assignments_received[consumer_a].pop()
         consumer_b = SynchronizedConsumer(
@@ -315,7 +316,7 @@ def test_consumer_rebalance_from_partition_start(requires_kafka):
             i = assignments_received[consumer][0][0]
             assignments[(i.topic, i.partition)] = consumer
 
-        assert set(assignments.keys()) == set([(topic, 0), (topic, 1)])
+        assert set(assignments.keys()) == {(topic, 0), (topic, 1)}
 
         for expected_message in messages_delivered[topic]:
             consumer = assignments[(expected_message.topic(), expected_message.partition())]
@@ -411,9 +412,10 @@ def test_consumer_rebalance_from_committed_offset(requires_kafka):
         assert (
             len(assignments_received[consumer_a]) == 1
         ), "expected to receive partition assignment"
-        assert set((i.topic, i.partition) for i in assignments_received[consumer_a][0]) == set(
-            [(topic, 0), (topic, 1)]
-        )
+        assert {(i.topic, i.partition) for i in assignments_received[consumer_a][0]} == {
+            (topic, 0),
+            (topic, 1),
+        }
 
         assignments_received[consumer_a].pop()
 
@@ -446,7 +448,7 @@ def test_consumer_rebalance_from_committed_offset(requires_kafka):
             i = assignments_received[consumer][0][0]
             assignments[(i.topic, i.partition)] = consumer
 
-        assert set(assignments.keys()) == set([(topic, 0), (topic, 1)])
+        assert set(assignments.keys()) == {(topic, 0), (topic, 1)}
 
         for expected_message in messages_delivered[topic][2:]:
             consumer = assignments[(expected_message.topic(), expected_message.partition())]
@@ -579,9 +581,10 @@ def test_consumer_rebalance_from_uncommitted_offset(requires_kafka):
         assert (
             len(assignments_received[consumer_a]) == 1
         ), "expected to receive partition assignment"
-        assert set((i.topic, i.partition) for i in assignments_received[consumer_a][0]) == set(
-            [(topic, 0), (topic, 1)]
-        )
+        assert {(i.topic, i.partition) for i in assignments_received[consumer_a][0]} == {
+            (topic, 0),
+            (topic, 1),
+        }
         assignments_received[consumer_a].pop()
 
         message = consumer_a.poll(1)

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -470,16 +470,14 @@ class TestAlertRuleSerializer(TestCase):
         serializer = AlertRuleSerializer(context=self.context, data=params, partial=True)
         assert serializer.is_valid()
         alert_rule = serializer.save()
-        assert set(alert_rule.snuba_query.event_types) == set(
-            [SnubaQueryEventType.EventType.DEFAULT]
-        )
+        assert set(alert_rule.snuba_query.event_types) == {SnubaQueryEventType.EventType.DEFAULT}
         params["event_types"] = [SnubaQueryEventType.EventType.ERROR.name.lower()]
         serializer = AlertRuleSerializer(
             context=self.context, instance=alert_rule, data=params, partial=True
         )
         assert serializer.is_valid()
         alert_rule = serializer.save()
-        assert set(alert_rule.snuba_query.event_types) == set([SnubaQueryEventType.EventType.ERROR])
+        assert set(alert_rule.snuba_query.event_types) == {SnubaQueryEventType.EventType.ERROR}
 
     def test_unsupported_query(self):
         self.run_fail_validation_test(

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -63,9 +63,10 @@ class EmailActionHandlerGetTargetsTest(TestCase):
             target_identifier=str(self.team.id),
         )
         handler = EmailActionHandler(action, self.incident, self.project)
-        assert set(handler.get_targets()) == set(
-            [(self.user.id, self.user.email), (new_user.id, new_user.email)]
-        )
+        assert set(handler.get_targets()) == {
+            (self.user.id, self.user.email),
+            (new_user.id, new_user.email),
+        }
 
     def test_team_alert_disabled(self):
         UserOption.objects.set_value(
@@ -81,7 +82,7 @@ class EmailActionHandlerGetTargetsTest(TestCase):
             target_identifier=str(self.team.id),
         )
         handler = EmailActionHandler(action, self.incident, self.project)
-        assert set(handler.get_targets()) == set([(new_user.id, new_user.email)])
+        assert set(handler.get_targets()) == {(new_user.id, new_user.email)}
 
 
 @freeze_time()

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -857,7 +857,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert self.alert_rule.id == updated_rule.id
         assert self.alert_rule.name == name
         updated_subscriptions = self.alert_rule.snuba_query.subscriptions.all()
-        assert set([sub.project for sub in updated_subscriptions]) == set(updated_projects)
+        assert {sub.project for sub in updated_subscriptions} == set(updated_projects)
         for subscription in updated_subscriptions:
             assert subscription.snuba_query.query == query
             assert subscription.snuba_query.aggregate == aggregate
@@ -910,7 +910,7 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         with self.tasks():
             update_alert_rule(alert_rule, projects=updated_projects, query=query_update)
         updated_subscriptions = alert_rule.snuba_query.subscriptions.all()
-        assert set([sub.project for sub in updated_subscriptions]) == set(updated_projects)
+        assert {sub.project for sub in updated_subscriptions} == set(updated_projects)
         for sub in updated_subscriptions:
             assert sub.snuba_query.query == query_update
 
@@ -920,9 +920,10 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         new_project = self.create_project(fire_project_created=True)
         assert not alert_rule.snuba_query.subscriptions.filter(project=new_project).exists()
         update_alert_rule(alert_rule, include_all_projects=True)
-        assert set([sub.project for sub in alert_rule.snuba_query.subscriptions.all()]) == set(
-            [new_project, orig_project]
-        )
+        assert {sub.project for sub in alert_rule.snuba_query.subscriptions.all()} == {
+            new_project,
+            orig_project,
+        }
 
     def test_update_to_include_all_with_exclude(self):
         orig_project = self.project
@@ -933,27 +934,28 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         update_alert_rule(
             alert_rule, include_all_projects=True, excluded_projects=[excluded_project]
         )
-        assert set([sub.project for sub in alert_rule.snuba_query.subscriptions.all()]) == set(
-            [orig_project, new_project]
-        )
+        assert {sub.project for sub in alert_rule.snuba_query.subscriptions.all()} == {
+            orig_project,
+            new_project,
+        }
 
     def test_update_include_all_exclude_list(self):
         new_project = self.create_project(fire_project_created=True)
-        projects = set([new_project, self.project])
+        projects = {new_project, self.project}
         alert_rule = self.create_alert_rule(include_all_projects=True)
-        assert set([sub.project for sub in alert_rule.snuba_query.subscriptions.all()]) == projects
+        assert {sub.project for sub in alert_rule.snuba_query.subscriptions.all()} == projects
         with self.tasks():
             update_alert_rule(alert_rule, excluded_projects=[self.project])
         assert [sub.project for sub in alert_rule.snuba_query.subscriptions.all()] == [new_project]
 
         update_alert_rule(alert_rule, excluded_projects=[])
-        assert set([sub.project for sub in alert_rule.snuba_query.subscriptions.all()]) == projects
+        assert {sub.project for sub in alert_rule.snuba_query.subscriptions.all()} == projects
 
     def test_update_from_include_all(self):
         new_project = self.create_project(fire_project_created=True)
-        projects = set([new_project, self.project])
+        projects = {new_project, self.project}
         alert_rule = self.create_alert_rule(include_all_projects=True)
-        assert set([sub.project for sub in alert_rule.snuba_query.subscriptions.all()]) == projects
+        assert {sub.project for sub in alert_rule.snuba_query.subscriptions.all()} == projects
         with self.tasks():
             update_alert_rule(alert_rule, projects=[new_project], include_all_projects=False)
         assert [sub.project for sub in alert_rule.snuba_query.subscriptions.all()] == [new_project]
@@ -1195,7 +1197,7 @@ class UpdateAlertRuleTriggerTest(TestCase):
         excluded_projects = [
             exclusion.query_subscription.project for exclusion in trigger.exclusions.all()
         ]
-        assert set(excluded_projects) == set([other_project, excluded_project])
+        assert set(excluded_projects) == {other_project, excluded_project}
 
     def test_excluded_projects_not_associated_with_rule(self):
         other_project = self.create_project(fire_project_created=True)

--- a/tests/sentry/incidents/test_models.py
+++ b/tests/sentry/incidents/test_models.py
@@ -412,7 +412,7 @@ class AlertRuleFetchForOrganizationTest(TestCase):
         assert [alert_rule1] == list(
             AlertRule.objects.fetch_for_organization(self.organization, [self.project])
         )
-        assert set([alert_rule1, alert_rule2]) == set(
+        assert {alert_rule1, alert_rule2} == set(
             AlertRule.objects.fetch_for_organization(self.organization, [project])
         )
 

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -99,7 +99,7 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
             max_batch_size=2,
             max_batch_time=5000,
             group_id=group_id,
-            consumer_types=set([ConsumerType.Events]),
+            consumer_types={ConsumerType.Events},
             auto_offset_reset="earliest",
         )
 
@@ -141,7 +141,7 @@ def test_ingest_consumer_fails_when_not_autocreating_topics(
             max_batch_size=2,
             max_batch_time=5000,
             group_id=group_id,
-            consumer_types=set([ConsumerType.Events]),
+            consumer_types={ConsumerType.Events},
             auto_offset_reset="earliest",
         )
 

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -89,7 +89,7 @@ class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
 
     def test_get_send_to_with_team_owners(self):
         event = self.store_event(data=self.make_event_data("foo.py"), project_id=self.project.id)
-        assert sorted(set([self.user.pk, self.user2.pk])) == sorted(
+        assert sorted({self.user.pk, self.user2.pk}) == sorted(
             self.adapter.get_send_to(self.project, ActionTargetType.ISSUE_OWNERS, event=event.data)
         )
 
@@ -97,13 +97,13 @@ class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
         UserOption.objects.set_value(
             user=self.user2, key="mail:alert", value=0, project=self.project
         )
-        assert set([self.user.pk]) == self.adapter.get_send_to(
+        assert {self.user.pk} == self.adapter.get_send_to(
             self.project, ActionTargetType.ISSUE_OWNERS, event=event.data
         )
 
     def test_get_send_to_with_user_owners(self):
         event = self.store_event(data=self.make_event_data("foo.cbl"), project_id=self.project.id)
-        assert sorted(set([self.user.pk, self.user2.pk])) == sorted(
+        assert sorted({self.user.pk, self.user2.pk}) == sorted(
             self.adapter.get_send_to(self.project, ActionTargetType.ISSUE_OWNERS, event=event.data)
         )
 
@@ -111,26 +111,26 @@ class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
         UserOption.objects.set_value(
             user=self.user2, key="mail:alert", value=0, project=self.project
         )
-        assert set([self.user.pk]) == self.adapter.get_send_to(
+        assert {self.user.pk} == self.adapter.get_send_to(
             self.project, ActionTargetType.ISSUE_OWNERS, event=event.data
         )
 
     def test_get_send_to_with_user_owner(self):
         event = self.store_event(data=self.make_event_data("foo.jx"), project_id=self.project.id)
-        assert set([self.user2.pk]) == self.adapter.get_send_to(
+        assert {self.user2.pk} == self.adapter.get_send_to(
             self.project, ActionTargetType.ISSUE_OWNERS, event=event.data
         )
 
     def test_get_send_to_with_fallthrough(self):
         event = self.store_event(data=self.make_event_data("foo.cpp"), project_id=self.project.id)
-        assert set([self.user.pk, self.user2.pk]) == set(
+        assert {self.user.pk, self.user2.pk} == set(
             self.adapter.get_send_to(self.project, ActionTargetType.ISSUE_OWNERS, event=event.data)
         )
 
     def test_get_send_to_without_fallthrough(self):
         ProjectOwnership.objects.get(project_id=self.project.id).update(fallthrough=False)
         event = self.store_event(data=self.make_event_data("foo.cpp"), project_id=self.project.id)
-        assert set([]) == self.adapter.get_send_to(
+        assert set() == self.adapter.get_send_to(
             self.project, ActionTargetType.ISSUE_OWNERS, event=event.data
         )
 
@@ -157,7 +157,7 @@ class MailAdapterGetSendableUsersTest(BaseMailAdapterTest, TestCase):
         self.create_member(user=user2, organization=organization, teams=[team])
 
         # all members
-        assert sorted(set([user.pk, user2.pk])) == sorted(self.adapter.get_sendable_users(project))
+        assert sorted({user.pk, user2.pk}) == sorted(self.adapter.get_sendable_users(project))
 
         # disabled user2
         UserOption.objects.create(key="mail:alert", value=0, project=project, user=user2)
@@ -205,7 +205,7 @@ class MailAdapterBuildMessageTest(BaseMailAdapterTest, TestCase):
         subject = "hello"
         send_to_user = self.create_user("hello@timecube.com")
         msg = self.adapter._build_message(self.project, subject, send_to=[send_to_user.id])
-        assert msg._send_to == set([send_to_user.email])
+        assert msg._send_to == {send_to_user.email}
         assert msg.subject.endswith(subject)
 
 
@@ -611,25 +611,26 @@ class MailAdapterGetSendToOwnersTest(BaseMailAdapterTest, TestCase):
         event_all_users = self.store_event(
             data=self.make_event_data("foo.cbl"), project_id=self.project.id
         )
-        assert self.adapter.get_send_to_owners(event_all_users, self.project) == set(
-            [self.user.id, self.user2.id, self.user3.id]
-        )
+        assert self.adapter.get_send_to_owners(event_all_users, self.project) == {
+            self.user.id,
+            self.user2.id,
+            self.user3.id,
+        }
 
     def test_team(self):
         event_team = self.store_event(
             data=self.make_event_data("foo.py"), project_id=self.project.id
         )
-        assert self.adapter.get_send_to_owners(event_team, self.project) == set(
-            [self.user2.id, self.user3.id]
-        )
+        assert self.adapter.get_send_to_owners(event_team, self.project) == {
+            self.user2.id,
+            self.user3.id,
+        }
 
     def test_single_user(self):
         event_single_user = self.store_event(
             data=self.make_event_data("foo.jx"), project_id=self.project.id
         )
-        assert self.adapter.get_send_to_owners(event_single_user, self.project) == set(
-            [self.user2.id]
-        )
+        assert self.adapter.get_send_to_owners(event_single_user, self.project) == {self.user2.id}
 
     def test_disable_alerts(self):
         # Make sure that disabling mail alerts works as expected
@@ -639,14 +640,15 @@ class MailAdapterGetSendToOwnersTest(BaseMailAdapterTest, TestCase):
         event_all_users = self.store_event(
             data=self.make_event_data("foo.cbl"), project_id=self.project.id
         )
-        assert self.adapter.get_send_to_owners(event_all_users, self.project) == set(
-            [self.user.id, self.user3.id]
-        )
+        assert self.adapter.get_send_to_owners(event_all_users, self.project) == {
+            self.user.id,
+            self.user3.id,
+        }
 
 
 class MailAdapterGetSendToTeamTest(BaseMailAdapterTest, TestCase):
     def test_send_to_team(self):
-        assert set([self.user.id]) == self.adapter.get_send_to_team(self.project, str(self.team.id))
+        assert {self.user.id} == self.adapter.get_send_to_team(self.project, str(self.team.id))
 
     def test_send_disabled(self):
         UserOption.objects.create(key="mail:alert", value=0, project=self.project, user=self.user)
@@ -659,7 +661,7 @@ class MailAdapterGetSendToTeamTest(BaseMailAdapterTest, TestCase):
         user_2 = self.create_user()
         team_2 = self.create_team(self.organization, members=[user_2])
         project_2 = self.create_project(organization=self.organization, teams=[team_2])
-        assert set([user_2.id]) == self.adapter.get_send_to_team(project_2, str(team_2.id))
+        assert {user_2.id} == self.adapter.get_send_to_team(project_2, str(team_2.id))
         assert set() == self.adapter.get_send_to_team(self.project, str(team_2.id))
 
     def test_other_org_team(self):
@@ -667,21 +669,17 @@ class MailAdapterGetSendToTeamTest(BaseMailAdapterTest, TestCase):
         user_2 = self.create_user()
         team_2 = self.create_team(org_2, members=[user_2])
         project_2 = self.create_project(organization=org_2, teams=[team_2])
-        assert set([user_2.id]) == self.adapter.get_send_to_team(project_2, str(team_2.id))
+        assert {user_2.id} == self.adapter.get_send_to_team(project_2, str(team_2.id))
         assert set() == self.adapter.get_send_to_team(self.project, str(team_2.id))
 
 
 class MailAdapterGetSendToMemberTest(BaseMailAdapterTest, TestCase):
     def test_send_to_user(self):
-        assert set([self.user.id]) == self.adapter.get_send_to_member(
-            self.project, str(self.user.id)
-        )
+        assert {self.user.id} == self.adapter.get_send_to_member(self.project, str(self.user.id))
 
     def test_send_disabled_still_sends(self):
         UserOption.objects.create(key="mail:alert", value=0, project=self.project, user=self.user)
-        assert set([self.user.id]) == self.adapter.get_send_to_member(
-            self.project, str(self.user.id)
-        )
+        assert {self.user.id} == self.adapter.get_send_to_member(self.project, str(self.user.id))
 
     def test_invalid_user(self):
         assert set() == self.adapter.get_send_to_member(self.project, "900001")
@@ -692,7 +690,7 @@ class MailAdapterGetSendToMemberTest(BaseMailAdapterTest, TestCase):
         team_2 = self.create_team(org_2, members=[user_2])
         team_3 = self.create_team(org_2, members=[user_2])
         project_2 = self.create_project(organization=org_2, teams=[team_2, team_3])
-        assert set([user_2.id]) == self.adapter.get_send_to_member(project_2, str(user_2.id))
+        assert {user_2.id} == self.adapter.get_send_to_member(project_2, str(user_2.id))
         assert set() == self.adapter.get_send_to_member(self.project, str(user_2.id))
 
     def test_no_project_access(self):
@@ -702,7 +700,7 @@ class MailAdapterGetSendToMemberTest(BaseMailAdapterTest, TestCase):
         user_3 = self.create_user()
         self.create_team(org_2, members=[user_3])
         project_2 = self.create_project(organization=org_2, teams=[team_2])
-        assert set([user_2.id]) == self.adapter.get_send_to_member(project_2, str(user_2.id))
+        assert {user_2.id} == self.adapter.get_send_to_member(project_2, str(user_2.id))
         assert set() == self.adapter.get_send_to_member(self.project, str(user_3.id))
 
 

--- a/tests/sentry/mediators/service_hooks/test_creator.py
+++ b/tests/sentry/mediators/service_hooks/test_creator.py
@@ -35,14 +35,20 @@ class TestCreator(TestCase):
         self.creator.events = ["issue"]
         service_hook = self.creator.call()
 
-        assert set(service_hook.events) == set(
-            ["issue.created", "issue.resolved", "issue.ignored", "issue.assigned"]
-        )
+        assert set(service_hook.events) == {
+            "issue.created",
+            "issue.resolved",
+            "issue.ignored",
+            "issue.assigned",
+        }
 
     def test_expand_events(self):
-        assert expand_events(["issue"]) == set(
-            ["issue.created", "issue.resolved", "issue.ignored", "issue.assigned"]
-        )
+        assert expand_events(["issue"]) == {
+            "issue.created",
+            "issue.resolved",
+            "issue.ignored",
+            "issue.assigned",
+        }
 
     def test_consolidate_events(self):
-        assert consolidate_events(["issue.created"]) == set(["issue"])
+        assert consolidate_events(["issue.created"]) == {"issue"}

--- a/tests/sentry/models/test_user.py
+++ b/tests/sentry/models/test_user.py
@@ -76,7 +76,7 @@ class GetUsersFromTeamsTest(TestCase):
         assert list(User.objects.get_from_teams(org, [team])) == [user2]
         user3 = self.create_user("bar@example.com")
         self.create_member(user=user3, organization=org, role="admin", teams=[team])
-        assert set(list(User.objects.get_from_teams(org, [team]))) == set([user2, user3])
+        assert set(list(User.objects.get_from_teams(org, [team]))) == {user2, user3}
         assert list(User.objects.get_from_teams(org2, [team])) == []
         assert list(User.objects.get_from_teams(org2, [team2])) == []
         self.create_member(user=user, organization=org2, role="member", teams=[team2])
@@ -98,7 +98,7 @@ class GetUsersFromProjectsTest(TestCase):
         assert list(User.objects.get_from_projects(org, [project])) == [user2]
         user3 = self.create_user("bar@example.com")
         self.create_member(user=user3, organization=org, role="admin", teams=[team])
-        assert set(list(User.objects.get_from_projects(org, [project]))) == set([user2, user3])
+        assert set(list(User.objects.get_from_projects(org, [project]))) == {user2, user3}
         assert list(User.objects.get_from_projects(org2, [project])) == []
         assert list(User.objects.get_from_projects(org2, [project2])) == []
         self.create_member(user=user, organization=org2, role="member", teams=[team2])

--- a/tests/sentry/nodestore/test_common.py
+++ b/tests/sentry/nodestore/test_common.py
@@ -33,7 +33,7 @@ def test_get_multi(ns):
     ns.set(nodes[1][0], nodes[1][1])
 
     result = ns.get_multi([nodes[0][0], nodes[1][0]])
-    assert result == dict((n[0], n[1]) for n in nodes)
+    assert result == {n[0]: n[1] for n in nodes}
 
 
 def test_set(ns):

--- a/tests/sentry/similarity/test_encoder.py
+++ b/tests/sentry/similarity/test_encoder.py
@@ -13,7 +13,7 @@ def test_builtin_types():
         ("a", "b", "c"),
         ["a", "b", "c"],
         {"a": 1, "b": 2, "c": 3},
-        set(["a", "b", "c"]),
+        {"a", "b", "c"},
         frozenset(["a", "b", "c"]),
         [{"a": 1}, set("b"), ["c"], "text"],
     ]

--- a/tests/sentry/similarity/test_signatures.py
+++ b/tests/sentry/similarity/test_signatures.py
@@ -11,7 +11,7 @@ class MinHashSignatureBuilderTestCase(TestCase):
         n = 32
         r = 0xFFFF
         get_signature = MinHashSignatureBuilder(n, r)
-        get_signature(set(["foo", "bar", "baz"])) == get_signature(set(["foo", "bar", "baz"]))
+        get_signature({"foo", "bar", "baz"}) == get_signature({"foo", "bar", "baz"})
 
         assert len(get_signature("hello world")) == n
         for value in get_signature("hello world"):

--- a/tests/sentry/snuba/test_models.py
+++ b/tests/sentry/snuba/test_models.py
@@ -16,6 +16,7 @@ class SnubaQueryEventTypesTest(TestCase):
             None,
             [SnubaQueryEventType.EventType.DEFAULT, SnubaQueryEventType.EventType.ERROR],
         )
-        assert set(snuba_query.event_types) == set(
-            [SnubaQueryEventType.EventType.DEFAULT, SnubaQueryEventType.EventType.ERROR]
-        )
+        assert set(snuba_query.event_types) == {
+            SnubaQueryEventType.EventType.DEFAULT,
+            SnubaQueryEventType.EventType.ERROR,
+        }

--- a/tests/sentry/snuba/test_subscriptions.py
+++ b/tests/sentry/snuba/test_subscriptions.py
@@ -26,7 +26,7 @@ class CreateSnubaQueryTest(TestCase):
         assert snuba_query.time_window == int(time_window.total_seconds())
         assert snuba_query.resolution == int(resolution.total_seconds())
         assert snuba_query.environment is None
-        assert set(snuba_query.event_types) == set([SnubaQueryEventType.EventType.ERROR])
+        assert set(snuba_query.event_types) == {SnubaQueryEventType.EventType.ERROR}
 
     def test_environment(self):
         dataset = QueryDatasets.EVENTS
@@ -43,7 +43,7 @@ class CreateSnubaQueryTest(TestCase):
         assert snuba_query.time_window == int(time_window.total_seconds())
         assert snuba_query.resolution == int(resolution.total_seconds())
         assert snuba_query.environment == self.environment
-        assert set(snuba_query.event_types) == set([SnubaQueryEventType.EventType.ERROR])
+        assert set(snuba_query.event_types) == {SnubaQueryEventType.EventType.ERROR}
 
     def test_event_types(self):
         dataset = QueryDatasets.EVENTS
@@ -66,7 +66,7 @@ class CreateSnubaQueryTest(TestCase):
         assert snuba_query.time_window == int(time_window.total_seconds())
         assert snuba_query.resolution == int(resolution.total_seconds())
         assert snuba_query.environment is None
-        assert set(snuba_query.event_types) == set([SnubaQueryEventType.EventType.DEFAULT])
+        assert set(snuba_query.event_types) == {SnubaQueryEventType.EventType.DEFAULT}
 
 
 class CreateSnubaSubscriptionTest(TestCase):

--- a/tests/sentry/tasks/post_process/tests.py
+++ b/tests/sentry/tasks/post_process/tests.py
@@ -300,7 +300,7 @@ class PostProcessGroupTest(TestCase):
 
             owners = list(GroupOwner.objects.filter(group=event.group))
             assert len(owners) == 2
-            assert set([(self.user.id, None), (None, self.team.id)]) == {
+            assert {(self.user.id, None), (None, self.team.id)} == {
                 (o.user_id, o.team_id) for o in owners
             }
 
@@ -335,7 +335,7 @@ class PostProcessGroupTest(TestCase):
 
             owners = list(GroupOwner.objects.filter(group=event.group))
             assert len(owners) == 2
-            assert set([(extra_user.id, None), (None, self.team.id)]) == {
+            assert {(extra_user.id, None), (None, self.team.id)} == {
                 (o.user_id, o.team_id) for o in owners
             }
 
@@ -377,7 +377,7 @@ class PostProcessGroupTest(TestCase):
 
             owners = list(GroupOwner.objects.filter(group=event.group))
             assert len(owners) == 2
-            assert set([(extra_user.id, None), (None, self.team.id)]) == {
+            assert {(extra_user.id, None), (None, self.team.id)} == {
                 (o.user_id, o.team_id) for o in owners
             }
 

--- a/tests/sentry/tasks/test_enqueue_scheduled_jobs.py
+++ b/tests/sentry/tasks/test_enqueue_scheduled_jobs.py
@@ -55,9 +55,7 @@ class EnqueueScheduledJobsTest(TestCase):
         schedule_jobs(job)
         assert set(
             ScheduledJob.objects.filter(payload={"foo": "baz"}).values_list("name", flat=True)
-        ) == set(
-            ["sentry.tasks.enqueue_scheduled_jobs", "sentry.tasks.enqueue_scheduled_jobs_followup"]
-        )
+        ) == {"sentry.tasks.enqueue_scheduled_jobs", "sentry.tasks.enqueue_scheduled_jobs_followup"}
 
     def test_schedule_job_order(self):
         with pytest.raises(

--- a/tests/sentry/tasks/test_queues_registered.py
+++ b/tests/sentry/tasks/test_queues_registered.py
@@ -6,7 +6,7 @@ from sentry.testutils import TestCase
 
 class CeleryQueueRegisteredTest(TestCase):
     def test(self):
-        queue_names = set([q.name for q in settings.CELERY_QUEUES])
+        queue_names = {q.name for q in settings.CELERY_QUEUES}
         missing_queue_tasks = []
         for task in current_app.tasks.values():
             # Filter out any tasks that aren't sentry specific, or don't specify `queue`.

--- a/tests/sentry/test_stacktraces.py
+++ b/tests/sentry/test_stacktraces.py
@@ -36,7 +36,7 @@ class FindStacktracesTest(TestCase):
         infos = find_stacktraces_in_data(data)
         assert len(infos) == 1
         assert len(infos[0].stacktrace["frames"]) == 2
-        assert infos[0].platforms == set(["javascript", "native"])
+        assert infos[0].platforms == {"javascript", "native"}
 
     def test_stacktraces_exception(self):
         data = {

--- a/tests/sentry/tsdb/test_redis.py
+++ b/tests/sentry/tsdb/test_redis.py
@@ -323,9 +323,7 @@ class RedisTSDBTest(TestCase):
 
         # None of the registered frequency tables actually support
         # environments, so we have to pretend like one actually does
-        self.db.models_with_environment_support = self.db.models_with_environment_support | set(
-            [model]
-        )
+        self.db.models_with_environment_support = self.db.models_with_environment_support | {model}
 
         rollup = 3600
 

--- a/tests/sentry/tsdb/test_redissnuba.py
+++ b/tests/sentry/tsdb/test_redissnuba.py
@@ -23,7 +23,7 @@ def test_redissnuba_connects_to_correct_backend():
     assert TSDBModel.project_total_received in should_resolve_to_snuba
     assert TSDBModel.organization_total_received in should_resolve_to_snuba
 
-    methods = set(method_specifications.keys()) - set(["flush"])
+    methods = set(method_specifications.keys()) - {"flush"}
 
     for method in methods:
         for model in should_resolve_to_redis:

--- a/tests/sentry/utils/json/tests.py
+++ b/tests/sentry/utils/json/tests.py
@@ -18,7 +18,7 @@ class JSONTest(TestCase):
         self.assertEquals(json.dumps(res), '"2011-01-01T01:01:01.000000Z"')
 
     def test_set(self):
-        res = set(["foo"])
+        res = {"foo"}
         self.assertEquals(json.dumps(res), '["foo"]')
 
     def test_frozenset(self):

--- a/tests/sentry/utils/test_safe.py
+++ b/tests/sentry/utils/test_safe.py
@@ -56,7 +56,7 @@ class TrimTest(unittest.TestCase):
 
 class TrimDictTest(unittest.TestCase):
     def test_large_dict(self):
-        value = dict((k, k) for k in range(500))
+        value = {k: k for k in range(500)}
         trim_dict(value)
         assert len(value) == 50
 

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -105,9 +105,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url + "?query=!bar:baz", format="json")
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert set([e["eventID"] for e in response.data]) == set(
-            [event_1.event_id, event_2.event_id]
-        )
+        assert {e["eventID"] for e in response.data} == {event_1.event_id, event_2.event_id}
 
     def test_search_event_by_id(self):
         self.login_as(user=self.user)
@@ -213,23 +211,23 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             )
 
         # Asserts that all are in the same group
-        (group_id,) = set(e.group.id for e in events.values())
+        (group_id,) = {e.group.id for e in events.values()}
 
         url = f"/api/0/issues/{group_id}/events/"
         response = self.client.get(url + "?environment=production", format="json")
 
         assert response.status_code == 200, response.content
-        assert set(map(lambda x: x["eventID"], response.data)) == set(
-            [str(events["production"].event_id)]
-        )
+        assert set(map(lambda x: x["eventID"], response.data)) == {
+            str(events["production"].event_id)
+        }
 
         response = self.client.get(
             url, data={"environment": ["production", "development"]}, format="json"
         )
         assert response.status_code == 200, response.content
-        assert set(map(lambda x: x["eventID"], response.data)) == set(
-            [str(event.event_id) for event in events.values()]
-        )
+        assert set(map(lambda x: x["eventID"], response.data)) == {
+            str(event.event_id) for event in events.values()
+        }
 
         response = self.client.get(url + "?environment=invalid", format="json")
 

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1614,8 +1614,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 2
-        result = set([r["user.display"] for r in data])
-        assert result == set(["catherine", "cathy@example.com"])
+        result = {r["user.display"] for r in data}
+        assert result == {"catherine", "cathy@example.com"}
 
     def test_user_display_with_aggregates(self):
         self.login_as(user=self.user)
@@ -1641,8 +1641,8 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         data = response.data["data"]
         assert len(data) == 1
-        result = set([r["user.display"] for r in data])
-        assert result == set(["cathy@example.com"])
+        result = {r["user.display"] for r in data}
+        assert result == {"cathy@example.com"}
 
         query = {"field": ["event.type", "count_unique(user.display)"], "statsPeriod": "24h"}
         response = self.do_request(query, features=features)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -405,7 +405,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.data[0]["id"] == str(self.group.id)
         group_2 = self.create_group()
         response = self.get_valid_response(group=[self.group.id, group_2.id])
-        assert set([g["id"] for g in response.data]) == set([str(self.group.id), str(group_2.id)])
+        assert {g["id"] for g in response.data} == {str(self.group.id), str(group_2.id)}
 
     def test_lookup_by_group_id_no_perms(self):
         organization = self.create_organization()

--- a/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
+++ b/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
@@ -67,7 +67,7 @@ class OrganizationIssuesResolvedInReleaseEndpointTest(APITestCase, SnubaTestCase
         response = self.get_valid_response(self.org.slug, self.release.version, **params)
         assert len(response.data) == len(expected_groups)
         expected = set(map(str, [g.id for g in expected_groups]))
-        assert set([item["id"] for item in response.data]) == expected
+        assert {item["id"] for item in response.data} == expected
 
     def test_shows_issues_from_groupresolution(self):
         """

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -296,7 +296,7 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
             )
 
         # Assert all events are in the same group
-        (group_id,) = set(e.group.id for e in events)
+        (group_id,) = {e.group.id for e in events}
 
         group = Group.objects.get(id=group_id)
         group.times_seen = 3

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -230,31 +230,31 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
 
     def test_query(self):
         results = self.make_query(search_filter_query="foo")
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(search_filter_query="bar")
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
     def test_query_multi_project(self):
         self.set_up_multi_project()
         results = self.make_query([self.project, self.project2], search_filter_query="foo")
-        assert set(results) == set([self.group1, self.group_p2])
+        assert set(results) == {self.group1, self.group_p2}
 
     def test_query_with_environment(self):
         results = self.make_query(
             environments=[self.environments["production"]], search_filter_query="foo"
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             environments=[self.environments["production"]], search_filter_query="bar"
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
         results = self.make_query(
             environments=[self.environments["staging"]], search_filter_query="bar"
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
     def test_query_for_text_in_long_message(self):
         results = self.make_query(
@@ -263,7 +263,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             search_filter_query="santryrox",
         )
 
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
     def test_multi_environments(self):
         self.set_up_multi_project()
@@ -271,7 +271,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             [self.project, self.project2],
             environments=[self.environments["production"], self.environments["staging"]],
         )
-        assert set(results) == set([self.group1, self.group2, self.group_p2])
+        assert set(results) == {self.group1, self.group2, self.group_p2}
 
     def test_query_with_environment_multi_project(self):
         self.set_up_multi_project()
@@ -280,14 +280,14 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             environments=[self.environments["production"]],
             search_filter_query="foo",
         )
-        assert set(results) == set([self.group1, self.group_p2])
+        assert set(results) == {self.group1, self.group_p2}
 
         results = self.make_query(
             [self.project, self.project2],
             environments=[self.environments["production"]],
             search_filter_query="bar",
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
     def test_sort(self):
         results = self.make_query(sort_by="date")
@@ -340,99 +340,99 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
 
     def test_status(self):
         results = self.make_query(search_filter_query="is:unresolved")
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(search_filter_query="is:resolved")
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
     def test_status_with_environment(self):
         results = self.make_query(
             environments=[self.environments["production"]], search_filter_query="is:unresolved"
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             environments=[self.environments["staging"]], search_filter_query="is:resolved"
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(
             environments=[self.environments["production"]], search_filter_query="is:resolved"
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
     def test_tags(self):
         results = self.make_query(search_filter_query="environment:staging")
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(search_filter_query="environment:example.com")
-        assert set(results) == set([])
+        assert set(results) == set()
 
         results = self.make_query(search_filter_query="has:environment")
-        assert set(results) == set([self.group2, self.group1])
+        assert set(results) == {self.group2, self.group1}
 
         results = self.make_query(search_filter_query="environment:staging server:example.com")
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(search_filter_query='url:"http://example.com"')
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(search_filter_query="environment:staging has:server")
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(search_filter_query="environment:staging server:bar.example.com")
-        assert set(results) == set([])
+        assert set(results) == set()
 
     def test_tags_with_environment(self):
         results = self.make_query(
             environments=[self.environments["production"]], search_filter_query="server:example.com"
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             environments=[self.environments["staging"]], search_filter_query="server:example.com"
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(
             environments=[self.environments["staging"]], search_filter_query="has:server"
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(
             environments=[self.environments["production"]],
             search_filter_query='url:"http://example.com"',
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
         results = self.make_query(
             environments=[self.environments["staging"]],
             search_filter_query='url:"http://example.com"',
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(
             environments=[self.environments["staging"]],
             search_filter_query="server:bar.example.com",
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
     def test_bookmarked_by(self):
         results = self.make_query(search_filter_query="bookmarks:%s" % self.user.username)
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
     def test_bookmarked_by_with_environment(self):
         results = self.make_query(
             environments=[self.environments["staging"]],
             search_filter_query="bookmarks:%s" % self.user.username,
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(
             environments=[self.environments["production"]],
             search_filter_query="bookmarks:%s" % self.user.username,
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
     def test_search_filter_query_with_custom_priority_tag(self):
         priority = "high"
@@ -449,7 +449,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
 
         results = self.make_query(search_filter_query="priority:%s" % priority)
 
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
     def test_search_filter_query_with_custom_priority_tag_and_priority_sort(self):
         priority = "high"
@@ -491,11 +491,11 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             project_id=self.project.id,
         )
         results = self.make_query(search_filter_query="email:tags@example.com")
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
     def test_project(self):
         results = self.make_query([self.create_project(name="other")])
-        assert set(results) == set([])
+        assert set(results) == set()
 
     def test_pagination(self):
         for options_set in [
@@ -504,14 +504,14 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         ]:
             with self.options(options_set):
                 results = self.backend.query([self.project], limit=1, sort_by="date")
-                assert set(results) == set([self.group1])
+                assert set(results) == {self.group1}
                 assert not results.prev.has_results
                 assert results.next.has_results
 
                 results = self.backend.query(
                     [self.project], cursor=results.next, limit=1, sort_by="date"
                 )
-                assert set(results) == set([self.group2])
+                assert set(results) == {self.group2}
                 assert results.prev.has_results
                 assert not results.next.has_results
 
@@ -519,7 +519,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 results = self.backend.query(
                     [self.project], cursor=results.prev, limit=1, sort_by="date"
                 )
-                assert set(results) == set([self.group1])
+                assert set(results) == {self.group1}
                 assert results.prev.has_results
                 assert results.next.has_results
 
@@ -527,28 +527,28 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 results = self.backend.query(
                     [self.project], cursor=results.prev, limit=1, sort_by="date"
                 )
-                assert set(results) == set([])
+                assert set(results) == set()
                 assert not results.prev.has_results
                 assert results.next.has_results
 
                 results = self.backend.query(
                     [self.project], cursor=results.next, limit=1, sort_by="date"
                 )
-                assert set(results) == set([self.group1])
+                assert set(results) == {self.group1}
                 assert results.prev.has_results
                 assert results.next.has_results
 
                 results = self.backend.query(
                     [self.project], cursor=results.next, limit=1, sort_by="date"
                 )
-                assert set(results) == set([self.group2])
+                assert set(results) == {self.group2}
                 assert results.prev.has_results
                 assert not results.next.has_results
 
                 results = self.backend.query(
                     [self.project], cursor=results.next, limit=1, sort_by="date"
                 )
-                assert set(results) == set([])
+                assert set(results) == set()
                 assert results.prev.has_results
                 assert not results.next.has_results
 
@@ -605,13 +605,13 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         results = self.make_query(
             search_filter_query="activeSince:>=%s" % date_to_query_format(self.group2.active_at)
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(
             search_filter_query="activeSince:<=%s"
             % date_to_query_format(self.group1.active_at + timedelta(minutes=1))
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             search_filter_query="activeSince:>=%s activeSince:<=%s"
@@ -620,19 +620,19 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 date_to_query_format(self.group1.active_at + timedelta(minutes=1)),
             )
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
     def test_age_filter(self):
         results = self.make_query(
             search_filter_query="firstSeen:>=%s" % date_to_query_format(self.group2.first_seen)
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(
             search_filter_query="firstSeen:<=%s"
             % date_to_query_format(self.group1.first_seen + timedelta(minutes=1))
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             search_filter_query="firstSeen:>=%s firstSeen:<=%s"
@@ -641,7 +641,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 date_to_query_format(self.group1.first_seen + timedelta(minutes=1)),
             )
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
     def test_age_filter_with_environment(self):
         # add time instead to make it greater than or less than as needed.
@@ -653,19 +653,19 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             environments=[self.environments["production"]],
             search_filter_query="firstSeen:>=%s" % date_to_query_format(group1_first_seen),
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             environments=[self.environments["production"]],
             search_filter_query="firstSeen:<=%s" % date_to_query_format(group1_first_seen),
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             environments=[self.environments["production"]],
             search_filter_query="firstSeen:>%s" % date_to_query_format(group1_first_seen),
         )
-        assert set(results) == set([])
+        assert set(results) == set()
         self.store_event(
             data={
                 "fingerprint": ["put-me-in-group1"],
@@ -681,29 +681,29 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             environments=[self.environments["production"]],
             search_filter_query="firstSeen:>%s" % date_to_query_format(group1_first_seen),
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
         results = self.make_query(
             environments=[Environment.objects.get(name="development")],
             search_filter_query="firstSeen:>%s" % date_to_query_format(group1_first_seen),
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
     def test_times_seen_filter(self):
         results = self.make_query([self.project], search_filter_query="times_seen:2")
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query([self.project], search_filter_query="times_seen:>=2")
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query([self.project], search_filter_query="times_seen:<=1")
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
     def test_last_seen_filter(self):
         results = self.make_query(
             search_filter_query="lastSeen:>=%s" % date_to_query_format(self.group1.last_seen)
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             search_filter_query="lastSeen:>=%s lastSeen:<=%s"
@@ -712,26 +712,26 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 date_to_query_format(self.group1.last_seen + timedelta(minutes=1)),
             )
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
     def test_last_seen_filter_with_environment(self):
         results = self.make_query(
             environments=[self.environments["production"]],
             search_filter_query="lastSeen:>=%s" % date_to_query_format(self.group1.last_seen),
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             environments=[self.environments["production"]],
             search_filter_query="lastSeen:<=%s" % date_to_query_format(self.group1.last_seen),
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             environments=[self.environments["production"]],
             search_filter_query="lastSeen:>%s" % date_to_query_format(self.group1.last_seen),
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
         self.store_event(
             data={
@@ -750,7 +750,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             environments=[self.environments["production"]],
             search_filter_query="lastSeen:>%s" % date_to_query_format(self.group1.last_seen),
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
         results = self.make_query(
             environments=[Environment.objects.get(name="development")],
@@ -762,21 +762,21 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             environments=[Environment.objects.get(name="development")],
             search_filter_query="lastSeen:>=%s" % date_to_query_format(self.group1.last_seen),
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
     def test_date_filter(self):
         results = self.make_query(
             date_from=self.event2.datetime,
             search_filter_query="timestamp:>=%s" % date_to_query_format(self.event2.datetime),
         )
-        assert set(results) == set([self.group1, self.group2])
+        assert set(results) == {self.group1, self.group2}
 
         results = self.make_query(
             date_to=self.event1.datetime + timedelta(minutes=1),
             search_filter_query="timestamp:<=%s"
             % date_to_query_format(self.event1.datetime + timedelta(minutes=1)),
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             date_from=self.event1.datetime,
@@ -787,7 +787,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 date_to_query_format(self.event2.datetime + timedelta(minutes=1)),
             ),
         )
-        assert set(results) == set([self.group1, self.group2])
+        assert set(results) == {self.group1, self.group2}
 
         # Test with `Z` utc marker, should be equivalent
         results = self.make_query(
@@ -799,7 +799,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 date_to_query_format(self.event2.datetime + timedelta(minutes=1)) + "Z",
             ),
         )
-        assert set(results) == set([self.group1, self.group2])
+        assert set(results) == {self.group1, self.group2}
 
     def test_date_filter_with_environment(self):
         results = self.backend.query(
@@ -807,14 +807,14 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             environments=[self.environments["production"]],
             date_from=self.event2.datetime,
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.backend.query(
             [self.project],
             environments=[self.environments["production"]],
             date_to=self.event1.datetime + timedelta(minutes=1),
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.backend.query(
             [self.project],
@@ -822,35 +822,35 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             date_from=self.event1.datetime,
             date_to=self.event2.datetime + timedelta(minutes=1),
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
     def test_linked(self):
         linked_group1 = self.create_group_with_integration_external_issue()
         linked_group2 = self.create_group_with_platform_external_issue()
 
         results = self.make_query(search_filter_query="is:unlinked")
-        assert set(results) == set([self.group1, self.group2])
+        assert set(results) == {self.group1, self.group2}
 
         results = self.make_query(search_filter_query="is:linked")
-        assert set(results) == set([linked_group1, linked_group2])
+        assert set(results) == {linked_group1, linked_group2}
 
     def test_linked_with_only_integration_external_issue(self):
         linked_group = self.create_group_with_integration_external_issue()
 
         results = self.make_query(search_filter_query="is:unlinked")
-        assert set(results) == set([self.group1, self.group2])
+        assert set(results) == {self.group1, self.group2}
 
         results = self.make_query(search_filter_query="is:linked")
-        assert set(results) == set([linked_group])
+        assert set(results) == {linked_group}
 
     def test_linked_with_only_platform_external_issue(self):
         linked_group = self.create_group_with_platform_external_issue()
 
         results = self.make_query(search_filter_query="is:unlinked")
-        assert set(results) == set([self.group1, self.group2])
+        assert set(results) == {self.group1, self.group2}
 
         results = self.make_query(search_filter_query="is:linked")
-        assert set(results) == set([linked_group])
+        assert set(results) == {linked_group}
 
     def test_linked_with_environment(self):
         linked_group1 = self.create_group_with_integration_external_issue(environment="production")
@@ -859,49 +859,49 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         results = self.make_query(
             environments=[self.environments["production"]], search_filter_query="is:unlinked"
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             environments=[self.environments["staging"]], search_filter_query="is:unlinked"
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(
             environments=[self.environments["production"]], search_filter_query="is:linked"
         )
-        assert set(results) == set([linked_group1])
+        assert set(results) == {linked_group1}
 
         results = self.make_query(
             environments=[self.environments["staging"]], search_filter_query="is:linked"
         )
-        assert set(results) == set([linked_group2])
+        assert set(results) == {linked_group2}
 
     def test_unassigned(self):
         results = self.make_query(search_filter_query="is:unassigned")
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(search_filter_query="is:assigned")
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
     def test_unassigned_with_environment(self):
         results = self.make_query(
             environments=[self.environments["production"]], search_filter_query="is:unassigned"
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             environments=[self.environments["staging"]], search_filter_query="is:assigned"
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(
             environments=[self.environments["production"]], search_filter_query="is:assigned"
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
     def test_assigned_to(self):
         results = self.make_query(search_filter_query="assigned:%s" % self.user.username)
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         # test team assignee
         ga = GroupAssignee.objects.get(
@@ -911,12 +911,12 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         assert GroupAssignee.objects.get(id=ga.id).user is None
 
         results = self.make_query(search_filter_query="assigned:%s" % self.user.username)
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         # test when there should be no results
         other_user = self.create_user()
         results = self.make_query(search_filter_query="assigned:%s" % other_user.username)
-        assert set(results) == set([])
+        assert set(results) == set()
 
         owner = self.create_user()
         self.create_member(
@@ -925,26 +925,26 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
 
         # test that owners don't see results for all teams
         results = self.make_query(search_filter_query="assigned:%s" % owner.username)
-        assert set(results) == set([])
+        assert set(results) == set()
 
     def test_assigned_to_with_environment(self):
         results = self.make_query(
             environments=[self.environments["staging"]],
             search_filter_query="assigned:%s" % self.user.username,
         )
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
         results = self.make_query(
             environments=[self.environments["production"]],
             search_filter_query="assigned:%s" % self.user.username,
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
     def test_subscribed_by(self):
         results = self.make_query(
             [self.group1.project], search_filter_query="subscribed:%s" % self.user.username
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
     def test_subscribed_by_with_environment(self):
         results = self.make_query(
@@ -952,14 +952,14 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             environments=[self.environments["production"]],
             search_filter_query="subscribed:%s" % self.user.username,
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(
             [self.group1.project],
             environments=[self.environments["staging"]],
             search_filter_query="subscribed:%s" % self.user.username,
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
     @mock.patch("sentry.utils.snuba.raw_query")
     def test_snuba_not_called_optimization(self, query_mock):
@@ -1071,9 +1071,9 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         try:
             # normal queries work as expected
             results = self.make_query(search_filter_query="foo")
-            assert set(results) == set([self.group1])
+            assert set(results) == {self.group1}
             results = self.make_query(search_filter_query="bar")
-            assert set(results) == set([self.group2])
+            assert set(results) == {self.group2}
 
             # no candidate matches in Sentry, immediately return empty paginator
             results = self.make_query(search_filter_query="NO MATCHES IN SENTRY")
@@ -1081,7 +1081,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
 
             # too many candidates, skip pre-filter, requires >1 postfilter queries
             results = self.make_query()
-            assert set(results) == set([self.group1, self.group2])
+            assert set(results) == {self.group1, self.group2}
         finally:
             options.set("snuba.search.max-pre-snuba-candidates", prev_max_pre)
 
@@ -1094,7 +1094,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
                 search_filter_query="server:example.com",
                 environments=[self.environments["production"]],
             )
-            assert set(results) == set([self.group1])
+            assert set(results) == {self.group1}
         finally:
             options.set("snuba.search.pre-snuba-candidates-optimizer", prev_optimizer_enabled)
 
@@ -1105,7 +1105,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             date_from=the_date,
             date_to=the_date,
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
     def test_hits_estimate(self):
         # 400 Groups/Events
@@ -1172,7 +1172,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         # expect no groups within the results since there are no releases
 
         results = self.make_query(search_filter_query="first_release:%s" % "fake")
-        assert set(results) == set([])
+        assert set(results) == set()
 
         # expect no groups even though there is a release; since no group
         # is attached to a release
@@ -1180,7 +1180,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         release_1 = self.create_release(self.project)
 
         results = self.make_query(search_filter_query="first_release:%s" % release_1.version)
-        assert set(results) == set([])
+        assert set(results) == set()
 
         # Create a new event so that we get a group in this release
         group = self.store_event(
@@ -1197,14 +1197,14 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         ).group
 
         results = self.make_query(search_filter_query="first_release:%s" % release_1.version)
-        assert set(results) == set([group])
+        assert set(results) == {group}
 
     def test_first_release_environments(self):
         results = self.make_query(
             environments=[self.environments["production"]],
             search_filter_query="first_release:%s" % "fake",
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
         release = self.create_release(self.project)
         group_env = GroupEnvironment.get_or_create(
@@ -1215,7 +1215,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             environments=[self.environments["production"]],
             search_filter_query="first_release:%s" % release.version,
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
         group_env.first_release = release
         group_env.save()
@@ -1224,14 +1224,14 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             environments=[self.environments["production"]],
             search_filter_query="first_release:%s" % release.version,
         )
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
     def test_query_enclosed_in_quotes(self):
         results = self.make_query(search_filter_query='"foo"')
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
 
         results = self.make_query(search_filter_query='"bar"')
-        assert set(results) == set([self.group2])
+        assert set(results) == {self.group2}
 
     @xfail_if_not_postgres("Wildcard searching only supported in Postgres")
     def test_wildcard(self):
@@ -1250,20 +1250,20 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         # Note: Adding in `environment:production` so that we make sure we query
         # in both snuba and postgres
         results = self.make_query(search_filter_query="environment:production so*t")
-        assert set(results) == set([escaped_event.group])
+        assert set(results) == {escaped_event.group}
         # Make sure it's case insensitive
         results = self.make_query(search_filter_query="environment:production SO*t")
-        assert set(results) == set([escaped_event.group])
+        assert set(results) == {escaped_event.group}
         results = self.make_query(search_filter_query="environment:production so*zz")
         assert set(results) == set()
         results = self.make_query(search_filter_query="environment:production [hing]")
-        assert set(results) == set([escaped_event.group])
+        assert set(results) == {escaped_event.group}
         results = self.make_query(search_filter_query="environment:production s*]")
-        assert set(results) == set([escaped_event.group])
+        assert set(results) == {escaped_event.group}
         results = self.make_query(search_filter_query="environment:production server:example.*")
-        assert set(results) == set([self.group1, escaped_event.group])
+        assert set(results) == {self.group1, escaped_event.group}
         results = self.make_query(search_filter_query="environment:production !server:*net")
-        assert set(results) == set([self.group1])
+        assert set(results) == {self.group1}
         # TODO: Disabling tests that use [] syntax for the moment. Re-enable
         # these if we decide to add back in, or remove if this comment has been
         # here a while.
@@ -1301,17 +1301,17 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             project_id=self.project.id,
         )
         results = self.make_query(search_filter_query="environment:production !server:*net")
-        assert set(results) == set([self.group1, no_tag_event.group])
+        assert set(results) == {self.group1, no_tag_event.group}
         results = self.make_query(search_filter_query="environment:production server:*net")
-        assert set(results) == set([tag_event.group])
+        assert set(results) == {tag_event.group}
         results = self.make_query(search_filter_query="environment:production !server:example.net")
-        assert set(results) == set([self.group1, no_tag_event.group])
+        assert set(results) == {self.group1, no_tag_event.group}
         results = self.make_query(search_filter_query="environment:production server:example.net")
-        assert set(results) == set([tag_event.group])
+        assert set(results) == {tag_event.group}
         results = self.make_query(search_filter_query="environment:production has:server")
-        assert set(results) == set([self.group1, tag_event.group])
+        assert set(results) == {self.group1, tag_event.group}
         results = self.make_query(search_filter_query="environment:production !has:server")
-        assert set(results) == set([no_tag_event.group])
+        assert set(results) == {no_tag_event.group}
 
     def test_null_promoted_tags(self):
         tag_event = self.store_event(
@@ -1338,17 +1338,17 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             project_id=self.project.id,
         )
         results = self.make_query(search_filter_query="environment:production !logger:*sp")
-        assert set(results) == set([self.group1, no_tag_event.group])
+        assert set(results) == {self.group1, no_tag_event.group}
         results = self.make_query(search_filter_query="environment:production logger:*sp")
-        assert set(results) == set([tag_event.group])
+        assert set(results) == {tag_event.group}
         results = self.make_query(search_filter_query="environment:production !logger:csp")
-        assert set(results) == set([self.group1, no_tag_event.group])
+        assert set(results) == {self.group1, no_tag_event.group}
         results = self.make_query(search_filter_query="environment:production logger:csp")
-        assert set(results) == set([tag_event.group])
+        assert set(results) == {tag_event.group}
         results = self.make_query(search_filter_query="environment:production has:logger")
-        assert set(results) == set([tag_event.group])
+        assert set(results) == {tag_event.group}
         results = self.make_query(search_filter_query="environment:production !has:logger")
-        assert set(results) == set([self.group1, no_tag_event.group])
+        assert set(results) == {self.group1, no_tag_event.group}
 
     def test_sort_multi_project(self):
         self.set_up_multi_project()
@@ -1441,7 +1441,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         results = self.make_query([self.project], sort_by="trend", date_from=start, date_to=end)
         assert results[:2] == [self.group1, fewer_events_group]
         # These will be arbitrarily ordered since their trend values are all 0
-        assert set(results[2:]) == set([self.group2, no_before_group, no_after_group])
+        assert set(results[2:]) == {self.group2, no_before_group, no_after_group}
 
     def test_sort_inbox(self):
         start = self.group1.first_seen - timedelta(days=1)
@@ -1591,44 +1591,44 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         # query by release release_1
 
         results = self.make_query(search_filter_query="first_release:%s" % "release_1")
-        assert set(results) == set([group_a, group_b])
+        assert set(results) == {group_a, group_b}
 
         results = self.make_query(
             environments=[staging_env, prod_env],
             search_filter_query="first_release:%s" % "release_1",
         )
-        assert set(results) == set([group_a])
+        assert set(results) == {group_a}
 
         results = self.make_query(
             environments=[staging_env], search_filter_query="first_release:%s" % "release_1"
         )
-        assert set(results) == set([group_a])
+        assert set(results) == {group_a}
 
         results = self.make_query(
             environments=[prod_env], search_filter_query="first_release:%s" % "release_1"
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
         # query by release release_2
 
         results = self.make_query(search_filter_query="first_release:%s" % "release_2")
-        assert set(results) == set([group_a, group_c])
+        assert set(results) == {group_a, group_c}
 
         results = self.make_query(
             environments=[staging_env, prod_env],
             search_filter_query="first_release:%s" % "release_2",
         )
-        assert set(results) == set([group_a])
+        assert set(results) == {group_a}
 
         results = self.make_query(
             environments=[staging_env], search_filter_query="first_release:%s" % "release_2"
         )
-        assert set(results) == set([])
+        assert set(results) == set()
 
         results = self.make_query(
             environments=[prod_env], search_filter_query="first_release:%s" % "release_2"
         )
-        assert set(results) == set([group_a])
+        assert set(results) == {group_a}
 
     def test_all_fields_do_not_error(self):
         # Just a sanity check to make sure that all fields can be successfully

--- a/tests/snuba/sessions/test_sessions.py
+++ b/tests/snuba/sessions/test_sessions.py
@@ -114,7 +114,7 @@ class SnubaSessionsTest(TestCase, SnubaTestCase):
         data = check_has_health_data(
             [(self.project.id, self.session_release), (self.project.id, "dummy-release")]
         )
-        assert data == set([(self.project.id, self.session_release)])
+        assert data == {(self.project.id, self.session_release)}
 
     def test_get_project_releases_by_stability(self):
         # Add an extra session with a different `distinct_id` so that sorting by users

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -124,9 +124,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
             )
         )
         tags = [r.key for r in result]
-        assert set(tags) == set(
-            ["foo", "baz", "environment", "sentry:release", "sentry:user", "level"]
-        )
+        assert set(tags) == {"foo", "baz", "environment", "sentry:release", "sentry:user", "level"}
 
         result.sort(key=lambda r: r.key)
         assert result[0].key == "baz"
@@ -137,7 +135,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
         assert result[4].count == 2
         top_release_values = result[4].top_values
         assert len(top_release_values) == 2
-        assert set(v.value for v in top_release_values) == set(["100", "200"])
+        assert {v.value for v in top_release_values} == {"100", "200"}
         assert all(v.times_seen == 1 for v in top_release_values)
 
         # Now with only a specific set of keys,
@@ -150,7 +148,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
             )
         )
         tags = [r.key for r in result]
-        assert set(tags) == set(["environment", "sentry:release"])
+        assert set(tags) == {"environment", "sentry:release"}
 
         result.sort(key=lambda r: r.key)
         assert result[0].key == "environment"
@@ -159,7 +157,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
         assert result[1].key == "sentry:release"
         top_release_values = result[1].top_values
         assert len(top_release_values) == 2
-        assert set(v.value for v in top_release_values) == set(["100", "200"])
+        assert {v.value for v in top_release_values} == {"100", "200"}
         assert all(v.times_seen == 1 for v in top_release_values)
 
     def test_get_top_group_tag_values(self):
@@ -181,9 +179,15 @@ class TagStorageTest(TestCase, SnubaTestCase):
         )
 
     def test_get_tag_keys(self):
-        expected_keys = set(
-            ["baz", "browser", "environment", "foo", "sentry:release", "sentry:user", "level"]
-        )
+        expected_keys = {
+            "baz",
+            "browser",
+            "environment",
+            "foo",
+            "sentry:release",
+            "sentry:user",
+            "level",
+        }
         keys = {
             k.key: k
             for k in self.ts.get_tag_keys(
@@ -226,9 +230,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
                 environment_ids=[self.proj1env1.id],
             )
         }
-        assert set(keys) == set(
-            ["baz", "environment", "foo", "sentry:release", "sentry:user", "level"]
-        )
+        assert set(keys) == {"baz", "environment", "foo", "sentry:release", "sentry:user", "level"}
 
     def test_get_group_tag_value(self):
         with pytest.raises(GroupTagValueNotFound):
@@ -247,7 +249,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
                 environment_id=self.proj1env1.id,
                 key="notreal",
             )
-            == set([])
+            == set()
         )
 
         assert (
@@ -341,21 +343,22 @@ class TagStorageTest(TestCase, SnubaTestCase):
     def test_get_group_ids_for_users(self):
         assert self.ts.get_group_ids_for_users(
             [self.proj1.id], [EventUser(project_id=self.proj1.id, ident="user1")]
-        ) == set([self.proj1group1.id, self.proj1group2.id])
+        ) == {self.proj1group1.id, self.proj1group2.id}
 
         assert self.ts.get_group_ids_for_users(
             [self.proj1.id], [EventUser(project_id=self.proj1.id, ident="user2")]
-        ) == set([self.proj1group1.id])
+        ) == {self.proj1group1.id}
 
     def test_get_group_tag_values_for_users(self):
         result = self.ts.get_group_tag_values_for_users(
             [EventUser(project_id=self.proj1.id, ident="user1")]
         )
         assert len(result) == 2
-        assert set(v.group_id for v in result) == set([self.proj1group1.id, self.proj1group2.id])
-        assert set(v.last_seen for v in result) == set(
-            [self.now - timedelta(seconds=1), self.now - timedelta(seconds=2)]
-        )
+        assert {v.group_id for v in result} == {self.proj1group1.id, self.proj1group2.id}
+        assert {v.last_seen for v in result} == {
+            self.now - timedelta(seconds=1),
+            self.now - timedelta(seconds=2),
+        }
         result.sort(key=lambda x: x.last_seen)
         assert result[0].last_seen == self.now - timedelta(seconds=2)
         assert result[1].last_seen == self.now - timedelta(seconds=1)
@@ -382,7 +385,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
     def test_get_group_event_filter(self):
         assert self.ts.get_group_event_filter(
             self.proj1.id, self.proj1group1.id, [self.proj1env1.id], {"foo": "bar"}, None, None
-        ) == {"event_id__in": set(["1" * 32, "2" * 32])}
+        ) == {"event_id__in": {"1" * 32, "2" * 32}}
 
         assert (
             self.ts.get_group_event_filter(
@@ -393,7 +396,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
                 (self.now - timedelta(seconds=1)),
                 None,
             )
-            == {"event_id__in": set(["1" * 32])}
+            == {"event_id__in": {"1" * 32}}
         )
 
         assert (
@@ -405,7 +408,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
                 None,
                 (self.now - timedelta(seconds=1)),
             )
-            == {"event_id__in": set(["2" * 32])}
+            == {"event_id__in": {"2" * 32}}
         )
 
         assert (
@@ -417,7 +420,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
                 None,
                 None,
             )
-            == {"event_id__in": set(["1" * 32, "2" * 32, "4" * 32])}
+            == {"event_id__in": {"1" * 32, "2" * 32, "4" * 32}}
         )
 
         assert (
@@ -429,7 +432,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
                 None,
                 None,
             )
-            == {"event_id__in": set(["2" * 32])}
+            == {"event_id__in": {"2" * 32}}
         )
 
         assert (
@@ -441,7 +444,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
                 None,
                 None,
             )
-            == {"event_id__in": set(["3" * 32])}
+            == {"event_id__in": {"3" * 32}}
         )
 
         assert (

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -264,14 +264,12 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             merge_groups.delay([merge_source.id], source.id)
             eventstream.end_merge(eventstream_state)
 
-        assert set(
-            [
-                (gtv.value, gtv.times_seen)
-                for gtv in tagstore.get_group_tag_values(
-                    project.id, source.id, production_environment.id, "color"
-                )
-            ]
-        ) == set([("red", 6), ("green", 5), ("blue", 5)])
+        assert {
+            (gtv.value, gtv.times_seen)
+            for gtv in tagstore.get_group_tag_values(
+                project.id, source.id, production_environment.id, "color"
+            )
+        } == {("red", 6), ("green", 5), ("blue", 5)}
 
         similar_items = features.compare(source)
         assert len(similar_items) == 2
@@ -325,16 +323,14 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             GroupRelease.objects.filter(group_id=source.id).values_list(
                 "environment", "first_seen", "last_seen"
             )
-        ) == set([("production", time_from_now(10), time_from_now(15))])
+        ) == {("production", time_from_now(10), time_from_now(15))}
 
-        assert set(
-            [
-                (gtv.value, gtv.times_seen)
-                for gtv in tagstore.get_group_tag_values(
-                    project.id, destination.id, production_environment.id, "color"
-                )
-            ]
-        ) == set([("red", 4), ("green", 3), ("blue", 3)])
+        assert {
+            (gtv.value, gtv.times_seen)
+            for gtv in tagstore.get_group_tag_values(
+                project.id, destination.id, production_environment.id, "color"
+            )
+        } == {("red", 4), ("green", 3), ("blue", 3)}
 
         destination_event_ids = map(
             lambda event: event.event_id, list(events.values())[0] + list(events.values())[2]
@@ -352,21 +348,17 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             GroupRelease.objects.filter(group_id=destination.id).values_list(
                 "environment", "first_seen", "last_seen"
             )
-        ) == set(
-            [
-                ("production", time_from_now(0), time_from_now(9)),
-                ("staging", time_from_now(16), time_from_now(16)),
-            ]
-        )
+        ) == {
+            ("production", time_from_now(0), time_from_now(9)),
+            ("staging", time_from_now(16), time_from_now(16)),
+        }
 
-        assert set(
-            [
-                (gtk.value, gtk.times_seen)
-                for gtk in tagstore.get_group_tag_values(
-                    project.id, destination.id, production_environment.id, "color"
-                )
-            ]
-        ) == set([("red", 4), ("blue", 3), ("green", 3)])
+        assert {
+            (gtk.value, gtk.times_seen)
+            for gtk in tagstore.get_group_tag_values(
+                project.id, destination.id, production_environment.id, "color"
+            )
+        } == {("red", 4), ("blue", 3), ("green", 3)}
 
         rollup_duration = 3600
 

--- a/tests/snuba/test_util.py
+++ b/tests/snuba/test_util.py
@@ -10,7 +10,7 @@ class SnubaUtilTest(TestCase, SnubaTestCase):
         snuba.raw_query(
             start=datetime.now(),
             end=datetime.now(),
-            filter_keys={"project_id": set([1]), "logger": set(["asdf"])},
+            filter_keys={"project_id": {1}, "logger": {"asdf"}},
             aggregations=[["count()", "", "count"]],
         )
 


### PR DESCRIPTION
This is the last big sweeping change pyupgrade does on our `tests/`. The remaining ones can be applied all at once for manual review.

I particularly like this one, set and dict literals when possible are more performant.