### PR TITLE
fix(ui) Make select control indicators have more contrast

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.jsx
@@ -70,6 +70,7 @@ const SelectControl = props => {
     padding: '4px',
     alignItems: 'center',
     cursor: 'pointer',
+    color: theme.subText,
   });
 
   const defaultStyles = {


### PR DESCRIPTION
The current colour is the same as our disabled colour which makes select controls appear disabled. Using subText gives them a bit more contrast and should help make the select boxes not look disabled.