### PR TITLE
build(ci): Separate webpack from acceptance test runner

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -70,8 +70,49 @@ jobs:
       - name: Handle artifacts
         uses: ./.github/actions/artifacts
 
+  webpack:
+    name: create frontend bundle
+    runs-on: ubuntu-16.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout sentry
+
+      - uses: volta-cli/action@v1
+
+      - name: yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.setup.outputs.yarn-cache-dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Javascript Dependencies
+        run: |
+          yarn install --frozen-lockfile
+
+      - name: webpack
+        env:
+          SENTRY_INSTRUMENTATION: 1
+          # this is fine to not have for forks, it shouldn't fail
+          SENTRY_WEBPACK_WEBHOOK_SECRET: ${{ secrets.SENTRY_WEBPACK_WEBHOOK_SECRET }}
+        run: |
+          yarn build-acceptance
+
+
+      - name: Save frontend dist
+        uses: actions/upload-artifact@v2
+        with:
+          name: frontend-dist
+          path: |
+            static/dist
+
   acceptance:
     name: acceptance
+    needs: [webpack]
     runs-on: ubuntu-16.04
     timeout-minutes: 20
     strategy:
@@ -85,8 +126,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         name: Checkout sentry
-
-      - uses: volta-cli/action@v1
 
       - name: Set python version output
         id: python-version
@@ -116,26 +155,10 @@ jobs:
         with:
           snuba: true
 
-      - name: yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      - name: Download frontend dist
+        uses: actions/download-artifact@v2
         with:
-          path: ${{ steps.setup.outputs.yarn-cache-dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install Javascript Dependencies
-        run: |
-          yarn install --frozen-lockfile
-
-      - name: webpack
-        env:
-          SENTRY_INSTRUMENTATION: 1
-          # this is fine to not have for forks, it shouldn't fail
-          SENTRY_WEBPACK_WEBHOOK_SECRET: ${{ secrets.SENTRY_WEBPACK_WEBHOOK_SECRET }}
-        run: |
-          yarn webpack --display errors-only
+          name: frontend-dist
 
       - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
         if: always()

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -104,7 +104,7 @@ jobs:
           # this is fine to not have for forks, it shouldn't fail
           SENTRY_WEBPACK_WEBHOOK_SECRET: ${{ secrets.SENTRY_WEBPACK_WEBHOOK_SECRET }}
         run: |
-          yarn build-acceptance
+          yarn webpack --display errors-only
 
 
       - name: Save frontend dist
@@ -163,6 +163,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: frontend-dist
+          path: static/dist
 
       - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
         if: always()

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -89,7 +89,7 @@ jobs:
         uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: ${{ steps.setup.outputs.yarn-cache-dir }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -81,6 +81,10 @@ jobs:
 
       - uses: volta-cli/action@v1
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
       - name: yarn cache
         uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)


### PR DESCRIPTION
This creates a new webpack job that prepares our frontend assets for acceptance tests. The acceptance test runners will wait until this is completed before running.