### PR TITLE
build(pre-commit): Add shellcheck pre-commit

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -31,6 +31,8 @@ backend_lintable: &backend_lintable
 
 backend: &backend
   - *backend_lintable
+  - '.pre-commit-config.yaml'
+  - '**/*.sh'
   - '**/*.pysnap'
   - 'src/sentry/!(static)/**'
   - 'requirements-*.txt'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,11 @@ repos:
     hooks:
     -   id: check-github-actions
     -   id: check-github-workflows
+-   repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.7.1.1
+    hooks:
+      - id: shellcheck
+        types: [shell]
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:


### PR DESCRIPTION
shellcheck catches issues in our shell scripts and makes good recommendations.

This does not tackle existing issues. I was considering letting whoever tackles those files next to investigate each one of them.

```
In docker/builder.sh line 14:
export YARN_CACHE_FOLDER="$(mktemp -d)"
       ^---------------^ SC2155: Declare and assign separately to avoid masking return values.


In scripts/bump-version.sh line 5:
cd $SCRIPT_DIR/..
   ^---------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
cd "$SCRIPT_DIR"/..


In scripts/bump-version.sh line 7:
OLD_VERSION="$1"
^---------^ SC2034: OLD_VERSION appears unused. Verify use (or export if used externally).


In src/sentry/templates/sentry/reprocessing-script.sh line 1:
{% load i18n %}{% autoescape off %}#!/bin/bash
 ^-- SC1054: You need a space after the '{'.
              ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.
               ^-- SC1083: This { is literal. Check expression (missing ;/\n?) or quote it.
                                  ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.


In src/sentry/templates/sentry/reprocessing-script.sh line 8:
{% if not token %}
 ^-- SC1054: You need a space after the '{'.
                 ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.


In src/sentry/templates/sentry/reprocessing-script.sh line 11:
{% elif issues %}
 ^-- SC1054: You need a space after the '{'.
                ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.


In src/sentry/templates/sentry/reprocessing-script.sh line 13:
{% for issue in issues %}
 ^-- SC1054: You need a space after the '{'.
                        ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.


In src/sentry/templates/sentry/reprocessing-script.sh line 15:
{% endfor %}
 ^-- SC1054: You need a space after the '{'.
           ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.


In src/sentry/templates/sentry/reprocessing-script.sh line 57:
"$CLI" upload-dsym --derived-data --no-zips{% for issue in issues %} --uuid {{ issue.uuid }}{% endfor %} --require-all
                                           ^-- SC1083: This { is literal. Check expression (missing ;/\n?) or quote it.
                                                                   ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.
                                                                            ^-- SC1083: This { is literal. Check expression (missing ;/\n?) or quote it.
                                                                             ^-- SC1083: This { is literal. Check expression (missing ;/\n?) or quote it.
                                                                                          ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.
                                                                                           ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.
                                                                                            ^-- SC1083: This { is literal. Check expression (missing ;/\n?) or quote it.
                                                                                                       ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.


In src/sentry/templates/sentry/reprocessing-script.sh line 60:
{% else %}
 ^-- SC1054: You need a space after the '{'.
         ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.


In src/sentry/templates/sentry/reprocessing-script.sh line 62:
{% endif %}
^-- SC1009: The mentioned syntax error was in this brace group.
 ^-- SC1054: You need a space after the '{'.
          ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.


In src/sentry/templates/sentry/reprocessing-script.sh line 63:
{% endautoescape %}
^-- SC1073: Couldn't parse this brace group. Fix to allow more checks.
 ^-- SC1054: You need a space after the '{'.
                  ^-- SC1083: This } is literal. Check expression (missing ;/\n?) or quote it.


In src/sentry/templates/sentry/reprocessing-script.sh line 64:

^-- SC1056: Expected a '}'. If you have one, try a ; or \n in front of it.
^-- SC1072: Missing '}'. Fix any mentioned problems and try again.


In scripts/ensure-venv.sh line 24:
    major=`python -c "import sys; print(sys.version_info[0])"`
    ^---^ SC2034: major appears unused. Verify use (or export if used externally).
          ^-- SC2006: Use $(...) notation instead of legacy backticked `...`.

Did you mean: 
    major=$(python -c "import sys; print(sys.version_info[0])")


In scripts/ensure-venv.sh line 25:
    minor=`python -c "import sys; print(sys.version_info[1])"`
          ^-- SC2006: Use $(...) notation instead of legacy backticked `...`.

Did you mean: 
    minor=$(python -c "import sys; print(sys.version_info[1])")


In scripts/post-release.sh line 5:
./scripts/bump-version.sh '' $(date -d "$(echo $CRAFT_NEW_VERSION | sed -e 's/^\([0-9]\{2\}\)\.\([0-9]\{1,2\}\)\.[0-9]\+$/20\1-\2-1/') 1 month" +%y.%-m.0.dev0)
                             ^-- SC2046: Quote this to prevent word splitting.
                                          ^-- SC2001: See if you can use ${variable//search/replace} instead.
                                               ^----------------^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean: 
./scripts/bump-version.sh '' $(date -d "$(echo "$CRAFT_NEW_VERSION" | sed -e 's/^\([0-9]\{2\}\)\.\([0-9]\{1,2\}\)\.[0-9]\+$/20\1-\2-1/') 1 month" +%y.%-m.0.dev0)

For more information:
  https://www.shellcheck.net/wiki/SC1054 -- You need a space after the '{'.
  https://www.shellcheck.net/wiki/SC1056 -- Expected a '}'. If you have one, ...
  https://www.shellcheck.net/wiki/SC1083 -- This { is literal. Check expressi...
```