### PR TITLE
feat(ui): Change default period for fresh releases

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/getParams.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/getParams.tsx
@@ -140,10 +140,15 @@ type InputParams = {
 type GetParamsOptions = {
   allowEmptyPeriod?: boolean;
   allowAbsoluteDatetime?: boolean;
+  defaultStatsPeriod?: string;
 };
 export function getParams(
   params: InputParams,
-  {allowEmptyPeriod = false, allowAbsoluteDatetime = true}: GetParamsOptions = {}
+  {
+    allowEmptyPeriod = false,
+    allowAbsoluteDatetime = true,
+    defaultStatsPeriod = DEFAULT_STATS_PERIOD,
+  }: GetParamsOptions = {}
 ): ParsedParams {
   const {start, end, period, statsPeriod, utc, ...otherParams} = params;
 
@@ -155,7 +160,7 @@ export function getParams(
 
   if (!(dateTimeStart && dateTimeEnd)) {
     if (!coercedPeriod && !allowEmptyPeriod) {
-      coercedPeriod = DEFAULT_STATS_PERIOD;
+      coercedPeriod = defaultStatsPeriod;
     }
   }
 

--- a/src/sentry/static/sentry/app/views/releases/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import pick from 'lodash/pick';
+import moment from 'moment';
 
 import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {IconInfo, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
@@ -30,12 +33,15 @@ import AsyncView from 'app/views/asyncView';
 import PickProjectToContinue from './pickProjectToContinue';
 import ReleaseHeader from './releaseHeader';
 
+const DEFAULT_FRESH_RELEASE_STATS_PERIOD = '24h';
+
 type ReleaseContext = {
   release: ReleaseWithHealth;
   project: Required<ReleaseProject>;
   deploys: Deploy[];
   releaseMeta: ReleaseMeta;
   refetchData: () => void;
+  defaultStatsPeriod: string;
 };
 const ReleaseContext = React.createContext<ReleaseContext>({} as ReleaseContext);
 
@@ -48,6 +54,7 @@ type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
   selection: GlobalSelection;
   releaseMeta: ReleaseMeta;
+  defaultStatsPeriod: string;
 };
 
 type State = {
@@ -75,10 +82,12 @@ class ReleasesDetail extends AsyncView<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {organization, location, params, releaseMeta} = this.props;
+    const {organization, location, params, releaseMeta, defaultStatsPeriod} = this.props;
 
     const query = {
-      ...pick(location.query, [...Object.values(URL_PARAM)]),
+      ...getParams(pick(location.query, [...Object.values(URL_PARAM)]), {
+        defaultStatsPeriod,
+      }),
       health: 1,
     };
 
@@ -124,7 +133,13 @@ class ReleasesDetail extends AsyncView<Props, State> {
   }
 
   renderBody() {
-    const {organization, location, selection, releaseMeta} = this.props;
+    const {
+      organization,
+      location,
+      selection,
+      releaseMeta,
+      defaultStatsPeriod,
+    } = this.props;
     const {release, deploys, reloading} = this.state;
     const project = release?.projects.find(p => p.id === selection.projects[0]);
 
@@ -154,6 +169,7 @@ class ReleasesDetail extends AsyncView<Props, State> {
               deploys,
               releaseMeta,
               refetchData: this.fetchData,
+              defaultStatsPeriod,
             }}
           >
             {this.props.children}
@@ -223,6 +239,12 @@ class ReleasesDetailContainer extends AsyncComponent<Omit<Props, 'releaseMeta'>>
     const {organization, params, router} = this.props;
     const {releaseMeta} = this.state;
     const {projects} = releaseMeta;
+    const isFreshRelease = moment(releaseMeta.released).isAfter(
+      moment().subtract(24, 'hours')
+    );
+    const defaultStatsPeriod = isFreshRelease
+      ? DEFAULT_FRESH_RELEASE_STATS_PERIOD
+      : DEFAULT_STATS_PERIOD;
 
     if (this.isProjectMissingInUrl()) {
       return (
@@ -244,8 +266,20 @@ class ReleasesDetailContainer extends AsyncComponent<Omit<Props, 'releaseMeta'>>
         disableMultipleProjectSelection
         showProjectSettingsLink
         projectsFooterMessage={this.renderProjectsFooterMessage()}
+        defaultSelection={{
+          datetime: {
+            start: null,
+            end: null,
+            utc: false,
+            period: defaultStatsPeriod,
+          },
+        }}
       >
-        <ReleasesDetail {...this.props} releaseMeta={releaseMeta} />
+        <ReleasesDetail
+          {...this.props}
+          releaseMeta={releaseMeta}
+          defaultStatsPeriod={defaultStatsPeriod}
+        />
       </GlobalSelectionHeader>
     );
   }

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -245,7 +245,7 @@ class ReleaseOverview extends AsyncView<Props> {
 
     return (
       <ReleaseContext.Consumer>
-        {({release, project, deploys, releaseMeta, refetchData}) => {
+        {({release, project, deploys, releaseMeta, refetchData, defaultStatsPeriod}) => {
           const {commitCount, version} = release;
           const {hasHealthData} = project.healthData || {};
           const hasDiscover = organization.features.includes('discover-basic');
@@ -293,6 +293,7 @@ class ReleaseOverview extends AsyncView<Props> {
               hasHealthData={hasHealthData}
               hasDiscover={hasDiscover}
               hasPerformance={hasPerformance}
+              defaultStatsPeriod={defaultStatsPeriod}
             >
               {({crashFreeTimeBreakdown, ...releaseStatsProps}) => (
                 <Body>
@@ -330,6 +331,7 @@ class ReleaseOverview extends AsyncView<Props> {
                       selection={selection}
                       version={version}
                       location={location}
+                      defaultStatsPeriod={defaultStatsPeriod}
                     />
                     <Feature features={['performance-view']}>
                       <TransactionsList

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/issues.tsx
@@ -10,6 +10,7 @@ import DiscoverButton from 'app/components/discoverButton';
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import GroupList from 'app/components/issues/groupList';
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel} from 'app/components/panels';
 import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
@@ -40,6 +41,7 @@ type Props = {
   version: string;
   selection: GlobalSelection;
   location: Location;
+  defaultStatsPeriod: string;
 };
 
 type State = {
@@ -90,10 +92,12 @@ class Issues extends React.Component<Props, State> {
   }
 
   getIssuesEndpoint(): {path: string; queryParams: IssuesQueryParams} {
-    const {version, orgId, location} = this.props;
+    const {version, orgId, location, defaultStatsPeriod} = this.props;
     const {issuesType} = this.state;
     const queryParams = {
-      ...pick(location.query, [...Object.values(URL_PARAM), 'cursor']),
+      ...getParams(pick(location.query, [...Object.values(URL_PARAM), 'cursor']), {
+        defaultStatsPeriod,
+      }),
       limit: 10,
       sort: 'new',
     };

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/releaseStatsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/releaseStatsRequest.tsx
@@ -58,6 +58,7 @@ type Props = {
   hasHealthData: boolean;
   hasDiscover: boolean;
   hasPerformance: boolean;
+  defaultStatsPeriod: string;
 };
 type State = {
   reloading: boolean;
@@ -233,10 +234,12 @@ class ReleaseStatsRequest extends React.Component<Props, State> {
   }
 
   get baseQueryParams() {
-    const {location, selection} = this.props;
+    const {location, selection, defaultStatsPeriod} = this.props;
 
     return {
-      ...getParams(pick(location.query, [...Object.values(URL_PARAM)])),
+      ...getParams(pick(location.query, [...Object.values(URL_PARAM)]), {
+        defaultStatsPeriod,
+      }),
       interval: getInterval(selection.datetime),
     };
   }

--- a/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
+++ b/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
@@ -27,20 +27,22 @@ describe('Release Issues', function () {
     });
 
     newIssuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.orgId}/issues/?limit=10&query=first-release%3A1.0.0&sort=new`,
+      url: `/organizations/${props.orgId}/issues/?limit=10&query=first-release%3A1.0.0&sort=new&statsPeriod=14d`,
       body: [],
     });
     resolvedIssuesEndpoint = MockApiClient.addMockResponse({
-      url: '/organizations/org/releases/1.0.0/resolved/?limit=10&query=&sort=new',
+      url:
+        '/organizations/org/releases/1.0.0/resolved/?limit=10&query=&sort=new&statsPeriod=14d',
       body: [],
     });
     unhandledIssuesEndpoint = MockApiClient.addMockResponse({
       url:
-        '/organizations/org/issues/?limit=10&query=release%3A1.0.0%20error.handled%3A0&sort=new',
+        '/organizations/org/issues/?limit=10&query=release%3A1.0.0%20error.handled%3A0&sort=new&statsPeriod=14d',
       body: [],
     });
     allIssuesEndpoint = MockApiClient.addMockResponse({
-      url: '/organizations/org/issues/?limit=10&query=release%3A1.0.0&sort=new',
+      url:
+        '/organizations/org/issues/?limit=10&query=release%3A1.0.0&sort=new&statsPeriod=14d',
       body: [],
     });
   });
@@ -146,25 +148,49 @@ describe('Release Issues', function () {
 
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
-      query: {sort: 'new', query: 'firstRelease:1.0.0'},
+      query: {
+        sort: 'new',
+        query: 'firstRelease:1.0.0',
+        cursor: undefined,
+        limit: undefined,
+        statsPeriod: '14d',
+      },
     });
 
     filterIssues(wrapper, 'resolved');
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
-      query: {sort: 'new', query: 'release:1.0.0'},
+      query: {
+        sort: 'new',
+        query: 'release:1.0.0',
+        cursor: undefined,
+        limit: undefined,
+        statsPeriod: '14d',
+      },
     });
 
     filterIssues(wrapper, 'unhandled');
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
-      query: {sort: 'new', query: 'release:1.0.0 error.handled:0'},
+      query: {
+        sort: 'new',
+        query: 'release:1.0.0 error.handled:0',
+        cursor: undefined,
+        limit: undefined,
+        statsPeriod: '14d',
+      },
     });
 
     filterIssues(wrapper, 'all');
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
-      query: {sort: 'new', query: 'release:1.0.0'},
+      query: {
+        sort: 'new',
+        query: 'release:1.0.0',
+        cursor: undefined,
+        limit: undefined,
+        statsPeriod: '14d',
+      },
     });
   });
 });


### PR DESCRIPTION
The fresh releases (not older than one day) will have default statsPeriod on the release detail page set to 24 hours.