### PR TITLE
ref(images-loaded): Reorder List of candidates

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/status.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/status.tsx
@@ -77,7 +77,7 @@ function Status({candidate}: Props) {
     case CandidateDownloadStatus.DELETED: {
       return (
         <StatusTooltip label={t('This file was deleted after the issue was processed.')}>
-          <Tag type="error">{t('Deleted')}</Tag>
+          <Tag type="success">{t('Deleted')}</Tag>
         </StatusTooltip>
       );
     }

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/status.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/status.tsx
@@ -28,6 +28,7 @@ function Status({candidate}: Props) {
         </StatusTooltip>
       );
     }
+    case CandidateDownloadStatus.ERROR:
     case CandidateDownloadStatus.MALFORMED: {
       const {details} = download;
       return (

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -36,7 +36,7 @@ type State = AsyncComponent['state'] & {
   builtinSymbolSources: Array<BuiltinSymbolSource> | null;
 };
 
-class DebugFileDetails extends AsyncComponent<Props, State> {
+class DebugImageDetails extends AsyncComponent<Props, State> {
   getDefaultState() {
     return {
       ...super.getDefaultState(),
@@ -132,9 +132,11 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
       return candidates;
     }
 
-    const imageCandidates = candidates.map(candidate => ({
+    const imageCandidates = candidates.map(({location, ...candidate}) => ({
       ...candidate,
-      location: candidate.location?.split(INTERNAL_SOURCE_LOCATION)[1],
+      location: location?.includes(INTERNAL_SOURCE_LOCATION)
+        ? location.split(INTERNAL_SOURCE_LOCATION)[1]
+        : location,
     }));
 
     // Check for unapplied candidates (debug files)
@@ -212,7 +214,9 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
 
     return (
       <React.Fragment>
-        <Header closeButton>{title ?? t('Unknown')}</Header>
+        <Header closeButton>
+          <span data-test-id="modal-title">{title ?? t('Unknown')}</span>
+        </Header>
         <Body>
           <Content>
             <GeneralInfo>
@@ -258,7 +262,7 @@ class DebugFileDetails extends AsyncComponent<Props, State> {
   }
 }
 
-export default DebugFileDetails;
+export default DebugImageDetails;
 
 const Content = styled('div')`
   display: grid;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -25,7 +25,7 @@ import DebugMetaStore, {DebugMetaActions} from 'app/stores/debugMetaStore';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
-import {CandidateDownloadStatus, Image, ImageStatus} from 'app/types/debugImage';
+import {Image, ImageStatus} from 'app/types/debugImage';
 import {Event} from 'app/types/event';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -25,7 +25,7 @@ import DebugMetaStore, {DebugMetaActions} from 'app/stores/debugMetaStore';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
-import {Image, ImageStatus} from 'app/types/debugImage';
+import {CandidateDownloadStatus, Image, ImageStatus} from 'app/types/debugImage';
 import {Event} from 'app/types/event';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 

--- a/tests/js/sentry-test/fixtures/eventEntryDebugMeta.js
+++ b/tests/js/sentry-test/fixtures/eventEntryDebugMeta.js
@@ -1,0 +1,73 @@
+export function EventEntryDebugMeta(params) {
+  return {
+    type: 'debugmeta',
+    data: {
+      images: [
+        {
+          arch: 'x86_64',
+          candidates: [
+            {
+              download: {
+                status: 'notfound',
+              },
+              source: 'sentry:microsoft',
+              source_name: 'Microsoft',
+            },
+            {
+              debug: {status: 'ok'},
+              download: {
+                features: {
+                  has_debug_info: true,
+                  has_sources: false,
+                  has_symbols: true,
+                  has_unwind_info: false,
+                },
+                status: 'ok',
+              },
+              location: 'sentry://project_debug_file/17',
+              source: 'sentry:project',
+              source_name: 'Sentry',
+            },
+            {
+              download: {
+                status: 'malformed',
+              },
+              location: 'burgenland',
+              source_name: 'Austria',
+            },
+            {
+              download: {
+                status: 'malformed',
+              },
+              location: 'brussels',
+              source_name: 'Belgium',
+            },
+            {
+              download: {
+                status: 'malformed',
+              },
+              location: 'arizona',
+              source_name: 'America',
+            },
+          ],
+          code_file: '/Users/foo/Coding/sentry-native/build/./sentry_example',
+          code_id: '43fd26cc39043633a546f1b003ea17a4',
+          debug_file: 'sentry_example',
+          debug_id: '43fd26cc-3904-3633-a546-f1b003ea17a4',
+          debug_status: 'found',
+          features: {
+            has_debug_info: true,
+            has_sources: false,
+            has_symbols: true,
+            has_unwind_info: false,
+          },
+          image_addr: '0x10753f000',
+          image_size: 16384,
+          type: 'macho',
+          unwind_status: 'unused',
+        },
+      ],
+    },
+    ...params,
+  };
+}

--- a/tests/js/spec/components/events/interfaces/debugMeta-v2/imageDetailsCandidates.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/debugMeta-v2/imageDetailsCandidates.spec.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+
+import {openModal} from 'app/actionCreators/modal';
+import DebugImageDetails, {
+  modalCss,
+} from 'app/components/events/interfaces/debugMeta-v2/debugImageDetails';
+import {getFileName} from 'app/components/events/interfaces/debugMeta-v2/utils';
+import GlobalModal from 'app/components/globalModal';
+
+describe('Debug Meta - Image Details Candidates', function () {
+  let wrapper: ReturnType<typeof mountWithTheme>;
+  const projectId = 'foo';
+  // @ts-expect-error
+  const organization = TestStubs.Organization();
+  // @ts-expect-error
+  const eventEntryDebugMeta = TestStubs.EventEntryDebugMeta();
+  const {data} = eventEntryDebugMeta;
+  const {images} = data;
+  const debugImage = images[0];
+
+  beforeAll(async function () {
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${projectId}/files/dsyms/?debug_id=${debugImage.debug_id}`,
+      method: 'GET',
+      body: [],
+    });
+
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: `/builtin-symbol-sources/`,
+      method: 'GET',
+      body: [],
+    });
+
+    wrapper = mountWithTheme(<GlobalModal />);
+
+    openModal(
+      modalProps => (
+        <DebugImageDetails
+          {...modalProps}
+          image={debugImage}
+          organization={organization}
+          projectId={projectId}
+        />
+      ),
+      {
+        modalCss,
+        onClose: jest.fn(),
+      }
+    );
+
+    // @ts-expect-error
+    await tick();
+    wrapper.update();
+  });
+
+  it('Image Details Modal is open', () => {
+    expect(wrapper.find('[data-test-id="modal-title"]').text()).toEqual(
+      getFileName(debugImage.code_file)
+    );
+  });
+
+  it('Image Candidates correctly sorted', () => {
+    const candidates = wrapper.find('Candidate');
+
+    // Check status order.
+    // The UI shall sort the candidates by status. However, this sorting is not alphabetical but in the following order:
+    // Permissions -> Failed -> Ok -> Deleted (previous Ok) -> Unapplied -> Not Found
+    const statusColumns = candidates
+      .find('Status')
+      .map(statusColumn => statusColumn.text());
+    expect(statusColumns).toEqual(['Failed', 'Failed', 'Failed', 'Deleted', 'Not Found']);
+
+    const debugFileColumn = candidates.find('DebugFileColumn');
+
+    // Check source names order.
+    // The UI shall sort the candidates by source name (alphabetical)
+    const sourceNames = debugFileColumn
+      .find('SourceName')
+      .map(sourceName => sourceName.text());
+    expect(sourceNames).toEqual(['America', 'Austria', 'Belgium', 'Sentry', 'Microsoft']);
+
+    // Check location order.
+    // The UI shall sort the candidates by source location (alphabetical)
+    const locations = debugFileColumn.find('Location').map(location => location.text());
+    // Only 3 results are returned, as the UI only displays the Location component
+    // when the location is defined and when it is not an internal location
+    expect(locations).toEqual(['arizona', 'burgenland', 'brussels']);
+  });
+});

--- a/tests/js/spec/components/events/interfaces/debugMeta-v2/imageDetailsCandidates.spec.tsx
+++ b/tests/js/spec/components/events/interfaces/debugMeta-v2/imageDetailsCandidates.spec.tsx
@@ -87,7 +87,7 @@ describe('Debug Meta - Image Details Candidates', function () {
     // The UI shall sort the candidates by source location (alphabetical)
     const locations = debugFileColumn.find('Location').map(location => location.text());
     // Only 3 results are returned, as the UI only displays the Location component
-    // when the location is defined and when it is not an internal location
+    // when the location is defined and when it is not internal
     expect(locations).toEqual(['arizona', 'burgenland', 'brussels']);
   });
 });


### PR DESCRIPTION
Changes that this PR brings:

- New candidates order
   1º - Sort candidates by status.  However, this sorting is not alphabetical but in the following order:
      `permission -> mal-formed (failed) ->  error (failed) -> ok ->  deleted (previous ok) -> unapplied -> notfound`
   2º - Sort candidates by source name (alphabetical)
   3º - Sort candidates by source location (alphabetical)

- The Deleted Status background color is now green as it was primarily found (ok status)