### PR TITLE
fix(ui): direction of dropdown arrow icons

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
@@ -214,7 +214,7 @@ export class Line extends React.Component<Props, State> {
           }
           onClick={this.toggleContext}
         >
-          <IconChevron direction={isExpanded ? 'down' : 'up'} size="8px" />
+          <IconChevron direction={isExpanded ? 'up' : 'down'} size="8px" />
         </ToggleContextButton>
       </ToggleContextButtonWrapper>
     );


### PR DESCRIPTION
## Before

<img width="1119" alt="Screen Shot 2021-02-02 at 6 34 31 PM" src="https://user-images.githubusercontent.com/1900676/106690021-db588780-6585-11eb-80ca-7959e9837e7c.png">

## After

<img width="941" alt="Screen Shot 2021-02-02 at 6 34 04 PM" src="https://user-images.githubusercontent.com/1900676/106690041-e1e6ff00-6585-11eb-9ecf-f96203d18a46.png">
