### PR TITLE
fix: Pass organization prop to the simple table chart

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -132,6 +132,7 @@ class WidgetCard extends React.Component<Props> {
                     widget={widget}
                     selection={selection}
                     router={router}
+                    organization={organization}
                   />
                   {this.renderToolbar()}
                 </React.Fragment>

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
@@ -18,7 +18,7 @@ import LoadingIndicator from 'app/components/loadingIndicator';
 import Placeholder from 'app/components/placeholder';
 import {IconWarning} from 'app/icons';
 import space from 'app/styles/space';
-import {GlobalSelection} from 'app/types';
+import {GlobalSelection, Organization} from 'app/types';
 import {axisLabelFormatter, tooltipFormatter} from 'app/utils/discover/charts';
 import {getFieldFormatter} from 'app/utils/discover/fieldRenderers';
 import {getAggregateArg, getMeasurementSlug} from 'app/utils/discover/fields';
@@ -38,6 +38,7 @@ type WidgetCardChartProps = Pick<ReactRouter.WithRouterProps, 'router'> &
     WidgetQueries['state'],
     'timeseriesResults' | 'tableResults' | 'errorMessage' | 'loading'
   > & {
+    organization: Organization;
     location: Location;
     widget: Widget;
     selection: GlobalSelection;
@@ -70,7 +71,7 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
     errorMessage,
     tableResults,
   }: TableResultProps): React.ReactNode {
-    const {location, widget} = this.props;
+    const {location, widget, organization} = this.props;
     if (errorMessage) {
       return (
         <ErrorPanel>
@@ -95,6 +96,7 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
           loading={loading}
           metadata={result.meta}
           data={result.data}
+          organization={organization}
         />
       );
     });


### PR DESCRIPTION
Modals do not have access to the organization context, so we need to pass the organization prop around manually to the widget modal. Certain field renderers require access to the organization prop. 

Before:

<img width="642" alt="Screen Shot 2021-02-09 at 1 50 52 PM" src="https://user-images.githubusercontent.com/139499/107413281-95984380-6ade-11eb-981d-310024147e0f.png">

After:

<img width="651" alt="Screen Shot 2021-02-09 at 1 52 35 PM" src="https://user-images.githubusercontent.com/139499/107413274-94671680-6ade-11eb-9205-a6646beeade5.png">


Fixes JAVASCRIPT-23Q9