### PR TITLE
feat(workflow): Implementing `assigned:me_or_none`

### DIFF
--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -13,7 +13,7 @@ from sentry.api.event_search import (
 from sentry.models.group import STATUS_QUERY_CHOICES
 from sentry.search.utils import (
     parse_actor_value,
-    parse_assigned_or_suggested_value,
+    parse_actor_or_none_value,
     parse_user_value,
     parse_release,
     parse_status_value,
@@ -94,8 +94,8 @@ def convert_actor_value(value, projects, user, environments):
     return parse_actor_value(projects, value, user)
 
 
-def convert_assigned_or_suggested_value(value, projects, user, environments):
-    return parse_assigned_or_suggested_value(projects, value, user)
+def convert_actor_or_none_value(value, projects, user, environments):
+    return parse_actor_or_none_value(projects, value, user)
 
 
 def convert_user_value(value, projects, user, environments):
@@ -114,8 +114,8 @@ def convert_status_value(value, projects, user, environments):
 
 
 value_converters = {
-    "assigned_or_suggested": convert_assigned_or_suggested_value,
-    "assigned_to": convert_actor_value,
+    "assigned_or_suggested": convert_actor_or_none_value,
+    "assigned_to": convert_actor_or_none_value,
     "bookmarked_by": convert_user_value,
     "subscribed_by": convert_user_value,
     "first_release": convert_release_value,

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -36,39 +36,37 @@ def assigned_to_filter(actor, projects):
                 team=actor, project_id__in=[p.id for p in projects]
             ).values_list("group_id", flat=True)
         )
-    elif isinstance(actor, User) or (isinstance(actor, list) and actor[0] == "me_or_none"):
-        include_none = False
-        if isinstance(actor, list) and actor[0] == "me_or_none":
-            include_none = True
-            actor = actor[1]
 
-        assigned_to_user = Q(
-            id__in=GroupAssignee.objects.filter(
-                user=actor, project_id__in=[p.id for p in projects]
-            ).values_list("group_id", flat=True)
-        )
-        assigned_to_team = Q(
-            id__in=GroupAssignee.objects.filter(
-                project_id__in=[p.id for p in projects],
-                team_id__in=Team.objects.filter(
-                    id__in=OrganizationMemberTeam.objects.filter(
-                        organizationmember__in=OrganizationMember.objects.filter(
-                            user=actor, organization_id=projects[0].organization_id
-                        ),
-                        is_active=True,
-                    ).values("team")
-                ),
-            ).values_list("group_id", flat=True)
-        )
+    include_none = False
+    if isinstance(actor, list) and actor[0] == "me_or_none":
+        include_none = True
+        actor = actor[1]
 
-        assigned_query = assigned_to_user | assigned_to_team
+    assigned_to_user = Q(
+        id__in=GroupAssignee.objects.filter(
+            user=actor, project_id__in=[p.id for p in projects]
+        ).values_list("group_id", flat=True)
+    )
+    assigned_to_team = Q(
+        id__in=GroupAssignee.objects.filter(
+            project_id__in=[p.id for p in projects],
+            team_id__in=Team.objects.filter(
+                id__in=OrganizationMemberTeam.objects.filter(
+                    organizationmember__in=OrganizationMember.objects.filter(
+                        user=actor, organization_id=projects[0].organization_id
+                    ),
+                    is_active=True,
+                ).values("team")
+            ),
+        ).values_list("group_id", flat=True)
+    )
 
-        if include_none:
-            return assigned_query | unassigned_filter(True, projects)
-        else:
-            return assigned_query
+    assigned_query = assigned_to_user | assigned_to_team
 
-    raise InvalidSearchQuery("Unsupported assignee type.")
+    if include_none:
+        return assigned_query | unassigned_filter(True, projects)
+    else:
+        return assigned_query
 
 
 def unassigned_filter(unassigned, projects):

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -217,7 +217,7 @@ def parse_actor_value(projects, value, user):
     return parse_user_value(value, user)
 
 
-def parse_assigned_or_suggested_value(projects, value, user):
+def parse_actor_or_none_value(projects, value, user):
     if value == "me_or_none":
         return ["me_or_none", user]
     return parse_actor_value(projects, value, user)
@@ -450,11 +450,9 @@ def parse_query(projects, query, user, environments):
                     except KeyError:
                         raise InvalidQuery("'is:' had unknown status code '{}'.".format(value))
             elif key == "assigned":
-                results["assigned_to"] = parse_actor_value(projects, value, user)
+                results["assigned_to"] = parse_actor_or_none_value(projects, value, user)
             elif key == "assigned_or_suggested":
-                results["assigned_or_suggested"] = parse_assigned_or_suggested_value(
-                    projects, value, user
-                )
+                results["assigned_or_suggested"] = parse_actor_or_none_value(projects, value, user)
             elif key == "bookmarks":
                 results["bookmarked_by"] = parse_user_value(value, user)
             elif key == "subscribed":

--- a/src/sentry/static/sentry/app/utils/withIssueTags.tsx
+++ b/src/sentry/static/sentry/app/utils/withIssueTags.tsx
@@ -86,10 +86,9 @@ const withIssueTags = <P extends InjectedTagsProps>(
       const teamnames: string[] = teams
         .filter(team => team.isMember)
         .map(team => `#${team.slug}`);
-      const allAssigned = usernames.concat(teamnames);
+      const allAssigned = ['me_or_none', ...usernames.concat(teamnames)];
       allAssigned.unshift('me');
       usernames.unshift('me');
-      const allOwners = ['me_or_none', ...allAssigned];
 
       this.setState({
         tags: {
@@ -104,7 +103,7 @@ const withIssueTags = <P extends InjectedTagsProps>(
           },
           assigned_or_suggested: {
             ...tags.assigned_or_suggested,
-            values: allOwners,
+            values: allAssigned,
           },
         },
       });

--- a/tests/js/spec/utils/withIssueTags.spec.jsx
+++ b/tests/js/spec/utils/withIssueTags.spec.jsx
@@ -51,7 +51,10 @@ describe('withIssueTags HoC', function () {
 
     let tagsProp = wrapper.find('MyComponent').prop('tags');
     expect(tagsProp.assigned).toBeTruthy();
-    expect(tagsProp.assigned.values).toEqual(['me']);
+    expect(tagsProp.assigned.values).toEqual(['me', 'me_or_none']);
+
+    expect(tagsProp.assigned_or_suggested).toBeTruthy();
+    expect(tagsProp.assigned_or_suggested.values).toEqual(['me', 'me_or_none']);
 
     const users = [TestStubs.User(), TestStubs.User({username: 'joe@example.com'})];
     TeamStore.loadInitialData([
@@ -63,13 +66,14 @@ describe('withIssueTags HoC', function () {
     tagsProp = wrapper.find('MyComponent').prop('tags');
     expect(tagsProp.assigned.values).toEqual([
       'me',
+      'me_or_none',
       'foo@example.com',
       'joe@example.com',
       '#best-team-na',
     ]);
     expect(tagsProp.assigned_or_suggested.values).toEqual([
-      'me_or_none',
       'me',
+      'me_or_none',
       'foo@example.com',
       'joe@example.com',
       '#best-team-na',

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -289,7 +289,7 @@ class ParseQueryTest(TestCase):
 
     def test_assigned_me_or_none(self):
         result = self.parse_query("assigned:me_or_none")
-        assert result == {"assigned_to": ["me_or_none",self.user], "tags": {}, "query": ""}
+        assert result == {"assigned_to": ["me_or_none", self.user], "tags": {}, "query": ""}
 
     def test_assigned_email(self):
         result = self.parse_query(f"assigned:{self.user.email}")
@@ -524,8 +524,11 @@ class ParseQueryTest(TestCase):
 
     def test_assigned_or_suggested_me_or_none(self):
         result = self.parse_query("assigned_or_suggested:me_or_none")
-        print("result:",result)
-        assert result == {"assigned_or_suggested": self.user, "tags": {}, "query": ""}
+        assert result == {
+            "assigned_or_suggested": ["me_or_none", self.user],
+            "tags": {},
+            "query": "",
+        }
 
     def test_owner_email(self):
         result = self.parse_query(f"assigned_or_suggested:{self.user.email}")

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -287,6 +287,10 @@ class ParseQueryTest(TestCase):
         result = self.parse_query("assigned:me")
         assert result == {"assigned_to": self.user, "tags": {}, "query": ""}
 
+    def test_assigned_me_or_none(self):
+        result = self.parse_query("assigned:me_or_none")
+        assert result == {"assigned_to": ["me_or_none",self.user], "tags": {}, "query": ""}
+
     def test_assigned_email(self):
         result = self.parse_query(f"assigned:{self.user.email}")
         assert result == {"assigned_to": self.user, "tags": {}, "query": ""}
@@ -516,6 +520,11 @@ class ParseQueryTest(TestCase):
 
     def test_assigned_or_suggested_me(self):
         result = self.parse_query("assigned_or_suggested:me")
+        assert result == {"assigned_or_suggested": self.user, "tags": {}, "query": ""}
+
+    def test_assigned_or_suggested_me_or_none(self):
+        result = self.parse_query("assigned_or_suggested:me_or_none")
+        print("result:",result)
         assert result == {"assigned_or_suggested": self.user, "tags": {}, "query": ""}
 
     def test_owner_email(self):

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -618,7 +618,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         response = self.get_response(limit=10, query="assigned:me_or_none")
         assert len(response.data) == 5
 
-        GroupAssignee.objects.assign(ag, self.create_user("other@user.com"))
+        GroupAssignee.objects.assign(assigned_groups[1], self.create_user("other@user.com"))
         response = self.get_response(limit=10, query="assigned:me_or_none")
         assert len(response.data) == 4
 

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -595,6 +595,10 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         assert options.set("snuba.search.hits-sample-size", old_sample_size)
 
+        # Test a me_or_none query
+        response = self.get_response(limit=1, cursor=cursor, query=f"assigned:me_or_none")
+        assert len(response.data) == 4
+
     def test_seen_stats(self):
         self.store_event(
             data={"timestamp": iso_format(before_now(seconds=500)), "fingerprint": ["group-1"]},

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -610,7 +610,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         assigned_groups = groups[:2]
         for ag in assigned_groups:
-            ag.update(status=GroupStatus.RESOLVED, resolved_at=before_now(seconds=5))
             GroupAssignee.objects.assign(ag, self.user)
 
         response = self.get_response(limit=10, query="assigned:me")
@@ -618,6 +617,10 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         response = self.get_response(limit=10, query="assigned:me_or_none")
         assert len(response.data) == 5
+
+        GroupAssignee.objects.assign(ag, self.create_user("other@user.com"))
+        response = self.get_response(limit=10, query="assigned:me_or_none")
+        assert len(response.data) == 4
 
     def test_seen_stats(self):
         self.store_event(

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -595,9 +595,29 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         assert options.set("snuba.search.hits-sample-size", old_sample_size)
 
-        # Test a me_or_none query
-        response = self.get_response(limit=1, cursor=cursor, query=f"assigned:me_or_none")
-        assert len(response.data) == 4
+    def test_assigned_me_or_none(self):
+        self.login_as(user=self.user)
+        groups = []
+        for i in range(5):
+            group = self.store_event(
+                data={
+                    "timestamp": iso_format(before_now(days=i)),
+                    "fingerprint": [f"group-{i}"],
+                },
+                project_id=self.project.id,
+            ).group
+            groups.append(group)
+
+        assigned_groups = groups[:2]
+        for ag in assigned_groups:
+            ag.update(status=GroupStatus.RESOLVED, resolved_at=before_now(seconds=5))
+            GroupAssignee.objects.assign(ag, self.user)
+
+        response = self.get_response(limit=10, query="assigned:me")
+        assert len(response.data) == 2
+
+        response = self.get_response(limit=10, query="assigned:me_or_none")
+        assert len(response.data) == 5
 
     def test_seen_stats(self):
         self.store_event(


### PR DESCRIPTION
Implementing this search syntax for consistency with "owner" (`assigned_or_suggested`) search syntax.