### PR TITLE
fix(inbox): Fix inbox date_added sort to correctly filter out tasks assigned to others when using me_or_none.

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -112,7 +112,7 @@ def inbox_search(
             .distinct()
         )
 
-    owner_search = get_search_filter(search_filters, "owner", "=")
+    owner_search = get_search_filter(search_filters, "assigned_or_suggested", "=")
     if owner_search:
         qs = qs.filter(
             assigned_or_suggested_filter(owner_search, projects, field_filter="group_id")

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -26,14 +26,16 @@ from sentry.search.base import SearchBackend
 from sentry.search.snuba.executors import PostgresSnubaQueryExecutor
 
 
-def assigned_to_filter(actor, projects):
+def assigned_to_filter(actor, projects, field_filter="id"):
     from sentry.models import OrganizationMember, OrganizationMemberTeam, Team
 
     if isinstance(actor, Team):
         return Q(
-            id__in=GroupAssignee.objects.filter(
-                team=actor, project_id__in=[p.id for p in projects]
-            ).values_list("group_id", flat=True)
+            **{
+                f"{field_filter}__in": GroupAssignee.objects.filter(
+                    team=actor, project_id__in=[p.id for p in projects]
+                ).values_list("group_id", flat=True)
+            }
         )
 
     include_none = False
@@ -42,37 +44,43 @@ def assigned_to_filter(actor, projects):
         actor = actor[1]
 
     assigned_to_user = Q(
-        id__in=GroupAssignee.objects.filter(
-            user=actor, project_id__in=[p.id for p in projects]
-        ).values_list("group_id", flat=True)
+        **{
+            f"{field_filter}__in": GroupAssignee.objects.filter(
+                user=actor, project_id__in=[p.id for p in projects]
+            ).values_list("group_id", flat=True)
+        }
     )
     assigned_to_team = Q(
-        id__in=GroupAssignee.objects.filter(
-            project_id__in=[p.id for p in projects],
-            team_id__in=Team.objects.filter(
-                id__in=OrganizationMemberTeam.objects.filter(
-                    organizationmember__in=OrganizationMember.objects.filter(
-                        user=actor, organization_id=projects[0].organization_id
-                    ),
-                    is_active=True,
-                ).values("team")
-            ),
-        ).values_list("group_id", flat=True)
+        **{
+            f"{field_filter}__in": GroupAssignee.objects.filter(
+                project_id__in=[p.id for p in projects],
+                team_id__in=Team.objects.filter(
+                    id__in=OrganizationMemberTeam.objects.filter(
+                        organizationmember__in=OrganizationMember.objects.filter(
+                            user=actor, organization_id=projects[0].organization_id
+                        ),
+                        is_active=True,
+                    ).values("team")
+                ),
+            ).values_list("group_id", flat=True)
+        }
     )
 
     assigned_query = assigned_to_user | assigned_to_team
 
     if include_none:
-        return assigned_query | unassigned_filter(True, projects)
+        return assigned_query | unassigned_filter(True, projects, field_filter=field_filter)
     else:
         return assigned_query
 
 
-def unassigned_filter(unassigned, projects):
+def unassigned_filter(unassigned, projects, field_filter="id"):
     query = Q(
-        id__in=GroupAssignee.objects.filter(project_id__in=[p.id for p in projects]).values_list(
-            "group_id", flat=True
-        )
+        **{
+            f"{field_filter}__in": GroupAssignee.objects.filter(
+                project_id__in=[p.id for p in projects]
+            ).values_list("group_id", flat=True)
+        }
     )
     if unassigned:
         query = ~query
@@ -157,7 +165,7 @@ def assigned_or_suggested_filter(owner, projects, field_filter="id"):
                     .distinct()
                 }
             )
-            | assigned_to_filter(owner, projects)
+            | assigned_to_filter(owner, projects, field_filter=field_filter)
         )
     elif isinstance(owner, User) or (isinstance(owner, list) and owner[0] == "me_or_none"):
         include_none = False
@@ -186,13 +194,15 @@ def assigned_or_suggested_filter(owner, projects, field_filter="id"):
             }
         )
 
-        owner_query = owned_by_me | assigned_to_filter(owner, projects)
+        owner_query = owned_by_me | assigned_to_filter(owner, projects, field_filter=field_filter)
 
         if include_none:
-            no_owner = unassigned_filter(True, projects) & ~Q(
-                id__in=GroupOwner.objects.filter(
-                    project_id__in=[p.id for p in projects],
-                ).values_list("group_id", flat=True)
+            no_owner = unassigned_filter(True, projects, field_filter) & ~Q(
+                **{
+                    f"{field_filter}__in": GroupOwner.objects.filter(
+                        project_id__in=[p.id for p in projects],
+                    ).values_list("group_id", flat=True)
+                }
             )
             return no_owner | owner_query
         else:

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -177,7 +177,7 @@ def assigned_or_suggested_filter(owner, projects, field_filter="id"):
             **{
                 f"{field_filter}__in": GroupOwner.objects.filter(
                     Q(user_id=owner.id) | Q(team__in=teams),
-                    Q(group__assignee_set__isnull=True),
+                    group__assignee_set__isnull=True,
                     project_id__in=[p.id for p in projects],
                     organization_id=organization_id,
                 )
@@ -191,7 +191,7 @@ def assigned_or_suggested_filter(owner, projects, field_filter="id"):
         if include_none:
             no_owner = unassigned_filter(True, projects) & ~Q(
                 id__in=GroupOwner.objects.filter(
-                    project_id__in=[p.id for p in projects]
+                    project_id__in=[p.id for p in projects],
                 ).values_list("group_id", flat=True)
             )
             return no_owner | owner_query

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -122,8 +122,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         response = self.get_response(
             sort="inbox", cursor=cursor, query="is:unresolved is:for_review", limit=1
         )
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == str(group_2.id)
+        assert [item["id"] for item in response.data] == [str(group_2.id)]
 
     def test_sort_by_inbox_me_or_none(self):
         group_1 = self.store_event(
@@ -137,7 +136,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         inbox_1 = add_group_to_inbox(group_1, GroupInboxReason.NEW)
         group_2 = self.store_event(
             data={
-                "event_id": "a" * 32,
+                "event_id": "b" * 32,
                 "timestamp": iso_format(before_now(seconds=1)),
                 "fingerprint": ["group-2"],
             },
@@ -154,21 +153,53 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
         owner_by_other = self.store_event(
             data={
-                "event_id": "a" * 32,
+                "event_id": "c" * 32,
                 "timestamp": iso_format(before_now(seconds=1)),
-                "fingerprint": ["group-2"],
+                "fingerprint": ["group-3"],
             },
             project_id=self.project.id,
         ).group
-        inbox_2 = add_group_to_inbox(owner_by_other, GroupInboxReason.NEW)
-        inbox_2.update(date_added=inbox_1.date_added - timedelta(hours=1))
+        inbox_3 = add_group_to_inbox(owner_by_other, GroupInboxReason.NEW)
+        inbox_3.update(date_added=inbox_1.date_added - timedelta(hours=1))
+        other_user = self.create_user()
         GroupOwner.objects.create(
             group=owner_by_other,
             project=self.project,
             organization=self.organization,
             type=GroupOwnerType.OWNERSHIP_RULE.value,
-            user=self.create_user(),
+            user=other_user,
         )
+
+        owned_me_assigned_to_other = self.store_event(
+            data={
+                "event_id": "d" * 32,
+                "timestamp": iso_format(before_now(seconds=1)),
+                "fingerprint": ["group-4"],
+            },
+            project_id=self.project.id,
+        ).group
+        inbox_4 = add_group_to_inbox(owned_me_assigned_to_other, GroupInboxReason.NEW)
+        inbox_4.update(date_added=inbox_1.date_added - timedelta(hours=1))
+        GroupAssignee.objects.assign(owned_me_assigned_to_other, other_user)
+        GroupOwner.objects.create(
+            group=owned_me_assigned_to_other,
+            project=self.project,
+            organization=self.organization,
+            type=GroupOwnerType.OWNERSHIP_RULE.value,
+            user=self.user,
+        )
+
+        unowned_assigned_to_other = self.store_event(
+            data={
+                "event_id": "e" * 32,
+                "timestamp": iso_format(before_now(seconds=1)),
+                "fingerprint": ["group-5"],
+            },
+            project_id=self.project.id,
+        ).group
+        inbox_5 = add_group_to_inbox(unowned_assigned_to_other, GroupInboxReason.NEW)
+        inbox_5.update(date_added=inbox_1.date_added - timedelta(hours=1))
+        GroupAssignee.objects.assign(unowned_assigned_to_other, other_user)
 
         self.login_as(user=self.user)
         response = self.get_valid_response(
@@ -176,9 +207,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             query="is:unresolved is:for_review assigned_or_suggested:me_or_none",
             limit=10,
         )
-        assert len(response.data) == 2
-        assert response.data[0]["id"] == str(group_1.id)
-        assert response.data[1]["id"] == str(group_2.id)
+        assert [item["id"] for item in response.data] == [str(group_1.id), str(group_2.id)]
 
     def test_trace_search(self):
         event = self.store_event(


### PR DESCRIPTION
This just fixes a bug with the new sort - we missed using the right search filter after renaming
from owner