### PR TITLE
ci(feature): Cache Brew files and use Catalina instead of Big Sur

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -26,6 +26,7 @@ jobs:
         shell: bash
         run: |
           echo "HOMEBREW_CACHE=`brew --cache`" >> $GITHUB_ENV
+          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
           echo "VOLTA_HOME=$HOME/.volta" >> $GITHUB_ENV
           echo "PATH=$HOME/.pyenv/shims:$HOME/.volta/bin:$PATH" >> $GITHUB_ENV
 

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -16,10 +16,27 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        os: [ macos-11.0 ]
+        os: [ macos-latest ]
 
     steps:
       - uses: actions/checkout@v2
+
+      - name: Set environment variables & others
+        if: ${{ runner.os == 'macOS' }}
+        shell: bash
+        run: |
+          echo "HOMEBREW_CACHE=`brew --cache`" >> $GITHUB_ENV
+          echo "VOLTA_HOME=$HOME/.volta" >> $GITHUB_ENV
+          echo "PATH=$HOME/.pyenv/shims:$HOME/.volta/bin:$PATH" >> $GITHUB_ENV
+
+      - name: Cache (brew)
+        uses: actions/cache@v2
+        if: ${{ runner.os == 'macOS' }}
+        with:
+          path: $HOMEBREW_CACHE
+          key: ${{ runner.os }}-brew-${{ hashFiles('Brewfile') }}
+          restore-keys: |
+            ${{ runner.os }}-brew
 
       - name: Install prerequisites
         if: ${{ runner.os == 'macOS' }}
@@ -30,13 +47,6 @@ jobs:
         # XXX: Can the Brew set up be cached?
         run: |
           brew bundle
-
-      - name: Set environment variables
-        shell: bash
-        run: |
-          echo "PYENV_ROOT=$HOME/.pyenv" >> $GITHUB_ENV
-          echo "VOLTA_HOME=$HOME/.volta" >> $GITHUB_ENV
-          echo "PATH=$HOME/.pyenv/shims:$HOME/.volta/bin:$PATH" >> $GITHUB_ENV
 
       - name: Install Python (via Pyenv)
         id: python-version

--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,5 @@
+# 2021-02-08 - The CI checks the hash of this file to determine if to create a new
+# cache or not. If you want to force a new cache simply change the date on the line above
 brew 'pyenv'
 
 # required for pyenv's python-build


### PR DESCRIPTION
This speeds up the CI to install Sentry dependencies via Brew.

We also change the OS in order to speed up the execution of this workflow.