### PR TITLE
fix(inbox): Adjust custom search tab overflow

### DIFF
--- a/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
+++ b/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
 import DateTime from 'app/components/dateTime';
@@ -168,7 +169,9 @@ const TooltipDescription = styled('div')`
   color: ${p => p.theme.gray200};
 `;
 
-const StyledTag = styled(Tag)<{fontSize: 'sm' | 'md'}>`
+const StyledTag = styled(Tag, {
+  shouldForwardProp: p => isPropValid(p) && p !== 'fontSize',
+})<{fontSize: 'sm' | 'md'}>`
   font-size: ${p =>
     p.fontSize === 'sm' ? p.theme.fontSizeSmall : p.theme.fontSizeMedium};
 `;

--- a/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
@@ -42,18 +42,20 @@ function SavedSearchTab({
   );
 
   const title = (
-    <TitleWrapper>
-      <Tooltip title={tooltipTitle} position="bottom" isHoverable delay={1000}>
+    <Tooltip title={tooltipTitle} position="bottom" isHoverable delay={1000}>
+      <TitleWrapper>
         {isActive ? (
           <React.Fragment>
-            {savedSearch ? savedSearch.name : t('Custom Search')}{' '}
+            <TitleTextOverflow>
+              {savedSearch ? savedSearch.name : t('Custom Search')}
+            </TitleTextOverflow>{' '}
             <StyledQueryCount isTag count={queryCount} max={1000} />
           </React.Fragment>
         ) : (
           t('Saved Searches')
         )}
-      </Tooltip>
-    </TitleWrapper>
+      </TitleWrapper>
+    </Tooltip>
   );
 
   return (
@@ -113,8 +115,13 @@ const TabWrapper = styled('li')<{isActive?: boolean}>`
 
 const TitleWrapper = styled('span')`
   margin-right: ${space(0.5)};
-  max-width: 150px;
   user-select: none;
+  display: flex;
+  align-items: center;
+`;
+
+const TitleTextOverflow = styled('span')`
+  max-width: 150px;
   ${overflowEllipsis};
 `;
 


### PR DESCRIPTION
fix text overflow on saved search tab bumping off count badge
<img width="213" alt="Screen Shot 2021-02-05 at 12 34 09 PM" src="https://user-images.githubusercontent.com/1400464/107089349-55218880-67b3-11eb-8f02-3c6488892542.png">

fixes a prop being applied to a span on the inbox reason