### PR TITLE
feat(teams): Detailed includes list of external_teams

### DIFF
--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -3,7 +3,15 @@ from collections import defaultdict
 
 from sentry import features
 from sentry.api.serializers import Serializer, register, serialize
-from sentry.models import ExternalIssue, GroupLink, Integration, OrganizationIntegration
+from sentry.models import (
+    ExternalIssue,
+    GroupLink,
+    Integration,
+    OrganizationIntegration,
+    ExternalTeam,
+    EXTERNAL_PROVIDERS,
+    ExternalProviders,
+)
 
 
 # converts the provider to JSON
@@ -197,3 +205,15 @@ class IntegrationIssueSerializer(IntegrationSerializer):
         data = super().serialize(obj, attrs, user)
         data["externalIssues"] = attrs.get("external_issues", [])
         return data
+
+
+@register(ExternalTeam)
+class ExternalTeamSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        provider = EXTERNAL_PROVIDERS.get(ExternalProviders(obj.provider), "unknown")
+        return {
+            "id": obj.id,
+            "team_id": obj.team_id,
+            "provider": provider,
+            "external_id": obj.external_id,
+        }

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -210,10 +210,13 @@ class IntegrationIssueSerializer(IntegrationSerializer):
 @register(ExternalTeam)
 class ExternalTeamSerializer(Serializer):
     def serialize(self, obj, attrs, user):
-        provider = EXTERNAL_PROVIDERS.get(ExternalProviders(obj.provider), "unknown")
+        provider = self.get_provider_string(obj.provider)
         return {
             "id": obj.id,
             "team_id": obj.team_id,
             "provider": provider,
             "external_id": obj.external_id,
         }
+
+    def get_provider_string(self, provider):
+        return EXTERNAL_PROVIDERS.get(ExternalProviders(provider), "unknown")

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -160,11 +160,11 @@ class TeamWithProjectsSerializer(TeamSerializer):
         result = super().get_attrs(item_list, user)
         for team in item_list:
             result[team]["projects"] = project_map[team.id]
-            result[team]["external_teams"] = external_teams_map[team.id]
+            result[team]["externalTeams"] = external_teams_map[team.id]
         return result
 
     def serialize(self, obj, attrs, user):
         d = super().serialize(obj, attrs, user)
         d["projects"] = attrs["projects"]
-        d["external_teams"] = attrs["external_teams"]
+        d["externalTeams"] = attrs["externalTeams"]
         return d

--- a/tests/sentry/api/serializers/test_team.py
+++ b/tests/sentry/api/serializers/test_team.py
@@ -184,4 +184,5 @@ class TeamWithProjectsSerializerTest(TestCase):
             "avatar": {"avatarType": "letter_avatar", "avatarUuid": None},
             "memberCount": 0,
             "dateCreated": team.date_added,
+            "externalTeams": [],
         }


### PR DESCRIPTION
## Objective:
We already have a `getList` of Teams endpoint:  https://docs.sentry.io/api/teams/list-an-organizations-teams/

We will need to add `externalTeams` to the getList response schema. `externalTeams` will come from `sentry_externalteam` table.

`externalTeams` will have a type of `{id: int, provider: enum(“github”, “gitlab”), team_id: int, external_id: string}[]`