### PR TITLE
feat(inbox): Implement faster version of inbox sort

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -1,13 +1,17 @@
 import functools
 import six
+from datetime import datetime, timedelta
+from typing import List, Mapping, Optional, Sequence
 
 from django.conf import settings
-
+from django.utils import timezone
 from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.response import Response
 
 from sentry import features
 from sentry.api.bases import OrganizationEventsEndpointBase, OrganizationEventPermission
+from sentry.constants import ALLOWED_FUTURE_DELTA
+from sentry.api.event_search import SearchFilter
 from sentry.api.helpers.group_index import (
     build_query_params_from_request,
     calculate_stats_period,
@@ -17,20 +21,118 @@ from sentry.api.helpers.group_index import (
     update_groups,
     ValidationError,
 )
+from sentry.api.paginator import DateTimePaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import get_date_range_from_params, InvalidParams
-from sentry.models import Group, GroupStatus
-from sentry.search.snuba.backend import EventsDatasetSnubaSearchBackend
+from sentry.models import Environment, Group, GroupEnvironment, GroupInbox, GroupStatus, Project
+from sentry.search.snuba.backend import (
+    assigned_or_suggested_filter,
+    EventsDatasetSnubaSearchBackend,
+)
+from sentry.search.snuba.executors import (
+    get_search_filter,
+    InvalidSearchQuery,
+    PostgresSnubaQueryExecutor,
+)
 from sentry.snuba import discover
-from sentry.utils.validators import normalize_event_id
 from sentry.utils.compat import map
+from sentry.utils.cursors import Cursor, CursorResult
+
+from sentry.utils.validators import normalize_event_id
 
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
 
 
 search = EventsDatasetSnubaSearchBackend(**settings.SENTRY_SEARCH_OPTIONS)
+
+
+allowed_inbox_search_terms = frozenset(["date", "status", "for_review", "assigned_or_suggested"])
+
+
+def inbox_search(
+    projects: Sequence[Project],
+    environments: Optional[Sequence[Environment]] = None,
+    limit: int = 100,
+    cursor: Optional[Cursor] = None,
+    count_hits: bool = False,
+    search_filters: Optional[Sequence[SearchFilter]] = None,
+    date_from: Optional[datetime] = None,
+    date_to: Optional[datetime] = None,
+    max_hits: Optional[int] = None,
+) -> CursorResult:
+    now: datetime = timezone.now()
+    end: Optional[datetime] = None
+    end_params: List[datetime] = [
+        _f for _f in [date_to, get_search_filter(search_filters, "date", "<")] if _f
+    ]
+    if end_params:
+        end = min(end_params)
+
+    end = end if end else now + ALLOWED_FUTURE_DELTA
+
+    # We only want to search back a week at most, since that's the oldest inbox rows
+    # can be.
+    earliest_date = now - timedelta(days=7)
+    start_params = [date_from, earliest_date, get_search_filter(search_filters, "date", ">")]
+    start = max([_f for _f in start_params if _f])
+    end = max([earliest_date, end])
+
+    if start >= end:
+        return PostgresSnubaQueryExecutor.empty_result
+
+    # Make sure search terms are valid
+    invalid_search_terms = [
+        str(sf) for sf in search_filters if sf.key.name not in allowed_inbox_search_terms
+    ]
+    if invalid_search_terms:
+        raise InvalidSearchQuery(f"Invalid search terms for 'inbox' search: {invalid_search_terms}")
+
+    # Make sure this is an inbox search
+    if not get_search_filter(search_filters, "for_review", "="):
+        raise InvalidSearchQuery("Sort key 'inbox' only supported for inbox search")
+
+    if get_search_filter(search_filters, "status", "=") != GroupStatus.UNRESOLVED:
+        raise InvalidSearchQuery("Inbox search only works for 'unresolved' status")
+
+    # We just filter on `GroupInbox.date_added` here, and don't filter by date
+    # on the group. This keeps the query simpler and faster in some edge cases,
+    # and date_added is a good enough proxy when we're using this sort.
+    qs = GroupInbox.objects.filter(
+        date_added__gte=start,
+        date_added__lte=end,
+        project__in=projects,
+    )
+
+    if environments is not None:
+        environment_ids: List[int] = [environment.id for environment in environments]
+        qs = qs.filter(
+            group_id__in=GroupEnvironment.objects.filter(environment_id__in=environment_ids)
+            .values_list("group_id", flat=True)
+            .distinct()
+        )
+
+    owner_search = get_search_filter(search_filters, "owner", "=")
+    if owner_search:
+        qs = qs.filter(
+            assigned_or_suggested_filter(owner_search, projects, field_filter="group_id")
+        )
+
+    paginator = DateTimePaginator(qs.order_by("date_added"), "-date_added")
+    results = paginator.get_result(limit, cursor, count_hits=count_hits, max_hits=max_hits)
+
+    # We want to return groups from the endpoint, but have the cursor be related to the
+    # GroupInbox rows. So we paginate on the GroupInbox results queryset, then fetch
+    # the group_ids out and use them to get the actual groups.
+    group_qs = Group.objects.filter(
+        id__in=[r.group_id for r in results.results],
+        project__in=projects,
+        status=GroupStatus.UNRESOLVED,
+    )
+    groups: Mapping[int, Group] = {g.id: g for g in group_qs}
+    results.results = [groups[r.group_id] for r in results.results if r.group_id in groups]
+    return results
 
 
 class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
@@ -57,7 +159,11 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
             query_kwargs.update(extra_query_kwargs)
 
         query_kwargs["environments"] = environments if environments else None
-        result = search.query(**query_kwargs)
+        if query_kwargs["sort_by"] == "inbox":
+            query_kwargs.pop("sort_by")
+            result = inbox_search(**query_kwargs)
+        else:
+            result = search.query(**query_kwargs)
         return result, query_kwargs
 
     @rate_limit_endpoint(limit=10, window=1)

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -130,20 +130,22 @@ def inbox_filter(inbox, projects):
     return query
 
 
-def assigned_or_suggested_filter(owner, projects):
+def assigned_or_suggested_filter(owner, projects, field_filter="id"):
     organization_id = projects[0].organization_id
     project_ids = [p.id for p in projects]
     if isinstance(owner, Team):
         return (
             Q(
-                id__in=GroupOwner.objects.filter(
-                    Q(group__assignee_set__isnull=True),
-                    team=owner,
-                    project_id__in=project_ids,
-                    organization_id=organization_id,
-                )
-                .values_list("group_id", flat=True)
-                .distinct()
+                **{
+                    f"{field_filter}__in": GroupOwner.objects.filter(
+                        Q(group__assignee_set__isnull=True),
+                        team=owner,
+                        project_id__in=project_ids,
+                        organization_id=organization_id,
+                    )
+                    .values_list("group_id", flat=True)
+                    .distinct()
+                }
             )
             | assigned_to_filter(owner, projects)
         )
@@ -162,14 +164,16 @@ def assigned_or_suggested_filter(owner, projects):
             ).values("team")
         )
         owned_by_me = Q(
-            id__in=GroupOwner.objects.filter(
-                Q(user_id=owner.id) | Q(team__in=teams),
-                Q(group__assignee_set__isnull=True),
-                project_id__in=[p.id for p in projects],
-                organization_id=organization_id,
-            )
-            .values_list("group_id", flat=True)
-            .distinct()
+            **{
+                f"{field_filter}__in": GroupOwner.objects.filter(
+                    Q(user_id=owner.id) | Q(team__in=teams),
+                    Q(group__assignee_set__isnull=True),
+                    project_id__in=[p.id for p in projects],
+                    organization_id=organization_id,
+                )
+                .values_list("group_id", flat=True)
+                .distinct()
+            }
         )
 
         owner_query = owned_by_me | assigned_to_filter(owner, projects)


### PR DESCRIPTION
This is a bit of a hack. When we see that the user wants to make an inbox sort, we direct to a
separate codepath that is built specifically to handle a limited inbox search + sort. This allows us
to avoid the join to group, which makes the query a bit faster and more scalable.

We can do this because groups are only ever in inbox when they're unresolved. So we don't actually
need to join to group to make sure we have valid rows. We do just filter out resolved groups at the
end, just in case, but likely this will not have any effect unless the status happens to change part
way through the query.

We also do some hacking of the paginator. We have to paginate on the `GroupInbox` rows so that the
cursor is built to use the `date_added` field. But we want to return the groups instead. So we pass
the `GroupInbox` rows to the paginator, but replace the results with the actual `Group` instances
afterwards.