### PR TITLE
fix(integrations): StacktraceLinkModal deprecation warnings

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -173,7 +173,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
                 deps =>
                   this.project && (
                     <StacktraceLinkModal
-                      onSubmit={() => this.handleSubmit()}
+                      onSubmit={this.handleSubmit}
                       filename={filename}
                       project={this.project}
                       organization={organization}

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -62,7 +62,7 @@ class StacktraceLinkModal extends React.Component<Props, State> {
         setup_type: 'automatic',
         view: 'stacktrace_issue_details',
       },
-      this.props.organization
+      organization
     );
 
     const parsingEndpoint = `/projects/${organization.slug}/${project.slug}/repo-path-parsing/`;
@@ -90,10 +90,10 @@ class StacktraceLinkModal extends React.Component<Props, State> {
           provider: configData.config?.provider.key,
           view: 'stacktrace_issue_details',
         },
-        this.props.organization
+        organization
       );
-      this.props.closeModal();
-      this.props.onSubmit();
+      closeModal();
+      onSubmit();
     } catch (err) {
       const errors = err?.responseJSON
         ? Array.isArray(err?.responseJSON)

--- a/tests/js/spec/components/events/interfaces/stacktraceLinkModal.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/stacktraceLinkModal.spec.jsx
@@ -11,6 +11,7 @@ describe('StacktraceLinkModal', function () {
   const filename = '/sentry/app.py';
   const repo = TestStubs.Repository({integrationId: integration.id});
   const config = TestStubs.RepositoryProjectPathConfig(project, repo, integration);
+  const sourceUrl = 'https://github.com/getsentry/sentry/blob/master/src/sentry/app.py';
 
   const closeModal = jest.fn();
   const modalElements = {
@@ -19,120 +20,73 @@ describe('StacktraceLinkModal', function () {
     Footer: p => p.children,
   };
 
+  const createWrapper = (statusCode = 200) => {
+    const configData = {
+      stackRoot: '',
+      sourceRoot: 'src/',
+      integrationId: integration.id,
+      repositoryId: repo.id,
+      defaultBranch: 'master',
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/repo-path-parsing/`,
+      method: 'POST',
+      body: {...configData},
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/integrations/${integration.id}/repo-project-path-configs/`,
+      method: 'POST',
+      statusCode,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      query: {file: filename, commitId: 'master', platform: 'python'},
+      body: {config, sourceUrl, integrations: [integration]},
+    });
+
+    return mountWithTheme(
+      <StacktraceLinkModal
+        {...modalElements}
+        closeModal={closeModal}
+        filename={filename}
+        integrations={[integration]}
+        organization={org}
+        project={project}
+      />,
+      TestStubs.routerContext()
+    );
+  };
+
+  const submitQuickSetupInput = async wrapper => {
+    wrapper.find('input').simulate('change', {target: {value: sourceUrl}});
+    wrapper.find('Button[data-test-id="quick-setup-button"]').simulate('click');
+
+    await tick();
+    wrapper.update();
+  };
+
   beforeEach(function () {
     closeModal.mockReset();
     MockApiClient.clearMockResponses();
   });
 
   it('renders manual setup option', async function () {
-    const wrapper = mountWithTheme(
-      <StacktraceLinkModal
-        {...modalElements}
-        project={project}
-        organization={org}
-        integrations={[integration]}
-        filename={filename}
-        closeModal={closeModal}
-      />,
-      TestStubs.routerContext()
-    );
+    const wrapper = createWrapper();
     expect(wrapper.find('IntegrationName').text()).toEqual('Test Integration');
   });
 
   it('closes modal after successful quick setup', async function () {
-    const configData = {
-      stackRoot: '',
-      sourceRoot: 'src/',
-      integrationId: integration.id,
-      repositoryId: repo.id,
-      defaultBranch: 'master',
-    };
-    const sourceUrl = 'https://github.com/getsentry/sentry/blob/master/src/sentry/app.py';
-
-    MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/repo-path-parsing/`,
-      method: 'POST',
-      body: {...configData},
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/integrations/${integration.id}/repo-project-path-configs/`,
-      method: 'POST',
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-      query: {file: filename, commitId: 'master', platform: 'python'},
-      body: {config, sourceUrl, integrations: [integration]},
-    });
-
-    const wrapper = mountWithTheme(
-      <StacktraceLinkModal
-        {...modalElements}
-        project={project}
-        organization={org}
-        integrations={[integration]}
-        filename={filename}
-        closeModal={closeModal}
-      />,
-      TestStubs.routerContext()
-    );
-    wrapper.find('input').simulate('change', {target: {value: sourceUrl}});
-    // submit quick setup input
-    wrapper.find('Button[data-test-id="quick-setup-button"]').simulate('click');
-
-    await tick();
-    wrapper.update();
-
+    const wrapper = createWrapper();
+    await submitQuickSetupInput(wrapper);
     expect(closeModal).toHaveBeenCalled();
   });
 
   it('keeps modal open on unsuccessful quick setup', async function () {
-    const configData = {
-      stackRoot: '',
-      sourceRoot: 'src/',
-      integrationId: integration.id,
-      repositoryId: repo.id,
-      defaultBranch: 'master',
-    };
-    const sourceUrl = 'https://github.com/getsentry/sentry/blob/master/src/sentry/app.py';
-
-    MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/repo-path-parsing/`,
-      method: 'POST',
-      body: {...configData},
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/integrations/${integration.id}/repo-project-path-configs/`,
-      method: 'POST',
-      statusCode: 400,
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
-      query: {file: filename, commitId: 'master', platform: 'python'},
-      body: {config, sourceUrl, integrations: [integration]},
-    });
-
-    const wrapper = mountWithTheme(
-      <StacktraceLinkModal
-        {...modalElements}
-        project={project}
-        organization={org}
-        integrations={[integration]}
-        filename={filename}
-        closeModal={closeModal}
-      />,
-      TestStubs.routerContext()
-    );
-    wrapper.find('input').simulate('change', {target: {value: sourceUrl}});
-    // submit quick setup input
-    wrapper.find('Button[data-test-id="quick-setup-button"]').simulate('click');
-
-    await tick();
-    wrapper.update();
-
+    const wrapper = createWrapper(400);
+    await submitQuickSetupInput(wrapper);
     expect(closeModal).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes [API-1642](https://getsentry.atlassian.net/browse/API-1642). We're seeing a lot of deprecation warning in tests caused by `AsyncComponent`. This PR moves async logic out of the Stacktrace Linking modal.
