### PR TITLE
fix(integrations): Add `defaultOptions` to the `SelectControl`

### DIFF
--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -198,13 +198,13 @@ export default class AbstractExternalIssueForm<
   getFieldProps = (field: IssueConfigField) =>
     field.url
       ? {
-          loadOptions: (input: string) => this.getOptions(field, input),
           async: true,
-          cache: false,
-          onSelectResetsInput: false,
-          onCloseResetsInput: false,
-          onBlurResetsInput: false,
           autoload: true,
+          cache: false,
+          loadOptions: (input: string) => this.getOptions(field, input),
+          onBlurResetsInput: false,
+          onCloseResetsInput: false,
+          onSelectResetsInput: false,
         }
       : {};
 

--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -151,10 +151,7 @@ export default class AbstractExternalIssueForm<
   getOptions = (field: IssueConfigField, input: string) =>
     new Promise((resolve, reject) => {
       if (!input) {
-        const choices =
-          (field.choices as Array<[number | string, number | string]>) || [];
-        const options = choices.map(([value, label]) => ({value, label}));
-        return resolve(options);
+        return resolve(this.getDefaultOptions(field));
       }
       return this.debouncedOptionLoad(field, input, (err, result) => {
         if (err) {
@@ -194,6 +191,11 @@ export default class AbstractExternalIssueForm<
     {trailing: true}
   );
 
+  getDefaultOptions = (field: IssueConfigField) => {
+    const choices = (field.choices as Array<[number | string, number | string]>) || [];
+    return choices.map(([value, label]) => ({value, label}));
+  };
+
   /** If this field is an async select (field.url is not null), add async props. */
   getFieldProps = (field: IssueConfigField) =>
     field.url
@@ -202,6 +204,7 @@ export default class AbstractExternalIssueForm<
           autoload: true,
           cache: false,
           loadOptions: (input: string) => this.getOptions(field, input),
+          defaultOptions: this.getDefaultOptions(field),
           onBlurResetsInput: false,
           onCloseResetsInput: false,
           onSelectResetsInput: false,

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -286,6 +286,7 @@ const SelectControl = props => {
       value={mappedValue}
       isMulti={props.multiple || props.multi}
       isDisabled={props.isDisabled || props.disabled}
+      defaultOptions={choicesOrOptions}
       options={choicesOrOptions}
       openMenuOnFocus={props.openMenuOnFocus === undefined ? true : props.openMenuOnFocus}
       {...rest}

--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -286,7 +286,6 @@ const SelectControl = props => {
       value={mappedValue}
       isMulti={props.multiple || props.multi}
       isDisabled={props.isDisabled || props.disabled}
-      defaultOptions={choicesOrOptions}
       options={choicesOrOptions}
       openMenuOnFocus={props.openMenuOnFocus === undefined ? true : props.openMenuOnFocus}
       {...rest}


### PR DESCRIPTION
Fixes [API-1638](https://getsentry.atlassian.net/browse/API-1638).

When an Async Select has both `url` and `choices` props, we need to set `defaultOptions` or else it won't show options until the user adds input.

Before:
![image (2)](https://user-images.githubusercontent.com/31750075/106795836-73e71a00-660f-11eb-89c9-93231742f1f2.png)

After:
<img width="618" alt="Screen Shot 2021-02-03 at 10 57 59 AM" src="https://user-images.githubusercontent.com/31750075/106795865-7d708200-660f-11eb-85b7-52d42693d808.png">

