### PR TITLE
feat(dashboards) Add additional feature flags for dashboards

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -895,8 +895,12 @@ SENTRY_FEATURES = {
     "organizations:slack-allow-workspace": False,
     # Enable data forwarding functionality for organizations.
     "organizations:data-forwarding": True,
-    # Enable custom dashboards (dashboards 2)
+    # Deprecated flag for dashboards 2
     "organizations:dashboards-v2": False,
+    # Enable readonly dashboards (dashboards 2)
+    "organizations:dashboards-basic": False,
+    # Enable custom editable dashboards (dashboards 2)
+    "organizations:dashboards-full": False,
     # Enable experimental performance improvements.
     "organizations:enterprise-perf": False,
     # Special feature flag primarily used on the sentry.io SAAS product for

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -900,7 +900,7 @@ SENTRY_FEATURES = {
     # Enable readonly dashboards (dashboards 2)
     "organizations:dashboards-basic": False,
     # Enable custom editable dashboards (dashboards 2)
-    "organizations:dashboards-full": False,
+    "organizations:dashboards-edit": False,
     # Enable experimental performance improvements.
     "organizations:enterprise-perf": False,
     # Special feature flag primarily used on the sentry.io SAAS product for

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -61,7 +61,7 @@ default_manager.add("organizations:custom-symbol-sources", OrganizationFeature) 
 default_manager.add("organizations:data-forwarding", OrganizationFeature)  # NOQA
 default_manager.add("organizations:dashboards-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:dashboards-basic", OrganizationFeature)  # NOQA
-default_manager.add("organizations:dashboards-full", OrganizationFeature)  # NOQA
+default_manager.add("organizations:dashboards-edit", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover-query", OrganizationFeature)  # NOQA

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -59,6 +59,9 @@ default_manager.add("organizations:related-events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:alert-filters", OrganizationFeature)  # NOQA
 default_manager.add("organizations:custom-symbol-sources", OrganizationFeature)  # NOQA
 default_manager.add("organizations:data-forwarding", OrganizationFeature)  # NOQA
+default_manager.add("organizations:dashboards-v2", OrganizationFeature)  # NOQA
+default_manager.add("organizations:dashboards-basic", OrganizationFeature)  # NOQA
+default_manager.add("organizations:dashboards-full", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover-query", OrganizationFeature)  # NOQA
@@ -113,7 +116,6 @@ default_manager.add("organizations:inbox-owners-query", OrganizationFeature)  # 
 default_manager.add("organizations:alert-details-redesign", OrganizationFeature)  # NOQA
 default_manager.add("organizations:invite-members-rate-limits", OrganizationFeature)  # NOQA
 default_manager.add("organizations:issue-list-trend-sort", OrganizationFeature)  # NOQA
-default_manager.add("organizations:dashboards-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:performance-landing-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:performance-vitals-overview", OrganizationFeature)  # NOQA
 


### PR DESCRIPTION
Dashboards will be split up into read-only and custom tiers that are assigned to different plans in Saas. These new feature flags will replace `dashboards-v2` which will be removed once these flags are in use. The `dashboards-v2` flag isn't really descriptive enough to keep around long term.