### PR TITLE
fix(ui) Revert changes made to convertFromSelect2Choices()

### DIFF
--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1523,7 +1523,7 @@ export type SavedQueryState = {
  * The option format used by react-select based components
  */
 export type SelectValue<T> = {
-  label: string;
+  label: string | number | React.ReactElement;
   value: T;
   disabled?: boolean;
   tooltip?: string;
@@ -1532,7 +1532,10 @@ export type SelectValue<T> = {
 /**
  * The 'other' option format used by checkboxes, radios and more.
  */
-export type Choices = [value: string | number, label: string | number][];
+export type Choices = [
+  value: string | number,
+  label: string | number | React.ReactElement
+][];
 
 /**
  * The issue config form fields we get are basically the form fields we use in

--- a/src/sentry/static/sentry/app/utils/convertFromSelect2Choices.tsx
+++ b/src/sentry/static/sentry/app/utils/convertFromSelect2Choices.tsx
@@ -18,7 +18,7 @@ const convertFromSelect2Choices = (choices: Input): SelectValue<any>[] | null =>
   if (isStringList(choices)) {
     return choices.map(choice => ({value: choice, label: choice}));
   }
-  return choices.map(choice => ({value: choice[0], label: String(choice[1])}));
+  return choices.map(choice => ({value: choice[0], label: choice[1]}));
 };
 
 export default convertFromSelect2Choices;

--- a/src/sentry/static/sentry/app/views/discover/types.tsx
+++ b/src/sentry/static/sentry/app/views/discover/types.tsx
@@ -1,5 +1,3 @@
-import {SelectValue} from 'app/types';
-
 export type Aggregation = [string, string | null, string];
 
 export type Condition = [string, string | null, string | number | boolean | null];
@@ -50,7 +48,9 @@ export type Column = {
   isTag?: boolean;
 };
 
-export type ReactSelectOption = SelectValue<string> & {
+export type ReactSelectOption = {
+  label: string;
+  value: string;
   isTag?: boolean;
 };
 

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -83,6 +83,7 @@ export function getAxisOptions(organization: LightWeightOrganization): TooltipOp
 
 export type AxisOption = TooltipOption & {
   field: string;
+  label: string;
   isDistribution?: boolean;
   isLeftDefault?: boolean;
   isRightDefault?: boolean;


### PR DESCRIPTION
When adding more types, I added a string cast to this function as all the types I could find and usage I came across had the label as string.  This was not the case as project settings has ReactNode labels. I've widened the core type and reverted changes made to other types to avoid the need to add more casts.