### PR TITLE
feat(dashboards2): Introduce Add Overlay Button

### DIFF
--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -115,8 +115,8 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
               borderless
               onClick={event => handleRemove(event, i)}
               icon={<IconDelete />}
-              title={t('Remove this Y-axis')}
-              label={t('Remove this Y-axis')}
+              title={t('Remove this Y-Axis')}
+              label={t('Remove this Y-Axis')}
             />
           )}
         </QueryFieldWrapper>
@@ -124,7 +124,7 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
       <div>
         {showAddYAxisButton && (
           <Button size="small" onClick={handleAdd} icon={<IconAdd isCircled />}>
-            {t('Add Y-axis')}
+            {t('Add Y-Axis')}
           </Button>
         )}
       </div>

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -85,7 +85,7 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
     );
   }
 
-  const showAddOverlay = !(
+  const showAddYAxisButton = !(
     ['world_map', 'big_number'].includes(displayType) && fields.length === 1
   );
 
@@ -115,16 +115,16 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
               borderless
               onClick={event => handleRemove(event, i)}
               icon={<IconDelete />}
-              title={t('Remove this overlay')}
-              label={t('Remove this overlay')}
+              title={t('Remove this Y-axis')}
+              label={t('Remove this Y-axis')}
             />
           )}
         </QueryFieldWrapper>
       ))}
       <div>
-        {showAddOverlay && (
+        {showAddYAxisButton && (
           <Button size="small" onClick={handleAdd} icon={<IconAdd isCircled />}>
-            {t('Add an overlay')}
+            {t('Add Y-axis')}
           </Button>
         )}
       </div>

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
@@ -160,6 +160,8 @@ class WidgetQueryForm extends React.Component<Props> {
 
 const QueryWrapper = styled('div')`
   padding-bottom: ${space(2)};
+  margin-bottom: ${space(2)};
+  border-bottom: 1px solid #e2dee6;
 `;
 
 export default WidgetQueryForm;

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
@@ -162,7 +162,7 @@ class WidgetQueryForm extends React.Component<Props> {
 const QueryWrapper = styled('div')`
   padding-bottom: ${space(2)};
   margin-bottom: ${space(2)};
-  border-bottom: 1px solid #e2dee6;
+  border-bottom: 1px solid ${p => p.theme.border};
 `;
 
 export default WidgetQueryForm;

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
@@ -80,12 +80,13 @@ class WidgetQueryForm extends React.Component<Props> {
           {canRemove && (
             <Button
               data-test-id="remove-query"
-              size="zero"
-              borderless
+              size="small"
+              priority="danger"
               onClick={this.props.onRemove}
               icon={<IconDelete />}
-              title={t('Remove this query')}
-            />
+            >
+              {t('Remove Overlay')}
+            </Button>
           )}
         </QueryFieldWrapper>
         <Field

--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -228,6 +228,10 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
     });
   };
 
+  canAddOverlay() {
+    return ['line', 'area', 'stacked_area', 'bar'].includes(this.state.displayType);
+  }
+
   render() {
     const {
       Footer,
@@ -330,15 +334,17 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
               );
             }}
           </Measurements>
-          <AddOverlayButton
-            size="small"
-            onClick={(event: React.MouseEvent) => {
-              event.preventDefault();
-              this.handleAddOverlay();
-            }}
-          >
-            {t('Add Overlay')}
-          </AddOverlayButton>
+          {this.canAddOverlay() && (
+            <AddOverlayButton
+              size="small"
+              onClick={(event: React.MouseEvent) => {
+                event.preventDefault();
+                this.handleAddOverlay();
+              }}
+            >
+              {t('Add Overlay')}
+            </AddOverlayButton>
+          )}
           <WidgetCard
             api={api}
             organization={organization}

--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -184,7 +184,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
           };
         });
 
-        if (value === 'world_map') {
+        if (['world_map', 'big_number'].includes(value)) {
           // For world map chart, cap fields of the queries to only one field.
           newQueries = newQueries.map(query => {
             return {

--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -219,6 +219,15 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
     });
   };
 
+  handleAddOverlay = () => {
+    this.setState(prevState => {
+      const newState = cloneDeep(prevState);
+      newState.queries.push(cloneDeep(newQuery));
+
+      return newState;
+    });
+  };
+
   render() {
     const {
       Footer,
@@ -321,6 +330,15 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
               );
             }}
           </Measurements>
+          <AddOverlayButton
+            size="small"
+            onClick={(event: React.MouseEvent) => {
+              event.preventDefault();
+              this.handleAddOverlay();
+            }}
+          >
+            {t('Add Overlay')}
+          </AddOverlayButton>
           <WidgetCard
             api={api}
             organization={organization}
@@ -368,6 +386,10 @@ const DoubleFieldWrapper = styled('div')`
   grid-template-columns: repeat(2, 1fr);
   grid-column-gap: ${space(1)};
   width: 100%;
+`;
+
+const AddOverlayButton = styled(Button)`
+  margin-bottom: ${space(2)};
 `;
 
 export default withApi(withGlobalSelection(withTags(AddDashboardWidgetModal)));

--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -215,6 +215,11 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       const newState = cloneDeep(prevState);
       newState.queries.splice(index, index + 1);
 
+      // If there is only one query, then its name will not be visible.
+      if (newState.queries.length === 1) {
+        newState.queries[0].name = '';
+      }
+
       return newState;
     });
   };

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -131,7 +131,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     });
 
     // Click the add button
-    const add = wrapper.find('button[aria-label="Add an overlay"]');
+    const add = wrapper.find('button[aria-label="Add Y-Axis"]');
     add.simulate('click');
     wrapper.update();
 


### PR DESCRIPTION

<img width="500" alt="Screen Shot 2021-02-05 at 7 21 29 PM" src="https://user-images.githubusercontent.com/139499/107102090-5ec4e380-67e7-11eb-99dd-f604b4bec80c.png">

- Rename "Add an overlay" to "Add Y-Axis". This is consistent with how we use the terminology of y-axis in other areas of the product. For example: Discover.
- Use the concept of overlays to refer to group of y-axes. Reintroduced "Add Overlay" button. This button is only shown for line, bars, stacked area, and area charts. 
- Revised "Remove Overlay" button
- Added line separators between query forms
- When removing overlays, if there is only one query left, set its name to be a blank string. This is consistent for when the query name form is not displayed if there is only one query form.