### PR TITLE
chore: Update the default error dashboard

### DIFF
--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -80,6 +80,30 @@ PREBUILT_DASHBOARDS = {
             "createdBy": "",
             "widgets": [
                 {
+                    "title": "Number of Errors",
+                    "displayType": "big_number",
+                    "interval": "5m",
+                    "queries": [
+                        {
+                            "name": "",
+                            "conditions": "!event.type:transaction",
+                            "fields": ["count()"],
+                        }
+                    ],
+                },
+                {
+                    "title": "Number of Issues",
+                    "displayType": "big_number",
+                    "interval": "5m",
+                    "queries": [
+                        {
+                            "name": "",
+                            "conditions": "!event.type:transaction",
+                            "fields": ["count_unique(issue)"],
+                        }
+                    ],
+                },
+                {
                     "title": "Events",
                     "displayType": "line",
                     "interval": "5m",

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -98,12 +98,12 @@ PREBUILT_DASHBOARDS = {
                     "queries": [
                         {
                             "name": "Known Users",
-                            "conditions": "has:user.email",
+                            "conditions": "has:user.email !event.type:transaction",
                             "fields": ["count_unique(user.email)"],
                         },
                         {
                             "name": "Anonymous Users",
-                            "conditions": "!has:user.email",
+                            "conditions": "!has:user.email !event.type:transaction",
                             "fields": ["count()"],
                         },
                     ],
@@ -131,7 +131,7 @@ PREBUILT_DASHBOARDS = {
                     "queries": [
                         {
                             "name": "Error counts",
-                            "conditions": "event.type:error has:geo.country_code",
+                            "conditions": "!event.type:transaction has:geo.country_code",
                             "fields": ["count()"],
                         }
                     ],

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -168,7 +168,7 @@ PREBUILT_DASHBOARDS = {
                         {
                             "name": "",
                             "conditions": "!event.type:transaction has:browser.name",
-                            "fields": ["count()", "browser.name"],
+                            "fields": ["browser.name", "count()"],
                             "orderby": "-count",
                         }
                     ],

--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -160,6 +160,19 @@ PREBUILT_DASHBOARDS = {
                         }
                     ],
                 },
+                {
+                    "title": "Errors by Browser",
+                    "displayType": "table",
+                    "interval": "5m",
+                    "queries": [
+                        {
+                            "name": "",
+                            "conditions": "!event.type:transaction has:browser.name",
+                            "fields": ["count()", "browser.name"],
+                            "orderby": "-count",
+                        }
+                    ],
+                },
             ],
         }
     ]


### PR DESCRIPTION
Revise and add default widgets to the default error dashboard. For some widgets, I've added conditions to filter out transaction events.

<img width="1652" alt="Screen Shot 2021-02-09 at 1 19 51 PM" src="https://user-images.githubusercontent.com/139499/107408994-abefd080-6ad9-11eb-9bcd-5570204698c3.png">
