### PR TITLE
feat(ui): Change redesign flag behavior to be less intrusive

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -192,7 +192,6 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
   renderList() {
     const {loading, incidentList, incidentListPageLinks, hasAlertRule} = this.state;
     const {
-      organization,
       params: {orgId},
     } = this.props;
 
@@ -238,7 +237,6 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
                           projects={projects as Project[]}
                           incident={incident}
                           orgId={orgId}
-                          organization={organization}
                           filteredStatus={status}
                         />
                       ))

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -15,7 +15,7 @@ import {IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
-import {Organization, Project} from 'app/types';
+import {Project} from 'app/types';
 import getDynamicText from 'app/utils/getDynamicText';
 import theme from 'app/utils/theme';
 
@@ -31,7 +31,6 @@ type Props = {
   projectsLoaded: boolean;
   orgId: string;
   filteredStatus: 'open' | 'closed';
-  organization: Organization;
 } & AsyncComponent['props'];
 
 type State = {
@@ -95,23 +94,13 @@ class AlertListRow extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    const {
-      incident,
-      orgId,
-      organization,
-      projectsLoaded,
-      projects,
-      filteredStatus,
-    } = this.props;
+    const {incident, orgId, projectsLoaded, projects, filteredStatus} = this.props;
     const {error, stats} = this.state;
     const started = moment(incident.dateStarted);
     const duration = moment
       .duration(moment(incident.dateClosed || new Date()).diff(started))
       .as('seconds');
     const slug = incident.projects[0];
-    const incidentLink = organization.features.includes('alert-details-redesign')
-      ? `/organizations/${orgId}/alerts/rules/details/${incident.alertRule.id}/`
-      : `/organizations/${orgId}/alerts/${incident.identifier}/`;
 
     return (
       <ErrorBoundary>
@@ -120,7 +109,11 @@ class AlertListRow extends AsyncComponent<Props, State> {
             <TitleAndSparkLine status={filteredStatus}>
               <Title>
                 {this.renderStatusIndicator()}
-                <IncidentLink to={incidentLink}>Alert #{incident.id}</IncidentLink>
+                <IncidentLink
+                  to={`/organizations/${orgId}/alerts/${incident.identifier}/`}
+                >
+                  Alert #{incident.id}
+                </IncidentLink>
                 {incident.title}
               </Title>
 


### PR DESCRIPTION
Changed the way the redesign flag allows you to view metric details. Removed the behavior of having the incidents serve as a way to enter the new metric alert details UX. Now only clicking the alert name inside of the alert rules list will bring you to the metric details page. This allows users to still see active incidents by clicking on them in the `metric alerts` tab.

**Click the alert rule names to view the new details page:**
![image](https://user-images.githubusercontent.com/9372512/107280682-82697300-6a0d-11eb-8d0e-a1258e4276b0.png)
