### PR TITLE
ref(pyupgrade): trivial changes for src/

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -97,13 +97,13 @@ class Endpoint(APIView):
 
     def build_cursor_link(self, request, name, cursor):
         querystring = "&".join(
-            "{0}={1}".format(urlquote(k), urlquote(v))
+            "{}={}".format(urlquote(k), urlquote(v))
             for k, v in six.iteritems(request.GET)
             if k != "cursor"
         )
         base_url = absolute_uri(urlquote(request.path))
         if querystring:
-            base_url = "{0}?{1}".format(base_url, querystring)
+            base_url = "{}?{}".format(base_url, querystring)
         else:
             base_url = base_url + "?"
 

--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -41,7 +41,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         with sentry_sdk.start_span(op="discover.endpoint", description="filter_params"):
             if len(request.GET.getlist("field")) > MAX_FIELDS:
                 raise ParseError(
-                    detail="You can view up to {0} fields at a time. Please delete some and try again.".format(
+                    detail="You can view up to {} fields at a time. Please delete some and try again.".format(
                         MAX_FIELDS
                     )
                 )
@@ -156,7 +156,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
         # The base API function only uses the last query parameter, but this endpoint
         # needs all the parameters, particularly for the "field" query param.
         querystring = "&".join(
-            "{0}={1}".format(urlquote(query[0]), urlquote(value))
+            "{}={}".format(urlquote(query[0]), urlquote(value))
             for query in request.GET.lists()
             if query[0] != "cursor"
             for value in query[1]
@@ -164,7 +164,7 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
 
         base_url = absolute_uri(urlquote(request.path))
         if querystring:
-            base_url = "{0}?{1}".format(base_url, querystring)
+            base_url = "{}?{}".format(base_url, querystring)
         else:
             base_url = base_url + "?"
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1452,7 +1452,7 @@ VALID_FIELD_PATTERN = re.compile(r"^[a-zA-Z0-9_.:-]*$")
 
 # The regex for alias here is to match any word, but exclude anything that is only digits
 # eg. 123 doesn't match, but test_123 will match
-ALIAS_REGEX = "(\w+)?(?!\d+)\w+"
+ALIAS_REGEX = r"(\w+)?(?!\d+)\w+"
 
 ALIAS_PATTERN = re.compile(r"{}$".format(ALIAS_REGEX))
 FUNCTION_PATTERN = re.compile(
@@ -2373,7 +2373,7 @@ def get_function_alias(field):
 
 
 def get_function_alias_with_columns(function_name, columns):
-    columns = re.sub("[^\w]", "_", "_".join(columns))
+    columns = re.sub(r"[^\w]", "_", "_".join(columns))
     return "{}_{}".format(function_name, columns).rstrip("_")
 
 

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -160,7 +160,7 @@ class ReleaseSerializer(Serializer):
         else:
             users_by_author = {}
 
-        commit_ids = set((o.last_commit_id for o in item_list if o.last_commit_id))
+        commit_ids = set(o.last_commit_id for o in item_list if o.last_commit_id)
         if commit_ids:
             commit_list = list(Commit.objects.filter(id__in=commit_ids).select_related("author"))
             commits = {c.id: d for c, d in zip(commit_list, serialize(commit_list, user))}
@@ -196,7 +196,7 @@ class ReleaseSerializer(Serializer):
             ...
         }
         """
-        deploy_ids = set((o.last_deploy_id for o in item_list if o.last_deploy_id))
+        deploy_ids = set(o.last_deploy_id for o in item_list if o.last_deploy_id)
         if deploy_ids:
             deploy_list = list(Deploy.objects.filter(id__in=deploy_ids))
             deploys = {d.id: c for d, c in zip(deploy_list, serialize(deploy_list, user))}

--- a/src/sentry/auth/providers/github/client.py
+++ b/src/sentry/auth/providers/github/client.py
@@ -18,11 +18,11 @@ class GitHubClient(object):
         self.access_token = access_token
 
     def _request(self, path):
-        headers = {"Authorization": "token {0}".format(self.access_token)}
+        headers = {"Authorization": "token {}".format(self.access_token)}
 
         try:
             req = self.http.get(
-                "https://{0}/{1}".format(API_DOMAIN, path.lstrip("/")),
+                "https://{}/{}".format(API_DOMAIN, path.lstrip("/")),
                 headers=headers,
             )
         except RequestException as e:
@@ -43,6 +43,6 @@ class GitHubClient(object):
     def is_org_member(self, org_id):
         org_id = six.text_type(org_id)
         for o in self.get_org_list():
-            if six.text_type((o["id"])) == org_id:
+            if six.text_type(o["id"]) == org_id:
                 return True
         return False

--- a/src/sentry/auth/providers/github/constants.py
+++ b/src/sentry/auth/providers/github/constants.py
@@ -31,5 +31,5 @@ DOMAIN = getattr(settings, "GITHUB_DOMAIN", "api.github.com")
 BASE_DOMAIN = settings.GITHUB_BASE_DOMAIN
 API_DOMAIN = settings.GITHUB_API_DOMAIN
 
-ACCESS_TOKEN_URL = "https://{0}/login/oauth/access_token".format(BASE_DOMAIN)
-AUTHORIZE_URL = "https://{0}/login/oauth/authorize".format(BASE_DOMAIN)
+ACCESS_TOKEN_URL = "https://{}/login/oauth/access_token".format(BASE_DOMAIN)
+AUTHORIZE_URL = "https://{}/login/oauth/authorize".format(BASE_DOMAIN)

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -608,7 +608,7 @@ CELERY_ROUTES = ("sentry.queue.routers.SplitQueueRouter",)
 def create_partitioned_queues(name):
     exchange = Exchange(name, type="direct")
     for num in range(1):
-        CELERY_QUEUES.append(Queue("{0}-{1}".format(name, num), exchange=exchange))
+        CELERY_QUEUES.append(Queue("{}-{}".format(name, num), exchange=exchange))
 
 
 create_partitioned_queues("counters")

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -47,7 +47,7 @@ class DataExportQuerySerializer(serializers.Serializer):
                 fields = [fields]
 
             if len(fields) > MAX_FIELDS:
-                detail = "You can export up to {0} fields at a time. Please delete some and try again.".format(
+                detail = "You can export up to {} fields at a time. Please delete some and try again.".format(
                     MAX_FIELDS
                 )
                 raise serializers.ValidationError(detail)

--- a/src/sentry/debug/utils/packages.py
+++ b/src/sentry/debug/utils/packages.py
@@ -64,6 +64,6 @@ def get_all_package_versions():
 
         packages[module_name] = version
 
-    packages["sys"] = "{0}.{1}.{2}".format(*sys.version_info)
+    packages["sys"] = "{}.{}.{}".format(*sys.version_info)
 
     return packages

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -92,7 +92,7 @@ class DiscoverQuerySerializer(serializers.Serializer):
         requested_functions = set(agg[0] for agg in value)
 
         if not requested_functions.issubset(valid_functions):
-            invalid_functions = ", ".join((requested_functions - valid_functions))
+            invalid_functions = ", ".join(requested_functions - valid_functions)
 
             raise serializers.ValidationError(
                 "Invalid aggregate function - {}".format(invalid_functions)

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -71,7 +71,7 @@ class RegisteredFeatureManager(object):
 
             with sentry_sdk.start_span(
                 op="feature.has_for_batch.handler",
-                description="{0} ({1})".format(type(handler).__name__, name),
+                description="{} ({})".format(type(handler).__name__, name),
             ) as span:
                 batch_size = len(remaining)
                 span.set_data("Batch Size", batch_size)

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -124,7 +124,7 @@ def get_filter_state(filter_id, project):
 
     if filter_state is None:
         raise ValueError(
-            "Could not find filter state for filter {0}."
+            "Could not find filter state for filter {}."
             " You need to register default filter state in projectoptions.defaults.".format(
                 filter_id
             )

--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -211,7 +211,7 @@ def get_invalid_layer_name(err_message):
     :return the layer name if it's a invalid layer
     """
     match = re.search(
-        "Layer version arn:aws:lambda:[^:]+:\d+:layer:([^:]+):\d+ does not exist",
+        r"Layer version arn:aws:lambda:[^:]+:\d+:layer:([^:]+):\d+ does not exist",
         err_message,
     )
     if match:

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -612,7 +612,7 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
         # make sure default issue type is actually
         # one that is allowed for project
         if issue_type:
-            if not any((c for c in issue_type_choices if c[0] == issue_type)):
+            if not any(c for c in issue_type_choices if c[0] == issue_type):
                 issue_type = issue_type_meta["id"]
 
         fields = (

--- a/src/sentry/interfaces/exception.py
+++ b/src/sentry/interfaces/exception.py
@@ -8,7 +8,7 @@ from sentry.utils.json import prune_empty_keys
 from sentry.interfaces.stacktrace import Stacktrace
 from sentry.utils.safe import get_path
 
-_type_value_re = re.compile("^(\w+):(.*)$")
+_type_value_re = re.compile(r"^(\w+):(.*)$")
 
 
 def upgrade_legacy_mechanism(data):
@@ -434,7 +434,7 @@ class Exception(Interface):
             if not exc:
                 continue
 
-            output.append("{0}: {1}\n".format(exc.type, exc.value))
+            output.append("{}: {}\n".format(exc.type, exc.value))
             if exc.stacktrace:
                 output.append(
                     exc.stacktrace.get_stacktrace(

--- a/src/sentry/lang/javascript/errorlocale.py
+++ b/src/sentry/lang/javascript/errorlocale.py
@@ -28,7 +28,7 @@ def populate_target_locale_lookup_table():
                 else:
                     translation_regexp = re.escape(translation)
                     translation_regexp = translation_regexp.replace(
-                        "\%s", r"(?P<format_string_data>[a-zA-Z0-9-_\$]+)"
+                        r"\%s", r"(?P<format_string_data>[a-zA-Z0-9-_\$]+)"
                     )
                     # Some errors are substrings of more detailed ones, so we need exact match
                     translation_regexp = re.compile("^" + translation_regexp + "$")

--- a/src/sentry/lang/javascript/processor.py
+++ b/src/sentry/lang/javascript/processor.py
@@ -273,7 +273,7 @@ def fetch_release_file(filename, release, dist=None):
             # This is O(N*M) but there are only ever at most 4 things here
             # so not really worth optimizing.
             releasefile = next(
-                (rf for ident in filename_idents for rf in possible_files if rf.ident == ident)
+                rf for ident in filename_idents for rf in possible_files if rf.ident == ident
             )
 
         # If the release file is not in cache, check if we can retrieve at

--- a/src/sentry/lint/engine.py
+++ b/src/sentry/lint/engine.py
@@ -86,7 +86,7 @@ def get_js_files(file_list=None, snapshots=False):
 def get_less_files(file_list=None):
     if file_list is None:
         file_list = ["src/sentry/static/sentry/less", "src/sentry/static/sentry/app"]
-    return [x for x in get_files_for_list(file_list) if x.endswith((".less"))]
+    return [x for x in get_files_for_list(file_list) if x.endswith(".less")]
 
 
 def js_lint(file_list=None, parseable=False, format=False):

--- a/src/sentry/logging/handlers.py
+++ b/src/sentry/logging/handlers.py
@@ -115,7 +115,7 @@ class MessageContainsFilter(logging.Filter):
         return any(c in message for c in self.contains)
 
 
-whitespace_re = re.compile("\s+")
+whitespace_re = re.compile(r"\s+")
 metrics_badchars_re = re.compile("[^a-z0-9_.]")
 
 

--- a/src/sentry/migrations/0056_remove_old_functions.py
+++ b/src/sentry/migrations/0056_remove_old_functions.py
@@ -19,7 +19,7 @@ FUNCTION_CHANGE = {
     "last_seen": "last_seen()",
     "latest_event": "latest_event()",
 }
-COUNT_REGEX = re.compile(".*(count\([a-zA-Z\._]+\)).*")
+COUNT_REGEX = re.compile(r".*(count\([a-zA-Z\._]+\)).*")
 FUNCTION_PATTERN = re.compile(r"^(?P<function>[^\(]+)\((?P<columns>[^\)]*)\)$")
 
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -263,13 +263,11 @@ class Project(Model, PendingDeletionMixin):
         members_to_check = set(u for u in member_set if u not in alert_settings)
         if members_to_check:
             disabled = set(
-                (
-                    uo.user_id
-                    for uo in UserOption.objects.filter(
-                        key="subscribe_by_default", user__in=members_to_check
-                    )
-                    if uo.value == "0"
+                uo.user_id
+                for uo in UserOption.objects.filter(
+                    key="subscribe_by_default", user__in=members_to_check
                 )
+                if uo.value == "0"
             )
             member_set = [x for x in member_set if x not in disabled]
 

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -127,7 +127,7 @@ class NotificationPlugin(Plugin):
         if not (
             hasattr(self, "notify_digest") and digests.enabled(project)
         ) and self.__is_rate_limited(group, event):
-            logger = logging.getLogger("sentry.plugins.{0}".format(self.get_conf_key()))
+            logger = logging.getLogger("sentry.plugins.{}".format(self.get_conf_key()))
             logger.info("notification.rate_limited", extra={"project_id": project.id})
             return False
 

--- a/src/sentry/plugins/config.py
+++ b/src/sentry/plugins/config.py
@@ -25,7 +25,7 @@ class ConfigValidator(object):
         self.result = {}
         self.context = context or {}
 
-        self.config = OrderedDict(((f["name"], f) for f in config))
+        self.config = OrderedDict((f["name"], f) for f in config)
 
         self._data = data or {}
         self._initial = initial or {}

--- a/src/sentry/receivers/stats.py
+++ b/src/sentry/receivers/stats.py
@@ -19,7 +19,7 @@ post_save.connect(
 
 
 def _get_task_name(task):
-    return task.name or "{0}.{1}".format(task.__module__, task.__name__)
+    return task.name or "{}.{}".format(task.__module__, task.__name__)
 
 
 def record_task_signal(signal, name, **options):
@@ -27,10 +27,10 @@ def record_task_signal(signal, name, **options):
         if not isinstance(sender, six.string_types):
             sender = _get_task_name(sender)
         options["skip_internal"] = options.get("skip_internal", False)
-        metrics.incr("jobs.{0}".format(name), instance=sender, **options)
-        metrics.incr("jobs.all.{0}".format(name), skip_internal=False)
+        metrics.incr("jobs.{}".format(name), instance=sender, **options)
+        metrics.incr("jobs.all.{}".format(name), skip_internal=False)
 
-    signal.connect(handler, weak=False, dispatch_uid="sentry.stats.tasks.{0}".format(name))
+    signal.connect(handler, weak=False, dispatch_uid="sentry.stats.tasks.{}".format(name))
 
 
 # TODO: https://github.com/getsentry/sentry/issues/2495

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -258,7 +258,7 @@ class _ConfigBase(object):
             return "Content Error:{}".format(e)
 
     def __repr__(self):
-        return "({0}){1}".format(self.__class__.__name__, self)
+        return "({}){}".format(self.__class__.__name__, self)
 
 
 class ProjectConfig(_ConfigBase):
@@ -299,7 +299,7 @@ def _filter_option_to_config_setting(flt, setting):
     """
     if setting is None:
         raise ValueError(
-            "Could not find filter state for filter {0}."
+            "Could not find filter state for filter {}."
             " You need to register default filter state in projectoptions.defaults.".format(flt.id)
         )
 

--- a/src/sentry/rules/conditions/level.py
+++ b/src/sentry/rules/conditions/level.py
@@ -6,7 +6,7 @@ from sentry.constants import LOG_LEVELS, LOG_LEVELS_MAP
 from sentry.rules.conditions.base import EventCondition
 
 LEVEL_CHOICES = OrderedDict(
-    [("{0}".format(k), v) for k, v in sorted(LOG_LEVELS.items(), key=lambda x: x[0], reverse=True)]
+    [("{}".format(k), v) for k, v in sorted(LOG_LEVELS.items(), key=lambda x: x[0], reverse=True)]
 )
 
 

--- a/src/sentry/runner/commands/devserver.py
+++ b/src/sentry/runner/commands/devserver.py
@@ -178,7 +178,7 @@ def devserver(
 
         # webpack and/or typescript is causing memory issues
         os.environ["NODE_OPTIONS"] = (
-            (os.environ.get("NODE_OPTIONS", "") + " --max-old-space-size=4096")
+            os.environ.get("NODE_OPTIONS", "") + " --max-old-space-size=4096"
         ).lstrip()
 
         # Replace the webpack watcher with the drop-in webpack-dev-server

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -98,7 +98,7 @@ class UpdateSDKSuggestion(Suggestion):
 
         new_sdk_version = self.new_sdk_version
         if self.ignore_patch_version:
-            new_sdk_version = ".".join((v for v in new_sdk_version.split(".")[:2]))
+            new_sdk_version = ".".join(v for v in new_sdk_version.split(".")[:2])
 
         try:
             has_newer_version = LooseVersion(old_state.sdk_version) < LooseVersion(new_sdk_version)

--- a/src/sentry/tagstore/base.py
+++ b/src/sentry/tagstore/base.py
@@ -92,7 +92,7 @@ class TagStorage(Service):
     def prefix_reserved_key(self, key):
         # XXX(dcramer): kill sentry prefix for internal reserved tags
         if self.is_reserved_key(key):
-            return "sentry:{0}".format(key)
+            return "sentry:{}".format(key)
         else:
             return key
 

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -62,7 +62,7 @@ def locale_js_include(context):
         nonce = ' nonce="{}"'.format(request.csp_nonce)
 
     href = get_asset_url("sentry", "dist/locale/" + lang_code + ".js")
-    return mark_safe('<script src="{0}"{1}{2}></script>'.format(href, crossorigin(), nonce))
+    return mark_safe('<script src="{}"{}{}></script>'.format(href, crossorigin(), nonce))
 
 
 @register.tag

--- a/src/sentry/testutils/helpers/link_header.py
+++ b/src/sentry/testutils/helpers/link_header.py
@@ -74,7 +74,7 @@ def parse_link_header(instr):
         url, params = link.split(">", 1)
         url = url[1:]
         param_dict = {}
-        for param in _splitstring(params, PARAMETER, "\s*;\s*"):
+        for param in _splitstring(params, PARAMETER, r"\s*;\s*"):
             try:
                 a, v = param.split("=", 1)
                 param_dict[a.lower()] = _unquotestring(v)

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -90,7 +90,7 @@ def parse_stats_period(period):
     Convert a value such as 1h into a
     proper timedelta.
     """
-    m = re.match("^(\d+)([hdmsw]?)$", period)
+    m = re.match(r"^(\d+)([hdmsw]?)$", period)
     if not m:
         return None
     value, unit = m.groups()

--- a/src/sentry/utils/distutils/commands/base.py
+++ b/src/sentry/utils/distutils/commands/base.py
@@ -127,7 +127,7 @@ class BaseBuildCommand(Command):
             sys.exit(1)
 
         if node_version[2] is not None:
-            log.info("using node ({0})".format(node_version))
+            log.info("using node ({})".format(node_version))
             self._run_command(["yarn", "install", "--production", "--frozen-lockfile", "--quiet"])
 
     def _run_command(self, cmd, env=None):

--- a/src/sentry/utils/distutils/commands/build_assets.py
+++ b/src/sentry/utils/distutils/commands/build_assets.py
@@ -129,9 +129,7 @@ class BuildAssetsCommand(BaseBuildCommand):
         env["SENTRY_STATIC_DIST_PATH"] = self.sentry_static_dist_path
         env["NODE_ENV"] = "production"
         # TODO: Our JS builds should not require 4GB heap space
-        env["NODE_OPTIONS"] = (
-            (env.get("NODE_OPTIONS", "") + " --max-old-space-size=4096")
-        ).lstrip()
+        env["NODE_OPTIONS"] = (env.get("NODE_OPTIONS", "") + " --max-old-space-size=4096").lstrip()
         self._run_command(["yarn", "tsc", "-p", "config/tsconfig.build.json"], env=env)
         self._run_command(["yarn", "webpack", "--bail"], env=env)
 

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -541,20 +541,20 @@ def _gather_url(item, report, driver, summary, extra):
     try:
         url = driver.current_url
     except Exception as e:
-        summary.append("WARNING: Failed to gather URL: {0}".format(e))
+        summary.append("WARNING: Failed to gather URL: {}".format(e))
         return
     pytest_html = item.config.pluginmanager.getplugin("html")
     if pytest_html is not None:
         # add url to the html report
         extra.append(pytest_html.extras.url(url))
-    summary.append("URL: {0}".format(url))
+    summary.append("URL: {}".format(url))
 
 
 def _gather_screenshot(item, report, driver, summary, extra):
     try:
         screenshot = driver.get_screenshot_as_base64()
     except Exception as e:
-        summary.append("WARNING: Failed to gather screenshot: {0}".format(e))
+        summary.append("WARNING: Failed to gather screenshot: {}".format(e))
         return
     pytest_html = item.config.pluginmanager.getplugin("html")
     if pytest_html is not None:
@@ -566,7 +566,7 @@ def _gather_html(item, report, driver, summary, extra):
     try:
         html = driver.page_source.encode("utf-8")
     except Exception as e:
-        summary.append("WARNING: Failed to gather HTML: {0}".format(e))
+        summary.append("WARNING: Failed to gather HTML: {}".format(e))
         return
     pytest_html = item.config.pluginmanager.getplugin("html")
     if pytest_html is not None:
@@ -579,13 +579,13 @@ def _gather_logs(item, report, driver, summary, extra):
         types = driver.log_types
     except Exception as e:
         # note that some drivers may not implement log types
-        summary.append("WARNING: Failed to gather log types: {0}".format(e))
+        summary.append("WARNING: Failed to gather log types: {}".format(e))
         return
     for name in types:
         try:
             log = driver.get_log(name)
         except Exception as e:
-            summary.append("WARNING: Failed to gather {0} log: {1}".format(name, e))
+            summary.append("WARNING: Failed to gather {} log: {}".format(name, e))
             return
         pytest_html = item.config.pluginmanager.getplugin("html")
         if pytest_html is not None:

--- a/src/sentry_plugins/jira/client.py
+++ b/src/sentry_plugins/jira/client.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 def md5(*bits):
-    return _md5(b":".join((force_bytes(bit, errors="replace") for bit in bits)))
+    return _md5(b":".join(force_bytes(bit, errors="replace") for bit in bits))
 
 
 class JiraClient(ApiClient):

--- a/src/sentry_plugins/jira/plugin.py
+++ b/src/sentry_plugins/jira/plugin.py
@@ -182,7 +182,7 @@ class JiraPlugin(CorePluginMixin, IssuePlugin2):
         # make sure default issue type is actually
         # one that is allowed for project
         if issue_type:
-            if not any((c for c in issue_type_choices if c[0] == issue_type)):
+            if not any(c for c in issue_type_choices if c[0] == issue_type):
                 issue_type = issue_type_meta["id"]
 
         fields = (

--- a/src/sentry_plugins/opsgenie/plugin.py
+++ b/src/sentry_plugins/opsgenie/plugin.py
@@ -70,7 +70,7 @@ class OpsGeniePlugin(CorePluginMixin, notify.NotificationPlugin):
     logger = logging.getLogger("sentry.plugins.opsgenie")
 
     def is_configured(self, project):
-        return all((self.get_option(k, project) for k in ("api_key", "alert_url")))
+        return all(self.get_option(k, project) for k in ("api_key", "alert_url"))
 
     def get_form_initial(self, project=None):
         return {"alert_url": "https://api.opsgenie.com/v2/alerts"}

--- a/src/sentry_plugins/redmine/plugin.py
+++ b/src/sentry_plugins/redmine/plugin.py
@@ -60,7 +60,7 @@ class RedminePlugin(CorePluginMixin, IssuePlugin):
         return True
 
     def is_configured(self, project, **kwargs):
-        return all((self.get_option(k, project) for k in ("host", "key", "project_id")))
+        return all(self.get_option(k, project) for k in ("host", "key", "project_id"))
 
     def get_new_issue_title(self, **kwargs):
         return "Create Redmine Task"

--- a/src/sentry_plugins/teamwork/client.py
+++ b/src/sentry_plugins/teamwork/client.py
@@ -26,11 +26,11 @@ class TeamworkClient(object):
         return self._request(path="/projects.json")["projects"]
 
     def list_tasklists(self, project_id):
-        return self._request(path="/projects/{0}/tasklists.json".format(project_id))["tasklists"]
+        return self._request(path="/projects/{}/tasklists.json".format(project_id))["tasklists"]
 
     def create_task(self, tasklist_id, **kwargs):
         return self._request(
             method="POST",
-            path="/tasklists/{0}/tasks.json".format(tasklist_id),
+            path="/tasklists/{}/tasks.json".format(tasklist_id),
             data={"todo-item": kwargs},
         )["id"]

--- a/src/sentry_plugins/teamwork/plugin.py
+++ b/src/sentry_plugins/teamwork/plugin.py
@@ -109,7 +109,7 @@ class TeamworkPlugin(CorePluginMixin, IssuePlugin):
         return "\n".join(output)
 
     def is_configured(self, request, project, **kwargs):
-        return all((self.get_option(key, project) for key in ("url", "token")))
+        return all(self.get_option(key, project) for key in ("url", "token"))
 
     def get_client(self, project):
         return TeamworkClient(

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -76,7 +76,7 @@ class TwilioConfigurationForm(forms.Form):
     def clean_sms_from(self):
         data = self.cleaned_data["sms_from"]
         if not validate_phone(data):
-            raise forms.ValidationError("{0} is not a valid phone number.".format(data))
+            raise forms.ValidationError("{} is not a valid phone number.".format(data))
         return clean_phone(data)
 
     def clean_sms_to(self):
@@ -84,11 +84,11 @@ class TwilioConfigurationForm(forms.Form):
         phones = split_sms_to(data)
         if len(phones) > 10:
             raise forms.ValidationError(
-                "Max of 10 phone numbers, {0} were given.".format(len(phones))
+                "Max of 10 phone numbers, {} were given.".format(len(phones))
             )
         for phone in phones:
             if not validate_phone(phone):
-                raise forms.ValidationError("{0} is not a valid phone number.".format(phone))
+                raise forms.ValidationError("{} is not a valid phone number.".format(phone))
         return ",".join(sorted(set(map(clean_phone, phones))))
 
     def clean(self):

--- a/src/social_auth/backends/github.py
+++ b/src/social_auth/backends/github.py
@@ -24,9 +24,9 @@ from sentry.utils import json
 # GitHub configuration
 GITHUB_BASE_DOMAIN = getattr(settings, "GITHUB_BASE_DOMAIN", "github.com")
 GITHUB_API_DOMAIN = getattr(settings, "GITHUB_API_DOMAIN", "api.github.com")
-GITHUB_AUTHORIZATION_URL = "https://{0}/login/oauth/authorize".format(GITHUB_BASE_DOMAIN)
-GITHUB_ACCESS_TOKEN_URL = "https://{0}/login/oauth/access_token".format(GITHUB_BASE_DOMAIN)
-GITHUB_USER_DATA_URL = "https://{0}/user".format(GITHUB_API_DOMAIN)
+GITHUB_AUTHORIZATION_URL = "https://{}/login/oauth/authorize".format(GITHUB_BASE_DOMAIN)
+GITHUB_ACCESS_TOKEN_URL = "https://{}/login/oauth/access_token".format(GITHUB_BASE_DOMAIN)
+GITHUB_USER_DATA_URL = "https://{}/user".format(GITHUB_API_DOMAIN)
 
 # GitHub organization configuration
 GITHUB_ORGANIZATION_MEMBER_OF_URL = "https://%s/orgs/{org}/members/{username}" % GITHUB_API_DOMAIN


### PR DESCRIPTION
This is a run of `pyupgrade src/**/*.py`, which performs imo trivial changes that are both 2 and 3 compatible. Going forward, this will make `--py36-plus` fixer diffs nicer, otherwise I'd have to figure out how to disable these fixers in my fork of pyupgrade. But I thought just doing these would be quicker, there's not a lot of them.