### PR TITLE
feat(ui): Allow project selector on project detail page

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
@@ -135,7 +135,7 @@ type Props = {
 
   // Callbacks //
   onChangeProjects?: (val: number[]) => void;
-  onUpdateProjects?: () => void;
+  onUpdateProjects?: (selectedProjects: number[]) => void;
   onChangeEnvironments?: (environments: Environment[]) => void;
   onUpdateEnvironments?: (environments: Environment[]) => void;
   onChangeTime?: (datetime: any) => void;

--- a/src/sentry/static/sentry/app/views/projectDetail/index.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/index.tsx
@@ -8,7 +8,12 @@ import withOrganization from 'app/utils/withOrganization';
 
 import ProjectDetail from './projectDetail';
 
-function ProjectDetailContainer(props: ProjectDetail['props']) {
+function ProjectDetailContainer(
+  props: Omit<
+    React.ComponentProps<typeof ProjectDetail>,
+    'projects' | 'loadingProjects' | 'selection'
+  >
+) {
   function renderNoAccess() {
     return (
       <PageContent>

--- a/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
+import {updateProjects} from 'app/actionCreators/globalSelection';
 import Feature from 'app/components/acl/feature';
+import Alert from 'app/components/alert';
 import Breadcrumbs from 'app/components/breadcrumbs';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
@@ -13,11 +15,14 @@ import * as Layout from 'app/components/layouts/thirds';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import TextOverflow from 'app/components/textOverflow';
-import {IconSettings} from 'app/icons';
+import {IconSettings, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
-import {Organization, Project} from 'app/types';
+import {GlobalSelection, Organization, Project} from 'app/types';
+import {defined} from 'app/utils';
 import routeTitleGen from 'app/utils/routeTitle';
+import withGlobalSelection from 'app/utils/withGlobalSelection';
+import withProjects from 'app/utils/withProjects';
 import AsyncView from 'app/views/asyncView';
 
 import ProjectScoreCards from './projectScoreCards/projectScoreCards';
@@ -35,11 +40,13 @@ type RouteParams = {
 
 type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
+  // HoC vvv
+  projects: Project[];
+  loadingProjects: boolean;
+  selection: GlobalSelection;
 };
 
-type State = {
-  project: Project | null;
-} & AsyncView['state'];
+type State = AsyncView['state'];
 
 class ProjectDetail extends AsyncView<Props, State> {
   getTitle() {
@@ -48,26 +55,95 @@ class ProjectDetail extends AsyncView<Props, State> {
     return routeTitleGen(t('Project %s', params.projectId), params.orgId, false);
   }
 
-  getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
-    const {params} = this.props;
+  componentDidMount() {
+    this.syncProjectWithSlug();
+  }
 
-    if (this.state?.project) {
-      return [];
+  componentDidUpdate() {
+    this.syncProjectWithSlug();
+  }
+
+  get project() {
+    const {projects, params} = this.props;
+
+    return projects.find(p => p.slug === params.projectId);
+  }
+
+  handleProjectChange = (selectedProjects: number[]) => {
+    const {projects, router, location, organization} = this.props;
+
+    const newlySelectedProject = projects.find(p => p.id === String(selectedProjects[0]));
+
+    // if we change project in global header, we need to sync the project slug in the URL
+    if (newlySelectedProject?.id) {
+      router.replace({
+        pathname: `/organizations/${organization.slug}/projects/${newlySelectedProject.slug}/`,
+        query: {
+          ...location.query,
+          project: newlySelectedProject.id,
+          environment: undefined,
+        },
+      });
     }
+  };
 
-    return [['project', `/projects/${params.orgId}/${params.projectId}/`]];
+  syncProjectWithSlug() {
+    const {router, location} = this.props;
+    const projectId = this.project?.id;
+
+    if (projectId && projectId !== location.query.project) {
+      // if someone visits /organizations/sentry/projects/javascript/ (without ?project=XXX) we need to update URL and globalSelection with the right project ID
+      updateProjects([Number(projectId)], router);
+    }
+  }
+
+  isProjectStabilized() {
+    const {selection, location} = this.props;
+    const projectId = this.project?.id;
+
+    return (
+      defined(projectId) &&
+      projectId === location.query.project &&
+      projectId === String(selection.projects[0])
+    );
   }
 
   renderLoading() {
     return this.renderBody();
   }
 
+  renderProjectNotFound() {
+    return (
+      <PageContent>
+        <Alert type="error" icon={<IconWarning />}>
+          {t('This project could not be found.')}
+        </Alert>
+      </PageContent>
+    );
+  }
+
   renderBody() {
-    const {organization, params, location, router} = this.props;
-    const {project} = this.state;
+    const {
+      organization,
+      params,
+      location,
+      router,
+      loadingProjects,
+      selection,
+    } = this.props;
+    const project = this.project;
+    const isProjectStabilized = this.isProjectStabilized();
+
+    if (!loadingProjects && !project) {
+      return this.renderProjectNotFound();
+    }
 
     return (
-      <GlobalSelectionHeader shouldForceProject forceProject={project}>
+      <GlobalSelectionHeader
+        disableMultipleProjectSelection
+        skipLoadLastUsed
+        onUpdateProjects={this.handleProjectChange}
+      >
         <LightWeightNoProjectMessage organization={organization}>
           <StyledPageContent>
             <Layout.Header>
@@ -122,17 +198,25 @@ class ProjectDetail extends AsyncView<Props, State> {
             <Layout.Body>
               <StyledSdkUpdatesAlert />
               <Layout.Main>
-                <ProjectScoreCards organization={organization} />
-                {[0, 1].map(id => (
-                  <ProjectCharts
-                    location={location}
-                    organization={organization}
-                    router={router}
-                    key={`project-charts-${id}`}
-                    index={id}
-                  />
-                ))}
-                <ProjectIssues organization={organization} location={location} />
+                <ProjectScoreCards
+                  organization={organization}
+                  isProjectStabilized={isProjectStabilized}
+                  selection={selection}
+                />
+                {isProjectStabilized && (
+                  <React.Fragment>
+                    {[0, 1].map(id => (
+                      <ProjectCharts
+                        location={location}
+                        organization={organization}
+                        router={router}
+                        key={`project-charts-${id}`}
+                        index={id}
+                      />
+                    ))}
+                    <ProjectIssues organization={organization} location={location} />
+                  </React.Fragment>
+                )}
               </Layout.Main>
               <Layout.Side>
                 <ProjectTeamAccess organization={organization} project={project} />
@@ -141,6 +225,7 @@ class ProjectDetail extends AsyncView<Props, State> {
                     organization={organization}
                     projectSlug={params.projectId}
                     location={location}
+                    isProjectStabilized={isProjectStabilized}
                   />
                 </Feature>
                 <ProjectLatestReleases
@@ -148,6 +233,7 @@ class ProjectDetail extends AsyncView<Props, State> {
                   projectSlug={params.projectId}
                   projectId={project?.id}
                   location={location}
+                  isProjectStabilized={isProjectStabilized}
                 />
                 <ProjectQuickLinks
                   organization={organization}
@@ -175,4 +261,4 @@ StyledSdkUpdatesAlert.defaultProps = {
   Wrapper: p => <Layout.Main fullWidth {...p} />,
 };
 
-export default ProjectDetail;
+export default withProjects(withGlobalSelection(ProjectDetail));

--- a/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
@@ -40,7 +40,6 @@ type RouteParams = {
 
 type Props = RouteComponentProps<RouteParams, {}> & {
   organization: Organization;
-  // HoC vvv
   projects: Project[];
   loadingProjects: boolean;
   selection: GlobalSelection;

--- a/src/sentry/static/sentry/app/views/projectDetail/projectLatestAlerts.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectLatestAlerts.tsx
@@ -21,6 +21,7 @@ import {Incident, IncidentStatus} from '../alerts/types';
 
 import MissingAlertsButtons from './missingFeatureButtons/missingAlertsButtons';
 import {SectionHeadingLink, SectionHeadingWrapper, SidebarSection} from './styles';
+import {didProjectOrEnvironmentChange} from './utils';
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;
@@ -42,8 +43,7 @@ class ProjectLatestAlerts extends AsyncComponent<Props, State> {
     // TODO(project-detail): we temporarily removed refetching based on timeselector
     if (
       this.state !== nextState ||
-      location.query.environment !== nextProps.location.query.environment ||
-      location.query.project !== nextProps.location.query.project ||
+      didProjectOrEnvironmentChange(location, nextProps.location) ||
       isProjectStabilized !== nextProps.isProjectStabilized
     ) {
       return true;
@@ -56,8 +56,7 @@ class ProjectLatestAlerts extends AsyncComponent<Props, State> {
     const {location, isProjectStabilized} = this.props;
 
     if (
-      prevProps.location.query.environment !== location.query.environment ||
-      prevProps.location.query.project !== location.query.project ||
+      didProjectOrEnvironmentChange(prevProps.location, location) ||
       prevProps.isProjectStabilized !== isProjectStabilized
     ) {
       this.remountComponent();

--- a/src/sentry/static/sentry/app/views/projectDetail/projectLatestReleases.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectLatestReleases.tsx
@@ -21,13 +21,14 @@ import {RELEASES_TOUR_STEPS} from 'app/views/releases/list/releaseLanding';
 
 import MissingReleasesButtons from './missingFeatureButtons/missingReleasesButtons';
 import {SectionHeadingLink, SectionHeadingWrapper, SidebarSection} from './styles';
+import {didProjectOrEnvironmentChange} from './utils';
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;
   projectSlug: string;
   location: Location;
-  projectId?: string;
   isProjectStabilized: boolean;
+  projectId?: string;
 };
 
 type State = {
@@ -41,8 +42,7 @@ class ProjectLatestReleases extends AsyncComponent<Props, State> {
     // TODO(project-detail): we temporarily removed refetching based on timeselector
     if (
       this.state !== nextState ||
-      location.query.environment !== nextProps.location.query.environment ||
-      location.query.project !== nextProps.location.query.project ||
+      didProjectOrEnvironmentChange(location, nextProps.location) ||
       isProjectStabilized !== nextProps.isProjectStabilized
     ) {
       return true;
@@ -55,8 +55,7 @@ class ProjectLatestReleases extends AsyncComponent<Props, State> {
     const {location, isProjectStabilized} = this.props;
 
     if (
-      prevProps.location.query.environment !== location.query.environment ||
-      prevProps.location.query.project !== location.query.project ||
+      didProjectOrEnvironmentChange(prevProps.location, location) ||
       prevProps.isProjectStabilized !== isProjectStabilized
     ) {
       this.remountComponent();

--- a/src/sentry/static/sentry/app/views/projectDetail/projectQuickLinks.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectQuickLinks.tsx
@@ -21,7 +21,7 @@ import {SidebarSection} from './styles';
 type Props = {
   organization: Organization;
   location: Location;
-  project: Project | null;
+  project?: Project;
 };
 
 function ProjectQuickLinks({organization, project, location}: Props) {

--- a/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -21,6 +21,7 @@ import {shouldFetchPreviousPeriod} from '../utils';
 type Props = AsyncComponent['props'] & {
   organization: Organization;
   selection: GlobalSelection;
+  isProjectStabilized: boolean;
 };
 
 type State = AsyncComponent['state'] & {
@@ -40,9 +41,9 @@ class ProjectApdexScoreCard extends AsyncComponent<Props, State> {
   }
 
   getEndpoints() {
-    const {organization, selection} = this.props;
+    const {organization, selection, isProjectStabilized} = this.props;
 
-    if (!this.hasFeature()) {
+    if (!this.hasFeature() || !isProjectStabilized) {
       return [];
     }
 
@@ -87,8 +88,12 @@ class ProjectApdexScoreCard extends AsyncComponent<Props, State> {
    * If there's no apdex in the time frame, check if there is one in the last 90 days (empty message differs then)
    */
   async onLoadAllEndpointsSuccess() {
-    const {organization, selection} = this.props;
+    const {organization, selection, isProjectStabilized} = this.props;
     const {projects} = selection;
+
+    if (!isProjectStabilized) {
+      return;
+    }
 
     if (defined(this.currentApdex) || defined(this.previousApdex)) {
       this.setState({noApdexEver: false});
@@ -116,7 +121,12 @@ class ProjectApdexScoreCard extends AsyncComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (prevProps.selection !== this.props.selection) {
+    const {selection, isProjectStabilized} = this.props;
+
+    if (
+      prevProps.selection !== selection ||
+      prevProps.isProjectStabilized !== isProjectStabilized
+    ) {
       this.remountComponent();
     }
   }

--- a/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectScoreCards.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import space from 'app/styles/space';
 import {GlobalSelection, Organization} from 'app/types';
-import withGlobalSelection from 'app/utils/withGlobalSelection';
 
 import ProjectApdexScoreCard from './projectApdexScoreCard';
 import ProjectStabilityScoreCard from './projectStabilityScoreCard';
@@ -12,16 +11,29 @@ import ProjectVelocityScoreCard from './projectVelocityScoreCard';
 type Props = {
   organization: Organization;
   selection: GlobalSelection;
+  isProjectStabilized: boolean;
 };
 
-function ProjectScoreCards({organization, selection}: Props) {
+function ProjectScoreCards({organization, selection, isProjectStabilized}: Props) {
   return (
     <CardWrapper>
-      <ProjectStabilityScoreCard organization={organization} selection={selection} />
+      <ProjectStabilityScoreCard
+        organization={organization}
+        selection={selection}
+        isProjectStabilized={isProjectStabilized}
+      />
 
-      <ProjectVelocityScoreCard organization={organization} selection={selection} />
+      <ProjectVelocityScoreCard
+        organization={organization}
+        selection={selection}
+        isProjectStabilized={isProjectStabilized}
+      />
 
-      <ProjectApdexScoreCard organization={organization} selection={selection} />
+      <ProjectApdexScoreCard
+        organization={organization}
+        selection={selection}
+        isProjectStabilized={isProjectStabilized}
+      />
     </CardWrapper>
   );
 }
@@ -37,4 +49,4 @@ const CardWrapper = styled('div')`
   }
 `;
 
-export default withGlobalSelection(ProjectScoreCards);
+export default ProjectScoreCards;

--- a/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -24,6 +24,7 @@ import {shouldFetchPreviousPeriod} from '../utils';
 type Props = AsyncComponent['props'] & {
   organization: Organization;
   selection: GlobalSelection;
+  isProjectStabilized: boolean;
 };
 
 type State = AsyncComponent['state'] & {
@@ -43,7 +44,11 @@ class ProjectStabilityScoreCard extends AsyncComponent<Props, State> {
   }
 
   getEndpoints() {
-    const {organization, selection} = this.props;
+    const {organization, selection, isProjectStabilized} = this.props;
+
+    if (!isProjectStabilized) {
+      return [];
+    }
 
     const {projects, environments: environment, datetime} = selection;
     const {period} = datetime;
@@ -97,7 +102,11 @@ class ProjectStabilityScoreCard extends AsyncComponent<Props, State> {
    * If there are no sessions in the time frame, check if there are any in the last 90 days (empty message differs then)
    */
   async onLoadAllEndpointsSuccess() {
-    const {organization, selection} = this.props;
+    const {organization, selection, isProjectStabilized} = this.props;
+
+    if (!isProjectStabilized) {
+      return;
+    }
 
     if (defined(this.score) || defined(this.trend)) {
       this.setState({noSessionEver: false});
@@ -158,7 +167,12 @@ class ProjectStabilityScoreCard extends AsyncComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (prevProps.selection !== this.props.selection) {
+    const {selection, isProjectStabilized} = this.props;
+
+    if (
+      prevProps.selection !== selection ||
+      prevProps.isProjectStabilized !== isProjectStabilized
+    ) {
       this.remountComponent();
     }
   }

--- a/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
@@ -21,6 +21,7 @@ type Release = {version: string; date: string};
 type Props = AsyncComponent['props'] & {
   organization: Organization;
   selection: GlobalSelection;
+  isProjectStabilized: boolean;
 };
 
 type State = AsyncComponent['state'] & {
@@ -40,7 +41,11 @@ class ProjectVelocityScoreCard extends AsyncComponent<Props, State> {
   }
 
   getEndpoints() {
-    const {organization, selection} = this.props;
+    const {organization, selection, isProjectStabilized} = this.props;
+
+    if (!isProjectStabilized) {
+      return [];
+    }
 
     const {projects, environments, datetime} = selection;
     const {period} = datetime;
@@ -95,7 +100,11 @@ class ProjectVelocityScoreCard extends AsyncComponent<Props, State> {
    */
   async onLoadAllEndpointsSuccess() {
     const {currentReleases, previousReleases} = this.state;
-    const {organization, selection} = this.props;
+    const {organization, selection, isProjectStabilized} = this.props;
+
+    if (!isProjectStabilized) {
+      return;
+    }
 
     if ([...(currentReleases ?? []), ...(previousReleases ?? [])].length !== 0) {
       this.setState({noReleaseEver: false});
@@ -142,7 +151,12 @@ class ProjectVelocityScoreCard extends AsyncComponent<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (prevProps.selection !== this.props.selection) {
+    const {selection, isProjectStabilized} = this.props;
+
+    if (
+      prevProps.selection !== selection ||
+      prevProps.isProjectStabilized !== isProjectStabilized
+    ) {
       this.remountComponent();
     }
   }

--- a/src/sentry/static/sentry/app/views/projectDetail/projectTeamAccess.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectTeamAccess.tsx
@@ -15,7 +15,7 @@ import {SidebarSection} from './styles';
 
 type Props = {
   organization: Organization;
-  project?: Project | null;
+  project?: Project;
 };
 
 function ProjectTeamAccess({organization, project}: Props) {

--- a/src/sentry/static/sentry/app/views/projectDetail/utils.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/utils.tsx
@@ -1,3 +1,5 @@
+import {Location} from 'history';
+
 import {canIncludePreviousPeriod} from 'app/components/charts/utils';
 import {GlobalSelection} from 'app/types';
 
@@ -5,4 +7,11 @@ export function shouldFetchPreviousPeriod(datetime: GlobalSelection['datetime'])
   const {start, end, period} = datetime;
 
   return !start && !end && canIncludePreviousPeriod(true, period);
+}
+
+export function didProjectOrEnvironmentChange(location1: Location, location2: Location) {
+  return (
+    location1.query.environment !== location2.query.environment ||
+    location1.query.project !== location2.query.project
+  );
 }

--- a/tests/js/spec/views/projectDetail/projectLatestAlerts.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectLatestAlerts.spec.jsx
@@ -178,4 +178,17 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
 
     expect(wrapper.find('AlertRowLink AlertDate').at(2).text()).toBe('Resolved ');
   });
+
+  it('does not call API if project is not stabilized yet', function () {
+    mountWithTheme(
+      <ProjectLatestAlerts
+        organization={organization}
+        projectSlug={project.slug}
+        location={router.location}
+        isProjectStabilized={false}
+      />
+    );
+
+    expect(endpointMock).toHaveBeenCalledTimes(0);
+  });
 });

--- a/tests/js/spec/views/projectDetail/projectLatestAlerts.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectLatestAlerts.spec.jsx
@@ -34,6 +34,7 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
         organization={organization}
         projectSlug={project.slug}
         location={router.location}
+        isProjectStabilized
       />
     );
 
@@ -82,6 +83,7 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
         organization={organization}
         projectSlug={project.slug}
         location={router.location}
+        isProjectStabilized
       />
     );
 
@@ -113,6 +115,7 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
         organization={organization}
         projectSlug={project.slug}
         location={router.location}
+        isProjectStabilized
       />
     );
 
@@ -142,6 +145,7 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
           query: {statsPeriod: '7d', environment: 'staging', somethingBad: 'nope'},
         }}
         projectId={project.slug}
+        isProjectStabilized
       />
     );
 
@@ -168,6 +172,7 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
         organization={organization}
         projectSlug={project.slug}
         location={router.location}
+        isProjectStabilized
       />
     );
 

--- a/tests/js/spec/views/projectDetail/projectLatestReleases.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectLatestReleases.spec.jsx
@@ -142,4 +142,20 @@ describe('ProjectDetail > ProjectLatestReleases', function () {
       })
     );
   });
+
+  it('does not call API if project is not stabilized yet', function () {
+    mountWithTheme(
+      <ProjectLatestReleases
+        organization={organization}
+        projectSlug={project.slug}
+        location={{
+          query: {statsPeriod: '7d', environment: 'staging', somethingBad: 'nope'},
+        }}
+        projectId={project.slug}
+        isProjectStabilized={false}
+      />
+    );
+
+    expect(endpointMock).toHaveBeenCalledTimes(0);
+  });
 });

--- a/tests/js/spec/views/projectDetail/projectLatestReleases.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectLatestReleases.spec.jsx
@@ -35,6 +35,7 @@ describe('ProjectDetail > ProjectLatestReleases', function () {
         projectSlug={project.slug}
         location={router.location}
         projectId={project.slug}
+        isProjectStabilized
       />
     );
 
@@ -66,6 +67,7 @@ describe('ProjectDetail > ProjectLatestReleases', function () {
         projectSlug={project.slug}
         location={router.location}
         projectId={project.slug}
+        isProjectStabilized
       />
     );
 
@@ -95,6 +97,7 @@ describe('ProjectDetail > ProjectLatestReleases', function () {
           projectSlug={project.slug}
           location={router.location}
           projectId={project.slug}
+          isProjectStabilized
         />
       </React.Fragment>
     );
@@ -127,6 +130,7 @@ describe('ProjectDetail > ProjectLatestReleases', function () {
           query: {statsPeriod: '7d', environment: 'staging', somethingBad: 'nope'},
         }}
         projectId={project.slug}
+        isProjectStabilized
       />
     );
 


### PR DESCRIPTION
This PR enables switching projects in the global header on the project detail page.