### PR TITLE
fix(integrations): ExternalIssuesForm deprecation warnings 

### DIFF
--- a/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/externalIssues/abstractExternalIssueForm.tsx
@@ -215,9 +215,9 @@ export default class AbstractExternalIssueForm<
   handleReceiveIntegrationDetails = (_data: any) => {
     // Do nothing.
   };
-  getEndPointString = (): string => {
+  getEndPointString(): string {
     throw new Error("Method 'getEndPointString()' must be implemented.");
-  };
+  }
   renderNavTabs = (): React.ReactNode => null;
   renderBodyText = (): React.ReactNode => null;
   getTitle = () => tct('Issue Link Settings', {});

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -37,16 +37,13 @@ export default class ExternalIssueForm extends AbstractExternalIssueForm<Props, 
     this.loadTransaction = this.startTransaction('load');
   }
 
-  getEndpoints = (): ReturnType<AsyncComponent['getEndpoints']> => {
-    const {group, integration} = this.props;
-    const {action} = this.state;
-    return [
-      [
-        'integrationDetails',
-        `/groups/${group.id}/integrations/${integration.id}/?action=${action}`,
-      ],
-    ];
-  };
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const query: {action?: ExternalIssueAction} = {};
+    if (this.state?.hasOwnProperty('action')) {
+      query.action = this.state.action;
+    }
+    return [['integrationDetails', this.getEndPointString(), {query}]];
+  }
 
   handleClick = (action: ExternalIssueAction) => {
     this.setState({action}, () => this.reloadData());

--- a/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
+++ b/src/sentry/static/sentry/app/components/group/externalIssueForm.tsx
@@ -89,10 +89,10 @@ export default class ExternalIssueForm extends AbstractExternalIssueForm<Props, 
     this.loadTransaction?.finish();
   };
 
-  getEndPointString = () => {
+  getEndPointString() {
     const {group, integration} = this.props;
     return `/groups/${group.id}/integrations/${integration.id}/`;
-  };
+  }
 
   getTitle = () => {
     const {integration} = this.props;

--- a/src/sentry/static/sentry/app/views/releases/detail/filesChanged.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/filesChanged.tsx
@@ -49,7 +49,7 @@ class FilesChanged extends AsyncView<Props, State> {
     };
   }
 
-  getEndpoints = (): ReturnType<AsyncView['getEndpoints']> => {
+  getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
     const {params, activeRepository, location} = this.props;
     const {orgId, release} = params;
     const query = getQuery({location, activeRepository});
@@ -61,7 +61,7 @@ class FilesChanged extends AsyncView<Props, State> {
         {query},
       ],
     ];
-  };
+  }
 
   renderContent() {
     const {fileList, fileListPageLinks} = this.state;

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/ticketRuleModal.tsx
@@ -80,10 +80,10 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
       .map(field => field.name);
   };
 
-  getEndPointString = (): string => {
+  getEndPointString(): string {
     const {instance, organization} = this.props;
     return `/organizations/${organization.slug}/integrations/${instance.integration}/`;
-  };
+  }
 
   /**
    * Clean up the form data before saving it to state.

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/ticketRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/ticketRuleModal.tsx
@@ -44,7 +44,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {instance, organization} = this.props;
+    const {instance} = this.props;
     const query = (instance.dynamic_form_fields || [])
       .filter(field => field.updatesForm)
       .filter(field => instance.hasOwnProperty(field.name))
@@ -55,13 +55,7 @@ class TicketRuleModal extends AbstractExternalIssueForm<Props, State> {
         },
         {action: 'create'}
       );
-    return [
-      [
-        'integrationDetails',
-        `/organizations/${organization.slug}/integrations/${instance.integration}/`,
-        {query},
-      ],
-    ];
+    return [['integrationDetails', this.getEndPointString(), {query}]];
   }
 
   handleReceiveIntegrationDetails = (integrationDetails: any) => {

--- a/tests/js/spec/components/discover/transactionsList.spec.jsx
+++ b/tests/js/spec/components/discover/transactionsList.spec.jsx
@@ -86,7 +86,7 @@ describe('TransactionsList', function () {
           },
         },
         {
-          predicate: (_, opts) => opts && opts.query && opts.query.sort === 'transaction',
+          predicate: (_, opts) => opts?.query?.sort === 'transaction',
         }
       );
       MockApiClient.addMockResponse(
@@ -101,7 +101,7 @@ describe('TransactionsList', function () {
           },
         },
         {
-          predicate: (_, opts) => opts && opts.query && opts.query.sort === '-count',
+          predicate: (_, opts) => opts?.query?.sort === '-count',
         }
       );
       MockApiClient.addMockResponse({

--- a/tests/js/spec/components/group/externalIssueForm.spec.jsx
+++ b/tests/js/spec/components/group/externalIssueForm.spec.jsx
@@ -35,10 +35,15 @@ describe('ExternalIssueForm', () => {
   });
 
   const generateWrapper = (action = 'create') => {
-    MockApiClient.addMockResponse({
-      url: `/groups/${group.id}/integrations/${integration.id}/?action=create`,
-      body: formConfig,
-    });
+    MockApiClient.addMockResponse(
+      {
+        url: `/groups/${group.id}/integrations/${integration.id}/`,
+        body: formConfig,
+      },
+      {
+        predicate: (_, options) => options?.query?.action === 'create',
+      }
+    );
     const component = mountWithTheme(
       <ExternalIssueForm
         Body={p => p.children}
@@ -60,7 +65,7 @@ describe('ExternalIssueForm', () => {
         createIssueConfig: [],
       };
       MockApiClient.addMockResponse({
-        url: `/groups/${group.id}/integrations/${integration.id}/?action=create`,
+        url: `/groups/${group.id}/integrations/${integration.id}/`,
         body: formConfig,
       });
     });
@@ -131,10 +136,15 @@ describe('ExternalIssueForm', () => {
         },
         id: '5',
       };
-      getFormConfigRequest = MockApiClient.addMockResponse({
-        url: `/groups/${group.id}/integrations/${integration.id}/?action=link`,
-        body: formConfig,
-      });
+      getFormConfigRequest = MockApiClient.addMockResponse(
+        {
+          url: `/groups/${group.id}/integrations/${integration.id}/`,
+          body: formConfig,
+        },
+        {
+          predicate: (_, options) => options?.query?.action === 'link',
+        }
+      );
     });
     it('renders', () => {
       wrapper = generateWrapper('link');


### PR DESCRIPTION
Fixes API-1642. We're seeing a lot of deprecation warning in tests caused by AsyncComponent. This PR makes sure `getEndpoints` has the correct method signature.