### PR TITLE
feat(dashboards) Make barcharts daily totals

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
@@ -31,16 +31,19 @@ import {Widget, WidgetQuery} from './types';
 const MAX_BIN_COUNT = 4000;
 
 function getWidgetInterval(
-  desired: string,
+  widget: Widget,
   datetimeObj: Partial<GlobalSelection['datetime']>
 ): string {
-  const desiredPeriod = parsePeriodToHours(desired);
+  // Bars charts are daily totals to aligned with discover. It also makes them
+  // usefully different from line/area charts until we expose the interval control, or remove it.
+  const interval = widget.displayType === 'bar' ? '1d' : widget.interval;
+  const desiredPeriod = parsePeriodToHours(interval);
   const selectedRange = getDiffInMinutes(datetimeObj);
 
   if (selectedRange / desiredPeriod > MAX_BIN_COUNT) {
     return getInterval(datetimeObj, true);
   }
-  return desired;
+  return interval;
 }
 
 type RawResult = EventsStats | MultiSeriesEventsStats;
@@ -214,7 +217,7 @@ class WidgetQueries extends React.Component<Props, State> {
 
     const {environments, projects} = selection;
     const {start, end, period: statsPeriod} = selection.datetime;
-    const interval = getWidgetInterval(widget.interval, {
+    const interval = getWidgetInterval(widget, {
       start,
       end,
       period: statsPeriod,

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -301,4 +301,41 @@ describe('Dashboards > WidgetQueries', function () {
     expect(childProps.tableResults[0].data[0]['sdk.name']).toBeDefined();
     expect(childProps.tableResults[1].data[0].title).toBeDefined();
   });
+
+  it('sets bar charts to 1d interval', async function () {
+    const errorMock = MockApiClient.addMockResponse(
+      {
+        url: '/organizations/org-slug/events-stats/',
+        body: [],
+      },
+      {
+        predicate(_url, options) {
+          return options.query.interval === '1d';
+        },
+      }
+    );
+    const barWidget = {
+      ...singleQueryWidget,
+      displayType: 'bar',
+      // Should be ignored for bars.
+      interval: '5m',
+    };
+    const wrapper = mountWithTheme(
+      <WidgetQueries
+        api={api}
+        widget={barWidget}
+        organization={initialData.organization}
+        selection={selection}
+      >
+        {() => <div data-test-id="child" />}
+      </WidgetQueries>,
+      initialData.routerContext
+    );
+    await tick();
+    await tick();
+
+    // Child should be rendered and 1 requests should be sent.
+    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(errorMock).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Currently bar charts use the default widget interval, which results in hard to read results as we try to pack a lot of bars into a small space. By making bar charts daily totals each bar has more room, and we make bars usefully distinct from line/area. This change also helps replicate another discover chart leaving only top5 modes missing.