### PR TITLE
feat(releases): Disable snuba queries on release creation

### DIFF
--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -181,6 +181,9 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
                     created_status=status,
                 )
                 scope.set_tag("success_status", status)
-                return Response(serialize(release, request.user), status=status)
+
+                # Disable snuba here as it often causes 429s when overloaded and
+                # a freshly created release won't have health data anyways.
+                return Response(serialize(release, request.user, no_snuba=True), status=status)
             scope.set_tag("failure_reason", "serializer_error")
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -306,6 +306,9 @@ class ReleaseSerializer(Serializer):
         health_stat = kwargs.get("health_stat", None)
         health_stats_period = kwargs.get("health_stats_period")
         summary_stats_period = kwargs.get("summary_stats_period")
+        no_snuba = kwargs.get("no_snuba")
+        if with_health_data and no_snuba:
+            raise TypeError("health data requires snuba")
 
         if environments is None:
             first_seen, last_seen, issue_counts_by_release = self.__get_release_data_no_environment(
@@ -354,9 +357,12 @@ class ReleaseSerializer(Serializer):
             has_health_data = None
         else:
             health_data = None
-            has_health_data = check_has_health_data(
-                [(pr["project__id"], pr["release__version"]) for pr in project_releases]
-            )
+            if no_snuba:
+                has_health_data = {}
+            else:
+                has_health_data = check_has_health_data(
+                    [(pr["project__id"], pr["release__version"]) for pr in project_releases]
+                )
 
         for pr in project_releases:
             pr_rv = {


### PR DESCRIPTION
This is a wacky workaround for release creation to avoid going to snuba.