### PR TITLE
chore: Refactor Dashboardsv2 Drag and Drop implementation to use dndkit

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -335,7 +335,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
               )
             }
             isDragging={false}
-            startWidgetDrag={() => undefined}
+            currentWidgetDragging={false}
           />
         </Body>
         <Footer>

--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -334,7 +334,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
                 <PanelAlert type="error">{errorMessage}</PanelAlert>
               )
             }
-            isDragging={false}
+            isSorting={false}
             currentWidgetDragging={false}
           />
         </Body>

--- a/src/sentry/static/sentry/app/views/dashboardsV2/addWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/addWidget.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {IconAdd} from 'app/icons';
 
-import {WidgetWrapper} from './styles';
+import WidgetWrapper from './widgetWrapper';
 
 export const ADD_WIDGET_BUTTON_DRAG_ID = 'add-widget-button';
 

--- a/src/sentry/static/sentry/app/views/dashboardsV2/addWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/addWidget.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import {useSortable} from '@dnd-kit/sortable';
+import styled from '@emotion/styled';
+
+import {IconAdd} from 'app/icons';
+
+import {WidgetWrapper} from './styles';
+
+export const ADD_WIDGET_BUTTON_DRAG_ID = 'add-widget-button';
+
+function AddWidget(props: {onClick: () => void}) {
+  const {onClick} = props;
+
+  const initialStyles = {
+    x: 0,
+    y: 0,
+    scaleX: 1,
+    scaleY: 1,
+  };
+
+  const {setNodeRef, transform} = useSortable({
+    disabled: true,
+    id: ADD_WIDGET_BUTTON_DRAG_ID,
+    transition: null,
+  });
+
+  return (
+    <WidgetWrapper
+      key="add"
+      ref={setNodeRef}
+      displayType="big_number"
+      layoutId={ADD_WIDGET_BUTTON_DRAG_ID}
+      style={{originX: 0, originY: 0}}
+      animate={
+        transform
+          ? {
+              x: transform.x,
+              y: transform.y,
+              scaleX: transform?.scaleX && transform.scaleX <= 1 ? transform.scaleX : 1,
+              scaleY: transform?.scaleY && transform.scaleY <= 1 ? transform.scaleY : 1,
+            }
+          : initialStyles
+      }
+      transition={{
+        duration: 0.25,
+      }}
+    >
+      <AddWidgetWrapper key="add" data-test-id="widget-add" onClick={onClick}>
+        <IconAdd size="lg" isCircled color="inactive" />
+      </AddWidgetWrapper>
+    </WidgetWrapper>
+  );
+}
+
+const AddWidgetWrapper = styled('a')`
+  width: 100%;
+  height: 110px;
+  border: 2px dashed ${p => p.theme.border};
+  border-radius: ${p => p.theme.borderRadius};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export default AddWidget;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/addWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/addWidget.tsx
@@ -8,15 +8,15 @@ import WidgetWrapper from './widgetWrapper';
 
 export const ADD_WIDGET_BUTTON_DRAG_ID = 'add-widget-button';
 
+const initialStyles = {
+  x: 0,
+  y: 0,
+  scaleX: 1,
+  scaleY: 1,
+};
+
 function AddWidget(props: {onClick: () => void}) {
   const {onClick} = props;
-
-  const initialStyles = {
-    x: 0,
-    y: 0,
-    scaleX: 1,
-    scaleY: 1,
-  };
 
   const {setNodeRef, transform} = useSortable({
     disabled: true,

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -1,28 +1,21 @@
 import React from 'react';
 import LazyLoad from 'react-lazyload';
 import {DndContext} from '@dnd-kit/core';
-import {
-  arrayMove,
-  rectSwappingStrategy,
-  SortableContext,
-  useSortable,
-} from '@dnd-kit/sortable';
+import {arrayMove, rectSwappingStrategy, SortableContext} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 
 import {openAddDashboardWidgetModal} from 'app/actionCreators/modal';
 import {loadOrganizationTags} from 'app/actionCreators/tags';
 import {Client} from 'app/api';
-import {IconAdd} from 'app/icons';
 import space from 'app/styles/space';
 import {GlobalSelection, Organization} from 'app/types';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 
+import AddWidget, {ADD_WIDGET_BUTTON_DRAG_ID} from './addWidget';
 import SortableWidget from './sortableWidget';
-import {WidgetWrapper} from './styles';
 import {DashboardDetails, Widget} from './types';
 
-const ADD_WIDGET_BUTTON_DRAG_ID = 'add-widget-button';
 type Props = {
   api: Client;
   organization: Organization;
@@ -173,60 +166,6 @@ const WidgetContainer = styled('div')`
     grid-template-columns: 1fr;
   }
 `;
-
-const AddWidgetWrapper = styled('a')`
-  width: 100%;
-  height: 110px;
-  border: 2px dashed ${p => p.theme.border};
-  border-radius: ${p => p.theme.borderRadius};
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
-
-function AddWidget(props: {onClick: () => void}) {
-  const {onClick} = props;
-
-  const initialStyles = {
-    x: 0,
-    y: 0,
-    scaleX: 1,
-    scaleY: 1,
-  };
-
-  const {setNodeRef, transform} = useSortable({
-    disabled: true,
-    id: ADD_WIDGET_BUTTON_DRAG_ID,
-    transition: null,
-  });
-
-  return (
-    <WidgetWrapper
-      key="add"
-      ref={setNodeRef}
-      displayType="big_number"
-      layoutId={ADD_WIDGET_BUTTON_DRAG_ID}
-      style={{originX: 0, originY: 0}}
-      animate={
-        transform
-          ? {
-              x: transform.x,
-              y: transform.y,
-              scaleX: transform?.scaleX && transform.scaleX <= 1 ? transform.scaleX : 1,
-              scaleY: transform?.scaleY && transform.scaleY <= 1 ? transform.scaleY : 1,
-            }
-          : initialStyles
-      }
-      transition={{
-        duration: 0.25,
-      }}
-    >
-      <AddWidgetWrapper key="add" data-test-id="widget-add" onClick={onClick}>
-        <IconAdd size="lg" isCircled color="inactive" />
-      </AddWidgetWrapper>
-    </WidgetWrapper>
-  );
-}
 
 function generateWidgetId(widget: Widget, index: number) {
   return widget.id ?? `index-${index}`;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -2,7 +2,7 @@
 import React, {useEffect} from 'react';
 import LazyLoad from 'react-lazyload';
 import {DndContext} from '@dnd-kit/core';
-import {SortableContext, useSortable} from '@dnd-kit/sortable';
+import {rectSwappingStrategy, SortableContext, useSortable} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
@@ -178,7 +178,7 @@ class Dashboard extends React.Component<Props, State> {
         }}
       >
         <WidgetContainer>
-          <SortableContext items={this.getWidgetIds()}>
+          <SortableContext items={this.getWidgetIds()} strategy={rectSwappingStrategy}>
             {dashboard.widgets.map((widget, index) => this.renderWidget(widget, index))}
             {isEditing && <AddWidget onClick={this.handleStartAdd} />}
           </SortableContext>
@@ -272,6 +272,7 @@ function SortableWidget(props: SortableWidgetProps) {
     scaleX: 1,
     scaleY: 1,
     boxShadow: 'none',
+    zIndex: 0,
   };
 
   return (
@@ -332,6 +333,7 @@ function AddWidget(props: {onClick: () => void}) {
     y: 0,
     scaleX: 1,
     scaleY: 1,
+    zIndex: 0,
   };
 
   const {setNodeRef, transform} = useSortable({

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -125,12 +125,6 @@ class Dashboard extends React.Component<Props> {
     );
   }
 
-  resetDragState() {
-    this.setState({
-      isDragging: false,
-    });
-  }
-
   render() {
     const {
       isEditing,
@@ -154,10 +148,7 @@ class Dashboard extends React.Component<Props> {
               onUpdate(arrayMove(widgets, activeIndex, overIndex));
             }
           }
-
-          this.resetDragState();
         }}
-        onDragCancel={this.resetDragState}
       >
         <WidgetContainer>
           <SortableContext items={items} strategy={rectSwappingStrategy}>

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -147,6 +147,8 @@ class Dashboard extends React.Component<Props, State> {
       dashboard: {widgets},
     } = this.props;
 
+    const items = this.getWidgetIds();
+
     return (
       <DndContext
         onDragStart={({active}) => {
@@ -161,7 +163,6 @@ class Dashboard extends React.Component<Props, State> {
         }}
         onDragEnd={({over}) => {
           const {activeDragId} = this.state;
-          const items = this.getWidgetIds();
           const getIndex = items.indexOf.bind(items);
 
           const activeIndex = activeDragId ? getIndex(activeDragId) : -1;
@@ -181,7 +182,7 @@ class Dashboard extends React.Component<Props, State> {
         onDragCancel={this.resetDragState}
       >
         <WidgetContainer>
-          <SortableContext items={this.getWidgetIds()} strategy={rectSwappingStrategy}>
+          <SortableContext items={items} strategy={rectSwappingStrategy}>
             {widgets.map((widget, index) => this.renderWidget(widget, index))}
             {isEditing && <AddWidget onClick={this.handleStartAdd} />}
           </SortableContext>

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -133,6 +133,13 @@ class Dashboard extends React.Component<Props, State> {
     );
   }
 
+  resetDragState() {
+    this.setState({
+      isDragging: false,
+      activeDragId: undefined,
+    });
+  }
+
   render() {
     const {
       isEditing,
@@ -169,17 +176,9 @@ class Dashboard extends React.Component<Props, State> {
             }
           }
 
-          this.setState({
-            isDragging: false,
-            activeDragId: undefined,
-          });
+          this.resetDragState();
         }}
-        onDragCancel={() => {
-          this.setState({
-            isDragging: false,
-            activeDragId: undefined,
-          });
-        }}
+        onDragCancel={this.resetDragState}
       >
         <WidgetContainer>
           <SortableContext items={this.getWidgetIds()} strategy={rectSwappingStrategy}>

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -205,10 +205,6 @@ const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
   position: relative;
   /* Min-width prevents grid items from stretching the grid */
   min-width: 200px;
-
-  transform: translate3d(var(--translate-x, 0), var(--translate-y, 0), 0)
-    scaleX(var(--scale-x, 1)) scaleY(var(--scale-y, 1));
-  transform-origin: 0 0;
   touch-action: manipulation;
 
   ${p => {

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -134,7 +134,10 @@ class Dashboard extends React.Component<Props, State> {
   }
 
   render() {
-    const {isEditing, dashboard} = this.props;
+    const {
+      isEditing,
+      dashboard: {widgets},
+    } = this.props;
 
     return (
       <DndContext
@@ -158,7 +161,7 @@ class Dashboard extends React.Component<Props, State> {
           if (over?.id !== ADD_WIDGET_BUTTON_DRAG_ID) {
             const overIndex = getIndex(over.id);
             if (activeIndex !== overIndex) {
-              const newWidgets = [...this.props.dashboard.widgets];
+              const newWidgets = [...widgets];
               const removed = newWidgets.splice(activeIndex, 1);
               newWidgets.splice(overIndex, 0, removed[0]);
               this.props.onUpdate(newWidgets);
@@ -179,7 +182,7 @@ class Dashboard extends React.Component<Props, State> {
       >
         <WidgetContainer>
           <SortableContext items={this.getWidgetIds()} strategy={rectSwappingStrategy}>
-            {dashboard.widgets.map((widget, index) => this.renderWidget(widget, index))}
+            {widgets.map((widget, index) => this.renderWidget(widget, index))}
             {isEditing && <AddWidget onClick={this.handleStartAdd} />}
           </SortableContext>
         </WidgetContainer>

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -221,7 +221,6 @@ function AddWidget(props: {onClick: () => void}) {
     y: 0,
     scaleX: 1,
     scaleY: 1,
-    zIndex: 0,
   };
 
   const {setNodeRef, transform} = useSortable({
@@ -236,6 +235,7 @@ function AddWidget(props: {onClick: () => void}) {
       ref={setNodeRef}
       displayType="big_number"
       layoutId={ADD_WIDGET_BUTTON_DRAG_ID}
+      style={{originX: 0, originY: 0}}
       animate={
         transform
           ? {
@@ -247,14 +247,7 @@ function AddWidget(props: {onClick: () => void}) {
           : initialStyles
       }
       transition={{
-        duration: 0,
-        easings: {
-          type: 'spring',
-        },
-        transform: {duration: 0},
-        scale: {
-          duration: 0.25,
-        },
+        duration: 0.25,
       }}
     >
       <AddWidgetWrapper key="add" data-test-id="widget-add" onClick={onClick}>

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -35,15 +35,7 @@ type Props = {
   onUpdate: (widgets: Widget[]) => void;
 };
 
-type State = {
-  isDragging: boolean;
-};
-
-class Dashboard extends React.Component<Props, State> {
-  state: State = {
-    isDragging: false,
-  };
-
+class Dashboard extends React.Component<Props> {
   componentDidMount() {
     const {isEditing} = this.props;
     // Load organization tags when in edit mode.
@@ -126,7 +118,6 @@ class Dashboard extends React.Component<Props, State> {
           widget={widget}
           dragId={dragId}
           isEditing={isEditing}
-          isDragging={this.state.isDragging}
           onDelete={this.handleDeleteWidget(index)}
           onEdit={this.handleEditWidget(widget, index)}
         />
@@ -151,15 +142,6 @@ class Dashboard extends React.Component<Props, State> {
 
     return (
       <DndContext
-        onDragStart={({active}) => {
-          if (!active) {
-            return;
-          }
-
-          this.setState({
-            isDragging: true,
-          });
-        }}
         onDragEnd={({over, active}) => {
           const activeDragId = active.id;
           const getIndex = items.indexOf.bind(items);

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -155,7 +155,7 @@ class Dashboard extends React.Component<Props, State> {
 
           const activeIndex = activeDragId ? getIndex(activeDragId) : -1;
 
-          if (over && over.id !== ADD_WIDGET_BUTTON_DRAG_ID) {
+          if (over?.id !== ADD_WIDGET_BUTTON_DRAG_ID) {
             const overIndex = getIndex(over.id);
             if (activeIndex !== overIndex) {
               const newWidgets = [...this.props.dashboard.widgets];

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -136,6 +136,7 @@ class Dashboard extends React.Component<Props, State> {
   render() {
     const {
       isEditing,
+      onUpdate,
       dashboard: {widgets},
     } = this.props;
 
@@ -164,7 +165,7 @@ class Dashboard extends React.Component<Props, State> {
               const newWidgets = [...widgets];
               const removed = newWidgets.splice(activeIndex, 1);
               newWidgets.splice(overIndex, 0, removed[0]);
-              this.props.onUpdate(newWidgets);
+              onUpdate(newWidgets);
             }
           }
 

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -158,7 +158,7 @@ class Dashboard extends React.Component<Props, State> {
 
           const activeIndex = activeDragId ? getIndex(activeDragId) : -1;
 
-          if (over?.id !== ADD_WIDGET_BUTTON_DRAG_ID) {
+          if (over && over.id !== ADD_WIDGET_BUTTON_DRAG_ID) {
             const overIndex = getIndex(over.id);
             if (activeIndex !== overIndex) {
               const newWidgets = [...widgets];

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -37,12 +37,10 @@ type Props = {
 
 type State = {
   isDragging: boolean;
-  activeDragId?: string;
 };
 
 class Dashboard extends React.Component<Props, State> {
   state: State = {
-    activeDragId: undefined,
     isDragging: false,
   };
 
@@ -139,7 +137,6 @@ class Dashboard extends React.Component<Props, State> {
   resetDragState() {
     this.setState({
       isDragging: false,
-      activeDragId: undefined,
     });
   }
 
@@ -161,11 +158,10 @@ class Dashboard extends React.Component<Props, State> {
 
           this.setState({
             isDragging: true,
-            activeDragId: active.id,
           });
         }}
-        onDragEnd={({over}) => {
-          const {activeDragId} = this.state;
+        onDragEnd={({over, active}) => {
+          const activeDragId = active.id;
           const getIndex = items.indexOf.bind(items);
 
           const activeIndex = activeDragId ? getIndex(activeDragId) : -1;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import LazyLoad from 'react-lazyload';
 import {DndContext} from '@dnd-kit/core';
-import {rectSwappingStrategy, SortableContext, useSortable} from '@dnd-kit/sortable';
+import {
+  arrayMove,
+  rectSwappingStrategy,
+  SortableContext,
+  useSortable,
+} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 
 import {openAddDashboardWidgetModal} from 'app/actionCreators/modal';
@@ -168,10 +173,7 @@ class Dashboard extends React.Component<Props, State> {
           if (over && over.id !== ADD_WIDGET_BUTTON_DRAG_ID) {
             const overIndex = getIndex(over.id);
             if (activeIndex !== overIndex) {
-              const newWidgets = [...widgets];
-              const removed = newWidgets.splice(activeIndex, 1);
-              newWidgets.splice(overIndex, 0, removed[0]);
-              onUpdate(newWidgets);
+              onUpdate(arrayMove(widgets, activeIndex, overIndex));
             }
           }
 

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -34,7 +34,7 @@ type Props = {
 
 type State = {
   isDragging: boolean;
-  activeDragId: undefined | string;
+  activeDragId?: string;
 };
 
 class Dashboard extends React.Component<Props, State> {

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -1,10 +1,8 @@
-// eslint-disable-next-line sentry/no-react-hooks
-import React, {useEffect} from 'react';
+import React from 'react';
 import LazyLoad from 'react-lazyload';
 import {DndContext} from '@dnd-kit/core';
 import {rectSwappingStrategy, SortableContext, useSortable} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
-import {motion} from 'framer-motion';
 
 import {openAddDashboardWidgetModal} from 'app/actionCreators/modal';
 import {loadOrganizationTags} from 'app/actionCreators/tags';
@@ -12,12 +10,12 @@ import {Client} from 'app/api';
 import {IconAdd} from 'app/icons';
 import space from 'app/styles/space';
 import {GlobalSelection, Organization} from 'app/types';
-import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 
+import SortableWidget from './sortableWidget';
+import {WidgetWrapper} from './styles';
 import {DashboardDetails, Widget} from './types';
-import WidgetCard from './widgetCard';
 
 const ADD_WIDGET_BUTTON_DRAG_ID = 'add-widget-button';
 type Props = {
@@ -205,22 +203,6 @@ const WidgetContainer = styled('div')`
   }
 `;
 
-const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
-  position: relative;
-  /* Min-width prevents grid items from stretching the grid */
-  min-width: 200px;
-  touch-action: manipulation;
-
-  ${p => {
-    switch (p.displayType) {
-      case 'big_number':
-        return 'grid-area: span 1 / span 1;';
-      default:
-        return 'grid-area: span 2 / span 2;';
-    }
-  }};
-`;
-
 const AddWidgetWrapper = styled('a')`
   width: 100%;
   height: 110px;
@@ -230,100 +212,6 @@ const AddWidgetWrapper = styled('a')`
   align-items: center;
   justify-content: center;
 `;
-
-type SortableWidgetProps = {
-  widget: Widget;
-  dragId: string;
-  isEditing: boolean;
-  isDragging: boolean;
-  onDelete: () => void;
-  onEdit: () => void;
-};
-
-function SortableWidget(props: SortableWidgetProps) {
-  const {widget, dragId, isDragging, isEditing, onDelete, onEdit} = props;
-
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    isDragging: currentWidgetDragging,
-  } = useSortable({
-    id: dragId,
-    transition: null,
-  });
-
-  useEffect(() => {
-    if (!currentWidgetDragging) {
-      return undefined;
-    }
-
-    document.body.style.cursor = 'grabbing';
-
-    return function cleanup() {
-      document.body.style.cursor = '';
-    };
-  }, [currentWidgetDragging]);
-
-  const initialStyles = {
-    x: 0,
-    y: 0,
-    scaleX: 1,
-    scaleY: 1,
-    boxShadow: 'none',
-    zIndex: 0,
-  };
-
-  return (
-    <WidgetWrapper
-      ref={setNodeRef}
-      displayType={widget.displayType}
-      layoutId={dragId}
-      animate={
-        transform
-          ? {
-              x: transform.x,
-              y: transform.y,
-              scaleX: transform?.scaleX && transform.scaleX <= 1 ? transform.scaleX : 1,
-              scaleY: transform?.scaleY && transform.scaleY <= 1 ? transform.scaleY : 1,
-              zIndex: currentWidgetDragging ? theme.zIndex.modal : 0,
-              boxShadow: currentWidgetDragging
-                ? '0 0 0 1px rgba(63, 63, 68, 0.05), 0px 15px 15px 0 rgba(34, 33, 81, 0.25)'
-                : 'none',
-            }
-          : initialStyles
-      }
-      transition={{
-        duration: !currentWidgetDragging ? 0.25 : 0,
-        easings: {
-          type: 'spring',
-        },
-        transform: {duration: 0},
-        scale: {
-          duration: 0.25,
-        },
-        zIndex: {
-          delay: currentWidgetDragging ? 0 : 0.25,
-        },
-      }}
-    >
-      <WidgetCard
-        widget={widget}
-        isEditing={isEditing}
-        onDelete={onDelete}
-        onEdit={onEdit}
-        isDragging={isDragging}
-        hideToolbar={isDragging}
-        currentWidgetDragging={currentWidgetDragging}
-        draggableProps={{
-          attributes,
-          listeners,
-        }}
-      />
-    </WidgetWrapper>
-  );
-}
 
 function AddWidget(props: {onClick: () => void}) {
   const {onClick} = props;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
@@ -1,0 +1,106 @@
+// eslint-disable-next-line sentry/no-react-hooks
+import React, {useEffect} from 'react';
+import {useSortable} from '@dnd-kit/sortable';
+
+import theme from 'app/utils/theme';
+
+import {WidgetWrapper} from './styles';
+import {Widget} from './types';
+import WidgetCard from './widgetCard';
+
+type Props = {
+  widget: Widget;
+  dragId: string;
+  isEditing: boolean;
+  isDragging: boolean;
+  onDelete: () => void;
+  onEdit: () => void;
+};
+
+function SortableWidget(props: Props) {
+  const {widget, dragId, isDragging, isEditing, onDelete, onEdit} = props;
+
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    isDragging: currentWidgetDragging,
+  } = useSortable({
+    id: dragId,
+    transition: null,
+  });
+
+  useEffect(() => {
+    if (!currentWidgetDragging) {
+      return undefined;
+    }
+
+    document.body.style.cursor = 'grabbing';
+
+    return function cleanup() {
+      document.body.style.cursor = '';
+    };
+  }, [currentWidgetDragging]);
+
+  const initialStyles = {
+    x: 0,
+    y: 0,
+    scaleX: 1,
+    scaleY: 1,
+    boxShadow: 'none',
+    zIndex: 0,
+  };
+
+  return (
+    <WidgetWrapper
+      ref={setNodeRef}
+      displayType={widget.displayType}
+      layoutId={dragId}
+      style={{originX: 0, originY: 0}}
+      animate={
+        transform
+          ? {
+              x: transform.x,
+              y: transform.y,
+              scaleX: transform?.scaleX && transform.scaleX <= 1 ? transform.scaleX : 1,
+              scaleY: transform?.scaleY && transform.scaleY <= 1 ? transform.scaleY : 1,
+              zIndex: currentWidgetDragging ? theme.zIndex.modal : 0,
+              boxShadow: currentWidgetDragging
+                ? '0 0 0 1px rgba(63, 63, 68, 0.05), 0px 15px 15px 0 rgba(34, 33, 81, 0.25)'
+                : 'none',
+            }
+          : initialStyles
+      }
+      transition={{
+        duration: !currentWidgetDragging ? 0.25 : 0,
+        easings: {
+          type: 'spring',
+        },
+        transform: {duration: 0},
+        scale: {
+          duration: 0.25,
+        },
+        zIndex: {
+          delay: currentWidgetDragging ? 0 : 0.25,
+        },
+      }}
+    >
+      <WidgetCard
+        widget={widget}
+        isEditing={isEditing}
+        onDelete={onDelete}
+        onEdit={onEdit}
+        isDragging={isDragging}
+        hideToolbar={isDragging}
+        currentWidgetDragging={currentWidgetDragging}
+        draggableProps={{
+          attributes,
+          listeners,
+        }}
+      />
+    </WidgetWrapper>
+  );
+}
+
+export default SortableWidget;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
@@ -59,9 +59,8 @@ function SortableWidget(props: Props) {
       style={{
         originX: 0,
         originY: 0,
-        boxShadow: currentWidgetDragging
-          ? '0 0 0 1px rgba(63, 63, 68, 0.05), 0px 15px 15px 0 rgba(34, 33, 81, 0.25)'
-          : 'none',
+        boxShadow: currentWidgetDragging ? theme.dropShadowHeavy : 'none',
+        borderRadius: currentWidgetDragging ? theme.borderRadius : undefined,
       }}
       animate={
         transform

--- a/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
@@ -48,7 +48,6 @@ function SortableWidget(props: Props) {
     y: 0,
     scaleX: 1,
     scaleY: 1,
-    boxShadow: 'none',
     zIndex: 0,
   };
 
@@ -57,7 +56,13 @@ function SortableWidget(props: Props) {
       ref={setNodeRef}
       displayType={widget.displayType}
       layoutId={dragId}
-      style={{originX: 0, originY: 0}}
+      style={{
+        originX: 0,
+        originY: 0,
+        boxShadow: currentWidgetDragging
+          ? '0 0 0 1px rgba(63, 63, 68, 0.05), 0px 15px 15px 0 rgba(34, 33, 81, 0.25)'
+          : 'none',
+      }}
       animate={
         transform
           ? {
@@ -66,9 +71,6 @@ function SortableWidget(props: Props) {
               scaleX: transform?.scaleX && transform.scaleX <= 1 ? transform.scaleX : 1,
               scaleY: transform?.scaleY && transform.scaleY <= 1 ? transform.scaleY : 1,
               zIndex: currentWidgetDragging ? theme.zIndex.modal : 0,
-              boxShadow: currentWidgetDragging
-                ? '0 0 0 1px rgba(63, 63, 68, 0.05), 0px 15px 15px 0 rgba(34, 33, 81, 0.25)'
-                : 'none',
             }
           : initialStyles
       }
@@ -76,13 +78,6 @@ function SortableWidget(props: Props) {
         duration: !currentWidgetDragging ? 0.25 : 0,
         easings: {
           type: 'spring',
-        },
-        transform: {duration: 0},
-        scale: {
-          duration: 0.25,
-        },
-        zIndex: {
-          delay: currentWidgetDragging ? 0 : 0.25,
         },
       }}
     >

--- a/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
@@ -8,6 +8,14 @@ import {Widget} from './types';
 import WidgetCard from './widgetCard';
 import WidgetWrapper from './widgetWrapper';
 
+const initialStyles = {
+  x: 0,
+  y: 0,
+  scaleX: 1,
+  scaleY: 1,
+  zIndex: 0,
+};
+
 type Props = {
   widget: Widget;
   dragId: string;
@@ -42,14 +50,6 @@ function SortableWidget(props: Props) {
       document.body.style.cursor = '';
     };
   }, [currentWidgetDragging]);
-
-  const initialStyles = {
-    x: 0,
-    y: 0,
-    scaleX: 1,
-    scaleY: 1,
-    zIndex: 0,
-  };
 
   return (
     <WidgetWrapper

--- a/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
@@ -4,9 +4,9 @@ import {useSortable} from '@dnd-kit/sortable';
 
 import theme from 'app/utils/theme';
 
-import WidgetWrapper from './widgetWrapper';
 import {Widget} from './types';
 import WidgetCard from './widgetCard';
+import WidgetWrapper from './widgetWrapper';
 
 type Props = {
   widget: Widget;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
@@ -12,13 +12,12 @@ type Props = {
   widget: Widget;
   dragId: string;
   isEditing: boolean;
-  isDragging: boolean;
   onDelete: () => void;
   onEdit: () => void;
 };
 
 function SortableWidget(props: Props) {
-  const {widget, dragId, isDragging, isEditing, onDelete, onEdit} = props;
+  const {widget, dragId, isEditing, onDelete, onEdit} = props;
 
   const {
     attributes,
@@ -26,6 +25,7 @@ function SortableWidget(props: Props) {
     setNodeRef,
     transform,
     isDragging: currentWidgetDragging,
+    isSorting,
   } = useSortable({
     id: dragId,
     transition: null,
@@ -85,8 +85,8 @@ function SortableWidget(props: Props) {
         isEditing={isEditing}
         onDelete={onDelete}
         onEdit={onEdit}
-        isDragging={isDragging}
-        hideToolbar={isDragging}
+        isSorting={isSorting}
+        hideToolbar={isSorting}
         currentWidgetDragging={currentWidgetDragging}
         draggableProps={{
           attributes,

--- a/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
@@ -4,7 +4,7 @@ import {useSortable} from '@dnd-kit/sortable';
 
 import theme from 'app/utils/theme';
 
-import {WidgetWrapper} from './styles';
+import WidgetWrapper from './widgetWrapper';
 import {Widget} from './types';
 import WidgetCard from './widgetCard';
 

--- a/src/sentry/static/sentry/app/views/dashboardsV2/styles.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/styles.tsx
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+import {motion} from 'framer-motion';
+
+import {Widget} from './types';
+
+export const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
+  position: relative;
+  /* Min-width prevents grid items from stretching the grid */
+  min-width: 200px;
+  touch-action: manipulation;
+
+  ${p => {
+    switch (p.displayType) {
+      case 'big_number':
+        return 'grid-area: span 1 / span 1;';
+      default:
+        return 'grid-area: span 2 / span 2;';
+    }
+  }};
+`;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -24,6 +24,8 @@ import {Widget} from './types';
 import WidgetCardChart from './widgetCardChart';
 import WidgetQueries from './widgetQueries';
 
+type DraggableProps = Pick<ReturnType<typeof useSortable>, 'attributes' | 'listeners'>;
+
 type Props = ReactRouter.WithRouterProps & {
   api: Client;
   organization: Organization;
@@ -37,10 +39,7 @@ type Props = ReactRouter.WithRouterProps & {
   isDragging: boolean;
   currentWidgetDragging: boolean;
   hideToolbar?: boolean;
-  draggableProps?: {
-    attributes: ReturnType<typeof useSortable>['attributes'];
-    listeners: ReturnType<typeof useSortable>['listeners'];
-  };
+  draggableProps?: DraggableProps;
 };
 
 class WidgetCard extends React.Component<Props> {

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -37,7 +37,7 @@ type Props = ReactRouter.WithRouterProps & {
   isDragging: boolean;
   currentWidgetDragging: boolean;
   hideToolbar?: boolean;
-  draggableProps: {
+  draggableProps?: {
     attributes: ReturnType<typeof useSortable>['attributes'];
     listeners: ReturnType<typeof useSortable>['listeners'];
   };
@@ -62,11 +62,7 @@ class WidgetCard extends React.Component<Props> {
       return null;
     }
 
-    const {
-      onEdit,
-      onDelete,
-      draggableProps: {attributes, listeners},
-    } = this.props;
+    const {onEdit, onDelete, draggableProps} = this.props;
 
     return (
       <ToolbarPanel>
@@ -77,8 +73,8 @@ class WidgetCard extends React.Component<Props> {
             <StyledIconGrabbable
               color="gray500"
               size="md"
-              {...listeners}
-              {...attributes}
+              {...draggableProps?.listeners}
+              {...draggableProps?.attributes}
             />
           </IconClick>
           <IconClick

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -36,7 +36,7 @@ type Props = ReactRouter.WithRouterProps & {
   onDelete: () => void;
   onEdit: () => void;
   renderErrorMessage?: (errorMessage: string | undefined) => React.ReactNode;
-  isDragging: boolean;
+  isSorting: boolean;
   currentWidgetDragging: boolean;
   hideToolbar?: boolean;
   draggableProps?: DraggableProps;
@@ -48,7 +48,7 @@ class WidgetCard extends React.Component<Props> {
       !isEqual(nextProps.widget, this.props.widget) ||
       !isSelectionEqual(nextProps.selection, this.props.selection) ||
       this.props.isEditing !== nextProps.isEditing ||
-      this.props.isDragging !== nextProps.isDragging ||
+      this.props.isSorting !== nextProps.isSorting ||
       this.props.hideToolbar !== nextProps.hideToolbar
     ) {
       return true;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -35,7 +35,7 @@ type Props = ReactRouter.WithRouterProps & {
   selection: GlobalSelection;
   onDelete: () => void;
   onEdit: () => void;
-  renderErrorMessage?: (errorMessage: string | undefined) => React.ReactNode;
+  renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
   isSorting: boolean;
   currentWidgetDragging: boolean;
   hideToolbar?: boolean;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -35,11 +35,11 @@ type Props = ReactRouter.WithRouterProps & {
   selection: GlobalSelection;
   onDelete: () => void;
   onEdit: () => void;
-  renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
   isSorting: boolean;
   currentWidgetDragging: boolean;
   hideToolbar?: boolean;
   draggableProps?: DraggableProps;
+  renderErrorMessage?: (errorMessage?: string) => React.ReactNode;
 };
 
 class WidgetCard extends React.Component<Props> {

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -57,17 +57,15 @@ class WidgetCard extends React.Component<Props> {
   }
 
   renderToolbar() {
-    if (!this.props.isEditing) {
+    const {onEdit, onDelete, draggableProps, hideToolbar, isEditing} = this.props;
+
+    if (!isEditing) {
       return null;
     }
 
-    const {onEdit, onDelete, draggableProps} = this.props;
-
     return (
       <ToolbarPanel>
-        <IconContainer
-          style={{visibility: this.props.hideToolbar ? 'hidden' : 'visible'}}
-        >
+        <IconContainer style={{visibility: hideToolbar ? 'hidden' : 'visible'}}>
           <IconClick>
             <StyledIconGrabbable
               color="gray500"

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetWrapper.tsx
@@ -3,7 +3,7 @@ import {motion} from 'framer-motion';
 
 import {Widget} from './types';
 
-export const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
+const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
   position: relative;
   /* Min-width prevents grid items from stretching the grid */
   min-width: 200px;
@@ -18,3 +18,5 @@ export const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayTyp
     }
   }};
 `;
+
+export default WidgetWrapper;


### PR DESCRIPTION
Refactor out custom drag and drop implementation in favour of dndkit (https://github.com/clauderic/dnd-kit); which is a more reliable, and less error-prone library.

Caveat: dnd-kit re-orders items by the use of css translations and scaling before the ordered dashboard widgets is committed to DOM. 

Depends on https://github.com/getsentry/sentry/pull/23497 for dependencies. 

https://user-images.githubusercontent.com/139499/106814288-2afb8980-6640-11eb-8d7a-f55bf797fb7a.mp4

