### PR TITLE
chore(features) Remove unused feature for dashboards

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -899,8 +899,6 @@ SENTRY_FEATURES = {
     "organizations:slack-allow-workspace": False,
     # Enable data forwarding functionality for organizations.
     "organizations:data-forwarding": True,
-    # Deprecated flag for dashboards 2
-    "organizations:dashboards-v2": False,
     # Enable readonly dashboards (dashboards 2)
     "organizations:dashboards-basic": False,
     # Enable custom editable dashboards (dashboards 2)

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -59,7 +59,6 @@ default_manager.add("organizations:related-events", OrganizationFeature)  # NOQA
 default_manager.add("organizations:alert-filters", OrganizationFeature)  # NOQA
 default_manager.add("organizations:custom-symbol-sources", OrganizationFeature)  # NOQA
 default_manager.add("organizations:data-forwarding", OrganizationFeature)  # NOQA
-default_manager.add("organizations:dashboards-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:dashboards-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:dashboards-edit", OrganizationFeature)  # NOQA
 default_manager.add("organizations:discover", OrganizationFeature)  # NOQA


### PR DESCRIPTION
We split dashboards into two features because they will be on different
pricing plans, so this feature isn't needed anymore.