### PR TITLE
fix(performance): Don't remove ORs between brackets

### DIFF
--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -20,6 +20,10 @@ function isBooleanOp(value: string) {
   return ['OR', 'AND'].includes(value.toUpperCase());
 }
 
+function isParen(token: Token) {
+  return token !== undefined && isOp(token) && ['(', ')'].includes(token.value);
+}
+
 export class QueryResults {
   tagValues: Record<string, string[]>;
   tokens: Token[];
@@ -208,18 +212,16 @@ export class QueryResults {
         const prev = this.tokens[i - 1];
         const next = this.tokens[i + 1];
         if (isOp(token) && isBooleanOp(token.value)) {
-          if (
-            (prev === undefined || isOp(prev) || next === undefined || isOp(next)) &&
+          if (prev === undefined || isOp(prev) || next === undefined || isOp(next)) {
             // Want to avoid removing `(term) OR (term)`
-            !(
-              prev !== undefined &&
-              next !== undefined &&
-              isOp(prev) &&
+            if (
+              isParen(prev) &&
+              isParen(next) &&
               prev.value === ')' &&
-              isOp(next) &&
               next.value === '('
-            )
-          ) {
+            ) {
+              continue;
+            }
             toRemove = i;
             break;
           }

--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -16,7 +16,7 @@ function isOp(t: Token) {
   return t.type === TokenType.OP;
 }
 
-function isNotParen(value: string) {
+function isBooleanOp(value: string) {
   return ['OR', 'AND'].includes(value.toUpperCase());
 }
 
@@ -30,7 +30,7 @@ export class QueryResults {
     for (let token of strTokens) {
       let tokenState = TokenType.QUERY;
 
-      if (isNotParen(token)) {
+      if (isBooleanOp(token)) {
         this.addOp(token.toUpperCase());
         continue;
       }
@@ -207,7 +207,7 @@ export class QueryResults {
         const token = this.tokens[i];
         const prev = this.tokens[i - 1];
         const next = this.tokens[i + 1];
-        if (isOp(token) && isNotParen(token.value)) {
+        if (isOp(token) && isBooleanOp(token.value)) {
           if (
             (prev === undefined || isOp(prev) || next === undefined || isOp(next)) &&
             // Want to avoid removing `(term) OR (term)`

--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -20,8 +20,13 @@ function isBooleanOp(value: string) {
   return ['OR', 'AND'].includes(value.toUpperCase());
 }
 
-function isParen(token: Token) {
-  return token !== undefined && isOp(token) && ['(', ')'].includes(token.value);
+function isParen(token: Token, character: '(' | ')') {
+  return (
+    token !== undefined &&
+    isOp(token) &&
+    ['(', ')'].includes(token.value) &&
+    token.value === character
+  );
 }
 
 export class QueryResults {
@@ -214,12 +219,7 @@ export class QueryResults {
         if (isOp(token) && isBooleanOp(token.value)) {
           if (prev === undefined || isOp(prev) || next === undefined || isOp(next)) {
             // Want to avoid removing `(term) OR (term)`
-            if (
-              isParen(prev) &&
-              isParen(next) &&
-              prev.value === ')' &&
-              next.value === '('
-            ) {
+            if (isParen(prev, ')') && isParen(next, '(')) {
               continue;
             }
             toRemove = i;

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -271,6 +271,27 @@ describe('utils/tokenizeSearch', function () {
       expect(results.formatString()).toEqual('transaction:def');
     });
 
+    it('does not remove boolean operators after setting tag values', function () {
+      const results = new QueryResults([
+        '(',
+        'start:xyz',
+        'AND',
+        'end:abc',
+        ')',
+        'OR',
+        '(',
+        'start:abc',
+        'AND',
+        'end:xyz',
+        ')',
+      ]);
+
+      results.setTagValues('transaction', ['def']);
+      expect(results.formatString()).toEqual(
+        '( start:xyz AND end:abc ) OR ( start:abc AND end:xyz ) transaction:def'
+      );
+    });
+
     it('removes tags from query object', function () {
       let results = new QueryResults(['x', 'a:a', 'b:b']);
       results.removeTag('a');


### PR DESCRIPTION
- This fixes a bug where `(a:b) OR (b:c)` was being turned into
  `(a:b) (b:c)` in performance