### PR TITLE
feat(ui): Change order of crash free columns

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/detail/overview/releaseStats.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/releaseStats.tsx
@@ -81,10 +81,10 @@ function ReleaseStats({organization, release, project, location, selection}: Pro
       </div>
 
       <div>
-        <SectionHeading>{t('Crash Free Users')}</SectionHeading>
+        <SectionHeading>{t('Crash Free Sessions')}</SectionHeading>
         <div>
-          {defined(crashFreeUsers) ? (
-            <CrashFree percent={crashFreeUsers} iconSize="md" />
+          {defined(crashFreeSessions) ? (
+            <CrashFree percent={crashFreeSessions} iconSize="md" />
           ) : (
             <NotAvailable tooltip={NOT_AVAILABLE_MESSAGES.releaseHealth} />
           )}
@@ -92,10 +92,10 @@ function ReleaseStats({organization, release, project, location, selection}: Pro
       </div>
 
       <div>
-        <SectionHeading>{t('Crash Free Sessions')}</SectionHeading>
+        <SectionHeading>{t('Crash Free Users')}</SectionHeading>
         <div>
-          {defined(crashFreeSessions) ? (
-            <CrashFree percent={crashFreeSessions} iconSize="md" />
+          {defined(crashFreeUsers) ? (
+            <CrashFree percent={crashFreeUsers} iconSize="md" />
           ) : (
             <NotAvailable tooltip={NOT_AVAILABLE_MESSAGES.releaseHealth} />
           )}


### PR DESCRIPTION
Changing order so that `Crash Free Sessions` are first and the `Crash Free Users` second - it's more consistent with the overview page this way.

![image](https://user-images.githubusercontent.com/9060071/106750679-6d18d100-6628-11eb-98b4-5982916be6f6.png)
