### PR TITLE
ref(workflow): Changing default owner search

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -948,7 +948,7 @@ SENTRY_FEATURES = {
     "organizations:inbox": False,
     # Set default tab to inbox
     "organizations:inbox-tab-default": False,
-    # Add `owner:me_or_none` to inbox tab query
+    # Add `assigned_or_suggested:me_or_none` to inbox tab query
     "organizations:inbox-owners-query": False,
     # Enable the new alert details ux design
     "organizations:alert-details-redesign": False,

--- a/src/sentry/static/sentry/app/views/issueList/utils.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/utils.tsx
@@ -3,7 +3,7 @@ import {Organization} from 'app/types';
 
 export enum Query {
   FOR_REVIEW = 'is:unresolved is:for_review',
-  FOR_REVIEW_OWNER = 'is:unresolved is:for_review owner:me_or_none',
+  FOR_REVIEW_OWNER = 'is:unresolved is:for_review assigned_or_suggested:me_or_none',
   UNRESOLVED = 'is:unresolved',
   IGNORED = 'is:ignored',
   REPROCESSING = 'is:reprocessing',

--- a/tests/js/spec/views/issueList/header.spec.jsx
+++ b/tests/js/spec/views/issueList/header.spec.jsx
@@ -5,7 +5,7 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import IssueListHeader from 'app/views/issueList/header';
 
 const queryCounts = {
-  'is:unresolved is:for_review owner:me_or_none': {
+  'is:unresolved is:for_review assigned_or_suggested:me_or_none': {
     count: 22,
     hasMore: false,
   },
@@ -62,12 +62,12 @@ describe('IssueListHeader', () => {
     expect(wrapper.find('.active').text()).toBe('For Review 1');
   });
 
-  it('renders active tab with count when query matches inbox with owners:me_or_none', () => {
+  it('renders active tab with count when query matches inbox with assigned_or_suggested:me_or_none', () => {
     organization.features = ['inbox-owners-query'];
     const wrapper = mountWithTheme(
       <IssueListHeader
         organization={organization}
-        query="is:unresolved is:for_review owner:me_or_none"
+        query="is:unresolved is:for_review assigned_or_suggested:me_or_none"
         queryCount={0}
         queryCounts={queryCounts}
         projectIds={[]}


### PR DESCRIPTION
We just changed `owner:X` to `assigned_or_suggested:X` and this will update the default search on the frontend.