### PR TITLE
fix(integrations): Update `dynamic_form_fields` choices from cache

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/ruleNode.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/ruleNode.tsx
@@ -298,22 +298,24 @@ class RuleNode extends React.Component<Props> {
     formData: {[key: string]: string},
     fetchedFieldOptionsCache: Record<string, Choices>
   ): void => {
-    const {data, index, onPropertyChange} = this.props;
-    for (const [name, value] of Object.entries(formData)) {
-      onPropertyChange(index, name, value);
-    }
+    const {index, onPropertyChange} = this.props;
 
     // We only know the choices after the form loads.
-    for (const [name, choices] of Object.entries(fetchedFieldOptionsCache)) {
-      // If a value was actually selected.
-      if (name in formData) {
-        const dynamicFormFieldsCopy = data.dynamic_form_fields as any;
+    formData.dynamic_form_fields = ((formData.dynamic_form_fields as any) || []).map(
+      field => {
         // Overwrite the choices because the user's pick is in this list.
-        if (dynamicFormFieldsCopy?.hasOwnProperty(name)) {
-          dynamicFormFieldsCopy[name].choices = choices;
-          onPropertyChange(index, 'dynamic_form_fields', dynamicFormFieldsCopy);
+        if (
+          field.name in formData &&
+          fetchedFieldOptionsCache?.hasOwnProperty(field.name)
+        ) {
+          field.choices = fetchedFieldOptionsCache[field.name];
         }
+        return field;
       }
+    );
+
+    for (const [name, value] of Object.entries(formData)) {
+      onPropertyChange(index, name, value);
     }
   };
 


### PR DESCRIPTION
Fixes [ISSUE-1126](https://getsentry.atlassian.net/browse/ISSUE-1126).
We were treating `dynamic_form_fields` as a map of names to fields instead of an array of fields. This PR correctly caches the fetched asynchronous options.
![Screen Shot 2021-02-03 at 2 29 28 PM](https://user-images.githubusercontent.com/31750075/106817803-3b096e00-662c-11eb-98ac-27300db27370.png)
