### PR TITLE
feat(trace-view): Add feature flags for trace views

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -855,6 +855,10 @@ SENTRY_FEATURES = {
     "organizations:discover-query": True,
     # Enable Performance view
     "organizations:performance-view": False,
+    # Enable the quick trace view on event details and errors
+    "organizations:trace-view-quick": False,
+    # Enable the trace view summary
+    "organizations:trace-view-summary": False,
     # Enable multi project selection
     "organizations:global-views": False,
     # Lets organizations manage grouping configs

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -90,6 +90,8 @@ default_manager.add("organizations:onboarding", OrganizationFeature)  # NOQA
 default_manager.add("organizations:org-saved-searches", OrganizationFeature)  # NOQA
 default_manager.add("organizations:org-subdomains", OrganizationFeature)  # NOQA
 default_manager.add("organizations:performance-view", OrganizationFeature)  # NOQA
+default_manager.add("organizations:trace-view-quick", OrganizationFeature)  # NOQA
+default_manager.add("organizations:trace-view-summary", OrganizationFeature)  # NOQA
 default_manager.add("organizations:project-detail", OrganizationFeature)  # NOQA
 default_manager.add("organizations:relay", OrganizationFeature)  # NOQA
 default_manager.add("organizations:releases-top-charts", OrganizationFeature)  # NOQA


### PR DESCRIPTION
- We want to be able to control these two components separately so
  creating a feature flag for both the quick trace view that will go on
  event details and errorsand the full trace view summary
- getsentry PR: https://github.com/getsentry/getsentry/pull/5057