### PR TITLE
build(ci): Only run `visual diff` workflow on sentry repo

### DIFF
--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   visual-diff:
+    if: github.repository == 'getsentry/sentry'
     runs-on: ubuntu-16.04
     timeout-minutes: 20
 


### PR DESCRIPTION
This disables running visual diffs on forks. There are a number of forks that use this bot https://github.com/wei/pull to sync their fork and it causes a lot of noise for people that work on the sentry repo.