### PR TITLE
feat(trace-view): Light trace view endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -1,0 +1,139 @@
+import logging
+import sentry_sdk
+
+from rest_framework.response import Response
+from rest_framework.exceptions import ParseError
+
+from sentry import features, eventstore
+from sentry.api.bases import OrganizationEventsEndpointBase, NoProjects
+from sentry.snuba import discover
+
+
+logger = logging.getLogger(__name__)
+
+
+class OrganizationEventsTraceLightEndpoint(OrganizationEventsEndpointBase):
+    def has_feature(self, organization, request):
+        return features.has(
+            "organizations:trace-view-quick", organization, actor=request.user
+        ) or features.has("organizations:trace-view-summary", organization, actor=request.user)
+
+    def get(self, request, organization, trace_id):
+        if not self.has_feature(organization, request):
+            return Response(status=404)
+
+        try:
+            params = self.get_snuba_params(request, organization)
+        except NoProjects:
+            return Response([])
+
+        with self.handle_query_errors():
+            result = discover.query(
+                selected_columns=[
+                    "id",
+                    "timestamp",
+                    "transaction",
+                    "project_id",
+                    "trace.span",
+                    "trace.parent_span",
+                    'to_other(trace.parent_span, "", 0, 1) AS root',
+                ],
+                # We want to guarantee at least getting the root, and hopefully events near it with timestamp
+                # id is just for consistent results
+                orderby=["-root", "-timestamp", "id"],
+                params=params,
+                query=f"event.type:transaction trace:{trace_id}",
+                limit=100,
+                referrer="api.trace-view.get_ids",
+            )
+            if len(result["data"]) == 0:
+                return Response(status=404)
+
+        event_id = request.GET.get("event_id")
+        if event_id is None:
+            raise ParseError("Only the light trace view is supported at this time")
+        is_root = lambda item: item["root"] == "1"
+
+        if is_root(result["data"][0]):
+            root = result["data"][0]
+        else:
+            root = None
+            logger.warning(
+                "discover.trace-view.root.not-found",
+                extra={"trace": trace_id, "organization": organization},
+            )
+            return Response(status=204)
+
+        # Look for extra roots
+        extra_roots = 0
+        for item in result["data"][1:]:
+            if is_root(item):
+                extra_roots += 1
+            else:
+                break
+        if extra_roots > 0:
+            logger.warning(
+                "discover.trace-view.root.extra-found",
+                extra={"trace": trace_id, "organization": organization, "extra_roots": extra_roots},
+            )
+
+        return Response(self.serialize(result["data"], root, event_id))
+
+    def serialize(self, result, root, event_id=None):
+        parent_map = {item["trace.parent_span"]: item for item in result}
+        trace_results = [
+            {
+                "event_id": root["id"],
+                "span_id": root["trace.span"],
+                "transaction": root["transaction"],
+                "project_id": root["project_id"],
+                "parent_event_id": None,
+                "is_root": True,
+            }
+        ]
+
+        snuba_event = next((item for item in result if item["id"] == event_id), None)
+        if snuba_event is None:
+            sentry_sdk.set_tag("query.error_reason", "Matching event not found")
+            raise ParseError("event matching matching requested id not found")
+
+        if root["id"] != event_id:
+            # Get the root event and see if the current event's span is in the root event
+            root_event = eventstore.get_event_by_id(root["project_id"], root["id"])
+            root_span = next(
+                (
+                    item
+                    for item in root_event.data.get("spans", [])
+                    if item["span_id"] == snuba_event["trace.parent_span"]
+                ),
+                None,
+            )
+
+            trace_results.append(
+                {
+                    "event_id": snuba_event["id"],
+                    "span_id": snuba_event["trace.span"],
+                    "transaction": snuba_event["transaction"],
+                    "project_id": snuba_event["project_id"],
+                    # For the light response, the parent will be unknown unless we're a direct descendent of the root
+                    "parent_event_id": root["id"] if root_span is not None else None,
+                    "is_root": False,
+                }
+            )
+
+        event = eventstore.get_event_by_id(snuba_event["project_id"], event_id)
+        for span in event.data.get("spans", []):
+            if span["span_id"] in parent_map:
+                child_event = parent_map[span["span_id"]]
+                trace_results.append(
+                    {
+                        "event_id": child_event["id"],
+                        "span_id": span["span_id"],
+                        "transaction": child_event["transaction"],
+                        "project_id": child_event["project_id"],
+                        "parent_event_id": event_id,
+                        "is_root": False,
+                    }
+                )
+
+        return trace_results

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 def find_event(items, function, default=None):
-    return next((item for item in items if function(item)), default)
+    return next(filter(function, items), default)
 
 
 def is_root(item):

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -2317,7 +2317,7 @@ FUNCTIONS = {
         Function(
             "to_other",
             required_args=[
-                ColumnNoLookup("column", allowed_columns=["release"]),
+                ColumnNoLookup("column", allowed_columns=["release", "trace.parent_span"]),
                 StringArg("value", unquote=True, unescape_quotes=True),
             ],
             optional_args=[
@@ -2511,7 +2511,10 @@ def resolve_function(field, match=None, params=None, functions_acl=False):
         if isinstance(addition[1], (list, tuple)):
             format_column_arguments(addition[1], arguments)
         if len(addition) < 3:
-            addition.append(get_function_alias_with_columns(function.name, columns))
+            if alias is not None:
+                addition.append(alias)
+            else:
+                addition.append(get_function_alias_with_columns(function.name, columns))
         elif len(addition) == 3:
             if alias is not None:
                 addition[2] = alias

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -107,6 +107,7 @@ from .endpoints.organization_events_trends import (
     OrganizationEventsTrendsEndpoint,
     OrganizationEventsTrendsStatsEndpoint,
 )
+from .endpoints.organization_events_trace import OrganizationEventsTraceLightEndpoint
 from .endpoints.organization_events_vitals import OrganizationEventsVitalsEndpoint
 from .endpoints.organization_group_index import OrganizationGroupIndexEndpoint
 from .endpoints.organization_group_index_stats import OrganizationGroupIndexStatsEndpoint
@@ -893,6 +894,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/event-baseline/$",
                     OrganizationEventBaseline.as_view(),
                     name="sentry-api-0-organization-event-baseline",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/events-trace-light/(?P<trace_id>[^\/]+)/$",
+                    OrganizationEventsTraceLightEndpoint.as_view(),
+                    name="sentry-api-0-organization-events-trace-light",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/issues/new/$",


### PR DESCRIPTION
- This adds a trace view endpoint that gets the trace ancestor, an event, and and children events. There will be a `events-trace` endpoint added later that will retrieve the full trace, these are separate endpoints so we can analyze the performance separately
- From the experiment in #23488 we found that making 10s of calls
  to eventstore will take seconds to load, this endpoint is so we can
  quickly load the important related events to the current event before
  making the much longer call for the rest of the trace
- fix: Allowing custom aliases on column functions (used here to avoid having to pass the resolved alias of `to_other(trace.parent_span, "", 0, 1)` around and just having `root` instead)
- TODO: Going to do tests in a following PR, getting this up so we can start building the quick-trace view