### PR TITLE
fix(django): Disable admin on prod

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -69,6 +69,8 @@ IS_DEV = ENVIRONMENT == "development"
 
 DEBUG = IS_DEV
 
+ADMIN_ENABLED = DEBUG
+
 MAINTENANCE = False
 
 ADMINS = ()


### PR DESCRIPTION
Reported here: https://forum.sentry.io/t/sentry-django-admin-portal/12787?u=byk
