### PR TITLE
feat(ui): Project detail polishes II

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/errorPanel.tsx
+++ b/src/sentry/static/sentry/app/components/charts/errorPanel.tsx
@@ -13,6 +13,7 @@ const ErrorPanel = styled('div')<{height?: string}>`
   border-color: transparent;
   margin-bottom: 0;
   color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeExtraLarge};
 `;
 
 export default ErrorPanel;

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
@@ -94,7 +94,7 @@ function ProjectStabilityChart({
                           <TransparentLoadingMask visible={reloading} />
 
                           <HeaderTitleLegend>
-                            {t('Crash Free Rate')}
+                            {t('Crash Free Sessions')}
                             <QuestionTooltip
                               size="sm"
                               position="top"
@@ -126,7 +126,7 @@ function ProjectStabilityChart({
             )}
           </ChartZoom>
         ),
-        fixed: t('Crash Free Rate Chart'),
+        fixed: t('Crash Free Sessions Chart'),
       })}
     </React.Fragment>
   );
@@ -233,7 +233,13 @@ class Chart extends React.Component<ChartProps, ChartState> {
       tooltip: {
         trigger: 'axis' as const,
         truncate: 80,
-        valueFormatter: (value: number) => displayCrashFreePercent(value, 0, 3),
+        valueFormatter: (value: number | null) => {
+          if (value === null) {
+            return '\u2014';
+          }
+
+          return displayCrashFreePercent(value, 0, 3);
+        },
       },
       yAxis: {
         axisLabel: {

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/sessionsRequest.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/sessionsRequest.tsx
@@ -218,14 +218,17 @@ class SessionsRequest extends React.Component<Props, State> {
 
             return {
               name: interval,
-              value: getCrashFreePercent(100 - crashedSessionsPercent),
+              value:
+                totalIntervalSessions === 0
+                  ? null
+                  : getCrashFreePercent(100 - crashedSessionsPercent),
             };
           }),
       },
-    ];
+    ] as Series[]; // TODO(project-detail): Change SeriesDataUnit value to support null
 
     const previousTimeseriesData = fetchedWithPrevious
-      ? {
+      ? ({
           seriesName: t('Previous Period'),
           data: responseData.intervals.slice(0, dataMiddleIndex).map((_interval, i) => {
             const totalIntervalSessions = responseData.groups.reduce(
@@ -246,10 +249,13 @@ class SessionsRequest extends React.Component<Props, State> {
 
             return {
               name: responseData.intervals[i + dataMiddleIndex],
-              value: getCrashFreePercent(100 - crashedSessionsPercent),
+              value:
+                totalIntervalSessions === 0
+                  ? null
+                  : getCrashFreePercent(100 - crashedSessionsPercent),
             };
           }),
-        }
+        } as Series) // TODO(project-detail): Change SeriesDataUnit value to support null
       : null;
 
     return {

--- a/src/sentry/static/sentry/app/views/projectDetail/missingFeatureButtons/missingReleasesButtons.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/missingFeatureButtons/missingReleasesButtons.tsx
@@ -51,19 +51,21 @@ function MissingReleasesButtons({organization, health, projectId}: Props) {
       >
         {t('Start Setup')}
       </Button>
-      <FeatureTourModal
-        steps={RELEASES_TOUR_STEPS}
-        onAdvance={handleTourAdvance}
-        onCloseModal={handleClose}
-        doneText={t('Start Setup')}
-        doneUrl={health ? DOCS_HEALTH_URL : DOCS_URL}
-      >
-        {({showModal}) => (
-          <Button size="small" onClick={showModal}>
-            {t('Get a tour')}
-          </Button>
-        )}
-      </FeatureTourModal>
+      {!health && (
+        <FeatureTourModal
+          steps={RELEASES_TOUR_STEPS}
+          onAdvance={handleTourAdvance}
+          onCloseModal={handleClose}
+          doneText={t('Start Setup')}
+          doneUrl={health ? DOCS_HEALTH_URL : DOCS_URL}
+        >
+          {({showModal}) => (
+            <Button size="small" onClick={showModal}>
+              {t('Get a tour')}
+            </Button>
+          )}
+        </FeatureTourModal>
+      )}
     </StyledButtonBar>
   );
 }

--- a/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
@@ -135,7 +135,7 @@ class ProjectCharts extends React.Component<Props, State> {
       },
       {
         value: DisplayModes.STABILITY,
-        label: t('Crash Free Rate'),
+        label: t('Crash Free Sessions'),
         disabled: this.otherActiveDisplayModes.includes(DisplayModes.STABILITY),
       },
     ];
@@ -241,6 +241,7 @@ class ProjectCharts extends React.Component<Props, State> {
               onTotalValuesChange={this.handleTotalValuesChange}
               colors={[theme.purple300, theme.purple200]}
               showDaily
+              disableReleases
             />
           )}
           {displayMode === DisplayModes.TRANSACTIONS && (
@@ -255,6 +256,7 @@ class ProjectCharts extends React.Component<Props, State> {
               onTotalValuesChange={this.handleTotalValuesChange}
               colors={[theme.gray200, theme.purple200]}
               showDaily
+              disableReleases
             />
           )}
           {displayMode === DisplayModes.STABILITY && (

--- a/src/sentry/static/sentry/app/views/projectDetail/projectIssues.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectIssues.tsx
@@ -70,7 +70,7 @@ function ProjectIssues({organization, location}: Props) {
   return (
     <React.Fragment>
       <ControlsWrapper>
-        <SectionHeading>{t('Project Issues')}</SectionHeading>
+        <SectionHeading>{t('Frequent Issues')}</SectionHeading>
         <Button
           data-test-id="issues-open"
           size="small"

--- a/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -195,7 +195,7 @@ class ProjectStabilityScoreCard extends AsyncComponent<Props, State> {
       <ScoreCard
         title={this.cardTitle}
         help={this.cardHelp}
-        score={<MissingReleasesButtons organization={organization} />}
+        score={<MissingReleasesButtons organization={organization} health />}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/projectDetail/projectTeamAccess.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectTeamAccess.tsx
@@ -7,11 +7,12 @@ import Collapsible from 'app/components/collapsible';
 import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
 import Placeholder from 'app/components/placeholder';
+import {IconOpen} from 'app/icons';
 import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 
-import {SidebarSection} from './styles';
+import {SectionHeadingLink, SectionHeadingWrapper, SidebarSection} from './styles';
 
 type Props = {
   organization: Organization;
@@ -19,18 +20,22 @@ type Props = {
 };
 
 function ProjectTeamAccess({organization, project}: Props) {
+  const hasEditPermissions = organization.access.includes('project:write');
+  const settingsLink = `/settings/${organization.slug}/projects/${project?.slug}/teams/`;
+
   function renderInnerBody() {
     if (!project) {
       return <Placeholder height="23px" />;
     }
 
     if (project.teams.length === 0) {
-      const hasPermission = organization.access.includes('project:write');
       return (
         <Button
-          to={`/settings/${organization.slug}/projects/${project.slug}/teams/`}
-          disabled={!hasPermission}
-          title={hasPermission ? undefined : t('You do not have permission to do this')}
+          to={settingsLink}
+          disabled={!hasEditPermissions}
+          title={
+            hasEditPermissions ? undefined : t('You do not have permission to do this')
+          }
           priority="primary"
           size="small"
         >
@@ -65,7 +70,12 @@ function ProjectTeamAccess({organization, project}: Props) {
 
   return (
     <StyledSidebarSection>
-      <SectionHeading>{t('Team Access')}</SectionHeading>
+      <SectionHeadingWrapper>
+        <SectionHeading>{t('Team Access')}</SectionHeading>
+        <SectionHeadingLink to={settingsLink}>
+          <IconOpen />
+        </SectionHeadingLink>
+      </SectionHeadingWrapper>
 
       <div>{renderInnerBody()}</div>
     </StyledSidebarSection>

--- a/src/sentry/static/sentry/app/views/projectDetail/styles.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/styles.tsx
@@ -1,10 +1,15 @@
 import styled from '@emotion/styled';
 
+import {SectionHeading} from 'app/components/charts/styles';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
 import space from 'app/styles/space';
 
 export const SidebarSection = styled('section')`
   margin-bottom: ${space(2)};
+
+  ${SectionHeading} {
+    line-height: 1;
+  }
 `;
 
 export const SectionHeadingWrapper = styled('div')`

--- a/tests/js/spec/views/projectDetail/projectIssues.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectIssues.spec.jsx
@@ -36,7 +36,7 @@ describe('ProjectDetail > ProjectIssues', function () {
       routerContext
     );
 
-    expect(wrapper.find('SectionHeading').text()).toBe('Project Issues');
+    expect(wrapper.find('SectionHeading').text()).toBe('Frequent Issues');
     expect(wrapper.find('StreamGroup').length).toBe(2);
   });
 


### PR DESCRIPTION
- rename Crash Free Rate to Crash Free Sessions
- display "holes" in session data correctly
- link crash free sessions set up to health docs
- disable release series on daily errors/transactions bar chart
- rename Project Issues to Frequent Issues
- link team access to settings
- center open icon in sidebar section heading