### PR TITLE
feat(sentry-apps): Add delete endpoint for external issue details

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -353,7 +353,7 @@ class SentryAppInstallationBaseEndpoint(IntegrationPlatformEndpoint):
 class SentryAppInstallationExternalIssuePermission(SentryAppInstallationPermission):
     scope_map = {
         "POST": ("event:read", "event:write", "event:admin"),
-        "DELETE": ("event:admin"),
+        "DELETE": ("event:admin",),
     }
 
 

--- a/src/sentry/api/endpoints/sentry_app_installation_external_issue_details.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_external_issue_details.py
@@ -8,14 +8,14 @@ from sentry.models import PlatformExternalIssue
 
 
 class SentryAppInstallationExternalIssueDetailsEndpoint(ExternalIssueBaseEndpoint):
-    def delete(self, request, external_issue_id):
+    def delete(self, request, installation, platform_external_issue):
         try:
-            external_issue = PlatformExternalIssue.objects.get(
-                id=external_issue_id,
+            platform_external_issue = PlatformExternalIssue.objects.get(
+                id=platform_external_issue,
             )
         except PlatformExternalIssue.DoesNotExist:
             return Response(status=404)
 
-        external_issues.Destroyer.run(external_issue=external_issue)
+        external_issues.Destroyer.run(external_issue=platform_external_issue)
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/sentry_app_installation_external_issue_details.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_external_issue_details.py
@@ -12,6 +12,8 @@ class SentryAppInstallationExternalIssueDetailsEndpoint(ExternalIssueBaseEndpoin
         try:
             platform_external_issue = PlatformExternalIssue.objects.get(
                 id=external_issue_id,
+                project__organization=installation.organization,
+                service_type=installation.sentry_app.slug,
             )
         except PlatformExternalIssue.DoesNotExist:
             return Response(status=404)

--- a/src/sentry/api/endpoints/sentry_app_installation_external_issue_details.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_external_issue_details.py
@@ -1,0 +1,21 @@
+from rest_framework.response import Response
+
+from sentry.api.bases import (
+    SentryAppInstallationExternalIssueBaseEndpoint as ExternalIssueBaseEndpoint,
+)
+from sentry.mediators import external_issues
+from sentry.models import PlatformExternalIssue
+
+
+class SentryAppInstallationExternalIssueDetailsEndpoint(ExternalIssueBaseEndpoint):
+    def delete(self, request, external_issue_id):
+        try:
+            external_issue = PlatformExternalIssue.objects.get(
+                id=external_issue_id,
+            )
+        except PlatformExternalIssue.DoesNotExist:
+            return Response(status=404)
+
+        external_issues.Destroyer.run(external_issue=external_issue)
+
+        return Response(status=204)

--- a/src/sentry/api/endpoints/sentry_app_installation_external_issue_details.py
+++ b/src/sentry/api/endpoints/sentry_app_installation_external_issue_details.py
@@ -8,10 +8,10 @@ from sentry.models import PlatformExternalIssue
 
 
 class SentryAppInstallationExternalIssueDetailsEndpoint(ExternalIssueBaseEndpoint):
-    def delete(self, request, installation, platform_external_issue):
+    def delete(self, request, installation, external_issue_id):
         try:
             platform_external_issue = PlatformExternalIssue.objects.get(
-                id=platform_external_issue,
+                id=external_issue_id,
             )
         except PlatformExternalIssue.DoesNotExist:
             return Response(status=404)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1236,7 +1236,7 @@ urlpatterns = [
         name="sentry-api-0-sentry-app-installation-external-issues",
     ),
     url(
-        r"^sentry-app-installations/(?P<uuid>[^\/]+)/external-issues/(?P<platform_external_issue_id>[^\/]+)/$",
+        r"^sentry-app-installations/(?P<uuid>[^\/]+)/external-issues/(?P<external_issue_id>[^\/]+)/$",
         SentryAppInstallationExternalIssueDetailsEndpoint.as_view(),
         name="sentry-api-0-sentry-app-installation-external-issue-details",
     ),

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -277,6 +277,9 @@ from .endpoints.sentry_app_installation_external_issues import (
 from .endpoints.sentry_app_installation_external_issue_actions import (
     SentryAppInstallationExternalIssueActionsEndpoint,
 )
+from .endpoints.sentry_app_installation_external_issue_details import (
+    SentryAppInstallationExternalIssueDetailsEndpoint,
+)
 from .endpoints.sentry_app_installation_external_requests import (
     SentryAppInstallationExternalRequestsEndpoint,
 )
@@ -1231,6 +1234,11 @@ urlpatterns = [
         r"^sentry-app-installations/(?P<uuid>[^\/]+)/external-issues/$",
         SentryAppInstallationExternalIssuesEndpoint.as_view(),
         name="sentry-api-0-sentry-app-installation-external-issues",
+    ),
+    url(
+        r"^sentry-app-installations/(?P<uuid>[^\/]+)/external-issues/(?P<id>[^\/]+)/$",
+        SentryAppInstallationExternalIssueDetailsEndpoint.as_view(),
+        name="sentry-api-0-sentry-app-installation-external-issue-details",
     ),
     # Teams
     url(

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1236,7 +1236,7 @@ urlpatterns = [
         name="sentry-api-0-sentry-app-installation-external-issues",
     ),
     url(
-        r"^sentry-app-installations/(?P<uuid>[^\/]+)/external-issues/(?P<id>[^\/]+)/$",
+        r"^sentry-app-installations/(?P<uuid>[^\/]+)/external-issues/(?P<platform_external_issue_id>[^\/]+)/$",
         SentryAppInstallationExternalIssueDetailsEndpoint.as_view(),
         name="sentry-api-0-sentry-app-installation-external-issue-details",
     ),

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_details.py
@@ -1,9 +1,11 @@
-from django.core.urlresolvers import reverse
 from sentry.models import PlatformExternalIssue
 from sentry.testutils import APITestCase
 
 
 class SentryAppInstallationExternalIssueDetailsEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-sentry-app-installation-external-issue-details"
+    method = "delete"
+
     def setUp(self):
         self.user = self.create_user(email="boop@example.com")
         self.org = self.create_organization(owner=self.user)
@@ -19,32 +21,39 @@ class SentryAppInstallationExternalIssueDetailsEndpointTest(APITestCase):
         self.install = self.create_sentry_app_installation(
             organization=self.org, slug=self.sentry_app.slug, user=self.user
         )
-        self.api_token = self.create_internal_integration_token(
-            install=self.install, user=self.user
-        )
         self.external_issue = self.create_platform_external_issue(
             group=self.group,
-            service_type="sentry-app",
+            service_type=self.sentry_app.slug,
             display_name="App#issue-1",
-            web_url="https://example.com/app/issues/1",
+            web_url=self.sentry_app.webhook_url,
         )
         self.login_as(self.user)
 
     def test_deletes_external_issue(self):
-        url = reverse(
-            "sentry-api-0-sentry-app-installation-external-issue-details",
-            args=[self.install.uuid, self.external_issue.id],
-        )
-        response = self.client.delete(url, format="json")
-
-        assert response.status_code == 204, response.content
+        assert PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()
+        self.get_valid_response(self.install.uuid, self.external_issue.id, status_code=204)
         assert not PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()
 
     def test_handles_non_existing_external_issue(self):
-        url = reverse(
-            "sentry-api-0-sentry-app-installation-external-issue-details",
-            args=[self.install.uuid, 999999],
-        )
-        response = self.client.delete(url, format="json")
+        self.get_valid_response(self.install.uuid, 999999, status_code=404)
 
-        assert response.status_code == 404, response.content
+    def test_handles_issue_from_wrong_org(self):
+        """
+        Ensure that an outside organization cannot delete another organization's external issue
+        """
+
+        evil_user = self.create_user(email="moop@example.com")
+        evil_org = self.create_organization(owner=evil_user)
+
+        evil_sentry_app = self.create_sentry_app(
+            name="bad-stuff",
+            organization=evil_org,
+            webhook_url="https://example.com",
+            scopes=["event:admin"],
+        )
+        evil_install = self.create_sentry_app_installation(
+            organization=evil_org, slug=evil_sentry_app.slug, user=evil_user
+        )
+
+        self.get_valid_response(evil_install.uuid, self.external_issue.id, status_code=404)
+        assert PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_details.py
@@ -5,9 +5,8 @@ from sentry.testutils import APITestCase
 
 class SentryAppInstallationExternalIssueDetailsEndpointTest(APITestCase):
     def setUp(self):
-        self.superuser = self.create_user(email="a@example.com", is_superuser=True)
+        # self.superuser = self.create_user(email="a@example.com", is_superuser=True)
         self.user = self.create_user(email="boop@example.com")
-        # self.login_as(user=self.user)
         self.org = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.org)
         self.group = self.create_group(project=self.project)
@@ -30,7 +29,7 @@ class SentryAppInstallationExternalIssueDetailsEndpointTest(APITestCase):
         #     display_name="App#issue-1",
         #     web_url="https://example.com/app/issues/1",
         # )
-        self.url = reverse(
+        self.create_url = reverse(
             "sentry-api-0-sentry-app-installation-external-issues", args=[self.install.uuid]
         )
 
@@ -41,19 +40,19 @@ class SentryAppInstallationExternalIssueDetailsEndpointTest(APITestCase):
             "project": "ExternalProj",
             "identifier": "issue-1",
         }
-        self.client.post(self.url, data=data, HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}")
+        self.client.post(
+            self.create_url, data=data, HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}"
+        )
         external_issue = PlatformExternalIssue.objects.first()
-
+        self.login_as(self.user)
         delete_url = reverse(
             "sentry-api-0-sentry-app-installation-external-issue-details",
             args=[self.install.uuid, external_issue.id],
         )
-        response = self.client.delete(
-            delete_url, HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}", format="json"
-        )
+        response = self.client.delete(delete_url, format="json")
 
         assert response.status_code == 204, response.content
-        assert not PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()
+        assert not PlatformExternalIssue.objects.filter(id=external_issue.id).exists()
 
     # def test_handles_non_existing_external_issue(self):
     # url = "/api/0/issues/{}/external-issues/{}/".format(self.group.id, 99999)

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_details.py
@@ -14,7 +14,7 @@ class SentryAppInstallationExternalIssueDetailsEndpointTest(APITestCase):
             name="testin",
             organization=self.org,
             webhook_url="https://example.com",
-            scopes=["event:write", "event:admin"],
+            scopes=["event:admin"],
         )
         self.install = self.create_sentry_app_installation(
             organization=self.org, slug=self.sentry_app.slug, user=self.user

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_details.py
@@ -1,0 +1,63 @@
+from django.core.urlresolvers import reverse
+from sentry.models import PlatformExternalIssue
+from sentry.testutils import APITestCase
+
+
+class SentryAppInstallationExternalIssueDetailsEndpointTest(APITestCase):
+    def setUp(self):
+        self.superuser = self.create_user(email="a@example.com", is_superuser=True)
+        self.user = self.create_user(email="boop@example.com")
+        # self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.org)
+        self.group = self.create_group(project=self.project)
+
+        self.sentry_app = self.create_sentry_app(
+            name="testin",
+            organization=self.org,
+            webhook_url="https://example.com",
+            scopes=["event:write", "event:admin"],
+        )
+        self.install = self.create_sentry_app_installation(
+            organization=self.org, slug=self.sentry_app.slug, user=self.user
+        )
+        self.api_token = self.create_internal_integration_token(
+            install=self.install, user=self.user
+        )
+        # self.external_issue = self.create_platform_external_issue(
+        #     group=self.group,
+        #     service_type="sentry-app",
+        #     display_name="App#issue-1",
+        #     web_url="https://example.com/app/issues/1",
+        # )
+        self.url = reverse(
+            "sentry-api-0-sentry-app-installation-external-issues", args=[self.install.uuid]
+        )
+
+    def test_deletes_external_issue(self):
+        data = {
+            "groupId": self.group.id,
+            "webUrl": "https://somerandom.io/project/issue-id",
+            "project": "ExternalProj",
+            "identifier": "issue-1",
+        }
+        self.client.post(self.url, data=data, HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}")
+        external_issue = PlatformExternalIssue.objects.first()
+
+        delete_url = reverse(
+            "sentry-api-0-sentry-app-installation-external-issue-details",
+            args=[self.install.uuid, external_issue.id],
+        )
+        response = self.client.delete(
+            delete_url, HTTP_AUTHORIZATION=f"Bearer {self.api_token.token}", format="json"
+        )
+
+        assert response.status_code == 204, response.content
+        assert not PlatformExternalIssue.objects.filter(id=self.external_issue.id).exists()
+
+    # def test_handles_non_existing_external_issue(self):
+    # url = "/api/0/issues/{}/external-issues/{}/".format(self.group.id, 99999)
+
+    # response = self.client.delete(url, format="json")
+
+    # assert response.status_code == 404, response.content


### PR DESCRIPTION
The delete counterpart to https://github.com/getsentry/sentry/pull/23630 

We're creating a new endpoint that will be publicly documented for users to get, create, and delete external issues created by their Sentry apps. This PR creates a new external issue details endpoint and implements a delete method.