### PR TITLE
fix(ui): cleaning up actions on Issue Details page

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/deleteAction.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/deleteAction.tsx
@@ -1,17 +1,11 @@
 import React from 'react';
-import styled from '@emotion/styled';
 
 import {ModalRenderProps, openModal} from 'app/actionCreators/modal';
 import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
-import ActionButton from 'app/components/actions/button';
-import MenuHeader from 'app/components/actions/menuHeader';
 import MenuItemActionLink from 'app/components/actions/menuItemActionLink';
 import Button from 'app/components/button';
-import ButtonBar from 'app/components/buttonBar';
 import Confirm from 'app/components/confirm';
-import DropdownLink from 'app/components/dropdownLink';
-import {IconChevron, IconDelete} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
@@ -79,7 +73,7 @@ function DeleteAction({disabled, project, organization, onDiscard, onDelete}: Pr
   }
 
   return (
-    <ButtonBar merged>
+    <React.Fragment>
       <Confirm
         message={t(
           'Deleting this issue is permanent. Are you sure you wish to continue?'
@@ -87,42 +81,18 @@ function DeleteAction({disabled, project, organization, onDiscard, onDelete}: Pr
         onConfirm={onDelete}
         disabled={disabled}
       >
-        <DeleteButton
-          disabled={disabled}
-          label={t('Delete issue')}
-          icon={<IconDelete size="xs" />}
-        />
-      </Confirm>
-      <DropdownLink
-        caret={false}
-        disabled={disabled}
-        customTitle={
-          <ActionButton
-            disabled={disabled}
-            label={t('More delete options')}
-            icon={<IconChevron direction="down" size="xs" />}
-          />
-        }
-      >
-        <MenuHeader>{t('Delete & Discard')}</MenuHeader>
-        <MenuItemActionLink title="" onAction={openDiscardModal}>
-          {t('Delete and discard future events')}
+        <MenuItemActionLink disabled={disabled} title={t('Delete issue')}>
+          {t('Delete issue')}
         </MenuItemActionLink>
-      </DropdownLink>
-    </ButtonBar>
+      </Confirm>
+      <MenuItemActionLink
+        title={t('Delete and discard future events')}
+        onAction={openDiscardModal}
+      >
+        {t('Delete and discard future events')}
+      </MenuItemActionLink>
+    </React.Fragment>
   );
 }
-
-const DeleteButton = styled(ActionButton)`
-  ${p =>
-    !p.disabled &&
-    `
-  &:hover {
-    background-color: ${p.theme.button.danger.background};
-    color: ${p.theme.button.danger.color};
-    border-color: ${p.theme.button.danger.border};
-  }
-  `}
-`;
 
 export default DeleteAction;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
@@ -283,14 +283,12 @@ class Actions extends React.Component<Props, State> {
           }
           anchorRight
         >
-          <MenuItemActionLink
+          <SubscribeAction
             disabled={disabled}
-            onAction={() => this.handleClick(disabled, this.onToggleSubscribe)}
-            shouldConfirm={false}
+            group={group}
+            onClick={this.handleClick(disabled, this.onToggleSubscribe)}
             title={subscribeTitle}
-          >
-            {subscribeTitle}
-          </MenuItemActionLink>
+          />
           {orgFeatures.has('discover-basic') && (
             <MenuItemActionLink
               disabled={disabled}
@@ -302,7 +300,7 @@ class Actions extends React.Component<Props, State> {
           )}
           <MenuItemActionLink
             disabled={disabled}
-            onAction={() => this.handleClick(disabled, this.onToggleBookmark)}
+            onClick={this.handleClick(disabled, this.onToggleBookmark)}
             title={bookmarkTitle}
           >
             {bookmarkTitle}
@@ -310,7 +308,7 @@ class Actions extends React.Component<Props, State> {
 
           {orgFeatures.has('reprocessing-v2') && (
             <MenuItemActionLink
-              onAction={() => this.handleClick(disabled, this.onReprocess)}
+              onClick={this.handleClick(disabled, this.onReprocess)}
               title={t('Reprocess')}
             >
               {t('Reprocess')}
@@ -325,54 +323,10 @@ class Actions extends React.Component<Props, State> {
             onDiscard={this.onDiscard}
           />
         </DropdownLink>
-
-        {/* --------------------------------------------- */}
-
-        {/* {orgFeatures.has('discover-basic') && (
-          <ActionButton disabled={disabled} to={disabled ? '' : this.getDiscoverUrl()}>
-            {t('Open in Discover')}
-          </ActionButton>
-        )} */}
-
-        {/* <BookmarkButton
-          disabled={disabled}
-          isActive={group.isBookmarked}
-          title={bookmarkTitle}
-          label={bookmarkTitle}
-          onClick={this.handleClick(disabled, this.onToggleBookmark)}
-          icon={<IconStar isSolid size="xs" />}
-        /> */}
-
-        {/* <SubscribeAction
-          disabled={disabled}
-          group={group}
-          onClick={this.handleClick(disabled, this.onToggleSubscribe)}
-        /> */}
-
-        {/* {orgFeatures.has('reprocessing-v2') && (
-          <ActionButton
-            disabled={disabled}
-            icon={<IconRefresh size="xs" />}
-            title={t('Reprocess this issue')}
-            label={t('Reprocess this issue')}
-            onClick={this.handleClick(disabled, this.onReprocess)}
-          />
-        )} */}
       </Wrapper>
     );
   }
 }
-
-const BookmarkButton = styled(ActionButton)<{isActive: boolean}>`
-  ${p =>
-    p.isActive &&
-    `
-    background: ${p.theme.yellow100};
-    color: ${p.theme.yellow300};
-    border-color: ${p.theme.yellow300};
-    text-shadow: 0 1px 0 rgba(0, 0, 0, 0.15);
-  `}
-`;
 
 const Wrapper = styled('div')`
   display: grid;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
@@ -12,10 +12,12 @@ import GroupActions from 'app/actions/groupActions';
 import {Client} from 'app/api';
 import ActionButton from 'app/components/actions/button';
 import IgnoreActions from 'app/components/actions/ignore';
+import MenuItemActionLink from 'app/components/actions/menuItemActionLink';
 import ResolveActions from 'app/components/actions/resolve';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
+import DropdownLink from 'app/components/dropdownLink';
 import Tooltip from 'app/components/tooltip';
-import {IconRefresh, IconStar} from 'app/icons';
+import {IconEllipsis} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {
@@ -222,7 +224,9 @@ class Actions extends React.Component<Props, State> {
     const {status, isBookmarked} = group;
 
     const orgFeatures = new Set(organization.features);
-
+    const subscribeTitle = group.isSubscribed
+      ? t('Subscribe to Notifications')
+      : t('Unsubscribe to Notifications');
     const bookmarkTitle = isBookmarked ? t('Remove bookmark') : t('Bookmark');
     const hasRelease = !!project.features?.includes('releases');
 
@@ -258,13 +262,6 @@ class Actions extends React.Component<Props, State> {
             disabled={disabled}
           />
         </GuideAnchor>
-        <DeleteAction
-          disabled={disabled}
-          organization={organization}
-          project={project}
-          onDelete={this.onDelete}
-          onDiscard={this.onDiscard}
-        />
         {orgFeatures.has('shared-issues') && (
           <ShareIssue
             disabled={disabled}
@@ -276,28 +273,83 @@ class Actions extends React.Component<Props, State> {
           />
         )}
 
-        {orgFeatures.has('discover-basic') && (
+        <DropdownLink
+          caret={false}
+          customTitle={
+            <ActionButton
+              label={t('More issue actions')}
+              icon={<IconEllipsis size="sm" />}
+            />
+          }
+          anchorRight
+        >
+          <MenuItemActionLink
+            disabled={disabled}
+            onAction={() => this.handleClick(disabled, this.onToggleSubscribe)}
+            shouldConfirm={false}
+            title={subscribeTitle}
+          >
+            {subscribeTitle}
+          </MenuItemActionLink>
+          {orgFeatures.has('discover-basic') && (
+            <MenuItemActionLink
+              disabled={disabled}
+              title={t('Open in Discover')}
+              to={disabled ? '' : this.getDiscoverUrl()}
+            >
+              {t('Open in Discover')}
+            </MenuItemActionLink>
+          )}
+          <MenuItemActionLink
+            disabled={disabled}
+            onAction={() => this.handleClick(disabled, this.onToggleBookmark)}
+            title={bookmarkTitle}
+          >
+            {bookmarkTitle}
+          </MenuItemActionLink>
+
+          {orgFeatures.has('reprocessing-v2') && (
+            <MenuItemActionLink
+              onAction={() => this.handleClick(disabled, this.onReprocess)}
+              title={t('Reprocess')}
+            >
+              {t('Reprocess')}
+            </MenuItemActionLink>
+          )}
+
+          <DeleteAction
+            disabled={disabled}
+            organization={organization}
+            project={project}
+            onDelete={this.onDelete}
+            onDiscard={this.onDiscard}
+          />
+        </DropdownLink>
+
+        {/* --------------------------------------------- */}
+
+        {/* {orgFeatures.has('discover-basic') && (
           <ActionButton disabled={disabled} to={disabled ? '' : this.getDiscoverUrl()}>
             {t('Open in Discover')}
           </ActionButton>
-        )}
+        )} */}
 
-        <BookmarkButton
+        {/* <BookmarkButton
           disabled={disabled}
           isActive={group.isBookmarked}
           title={bookmarkTitle}
           label={bookmarkTitle}
           onClick={this.handleClick(disabled, this.onToggleBookmark)}
           icon={<IconStar isSolid size="xs" />}
-        />
+        /> */}
 
-        <SubscribeAction
+        {/* <SubscribeAction
           disabled={disabled}
           group={group}
           onClick={this.handleClick(disabled, this.onToggleSubscribe)}
-        />
+        /> */}
 
-        {orgFeatures.has('reprocessing-v2') && (
+        {/* {orgFeatures.has('reprocessing-v2') && (
           <ActionButton
             disabled={disabled}
             icon={<IconRefresh size="xs" />}
@@ -305,7 +357,7 @@ class Actions extends React.Component<Props, State> {
             label={t('Reprocess this issue')}
             onClick={this.handleClick(disabled, this.onReprocess)}
           />
-        )}
+        )} */}
       </Wrapper>
     );
   }

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/subscribeAction.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/subscribeAction.tsx
@@ -1,19 +1,16 @@
 import React from 'react';
 
-import ActionButton from 'app/components/actions/button';
-import {IconBell} from 'app/icons';
-import {t} from 'app/locale';
+import MenuItemActionLink from 'app/components/actions/menuItemActionLink';
 import {Group} from 'app/types';
-
-import {getSubscriptionReason} from '../utils';
 
 type Props = {
   group: Group;
   onClick: (event: React.MouseEvent) => void;
   disabled?: boolean;
+  title: string;
 };
 
-function SubscribeAction({disabled, group, onClick}: Props) {
+function SubscribeAction({title, disabled, group, onClick}: Props) {
   const canChangeSubscriptionState = !(group.subscriptionDetails?.disabled ?? false);
 
   if (!canChangeSubscriptionState) {
@@ -21,15 +18,9 @@ function SubscribeAction({disabled, group, onClick}: Props) {
   }
 
   return (
-    <ActionButton
-      disabled={disabled}
-      title={getSubscriptionReason(group, true)}
-      priority={group.isSubscribed ? 'primary' : 'default'}
-      size="zero"
-      label={t('Subscribe')}
-      onClick={onClick}
-      icon={<IconBell size="xs" />}
-    />
+    <MenuItemActionLink disabled={disabled} title={title} onClick={onClick}>
+      {title}
+    </MenuItemActionLink>
   );
 }
 


### PR DESCRIPTION
On the Issue Details page: moving uncommon issue actions into a `...` button so that this page is less intimidating and confusing.

## Before 

![Today](https://user-images.githubusercontent.com/1900676/106970392-9c4f4100-6701-11eb-8c6d-2746da774515.png)

## After

<img width="1265" alt="Screen Shot 2021-02-04 at 3 57 28 PM" src="https://user-images.githubusercontent.com/1900676/106970451-bab53c80-6701-11eb-99d0-8b8ffc479c71.png">
