### PR TITLE
fix(stack-trace): Fix truncate image address

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
@@ -450,7 +450,7 @@ const NativeLineContent = styled('div')<{isFrameAfterLastNonApp: boolean}>`
   flex: 1;
   grid-gap: ${space(0.5)};
   grid-template-columns: ${p => (p.isFrameAfterLastNonApp ? '167px' : '117px')} 1fr;
-  align-items: flex-start;
+  align-items: align-center;
   justify-content: flex-start;
 
   @media (min-width: ${props => props.theme.breakpoints[0]}) {

--- a/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/togglableAddress.tsx
@@ -6,7 +6,6 @@ import {STACKTRACE_PREVIEW_TOOLTIP_DELAY} from 'app/components/stacktracePreview
 import Tooltip from 'app/components/tooltip';
 import {IconFilter} from 'app/icons';
 import {t} from 'app/locale';
-import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Theme} from 'app/utils/theme';
 
@@ -128,8 +127,8 @@ const getAddresstextBorderBottom = (
 const Address = styled('span')<Partial<Props> & {canBeConverted: boolean}>`
   padding-left: ${p => (p.canBeConverted ? null : '18px')};
   border-bottom: ${getAddresstextBorderBottom};
-  ${overflowEllipsis};
   max-width: 93px;
+  white-space: pre-wrap;
 `;
 
 const Wrapper = styled('span')`


### PR DESCRIPTION
. Remove `overflowEllipsis` style
. Add  `white-space: pre-wrap;`
. Centered NativeLineContent 

**Before:**

![image](https://user-images.githubusercontent.com/29228205/106732157-a47b8380-6610-11eb-9b19-1bc850003659.png)


**After:**


![image](https://user-images.githubusercontent.com/29228205/106732389-f0c6c380-6610-11eb-86eb-433c7471d252.png)
