### PR TITLE
feat(ui): Add event types and loading placeholder to metric alert redesign

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -297,7 +297,7 @@ export default class DetailsBody extends React.Component<Props> {
                         )}
                         start={timePeriod.start}
                         end={timePeriod.end}
-                        filter={DATASET_EVENT_TYPE_FILTERS[rule.dataset]}
+                        filter={queryWithTypeFilter}
                       />
                     )}
                   </ActivityWrapper>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -235,9 +235,7 @@ export default class DetailsBody extends React.Component<Props> {
 
     const {query, environment, aggregate, projects: projectSlugs} = rule;
     const timePeriod = this.getTimePeriod();
-    const queryWithTypeFilter = rule
-      ? `${query} ${extractEventTypeFilterFromRule(rule)}`.trim()
-      : query;
+    const queryWithTypeFilter = `${query} ${extractEventTypeFilterFromRule(rule)}`.trim();
 
     return (
       <Projects orgId={orgId} slugs={projectSlugs}>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -29,6 +29,7 @@ import {
   TimePeriod,
   TimeWindow,
 } from 'app/views/settings/incidentRules/types';
+import {extractEventTypeFilterFromRule} from 'app/views/settings/incidentRules/utils/getEventTypeFilter';
 
 import {Incident} from '../../types';
 import {DATA_SOURCE_LABELS, getIncidentRuleMetricPreset} from '../../utils';
@@ -198,6 +199,27 @@ export default class DetailsBody extends React.Component<Props> {
     );
   }
 
+  renderLoading() {
+    return (
+      <Layout.Body>
+        <Layout.Main>
+          <Placeholder height="38px" />
+          <ChartPanel>
+            <PanelBody withPadding>
+              <Placeholder height="200px" />
+            </PanelBody>
+          </ChartPanel>
+        </Layout.Main>
+        <Layout.Side>
+          <SidebarHeading>
+            <span>{t('Alert Rule')}</span>
+          </SidebarHeading>
+          {this.renderRuleDetails()}
+        </Layout.Side>
+      </Layout.Body>
+    );
+  }
+
   render() {
     const {
       api,
@@ -206,16 +228,24 @@ export default class DetailsBody extends React.Component<Props> {
       organization,
       params: {orgId},
     } = this.props;
-    const {query, environment, aggregate, projects: projectSlugs} = rule ?? {};
+
+    if (!rule) {
+      return this.renderLoading();
+    }
+
+    const {query, environment, aggregate, projects: projectSlugs} = rule;
     const timePeriod = this.getTimePeriod();
+    const queryWithTypeFilter = rule
+      ? `${query} ${extractEventTypeFilterFromRule(rule)}`.trim()
+      : query;
 
     return (
       <Projects orgId={orgId} slugs={projectSlugs}>
         {({initiallyLoaded, projects}) => {
-          return initiallyLoaded && rule ? (
+          return initiallyLoaded ? (
             <Layout.Body>
               <Layout.Main>
-                <StyledDropdownControl
+                <DropdownControl
                   buttonProps={{prefix: t('Display')}}
                   label={timePeriod.label}
                 >
@@ -228,7 +258,7 @@ export default class DetailsBody extends React.Component<Props> {
                       {label}
                     </DropdownItem>
                   ))}
-                </StyledDropdownControl>
+                </DropdownControl>
                 <ChartPanel>
                   <PanelBody withPadding>
                     <ChartHeader>
@@ -237,7 +267,7 @@ export default class DetailsBody extends React.Component<Props> {
                     <EventsRequest
                       api={api}
                       organization={organization}
-                      query={query}
+                      query={queryWithTypeFilter}
                       environment={environment ? [environment] : undefined}
                       project={(projects as Project[]).map(project => Number(project.id))}
                       // TODO(davidenwang): allow interval to be changed for larger time periods
@@ -333,11 +363,8 @@ const SidebarHeading = styled(SectionHeading)`
   justify-content: space-between;
 `;
 
-const ChartPanel = styled(Panel)``;
-
-const StyledDropdownControl = styled(DropdownControl)`
-  margin-bottom: ${space(2)};
-  margin-right: ${space(1)};
+const ChartPanel = styled(Panel)`
+  margin-top: ${space(2)};
 `;
 
 const ChartHeader = styled('header')`

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -18,7 +18,6 @@ import {t} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import {defined} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import {convertDatasetEventTypesToSource} from 'app/views/alerts/utils';
 import Form from 'app/views/settings/components/forms/form';
 import FormModel from 'app/views/settings/components/forms/model';
 import RuleNameForm from 'app/views/settings/incidentRules/ruleNameForm';
@@ -28,17 +27,12 @@ import {getEventTypeFilter} from 'app/views/settings/incidentRules/utils/getEven
 import hasThresholdValue from 'app/views/settings/incidentRules/utils/hasThresholdValue';
 
 import {addOrUpdateRule} from '../actions';
-import {
-  createDefaultTrigger,
-  DATASET_EVENT_TYPE_FILTERS,
-  DATASOURCE_EVENT_TYPE_FILTERS,
-} from '../constants';
+import {createDefaultTrigger} from '../constants';
 import RuleConditionsForm from '../ruleConditionsForm';
 import RuleConditionsFormWithGuiFilters from '../ruleConditionsFormWithGuiFilters';
 import {
   AlertRuleThresholdType,
   Dataset,
-  Datasource,
   IncidentRule,
   MetricActionTemplate,
   Trigger,
@@ -128,17 +122,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
     return [
       ['availableActions', `/organizations/${orgId}/alert-rules/available-actions/`],
     ];
-  }
-
-  get eventTypeFilter() {
-    if (this.state.eventTypes) {
-      return DATASOURCE_EVENT_TYPE_FILTERS[
-        convertDatasetEventTypesToSource(this.state.dataset, this.state.eventTypes) ??
-          Datasource.ERROR
-      ];
-    } else {
-      return DATASET_EVENT_TYPE_FILTERS[this.state.dataset ?? Dataset.ERRORS];
-    }
   }
 
   goBack() {

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -24,6 +24,7 @@ import FormModel from 'app/views/settings/components/forms/model';
 import RuleNameForm from 'app/views/settings/incidentRules/ruleNameForm';
 import Triggers from 'app/views/settings/incidentRules/triggers';
 import TriggersChart from 'app/views/settings/incidentRules/triggers/chart';
+import {getEventTypeFilter} from 'app/views/settings/incidentRules/utils/getEventTypeFilter';
 import hasThresholdValue from 'app/views/settings/incidentRules/utils/hasThresholdValue';
 
 import {addOrUpdateRule} from '../actions';
@@ -561,7 +562,8 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       resolveThreshold,
     } = this.state;
 
-    const queryWithTypeFilter = `${query} ${this.eventTypeFilter}`.trim();
+    const eventTypeFilter = getEventTypeFilter(this.state.dataset, this.state.eventTypes);
+    const queryWithTypeFilter = `${query} ${eventTypeFilter}`.trim();
 
     const chart = (
       <TriggersChart

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/utils/getEventTypeFilter.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/utils/getEventTypeFilter.tsx
@@ -1,0 +1,22 @@
+import {convertDatasetEventTypesToSource} from 'app/views/alerts/utils';
+
+import {DATASET_EVENT_TYPE_FILTERS, DATASOURCE_EVENT_TYPE_FILTERS} from '../constants';
+import {Dataset, Datasource, EventTypes, IncidentRule} from '../types';
+
+export function extractEventTypeFilterFromRule(metricRule: IncidentRule) {
+  const {dataset, eventTypes} = metricRule;
+  return getEventTypeFilter(dataset, eventTypes);
+}
+
+export function getEventTypeFilter(
+  dataset: Dataset,
+  eventTypes: EventTypes[] | undefined
+) {
+  if (eventTypes) {
+    return DATASOURCE_EVENT_TYPE_FILTERS[
+      convertDatasetEventTypesToSource(dataset, eventTypes) ?? Datasource.ERROR
+    ];
+  } else {
+    return DATASET_EVENT_TYPE_FILTERS[dataset ?? Dataset.ERRORS];
+  }
+}


### PR DESCRIPTION
Before, the graph data that was rendered by the metric alert details redesign page was not consistent with the actual metric alert rule because it didn't include the event type (`event.type: errors`, `event.type: default`, etc...). 

**Example metric alerts redesign summary graph:**
![image](https://user-images.githubusercontent.com/9372512/106824056-dacbf980-6636-11eb-9866-385a61afd5cb.png)

This PR extracts the function to get the event type from the metric alert builder view. Also while we wait for the rule to load and get the extracted event types, we must supply some kind of placeholder which this PR creates:

**Placeholder:**
<img width="1199" alt="Screen Shot 2021-02-03 at 3 42 21 PM" src="https://user-images.githubusercontent.com/9372512/106824038-cee03780-6636-11eb-86d6-9c1396f033f2.png">

