### PR TITLE
fix(grouping): Add SentryHub to internal functions

### DIFF
--- a/src/sentry/grouping/enhancement-configs/common@2019-03-23.txt
+++ b/src/sentry/grouping/enhancement-configs/common@2019-03-23.txt
@@ -56,8 +56,9 @@ family:native function:kscm_*                                     -app -group
 family:native function:sentrycrashcm_*                            -app -group
 family:native function:kscrash_*                                  -app -group
 family:native function:sentrycrash_*                              -app -group
-family:native function:"?[[]KSCrash *"                              -app -group
-family:native function:"?[[]SentryCrash *"                          -app -group
-family:native function:"?[[]SentryClient *"                         -app -group
-family:native function:"?[[]RNSentry *"                             -app -group
-family:native function:"?[[]SentrySDK *"                             -app -group
+family:native function:"?[[]KSCrash *"                            -app -group
+family:native function:"?[[]SentryCrash *"                        -app -group
+family:native function:"?[[]SentryClient *"                       -app -group
+family:native function:"?[[]SentryHub *"                          -app -group
+family:native function:"?[[]RNSentry *"                           -app -group
+family:native function:"?[[]SentrySDK *"                          -app -group

--- a/src/sentry/grouping/enhancement-configs/legacy@2019-03-12.txt
+++ b/src/sentry/grouping/enhancement-configs/legacy@2019-03-12.txt
@@ -28,5 +28,6 @@ family:native function:kscm_*                                        -app -group
 family:native function:kscrash_*                                     -app -group
 family:native function:"?[[]KSCrash *"                              -app -group
 family:native function:"?[[]SentryClient *"                         -app -group
+family:native function:"?[[]SentryHub *"                            -app -group
 family:native function:"?[[]RNSentry *"                             -app -group
 family:native function:"?[[]SentrySDK *"                             -app -group

--- a/tests/sentry/test_stacktraces.py
+++ b/tests/sentry/test_stacktraces.py
@@ -293,6 +293,11 @@ class NormalizeInApptest(TestCase):
                                     "instruction_addr": 4295098388,
                                 },
                                 {
+                                    "function": "+[SentryHub ]",
+                                    "package": "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/SentryTest",
+                                    "instruction_addr": 4295098388,
+                                },
+                                {
                                     "function": "+[SentryClient ]",
                                     "package": "/var/containers/Bundle/Application/B33C37A8-F933-4B6B-9FFA-152282BFDF13/SentryTest.app/SentryTest",
                                     "instruction_addr": 4295098388,
@@ -340,8 +345,9 @@ class NormalizeInApptest(TestCase):
         assert frames[2]["in_app"] is False
         assert frames[3]["in_app"] is False
         assert frames[4]["in_app"] is False
-        assert frames[5]["in_app"] is True
+        assert frames[5]["in_app"] is False
         assert frames[6]["in_app"] is True
+        assert frames[7]["in_app"] is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
SentryHub was missing from the internal functions for Cocoa. This is fixed now.