### PR TITLE
ref(reprocessing): Converting reprocessing python logic to ts

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -414,11 +414,11 @@ def process_payload(data):
 
 
 def get_symbolication_function(data):
-    # if is_minidump_event(data):
-    #     return process_minidump
-    # elif is_applecrashreport_event(data):
-    #     return process_applecrashreport
-    if is_native_event(data):
+    if is_minidump_event(data):
+        return process_minidump
+    elif is_applecrashreport_event(data):
+        return process_applecrashreport
+    elif is_native_event(data):
         return process_payload
 
 

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -414,11 +414,11 @@ def process_payload(data):
 
 
 def get_symbolication_function(data):
-    if is_minidump_event(data):
-        return process_minidump
-    elif is_applecrashreport_event(data):
-        return process_applecrashreport
-    elif is_native_event(data):
+    # if is_minidump_event(data):
+    #     return process_minidump
+    # elif is_applecrashreport_event(data):
+    #     return process_applecrashreport
+    if is_native_event(data):
         return process_payload
 
 

--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -187,6 +187,7 @@ def find_stacktraces_in_data(data, include_raw=False, with_exceptions=False):
             frame.get("platform") or data.get("platform")
             for frame in get_path(stacktrace, "frames", filter=True, default=())
         )
+
         rv.append(
             StacktraceInfo(
                 stacktrace=stacktrace,

--- a/src/sentry/static/sentry/app/components/events/interfaces/exceptionStacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/exceptionStacktraceContent.tsx
@@ -36,7 +36,7 @@ const ExceptionStacktraceContent = ({
 
   if (
     stackView === STACK_VIEW.APP &&
-    stacktrace.frames.filter(frame => frame.inApp).length === 0 &&
+    (stacktrace.frames ?? []).filter(frame => frame.inApp).length === 0 &&
     !chainedException
   ) {
     return (
@@ -68,7 +68,7 @@ const ExceptionStacktraceContent = ({
       expandFirstFrame={expandFirstFrame}
       includeSystemFrames={
         stackView === STACK_VIEW.FULL ||
-        (chainedException && stacktrace.frames.every(frame => !frame.inApp))
+        (chainedException && (stacktrace.frames ?? []).every(frame => !frame.inApp))
       }
       platform={platform}
       newestFirst={newestFirst}

--- a/src/sentry/static/sentry/app/components/events/interfaces/rawStacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/rawStacktraceContent.tsx
@@ -170,7 +170,7 @@ export default function render(
 ) {
   const frames: string[] = [];
 
-  data?.frames.forEach((frame, frameIdx) => {
+  (data?.frames ?? []).forEach((frame, frameIdx) => {
     frames.push(getFrame(frame, frameIdx, platform));
   });
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
@@ -59,7 +59,7 @@ export default class StacktraceContent extends React.Component<Props, State> {
   isFrameAfterLastNonApp(): boolean {
     const {data} = this.props;
 
-    const frames = data.frames;
+    const frames = data.frames ?? [];
 
     if (!frames.length || frames.length < 2) {
       return false;
@@ -146,20 +146,20 @@ export default class StacktraceContent extends React.Component<Props, State> {
 
     let lastFrameIdx: number | null = null;
 
-    data.frames.forEach((frame, frameIdx) => {
+    (data.frames ?? []).forEach((frame, frameIdx) => {
       if (frame.inApp) {
         lastFrameIdx = frameIdx;
       }
     });
 
     if (lastFrameIdx === null) {
-      lastFrameIdx = data.frames.length - 1;
+      lastFrameIdx = (data.frames ?? []).length - 1;
     }
 
     const frames: React.ReactElement[] = [];
     let nRepeats = 0;
 
-    const maxLengthOfAllRelativeAddresses = data.frames.reduce(
+    const maxLengthOfAllRelativeAddresses = (data.frames ?? []).reduce(
       (maxLengthUntilThisPoint, frame) => {
         const correspondingImage = this.findImageForAddress(
           frame.instructionAddr,
@@ -184,9 +184,9 @@ export default class StacktraceContent extends React.Component<Props, State> {
 
     const isFrameAfterLastNonApp = this.isFrameAfterLastNonApp();
 
-    data.frames.forEach((frame, frameIdx) => {
-      const prevFrame = data.frames[frameIdx - 1];
-      const nextFrame = data.frames[frameIdx + 1];
+    (data.frames ?? []).forEach((frame, frameIdx) => {
+      const prevFrame = (data.frames ?? [])[frameIdx - 1];
+      const nextFrame = (data.frames ?? [])[frameIdx + 1];
       const repeatedFrame =
         nextFrame &&
         frame.lineNo === nextFrame.lineNo &&
@@ -209,7 +209,7 @@ export default class StacktraceContent extends React.Component<Props, State> {
             data={frame}
             isExpanded={expandFirstFrame && lastFrameIdx === frameIdx}
             emptySourceNotation={lastFrameIdx === frameIdx && frameIdx === 0}
-            isOnlyFrame={data.frames.length === 1}
+            isOnlyFrame={(data.frames ?? []).length === 1}
             nextFrame={nextFrame}
             prevFrame={prevFrame}
             platform={platform}
@@ -254,7 +254,7 @@ export default class StacktraceContent extends React.Component<Props, State> {
     return (
       <Wrapper className={className}>
         <StyledPlatformIcon
-          platform={stackTracePlatformIcon(platform, data.frames)}
+          platform={stackTracePlatformIcon(platform, data.frames ?? [])}
           size="20px"
           style={{borderRadius: '3px 0 0 3px'}}
         />

--- a/src/sentry/static/sentry/app/components/stacktracePreview.tsx
+++ b/src/sentry/static/sentry/app/components/stacktracePreview.tsx
@@ -139,7 +139,7 @@ class StacktracePreview extends React.Component<Props, State> {
           <StacktraceContent
             data={stacktrace}
             expandFirstFrame={false}
-            includeSystemFrames={stacktrace.frames.every(frame => !frame.inApp)}
+            includeSystemFrames={(stacktrace.frames ?? []).every(frame => !frame.inApp)}
             platform={(event.platform ?? 'other') as PlatformType}
             newestFirst={isStacktraceNewestFirst()}
             event={event}

--- a/src/sentry/static/sentry/app/types/event.tsx
+++ b/src/sentry/static/sentry/app/types/event.tsx
@@ -1,6 +1,5 @@
 import {DebugImage} from 'app/components/events/interfaces/debugMeta/types';
 import {TraceContextType} from 'app/components/events/interfaces/spans/types';
-import {PlatformKey} from 'app/data/platformCategories';
 
 import {Breadcrumb} from './breadcrumbs';
 import {Thread} from './events';
@@ -10,6 +9,7 @@ import {
   EventMetadata,
   ExceptionType,
   Frame,
+  PlatformType,
   Release,
   SDKUpdatesSuggestion,
 } from '.';
@@ -44,14 +44,14 @@ type EntryBreadcrumbs = {
   };
 };
 
-type EntryThreads = {
+export type EntryThreads = {
   type: EntryType.THREADS;
   data: {
     values?: Array<Thread>;
   };
 };
 
-type EntryException = {
+export type EntryException = {
   type: EntryType.EXCEPTION;
   data: ExceptionType;
 };
@@ -195,7 +195,7 @@ type EventBase = {
   context?: Record<string, any>;
   device?: Record<string, any>;
   packages?: Record<string, string>;
-  platform?: PlatformKey;
+  platform?: PlatformType;
   dateReceived?: string;
   endTimestamp?: number;
   userReport?: any;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1902,7 +1902,7 @@ export type ExceptionValue = {
   rawStacktrace: RawStacktrace;
   mechanism: Mechanism | null;
   module: string | null;
-  frames: Frame[];
+  frames?: Frame[];
 };
 
 export type ExceptionType = {

--- a/src/sentry/static/sentry/app/types/stacktrace.tsx
+++ b/src/sentry/static/sentry/app/types/stacktrace.tsx
@@ -12,7 +12,7 @@ export enum STACK_TYPE {
 }
 
 export type StacktraceType = {
-  frames: Array<Frame>;
+  frames?: Array<Frame>;
   hasSystemFrames: boolean;
   registers: Record<string, any> | null;
   framesOmitted: any;

--- a/src/sentry/static/sentry/app/types/stacktrace.tsx
+++ b/src/sentry/static/sentry/app/types/stacktrace.tsx
@@ -12,10 +12,10 @@ export enum STACK_TYPE {
 }
 
 export type StacktraceType = {
-  frames?: Array<Frame>;
   hasSystemFrames: boolean;
   registers: Record<string, any> | null;
   framesOmitted: any;
+  frames?: Array<Frame>;
 };
 
 export type RawStacktrace = StacktraceType | null;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
@@ -15,7 +15,7 @@ import IgnoreActions from 'app/components/actions/ignore';
 import ResolveActions from 'app/components/actions/resolve';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
 import Tooltip from 'app/components/tooltip';
-import {IconRefresh, IconStar} from 'app/icons';
+import {IconStar} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {
@@ -25,6 +25,7 @@ import {
   SavedQueryVersions,
   UpdateResolutionStatus,
 } from 'app/types';
+import {Event} from 'app/types/event';
 import EventView from 'app/utils/discover/eventView';
 import {uniqueId} from 'app/utils/guid';
 import withApi from 'app/utils/withApi';
@@ -34,6 +35,7 @@ import ShareIssue from 'app/views/organizationGroupDetails/actions/shareIssue';
 import ReprocessingDialogForm from 'app/views/organizationGroupDetails/reprocessingDialogForm';
 
 import DeleteAction from './deleteAction';
+import ReprocessAction from './reprocessAction';
 import SubscribeAction from './subscribeAction';
 
 type Props = {
@@ -42,6 +44,7 @@ type Props = {
   project: Project;
   organization: Organization;
   disabled: boolean;
+  event?: Event;
 };
 
 type State = {
@@ -218,7 +221,7 @@ class Actions extends React.Component<Props, State> {
   }
 
   render() {
-    const {group, project, organization, disabled} = this.props;
+    const {group, project, organization, disabled, event} = this.props;
     const {status, isBookmarked} = group;
 
     const orgFeatures = new Set(organization.features);
@@ -298,11 +301,9 @@ class Actions extends React.Component<Props, State> {
         />
 
         {orgFeatures.has('reprocessing-v2') && (
-          <ActionButton
+          <ReprocessAction
+            event={event}
             disabled={disabled}
-            icon={<IconRefresh size="xs" />}
-            title={t('Reprocess this issue')}
-            label={t('Reprocess this issue')}
             onClick={this.handleClick(disabled, this.onReprocess)}
           />
         )}

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/reprocessAction/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/reprocessAction/index.tsx
@@ -5,7 +5,7 @@ import {IconRefresh} from 'app/icons/iconRefresh';
 import {t} from 'app/locale';
 import {EntryException, EntryType, Event} from 'app/types/event';
 
-import {isNativeEvent} from './utils';
+import {isAppleCrashReportEvent, isMinidumpEvent, isNativeEvent} from './utils';
 
 type Props = {
   disabled: boolean;
@@ -27,7 +27,13 @@ function ReprocessAction({event, disabled, onClick}: Props) {
     return null;
   }
 
-  isNativeEvent(event, exceptionEntry);
+  if (
+    !isMinidumpEvent(exceptionEntry) &&
+    !isAppleCrashReportEvent(exceptionEntry) &&
+    !isNativeEvent(event, exceptionEntry)
+  ) {
+    return null;
+  }
 
   return (
     <ActionButton

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/reprocessAction/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/reprocessAction/index.tsx
@@ -27,6 +27,12 @@ function ReprocessAction({event, disabled, onClick}: Props) {
     return null;
   }
 
+  // We want to show the reprocessing button if the issue in question is native or contains native frames.
+  // The logic is taken from the symbolication pipeline in Python, where it is used to determine whether reprocessing
+  // payloads should be stored:
+  // https://github.com/getsentry/sentry/blob/cb7baef414890336881d67b7a8433ee47198c701/src/sentry/lang/native/processing.py#L425-L426
+  // It is still not ideal as one can always merge native and non-native events together into one issue,
+  // but it's the best approximation we have.
   if (
     !isMinidumpEvent(exceptionEntry) &&
     !isAppleCrashReportEvent(exceptionEntry) &&

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/reprocessAction/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/reprocessAction/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+import ActionButton from 'app/components/actions/button';
+import {IconRefresh} from 'app/icons/iconRefresh';
+import {t} from 'app/locale';
+import {EntryException, EntryType, Event} from 'app/types/event';
+
+import {isNativeEvent} from './utils';
+
+type Props = {
+  disabled: boolean;
+  onClick: (event: React.MouseEvent) => void;
+  event?: Event;
+};
+
+function ReprocessAction({event, disabled, onClick}: Props) {
+  if (!event) {
+    return null;
+  }
+
+  const {entries} = event;
+  const exceptionEntry = entries.find(entry => entry.type === EntryType.EXCEPTION) as
+    | EntryException
+    | undefined;
+
+  if (!exceptionEntry) {
+    return null;
+  }
+
+  isNativeEvent(event, exceptionEntry);
+
+  return (
+    <ActionButton
+      disabled={disabled}
+      icon={<IconRefresh size="xs" />}
+      title={t('Reprocess this issue')}
+      label={t('Reprocess this issue')}
+      onClick={onClick}
+    />
+  );
+}
+
+export default ReprocessAction;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/reprocessAction/utils.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/reprocessAction/utils.tsx
@@ -26,22 +26,23 @@ function getStackTracePlatforms(event: Event, exceptionEntry: EntryException) {
   );
 
   // Fetch platforms in an exception entry
-  const stackTraceEntry = event.entries.find(entry => entry.type === EntryType.STACKTRACE)
-    ?.data as StacktraceType;
+  const stackTraceEntry = (event.entries.find(
+    entry => entry.type === EntryType.STACKTRACE
+  )?.data ?? {}) as StacktraceType;
 
   // Fetch platforms in an exception entry
-  const stackTraceEntryPlatforms = Object.keys(stackTraceEntry ?? {}).flatMap(key =>
+  const stackTraceEntryPlatforms = Object.keys(stackTraceEntry).flatMap(key =>
     getPlatforms(stackTraceEntry[key])
   );
 
   // Fetch platforms in an thread entry
-  const threadEntry = event.entries.find(entry => entry.type === EntryType.THREADS)?.data
-    .values;
+  const threadEntry = (event.entries.find(entry => entry.type === EntryType.THREADS)?.data
+    .values ?? []) as Array<Thread>;
 
   // Fetch platforms in a thread entry
-  const threadEntryPlatforms = ((threadEntry ?? []) as Array<
-    Thread
-  >).flatMap(({stacktrace}) => getPlatforms(stacktrace));
+  const threadEntryPlatforms = threadEntry.flatMap(({stacktrace}) =>
+    getPlatforms(stacktrace)
+  );
 
   return new Set([
     ...exceptionEntryPlatforms,

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/reprocessAction/utils.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/reprocessAction/utils.tsx
@@ -1,0 +1,87 @@
+import {ExceptionValue, PlatformType} from 'app/types';
+import {EntryException, EntryType, Event} from 'app/types/event';
+import {Thread} from 'app/types/events';
+import {StacktraceType} from 'app/types/stacktrace';
+
+// Finds all stracktraces in a given data blob and returns it
+// together with some meta information.
+// Raw stacktraces are not included and stacktraces of the exception are not always included.
+export function getPlatforms(exceptionValue: ExceptionValue | StacktraceType) {
+  const frames = exceptionValue.frames ?? [];
+  const stacktraceFrames = (exceptionValue as ExceptionValue)?.stacktrace?.frames ?? [];
+
+  if (!frames.length && !stacktraceFrames.length) {
+    return [];
+  }
+
+  return [...frames, ...stacktraceFrames]
+    .map(frame => frame.platform)
+    .filter(platform => !!platform) as Array<PlatformType>;
+}
+
+//     if not is_exception and (not stacktrace or not get_path(stacktrace, "frames", filter=True)):
+//     return
+// platforms = set(
+//     frame.get("platform") or data.get("platform")
+//     for frame in get_path(stacktrace, "frames", filter=True, default=())
+// )
+// rv.append(
+//     StacktraceInfo(
+//         stacktrace=stacktrace,
+//         container=container,
+//         platforms=platforms,
+//         is_exception=is_exception,
+//     )
+// )
+
+// Checks whether an event indicates that it has an apple crash report.
+export function isNativeEvent(event: Event, exceptionEntry: EntryException) {
+  const {platform} = event;
+
+  // if (platform === 'cocoa' || platform === 'native') {
+  //   return true;
+  // }
+
+  // Fetch platforms in stack traces of an exception entry
+  const exceptionEntryStackTraces = (exceptionEntry.data.values ?? []).map(value => {
+    const platforms: Array<PlatformType> = getPlatforms(value) ?? [event.platform];
+    return {...value, platforms};
+  });
+
+  // Fetch platforms in an exception entry
+  const stackTraceEntry = event.entries.find(entry => entry.type === EntryType.STACKTRACE)
+    ?.data as StacktraceType;
+
+  // Fetch platforms in an exception entry
+  const stackTraceEntryStackTraces = Object.keys(stackTraceEntry ?? {}).map(key => {
+    const stacktrace = stackTraceEntry[key];
+    const platforms: Array<PlatformType> = getPlatforms(stacktrace) ?? [event.platform];
+    return {...stacktrace, platforms};
+  });
+
+  // Fetch platforms in an thread entry
+  const threadEntry = event.entries.find(entry => entry.type === EntryType.THREADS)?.data
+    .values;
+
+  // Fetch platforms in a thread entry
+  const threadEntryStackTraces = ((threadEntry ?? []) as Array<Thread>).map(
+    ({stacktrace}) => {
+      const platforms: Array<PlatformType> = getPlatforms(stacktrace) ?? [event.platform];
+      return {...stacktrace, platforms};
+    }
+  );
+
+  return true;
+}
+
+//  Checks whether an event indicates that it has an associated minidump.
+export function isMinidumpEvent(exceptionEntry: EntryException) {
+  const {data} = exceptionEntry;
+  return (data.values ?? []).some(value => value.mechanism?.type === 'minidump');
+}
+
+// Checks whether an event indicates that it has an apple crash report.
+export function isAppleCrashReportEvent(exceptionEntry: EntryException) {
+  const {data} = exceptionEntry;
+  return (data.values ?? []).some(value => value.mechanism?.type === 'applecrashreport');
+}

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -397,6 +397,7 @@ class GroupDetails extends React.Component<Props, State> {
       <React.Fragment>
         <GroupHeader
           project={project as Project}
+          event={event}
           group={group}
           currentTab={currentTab}
           baseUrl={baseUrl}

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
@@ -27,6 +27,7 @@ import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
 import {Group, Project} from 'app/types';
+import {Event} from 'app/types/event';
 import {getMessage} from 'app/utils/events';
 import withApi from 'app/utils/withApi';
 
@@ -51,6 +52,7 @@ type Props = {
   group: Group;
   project: Project;
   api: Client;
+  event?: Event;
 };
 
 type MemberList = NonNullable<
@@ -81,7 +83,7 @@ class GroupHeader extends React.Component<Props, State> {
   }
 
   render() {
-    const {project, group, currentTab, baseUrl} = this.props;
+    const {project, group, currentTab, baseUrl, event} = this.props;
     const {organization, location} = this.context;
     const projectFeatures = new Set(project ? project.features : []);
     const organizationFeatures = new Set(organization ? organization.features : []);
@@ -240,6 +242,7 @@ class GroupHeader extends React.Component<Props, State> {
           group={group}
           project={project}
           disabled={isGroupBeingReprocessing}
+          event={event}
         />
         <NavTabs>
           <ListLink


### PR DESCRIPTION
We want to show the reprocessing button if the issue in question is native or contains native frames. The logic is taken from the symbolication pipeline in Python, where it is used to determine whether reprocessing payloads should be stored: https://github.com/getsentry/sentry/blob/cb7baef414890336881d67b7a8433ee47198c701/src/sentry/lang/native/processing.py#L425-L426

It is still not ideal as one can always merge native and non-native events together into one issue, but it's the best approximation we have.