### PR TITLE
ref(api): Remove old promptsactivity endpoint

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -460,12 +460,6 @@ urlpatterns = [
         name="sentry-api-0-api-authorizations",
     ),
     url(r"^api-tokens/$", ApiTokensEndpoint.as_view(), name="sentry-api-0-api-tokens"),
-    # TODO: Remove after deploy
-    url(
-        r"^promptsactivity/$",
-        PromptsActivityEndpoint.as_view(),
-        name="sentry-api-0-promptsactivity",
-    ),
     url(
         r"^prompts-activity/$",
         PromptsActivityEndpoint.as_view(),


### PR DESCRIPTION
Should not be merged / deployed until https://github.com/getsentry/sentry/pull/23548 goes out