### PR TITLE
feat(ui): Metric alerts redesign summary stats

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
+import {withTheme} from 'emotion-theming';
 import {Location} from 'history';
 import moment from 'moment';
 
@@ -14,12 +15,17 @@ import Duration from 'app/components/duration';
 import * as Layout from 'app/components/layouts/thirds';
 import {Panel, PanelBody, PanelFooter} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
+import TimeSince from 'app/components/timeSince';
+import {IconCheckmark} from 'app/icons/iconCheckmark';
+import {IconFire} from 'app/icons/iconFire';
+import {IconWarning} from 'app/icons/iconWarning';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project, SelectValue} from 'app/types';
 import {defined} from 'app/utils';
 import {getUtcDateString} from 'app/utils/dates';
 import Projects from 'app/utils/projects';
+import {Theme} from 'app/utils/theme';
 import {DATASET_EVENT_TYPE_FILTERS} from 'app/views/settings/incidentRules/constants';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {
@@ -31,7 +37,7 @@ import {
 } from 'app/views/settings/incidentRules/types';
 import {extractEventTypeFilterFromRule} from 'app/views/settings/incidentRules/utils/getEventTypeFilter';
 
-import {Incident} from '../../types';
+import {Incident, IncidentStatus} from '../../types';
 import {DATA_SOURCE_LABELS, getIncidentRuleMetricPreset} from '../../utils';
 
 import MetricChart from './metricChart';
@@ -43,6 +49,7 @@ type Props = {
   incidents?: Incident[];
   organization: Organization;
   location: Location;
+  theme: Theme;
 } & RouteComponentProps<{orgId: string}, {}>;
 
 const TIME_OPTIONS: SelectValue<string>[] = [
@@ -59,7 +66,7 @@ const TIME_WINDOWS = {
   [TimePeriod.SEVEN_DAYS]: TimeWindow.ONE_DAY * 7 * 60 * 1000,
 };
 
-export default class DetailsBody extends React.Component<Props> {
+class DetailsBody extends React.Component<Props> {
   get metricPreset() {
     const {rule} = this.props;
     return rule ? getIncidentRuleMetricPreset(rule) : undefined;
@@ -108,6 +115,40 @@ export default class DetailsBody extends React.Component<Props> {
       },
     });
   };
+
+  calculateSummaryPercentages(
+    incidents: Incident[] | undefined,
+    startTime: string,
+    endTime: string,
+    totalTime: number
+  ) {
+    let criticalPercent = '0';
+    let warningPercent = '0';
+    if (incidents) {
+      const startDate = moment.utc(startTime);
+      const filteredIncidents = incidents.filter(incident => {
+        return !incident.dateClosed || moment(incident.dateClosed).isAfter(startDate);
+      });
+      let criticalDuration = 0;
+      const warningDuration = 0;
+      for (const incident of filteredIncidents) {
+        // use the larger of the start of the incident or the start of the time period
+        const incidentStart = moment.max(moment(incident.dateStarted), startDate);
+        const incidentClose = incident.dateClosed
+          ? moment(incident.dateClosed)
+          : moment.utc(endTime);
+        criticalDuration += incidentClose.diff(incidentStart);
+      }
+      criticalPercent = ((criticalDuration / totalTime) * 100).toFixed(2);
+      warningPercent = ((warningDuration / totalTime) * 100).toFixed(2);
+    }
+    const resolvedPercent = (
+      100 -
+      (Number(criticalPercent) + Number(warningPercent))
+    ).toFixed(2);
+
+    return {criticalPercent, warningPercent, resolvedPercent};
+  }
 
   renderRuleDetails() {
     const {rule} = this.props;
@@ -171,8 +212,35 @@ export default class DetailsBody extends React.Component<Props> {
     );
   }
 
+  renderSummaryStatItems({
+    criticalPercent,
+    warningPercent,
+    resolvedPercent,
+  }: {
+    criticalPercent: string;
+    warningPercent: string;
+    resolvedPercent: string;
+  }) {
+    return (
+      <React.Fragment>
+        <StatItem>
+          <IconCheckmark color="green300" isCircled />
+          <StatCount>{resolvedPercent}%</StatCount>
+        </StatItem>
+        <StatItem>
+          <IconWarning color="yellow300" />
+          <StatCount>{warningPercent}%</StatCount>
+        </StatItem>
+        <StatItem>
+          <IconFire color="red300" />
+          <StatCount>{criticalPercent}%</StatCount>
+        </StatItem>
+      </React.Fragment>
+    );
+  }
+
   renderChartActions(projects: Project[]) {
-    const {rule, params} = this.props;
+    const {rule, params, incidents} = this.props;
     const timePeriod = this.getTimePeriod();
     const preset = this.metricPreset;
     const ctaOpts = {
@@ -187,15 +255,92 @@ export default class DetailsBody extends React.Component<Props> {
       ? preset.makeCtaParams(ctaOpts)
       : makeDefaultCta(ctaOpts);
 
+    const percentages = this.calculateSummaryPercentages(
+      incidents,
+      timePeriod.start,
+      timePeriod.end,
+      TIME_WINDOWS[timePeriod.value]
+    );
+
     return (
-      // Currently only one button in panel, hide panel if not available
-      <Feature features={['discover-basic']}>
-        <ChartActions>
+      <ChartActions>
+        <ChartSummary>
+          <SummaryText>{t('SUMMARY')}</SummaryText>
+          <SummaryStats>{this.renderSummaryStatItems(percentages)}</SummaryStats>
+        </ChartSummary>
+        <Feature features={['discover-basic']}>
           <Button size="small" priority="primary" disabled={!rule} {...props}>
             {buttonText}
           </Button>
-        </ChartActions>
-      </Feature>
+        </Feature>
+      </ChartActions>
+    );
+  }
+
+  renderLoading() {
+    return (
+      <Layout.Body>
+        <Layout.Main>
+          <Placeholder height="38px" />
+          <ChartPanel>
+            <PanelBody withPadding>
+              <Placeholder height="200px" />
+            </PanelBody>
+          </ChartPanel>
+        </Layout.Main>
+        <Layout.Side>
+          <SidebarHeading>
+            <span>{t('Alert Rule')}</span>
+          </SidebarHeading>
+          {this.renderRuleDetails()}
+        </Layout.Side>
+      </Layout.Body>
+    );
+  }
+
+  renderMetricStatus() {
+    const {incidents, theme} = this.props;
+
+    // get current status
+    const activeIncident = incidents?.find(({dateClosed}) => !dateClosed);
+    const status = activeIncident ? activeIncident.status : IncidentStatus.CLOSED;
+    let statusText = t('Okay');
+    let Icon = IconCheckmark;
+    let color: string = theme.green300;
+    if (status === IncidentStatus.CRITICAL) {
+      statusText = t('Critical');
+      Icon = IconFire;
+      color = theme.red300;
+    } else if (status === IncidentStatus.WARNING) {
+      statusText = t('Warning');
+      Icon = IconWarning;
+      color = theme.yellow300;
+    }
+
+    const latestIncident = incidents?.length ? incidents[0] : null;
+    // The date at which the alert was triggered or resolved
+    const activityDate = activeIncident
+      ? activeIncident.dateStarted
+      : latestIncident
+      ? latestIncident.dateClosed
+      : null;
+
+    return (
+      <GroupedHeaderItems>
+        <ItemTitle>{t('Current Status')}</ItemTitle>
+        <ItemTitle>
+          {activeIncident ? t('Alert Triggered') : t('Alert Resolved')}
+        </ItemTitle>
+        <ItemValue>
+          <AlertBadge color={color} icon={Icon}>
+            <AlertIconWrapper>
+              <Icon color="white" />
+            </AlertIconWrapper>
+          </AlertBadge>
+          <IncidentStatusValue color={color}>{statusText}</IncidentStatusValue>
+        </ItemValue>
+        <ItemValue>{activityDate ? <TimeSince date={activityDate} /> : '-'}</ItemValue>
+      </GroupedHeaderItems>
     );
   }
 
@@ -304,6 +449,7 @@ export default class DetailsBody extends React.Component<Props> {
                 </DetailWrapper>
               </Layout.Main>
               <Layout.Side>
+                {this.renderMetricStatus()}
                 <ChartParameters>
                   {tct('Metric: [metric] over [window]', {
                     metric: <code>{rule?.aggregate ?? '\u2026'}</code>,
@@ -356,6 +502,57 @@ const ActivityWrapper = styled('div')`
   width: 100%;
 `;
 
+const GroupedHeaderItems = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  grid-gap: ${space(1)} ${space(4)};
+  text-align: right;
+  margin-top: ${space(1)};
+  margin-bottom: ${space(4)};
+`;
+
+const ItemTitle = styled('h6')`
+  font-size: ${p => p.theme.fontSizeSmall};
+  margin-bottom: 0;
+  text-transform: uppercase;
+  color: ${p => p.theme.gray300};
+  letter-spacing: 0.1px;
+`;
+
+const ItemValue = styled('div')`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+`;
+
+const IncidentStatusValue = styled('div')<{color: string}>`
+  margin-left: ${space(1.5)};
+  color: ${p => p.color};
+`;
+
+const AlertBadge = styled('div')<{color: string; icon: React.ReactNode}>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  /* icon warning needs to be treated differently to look visually centered */
+  line-height: ${p => (p.icon === IconWarning ? undefined : 1)};
+
+  &:before {
+    content: '';
+    width: 30px;
+    height: 30px;
+    border-radius: ${p => p.theme.borderRadius};
+    background-color: ${p => p.color};
+    transform: rotate(45deg);
+  }
+`;
+
+const AlertIconWrapper = styled('div')`
+  position: absolute;
+`;
+
 const SidebarHeading = styled(SectionHeading)`
   display: flex;
   justify-content: space-between;
@@ -372,7 +569,37 @@ const ChartHeader = styled('header')`
 const ChartActions = styled(PanelFooter)`
   display: flex;
   justify-content: flex-end;
+  align-items: center;
   padding: ${space(2)};
+`;
+
+const ChartSummary = styled('div')`
+  display: flex;
+  margin-right: auto;
+`;
+
+const SummaryText = styled('span')`
+  margin-top: ${space(0.25)};
+  font-weight: bold;
+  font-size: ${p => p.theme.fontSizeSmall};
+`;
+
+const SummaryStats = styled('div')`
+  display: flex;
+  align-items: center;
+  margin: 0 ${space(2)};
+`;
+
+const StatItem = styled('div')`
+  display: flex;
+  align-items: center;
+  margin: 0 ${space(2)} 0 0;
+`;
+
+const StatCount = styled('span')`
+  margin-left: ${space(0.5)};
+  margin-top: ${space(0.25)};
+  color: black;
 `;
 
 const ChartParameters = styled('div')`
@@ -424,3 +651,5 @@ const RuleDetails = styled('div')`
     background-color: ${p => p.theme.rowBackground};
   }
 `;
+
+export default withTheme(DetailsBody);

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -277,27 +277,6 @@ class DetailsBody extends React.Component<Props> {
     );
   }
 
-  renderLoading() {
-    return (
-      <Layout.Body>
-        <Layout.Main>
-          <Placeholder height="38px" />
-          <ChartPanel>
-            <PanelBody withPadding>
-              <Placeholder height="200px" />
-            </PanelBody>
-          </ChartPanel>
-        </Layout.Main>
-        <Layout.Side>
-          <SidebarHeading>
-            <span>{t('Alert Rule')}</span>
-          </SidebarHeading>
-          {this.renderRuleDetails()}
-        </Layout.Side>
-      </Layout.Body>
-    );
-  }
-
   renderMetricStatus() {
     const {incidents, theme} = this.props;
 


### PR DESCRIPTION
Adds summary stat percentages for the redesigned metric alert details page on the graph. Also displays the current status of the metric as well as the time since latest relevant activity (alert triggered or resolved).

![image](https://user-images.githubusercontent.com/9372512/107093181-ad5b8900-67b9-11eb-8f15-ad2584711f5d.png)

**NOTE:** the backend currently does not give us information about when an incident has moved from `warning` to `critical` so determining warning percentage values would involve manual calculations on the frontend. My preference would be to have that information be provided by the backend and then we can fill in the warning percents appropriately in a follow-up PR.