### PR TITLE
fix(py3): Fix `returned non-iterator` error on warnings view

### DIFF
--- a/src/sentry/utils/warnings.py
+++ b/src/sentry/utils/warnings.py
@@ -75,7 +75,7 @@ class WarningSet(collections.Set):
         return len(self.__warnings)
 
     def __iter__(self):
-        return self.__warnings.values()
+        yield from self.__warnings.values()
 
     def __get_key(self, warning):
         return (type(warning), warning.args if hasattr(warning, "args") else str(warning))


### PR DESCRIPTION
This cropped up when I was trying to view the warnings on a recent self-hosted instance. Probably a left over/missed spot from the recent `six` fixes.
