### PR TITLE
ref(dynamic-sampling): Add dnd restrictions

### DIFF
--- a/src/sentry/static/sentry/app/types/dynamicSampling.tsx
+++ b/src/sentry/static/sentry/app/types/dynamicSampling.tsx
@@ -83,6 +83,10 @@ export type DynamicSamplingCondition =
 
 export type DynamicSamplingRule = {
   /**
+   * Describes the type of rule
+   */
+  type: DynamicSamplingRuleType;
+  /**
    * It is a possibly empty list of conditions to which the rule applies.
    * The conditions are combined using the and operator (so all the conditions must be satisfied for the rule to apply).
    * If the conditions field is an empty list the rule applies for all events that satisfy the projectIds and the ty fields.
@@ -92,10 +96,6 @@ export type DynamicSamplingRule = {
    * It is the sampling rate that will be applied if the rule is selected
    */
   sampleRate: number;
-  /**
-   * Describes the type of rule
-   */
-  type: DynamicSamplingRuleType;
 };
 
 export type DynamicSamplingRules = Array<DynamicSamplingRule>;

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/item.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/item.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
-import {DraggableSyntheticListeners, UseDraggableArguments} from '@dnd-kit/core';
+import {DraggableSyntheticListeners} from '@dnd-kit/core';
+import {useSortable} from '@dnd-kit/sortable';
 import {Transform} from '@dnd-kit/utilities';
 import styled from '@emotion/styled';
+
+type UseSortableOutputProps = ReturnType<typeof useSortable>;
 
 export type ItemProps = {
   value: React.ReactNode;
@@ -12,7 +15,7 @@ export type ItemProps = {
   sorting?: boolean;
   transition?: string;
   forwardRef?: React.Ref<HTMLElement>;
-  attributes?: UseDraggableArguments['attributes'];
+  attributes?: UseSortableOutputProps['attributes'];
   wrapperStyle?: React.CSSProperties;
   innerWrapperStyle?: React.CSSProperties;
   renderItem(args: {
@@ -23,7 +26,7 @@ export type ItemProps = {
     transition: ItemProps['transition'];
     value: ItemProps['value'];
     index?: number;
-    attributes?: UseDraggableArguments['attributes'];
+    attributes?: UseSortableOutputProps['attributes'];
   }): React.ReactElement | null;
 };
 

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/item.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/item.tsx
@@ -13,7 +13,6 @@ export type ItemProps = {
   transition?: string;
   forwardRef?: React.Ref<HTMLElement>;
   attributes?: UseDraggableArguments['attributes'];
-  style?: React.CSSProperties;
   wrapperStyle?: React.CSSProperties;
   innerWrapperStyle?: React.CSSProperties;
   renderItem(args: {
@@ -23,7 +22,6 @@ export type ItemProps = {
     transform: ItemProps['transform'];
     transition: ItemProps['transition'];
     value: ItemProps['value'];
-    style?: React.CSSProperties;
     index?: number;
     attributes?: UseDraggableArguments['attributes'];
   }): React.ReactElement | null;
@@ -40,7 +38,6 @@ function Item({
   forwardRef,
   attributes,
   renderItem,
-  style,
   wrapperStyle,
   innerWrapperStyle,
 }: ItemProps) {
@@ -63,7 +60,6 @@ function Item({
           dragging: Boolean(dragging),
           sorting: Boolean(sorting),
           listeners,
-          style,
           transform,
           transition,
           value,
@@ -92,10 +88,7 @@ const Wrapper = styled('div')`
 `;
 
 const InnerWrapper = styled('div')`
-  position: relative;
   background-color: ${p => p.theme.white};
-  -webkit-tap-highlight-color: transparent;
-  transition: box-shadow 200ms cubic-bezier(0.18, 0.67, 0.6, 1.22);
 
   animation: pop 200ms cubic-bezier(0.18, 0.67, 0.6, 1.22);
   box-shadow: var(--box-shadow-picked-up);

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/item.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/item.tsx
@@ -8,6 +8,16 @@ type UseSortableOutputProps = ReturnType<typeof useSortable>;
 
 export type ItemProps = {
   value: React.ReactNode;
+  renderItem(args: {
+    dragging: boolean;
+    sorting: boolean;
+    value: ItemProps['value'];
+    index?: ItemProps['index'];
+    listeners?: ItemProps['listeners'];
+    transform?: ItemProps['transform'];
+    transition?: ItemProps['transition'];
+    attributes?: ItemProps['attributes'];
+  }): React.ReactElement | null;
   dragging?: boolean;
   index?: number;
   transform?: Transform | null;
@@ -18,16 +28,6 @@ export type ItemProps = {
   attributes?: UseSortableOutputProps['attributes'];
   wrapperStyle?: React.CSSProperties;
   innerWrapperStyle?: React.CSSProperties;
-  renderItem(args: {
-    dragging: boolean;
-    sorting: boolean;
-    listeners: DraggableSyntheticListeners;
-    transform: ItemProps['transform'];
-    transition: ItemProps['transition'];
-    value: ItemProps['value'];
-    index?: number;
-    attributes?: UseSortableOutputProps['attributes'];
-  }): React.ReactElement | null;
 };
 
 function Item({

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/sortableItem.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/sortableItem.tsx
@@ -10,7 +10,6 @@ export type SortableItemProps = Pick<
 > & {
   id: string;
   index: number;
-  disabled?: boolean;
   wrapperStyle(args: {
     id: string;
     index: number;
@@ -25,6 +24,7 @@ export type SortableItemProps = Pick<
     isDragging: boolean;
     isDragOverlay: boolean;
   }): React.CSSProperties;
+  disabled?: boolean;
 };
 
 function SortableItem({

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/sortableItem.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/sortableItem.tsx
@@ -1,29 +1,47 @@
 import React from 'react';
+import {UniqueIdentifier} from '@dnd-kit/core';
 import {useSortable} from '@dnd-kit/sortable';
 
 import Item from './item';
 
 export type SortableItemProps = Pick<
   React.ComponentProps<typeof Item>,
-  'renderItem' | 'index' | 'wrapperStyle' | 'innerWrapperStyle'
+  'renderItem' | 'index' | 'innerWrapperStyle'
 > & {
   id: string;
+  index: number;
   disabled?: boolean;
+  wrapperStyle(args: {
+    id: string;
+    index: number;
+    isDragging: boolean;
+    isSorting: boolean;
+  }): React.CSSProperties;
+  innerWrapperStyle(args: {
+    id: UniqueIdentifier;
+    index: number;
+    isSorting: boolean;
+    overIndex: number;
+    isDragging: boolean;
+    isDragOverlay: boolean;
+  }): React.CSSProperties;
 };
 
 function SortableItem({
   id,
   index,
   renderItem,
+  disabled,
   wrapperStyle,
   innerWrapperStyle,
-  disabled,
 }: SortableItemProps) {
   const {
     attributes,
     isSorting,
+    isDragging,
     listeners,
     setNodeRef,
+    overIndex,
     transform,
     transition,
   } = useSortable({id, disabled});
@@ -37,10 +55,17 @@ function SortableItem({
       index={index}
       transform={transform}
       transition={transition}
-      wrapperStyle={wrapperStyle}
-      innerWrapperStyle={innerWrapperStyle}
       listeners={listeners}
       attributes={attributes}
+      wrapperStyle={wrapperStyle({id, index, isDragging, isSorting})}
+      innerWrapperStyle={innerWrapperStyle({
+        id,
+        index,
+        isDragging,
+        isSorting,
+        overIndex,
+        isDragOverlay: false,
+      })}
     />
   );
 }

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/index.tsx
@@ -58,9 +58,12 @@ class Rules extends React.PureComponent<Props, State> {
       .map(ruleId => rules.find(rule => rule.id === ruleId))
       .filter(rule => !!rule) as RulesWithId;
 
+    const activeRuleType = rules[activeIndex].type;
+    const overRuleType = rules[overIndex].type;
+
     if (
-      rules[activeIndex].type === DynamicSamplingRuleType.TRACE &&
-      rules[overIndex].type === DynamicSamplingRuleType.TRANSACTION
+      activeRuleType === DynamicSamplingRuleType.TRACE &&
+      overRuleType === DynamicSamplingRuleType.TRANSACTION
     ) {
       addErrorMessage(
         t('Transaction traces rules cannot be under individual transactions rules')
@@ -69,8 +72,8 @@ class Rules extends React.PureComponent<Props, State> {
     }
 
     if (
-      rules[activeIndex].type === DynamicSamplingRuleType.TRANSACTION &&
-      rules[overIndex].type === DynamicSamplingRuleType.TRACE
+      activeRuleType === DynamicSamplingRuleType.TRANSACTION &&
+      overRuleType === DynamicSamplingRuleType.TRACE
     ) {
       addErrorMessage(
         t('Individual transactions rules cannot be above transaction traces rules')

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/index.tsx
@@ -63,7 +63,7 @@ class Rules extends React.PureComponent<Props, State> {
       rules[overIndex].type === DynamicSamplingRuleType.TRANSACTION
     ) {
       addErrorMessage(
-        t('Transaction traces rules cannot be under Individual transactions rules')
+        t('Transaction traces rules cannot be under individual transactions rules')
       );
       return;
     }
@@ -73,7 +73,7 @@ class Rules extends React.PureComponent<Props, State> {
       rules[overIndex].type === DynamicSamplingRuleType.TRACE
     ) {
       addErrorMessage(
-        t('Individual transactions rules cannot be above Transaction traces rules')
+        t('Individual transactions rules cannot be above transaction traces rules')
       );
       return;
     }

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/index.tsx
@@ -73,7 +73,7 @@ class Rules extends React.PureComponent<Props, State> {
       rules[overIndex].type === DynamicSamplingRuleType.TRACE
     ) {
       addErrorMessage(
-        t('Individual transactionsrules cannot be above Transaction traces rules')
+        t('Individual transactions rules cannot be above Transaction traces rules')
       );
       return;
     }

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/rule/actions.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/rule/actions.tsx
@@ -22,11 +22,19 @@ const editRuleMessage = t('You do not have permission to edit dynamic sampling r
 
 type Props = {
   disabled: boolean;
+  isMenuActionsOpen: boolean;
   onEditRule: () => void;
   onDeleteRule: () => void;
+  onOpenMenuActions: () => void;
 };
 
-function Actions({disabled, onEditRule, onDeleteRule}: Props) {
+function Actions({
+  disabled,
+  onEditRule,
+  onDeleteRule,
+  onOpenMenuActions,
+  isMenuActionsOpen,
+}: Props) {
   return (
     <React.Fragment>
       <StyledButtonbar gap={1}>
@@ -55,8 +63,14 @@ function Actions({disabled, onEditRule, onDeleteRule}: Props) {
       <StyledDropdownLink
         caret={false}
         customTitle={
-          <Button label={t('Actions')} icon={<IconEllipsis size="sm" />} size="xsmall" />
+          <Button
+            label={t('Actions')}
+            icon={<IconEllipsis size="sm" />}
+            size="xsmall"
+            onClick={onOpenMenuActions}
+          />
         }
+        isOpen={isMenuActionsOpen}
         anchorRight
       >
         <MenuItemActionLink

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/rule/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/rule/index.tsx
@@ -50,11 +50,9 @@ class Rule extends React.Component<Props, State> {
   }
 
   handleChangeMenuAction = () => {
-    const isMenuActionsOpen = !this.state.isMenuActionsOpen;
-
-    this.setState({
-      isMenuActionsOpen,
-    });
+    this.setState(state => ({
+      isMenuActionsOpen: !state.isMenuActionsOpen,
+    }));
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/utils.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/utils.tsx
@@ -1,14 +1,9 @@
-import overflowEllipsis from 'app/styles/overflowEllipsis';
 import {Theme} from 'app/utils/theme';
 
 export const layout = (theme: Theme) => `
 > * {
-  ${overflowEllipsis};
   :nth-child(-n + 5):nth-child(5n - 1) {
     text-align: center;
-  }
-  :nth-child(5n) {
-    overflow: visible;
   }
   @media (max-width: ${theme.breakpoints[0]}) {
     :nth-child(5n - 4),


### PR DESCRIPTION
. Add the following restriction: 'Transaction traces' rules cannot be placed below 'Individual transactions' rules and vice versa.

![transactions-restrictions](https://user-images.githubusercontent.com/29228205/107200916-9eaee500-69f8-11eb-9708-37810e3a2299.gif)


. Fix bug with drop-down:

**Before:**

![image](https://user-images.githubusercontent.com/29228205/107201119-db7adc00-69f8-11eb-8f96-14dfd91bee45.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/107201153-e7ff3480-69f8-11eb-8815-896b37b7ed56.png)

. Update Table Header descriptions
Sample Rate -> Rate
Event Type -> Type
Category -> Conditions