### PR TITLE
ref(pyupgrade): wrapup on tests/

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -40,7 +40,7 @@ def pytest_configure(config):
                     )
                 )
                 return
-    except IOError:
+    except OSError:
         pass
     except Exception:
         pass

--- a/tests/acceptance/test_emails.py
+++ b/tests/acceptance/test_emails.py
@@ -40,7 +40,7 @@ def read_txt_email_fixture(name):
     path = join(dirname(__file__), os.pardir, "fixtures", "emails", filename)
 
     fixture = None
-    with open(path, "r") as f:
+    with open(path) as f:
         fixture = f.read()
     return fixture
 

--- a/tests/apidocs/util.py
+++ b/tests/apidocs/util.py
@@ -16,7 +16,7 @@ class APIDocsTestCase(APITestCase):
     def create_schema(self):
         if not APIDocsTestCase.cached_schema:
             path = os.path.join(os.path.dirname(__file__), "openapi-derefed.json")
-            with open(path, "r") as json_file:
+            with open(path) as json_file:
                 data = json.load(json_file)
                 data["servers"][0]["url"] = settings.SENTRY_OPTIONS["system.url-prefix"]
                 del data["components"]

--- a/tests/fixtures/integrations/mock_service.py
+++ b/tests/fixtures/integrations/mock_service.py
@@ -111,5 +111,5 @@ class MockService(StubService):
         if not os.path.exists(path):
             return None
 
-        with open(path, "r") as f:
+        with open(path) as f:
             return json.loads(f.read())

--- a/tests/fixtures/integrations/stub_service.py
+++ b/tests/fixtures/integrations/stub_service.py
@@ -28,7 +28,7 @@ class StubService:
         :return: string
         """
         path = os.path.join(FIXTURE_DIRECTORY, service_name, "stubs", name)
-        with open(path, "r") as f:
+        with open(path) as f:
             return f.read()
 
     @staticmethod

--- a/tests/sentry/api/endpoints/test_organization_activity.py
+++ b/tests/sentry/api/endpoints/test_organization_activity.py
@@ -33,7 +33,7 @@ class OrganizationActivityTest(APITestCase):
             user=self.user,
         )
         self.login_as(user=self.user)
-        url = "/api/0/organizations/{}/activity/".format(org.slug)
+        url = f"/api/0/organizations/{org.slug}/activity/"
         response = self.client.get(url, format="json")
         assert len(response.data) == 0
 

--- a/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
@@ -1,4 +1,3 @@
-import io
 import os
 
 from urllib.parse import parse_qsl
@@ -54,7 +53,7 @@ class UserAuthenticatorEnrollTest(APITestCase):
 
         assert resp.status_code == 200
         assert resp.data["secret"] == "Z" * 32
-        with io.open(get_fixture_path("totp_qrcode.json")) as f:
+        with open(get_fixture_path("totp_qrcode.json")) as f:
             assert resp.data["qrcode"] == json.loads(f.read())
         assert resp.data["form"]
         assert resp.data["secret"]

--- a/tests/sentry/buffer/redis/tests.py
+++ b/tests/sentry/buffer/redis/tests.py
@@ -17,7 +17,7 @@ class RedisBufferTest(TestCase):
         assert self.buf._coerce_val(Project(id=1)) == b"1"
 
     def test_coerce_val_handles_unicode(self):
-        assert self.buf._coerce_val("\u201d") == "”".encode("utf-8")
+        assert self.buf._coerce_val("\u201d") == "”".encode()
 
     @mock.patch("sentry.buffer.redis.RedisBuffer._make_key", mock.Mock(return_value="foo"))
     @mock.patch("sentry.buffer.redis.process_incr")


### PR DESCRIPTION
This runs pyupgrade entirely on tests/. There's not a lot of changes left since I selectively applied several classes of fixes in previous PRs.

It was run on tests/ like this just to try it out, turns out it's really good. With some of my modifications.

The next step is to do classes of fixes sections at a time on the rest of the codebase.

In the future, we might add it as a pre-commit hook to prevent regressions. Right now the idea is just bulk changes and any regressions introduced are fine, I'll just do a sweeping pass again sometime.