### PR TITLE
fix(dashboards): epm/eps functions should save in dashboards

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 from django.db.models import Max
 from rest_framework import serializers
 
@@ -68,7 +70,16 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
         fields = self._get_attr(data, "fields", [])
         orderby = self._get_attr(data, "orderby", "")
         try:
-            snuba_filter = get_filter(conditions)
+            # When using the eps/epm functions, they require an interval argument
+            # or to provide the start/end so that the interval can be computed.
+            # This uses a hard coded start/end to ensure the validation succeeds
+            # since the values themselves don't matter.
+            params = {
+                "start": datetime.now() - timedelta(days=1),
+                "end": datetime.now(),
+            }
+
+            snuba_filter = get_filter(conditions, params=params)
         except InvalidSearchQuery as err:
             raise serializers.ValidationError({"conditions": f"Invalid conditions: {err}"})
 

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -81,3 +81,16 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         )
         assert response.status_code == 400, response.data
         assert "displayType" in response.data, response.data
+
+    def test_valid_epm_widget(self):
+        data = {
+            "title": "EPM Big Number",
+            "displayType": "big_number",
+            "queries": [{"name": "", "fields": ["epm()"], "conditions": "", "orderby": ""}],
+        }
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+        assert response.status_code == 200, response.data


### PR DESCRIPTION
The epm/eps functions expect an interval argument or start/end to be present in
the params so it can compute the interval argument. Since dashboards are not
passing in an interval argument by default, it should provide start/end to
ensure validation is successful. This change provides some hard coded start/end
params. These params can be hard coded because it is not important what the
dates are during validation as long as they are valid.