### PR TITLE
fix(vercel): Implement pagination for get env var endpoint

### DIFF
--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -18,7 +18,7 @@ class VercelClient(ApiClient):
     PROJECTS_URL = "/v4/projects/"
     WEBHOOK_URL = "/v1/integrations/webhooks"
     ENV_VAR_URL = "/v4/projects/%s/env"
-    GET_ENV_VAR_URL = "/v5/projects/%s/env"
+    GET_ENV_VAR_URL = "/v5/projects/%s/env/"
     SECRETS_URL = "/v2/now/secrets"
     DELETE_ENV_VAR_URL = "/v4/projects/%s/env/%s"
 
@@ -48,23 +48,26 @@ class VercelClient(ApiClient):
     def get_user(self):
         return self.get(self.USER_URL)["user"]
 
-    def get_projects(self):
+    def paginate(self, url, type):
         limit = 20
         params = {"limit": limit}
-        projects = []
-        # no one should have more than 200 projects
+        results = []
+        # no one should have more than 200 results
         for i in range(10):
-            resp = self.get(self.PROJECTS_URL, params=params)
-            projects += resp["projects"]
-            # if we have less projects than the limit, we are done
+            resp = self.get(url, params=params)
+            results += resp[type]
+            # if we have less results than the limit, we are done
             if resp["pagination"]["count"] < limit:
-                return projects
+                return results
             # continue pagination by setting the until parameter
             params = params.copy()
             params["until"] = resp["pagination"]["next"]
         # log the warning if this happens so we can look into solutions
-        logger.warn("Did not finish project pagination", extra={"team_id": self.team_id})
-        return projects
+        logger.warn("Did not finish pagination", extra={"team_id": self.team_id, "url": url})
+        return results
+
+    def get_projects(self):
+        return self.paginate(self.PROJECTS_URL, "projects")
 
     def get_project(self, vercel_project_id):
         return self.get(self.PROJECT_URL % vercel_project_id)
@@ -79,7 +82,7 @@ class VercelClient(ApiClient):
         return response
 
     def get_env_vars(self, vercel_project_id):
-        return self.get(self.GET_ENV_VAR_URL % vercel_project_id)
+        return self.paginate(self.GET_ENV_VAR_URL % vercel_project_id, "envs")
 
     def create_secret(self, vercel_project_id, name, value):
         data = {"name": name, "value": value}

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -18,7 +18,7 @@ class VercelClient(ApiClient):
     PROJECTS_URL = "/v4/projects/"
     WEBHOOK_URL = "/v1/integrations/webhooks"
     ENV_VAR_URL = "/v4/projects/%s/env"
-    GET_ENV_VAR_URL = "/v5/projects/%s/env/"
+    GET_ENV_VAR_URL = "/v5/projects/%s/env"
     SECRETS_URL = "/v2/now/secrets"
     DELETE_ENV_VAR_URL = "/v4/projects/%s/env/%s"
 

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -289,7 +289,7 @@ class VercelIntegration(IntegrationInstallation):
         return any(
             [
                 env_var
-                for env_var in client.get_env_vars(vercel_project_id)["envs"]
+                for env_var in client.get_env_vars(vercel_project_id)
                 if env_var["key"] == name
             ]
         )

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -205,7 +205,10 @@ class VercelIntegrationTest(IntegrationTestCase):
             responses.GET,
             "https://api.vercel.com/v5/projects/%s/env"
             % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
-            json={"envs": []},
+            json={
+                "envs": [],
+                "pagination": {"count": 10},
+            },
         )
 
         for i, name in enumerate(secret_names):
@@ -331,6 +334,7 @@ class VercelIntegrationTest(IntegrationTestCase):
                 % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
                 json={
                     "envs": [{"value": "sec_%s" % i, "target": "production", "key": env_var_name}],
+                    "pagination": {"count": 10},
                 },
             )
         for i, env_var_name in enumerate(env_var_names):

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -207,7 +207,7 @@ class VercelIntegrationTest(IntegrationTestCase):
             % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
             json={
                 "envs": [],
-                "pagination": {"count": 10},
+                "pagination": {"count": 0},
             },
         )
 
@@ -334,7 +334,7 @@ class VercelIntegrationTest(IntegrationTestCase):
                 % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
                 json={
                     "envs": [{"value": "sec_%s" % i, "target": "production", "key": env_var_name}],
-                    "pagination": {"count": 10},
+                    "pagination": {"count": 4},
                 },
             )
         for i, env_var_name in enumerate(env_var_names):


### PR DESCRIPTION
If the first page (20 results) of environment variables that we fetch does not include the Sentry/Vercel env vars that we look for, `env_var_already_exists` will return False and we'll attempt to create the environment variable, only to find out upon creation that it does actually exist (but our env var is in another castle). The solution is to paginate to get all (well, 200) the env vars and then check if it already exists or not.

Fixes [SENTRY-N4D](https://sentry.io/organizations/sentry/issues/2201700901/?query=ENV_ALREADY_EXISTS&statsPeriod=14d), [SENTRY-N4G](https://sentry.io/organizations/sentry/issues/2201989893/?query=ENV_ALREADY_EXISTS&statsPeriod=14d), and [SENTRY-JW3](https://sentry.io/organizations/sentry/issues/2069926640/?query=ENV_ALREADY_EXISTS&statsPeriod=14d). 