### PR TITLE
feat: Add backdrop option to be able to prevent modals from closing when its background is clicked

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/modal.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/modal.tsx
@@ -21,6 +21,7 @@ export type ModalOptions = {
   modalClassName?: string;
   dialogClassName?: string;
   type?: string;
+  backdrop?: BoostrapModal['props']['backdrop'];
 };
 
 /**
@@ -220,5 +221,5 @@ export async function openAddDashboardWidgetModal(options: DashboardWidgetModalO
   );
   const {default: Modal} = mod;
 
-  openModal(deps => <Modal {...deps} {...options} />, {});
+  openModal(deps => <Modal {...deps} {...options} />, {backdrop: 'static'});
 }

--- a/src/sentry/static/sentry/app/components/globalModal.tsx
+++ b/src/sentry/static/sentry/app/components/globalModal.tsx
@@ -84,6 +84,7 @@ class GlobalModal extends React.Component<Props> {
             show={visible}
             animation={false}
             onHide={this.handleCloseModal}
+            backdrop={options?.backdrop}
           >
             {renderedChild}
           </Modal>


### PR DESCRIPTION
Need this for new dashboards since it can be quite easy to dismiss the widget modal in certain ways (e.g. drag and drop).

Option based on https://getbootstrap.com/docs/3.4/javascript/#modals-options

It's expected that bootstrap modals will be refactored out in the future. We'll ensure that any modal implementation replacement will preserve this behaviour; this is pretty trivial to do.