### PR TITLE
Support client.id and group.id kafka config keys

### DIFF
--- a/src/sentry/utils/kafka_config.py
+++ b/src/sentry/utils/kafka_config.py
@@ -5,7 +5,9 @@ SUPPORTED_KAFKA_CONFIGURATION = (
     # Check https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
     # for the full list of available options
     "bootstrap.servers",
+    "client.id",
     "compression.type",
+    "group.id",
     "message.max.bytes",
     "sasl.mechanism",
     "sasl.username",


### PR DESCRIPTION
Hi there. This PR adds `client.id` and `group.id` to the list of `SUPPORTED_KAFKA_CONFIGURATIONS`. These config keys are required for me to use the kafka infrastructure provided by the kafka team at my work. If permitted, I'm also looking to add this change to the [getsentry/snuba](github.com/getsentry/snuba) repo.

Please let me know if this can be accomplished without a PR, or if I should create an issue for this first.