### PR TITLE
fix(ui): Release column in discover is too tall

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/styles.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/styles.tsx
@@ -16,7 +16,7 @@ export const VersionContainer = styled('div')`
   ${overflowEllipsis};
   max-width: 100%;
   width: auto;
-  display: inline-block;
+  display: flex;
 `;
 
 export const NumberContainer = styled('div')`


### PR DESCRIPTION
The release column was making the table rows in discover taller.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/107089163-28c63600-67cc-11eb-948a-b073bc713e28.png)

## After

![image](https://user-images.githubusercontent.com/10239353/107089240-4d221280-67cc-11eb-95a5-c7c1ead67e65.png)