### PR TITLE
fix(ui) Fix project key rate limit indicators

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/indicator.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/indicator.tsx
@@ -101,7 +101,7 @@ const PRETTY_VALUES: Map<unknown, string> = new Map([
 
 // Transform form values into a string
 // Otherwise bool values will not get rendered and empty strings look like a bug
-const prettyFormString = (val: FieldValue, model: FormModel, fieldName: string) => {
+const prettyFormString = (val: ChangeValue, model: FormModel, fieldName: string) => {
   const descriptor = model.fieldDescriptor.get(fieldName);
 
   if (descriptor && typeof descriptor.formatMessageValue === 'function') {
@@ -119,9 +119,13 @@ const prettyFormString = (val: FieldValue, model: FormModel, fieldName: string) 
   return `${val}`;
 };
 
+// Some fields have objects in them.
+// For example project key rate limits.
+type ChangeValue = FieldValue | Record<string, any>;
+
 type Change = {
-  old: FieldValue;
-  new: FieldValue;
+  old: ChangeValue;
+  new: ChangeValue;
 };
 
 /**
@@ -146,7 +150,7 @@ export function saveOnBlurUndoMessage(
     return;
   }
 
-  const prettifyValue = (val: FieldValue) => prettyFormString(val, model, fieldName);
+  const prettifyValue = (val: ChangeValue) => prettyFormString(val, model, fieldName);
 
   // Hide the change text when formatMessageValue is explicitly set to false
   const showChangeText = model.getDescriptor(fieldName, 'formatMessageValue') !== false;

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -27,7 +27,13 @@ const RATE_LIMIT_FORMAT_MAP = new Map([
   [86400, '24 hours'],
 ]);
 
-const formatRateLimitWindow = val => RATE_LIMIT_FORMAT_MAP.get(val);
+type RateLimitValue = {
+  window: number;
+  count: number;
+};
+
+// This value isn't actually any, but the various angles on the types don't line up.
+const formatRateLimitWindow = (val: any) => RATE_LIMIT_FORMAT_MAP.get(val);
 
 type Props = {
   data: ProjectKey;
@@ -45,7 +51,13 @@ type Props = {
 >;
 
 class KeyRateLimitsForm extends React.Component<Props> {
-  handleChangeWindow = (onChange, onBlur, currentValueObj, value, e) => {
+  handleChangeWindow = (
+    onChange,
+    onBlur,
+    currentValueObj: RateLimitValue,
+    value: number,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
     const valueObj = {
       ...currentValueObj,
       window: value,
@@ -54,7 +66,11 @@ class KeyRateLimitsForm extends React.Component<Props> {
     onBlur(valueObj, e);
   };
 
-  handleChangeCount = (cb, value, e) => {
+  handleChangeCount = (
+    cb,
+    value: RateLimitValue,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
     const valueObj = {
       ...value,
       count: e.target.value,
@@ -126,6 +142,13 @@ class KeyRateLimitsForm extends React.Component<Props> {
                     }
 
                     return [['rateLimit', t('Fill in both fields first')]];
+                  }}
+                  formatMessageValue={(value: RateLimitValue) => {
+                    return t(
+                      '%s events in %s',
+                      value.count,
+                      formatRateLimitWindow(value.window)
+                    );
                   }}
                   help={t(
                     'Apply a rate limit to this credential to cap the amount of events accepted during a time window.'

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -109,10 +109,12 @@ class KeyRateLimitsForm extends React.Component<Props> {
               <PanelBody>
                 <PanelAlert type="info" icon={<IconFlag size="md" />}>
                   {t(
-                    `Rate limits provide a flexible way to manage your event
+                    `Rate limits provide a flexible way to manage your error
                       volume. If you have a noisy project or environment you
                       can configure a rate limit for this key to reduce the
-                      number of events processed.`
+                      number of errors processed. To manage your transaction
+                      volume, we recommend adjusting your sample rate in your
+                      SDK configuration.`
                   )}
                 </PanelAlert>
                 {!hasFeature &&

--- a/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectKeys/details/keyRateLimitsForm.tsx
@@ -145,7 +145,7 @@ class KeyRateLimitsForm extends React.Component<Props> {
                   }}
                   formatMessageValue={(value: RateLimitValue) => {
                     return t(
-                      '%s events in %s',
+                      '%s errors in %s',
                       value.count,
                       formatRateLimitWindow(value.window)
                     );


### PR DESCRIPTION
Format the update data so that we don't get `[object Object]` in success messages.

![Screen Shot 2021-02-09 at 2 33 16 PM](https://user-images.githubusercontent.com/24086/107421802-68e92980-6ae8-11eb-8744-65b5630fd74b.png)
