### PR TITLE
ref(slack): Remove slack-v2 creds and usage

### DIFF
--- a/src/sentry/identity/slack/provider.py
+++ b/src/sentry/identity/slack/provider.py
@@ -26,10 +26,10 @@ class SlackIdentityProvider(OAuth2Provider):
         return "https://slack.com/api/oauth.v2.access"
 
     def get_oauth_client_id(self):
-        return options.get("slack-v2.client-id") or options.get("slack.client-id")
+        return options.get("slack.client-id")
 
     def get_oauth_client_secret(self):
-        return options.get("slack-v2.client-secret") or options.get("slack.client-secret")
+        return options.get("slack.client-secret")
 
     def get_user_scopes(self):
         return self.config.get("user_scopes", self.user_scopes)

--- a/src/sentry/integrations/slack/requests.py
+++ b/src/sentry/integrations/slack/requests.py
@@ -93,19 +93,18 @@ class SlackRequest:
             raise SlackRequestError(status=400)
 
     def _authorize(self):
-        # check v1 then v2
+        # XXX(meredith): Signing secrets are the prefered way
+        # but self-hosted could still have an older slack bot
+        # app that just has the verification token.
         signing_secret = options.get("slack.signing-secret")
         verification_token = options.get("slack.verification-token")
-        # for v1, only check the verification_token if we don't have a signing_secret
+
         if signing_secret:
             if self._check_signing_secret(signing_secret):
                 return
         elif verification_token and self._check_verification_token(verification_token):
             return
-        # for v2, only check signing secret
-        signing_secret = options.get("slack-v2.signing-secret")
-        if signing_secret and self._check_signing_secret(signing_secret):
-            return
+
         # unfortunately, we can't know which auth was supposed to succeed
         self._error("slack.action.auth")
         raise SlackRequestError(status=401)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -119,14 +119,9 @@ register("cloudflare.secret-key", default="")
 # Slack Integration
 register("slack.client-id", flags=FLAG_PRIORITIZE_DISK)
 register("slack.client-secret", flags=FLAG_PRIORITIZE_DISK)
+# signing-secret is preferred, but need to keep verification-token for apps that use it
 register("slack.verification-token", flags=FLAG_PRIORITIZE_DISK)
 register("slack.signing-secret", flags=FLAG_PRIORITIZE_DISK)
-register("slack.legacy-app", flags=FLAG_PRIORITIZE_DISK, type=Bool, default=True)
-
-# Slack V2 Integration
-register("slack-v2.client-id", flags=FLAG_PRIORITIZE_DISK)
-register("slack-v2.client-secret", flags=FLAG_PRIORITIZE_DISK)
-register("slack-v2.signing-secret", flags=FLAG_PRIORITIZE_DISK)
 
 # GitHub Integration
 register("github-app.id", default=0)

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -116,7 +116,7 @@ def pytest_configure(config):
             "slack.client-id": "slack-client-id",
             "slack.client-secret": "slack-client-secret",
             "slack.verification-token": "slack-verification-token",
-            "slack.legacy-app": True,
+            "slack.signing-secret": "slack-signing-secret",
             "github-app.name": "sentry-test-app",
             "github-app.client-id": "github-client-id",
             "github-app.client-secret": "github-client-secret",

--- a/tests/sentry/integrations/slack/test_action_endpoint.py
+++ b/tests/sentry/integrations/slack/test_action_endpoint.py
@@ -4,7 +4,6 @@ from urllib.parse import parse_qs
 from sentry.utils.compat.mock import patch
 
 from sentry.api import client
-from sentry import options
 from sentry.models import (
     Integration,
     OrganizationIntegration,
@@ -64,14 +63,11 @@ class BaseEventTest(APITestCase):
         action_data=None,
         type="event_callback",
         data=None,
-        token=None,
         team_id="TXXXXXXX1",
         callback_id=None,
         slack_user=None,
         original_message=None,
     ):
-        if token is None:
-            token = options.get("slack.signing-secret")
 
         if slack_user is None:
             slack_user = {"id": self.identity.external_id, "domain": "example"}
@@ -83,7 +79,6 @@ class BaseEventTest(APITestCase):
             original_message = {}
 
         payload = {
-            "token": token,
             "team": {"id": team_id, "domain": "example.com"},
             "channel": {"id": "C065W1189", "domain": "forgotten-works"},
             "user": slack_user,
@@ -422,7 +417,6 @@ class StatusActionTest(BaseEventTest):
     )
     def test_sentry_docs_link_clicked(self, check_signing_secret_mock):
         payload = {
-            "token": options.get("slack.verification-token"),
             "team": {"id": "TXXXXXXX1", "domain": "example.com"},
             "user": {"id": self.identity.external_id, "domain": "example"},
             "type": "block_actions",

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -13,7 +13,6 @@ from sentry.models import (
     OrganizationIntegration,
 )
 from sentry.testutils import IntegrationTestCase, TestCase
-from sentry.testutils.helpers import override_options
 
 
 class SlackIntegrationTest(IntegrationTestCase):
@@ -148,16 +147,6 @@ class SlackIntegrationTest(IntegrationTestCase):
         self.assert_setup_flow(authorizing_user_id="UXXXXXXX2")
         identity = Identity.objects.get()
         assert identity.external_id == "UXXXXXXX2"
-
-    @responses.activate
-    def test_install_v2(self):
-        with override_options(
-            {"slack-v2.client-id": "other-id", "slack-v2.client-secret": "other-secret"}
-        ):
-            self.assert_setup_flow(
-                expected_client_id="other-id",
-                expected_client_secret="other-secret",
-            )
 
 
 class SlackIntegrationConfigTest(TestCase):

--- a/tests/sentry/integrations/slack/test_requests.py
+++ b/tests/sentry/integrations/slack/test_requests.py
@@ -163,16 +163,6 @@ class SlackEventRequestTest(TestCase):
             self.set_signature(options.get("slack.signing-secret"), self.request.body)
             self.slack_request.validate()
 
-    def test_signing_secret_v2(self):
-        with override_options({"slack-v2.signing-secret": "secret-v2"}):
-            self.request.data = {"challenge": "abc123", "type": "url_verification"}
-
-            # we get a url encoded body with Slack
-            self.request.body = urlencode(self.request.data).encode("utf-8")
-
-            self.set_signature(options.get("slack-v2.signing-secret"), self.request.body)
-            self.slack_request.validate()
-
     def test_signing_secret_bad(self):
         with override_options({"slack.signing-secret": "secret"}):
             # even though we provide the token, should still fail


### PR DESCRIPTION
Once https://github.com/getsentry/sentry/pull/23545 is merged and deployed, we will have removed basically all the functionality for slack workspace apps. The last piece is the app itself, and it's credentials. 

**IMPORTANT**: This PR should only be merged **AFTER** we have updated our slack-v2 credentials to replace our slack credentials. 

We started out with one slack app, our now deprecated workspace app. The credentials for this app are:
```python
"slack.client-id"
"slack.client-secret"
"slack.verification-token"
# added later when we introduced support for signing secrets
"slack.signing-secret"
```

We then introduced a new Slack integration, the bot app. The credentials for that app are:
```python
"slack-v2.client-id"
"slack-v2.client-secret"
"slack.signing-secret"
```

Now there is actually a third type of app which is a older bot app, this kind of bot app may still be used by self hosted sentry users, and may be using the `slack.verification-token` instead of the signing secret (though they should probably update their app to use the secret). But anyway this is the reason we need to keep that option, although sentry SaaS will not need it. 

mini clean up: we don't use the option `slack.legacy-app` anymore, so getting rid of it


Side Note: I'm mocking out the signing secret check in the endpoint tests because I couldn't get the payloads to match for some reason,I want to come back to this, but it isn't any worse that what it was before because these tests used the verification token which we don't use anymore

