### PR TITLE
fix(inbox): Fix guide copy and date threshold

### DIFF
--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -102,6 +102,7 @@ export default function getGuidesContent(): GuidesContent {
     },
     {
       guide: 'inbox_guide',
+      carryAssistantForward: true,
       requiredTargets: ['inbox_guide_tab'],
       dateThreshold: new Date(2021, 1, 26),
       steps: [

--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
@@ -147,7 +147,7 @@ const GuideAnchor = createReactClass<Props, State>({
                 )}
                 <StyledButton
                   size="small"
-                  href="#" // to clear `#assistant` from the url
+                  href={currentGuide.carryAssistantForward ? '#assistant' : '#'} // to clear `#assistant` from the url
                   to={to}
                   onClick={this.handleFinish}
                 >

--- a/src/sentry/static/sentry/app/components/assistant/types.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/types.tsx
@@ -18,6 +18,7 @@ export type Guide = {
   guide: string;
   requiredTargets: string[];
   dateThreshold?: Date;
+  carryAssistantForward?: boolean;
   steps: GuideStep[];
   seen: boolean;
 };
@@ -30,6 +31,7 @@ export type GuidesContent = {
    */
   requiredTargets: string[];
   dateThreshold?: Date;
+  carryAssistantForward?: boolean;
   steps: GuideStep[];
 }[];
 

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -201,7 +201,7 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
           return true;
         } else if (dateThreshold) {
           // Don't show the guide to users who've joined after the date threshold
-          return userDateJoined < dateThreshold;
+          return userDateJoined > dateThreshold;
         } else {
           return userDateJoined > assistantThreshold;
         }

--- a/src/sentry/static/sentry/app/views/issueList/utils.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/utils.tsx
@@ -60,7 +60,7 @@ export function getTabs(organization: Organization) {
         analyticsName: 'needs_review',
         count: true,
         enabled: !organization.features.includes('inbox-owners-query'),
-        tooltipTitle: t(`New and reopened issues. You can review, ignore, or resolve
+        tooltipTitle: t(`New and reopened issues that you can review, ignore, or resolve
         to move them out of this list. After seven days these issues are
         automatically marked as reviewed.`),
       },


### PR DESCRIPTION
This fixes the guide copy and the date threshold use and adds an option to carry assistant flag forward to the second guide.