### PR TITLE
fix(inbox): Add margin between custom search & count

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
@@ -47,8 +47,8 @@ function SavedSearchTab({
         {isActive ? (
           <React.Fragment>
             <TitleTextOverflow>
-              {savedSearch ? savedSearch.name : t('Custom Search')}
-            </TitleTextOverflow>{' '}
+              {savedSearch ? savedSearch.name : t('Custom Search')}{' '}
+            </TitleTextOverflow>
             <StyledQueryCount isTag count={queryCount} max={1000} />
           </React.Fragment>
         ) : (
@@ -121,6 +121,7 @@ const TitleWrapper = styled('span')`
 `;
 
 const TitleTextOverflow = styled('span')`
+  margin-right: ${space(0.5)};
   max-width: 150px;
   ${overflowEllipsis};
 `;


### PR DESCRIPTION
the white space elipsis change brought the count too close to shorter names...

before
![image](https://user-images.githubusercontent.com/1400464/107296953-3d523a80-6a27-11eb-8709-22f38ee137af.png)


after
![image](https://user-images.githubusercontent.com/1400464/107296924-2f9cb500-6a27-11eb-9cd5-4f8a3554c922.png)
![image](https://user-images.githubusercontent.com/1400464/107297031-5fe45380-6a27-11eb-8dec-322fcc2308fc.png)

