### PR TITLE
feat(ui): Link to releases and alerts from project detail

### DIFF
--- a/src/sentry/static/sentry/app/views/projectDetail/projectLatestAlerts.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectLatestAlerts.tsx
@@ -10,7 +10,7 @@ import Link from 'app/components/links/link';
 import Placeholder from 'app/components/placeholder';
 import TimeSince from 'app/components/timeSince';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
-import {IconCheckmark, IconFire, IconWarning} from 'app/icons';
+import {IconCheckmark, IconFire, IconOpen, IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -20,6 +20,7 @@ import {Theme} from 'app/utils/theme';
 import {Incident, IncidentStatus} from '../alerts/types';
 
 import MissingAlertsButtons from './missingFeatureButtons/missingAlertsButtons';
+import {SectionHeadingLink, SectionHeadingWrapper, SidebarSection} from './styles';
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;
@@ -98,6 +99,21 @@ class ProjectLatestAlerts extends AsyncComponent<Props, State> {
     this.setState({hasAlertRule: alertRules.length > 0, loading: false});
   }
 
+  get alertsLink() {
+    const {organization} = this.props;
+
+    // as this is a link to latest alerts, we want to only preserve project and environment
+    return {
+      pathname: `/organizations/${organization.slug}/alerts/`,
+      query: {
+        statsPeriod: undefined,
+        start: undefined,
+        end: undefined,
+        utc: undefined,
+      },
+    };
+  }
+
   renderAlertRow = (alert: Incident) => {
     const {organization, theme} = this.props;
     const {status, id, identifier, title, dateClosed, dateStarted} = alert;
@@ -169,17 +185,19 @@ class ProjectLatestAlerts extends AsyncComponent<Props, State> {
 
   renderBody() {
     return (
-      <Section>
-        <SectionHeading>{t('Latest Alerts')}</SectionHeading>
+      <SidebarSection>
+        <SectionHeadingWrapper>
+          <SectionHeading>{t('Latest Alerts')}</SectionHeading>
+          <SectionHeadingLink to={this.alertsLink}>
+            <IconOpen />
+          </SectionHeadingLink>
+        </SectionHeadingWrapper>
+
         <div>{this.renderInnerBody()}</div>
-      </Section>
+      </SidebarSection>
     );
   }
 }
-
-const Section = styled('section')`
-  margin-bottom: ${space(2)};
-`;
 
 const AlertRowLink = styled(Link)`
   display: flex;

--- a/src/sentry/static/sentry/app/views/projectDetail/projectLatestReleases.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectLatestReleases.tsx
@@ -11,6 +11,7 @@ import Placeholder from 'app/components/placeholder';
 import TextOverflow from 'app/components/textOverflow';
 import Version from 'app/components/version';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
+import {IconOpen} from 'app/icons';
 import {t} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -19,6 +20,7 @@ import {analytics} from 'app/utils/analytics';
 import {RELEASES_TOUR_STEPS} from 'app/views/releases/list/releaseLanding';
 
 import MissingReleasesButtons from './missingFeatureButtons/missingReleasesButtons';
+import {SectionHeadingLink, SectionHeadingWrapper, SidebarSection} from './styles';
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;
@@ -93,6 +95,21 @@ class ProjectLatestReleases extends AsyncComponent<Props, State> {
     });
   };
 
+  get releasesLink() {
+    const {organization} = this.props;
+
+    // as this is a link to latest releases, we want to only preserve project and environment
+    return {
+      pathname: `/organizations/${organization.slug}/releases/`,
+      query: {
+        statsPeriod: undefined,
+        start: undefined,
+        end: undefined,
+        utc: undefined,
+      },
+    };
+  }
+
   renderReleaseRow = (release: Release) => {
     const {projectId} = this.props;
     const {lastDeploy, dateCreated} = release;
@@ -139,17 +156,18 @@ class ProjectLatestReleases extends AsyncComponent<Props, State> {
 
   renderBody() {
     return (
-      <Section>
-        <SectionHeading>{t('Latest Releases')}</SectionHeading>
+      <SidebarSection>
+        <SectionHeadingWrapper>
+          <SectionHeading>{t('Latest Releases')}</SectionHeading>
+          <SectionHeadingLink to={this.releasesLink}>
+            <IconOpen />
+          </SectionHeadingLink>
+        </SectionHeadingWrapper>
         <div>{this.renderInnerBody()}</div>
-      </Section>
+      </SidebarSection>
     );
   }
 }
-
-const Section = styled('section')`
-  margin-bottom: ${space(2)};
-`;
 
 const ReleasesTable = styled('div')`
   display: grid;

--- a/src/sentry/static/sentry/app/views/projectDetail/projectQuickLinks.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectQuickLinks.tsx
@@ -16,6 +16,8 @@ import {FilterViews} from 'app/views/performance/landing';
 import {DEFAULT_MAX_DURATION} from 'app/views/performance/trends/utils';
 import {getPerformanceLandingUrl} from 'app/views/performance/utils';
 
+import {SidebarSection} from './styles';
+
 type Props = {
   organization: Organization;
   location: Location;
@@ -64,7 +66,7 @@ function ProjectQuickLinks({organization, project, location}: Props) {
   ];
 
   return (
-    <Section>
+    <SidebarSection>
       <SectionHeading>{t('Quick Links')}</SectionHeading>
       {quickLinks
         // push disabled links to the bottom
@@ -82,13 +84,9 @@ function ProjectQuickLinks({organization, project, location}: Props) {
             </Tooltip>
           </div>
         ))}
-    </Section>
+    </SidebarSection>
   );
 }
-
-const Section = styled('section')`
-  margin-bottom: ${space(2)};
-`;
 
 const QuickLink = styled(p =>
   p.disabled ? (

--- a/src/sentry/static/sentry/app/views/projectDetail/projectTeamAccess.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectTeamAccess.tsx
@@ -11,6 +11,8 @@ import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 
+import {SidebarSection} from './styles';
+
 type Props = {
   organization: Organization;
   project?: Project | null;
@@ -62,17 +64,16 @@ function ProjectTeamAccess({organization, project}: Props) {
   }
 
   return (
-    <Section>
+    <StyledSidebarSection>
       <SectionHeading>{t('Team Access')}</SectionHeading>
 
       <div>{renderInnerBody()}</div>
-    </Section>
+    </StyledSidebarSection>
   );
 }
 
-const Section = styled('section')`
+const StyledSidebarSection = styled(SidebarSection)`
   font-size: ${p => p.theme.fontSizeMedium};
-  margin-bottom: ${space(2)};
 `;
 
 const StyledLink = styled(Link)`

--- a/src/sentry/static/sentry/app/views/projectDetail/styles.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/styles.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+import GlobalSelectionLink from 'app/components/globalSelectionLink';
+import space from 'app/styles/space';
+
+export const SidebarSection = styled('section')`
+  margin-bottom: ${space(2)};
+`;
+
+export const SectionHeadingWrapper = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const SectionHeadingLink = styled(GlobalSelectionLink)`
+  display: flex;
+`;


### PR DESCRIPTION
Adding these `IconOpen` links to latest releases and latest alerts on project detail page.

![image](https://user-images.githubusercontent.com/9060071/106900433-cc451700-66f6-11eb-8469-da202b82ecc6.png)
