### PR TITLE
feat(dashboards) Use new flags that separate read and edit modes

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -6,6 +6,10 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework import DashboardDetailsSerializer
 from sentry.models.dashboard import DashboardTombstone
 from sentry.api.endpoints.organization_dashboards import OrganizationDashboardsPermission
+from sentry import features
+
+EDIT_FEATURE = "organizations:dashboards-edit"
+READ_FEATURE = "organizations:dashboards-basic"
 
 
 class OrganizationDashboardDetailsEndpoint(OrganizationDashboardEndpoint):
@@ -23,8 +27,12 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardEndpoint):
         :pparam int dashboard_id: the id of the dashboard.
         :auth: required
         """
+        if not features.has(READ_FEATURE, organization, actor=request.user):
+            return Response(status=404)
+
         if isinstance(dashboard, dict):
             return self.respond(dashboard)
+
         return self.respond(serialize(dashboard, request.user))
 
     def delete(self, request, organization, dashboard):
@@ -40,6 +48,9 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardEndpoint):
         :pparam int dashboard_id: the id of the dashboard.
         :auth: required
         """
+        if not features.has(EDIT_FEATURE, organization, actor=request.user):
+            return Response(status=404)
+
         if isinstance(dashboard, dict):
             DashboardTombstone.objects.get_or_create(
                 organization=organization, slug=dashboard["id"]
@@ -64,6 +75,9 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardEndpoint):
                             to be updated.
         :auth: required
         """
+        if not features.has(EDIT_FEATURE, organization, actor=request.user):
+            return Response(status=404)
+
         tombstone = None
         if isinstance(dashboard, dict):
             tombstone = dashboard["id"]

--- a/src/sentry/api/endpoints/organization_dashboard_widget_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_widget_details.py
@@ -3,6 +3,7 @@ from rest_framework.response import Response
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.serializers.rest_framework import DashboardWidgetSerializer
 from sentry.api.endpoints.organization_dashboards import OrganizationDashboardsPermission
+from sentry import features
 
 
 class OrganizationDashboardWidgetDetailsEndpoint(OrganizationEndpoint):
@@ -17,6 +18,9 @@ class OrganizationDashboardWidgetDetailsEndpoint(OrganizationEndpoint):
         and has a high chance of success when the dashboard is
         saved.
         """
+        if not features.has("organizations:dashboards-edit", organization, actor=request.user):
+            return Response(status=404)
+
         serializer = DashboardWidgetSerializer(
             data=request.data, context={"organization": organization}
         )

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -6,6 +6,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.dashboard import DashboardListSerializer
 from sentry.api.serializers.rest_framework import DashboardSerializer
 from sentry.models import Dashboard
+from sentry import features
 from rest_framework.response import Response
 
 
@@ -35,6 +36,9 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         :qparam string query: the title of the dashboard being searched for.
         :auth: required
         """
+        if not features.has("organizations:dashboards-basic", organization, actor=request.user):
+            return Response(status=404)
+
         dashboards = Dashboard.objects.filter(organization_id=organization.id)
         query = request.GET.get("query")
         if query:
@@ -66,11 +70,14 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
         """
         Create a New Dashboard for an Organization
         ``````````````````````````````````````````
+
         Create a new dashboard for the given Organization
         :pparam string organization_slug: the slug of the organization the
                                           dashboards belongs to.
-        :param string title: the title of the dashboard.
         """
+        if not features.has("organizations:dashboards-edit", organization, actor=request.user):
+            return Response(status=404)
+
         serializer = DashboardSerializer(
             data=request.data, context={"organization": organization, "request": request}
         )

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -131,7 +131,7 @@ class OrganizationEventsV2Endpoint(OrganizationEventsV2EndpointBase):
 
 class OrganizationEventsGeoEndpoint(OrganizationEventsV2EndpointBase):
     def has_feature(self, request, organization):
-        return features.has("organizations:dashboards-v2", organization, actor=request.user)
+        return features.has("organizations:dashboards-basic", organization, actor=request.user)
 
     def get(self, request, organization):
         if not self.has_feature(request, organization):

--- a/src/sentry/static/sentry/app/views/dashboards/overviewDashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboards/overviewDashboard.tsx
@@ -65,7 +65,7 @@ type DashboardLandingProps = {
 function DashboardLanding(props: DashboardLandingProps) {
   const {organization, params, ...restProps} = props;
 
-  const showDashboardV2 = organization.features.includes('dashboards-v2');
+  const showDashboardV2 = organization.features.includes('dashboards-basic');
 
   if (showDashboardV2) {
     const updatedParams = {...params, dashboardId: ''};

--- a/src/sentry/static/sentry/app/views/dashboardsV2/controls.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/controls.tsx
@@ -28,6 +28,7 @@ type Props = {
   onCommit: () => void;
   onDelete: () => void;
   dashboardState: DashboardState;
+  canEdit?: boolean;
 };
 
 class Controls extends React.Component<Props> {
@@ -41,6 +42,7 @@ class Controls extends React.Component<Props> {
       onCancel,
       onCommit,
       onDelete,
+      canEdit,
     } = this.props;
 
     const cancelButton = (
@@ -143,6 +145,8 @@ class Controls extends React.Component<Props> {
             onCreate();
           }}
           icon={<IconAdd size="xs" isCircled />}
+          disabled={!canEdit}
+          title={!canEdit ? t('Requires dashboard editing') : undefined}
         >
           {t('Create Dashboard')}
         </Button>
@@ -154,6 +158,8 @@ class Controls extends React.Component<Props> {
           }}
           priority="primary"
           icon={<IconEdit size="xs" />}
+          disabled={!canEdit}
+          title={!canEdit ? t('Requires dashboard editing') : undefined}
         >
           {t('Edit Dashboard')}
         </Button>

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -283,6 +283,7 @@ class DashboardDetail extends React.Component<Props, State> {
     const {modifiedDashboard, dashboardState} = this.state;
 
     const isEditing = ['edit', 'create', 'pending_delete'].includes(dashboardState);
+    const canEdit = organization.features.includes('dashboards-edit');
 
     return (
       <GlobalSelectionHeader
@@ -321,6 +322,7 @@ class DashboardDetail extends React.Component<Props, State> {
                     onCommit={this.onCommit({dashboard, reloadData})}
                     onDelete={this.onDelete(dashboard)}
                     dashboardState={dashboardState}
+                    canEdit={canEdit}
                   />
                 </StyledPageHeader>
                 {error ? (

--- a/src/sentry/static/sentry/app/views/dashboardsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/index.tsx
@@ -21,7 +21,7 @@ class DashboardsV2Container extends React.Component<Props> {
 
     return (
       <Feature
-        features={['dashboards-v2']}
+        features={['dashboards-basic']}
         requireAll={false}
         organization={organization}
         renderDisabled={this.renderNoAccess}

--- a/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
@@ -132,7 +132,7 @@ class OrgDashboards extends AsyncComponent<Props, State> {
   renderComponent() {
     const {organization, location} = this.props;
 
-    if (!organization.features.includes('dashboards-v2')) {
+    if (!organization.features.includes('dashboards-basic')) {
       // Redirect to Dashboards v1
       browserHistory.replace({
         pathname: `/organizations/${organization.slug}/dashboards/`,

--- a/src/sentry/static/sentry/app/views/dashboardsV2/title.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/title.tsx
@@ -71,7 +71,6 @@ const Container = styled('div')`
   margin-right: ${space(1)};
 
   @media (max-width: ${p => p.theme.breakpoints[2]}) {
-    margin-right: 0;
     margin-bottom: ${space(2)};
   }
 `;

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -969,6 +969,16 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
             "conditions": "has:geo.country_code",
         }
 
+    def do_request(self, method, url, data=None, features=None):
+        if features is None:
+            features = {
+                "organizations:dashboards-basic": True,
+                "organizations:dashboards-edit": True,
+            }
+        func = getattr(self.client, method)
+        with self.feature(features):
+            return func(url, data=data)
+
     def assert_widget_queries(self, widget_id, data):
         result_queries = DashboardWidgetQuery.objects.filter(widget_id=widget_id).order_by("order")
         for ds, expected_ds in zip(result_queries, data):

--- a/tests/acceptance/test_organization_dashboards.py
+++ b/tests/acceptance/test_organization_dashboards.py
@@ -4,7 +4,8 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 FEATURE_NAMES = [
     "organizations:discover-basic",
     "organizations:discover-query",
-    "organizations:dashboards-v2",
+    "organizations:dashboards-basic",
+    "organizations:dashboards-edit",
 ]
 
 

--- a/tests/js/spec/views/dashboardsV2/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/detail.spec.jsx
@@ -9,7 +9,7 @@ import DashboardDetail from 'app/views/dashboardsV2/detail';
 
 describe('Dashboards > Detail', function () {
   const organization = TestStubs.Organization({
-    features: ['global-views', 'dashboards-v2', 'discover-query'],
+    features: ['global-views', 'dashboards-basic', 'dashboards-edit', 'discover-query'],
     projects: [TestStubs.Project()],
   });
 
@@ -121,6 +121,35 @@ describe('Dashboards > Detail', function () {
           pathname: '/organizations/org-slug/dashboards/8/',
         })
       );
+    });
+
+    it('disables buttons based on features', async function () {
+      wrapper = mountWithTheme(
+        <DashboardDetail
+          organization={{
+            ...initialData.organization,
+            features: ['dashboards-basic', 'discover-basic'],
+          }}
+          params={{orgId: 'org-slug', dashboardId: 'default-overview'}}
+          router={initialData.router}
+          location={initialData.router.location}
+        />,
+        initialData.routerContext
+      );
+      await tick();
+      wrapper.update();
+
+      // Edit should be disabled
+      const editProps = wrapper
+        .find('Controls Button[data-test-id="dashboard-edit"]')
+        .props();
+      expect(editProps.disabled).toBe(true);
+
+      // Create should be disabled
+      const createProps = wrapper
+        .find('Controls Button[data-test-id="dashboard-create"]')
+        .props();
+      expect(createProps.disabled).toBe(true);
     });
   });
 

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -17,7 +17,8 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type:error", "fields": ["count()"]}
             ],
         }
-        response = self.client.post(
+        response = self.do_request(
+            "post",
             self.url(),
             data=data,
         )
@@ -35,7 +36,8 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type: tag:foo", "fields": ["count()"]}
             ],
         }
-        response = self.client.post(
+        response = self.do_request(
+            "post",
             self.url(),
             data=data,
         )
@@ -55,7 +57,8 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type:error", "fields": ["p95(user)"]}
             ],
         }
-        response = self.client.post(
+        response = self.do_request(
+            "post",
             self.url(),
             data=data,
         )
@@ -71,7 +74,8 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type:error", "fields": ["count()"]}
             ],
         }
-        response = self.client.post(
+        response = self.do_request(
+            "post",
             self.url(),
             data=data,
         )

--- a/tests/snuba/api/endpoints/test_organization_events_geo.py
+++ b/tests/snuba/api/endpoints/test_organization_events_geo.py
@@ -11,7 +11,7 @@ class OrganizationEventsGeoEndpointTest(APITestCase, SnubaTestCase):
 
     def do_request(self, query, features=None):
         if features is None:
-            features = {"organizations:dashboards-v2": True}
+            features = {"organizations:dashboards-basic": True}
         self.login_as(user=self.user)
         url = reverse(
             "sentry-api-0-organization-events-geo",


### PR DESCRIPTION
Update the dashboards to use the new read/edit feature flags instead of the general one.

![Screen Shot 2021-02-05 at 12 11 51 PM](https://user-images.githubusercontent.com/24086/107066097-85652900-67ab-11eb-93ef-ecc1b9207612.png)

I've roughed in a disabled tooltip. This will likely change in the future as we solidify plans on whether or not dashboards will encourage people to move to business.