### PR TITLE
fix(ui): adding a theme-color meta tag

### DIFF
--- a/src/sentry/static/sentry/index.ejs
+++ b/src/sentry/static/sentry/index.ejs
@@ -3,6 +3,7 @@
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8">
     <meta name="robots" content="NONE,NOARCHIVE" />
+    <meta name="theme-color" content="#000000">
     <title><%= htmlWebpackPlugin.options.title || 'Sentry Dev'%></title>
   </head>
 

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -14,6 +14,7 @@
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
   <meta name="robots" content="NONE,NOARCHIVE">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#000000">
 
   <link rel="icon" type="image/png" href="{% absolute_asset_url "sentry" "images/favicon.png" %}">
 


### PR DESCRIPTION
Adding a meta tag to set the `theme-color`. Good suggestion from https://github.com/getsentry/sentry/issues/23289

Screenshot from Sentry in PWA mode in Windows 10:

![Unknown](https://user-images.githubusercontent.com/1900676/107104367-341e5f00-67d6-11eb-90b8-c292040d528f.png)
