### PR TITLE
build(pre-commit): ShellCheck checks to ignore reprocessing-script.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     rev: v0.7.1.1
     hooks:
       - id: shellcheck
-        files: 'scripts/'
+        exclude: 'src/sentry/templates/sentry/reprocessing-script.sh'
         types: [shell]
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ repos:
     rev: v0.7.1.1
     hooks:
       - id: shellcheck
+        files: 'scripts/'
         types: [shell]
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -2,9 +2,8 @@
 set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $SCRIPT_DIR/..
+cd "$SCRIPT_DIR/.."
 
-OLD_VERSION="$1"
 NEW_VERSION="$2"
 
 sed -i -e "s/^VERSION = "'".*"'"\$/VERSION = "'"'"$NEW_VERSION"'"'"/" setup.py

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -4,6 +4,8 @@ set -eu
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR/.."
 
+# shellcheck disable=SC2034
+OLD_VERSION="$1"
 NEW_VERSION="$2"
 
 sed -i -e "s/^VERSION = "'".*"'"\$/VERSION = "'"'"$NEW_VERSION"'"'"/" setup.py

--- a/scripts/ensure-venv.sh
+++ b/scripts/ensure-venv.sh
@@ -21,8 +21,7 @@ EOF
 }
 
 if [[ -n "$VIRTUAL_ENV" ]]; then
-    major=`python -c "import sys; print(sys.version_info[0])"`
-    minor=`python -c "import sys; print(sys.version_info[1])"`
+    minor=$(python -c "import sys; print(sys.version_info[1])")
     # If .venv is less than Python 3.6 fail
     [[ "$minor" -lt 6 ]] &&
         die "Remove $VIRTUAL_ENV and try again since the Python version installed should be at least 3.6."

--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -2,5 +2,6 @@
 set -eu
 
 git checkout master && git pull
-./scripts/bump-version.sh '' $(date -d "$(echo $CRAFT_NEW_VERSION | sed -e 's/^\([0-9]\{2\}\)\.\([0-9]\{1,2\}\)\.[0-9]\+$/20\1-\2-1/') 1 month" +%y.%-m.0.dev0)
+# shellcheck disable=SC2001
+./scripts/bump-version.sh '' "$(date -d "$(echo "$CRAFT_NEW_VERSION" | sed -e 's/^\([0-9]\{2\}\)\.\([0-9]\{1,2\}\)\.[0-9]\+$/20\1-\2-1/') 1 month" +%y.%-m.0.dev0)"
 git diff --quiet || git commit -anm 'meta: Bump new development version' && git pull --rebase && git push


### PR DESCRIPTION
I also fixed the warnings that did not require testing.