### PR TITLE
ref(pyupgrade): remove six, partition 3

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-import six
 import time
 import sentry_sdk
 

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -98,7 +98,7 @@ class Endpoint(APIView):
     def build_cursor_link(self, request, name, cursor):
         querystring = "&".join(
             "{}={}".format(urlquote(k), urlquote(v))
-            for k, v in six.iteritems(request.GET)
+            for k, v in request.GET.items()
             if k != "cursor"
         )
         base_url = absolute_uri(urlquote(request.path))

--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -109,7 +109,7 @@ class Endpoint(APIView):
 
         return LINK_HEADER.format(
             uri=base_url,
-            cursor=six.text_type(cursor),
+            cursor=str(cursor),
             name=name,
             has_results="true" if bool(cursor) else "false",
         )
@@ -320,7 +320,7 @@ class Endpoint(APIView):
                 span.set_data("Limit", per_page)
                 cursor_result = paginator.get_result(limit=per_page, cursor=input_cursor)
         except BadPaginationError as e:
-            raise ParseError(detail=six.text_type(e))
+            raise ParseError(detail=str(e))
 
         # map results based on callback
         if on_results:

--- a/src/sentry/api/bases/integration.py
+++ b/src/sentry/api/bases/integration.py
@@ -15,7 +15,7 @@ class IntegrationEndpoint(OrganizationEndpoint):
         if hasattr(exc, "code") and exc.code == 503:
             sys.stderr.write(traceback.format_exc())
             event_id = capture_exception()
-            context = {"detail": six.text_type(exc), "errorId": event_id}
+            context = {"detail": str(exc), "errorId": event_id}
             response = Response(context, status=503)
             response.exception = True
             return response

--- a/src/sentry/api/bases/integration.py
+++ b/src/sentry/api/bases/integration.py
@@ -1,4 +1,3 @@
-import six
 import sys
 import traceback
 

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework.response import Response
 
 from sentry import roles

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -179,7 +179,7 @@ class ProjectEndpoint(Endpoint):
         try:
             start, end = get_date_range_from_params(request.GET, optional=date_filter_optional)
         except InvalidParams as e:
-            raise ProjectEventsError(six.text_type(e))
+            raise ProjectEventsError(str(e))
 
         environments = [env.name for env in get_environments(request, project.organization)]
         params = {"start": start, "end": end, "project_id": [project.id]}

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -3,7 +3,6 @@ from functools import wraps
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 from rest_framework.serializers import ValidationError
-from six import string_types
 
 from sentry.api.authentication import ClientIdSecretAuthentication
 from sentry.api.base import Endpoint

--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -103,7 +103,7 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
 
     def _get_organization_slug(self, request):
         organization_slug = request.json_body.get("organization")
-        if not organization_slug or not isinstance(organization_slug, string_types):
+        if not organization_slug or not isinstance(organization_slug, str):
             error_message = """
                 Please provide a valid value for the 'organization' field.
             """

--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -61,7 +61,7 @@ class AcceptProjectTransferEndpoint(Endpoint):
         try:
             data, project = self.get_validated_data(data, request.user)
         except InvalidPayload as e:
-            return Response({"detail": six.text_type(e)}, status=400)
+            return Response({"detail": str(e)}, status=400)
 
         organizations = Organization.objects.filter(
             status=OrganizationStatus.ACTIVE,
@@ -92,7 +92,7 @@ class AcceptProjectTransferEndpoint(Endpoint):
         try:
             data, project = self.get_validated_data(data, request.user)
         except InvalidPayload as e:
-            return Response({"detail": six.text_type(e)}, status=400)
+            return Response({"detail": str(e)}, status=400)
 
         transaction_id = data["transaction_id"]
 

--- a/src/sentry/api/endpoints/accept_project_transfer.py
+++ b/src/sentry/api/endpoints/accept_project_transfer.py
@@ -1,4 +1,3 @@
-import six
 from django.http import Http404
 from django.utils.encoding import force_str
 from django.core.signing import BadSignature, SignatureExpired

--- a/src/sentry/api/endpoints/assistant.py
+++ b/src/sentry/api/endpoints/assistant.py
@@ -1,5 +1,3 @@
-import six
-
 from copy import deepcopy
 
 from django.db import IntegrityError

--- a/src/sentry/api/endpoints/assistant.py
+++ b/src/sentry/api/endpoints/assistant.py
@@ -58,11 +58,11 @@ class AssistantEndpoint(Endpoint):
             AssistantActivity.objects.filter(user=request.user).values_list("guide_id", flat=True)
         )
 
-        for key, value in six.iteritems(guides):
+        for key, value in guides.items():
             value["seen"] = value["id"] in seen_ids
 
         if "v2" in request.GET:
-            guides = [{"guide": key, "seen": value["seen"]} for key, value in six.iteritems(guides)]
+            guides = [{"guide": key, "seen": value["seen"]} for key, value in guides.items()]
         return Response(guides)
 
     def put(self, request):

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -57,7 +57,7 @@ class BroadcastIndexEndpoint(OrganizationEndpoint):
         query = request.GET.get("query")
         if query:
             tokens = tokenize_query(query)
-            for key, value in six.iteritems(tokens):
+            for key, value in tokens.items():
                 if key == "query":
                     value = " ".join(value)
                     queryset = queryset.filter(

--- a/src/sentry/api/endpoints/broadcast_index.py
+++ b/src/sentry/api/endpoints/broadcast_index.py
@@ -1,5 +1,5 @@
+from functools import reduce
 import logging
-import six
 
 from django.db import IntegrityError, transaction
 from django.db.models import Q
@@ -83,7 +83,7 @@ class BroadcastIndexEndpoint(OrganizationEndpoint):
                         else:
                             queryset = queryset.none()
                     if filters:
-                        queryset = queryset.filter(six.moves.reduce(or_, filters))
+                        queryset = queryset.filter(reduce(or_, filters))
                 else:
                     queryset = queryset.none()
 

--- a/src/sentry/api/endpoints/builtin_symbol_sources.py
+++ b/src/sentry/api/endpoints/builtin_symbol_sources.py
@@ -1,5 +1,4 @@
 from rest_framework.response import Response
-import six
 
 from django.conf import settings
 from sentry.api.base import Endpoint

--- a/src/sentry/api/endpoints/builtin_symbol_sources.py
+++ b/src/sentry/api/endpoints/builtin_symbol_sources.py
@@ -21,7 +21,7 @@ class BuiltinSymbolSourcesEndpoint(Endpoint):
     def get(self, request):
         sources = [
             normalize_symbol_source(key, source)
-            for key, source in six.iteritems(settings.SENTRY_BUILTIN_SOURCES)
+            for key, source in settings.SENTRY_BUILTIN_SOURCES.items()
         ]
 
         sources.sort(key=lambda s: s["name"])

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -1,5 +1,4 @@
 import logging
-import six
 
 from io import BytesIO
 from gzip import GzipFile

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -119,7 +119,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             FileBlob.from_files(zip(files, checksums), organization=organization, logger=logger)
         except IOError as err:
             logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
-            return Response({"error": six.text_type(err)}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": str(err)}, status=status.HTTP_400_BAD_REQUEST)
 
         logger.info("chunkupload.end", extra={"status": status.HTTP_200_OK})
         return Response(status=status.HTTP_200_OK)

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -3,7 +3,7 @@ import logging
 from io import BytesIO
 from gzip import GzipFile
 from rest_framework import status
-from six.moves.urllib.parse import urljoin
+from urllib.parse import urljoin
 from rest_framework.response import Response
 from django.core.urlresolvers import reverse
 from django.conf import settings

--- a/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
+++ b/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
@@ -1,4 +1,3 @@
-import six
 from rest_framework.response import Response
 
 from sentry import eventstore

--- a/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
+++ b/src/sentry/api/endpoints/data_scrubbing_selector_suggestions.py
@@ -46,7 +46,7 @@ class DataScrubbingSelectorSuggestionsEndpoint(OrganizationEndpoint):
             {
                 "suggestions": [
                     {"type": "value", "value": value, "examples": examples}
-                    for value, examples in six.iteritems(suggestions)
+                    for value, examples in suggestions.items()
                 ]
             }
         )

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -310,7 +310,7 @@ class DifAssembleEndpoint(ProjectEndpoint):
 
         file_response = {}
 
-        for checksum, file_to_assemble in six.iteritems(files):
+        for checksum, file_to_assemble in files.items():
             name = file_to_assemble.get("name", None)
             debug_id = file_to_assemble.get("debug_id", None)
             chunks = file_to_assemble.get("chunks", [])

--- a/src/sentry/api/endpoints/debug_files.py
+++ b/src/sentry/api/endpoints/debug_files.py
@@ -1,5 +1,4 @@
 import re
-import six
 import jsonschema
 import logging
 import posixpath

--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -1,5 +1,3 @@
-import six
-
 from django.http import HttpResponse, StreamingHttpResponse
 
 from sentry import eventstore

--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -29,7 +29,7 @@ class EventAppleCrashReportEndpoint(ProjectEndpoint):
 
         symbolicated = request.GET.get("minified") not in ("1", "true")
 
-        apple_crash_report_string = six.text_type(
+        apple_crash_report_string = str(
             AppleCrashReport(
                 threads=get_path(event.data, "threads", "values", filter=True),
                 context=event.data.get("contexts"),

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -35,7 +35,7 @@ class EventAttachmentsEndpoint(ProjectEndpoint):
         query = request.GET.get("query")
         if query:
             tokens = tokenize_query(query)
-            for key, value in six.iteritems(tokens):
+            for key, value in tokens.items():
                 if key == "query":
                     value = " ".join(value)
                     queryset = queryset.filter(name__icontains=value)

--- a/src/sentry/api/endpoints/event_attachments.py
+++ b/src/sentry/api/endpoints/event_attachments.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry import eventstore, features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.paginator import OffsetPaginator

--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -1,5 +1,3 @@
-import six
-
 from django.http import HttpResponse
 
 from sentry import eventstore

--- a/src/sentry/api/endpoints/event_grouping_info.py
+++ b/src/sentry/api/endpoints/event_grouping_info.py
@@ -37,7 +37,7 @@ class EventGroupingInfoEndpoint(ProjectEndpoint):
         except GroupingConfigNotFound:
             raise ResourceDoesNotExist(detail="Unknown grouping config")
 
-        for (key, variant) in six.iteritems(variants):
+        for (key, variant) in variants.items():
             d = variant.as_dict()
             # Since the hashes are generated on the fly and might no
             # longer match the stored ones we indicate if the hash

--- a/src/sentry/api/endpoints/event_owners.py
+++ b/src/sentry/api/endpoints/event_owners.py
@@ -37,7 +37,7 @@ class EventOwnersEndpoint(ProjectEndpoint):
         ordered_owners = []
         owner_by_id = {(o["id"], o["type"]): o for o in serialized_owners}
         for o in owners:
-            key = (six.text_type(o.id), "team" if o.type == Team else "user")
+            key = (str(o.id), "team" if o.type == Team else "user")
             if owner_by_id.get(key):
                 ordered_owners.append(owner_by_id[key])
 

--- a/src/sentry/api/endpoints/event_owners.py
+++ b/src/sentry/api/endpoints/event_owners.py
@@ -1,4 +1,3 @@
-import six
 from rest_framework.response import Response
 
 from sentry import eventstore

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -1,5 +1,3 @@
-import six
-
 from datetime import timedelta
 from django.utils import timezone
 from rest_framework.exceptions import ParseError

--- a/src/sentry/api/endpoints/group_events.py
+++ b/src/sentry/api/endpoints/group_events.py
@@ -48,19 +48,19 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
             environments = get_environments(request, group.project.organization)
             query, tags = self._get_search_query_and_tags(request, group, environments)
         except InvalidQuery as exc:
-            return Response({"detail": six.text_type(exc)}, status=400)
+            return Response({"detail": str(exc)}, status=400)
         except (NoResults, ResourceDoesNotExist):
             return Response([])
 
         try:
             start, end = get_date_range_from_params(request.GET, optional=True)
         except InvalidParams as e:
-            raise ParseError(detail=six.text_type(e))
+            raise ParseError(detail=str(e))
 
         try:
             return self._get_events_snuba(request, group, environments, query, tags, start, end)
         except GroupEventsError as exc:
-            raise ParseError(detail=six.text_type(exc))
+            raise ParseError(detail=str(exc))
 
     def _get_events_snuba(self, request, group, environments, query, tags, start, end):
         default_end = timezone.now()
@@ -83,7 +83,7 @@ class GroupEventsEndpoint(GroupEndpoint, EnvironmentMixin):
         try:
             snuba_filter = get_filter(request.GET.get("query", None), params)
         except InvalidSearchQuery as e:
-            raise ParseError(detail=six.text_type(e))
+            raise ParseError(detail=str(e))
 
         snuba_filter.conditions.append(["event.type", "!=", "transaction"])
 

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -1,4 +1,3 @@
-import six
 from django.db import IntegrityError, transaction
 from rest_framework.response import Response
 

--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -79,7 +79,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
                 )
             )
         except IntegrationError as e:
-            return Response({"detail": six.text_type(e)}, status=400)
+            return Response({"detail": str(e)}, status=400)
 
     # was thinking put for link an existing issue, post for create new issue?
     @transaction_start("GroupIntegrationDetailsEndpoint")
@@ -111,7 +111,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         except IntegrationFormError as exc:
             return Response(exc.field_errors, status=400)
         except IntegrationError as e:
-            return Response({"non_field_errors": [six.text_type(e)]}, status=400)
+            return Response({"non_field_errors": [str(e)]}, status=400)
 
         defaults = {
             "title": data.get("title"),
@@ -143,7 +143,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         except IntegrationFormError as exc:
             return Response(exc.field_errors, status=400)
         except IntegrationError as e:
-            return Response({"non_field_errors": [six.text_type(e)]}, status=400)
+            return Response({"non_field_errors": [str(e)]}, status=400)
 
         try:
             with transaction.atomic():
@@ -196,7 +196,7 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         except IntegrationFormError as exc:
             return Response(exc.field_errors, status=400)
         except IntegrationError as e:
-            return Response({"non_field_errors": [six.text_type(e)]}, status=400)
+            return Response({"non_field_errors": [str(e)]}, status=400)
 
         external_issue_key = installation.make_external_key(data)
         external_issue, created = ExternalIssue.objects.get_or_create(

--- a/src/sentry/api/endpoints/internal_mail.py
+++ b/src/sentry/api/endpoints/internal_mail.py
@@ -1,4 +1,3 @@
-import six
 from rest_framework.response import Response
 
 from sentry import options

--- a/src/sentry/api/endpoints/internal_mail.py
+++ b/src/sentry/api/endpoints/internal_mail.py
@@ -40,6 +40,6 @@ class InternalMailEndpoint(Endpoint):
                 fail_silently=False,
             )
         except Exception as e:
-            error = six.text_type(e)
+            error = str(e)
 
         return Response({"error": error}, status=500 if error else 200)

--- a/src/sentry/api/endpoints/internal_warnings.py
+++ b/src/sentry/api/endpoints/internal_warnings.py
@@ -23,11 +23,11 @@ class InternalWarningsEndpoint(Endpoint):
         for warning in seen_warnings:
             cls = type(warning)
             if cls in groupings:
-                groups[cls].append(six.text_type(warning))
+                groups[cls].append(str(warning))
             else:
-                warnings.append(six.text_type(warning))
+                warnings.append(str(warning))
 
-        sort_by_message = functools.partial(sorted, key=six.text_type)
+        sort_by_message = functools.partial(sorted, key=str)
 
         data = {
             "groups": sorted(

--- a/src/sentry/api/endpoints/internal_warnings.py
+++ b/src/sentry/api/endpoints/internal_warnings.py
@@ -1,5 +1,4 @@
 import functools
-import six
 from collections import defaultdict
 
 from rest_framework.response import Response

--- a/src/sentry/api/endpoints/monitor_stats.py
+++ b/src/sentry/api/endpoints/monitor_stats.py
@@ -33,6 +33,6 @@ class MonitorStatsEndpoint(MonitorEndpoint, StatsMixin):
         return Response(
             [
                 {"ts": ts, "ok": data[CheckInStatus.OK], "error": data[CheckInStatus.ERROR]}
-                for ts, data in six.iteritems(stats)
+                for ts, data in stats.items()
             ]
         )

--- a/src/sentry/api/endpoints/monitor_stats.py
+++ b/src/sentry/api/endpoints/monitor_stats.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import OrderedDict
 from rest_framework.response import Response
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -1,5 +1,4 @@
 import logging
-import six
 
 from datetime import datetime
 

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -77,13 +77,13 @@ ORG_OPTIONS = (
     (
         "attachmentsRole",
         "sentry:attachments_role",
-        six.text_type,
+        str,
         org_serializers.ATTACHMENTS_ROLE_DEFAULT,
     ),
     (
         "debugFilesRole",
         "sentry:debug_files_role",
-        six.text_type,
+        str,
         org_serializers.DEBUG_FILES_ROLE_DEFAULT,
     ),
     (
@@ -104,7 +104,7 @@ ORG_OPTIONS = (
         bool,
         org_serializers.REQUIRE_SCRUB_IP_ADDRESS_DEFAULT,
     ),
-    ("relayPiiConfig", "sentry:relay_pii_config", six.text_type, None),
+    ("relayPiiConfig", "sentry:relay_pii_config", str, None),
     ("allowJoinRequests", "sentry:join_requests", bool, org_serializers.JOIN_REQUESTS_DEFAULT),
     ("apdexThreshold", "sentry:apdex_threshold", int, None),
 )

--- a/src/sentry/api/endpoints/organization_details.py
+++ b/src/sentry/api/endpoints/organization_details.py
@@ -378,14 +378,14 @@ class OrganizationSerializer(serializers.Serializer):
         }
 
         # check if fields changed
-        for f, v in six.iteritems(org_tracked_field):
+        for f, v in org_tracked_field.items():
             if f != "flag_field":
                 if org.has_changed(f):
                     old_val = org.old_value(f)
                     changed_data[f] = "from {} to {}".format(old_val, v)
             else:
                 # check if flag fields changed
-                for f, v in six.iteritems(org_tracked_field["flag_field"]):
+                for f, v in org_tracked_field["flag_field"].items():
                     if org.flag_has_changed(f):
                         changed_data[f] = "to {}".format(v)
 

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -46,8 +46,8 @@ class EventIdLookupEndpoint(OrganizationEndpoint):
                 {
                     "organizationSlug": organization.slug,
                     "projectSlug": project_slugs_by_id[event.project_id],
-                    "groupId": six.text_type(event.group_id),
-                    "eventId": six.text_type(event.event_id),
+                    "groupId": str(event.group_id),
+                    "eventId": str(event.event_id),
                     "event": serialize(event, request.user),
                 }
             )

--- a/src/sentry/api/endpoints/organization_eventid.py
+++ b/src/sentry/api/endpoints/organization_eventid.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework.response import Response
 
 from sentry import eventstore

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -1,5 +1,4 @@
 import sentry_sdk
-import six
 
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -69,7 +69,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
         try:
             snuba_args = self.get_snuba_query_args_legacy(request, organization)
         except InvalidSearchQuery as exc:
-            raise ParseError(detail=six.text_type(exc))
+            raise ParseError(detail=str(exc))
         except NoProjects:
             return Response({"data": []})
 
@@ -122,7 +122,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
         try:
             resolved = resolve_field_list([y_axis], snuba_filter)
         except InvalidSearchQuery as err:
-            raise ParseError(detail=six.text_type(err))
+            raise ParseError(detail=str(err))
         try:
             aggregate = resolved["aggregations"][0]
         except IndexError:

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -214,7 +214,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
         try:
             start, end = get_date_range_from_params(request.GET)
         except InvalidParams as e:
-            raise ParseError(detail=six.text_type(e))
+            raise ParseError(detail=str(e))
 
         expand = request.GET.getlist("expand", [])
         collapse = request.GET.getlist("collapse", [])
@@ -305,7 +305,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
                 {"count_hits": True, "date_to": end, "date_from": start},
             )
         except (ValidationError, discover.InvalidSearchQuery) as exc:
-            return Response({"detail": six.text_type(exc)}, status=400)
+            return Response({"detail": str(exc)}, status=400)
 
         results = list(cursor_result)
 

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -1,5 +1,4 @@
 import functools
-import six
 from datetime import datetime, timedelta
 from typing import List, Mapping, Optional, Sequence
 

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -1,6 +1,3 @@
-import six
-
-
 from rest_framework.exceptions import ParseError, PermissionDenied
 from rest_framework.response import Response
 

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -56,7 +56,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
         try:
             start, end = get_date_range_from_params(request.GET)
         except InvalidParams as e:
-            raise ParseError(detail=six.text_type(e))
+            raise ParseError(detail=str(e))
 
         expand = request.GET.getlist("expand", [])
         collapse = request.GET.getlist("collapse", ["base"])

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -1,5 +1,3 @@
-import six
-
 from django.conf import settings
 from django.db import IntegrityError, transaction
 from django.db.models import Count, Q, Sum

--- a/src/sentry/api/endpoints/organization_index.py
+++ b/src/sentry/api/endpoints/organization_index.py
@@ -95,7 +95,7 @@ class OrganizationIndexEndpoint(Endpoint):
         query = request.GET.get("query")
         if query:
             tokens = tokenize_query(query)
-            for key, value in six.iteritems(tokens):
+            for key, value in tokens.items():
                 if key == "query":
                     value = " ".join(value)
                     queryset = queryset.filter(

--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -59,6 +59,6 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
         try:
             installation.update_organization_config(request.data)
         except IntegrationError as e:
-            return self.respond({"detail": six.text_type(e)}, status=400)
+            return self.respond({"detail": str(e)}, status=400)
 
         return self.respond(status=200)

--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -1,6 +1,5 @@
 from uuid import uuid4
 
-import six
 
 from sentry.api.bases.organization import OrganizationIntegrationsPermission
 from sentry.api.bases.organization_integrations import OrganizationIntegrationBaseEndpoint

--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -33,7 +33,7 @@ class OrganizationIntegrationReposEndpoint(OrganizationIntegrationBaseEndpoint):
             try:
                 repositories = install.get_repositories(request.GET.get("search"))
             except IntegrationError as e:
-                return self.respond({"detail": six.text_type(e)}, status=400)
+                return self.respond({"detail": str(e)}, status=400)
 
             context = {"repos": repositories, "searchable": install.repo_search}
             return self.respond(context)

--- a/src/sentry/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/api/endpoints/organization_integration_repos.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.constants import ObjectStatus
 from sentry.api.bases.organization import OrganizationIntegrationsPermission
 from sentry.api.bases.organization_integrations import OrganizationIntegrationBaseEndpoint

--- a/src/sentry/api/endpoints/organization_integration_serverless_functions.py
+++ b/src/sentry/api/endpoints/organization_integration_serverless_functions.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework import serializers
 
 from sentry.api.bases.organization import OrganizationIntegrationsPermission

--- a/src/sentry/api/endpoints/organization_integration_serverless_functions.py
+++ b/src/sentry/api/endpoints/organization_integration_serverless_functions.py
@@ -32,7 +32,7 @@ class OrganizationIntegrationServerlessFunctionsEndpoint(OrganizationIntegration
         try:
             serverless_functions = install.get_serverless_functions()
         except IntegrationError as e:
-            return self.respond({"detail": six.text_type(e)}, status=400)
+            return self.respond({"detail": str(e)}, status=400)
 
         return self.respond(serverless_functions)
 
@@ -62,4 +62,4 @@ class OrganizationIntegrationServerlessFunctionsEndpoint(OrganizationIntegration
                 resp = install.update_function_to_latest_version(target)
             return self.respond(resp)
         except IntegrationError as e:
-            return self.respond({"detail": six.text_type(e)}, status=400)
+            return self.respond({"detail": str(e)}, status=400)

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 

--- a/src/sentry/api/endpoints/organization_issues_count.py
+++ b/src/sentry/api/endpoints/organization_issues_count.py
@@ -50,7 +50,7 @@ class OrganizationIssuesCountEndpoint(OrganizationEventsEndpointBase):
         try:
             start, end = get_date_range_from_params(request.GET)
         except InvalidParams as e:
-            raise ParseError(detail=six.text_type(e))
+            raise ParseError(detail=str(e))
 
         if stats_period not in (None, "", "24h", "14d", "auto"):
             return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
@@ -82,6 +82,6 @@ class OrganizationIssuesCountEndpoint(OrganizationEventsEndpointBase):
                 )
                 response[query] = count
             except (ValidationError, discover.InvalidSearchQuery) as exc:
-                return Response({"detail": six.text_type(exc)}, status=400)
+                return Response({"detail": str(exc)}, status=400)
 
         return Response(response)

--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -115,7 +115,7 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
 
         if query:
             tokens = tokenize_query(query)
-            for key, value in six.iteritems(tokens):
+            for key, value in tokens.items():
                 if key == "email":
                     queryset = queryset.filter(
                         Q(email__in=value)

--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -1,5 +1,3 @@
-import six
-
 from django.db import transaction
 from django.db.models import Q, F
 from rest_framework import serializers

--- a/src/sentry/api/endpoints/organization_member_unreleased_commits.py
+++ b/src/sentry/api/endpoints/organization_member_unreleased_commits.py
@@ -69,12 +69,12 @@ class OrganizationMemberUnreleasedCommitsEndpoint(OrganizationMemberEndpoint):
                         "id": c.key,
                         "message": c.message,
                         "dateCreated": c.date_added,
-                        "repositoryID": six.text_type(c.repository_id),
+                        "repositoryID": str(c.repository_id),
                     }
                     for c in results
                 ],
                 "repositories": {
-                    six.text_type(r.id): d for r, d in zip(repos, serialize(repos, request.user))
+                    str(r.id): d for r, d in zip(repos, serialize(repos, request.user))
                 },
             }
         )

--- a/src/sentry/api/endpoints/organization_member_unreleased_commits.py
+++ b/src/sentry/api/endpoints/organization_member_unreleased_commits.py
@@ -1,6 +1,3 @@
-import six
-
-
 from django.db import connections
 
 from sentry.api.bases import OrganizationMemberEndpoint

--- a/src/sentry/api/endpoints/organization_monitors.py
+++ b/src/sentry/api/endpoints/organization_monitors.py
@@ -46,7 +46,7 @@ class OrganizationMonitorsEndpoint(OrganizationEndpoint):
         query = request.GET.get("query")
         if query:
             tokens = tokenize_query(query)
-            for key, value in six.iteritems(tokens):
+            for key, value in tokens.items():
                 if key == "query":
                     value = " ".join(value)
                     queryset = queryset.filter(Q(name__icontains=value) | Q(id__iexact=value))

--- a/src/sentry/api/endpoints/organization_monitors.py
+++ b/src/sentry/api/endpoints/organization_monitors.py
@@ -1,5 +1,3 @@
-import six
-
 from django.db.models import Q
 
 from sentry import features

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -20,7 +20,7 @@ class OrganizationSearchSerializer(serializers.Serializer):
         try:
             SearchType(value)
         except ValueError as e:
-            raise serializers.ValidationError(six.text_type(e))
+            raise serializers.ValidationError(str(e))
         return value
 
 
@@ -63,9 +63,7 @@ class OrganizationPinnedSearchEndpoint(OrganizationEndpoint):
         try:
             search_type = SearchType(int(request.data.get("type", 0)))
         except ValueError as e:
-            return Response(
-                {"detail": "Invalid input for `type`. Error: %s" % six.text_type(e)}, status=400
-            )
+            return Response({"detail": "Invalid input for `type`. Error: %s" % str(e)}, status=400)
         SavedSearch.objects.filter(
             organization=organization, owner=request.user, type=search_type.value
         ).delete()

--- a/src/sentry/api/endpoints/organization_pinned_searches.py
+++ b/src/sentry/api/endpoints/organization_pinned_searches.py
@@ -1,7 +1,6 @@
 from rest_framework import serializers
 from rest_framework.response import Response
 from django.db.models import Q
-from django.utils import six
 
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPinnedSearchPermission
 from sentry.api.serializers import serialize

--- a/src/sentry/api/endpoints/organization_plugins_configs.py
+++ b/src/sentry/api/endpoints/organization_plugins_configs.py
@@ -1,5 +1,4 @@
 from rest_framework.response import Response
-import six
 
 from sentry.constants import ObjectStatus
 from sentry.plugins.base import plugins

--- a/src/sentry/api/endpoints/organization_plugins_configs.py
+++ b/src/sentry/api/endpoints/organization_plugins_configs.py
@@ -90,7 +90,7 @@ class OrganizationPluginsConfigsEndpoint(OrganizationEndpoint):
             info_by_project = info_by_plugin_project.get(plugin.slug, {})
 
             # iterate through the projects
-            for project_id, plugin_info in six.iteritems(info_by_project):
+            for project_id, plugin_info in info_by_project.items():
                 # if the project is being deleted
                 if project_id not in project_map:
                     continue

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -71,7 +71,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         query = request.GET.get("query")
         if query:
             tokens = tokenize_query(query)
-            for key, value in six.iteritems(tokens):
+            for key, value in tokens.items():
                 if key == "query":
                     value = " ".join(value)
                     queryset = queryset.filter(Q(name__icontains=value) | Q(slug__icontains=value))

--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -1,5 +1,3 @@
-import six
-
 from django.db.models import Q
 from rest_framework.response import Response
 

--- a/src/sentry/api/endpoints/organization_recent_searches.py
+++ b/src/sentry/api/endpoints/organization_recent_searches.py
@@ -35,16 +35,12 @@ class OrganizationRecentSearchesEndpoint(OrganizationEndpoint):
         try:
             search_type = SearchType(int(request.GET.get("type", 0)))
         except ValueError as e:
-            return Response(
-                {"detail": "Invalid input for `type`. Error: %s" % six.text_type(e)}, status=400
-            )
+            return Response({"detail": "Invalid input for `type`. Error: %s" % str(e)}, status=400)
 
         try:
             limit = int(request.GET.get("limit", 3))
         except ValueError as e:
-            return Response(
-                {"detail": "Invalid input for `limit`. Error: %s" % six.text_type(e)}, status=400
-            )
+            return Response({"detail": "Invalid input for `limit`. Error: %s" % str(e)}, status=400)
 
         query_kwargs = {"organization": organization, "user": request.user, "type": search_type}
 

--- a/src/sentry/api/endpoints/organization_recent_searches.py
+++ b/src/sentry/api/endpoints/organization_recent_searches.py
@@ -1,4 +1,4 @@
-from django.utils import six, timezone
+from django.utils import timezone
 from rest_framework import serializers
 from rest_framework.response import Response
 

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -183,7 +183,7 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint, Relea
                     release.set_refs(refs, request.user, fetch=fetch_commits)
                 except InvalidRepository as e:
                     scope.set_tag("failure_reason", "InvalidRepository")
-                    return Response({"refs": [six.text_type(e)]}, status=400)
+                    return Response({"refs": [str(e)]}, status=400)
 
             if not was_released and release.date_released:
                 for project in projects:
@@ -221,6 +221,6 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint, Relea
         try:
             release.safe_delete()
         except UnsafeReleaseDeletion as e:
-            return Response({"detail": six.text_type(e)}, status=400)
+            return Response({"detail": str(e)}, status=400)
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -1,4 +1,3 @@
-import six
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -399,7 +399,7 @@ class OrganizationReleasesEndpoint(
                         release.set_refs(refs, request.user, fetch=fetch_commits)
                     except InvalidRepository as e:
                         scope.set_tag("failure_reason", "InvalidRepository")
-                        return Response({"refs": [six.text_type(e)]}, status=400)
+                        return Response({"refs": [str(e)]}, status=400)
 
                 if not created and not new_projects:
                     # This is the closest status code that makes sense, and we want

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -1,5 +1,4 @@
 import re
-import six
 from django.db import IntegrityError
 from django.db.models import Q
 from django.db.models.functions import Coalesce

--- a/src/sentry/api/endpoints/organization_searches.py
+++ b/src/sentry/api/endpoints/organization_searches.py
@@ -33,9 +33,7 @@ class OrganizationSearchesEndpoint(OrganizationEndpoint):
         try:
             search_type = SearchType(int(request.GET.get("type", 0)))
         except ValueError as e:
-            return Response(
-                {"detail": "Invalid input for `type`. Error: %s" % six.text_type(e)}, status=400
-            )
+            return Response({"detail": "Invalid input for `type`. Error: %s" % str(e)}, status=400)
         org_searches_q = Q(Q(owner=request.user) | Q(owner__isnull=True), organization=organization)
         global_searches_q = Q(is_global=True)
         saved_searches = list(

--- a/src/sentry/api/endpoints/organization_searches.py
+++ b/src/sentry/api/endpoints/organization_searches.py
@@ -1,7 +1,6 @@
 from rest_framework import serializers
 from rest_framework.response import Response
 from django.db.models import Q
-from django.utils import six
 
 from sentry import analytics
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationSearchPermission

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -3,7 +3,6 @@ from contextlib import contextmanager
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
-import six
 import sentry_sdk
 
 from sentry.api.bases import OrganizationEventsEndpointBase, NoProjects

--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -47,4 +47,4 @@ class OrganizationSessionsEndpoint(OrganizationEventsEndpointBase):
             with super().handle_query_errors():
                 yield
         except (InvalidField, NoProjects) as error:
-            raise ParseError(detail=six.text_type(error))
+            raise ParseError(detail=str(error))

--- a/src/sentry/api/endpoints/organization_shortid.py
+++ b/src/sentry/api/endpoints/organization_shortid.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationEndpoint

--- a/src/sentry/api/endpoints/organization_shortid.py
+++ b/src/sentry/api/endpoints/organization_shortid.py
@@ -30,7 +30,7 @@ class ShortIdLookupEndpoint(OrganizationEndpoint):
             {
                 "organizationSlug": organization.slug,
                 "projectSlug": group.project.slug,
-                "groupId": six.text_type(group.id),
+                "groupId": str(group.id),
                 "group": serialize(group, request.user),
                 "shortId": group.qualified_short_id,
             }

--- a/src/sentry/api/endpoints/organization_slugs.py
+++ b/src/sentry/api/endpoints/organization_slugs.py
@@ -43,7 +43,7 @@ class SlugsUpdateEndpoint(OrganizationEndpoint):
             # Clear out all slugs first so that we can move them
             # around through the uniqueness
             for project in project_q:
-                projects[six.text_type(project.id)] = project
+                projects[str(project.id)] = project
                 project.slug = None
                 project.save()
 

--- a/src/sentry/api/endpoints/organization_slugs.py
+++ b/src/sentry/api/endpoints/organization_slugs.py
@@ -1,5 +1,3 @@
-import six
-
 from django.core.validators import validate_slug, ValidationError
 from django.db import transaction
 from rest_framework.response import Response

--- a/src/sentry/api/endpoints/organization_slugs.py
+++ b/src/sentry/api/endpoints/organization_slugs.py
@@ -22,7 +22,7 @@ class SlugsUpdateEndpoint(OrganizationEndpoint):
         :auth: required
         """
         slugs = request.data.get("slugs", {})
-        for project_id, slug in six.iteritems(slugs):
+        for project_id, slug in slugs.items():
             slug = slug.lower()
             try:
                 validate_slug(slug)
@@ -48,7 +48,7 @@ class SlugsUpdateEndpoint(OrganizationEndpoint):
                 project.save()
 
             # Set new ones
-            for project_id, slug in six.iteritems(slugs):
+            for project_id, slug in slugs.items():
                 project = projects.get(project_id)
                 if project is None:
                     continue

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -1,5 +1,3 @@
-import six
-
 from django.db import IntegrityError, transaction
 from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _

--- a/src/sentry/api/endpoints/organization_teams.py
+++ b/src/sentry/api/endpoints/organization_teams.py
@@ -87,7 +87,7 @@ class OrganizationTeamsEndpoint(OrganizationEndpoint):
 
         if query:
             tokens = tokenize_query(query)
-            for key, value in six.iteritems(tokens):
+            for key, value in tokens.items():
                 if key == "query":
                     value = " ".join(value)
                     queryset = queryset.filter(Q(name__icontains=value) | Q(slug__icontains=value))

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -84,7 +84,7 @@ class DynamicSamplingConditionSerializer(serializers.Serializer):
                 for child in inner:
                     self.validate(child)
         elif op == "eq":
-            for key in six.iterkeys(data):
+            for key in data.keys():
                 if key not in ["op", "name", "value", "ignoreCase"]:
                     raise serializers.ValidationError(
                         "Invalid filed {} for eq condition".format(key)
@@ -102,7 +102,7 @@ class DynamicSamplingConditionSerializer(serializers.Serializer):
             if data.get("value") is None:
                 raise serializers.ValidationError("Missing field 'value'")
         elif op == "glob":
-            for key in six.iterkeys(data):
+            for key in data.keys():
                 if key not in ["op", "name", "value", "ignoreCase"]:
                     raise serializers.ValidationError(
                         "Invalid filed {} for eq condition".format(key)
@@ -418,7 +418,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
 
         if not has_project_write:
             # options isn't part of the serializer, but should not be editable by members
-            for key in chain(six.iterkeys(ProjectAdminSerializer().fields), ["options"]):
+            for key in chain(ProjectAdminSerializer().fields.keys(), ["options"]):
                 if request.data.get(key) and not result.get(key):
                     return Response(
                         {"detail": ["You do not have permission to perform this action."]},

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -1,4 +1,3 @@
-import six
 import logging
 from itertools import chain
 from uuid import uuid4

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -90,7 +90,7 @@ class DynamicSamplingConditionSerializer(serializers.Serializer):
                         "Invalid filed {} for eq condition".format(key)
                     )
             name = data.get("name")
-            if type(name) not in six.string_types:
+            if type(name) not in (str,):
                 raise serializers.ValidationError(
                     "Invalid field value {} for name, expected string", format(name)
                 )
@@ -108,7 +108,7 @@ class DynamicSamplingConditionSerializer(serializers.Serializer):
                         "Invalid filed {} for eq condition".format(key)
                     )
             name = data.get("name")
-            if type(name) not in six.string_types:
+            if type(name) not in (str,):
                 raise serializers.ValidationError(
                     "Invalid field value {} for name, expected string", format(name)
                 )
@@ -265,7 +265,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
             sources = parse_sources(sources_json.strip())
             sources_json = json.dumps(sources) if sources else ""
         except InvalidSourcesError as e:
-            raise serializers.ValidationError(six.text_type(e))
+            raise serializers.ValidationError(str(e))
 
         return sources_json
 
@@ -276,7 +276,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
         try:
             Enhancements.from_config_string(value)
         except InvalidEnhancerConfig as e:
-            raise serializers.ValidationError(six.text_type(e))
+            raise serializers.ValidationError(str(e))
 
         return value
 
@@ -287,7 +287,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
         try:
             FingerprintingRules.from_config_string(value)
         except InvalidFingerprintingConfig as e:
-            raise serializers.ValidationError(six.text_type(e))
+            raise serializers.ValidationError(str(e))
 
         return value
 

--- a/src/sentry/api/endpoints/project_docs_platform.py
+++ b/src/sentry/api/endpoints/project_docs_platform.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.utils.http import absolute_uri
 from rest_framework.response import Response
 from django.core.urlresolvers import reverse

--- a/src/sentry/api/endpoints/project_docs_platform.py
+++ b/src/sentry/api/endpoints/project_docs_platform.py
@@ -17,7 +17,7 @@ def replace_keys(html, project_key):
     html = html.replace("___PUBLIC_DSN___", project_key.dsn_public)
     html = html.replace("___PUBLIC_KEY___", project_key.public_key)
     html = html.replace("___SECRET_KEY___", project_key.secret_key)
-    html = html.replace("___PROJECT_ID___", six.text_type(project_key.project_id))
+    html = html.replace("___PROJECT_ID___", str(project_key.project_id))
     html = html.replace("___MINIDUMP_URL___", project_key.minidump_endpoint)
     html = html.replace("___UNREAL_URL___", project_key.unreal_endpoint)
     html = html.replace(
@@ -30,8 +30,8 @@ def replace_keys(html, project_key):
     if "___PROJECT_NAME___" in html or "___ORG_NAME___" in html:
         project = project_key.project
         org = project.organization
-        html = html.replace("___ORG_NAME___", six.text_type(org.slug))
-        html = html.replace("___PROJECT_NAME___", six.text_type(project.slug))
+        html = html.replace("___ORG_NAME___", str(org.slug))
+        html = html.replace("___PROJECT_NAME___", str(project.slug))
 
     return html
 

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -145,7 +145,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         try:
             cursor_result, query_kwargs = self._search(request, project, {"count_hits": True})
         except ValidationError as exc:
-            return Response({"detail": six.text_type(exc)}, status=400)
+            return Response({"detail": str(exc)}, status=400)
 
         results = list(cursor_result)
 

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -1,6 +1,5 @@
 import functools
 
-import six
 from rest_framework.response import Response
 
 from sentry import analytics, eventstore, search, features

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -30,4 +30,4 @@ class ProjectGroupStatsEndpoint(ProjectEndpoint, EnvironmentMixin, StatsMixin):
             model=tsdb.models.group, keys=group_ids, **self._parse_args(request, environment_id)
         )
 
-        return Response({six.text_type(k): v for k, v in data.items()})
+        return Response({str(k): v for k, v in data.items()})

--- a/src/sentry/api/endpoints/project_group_stats.py
+++ b/src/sentry/api/endpoints/project_group_stats.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework.response import Response
 
 from sentry.app import tsdb

--- a/src/sentry/api/endpoints/project_index.py
+++ b/src/sentry/api/endpoints/project_index.py
@@ -51,7 +51,7 @@ class ProjectIndexEndpoint(Endpoint):
         query = request.GET.get("query")
         if query:
             tokens = tokenize_query(query)
-            for key, value in six.iteritems(tokens):
+            for key, value in tokens.items():
                 if key == "query":
                     value = " ".join(value)
                     queryset = queryset.filter(Q(name__icontains=value) | Q(slug__icontains=value))

--- a/src/sentry/api/endpoints/project_index.py
+++ b/src/sentry/api/endpoints/project_index.py
@@ -1,5 +1,3 @@
-import six
-
 from django.db.models import Q
 
 from sentry.api.base import Endpoint

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -33,7 +33,7 @@ class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
         ):
             # XXX (alex, 08/05/19) key stats were being stored under either key_id or str(key_id)
             # so merge both of those back into one stats result.
-            result = tsdb.get_range(model=model, keys=[key.id, six.text_type(key.id)], **stat_args)
+            result = tsdb.get_range(model=model, keys=[key.id, str(key.id)], **stat_args)
             for key_id, points in six.iteritems(result):
                 for ts, count in points:
                     bucket = stats.setdefault(int(ts), {})

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import OrderedDict
 from django.db.models import F
 from rest_framework.response import Response

--- a/src/sentry/api/endpoints/project_key_stats.py
+++ b/src/sentry/api/endpoints/project_key_stats.py
@@ -34,7 +34,7 @@ class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
             # XXX (alex, 08/05/19) key stats were being stored under either key_id or str(key_id)
             # so merge both of those back into one stats result.
             result = tsdb.get_range(model=model, keys=[key.id, str(key.id)], **stat_args)
-            for key_id, points in six.iteritems(result):
+            for key_id, points in result.items():
                 for ts, count in points:
                     bucket = stats.setdefault(int(ts), {})
                     bucket.setdefault(name, 0)
@@ -49,6 +49,6 @@ class ProjectKeyStatsEndpoint(ProjectEndpoint, StatsMixin):
                     "filtered": data["filtered"],
                     "accepted": data["total"] - data["dropped"] - data["filtered"],
                 }
-                for ts, data in six.iteritems(stats)
+                for ts, data in stats.items()
             ]
         )

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework import serializers
 from rest_framework.response import Response
 from django.utils import timezone

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -36,7 +36,7 @@ class ProjectOwnershipSerializer(serializers.Serializer):
         actors = resolve_actors(owners, self.context["ownership"].project_id)
 
         bad_actors = []
-        for owner, actor in six.iteritems(actors):
+        for owner, actor in actors.items():
             if actor is None:
                 if owner.type == "user":
                     bad_actors.append(owner.identifier)

--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -147,7 +147,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
         if errors:
             return Response({"errors": errors}, status=400)
 
-        for key, value in six.iteritems(cleaned):
+        for key, value in cleaned.items():
             if value is None:
                 plugin.unset_option(project=project, key=key)
             else:

--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -38,7 +38,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
             context = serialize(plugin, request.user, PluginWithConfigSerializer(project))
         except PluginIdentityRequired as e:
             context = serialize(plugin, request.user, PluginSerializer(project))
-            context["config_error"] = six.text_type(e)
+            context["config_error"] = str(e)
             context["auth_url"] = reverse("socialauth_associate", args=[plugin.slug])
 
         return Response(context)
@@ -131,7 +131,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
                 InvalidIdentity,
                 PluginError,
             ) as e:
-                errors[key] = six.text_type(e)
+                errors[key] = str(e)
 
             if not errors.get(key):
                 cleaned[key] = value
@@ -142,7 +142,7 @@ class ProjectPluginDetailsEndpoint(ProjectEndpoint):
                     project=project, config=cleaned, actor=request.user
                 )
             except (InvalidIdentity, PluginError) as e:
-                errors["__all__"] = six.text_type(e)
+                errors["__all__"] = str(e)
 
         if errors:
             return Response({"errors": errors}, status=400)

--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -1,5 +1,3 @@
-import six
-
 from django import forms
 from django.core.urlresolvers import reverse
 from rest_framework import serializers

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -170,6 +170,6 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
         try:
             release.safe_delete()
         except UnsafeReleaseDeletion as e:
-            return Response({"detail": six.text_type(e)}, status=400)
+            return Response({"detail": str(e)}, status=400)
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 

--- a/src/sentry/api/endpoints/project_release_stats.py
+++ b/src/sentry/api/endpoints/project_release_stats.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework.response import Response
 
 from sentry.api.exceptions import ResourceDoesNotExist

--- a/src/sentry/api/endpoints/project_release_stats.py
+++ b/src/sentry/api/endpoints/project_release_stats.py
@@ -62,7 +62,7 @@ class ProjectReleaseStatsEndpoint(ProjectEndpoint):
             # The minimum interval is one hour on the server
             rollup = max(rollup, 3600)
         except ProjectEventsError as e:
-            return Response({"detail": six.text_type(e)}, status=400)
+            return Response({"detail": str(e)}, status=400)
 
         release = upsert_missing_release(project, version)
         if release is None:

--- a/src/sentry/api/endpoints/project_servicehook_stats.py
+++ b/src/sentry/api/endpoints/project_servicehook_stats.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import OrderedDict
 
 from sentry import tsdb

--- a/src/sentry/api/endpoints/project_servicehook_stats.py
+++ b/src/sentry/api/endpoints/project_servicehook_stats.py
@@ -24,6 +24,4 @@ class ProjectServiceHookStatsEndpoint(ProjectEndpoint, StatsMixin):
             for ts, count in result:
                 stats.setdefault(int(ts), {})[name] = count
 
-        return self.respond(
-            [{"ts": ts, "total": data["total"]} for ts, data in six.iteritems(stats)]
-        )
+        return self.respond([{"ts": ts, "total": data["total"]} for ts, data in stats.items()])

--- a/src/sentry/api/endpoints/project_transfer.py
+++ b/src/sentry/api/endpoints/project_transfer.py
@@ -1,6 +1,6 @@
 import logging
 from uuid import uuid4
-from six.moves.urllib.parse import urlencode
+from urllib.parse import urlencode
 
 from django.utils import timezone
 from rest_framework import status

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -101,7 +101,7 @@ class ProjectUserReportsEndpoint(ProjectEndpoint, EnvironmentMixin):
         try:
             report_instance = save_userreport(project, report)
         except Conflict as e:
-            return self.respond({"detail": six.text_type(e)}, status=409)
+            return self.respond({"detail": str(e)}, status=409)
 
         if isinstance(request.auth, ProjectKey):
             return self.respond(status=200)

--- a/src/sentry/api/endpoints/project_user_reports.py
+++ b/src/sentry/api/endpoints/project_user_reports.py
@@ -1,4 +1,3 @@
-import six
 from rest_framework import serializers
 
 from sentry.api.authentication import DSNAuthentication

--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -175,7 +175,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
 
         configs = {}
         for project_id in project_ids:
-            configs[six.text_type(project_id)] = {"disabled": True}
+            configs[str(project_id)] = {"disabled": True}
 
             project = projects.get(int(project_id))
             if project is None:
@@ -197,7 +197,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
                         project_keys=project_keys.get(project.id) or [],
                     )
 
-            configs[six.text_type(project_id)] = project_config.to_dict()
+            configs[str(project_id)] = project_config.to_dict()
 
         if full_config_requested:
             projectconfig_cache.set_many(configs)

--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -1,6 +1,5 @@
 import random
 import logging
-import six
 from rest_framework.response import Response
 
 from django.conf import settings

--- a/src/sentry/api/endpoints/relay_projectconfigs.py
+++ b/src/sentry/api/endpoints/relay_projectconfigs.py
@@ -152,7 +152,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
         with start_span(op="relay_fetch_orgs"):
             # Preload all organizations and their options to prevent repeated
             # database access when computing the project configuration.
-            org_ids = {project.organization_id for project in six.itervalues(projects)}
+            org_ids = {project.organization_id for project in projects.values()}
             if org_ids:
                 with metrics.timer("relay_project_configs.fetching_orgs.duration"):
                     orgs = Organization.objects.get_many_from_cache(org_ids)
@@ -161,7 +161,7 @@ class RelayProjectConfigsEndpoint(Endpoint):
                 orgs = {}
 
             with metrics.timer("relay_project_configs.fetching_org_options.duration"):
-                for org_id in six.iterkeys(orgs):
+                for org_id in orgs.keys():
                     OrganizationOption.objects.get_all_values(org_id)
 
         with start_span(op="relay_fetch_keys"):

--- a/src/sentry/api/endpoints/relay_register.py
+++ b/src/sentry/api/endpoints/relay_register.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework.response import Response
 from rest_framework import serializers, status
 

--- a/src/sentry/api/endpoints/relay_register.py
+++ b/src/sentry/api/endpoints/relay_register.py
@@ -92,7 +92,7 @@ class RelayRegisterChallengeEndpoint(Endpoint):
                 {"detail": str(exc).splitlines()[0]}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        relay_id = six.text_type(challenge["relay_id"])
+        relay_id = str(challenge["relay_id"])
         if relay_id != get_header_relay_id(request):
             return Response(
                 {"detail": "relay_id in payload did not match header"},
@@ -104,7 +104,7 @@ class RelayRegisterChallengeEndpoint(Endpoint):
         except Relay.DoesNotExist:
             pass
         else:
-            if relay.public_key != six.text_type(public_key):
+            if relay.public_key != str(public_key):
                 # This happens if we have an ID collision or someone copies an existing id
                 return Response(
                     {"detail": "Attempted to register agent with a different public key"},
@@ -154,8 +154,8 @@ class RelayRegisterResponseEndpoint(Endpoint):
                 {"detail": str(exc).splitlines()[0]}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        relay_id = six.text_type(validated["relay_id"])
-        version = six.text_type(validated["version"])
+        relay_id = str(validated["relay_id"])
+        version = str(validated["version"])
         public_key = validated["public_key"]
 
         if relay_id != get_header_relay_id(request):

--- a/src/sentry/api/endpoints/sentry_internal_app_tokens.py
+++ b/src/sentry/api/endpoints/sentry_internal_app_tokens.py
@@ -1,4 +1,3 @@
-import six
 from rest_framework.response import Response
 from rest_framework import status
 

--- a/src/sentry/api/endpoints/sentry_internal_app_tokens.py
+++ b/src/sentry/api/endpoints/sentry_internal_app_tokens.py
@@ -44,7 +44,7 @@ class SentryInternalAppTokensEndpoint(SentryAppBaseEndpoint):
                 request=request, sentry_app_installation=sentry_app_installation, user=request.user
             )
         except ApiTokenLimitError as e:
-            return Response(six.text_type(e), status=status.HTTP_403_FORBIDDEN)
+            return Response(str(e), status=status.HTTP_403_FORBIDDEN)
 
         # hack so the token is included in the response
         attrs = {"application": None}

--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -54,7 +54,7 @@ class SystemOptionsEndpoint(Endpoint):
 
     def put(self, request):
         # TODO(dcramer): this should validate options before saving them
-        for k, v in six.iteritems(request.data):
+        for k, v in request.data.items():
             if v and isinstance(v, str):
                 v = v.strip()
             try:

--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -1,5 +1,3 @@
-import six
-
 import sentry
 
 from django.conf import settings

--- a/src/sentry/api/endpoints/system_options.py
+++ b/src/sentry/api/endpoints/system_options.py
@@ -55,7 +55,7 @@ class SystemOptionsEndpoint(Endpoint):
     def put(self, request):
         # TODO(dcramer): this should validate options before saving them
         for k, v in six.iteritems(request.data):
-            if v and isinstance(v, six.string_types):
+            if v and isinstance(v, str):
                 v = v.strip()
             try:
                 option = options.lookup_key(k)
@@ -77,7 +77,7 @@ class SystemOptionsEndpoint(Endpoint):
                 return Response(
                     {
                         "error": "invalid_type" if type(e) is TypeError else "immutable_option",
-                        "errorDetail": {"option": k, "message": six.text_type(e)},
+                        "errorDetail": {"option": k, "message": str(e)},
                     },
                     status=400,
                 )

--- a/src/sentry/api/endpoints/team_stats.py
+++ b/src/sentry/api/endpoints/team_stats.py
@@ -1,5 +1,4 @@
 from rest_framework.response import Response
-from six.moves import range
 
 from sentry import tsdb
 from sentry.api.base import EnvironmentMixin, StatsMixin

--- a/src/sentry/api/endpoints/user_index.py
+++ b/src/sentry/api/endpoints/user_index.py
@@ -20,7 +20,7 @@ class UserIndexEndpoint(Endpoint):
         query = request.GET.get("query")
         if query:
             tokens = tokenize_query(query)
-            for key, value in six.iteritems(tokens):
+            for key, value in tokens.items():
                 if key == "query":
                     value = " ".join(value)
                     queryset = queryset.filter(

--- a/src/sentry/api/endpoints/user_index.py
+++ b/src/sentry/api/endpoints/user_index.py
@@ -1,5 +1,3 @@
-import six
-
 from django.db.models import Q
 
 from sentry.api.base import Endpoint

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -97,7 +97,7 @@ class UserNotificationDetailsEndpoint(UserEndpoint):
         if serializer.is_valid():
             for key in serializer.validated_data:
                 db_key = USER_OPTION_SETTINGS[key]["key"]
-                val = six.text_type(int(serializer.validated_data[key]))
+                val = str(int(serializer.validated_data[key]))
                 (uo, created) = UserOption.objects.get_or_create(
                     user=user, key=db_key, project=None, organization=None
                 )

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import defaultdict
 
 from sentry.api.bases.user import UserEndpoint

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -172,7 +172,7 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
 
                     # Values have been saved as strings for `mail:alerts` *shrug*
                     # `reports:disabled-organizations` requires an array of ids
-                    user_option.update(value=int_val if key["type"] is int else six.text_type(val))
+                    user_option.update(value=int_val if key["type"] is int else str(val))
 
             return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -1,5 +1,3 @@
-import six
-
 from django.db import transaction
 from rest_framework import status
 from rest_framework.response import Response

--- a/src/sentry/api/endpoints/user_social_identity_details.py
+++ b/src/sentry/api/endpoints/user_social_identity_details.py
@@ -39,7 +39,7 @@ class UserSocialIdentityDetailsEndpoint(UserEndpoint):
             import sys
 
             exc_tb = sys.exc_info()[2]
-            six.reraise(Exception, exc, exc_tb)
+            raise exc.with_traceback(exc_tb)
             del exc_tb
 
         # XXX(dcramer): we experienced an issue where the identity still existed,

--- a/src/sentry/api/endpoints/user_social_identity_details.py
+++ b/src/sentry/api/endpoints/user_social_identity_details.py
@@ -1,5 +1,4 @@
 import logging
-import six
 
 from rest_framework.response import Response
 from social_auth.backends import get_backend

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -247,7 +247,7 @@ class ParenExpression(namedtuple("ParenExpression", "children")):
 
 class SearchFilter(namedtuple("SearchFilter", "key operator value")):
     def __str__(self):
-        return "".join(map(six.text_type, (self.key.name, self.operator, self.value.raw_value)))
+        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
 
     @cached_property
     def is_negation(self):
@@ -276,7 +276,7 @@ class SearchKey(namedtuple("SearchKey", "name")):
 
 class AggregateFilter(namedtuple("AggregateFilter", "key operator value")):
     def __str__(self):
-        return "".join(map(six.text_type, (self.key.name, self.operator, self.value.raw_value)))
+        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
 
 
 class AggregateKey(namedtuple("AggregateKey", "name")):
@@ -291,7 +291,7 @@ class SearchValue(namedtuple("SearchValue", "raw_value")):
         return self.raw_value
 
     def is_wildcard(self):
-        if not isinstance(self.raw_value, six.string_types):
+        if not isinstance(self.raw_value, str):
             return False
         return bool(WILDCARD_CHARS.search(self.raw_value))
 
@@ -488,7 +488,7 @@ class SearchVisitor(NodeVisitor):
         except ValueError:
             raise InvalidSearchQuery("Invalid aggregate query condition: {}".format(search_key))
         except InvalidQuery as exc:
-            raise InvalidSearchQuery(six.text_type(exc))
+            raise InvalidSearchQuery(str(exc))
         return AggregateFilter(search_key, operator, SearchValue(aggregate_value))
 
     def visit_aggregate_date_filter(self, node, children):
@@ -500,7 +500,7 @@ class SearchVisitor(NodeVisitor):
             try:
                 search_value = parse_datetime_string(search_value)
             except InvalidQuery as exc:
-                raise InvalidSearchQuery(six.text_type(exc))
+                raise InvalidSearchQuery(str(exc))
             return AggregateFilter(search_key, operator, SearchValue(search_value))
         else:
             search_value = operator + search_value if operator != "=" else search_value
@@ -514,7 +514,7 @@ class SearchVisitor(NodeVisitor):
             try:
                 from_val, to_val = parse_datetime_range(search_value.text)
             except InvalidQuery as exc:
-                raise InvalidSearchQuery(six.text_type(exc))
+                raise InvalidSearchQuery(str(exc))
 
             if from_val is not None:
                 operator = ">="
@@ -535,7 +535,7 @@ class SearchVisitor(NodeVisitor):
             try:
                 search_value = parse_datetime_string(search_value)
             except InvalidQuery as exc:
-                raise InvalidSearchQuery(six.text_type(exc))
+                raise InvalidSearchQuery(str(exc))
             return SearchFilter(search_key, operator, SearchValue(search_value))
         else:
             search_value = operator + search_value if operator != "=" else search_value
@@ -549,7 +549,7 @@ class SearchVisitor(NodeVisitor):
             try:
                 search_value = parse_duration(*search_value.match.groups())
             except InvalidQuery as exc:
-                raise InvalidSearchQuery(six.text_type(exc))
+                raise InvalidSearchQuery(str(exc))
             return SearchFilter(search_key, operator, SearchValue(search_value))
         else:
             search_value = operator + search_value.text if operator != "=" else search_value.text
@@ -561,7 +561,7 @@ class SearchVisitor(NodeVisitor):
             try:
                 from_val, to_val = parse_datetime_range(value.text)
             except InvalidQuery as exc:
-                raise InvalidSearchQuery(six.text_type(exc))
+                raise InvalidSearchQuery(str(exc))
 
             # TODO: Handle negations
             if from_val is not None:
@@ -587,7 +587,7 @@ class SearchVisitor(NodeVisitor):
         try:
             from_val, to_val = parse_datetime_value(date_value)
         except InvalidQuery as exc:
-            raise InvalidSearchQuery(six.text_type(exc))
+            raise InvalidSearchQuery(str(exc))
 
         # TODO: Handle negations here. This is tricky because these will be
         # separate filters, and to negate this range we need (< val or >= val).
@@ -1814,7 +1814,7 @@ class Function:
                 raise InvalidSearchQuery("{}: invalid arguments: {}".format(field, e))
 
             # Hacky, but we expect column arguments to be strings so easiest to convert it back
-            columns.append(six.text_type(default) if default else default)
+            columns.append(str(default) if default else default)
 
         return columns
 
@@ -2378,7 +2378,7 @@ def format_column_arguments(column_args, arguments):
             if isinstance(column_args[i][0], ArgValue):
                 column_args[i][0] = arguments[column_args[i][0].arg]
             format_column_arguments(column_args[i][1], arguments)
-        elif isinstance(column_args[i], six.string_types):
+        elif isinstance(column_args[i], str):
             column_args[i] = column_args[i].format(**arguments)
         elif isinstance(column_args[i], ArgValue):
             column_args[i] = arguments[column_args[i].arg]
@@ -2579,7 +2579,7 @@ def get_aggregate_alias(match):
 
 
 def resolve_field(field, params=None, functions_acl=None):
-    if not isinstance(field, six.string_types):
+    if not isinstance(field, str):
         raise InvalidSearchQuery("Field names must be strings")
 
     match = is_function(field)
@@ -2634,7 +2634,7 @@ def resolve_field_list(
             fields.append("project.id")
 
     for field in fields:
-        if isinstance(field, six.string_types) and field.strip() == "":
+        if isinstance(field, str) and field.strip() == "":
             continue
         function = resolve_field(field, snuba_filter.params, functions_acl)
         if function.column is not None and function.column not in columns:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -3,7 +3,6 @@ from collections import namedtuple, defaultdict
 from copy import deepcopy
 from datetime import datetime
 
-import six
 from django.utils.functional import cached_property
 from parsimonious.expressions import Optional
 from parsimonious.exceptions import IncompleteParseError, ParseError

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -26,7 +26,7 @@ class Actor(namedtuple("Actor", "id type")):
             "maisey@dogsrule.com" -> look up User by primary email
         """
         # If we have an integer, fall back to assuming it's a User
-        if isinstance(actor_identifier, six.integer_types):
+        if isinstance(actor_identifier, int):
             return Actor(actor_identifier, User)
 
         # If the actor_identifier is a simple integer as a string,

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import defaultdict, namedtuple
 from rest_framework import serializers
 from sentry.models import User, Team

--- a/src/sentry/api/fields/avatar.py
+++ b/src/sentry/api/fields/avatar.py
@@ -1,8 +1,9 @@
 from base64 import b64decode
+from io import BytesIO
+
 from django.conf import settings
 from rest_framework import serializers
 from PIL import Image
-from six import BytesIO
 
 from sentry.api.exceptions import SentryAPIException
 

--- a/src/sentry/api/fields/user.py
+++ b/src/sentry/api/fields/user.py
@@ -14,7 +14,7 @@ class UserField(serializers.Field):
         if not data:
             return None
 
-        if isinstance(data, six.integer_types) or data.isdigit():
+        if isinstance(data, int) or data.isdigit():
             try:
                 return User.objects.get(id=data)
             except User.DoesNotExist:

--- a/src/sentry/api/fields/user.py
+++ b/src/sentry/api/fields/user.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework import serializers
 
 from sentry.models import User

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -1,5 +1,4 @@
 import logging
-import six
 
 from collections import defaultdict
 from datetime import timedelta

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -98,9 +98,7 @@ def build_query_params_from_request(request, organization, projects, environment
                 parse_search_query(query), projects, request.user, environments
             )
         except InvalidSearchQuery as e:
-            raise ValidationError(
-                "Your search query could not be parsed: {}".format(six.text_type(e))
-            )
+            raise ValidationError("Your search query could not be parsed: {}".format(str(e)))
 
         validate_search_filter_permissions(organization, search_filters, request.user)
         query_kwargs["search_filters"] = search_filters
@@ -398,7 +396,7 @@ def delete_groups(request, projects, organization_id, search_fn):
             # a bit too complicated right now
             cursor_result, _ = search_fn({"limit": 1000, "paginator_options": {"max_limit": 1000}})
         except ValidationError as exc:
-            return Response({"detail": six.text_type(exc)}, status=400)
+            return Response({"detail": str(exc)}, status=400)
 
         group_list = list(cursor_result)
 
@@ -536,7 +534,7 @@ def update_groups(request, projects, organization_id, search_fn, has_inbox=False
             # a bit too complicated right now
             cursor_result, _ = search_fn({"limit": 1000, "paginator_options": {"max_limit": 1000}})
         except ValidationError as exc:
-            return Response({"detail": six.text_type(exc)}, status=400)
+            return Response({"detail": str(exc)}, status=400)
 
         group_list = list(cursor_result)
         group_ids = [g.id for g in group_list]
@@ -992,8 +990,8 @@ def update_groups(request, projects, organization_id, search_fn, has_inbox=False
         )
 
         result["merge"] = {
-            "parent": six.text_type(primary_group.id),
-            "children": [six.text_type(g.id) for g in groups_to_merge],
+            "parent": str(primary_group.id),
+            "children": [str(g.id) for g in groups_to_merge],
         }
 
     # Support moving groups in or out of the inbox

--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -1,4 +1,4 @@
-from six.moves.urllib.parse import urlencode, parse_qsl
+from urllib.parse import urlencode, parse_qsl
 from django.utils.crypto import constant_time_compare
 from django.core.urlresolvers import reverse
 

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -1,5 +1,4 @@
 import functools
-import six
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import Activity, Commit, Group, PullRequest

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -58,7 +58,7 @@ class ActivitySerializer(Serializer):
 
         return {
             item: {
-                "user": users[six.text_type(item.user_id)] if item.user_id else None,
+                "user": users[str(item.user_id)] if item.user_id else None,
                 "source": groups.get(item.data["source_id"])
                 if item.type == Activity.UNMERGE_DESTINATION
                 else None,
@@ -89,7 +89,7 @@ class ActivitySerializer(Serializer):
             data.pop("mentions", None)
 
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "user": attrs["user"],
             "type": obj.get_type_display(),
             "data": data,
@@ -116,8 +116,8 @@ class OrganizationActivitySerializer(ActivitySerializer):
         projects = {d["id"]: d for d in serialize({i.project for i in item_list}, user)}
 
         for item in item_list:
-            attrs[item]["issue"] = groups[six.text_type(item.group_id)] if item.group_id else None
-            attrs[item]["project"] = projects[six.text_type(item.project_id)]
+            attrs[item]["issue"] = groups[str(item.group_id)] if item.group_id else None
+            attrs[item]["project"] = projects[str(item.project_id)]
         return attrs
 
     def serialize(self, obj, attrs, user):

--- a/src/sentry/api/serializers/models/actor.py
+++ b/src/sentry/api/serializers/models/actor.py
@@ -1,4 +1,3 @@
-import six
 from sentry.api.serializers import Serializer
 from sentry.models import User, Team
 

--- a/src/sentry/api/serializers/models/actor.py
+++ b/src/sentry/api/serializers/models/actor.py
@@ -16,5 +16,5 @@ class ActorSerializer(Serializer):
         else:
             raise AssertionError("Invalid type to assign to: %r" % type(obj))
 
-        context.update({"type": actor_type, "id": six.text_type(obj.id), "name": name})
+        context.update({"type": actor_type, "id": str(obj.id), "name": name})
         return context

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -62,9 +62,9 @@ class AlertRuleSerializer(Serializer):
         # Temporary: Translate aggregate back here from `tags[sentry:user]` to `user` for the frontend.
         aggregate = translate_aggregate_field(obj.snuba_query.aggregate, reverse=True)
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "name": obj.name,
-            "organizationId": six.text_type(obj.organization_id),
+            "organizationId": str(obj.organization_id),
             "status": obj.status,
             "dataset": obj.snuba_query.dataset,
             "query": obj.snuba_query.query,

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-import six
 
 from sentry.api.serializers import register, serialize, Serializer
 from sentry.incidents.models import (

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-import six
 
 from sentry.api.serializers import register, serialize, Serializer
 from sentry.incidents.models import (

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -34,8 +34,8 @@ class AlertRuleTriggerSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
-            "alertRuleId": six.text_type(obj.alert_rule_id),
+            "id": str(obj.id),
+            "alertRuleId": str(obj.alert_rule_id),
             "label": obj.label,
             "thresholdType": obj.alert_rule.threshold_type,
             "alertThreshold": obj.alert_threshold,

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import register, Serializer
 from sentry.incidents.models import AlertRuleTriggerAction
 

--- a/src/sentry/api/serializers/models/alert_rule_trigger_action.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger_action.py
@@ -38,8 +38,8 @@ class AlertRuleTriggerActionSerializer(Serializer):
         from sentry.incidents.endpoints.serializers import action_target_type_to_string
 
         return {
-            "id": six.text_type(obj.id),
-            "alertRuleTriggerId": six.text_type(obj.alert_rule_trigger_id),
+            "id": str(obj.id),
+            "alertRuleTriggerId": str(obj.alert_rule_trigger_id),
             "type": AlertRuleTriggerAction.get_registered_type(
                 AlertRuleTriggerAction.Type(obj.type)
             ).slug,

--- a/src/sentry/api/serializers/models/apiauthorization.py
+++ b/src/sentry/api/serializers/models/apiauthorization.py
@@ -21,7 +21,7 @@ class ApiAuthorizationSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "scopes": obj.get_scopes(),
             "application": attrs["application"],
             "dateCreated": obj.date_added,

--- a/src/sentry/api/serializers/models/apiauthorization.py
+++ b/src/sentry/api/serializers/models/apiauthorization.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import ApiAuthorization
 

--- a/src/sentry/api/serializers/models/apikey.py
+++ b/src/sentry/api/serializers/models/apikey.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import ApiKey
 

--- a/src/sentry/api/serializers/models/apikey.py
+++ b/src/sentry/api/serializers/models/apikey.py
@@ -8,12 +8,10 @@ from sentry.models import ApiKey
 class ApiKeySerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "label": obj.label,
             "key": obj.key,
             "scope_list": obj.scope_list,
             "status": obj.status,
-            "allowed_origins": ""
-            if obj.allowed_origins is None
-            else six.text_type(obj.allowed_origins),
+            "allowed_origins": "" if obj.allowed_origins is None else str(obj.allowed_origins),
         }

--- a/src/sentry/api/serializers/models/apitoken.py
+++ b/src/sentry/api/serializers/models/apitoken.py
@@ -21,7 +21,7 @@ class ApiTokenSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         data = {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "scopes": obj.get_scopes(),
             "application": attrs["application"],
             "expiresAt": obj.expires_at,

--- a/src/sentry/api/serializers/models/apitoken.py
+++ b/src/sentry/api/serializers/models/apitoken.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import ApiToken
 

--- a/src/sentry/api/serializers/models/app_platform_event.py
+++ b/src/sentry/api/serializers/models/app_platform_event.py
@@ -1,4 +1,3 @@
-import six
 from time import time
 from uuid import uuid4
 from sentry.utils import json

--- a/src/sentry/api/serializers/models/app_platform_event.py
+++ b/src/sentry/api/serializers/models/app_platform_event.py
@@ -50,6 +50,6 @@ class AppPlatformEvent:
             "Content-Type": "application/json",
             "Request-ID": request_uuid,
             "Sentry-Hook-Resource": self.resource,
-            "Sentry-Hook-Timestamp": six.text_type(int(time())),
+            "Sentry-Hook-Timestamp": str(int(time())),
             "Sentry-Hook-Signature": self.install.sentry_app.build_signature(self.body),
         }

--- a/src/sentry/api/serializers/models/auditlogentry.py
+++ b/src/sentry/api/serializers/models/auditlogentry.py
@@ -30,17 +30,17 @@ class AuditLogEntrySerializer(Serializer):
 
         return {
             item: {
-                "actor": users[six.text_type(item.actor_id)]
+                "actor": users[str(item.actor_id)]
                 if item.actor_id
                 else {"name": item.get_actor_name()},
-                "targetUser": users.get(six.text_type(item.target_user_id)) or item.target_user_id,
+                "targetUser": users.get(str(item.target_user_id)) or item.target_user_id,
             }
             for item in item_list
         }
 
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "actor": attrs["actor"],
             "event": obj.get_event_display(),
             "ipAddress": obj.ip_address,

--- a/src/sentry/api/serializers/models/auditlogentry.py
+++ b/src/sentry/api/serializers/models/auditlogentry.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import AuditLogEntry
 

--- a/src/sentry/api/serializers/models/auth_provider.py
+++ b/src/sentry/api/serializers/models/auth_provider.py
@@ -19,7 +19,7 @@ class AuthProviderSerializer(Serializer):
         login_url = organization.get_url()
 
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "provider_name": obj.provider,
             "pending_links_count": pending_links_count,
             "login_url": absolute_uri(login_url),

--- a/src/sentry/api/serializers/models/auth_provider.py
+++ b/src/sentry/api/serializers/models/auth_provider.py
@@ -1,5 +1,3 @@
-import six
-
 from django.db.models import F
 
 from sentry.api.serializers import Serializer, register

--- a/src/sentry/api/serializers/models/authenticator.py
+++ b/src/sentry/api/serializers/models/authenticator.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.auth.authenticators import (
     AuthenticatorInterface,

--- a/src/sentry/api/serializers/models/authenticator.py
+++ b/src/sentry/api/serializers/models/authenticator.py
@@ -14,7 +14,7 @@ from sentry.auth.authenticators import (
 class AuthenticatorInterfaceSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         data = {
-            "id": six.text_type(obj.interface_id),
+            "id": str(obj.interface_id),
             "name": obj.name,
             "description": obj.description,
             "enrollButton": obj.enroll_button,
@@ -28,7 +28,7 @@ class AuthenticatorInterfaceSerializer(Serializer):
 
         # authenticator is enrolled
         if obj.authenticator is not None:
-            data["authId"] = six.text_type(obj.authenticator.id)
+            data["authId"] = str(obj.authenticator.id)
             data["createdAt"] = obj.authenticator.created_at
             data["lastUsedAt"] = obj.authenticator.last_used_at
 

--- a/src/sentry/api/serializers/models/broadcast.py
+++ b/src/sentry/api/serializers/models/broadcast.py
@@ -22,7 +22,7 @@ class BroadcastSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "message": obj.message,
             "title": obj.title,
             "link": obj.link,

--- a/src/sentry/api/serializers/models/broadcast.py
+++ b/src/sentry/api/serializers/models/broadcast.py
@@ -1,5 +1,3 @@
-import six
-
 from django.db.models import Count
 
 from sentry.api.serializers import Serializer, register

--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -43,10 +43,8 @@ class CommitSerializer(Serializer):
         result = {}
         for item in item_list:
             result[item] = {
-                "repository": repository_objs.get(six.text_type(item.repository_id), {}),
-                "user": users_by_author.get(six.text_type(item.author_id), {})
-                if item.author_id
-                else {},
+                "repository": repository_objs.get(str(item.repository_id), {}),
+                "user": users_by_author.get(str(item.author_id), {}) if item.author_id else {},
             }
 
         return result

--- a/src/sentry/api/serializers/models/commit.py
+++ b/src/sentry/api/serializers/models/commit.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import defaultdict
 
 from sentry.api.serializers import Serializer, register, serialize

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import (
     Dashboard,

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -22,22 +22,20 @@ class DashboardWidgetSerializer(Serializer):
         )
 
         for widget in item_list:
-            widget_data_sources = [
-                d for d in data_sources if d["widgetId"] == six.text_type(widget.id)
-            ]
+            widget_data_sources = [d for d in data_sources if d["widgetId"] == str(widget.id)]
             result[widget] = {"queries": widget_data_sources}
 
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "title": obj.title,
             "displayType": DashboardWidgetDisplayTypes.get_type_name(obj.display_type),
             # Default value until a backfill can be done.
-            "interval": six.text_type(obj.interval or "5m"),
+            "interval": str(obj.interval or "5m"),
             "dateCreated": obj.date_added,
-            "dashboardId": six.text_type(obj.dashboard_id),
+            "dashboardId": str(obj.dashboard_id),
             "queries": attrs["queries"],
         }
 
@@ -46,22 +44,22 @@ class DashboardWidgetSerializer(Serializer):
 class DashboardWidgetQuerySerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "name": obj.name,
             "fields": obj.fields,
-            "conditions": six.text_type(obj.conditions),
-            "orderby": six.text_type(obj.orderby),
-            "widgetId": six.text_type(obj.widget_id),
+            "conditions": str(obj.conditions),
+            "orderby": str(obj.orderby),
+            "widgetId": str(obj.widget_id),
         }
 
 
 class DashboardListSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs):
         data = {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "title": obj.title,
             "dateCreated": obj.date_added,
-            "createdBy": six.text_type(obj.created_by.id),
+            "createdBy": str(obj.created_by.id),
         }
         return data
 
@@ -80,19 +78,17 @@ class DashboardDetailsSerializer(Serializer):
         )
 
         for dashboard in item_list:
-            dashboard_widgets = [
-                w for w in widgets if w["dashboardId"] == six.text_type(dashboard.id)
-            ]
+            dashboard_widgets = [w for w in widgets if w["dashboardId"] == str(dashboard.id)]
             result[dashboard] = {"widgets": dashboard_widgets}
 
         return result
 
     def serialize(self, obj, attrs, user, **kwargs):
         data = {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "title": obj.title,
             "dateCreated": obj.date_added,
-            "createdBy": six.text_type(obj.created_by.id),
+            "createdBy": str(obj.created_by.id),
             "widgets": attrs["widgets"],
         }
         return data

--- a/src/sentry/api/serializers/models/debug_file.py
+++ b/src/sentry/api/serializers/models/debug_file.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import ProjectDebugFile
 

--- a/src/sentry/api/serializers/models/debug_file.py
+++ b/src/sentry/api/serializers/models/debug_file.py
@@ -8,7 +8,7 @@ from sentry.models import ProjectDebugFile
 class DebugFileSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         d = {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "uuid": obj.debug_id[:36],
             "debugId": obj.debug_id,
             "codeId": obj.code_id,

--- a/src/sentry/api/serializers/models/deploy.py
+++ b/src/sentry/api/serializers/models/deploy.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import Deploy, Environment
 

--- a/src/sentry/api/serializers/models/deploy.py
+++ b/src/sentry/api/serializers/models/deploy.py
@@ -22,7 +22,7 @@ class DeploySerializer(Serializer):
 
     def serialize(self, obj, attrs, user, **kwargs):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "environment": attrs.get("environment"),
             "dateStarted": obj.date_started,
             "dateFinished": obj.date_finished,

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -24,7 +24,7 @@ class DiscoverSavedQuerySerializer(Serializer):
             "display",
         ]
         data = {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "name": obj.name,
             "projects": [project.id for project in obj.projects.all()],
             "version": obj.version or obj.query.get("version", 1),

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -1,4 +1,3 @@
-import six
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.user import UserSerializer
 from sentry.constants import ALL_ACCESS_PROJECTS

--- a/src/sentry/api/serializers/models/environment.py
+++ b/src/sentry/api/serializers/models/environment.py
@@ -15,14 +15,14 @@ StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))
 @register(Environment)
 class EnvironmentSerializer(Serializer):
     def serialize(self, obj, attrs, user):
-        return {"id": six.text_type(obj.id), "name": obj.name}
+        return {"id": str(obj.id), "name": obj.name}
 
 
 @register(EnvironmentProject)
 class EnvironmentProjectSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "name": obj.environment.name,
             "isHidden": obj.is_hidden is True,
         }

--- a/src/sentry/api/serializers/models/environment.py
+++ b/src/sentry/api/serializers/models/environment.py
@@ -45,7 +45,7 @@ class GroupEnvironmentWithStatsSerializer(EnvironmentSerializer):
         for item in item_list:
             items[self.group.id].append(item.id)
 
-        for key, (segments, interval) in six.iteritems(self.STATS_PERIODS):
+        for key, (segments, interval) in self.STATS_PERIODS.items():
             until = self.until or timezone.now()
             since = self.since or until - (segments * interval)
 

--- a/src/sentry/api/serializers/models/environment.py
+++ b/src/sentry/api/serializers/models/environment.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import namedtuple
 from datetime import timedelta
 from django.utils import timezone

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -38,7 +38,7 @@ class EventSerializer(Serializer):
         meta = event.data.get("_meta") or {}
         interface_list = []
 
-        for key, interface in six.iteritems(event.interfaces):
+        for key, interface in event.interfaces.items():
             # we treat user as a special contextual item
             if key in self._reserved_keys:
                 continue

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -1,5 +1,3 @@
-import six
-
 from datetime import datetime
 from django.utils import timezone
 from sentry_relay import meta_with_chunks

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -101,8 +101,8 @@ class EventSerializer(Serializer):
                     "value": kv[1],
                     "_meta": prune_empty_keys(
                         {
-                            "key": get_path(meta, six.text_type(i), "0"),
-                            "value": get_path(meta, six.text_type(i), "1"),
+                            "key": get_path(meta, str(i), "0"),
+                            "value": get_path(meta, str(i), "1"),
                         }
                     )
                     or None,
@@ -120,7 +120,7 @@ class EventSerializer(Serializer):
             if query:
                 tag["query"] = query
 
-        tags_meta = prune_empty_keys({six.text_type(i): e.pop("_meta") for i, e in enumerate(tags)})
+        tags_meta = prune_empty_keys({str(i): e.pop("_meta") for i, e in enumerate(tags)})
 
         return (tags, meta_with_chunks(tags, tags_meta))
 
@@ -202,7 +202,7 @@ class EventSerializer(Serializer):
 
     def should_display_error(self, error):
         name = error.get("name")
-        if not isinstance(name, six.string_types):
+        if not isinstance(name, str):
             return True
 
         return (
@@ -237,9 +237,9 @@ class EventSerializer(Serializer):
 
         d = {
             "id": obj.event_id,
-            "groupID": six.text_type(obj.group_id) if obj.group_id else None,
+            "groupID": str(obj.group_id) if obj.group_id else None,
             "eventID": obj.event_id,
-            "projectID": six.text_type(obj.project_id),
+            "projectID": str(obj.project_id),
             "size": obj.size,
             "entries": attrs["entries"],
             "dist": obj.dist,
@@ -364,11 +364,11 @@ class SimpleEventSerializer(EventSerializer):
         user = obj.get_minimal_user()
 
         return {
-            "id": six.text_type(obj.event_id),
-            "event.type": six.text_type(obj.get_event_type()),
-            "groupID": six.text_type(obj.group_id) if obj.group_id else None,
-            "eventID": six.text_type(obj.event_id),
-            "projectID": six.text_type(obj.project_id),
+            "id": str(obj.event_id),
+            "event.type": str(obj.get_event_type()),
+            "groupID": str(obj.group_id) if obj.group_id else None,
+            "eventID": str(obj.event_id),
+            "projectID": str(obj.project_id),
             # XXX for 'message' this doesn't do the proper resolution of logentry
             # etc. that _get_legacy_message_with_meta does.
             "message": obj.message,
@@ -400,9 +400,9 @@ class ExternalEventSerializer(EventSerializer):
         user = obj.get_minimal_user()
 
         return {
-            "groupID": six.text_type(obj.group_id) if obj.group_id else None,
-            "eventID": six.text_type(obj.event_id),
-            "project": six.text_type(obj.project_id),
+            "groupID": str(obj.group_id) if obj.group_id else None,
+            "eventID": str(obj.event_id),
+            "project": str(obj.project_id),
             # XXX for 'message' this doesn't do the proper resolution of logentry
             # etc. that _get_legacy_message_with_meta does.
             "message": obj.message,

--- a/src/sentry/api/serializers/models/eventattachment.py
+++ b/src/sentry/api/serializers/models/eventattachment.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import EventAttachment, File
 

--- a/src/sentry/api/serializers/models/eventattachment.py
+++ b/src/sentry/api/serializers/models/eventattachment.py
@@ -13,7 +13,7 @@ class EventAttachmentSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         file = attrs["file"]
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "name": obj.name,
             "headers": file.headers,
             "mimetype": obj.mimetype,

--- a/src/sentry/api/serializers/models/eventuser.py
+++ b/src/sentry/api/serializers/models/eventuser.py
@@ -9,7 +9,7 @@ from sentry.utils.avatar import get_gravatar_url
 class EventUserSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "hash": obj.hash,
             "tagValue": obj.tag_value,
             "identifier": obj.ident,

--- a/src/sentry/api/serializers/models/eventuser.py
+++ b/src/sentry/api/serializers/models/eventuser.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import EventUser
 from sentry.utils.avatar import get_gravatar_url

--- a/src/sentry/api/serializers/models/filechange.py
+++ b/src/sentry/api/serializers/models/filechange.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import Commit, CommitFileChange, Repository
 from sentry.api.serializers.models.commit import get_users_for_commits

--- a/src/sentry/api/serializers/models/filechange.py
+++ b/src/sentry/api/serializers/models/filechange.py
@@ -24,9 +24,7 @@ class CommitFileChangeSerializer(Serializer):
         for item in item_list:
             commit = commits_by_id[item.commit_id]
             result[item] = {
-                "user": users_by_author.get(six.text_type(commit.author_id), {})
-                if commit.author_id
-                else {},
+                "user": users_by_author.get(str(commit.author_id), {}) if commit.author_id else {},
                 "message": commit.message,
                 "repository_name": repo_names_by_id.get(commit.repository_id),
             }
@@ -35,7 +33,7 @@ class CommitFileChangeSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "orgId": obj.organization_id,
             "author": attrs.get("user", {}),
             "commitMessage": attrs.get("message", ""),

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -75,7 +75,7 @@ logger = logging.getLogger(__name__)
 
 
 def merge_list_dictionaries(dict1, dict2):
-    for key, val in six.iteritems(dict2):
+    for key, val in dict2.items():
         dict1.setdefault(key, []).extend(val)
 
 
@@ -301,8 +301,8 @@ class GroupSerializerBase(Serializer):
             release_resolutions = {}
             commit_resolutions = {}
 
-        actor_ids = {r[-1] for r in six.itervalues(release_resolutions)}
-        actor_ids.update(r.actor_id for r in six.itervalues(ignore_items))
+        actor_ids = {r[-1] for r in release_resolutions.values()}
+        actor_ids.update(r.actor_id for r in ignore_items.values())
         if actor_ids:
             users = list(User.objects.filter(id__in=actor_ids, is_active=True))
             actors = {u.id: d for u, d in zip(users, serialize(users, user))}
@@ -851,7 +851,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
         )
         seen_data = {
             issue["group_id"]: fix_tag_value_data(
-                dict(filter(lambda key: key[0] != "group_id", six.iteritems(issue)))
+                dict(filter(lambda key: key[0] != "group_id", issue.items()))
             )
             for issue in result["data"]
         }

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -3,7 +3,6 @@ import itertools
 from collections import defaultdict
 from datetime import datetime, timedelta
 
-import six
 import pytz
 import logging
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -286,7 +286,7 @@ class GroupSerializerBase(Serializer):
                     where=[
                         "sentry_grouplink.linked_id = sentry_commit.id",
                         "sentry_grouplink.group_id IN ({})".format(
-                            ", ".join(six.text_type(i.id) for i in resolved_item_list)
+                            ", ".join(str(i.id) for i in resolved_item_list)
                         ),
                         "sentry_grouplink.linked_type = %s",
                         "sentry_grouplink.relationship = %s",
@@ -523,7 +523,7 @@ class GroupSerializerBase(Serializer):
         is_subscribed, subscription_details = self._get_subscription(attrs)
         share_id = attrs["share_id"]
         group_dict = {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "shareId": share_id,
             "shortId": obj.qualified_short_id,
             "title": obj.title,
@@ -536,7 +536,7 @@ class GroupSerializerBase(Serializer):
             "isPublic": share_id is not None,
             "platform": obj.platform,
             "project": {
-                "id": six.text_type(obj.project.id),
+                "id": str(obj.project.id),
                 "name": obj.project.name,
                 "slug": obj.project.slug,
                 "platform": obj.project.platform,
@@ -561,7 +561,7 @@ class GroupSerializerBase(Serializer):
 
     def _convert_seen_stats(self, stats):
         return {
-            "count": six.text_type(stats["times_seen"]),
+            "count": str(stats["times_seen"]),
             "userCount": stats["user_count"],
             "firstSeen": stats["first_seen"],
             "lastSeen": stats["last_seen"],
@@ -1015,7 +1015,7 @@ class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
             result = super().serialize(obj, attrs, user)
         else:
             result = {
-                "id": six.text_type(obj.id),
+                "id": str(obj.id),
             }
             if "times_seen" in attrs:
                 result.update(self._convert_seen_stats(attrs))

--- a/src/sentry/api/serializers/models/grouprelease.py
+++ b/src/sentry/api/serializers/models/grouprelease.py
@@ -50,7 +50,7 @@ class GroupReleaseWithStatsSerializer(GroupReleaseSerializer):
             items.setdefault(item.group_id, []).append(item.id)
             attrs[item]["stats"] = {}
 
-        for key, (segments, interval) in six.iteritems(self.STATS_PERIODS):
+        for key, (segments, interval) in self.STATS_PERIODS.items():
             until = self.until or timezone.now()
             since = self.since or until - (segments * interval)
 

--- a/src/sentry/api/serializers/models/grouprelease.py
+++ b/src/sentry/api/serializers/models/grouprelease.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import namedtuple
 from datetime import timedelta
 from django.utils import timezone

--- a/src/sentry/api/serializers/models/groupseen.py
+++ b/src/sentry/api/serializers/models/groupseen.py
@@ -11,7 +11,7 @@ class GroupSeenSerializer(Serializer):
 
         result = {}
         for item in item_list:
-            result[item] = {"user": user_map[six.text_type(item.user_id)]}
+            result[item] = {"user": user_map[str(item.user_id)]}
         return result
 
     def serialize(self, obj, attrs, user):

--- a/src/sentry/api/serializers/models/groupseen.py
+++ b/src/sentry/api/serializers/models/groupseen.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import GroupSeen
 

--- a/src/sentry/api/serializers/models/grouptombstone.py
+++ b/src/sentry/api/serializers/models/grouptombstone.py
@@ -20,7 +20,7 @@ class GroupTombstoneSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "level": LOG_LEVELS.get(obj.level, "unknown"),
             "message": obj.message,
             "culprit": obj.culprit,

--- a/src/sentry/api/serializers/models/grouptombstone.py
+++ b/src/sentry/api/serializers/models/grouptombstone.py
@@ -1,6 +1,3 @@
-import six
-
-
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.constants import LOG_LEVELS
 from sentry.models import GroupTombstone, User

--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-import six
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.incidents.models import Incident, IncidentProject, IncidentSubscription

--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -28,16 +28,16 @@ class IncidentSerializer(Serializer):
         results = {}
         for incident in item_list:
             results[incident] = {"projects": incident_projects.get(incident.id, [])}
-            results[incident]["alert_rule"] = alert_rules.get(six.text_type(incident.alert_rule.id))
+            results[incident]["alert_rule"] = alert_rules.get(str(incident.alert_rule.id))
 
         return results
 
     def serialize(self, obj, attrs, user):
         date_closed = obj.date_closed.replace(second=0, microsecond=0) if obj.date_closed else None
         return {
-            "id": six.text_type(obj.id),
-            "identifier": six.text_type(obj.identifier),
-            "organizationId": six.text_type(obj.organization_id),
+            "id": str(obj.id),
+            "identifier": str(obj.identifier),
+            "organizationId": str(obj.organization_id),
             "projects": attrs["projects"],
             "alertRule": attrs["alert_rule"],
             "status": obj.status,

--- a/src/sentry/api/serializers/models/incidentactivity.py
+++ b/src/sentry/api/serializers/models/incidentactivity.py
@@ -19,14 +19,14 @@ class IncidentActivitySerializer(Serializer):
             serializer=user_serializer,
         )
         user_lookup = {user["id"]: user for user in serialized_users}
-        return {item: {"user": user_lookup.get(six.text_type(item.user_id))} for item in item_list}
+        return {item: {"user": user_lookup.get(str(item.user_id))} for item in item_list}
 
     def serialize(self, obj, attrs, user):
         incident = obj.incident
 
         return {
-            "id": six.text_type(obj.id),
-            "incidentIdentifier": six.text_type(incident.identifier),
+            "id": str(obj.id),
+            "incidentIdentifier": str(incident.identifier),
             "user": attrs["user"],
             "type": obj.type,
             "value": obj.value,

--- a/src/sentry/api/serializers/models/incidentactivity.py
+++ b/src/sentry/api/serializers/models/incidentactivity.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.user import UserSerializer

--- a/src/sentry/api/serializers/models/incidentseen.py
+++ b/src/sentry/api/serializers/models/incidentseen.py
@@ -13,7 +13,7 @@ class IncidentSeenSerializer(Serializer):
 
         result = {}
         for item in item_list:
-            result[item] = {"user": user_map[six.text_type(item.user_id)]}
+            result[item] = {"user": user_map[str(item.user_id)]}
         return result
 
     def serialize(self, obj, attrs, user):

--- a/src/sentry/api/serializers/models/incidentseen.py
+++ b/src/sentry/api/serializers/models/incidentseen.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.incidents.models import IncidentSeen
 from sentry.utils.db import attach_foreignkey

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-import six
 
 from sentry import features
 from sentry.api.serializers import Serializer, register, serialize

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -25,7 +25,7 @@ class IntegrationSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         provider = obj.get_provider()
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "name": obj.name,
             "icon": obj.metadata.get("icon"),
             "domainName": obj.metadata.get("domain_name"),
@@ -181,7 +181,7 @@ class IntegrationIssueSerializer(IntegrationSerializer):
             )
             issues_by_integration[ei.integration_id].append(
                 {
-                    "id": six.text_type(ei.id),
+                    "id": str(ei.id),
                     "key": ei.key,
                     "url": installation.get_issue_url(ei.key),
                     "title": ei.title,

--- a/src/sentry/api/serializers/models/monitor.py
+++ b/src/sentry/api/serializers/models/monitor.py
@@ -16,7 +16,7 @@ class MonitorSerializer(Serializer):
         }
 
         return {
-            item: {"project": projects[six.text_type(item.project_id)] if item.project_id else None}
+            item: {"project": projects[str(item.project_id)] if item.project_id else None}
             for item in item_list
         }
 
@@ -25,7 +25,7 @@ class MonitorSerializer(Serializer):
         if "schedule_type" in config:
             config["schedule_type"] = obj.get_schedule_type_display()
         return {
-            "id": six.text_type(obj.guid),
+            "id": str(obj.guid),
             "status": obj.get_status_display(),
             "type": obj.get_type_display(),
             "name": obj.name,

--- a/src/sentry/api/serializers/models/monitor.py
+++ b/src/sentry/api/serializers/models/monitor.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import Monitor, Project
 

--- a/src/sentry/api/serializers/models/monitorcheckin.py
+++ b/src/sentry/api/serializers/models/monitorcheckin.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import MonitorCheckIn
 

--- a/src/sentry/api/serializers/models/monitorcheckin.py
+++ b/src/sentry/api/serializers/models/monitorcheckin.py
@@ -8,7 +8,7 @@ from sentry.models import MonitorCheckIn
 class MonitorCheckInSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.guid),
+            "id": str(obj.guid),
             "status": obj.get_status_display(),
             "duration": obj.duration,
             "dateCreated": obj.date_added,

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -1,4 +1,3 @@
-import six
 from rest_framework import serializers
 
 from sentry_relay.auth import PublicKey

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -171,7 +171,7 @@ class OrganizationSerializer(Serializer):
             feature_list.add("shared-issues")
 
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "slug": obj.slug,
             "status": {"id": status.name.lower(), "name": status.label},
             "name": obj.name or obj.slug,
@@ -192,7 +192,7 @@ class OnboardingTasksSerializer(Serializer):
 
         data = {}
         for item in item_list:
-            data[item] = {"user": user_map.get(six.text_type(item.user_id))}
+            data[item] = {"user": user_map.get(str(item.user_id))}
         return data
 
     def serialize(self, obj, attrs, user):
@@ -264,10 +264,10 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 "storeCrashReports": convert_crashreport_count(
                     obj.get_option("sentry:store_crash_reports")
                 ),
-                "attachmentsRole": six.text_type(
+                "attachmentsRole": str(
                     obj.get_option("sentry:attachments_role", ATTACHMENTS_ROLE_DEFAULT)
                 ),
-                "debugFilesRole": six.text_type(
+                "debugFilesRole": str(
                     obj.get_option("sentry:debug_files_role", DEBUG_FILES_ROLE_DEFAULT)
                 ),
                 "eventsMemberAdmin": bool(
@@ -287,8 +287,7 @@ class DetailedOrganizationSerializer(OrganizationSerializer):
                 "allowJoinRequests": bool(
                     obj.get_option("sentry:join_requests", JOIN_REQUESTS_DEFAULT)
                 ),
-                "relayPiiConfig": six.text_type(obj.get_option("sentry:relay_pii_config") or "")
-                or None,
+                "relayPiiConfig": str(obj.get_option("sentry:relay_pii_config") or "") or None,
                 "apdexThreshold": int(
                     obj.get_option("sentry:apdex_threshold", APDEX_THRESHOLD_DEFAULT)
                 ),

--- a/src/sentry/api/serializers/models/organization_access_request.py
+++ b/src/sentry/api/serializers/models/organization_access_request.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import OrganizationAccessRequest
 

--- a/src/sentry/api/serializers/models/organization_access_request.py
+++ b/src/sentry/api/serializers/models/organization_access_request.py
@@ -8,7 +8,7 @@ from sentry.models import OrganizationAccessRequest
 class OrganizationAccessRequestSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         d = {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "member": serialize(obj.member),
             "team": serialize(obj.team),
             "requester": serialize(obj.requester),

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -13,13 +13,12 @@ class OrganizationMemberSerializer(Serializer):
         users = {d["id"]: d for d in serialize({i.user for i in item_list if i.user_id}, user)}
 
         return {
-            item: {"user": users[six.text_type(item.user_id)] if item.user_id else None}
-            for item in item_list
+            item: {"user": users[str(item.user_id)] if item.user_id else None} for item in item_list
         }
 
     def serialize(self, obj, attrs, user):
         d = {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "email": obj.get_email(),
             "name": obj.user.get_display_name() if obj.user else obj.get_email(),
             "user": attrs["user"],

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -1,4 +1,3 @@
-import six
 from collections import defaultdict
 
 from sentry import roles

--- a/src/sentry/api/serializers/models/platformexternalissue.py
+++ b/src/sentry/api/serializers/models/platformexternalissue.py
@@ -8,8 +8,8 @@ from sentry.models import PlatformExternalIssue
 class PlatformExternalIssueSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
-            "groupId": six.text_type(obj.group_id),
+            "id": str(obj.id),
+            "groupId": str(obj.group_id),
             "serviceType": obj.service_type,
             "displayName": obj.display_name,
             "webUrl": obj.web_url,

--- a/src/sentry/api/serializers/models/platformexternalissue.py
+++ b/src/sentry/api/serializers/models/platformexternalissue.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import register, Serializer
 from sentry.models import PlatformExternalIssue
 

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer
 from sentry.utils.assets import get_asset_url
 from sentry.utils.http import absolute_uri

--- a/src/sentry/api/serializers/models/plugin.py
+++ b/src/sentry/api/serializers/models/plugin.py
@@ -32,9 +32,9 @@ class PluginSerializer(Serializer):
             contexts.extend(x.type for x in obj.get_custom_contexts() or ())
         d = {
             "id": obj.slug,
-            "name": six.text_type(obj.get_title()),
-            "slug": obj.slug or slugify(six.text_type(obj.get_title())),
-            "shortName": six.text_type(obj.get_short_title()),
+            "name": str(obj.get_title()),
+            "slug": obj.slug or slugify(str(obj.get_title())),
+            "shortName": str(obj.get_short_title()),
             "type": obj.get_plugin_type(),
             "canDisable": obj.can_disable,
             "isTestable": hasattr(obj, "is_testable") and obj.is_testable(),
@@ -52,15 +52,15 @@ class PluginSerializer(Serializer):
             d["enabled"] = obj.is_enabled(self.project)
 
         if obj.version:
-            d["version"] = six.text_type(obj.version)
+            d["version"] = str(obj.version)
 
         if obj.author:
-            d["author"] = {"name": six.text_type(obj.author), "url": six.text_type(obj.author_url)}
+            d["author"] = {"name": str(obj.author), "url": str(obj.author_url)}
 
         d["isHidden"] = d.get("enabled", False) is False and obj.is_hidden()
 
         if obj.description:
-            d["description"] = six.text_type(obj.description)
+            d["description"] = str(obj.description)
 
         d["features"] = list({f.featureGate.value for f in obj.feature_descriptions})
 
@@ -95,12 +95,12 @@ class PluginWithConfigSerializer(PluginSerializer):
 
 def serialize_field(project, plugin, field):
     data = {
-        "name": six.text_type(field["name"]),
-        "label": six.text_type(field.get("label") or field["name"].title().replace("_", " ")),
+        "name": str(field["name"]),
+        "label": str(field.get("label") or field["name"].title().replace("_", " ")),
         "type": field.get("type", "text"),
         "required": field.get("required", True),
-        "help": six.text_type(field["help"]) if field.get("help") else None,
-        "placeholder": six.text_type(field["placeholder"]) if field.get("placeholder") else None,
+        "help": str(field["help"]) if field.get("help") else None,
+        "placeholder": str(field["placeholder"]) if field.get("placeholder") else None,
         "choices": field.get("choices"),
         "readonly": field.get("readonly", False),
         "defaultValue": field.get("default"),

--- a/src/sentry/api/serializers/models/processingissue.py
+++ b/src/sentry/api/serializers/models/processingissue.py
@@ -31,7 +31,7 @@ class ProcessingIssueSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "type": obj.type,
             "checksum": obj.checksum,
             "numEvents": attrs["num_events"],

--- a/src/sentry/api/serializers/models/processingissue.py
+++ b/src/sentry/api/serializers/models/processingissue.py
@@ -10,7 +10,7 @@ class ProcessingIssueSerializer(Serializer):
         counts = {i.id: getattr(i, "num_events", None) for i in item_list}
 
         missing_counts = []
-        for pk, events in six.iteritems(counts):
+        for pk, events in counts.items():
             if events is None:
                 missing_counts.append(pk)
 

--- a/src/sentry/api/serializers/models/processingissue.py
+++ b/src/sentry/api/serializers/models/processingissue.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import register, Serializer
 from sentry.models import ProcessingIssue
 

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -205,7 +205,7 @@ class ProjectSerializer(Serializer):
         results = {}
         for project_id in project_ids:
             serialized = []
-            str_id = six.text_type(project_id)
+            str_id = str(project_id)
             if str_id in stats:
                 for item in stats[str_id].data["data"]:
                     serialized.append((item["time"], item.get("count", 0)))
@@ -274,7 +274,7 @@ class ProjectSerializer(Serializer):
             avatar = {"avatarType": "letter_avatar", "avatarUuid": None}
 
         context = {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "slug": obj.slug,
             "name": obj.name,
             "isPublic": obj.public,
@@ -304,7 +304,7 @@ class ProjectWithOrganizationSerializer(ProjectSerializer):
 
         orgs = {d["id"]: d for d in serialize(list({i.organization for i in item_list}), user)}
         for item in item_list:
-            attrs[item]["organization"] = orgs[six.text_type(item.organization_id)]
+            attrs[item]["organization"] = orgs[str(item.organization_id)]
         return attrs
 
     def serialize(self, obj, attrs, user):
@@ -323,7 +323,7 @@ class ProjectWithTeamSerializer(ProjectSerializer):
 
         teams = {
             pt.team_id: {
-                "id": six.text_type(pt.team.id),
+                "id": str(pt.team.id),
                 "slug": pt.team.slug,
                 "name": pt.team.name,
             }
@@ -461,7 +461,7 @@ class ProjectSummarySerializer(ProjectWithTeamSerializer):
         context = {
             "team": attrs["teams"][0] if attrs["teams"] else None,
             "teams": attrs["teams"],
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "name": obj.name,
             "slug": obj.slug,
             "isBookmarked": attrs["is_bookmarked"],
@@ -534,7 +534,7 @@ def bulk_fetch_project_latest_releases(projects):
                 release_project_join_sql
             ),
             # formatting tuples works specifically in psycopg2
-            (tuple(six.text_type(i.id) for i in projects),),
+            (tuple(str(i.id) for i in projects),),
         )
     )
 
@@ -611,7 +611,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             attrs[item].update(
                 {
                     "latest_release": latest_releases.get(item.id),
-                    "org": orgs[six.text_type(item.organization_id)],
+                    "org": orgs[str(item.organization_id)],
                     "options": options_by_project[item.id],
                     "processing_issues": processing_issues_by_project.get(item.id, 0),
                 }

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import defaultdict
 from datetime import timedelta
 from django.db import connection

--- a/src/sentry/api/serializers/models/pullrequest.py
+++ b/src/sentry/api/serializers/models/pullrequest.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import PullRequest, Repository, CommitAuthor
 from sentry.api.serializers.models.release import get_users_for_authors

--- a/src/sentry/api/serializers/models/pullrequest.py
+++ b/src/sentry/api/serializers/models/pullrequest.py
@@ -27,16 +27,14 @@ class PullRequestSerializer(Serializer):
 
         result = {}
         for item in item_list:
-            repository_id = six.text_type(item.repository_id)
+            repository_id = str(item.repository_id)
             external_url = ""
             if item.repository_id in repository_map:
                 external_url = self._external_url(repository_map[item.repository_id], item)
             result[item] = {
                 "repository": serialized_repos.get(repository_id, {}),
                 "external_url": external_url,
-                "user": users_by_author.get(six.text_type(item.author_id), {})
-                if item.author_id
-                else {},
+                "user": users_by_author.get(str(item.author_id), {}) if item.author_id else {},
             }
 
         return result

--- a/src/sentry/api/serializers/models/recentsearch.py
+++ b/src/sentry/api/serializers/models/recentsearch.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models.recentsearch import RecentSearch
 

--- a/src/sentry/api/serializers/models/recentsearch.py
+++ b/src/sentry/api/serializers/models/recentsearch.py
@@ -8,8 +8,8 @@ from sentry.models.recentsearch import RecentSearch
 class RecentSearchSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
-            "organizationId": six.text_type(obj.organization_id),
+            "id": str(obj.id),
+            "organizationId": str(obj.organization_id),
             "type": obj.type,
             "query": obj.query,
             "lastSeen": obj.last_seen,

--- a/src/sentry/api/serializers/models/relay.py
+++ b/src/sentry/api/serializers/models/relay.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import Relay
 

--- a/src/sentry/api/serializers/models/relay.py
+++ b/src/sentry/api/serializers/models/relay.py
@@ -8,8 +8,8 @@ from sentry.models import Relay
 class RelaySerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
-            "relayId": six.text_type(obj.relay_id),
+            "id": str(obj.id),
+            "relayId": str(obj.relay_id),
             "publicKey": obj.public_key,
             "firstSeen": obj.first_seen,
             "lastSeen": obj.last_seen,

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -79,7 +79,7 @@ def get_users_for_authors(organization_id, authors, user=None):
             if fetched_user is None:
                 missed.append(author)
             else:
-                results[six.text_type(author.id)] = fetched_user
+                results[str(author.id)] = fetched_user
     else:
         missed = authors
 
@@ -104,19 +104,17 @@ def get_users_for_authors(organization_id, authors, user=None):
             # force emails to lower case so we can do case insensitive matching
             lower_email = email.email.lower()
             if lower_email not in users_by_email:
-                user = users_by_id.get(six.text_type(email.user_id), None)
+                user = users_by_id.get(str(email.user_id), None)
                 # user can be None if there's a user associated
                 # with user_email in separate organization
                 if user:
                     users_by_email[lower_email] = user
         to_cache = {}
         for author in missed:
-            results[six.text_type(author.id)] = users_by_email.get(
+            results[str(author.id)] = users_by_email.get(
                 author.email.lower(), {"name": author.name, "email": author.email}
             )
-            to_cache[_user_to_author_cache_key(organization_id, author)] = results[
-                six.text_type(author.id)
-            ]
+            to_cache[_user_to_author_cache_key(organization_id, author)] = results[str(author.id)]
         cache.set_many(to_cache)
 
     metrics.incr("sentry.release.get_users_for_authors.missed", amount=len(missed))
@@ -398,7 +396,7 @@ class ReleaseSerializer(Serializer):
                 release_new_groups = sum((issue_counts_by_release.get(item.id) or {}).values())
 
             p = {
-                "owner": owners[six.text_type(item.owner_id)] if item.owner_id else None,
+                "owner": owners[str(item.owner_id)] if item.owner_id else None,
                 "new_groups": release_new_groups,
                 "projects": single_release_projects,
                 "first_seen": first_seen.get(item.version),

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import defaultdict
 
 from django.core.cache import cache

--- a/src/sentry/api/serializers/models/release_file.py
+++ b/src/sentry/api/serializers/models/release_file.py
@@ -8,7 +8,7 @@ from sentry.models import ReleaseFile
 class ReleaseFileSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "name": obj.name,
             "dist": obj.dist_id and obj.dist.name or None,
             "headers": obj.file.headers,

--- a/src/sentry/api/serializers/models/release_file.py
+++ b/src/sentry/api/serializers/models/release_file.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import ReleaseFile
 

--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -10,7 +10,7 @@ class RepositorySerializer(Serializer):
         external_slug = None
         integration_id = None
         if obj.integration_id:
-            integration_id = six.text_type(obj.integration_id)
+            integration_id = str(obj.integration_id)
         if obj.provider:
             repo_provider = obj.get_provider()
             provider = {"id": obj.provider, "name": repo_provider.name}
@@ -19,7 +19,7 @@ class RepositorySerializer(Serializer):
             provider = {"id": "unknown", "name": "Unknown Provider"}
 
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "name": obj.config.get("pending_deletion_name", obj.name),
             "url": obj.url,
             "provider": provider,

--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import Repository
 

--- a/src/sentry/api/serializers/models/repository_project_path_config.py
+++ b/src/sentry/api/serializers/models/repository_project_path_config.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.api.serializers.models.integration import serialize_provider
 from sentry.models import RepositoryProjectPathConfig

--- a/src/sentry/api/serializers/models/repository_project_path_config.py
+++ b/src/sentry/api/serializers/models/repository_project_path_config.py
@@ -11,12 +11,12 @@ class RepositoryProjectPathConfigSerializer(Serializer):
         integration = obj.organization_integration.integration
         provider = integration.get_provider()
         return {
-            "id": six.text_type(obj.id),
-            "projectId": six.text_type(obj.project_id),
+            "id": str(obj.id),
+            "projectId": str(obj.project_id),
             "projectSlug": obj.project.slug,
-            "repoId": six.text_type(obj.repository.id),
+            "repoId": str(obj.repository.id),
             "repoName": obj.repository.name,
-            "integrationId": six.text_type(integration.id),
+            "integrationId": str(integration.id),
             "provider": serialize_provider(provider),
             "stackRoot": obj.stack_root,
             "sourceRoot": obj.source_root,

--- a/src/sentry/api/serializers/models/role.py
+++ b/src/sentry/api/serializers/models/role.py
@@ -1,4 +1,3 @@
-import six
 from sentry.api.serializers import Serializer
 
 

--- a/src/sentry/api/serializers/models/role.py
+++ b/src/sentry/api/serializers/models/role.py
@@ -7,7 +7,7 @@ class RoleSerializer(Serializer):
         allowed_roles = kwargs.get("allowed_roles") or []
 
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "name": obj.name,
             "desc": obj.desc,
             "scopes": obj.scopes,

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import Environment, Rule, RuleActivity, RuleActivityType
 from sentry.utils.compat import filter

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -57,7 +57,7 @@ class RuleSerializer(Serializer):
         d = {
             # XXX(dcramer): we currently serialize unsaved rule objects
             # as part of the rule editor
-            "id": six.text_type(obj.id) if obj.id else None,
+            "id": str(obj.id) if obj.id else None,
             # conditions pertain to criteria that can trigger an alert
             "conditions": filter(lambda condition: not _is_filter(condition), all_conditions),
             # filters are not new conditions but are the subset of conditions that pertain to event attributes

--- a/src/sentry/api/serializers/models/savedsearch.py
+++ b/src/sentry/api/serializers/models/savedsearch.py
@@ -23,9 +23,9 @@ class SavedSearchSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             # TODO: Remove once we've completely deprecated Sentry 9
-            "projectId": six.text_type(obj.project_id) if obj.project_id else None,
+            "projectId": str(obj.project_id) if obj.project_id else None,
             "type": obj.type,
             "name": obj.name,
             "query": obj.query,

--- a/src/sentry/api/serializers/models/savedsearch.py
+++ b/src/sentry/api/serializers/models/savedsearch.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import SavedSearch, SavedSearchUserDefault
 

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import SentryAppComponent
 

--- a/src/sentry/api/serializers/models/sentry_app_component.py
+++ b/src/sentry/api/serializers/models/sentry_app_component.py
@@ -8,7 +8,7 @@ from sentry.models import SentryAppComponent
 class SentryAppComponentSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "uuid": six.text_type(obj.uuid),
+            "uuid": str(obj.uuid),
             "type": obj.type,
             "schema": obj.schema,
             "sentryApp": {

--- a/src/sentry/api/serializers/models/tagvalue.py
+++ b/src/sentry/api/serializers/models/tagvalue.py
@@ -7,7 +7,7 @@ from sentry.search.utils import convert_user_tag_to_query
 
 class EnvironmentTagValueSerializer(Serializer):
     def serialize(self, obj, attrs, user):
-        return {"id": six.text_type(obj.id), "name": obj.value}
+        return {"id": str(obj.id), "name": obj.value}
 
 
 class UserTagValueSerializer(Serializer):

--- a/src/sentry/api/serializers/models/tagvalue.py
+++ b/src/sentry/api/serializers/models/tagvalue.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, serialize
 from sentry.models import EventUser
 from sentry.search.utils import convert_user_tag_to_query

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import defaultdict
 from django.db.models import Count
 

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -116,7 +116,7 @@ class TeamSerializer(Serializer):
         else:
             avatar = {"avatarType": "letter_avatar", "avatarUuid": None}
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "slug": obj.slug,
             "name": obj.name,
             "dateCreated": obj.date_added,

--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import defaultdict
 from django.conf import settings
 

--- a/src/sentry/api/serializers/models/user.py
+++ b/src/sentry/api/serializers/models/user.py
@@ -66,7 +66,7 @@ class UserSerializer(Serializer):
         experiment_assignments = experiments.all(user=user)
 
         d = {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "name": obj.get_display_name(),
             "username": obj.username,
             "email": obj.email,
@@ -112,7 +112,7 @@ class UserSerializer(Serializer):
         if attrs["identities"] is not None:
             d["identities"] = [
                 {
-                    "id": six.text_type(i.id),
+                    "id": str(i.id),
                     "name": i.ident,
                     "organization": {
                         "slug": i.auth_provider.organization.slug,
@@ -129,7 +129,7 @@ class UserSerializer(Serializer):
             ]
 
         d["emails"] = [
-            {"id": six.text_type(e.id), "email": e.email, "is_verified": e.is_verified}
+            {"id": str(e.id), "email": e.email, "is_verified": e.is_verified}
             for e in attrs["emails"]
         ]
 
@@ -178,9 +178,9 @@ class DetailedUserSerializer(UserSerializer):
         d["permissions"] = [up.permission for up in attrs["permissions"]]
         d["authenticators"] = [
             {
-                "id": six.text_type(a.id),
+                "id": str(a.id),
                 "type": a.interface.interface_id,
-                "name": six.text_type(a.interface.name),
+                "name": str(a.interface.name),
                 "dateCreated": a.created_at,
                 "dateUsed": a.last_used_at,
             }

--- a/src/sentry/api/serializers/models/user_social_auth.py
+++ b/src/sentry/api/serializers/models/user_social_auth.py
@@ -10,7 +10,7 @@ from sentry.api.serializers import Serializer, register
 class UserSocialAuthSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "provider": obj.provider,
             "providerLabel": settings.AUTH_PROVIDER_LABELS[obj.provider],
         }

--- a/src/sentry/api/serializers/models/user_social_auth.py
+++ b/src/sentry/api/serializers/models/user_social_auth.py
@@ -1,5 +1,3 @@
-import six
-
 from django.conf import settings
 from social_auth.models import UserSocialAuth
 

--- a/src/sentry/api/serializers/models/userip.py
+++ b/src/sentry/api/serializers/models/userip.py
@@ -8,7 +8,7 @@ from sentry.models import UserIP
 class UserIPSerializer(Serializer):
     def serialize(self, obj, attrs, user):
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "ipAddress": obj.ip_address,
             "countryCode": obj.country_code,
             "regionCode": obj.region_code,

--- a/src/sentry/api/serializers/models/userip.py
+++ b/src/sentry/api/serializers/models/userip.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import Serializer, register
 from sentry.models import UserIP
 

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -35,7 +35,7 @@ class UserReportSerializer(Serializer):
                 name = name or event_user.get("name")
                 email = email or event_user.get("email")
         return {
-            "id": six.text_type(obj.id),
+            "id": str(obj.id),
             "eventID": obj.event_id,
             "name": name,
             "email": email,
@@ -68,11 +68,7 @@ class UserReportWithGroupSerializer(UserReportSerializer):
         attrs = super().get_attrs(item_list, user)
         for item in item_list:
             attrs[item].update(
-                {
-                    "group": serialized_groups[six.text_type(item.group_id)]
-                    if item.group_id
-                    else None
-                }
+                {"group": serialized_groups[str(item.group_id)] if item.group_id else None}
             )
         return attrs
 

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -1,5 +1,3 @@
-import six
-
 from sentry.api.serializers import register, serialize, Serializer
 from sentry.models import EventUser, Group, UserReport
 from sentry.utils.compat import zip

--- a/src/sentry/api/serializers/rest_framework/base.py
+++ b/src/sentry/api/serializers/rest_framework/base.py
@@ -1,4 +1,3 @@
-import six
 from django.utils.text import re_camel_case
 from rest_framework.fields import empty
 from rest_framework.serializers import ModelSerializer, Serializer

--- a/src/sentry/api/serializers/rest_framework/base.py
+++ b/src/sentry/api/serializers/rest_framework/base.py
@@ -30,7 +30,7 @@ def convert_dict_key_case(obj, converter):
         return obj
 
     obj = obj.copy()
-    for key in list(six.iterkeys(obj)):
+    for key in list(obj.keys()):
         converted_key = converter(key)
         obj[converted_key] = convert_dict_key_case(obj.pop(key), converter)
 

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -1,5 +1,3 @@
-import six
-
 from rest_framework import serializers
 
 from sentry import features

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -44,7 +44,7 @@ class RuleNodeField(serializers.Field):
             # XXX(epurkhiser): Very hacky, but we really just want validation
             # errors that are more specific, not just 'this wasn't filled out',
             # give a more generic error for those.
-            first_error = next(six.itervalues(form.errors))[0]
+            first_error = next(iter(form.errors.values()))[0]
 
             if first_error != "This field is required.":
                 raise ValidationError(first_error)

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -42,7 +42,7 @@ def geo_by_addr(ip):
     rv = {}
     for k in "country_code", "city", "region":
         d = geo.get(k)
-        if isinstance(d, six.binary_type):
+        if isinstance(d, bytes):
             d = d.decode("ISO-8859-1")
         rv[k] = d
 
@@ -75,7 +75,7 @@ def serialize_eventusers(organization, item_list, user, lookup):
         rv[(tag, project)] = {
             HEALTH_ID_KEY: make_health_id(lookup, [eu.tag_value, eu.project_id]),
             "value": {
-                "id": six.text_type(eu.id) if eu.id else None,
+                "id": str(eu.id) if eu.id else None,
                 "project": projects.get(eu.project_id),
                 "hash": eu.hash,
                 "tagValue": eu.tag_value,

--- a/src/sentry/api/serializers/snuba.py
+++ b/src/sentry/api/serializers/snuba.py
@@ -1,4 +1,3 @@
-import six
 import itertools
 from functools import reduce, partial
 from operator import or_
@@ -135,7 +134,7 @@ def zerofill(data, start, end, rollup):
     if rollup_end - rollup_start == rollup:
         rollup_end += 1
     i = 0
-    for key in six.moves.xrange(rollup_start, rollup_end, rollup):
+    for key in range(rollup_start, rollup_end, rollup):
         try:
             while data[i][0] < key:
                 rv.append(data[i])

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 import math
-import six
 from django.utils import timezone
 
 from sentry.search.utils import parse_datetime_string, InvalidQuery

--- a/src/sentry/api/utils.py
+++ b/src/sentry/api/utils.py
@@ -74,7 +74,7 @@ def get_date_range_from_params(params, optional=False):
             start = parse_datetime_string(params["start"])
             end = parse_datetime_string(params["end"])
         except InvalidQuery as e:
-            raise InvalidParams(six.text_type(e))
+            raise InvalidParams(str(e))
     elif optional:
         return None, None
 

--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -70,7 +70,7 @@ class CronJobValidator(serializers.Serializer):
             if value[1] not in INTERVAL_NAMES:
                 raise ValidationError("Invalid value for schedule unit name (index 1)")
         elif schedule_type == ScheduleType.CRONTAB:
-            if not isinstance(value, six.string_types):
+            if not isinstance(value, str):
                 raise ValidationError("Invalid value for schedule_type")
             value = value.strip()
             if value.startswith("@"):

--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -1,5 +1,3 @@
-import six
-
 from collections import OrderedDict
 from croniter import croniter
 from django.core.exceptions import ValidationError


### PR DESCRIPTION
This removes six from partition 3 which I've defined to be `src/sentry/api/**/*.py`.

I will note that there was some `django.utils.six` in here, which seems to be a vendored + modified six, but our usage of it is really basic.

For partition 2, see https://github.com/getsentry/sentry/pull/23674.