### PR TITLE
fix(dashboardsv2): padding and btn names

### DIFF
--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'app/components/button';
-import {IconAdd, IconDelete} from 'app/icons';
+import {IconDelete} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {
@@ -123,8 +123,8 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
       ))}
       <div>
         {showAddYAxisButton && (
-          <Button size="small" onClick={handleAdd} icon={<IconAdd isCircled />}>
-            {t('Add Y-Axis')}
+          <Button size="small" onClick={handleAdd}>
+            {t('Add Overlay')}
           </Button>
         )}
       </div>

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
@@ -16,7 +16,7 @@ import {generateFieldOptions} from 'app/views/eventsV2/utils';
 import Input from 'app/views/settings/components/forms/controls/input';
 import Field from 'app/views/settings/components/forms/field';
 
-import WidgetQueryFields, {QueryFieldWrapper} from './widgetQueryFields';
+import WidgetQueryFields from './widgetQueryFields';
 
 const generateOrderOptions = (fields: string[]): SelectValue<string>[] => {
   const options: SelectValue<string>[] = [];
@@ -76,19 +76,17 @@ class WidgetQueryForm extends React.Component<Props> {
 
     return (
       <QueryWrapper>
-        <QueryFieldWrapper>
-          {canRemove && (
+        {canRemove && (
+          <DeleteRow>
             <Button
               data-test-id="remove-query"
-              size="small"
+              size="xsmall"
               priority="danger"
               onClick={this.props.onRemove}
               icon={<IconDelete />}
-            >
-              {t('Remove Overlay')}
-            </Button>
-          )}
-        </QueryFieldWrapper>
+            />
+          </DeleteRow>
+        )}
         <Field
           data-test-id="new-query"
           label={t('Query')}
@@ -111,7 +109,7 @@ class WidgetQueryForm extends React.Component<Props> {
         {canRemove && (
           <Field
             data-test-id="Query Name"
-            label={t('Query name')}
+            label={t('Legend Alias')}
             inline={false}
             flexibleControlStateSize
             stacked
@@ -135,7 +133,7 @@ class WidgetQueryForm extends React.Component<Props> {
         />
         {displayType === 'table' && (
           <Field
-            label={t('Order by')}
+            label={t('Sort by')}
             inline={false}
             flexibleControlStateSize
             stacked
@@ -160,9 +158,12 @@ class WidgetQueryForm extends React.Component<Props> {
 }
 
 const QueryWrapper = styled('div')`
-  padding-bottom: ${space(2)};
-  margin-bottom: ${space(2)};
-  border-bottom: 1px solid ${p => p.theme.border};
+  padding-bottom: ${space(3)};
+  position: relative;
+`;
+
+const DeleteRow = styled('div')`
+  text-align: right;
 `;
 
 export default WidgetQueryForm;

--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -13,6 +13,7 @@ import ButtonBar from 'app/components/buttonBar';
 import WidgetQueryForm from 'app/components/dashboards/widgetQueryForm';
 import SelectControl from 'app/components/forms/selectControl';
 import {PanelAlert} from 'app/components/panels';
+import {IconAdd} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {GlobalSelection, Organization, TagCollection} from 'app/types';
@@ -291,7 +292,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
             </Field>
             <Field
               data-test-id="chart-type"
-              label={t('Visualization')}
+              label={t('Visualization Display')}
               inline={false}
               flexibleControlStateSize
               stacked
@@ -302,7 +303,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
                 required
                 options={DISPLAY_TYPE_CHOICES.slice()}
                 name="displayType"
-                label={t('Chart Style')}
+                label={t('Visualization Display')}
                 value={state.displayType}
                 onChange={(option: {label: string; value: Widget['displayType']}) => {
                   this.handleFieldChange('displayType')(option.value);
@@ -341,13 +342,13 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
           </Measurements>
           {this.canAddOverlay() && (
             <AddOverlayButton
-              size="small"
+              icon={<IconAdd isCircled />}
               onClick={(event: React.MouseEvent) => {
                 event.preventDefault();
                 this.handleAddOverlay();
               }}
             >
-              {t('Add Overlay')}
+              {t('New Query Overlay')}
             </AddOverlayButton>
           )}
           <WidgetCard

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -353,7 +353,7 @@ const StyledPageHeader = styled('div')`
   font-size: ${p => p.theme.headerFontSize};
   color: ${p => p.theme.textColor};
   height: 40px;
-  margin-bottom: ${space(1)};
+  margin-bottom: ${space(2)};
 
   @media (max-width: ${p => p.theme.breakpoints[2]}) {
     flex-direction: column;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -168,7 +168,7 @@ const StyledPanel = styled(Panel, {
   visibility: ${p => (p.isDragging ? 'hidden' : 'visible')};
   /* If a panel overflows due to a long title stretch its grid sibling */
   height: 100%;
-  min-height: 110px;
+  min-height: 96px;
 `;
 
 const ToolbarPanel = styled('div')`
@@ -215,6 +215,6 @@ const StyledIconGrabbable = styled(IconGrabbable)`
 `;
 
 const WidgetTitle = styled(HeaderTitle)`
-  padding: ${space(1)} ${space(2)};
+  padding: ${space(2)} ${space(3)} 0 ${space(3)};
   width: 100%;
 `;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
@@ -246,7 +246,7 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
     }
 
     const legend = {
-      right: 0,
+      left: 0,
       top: 3,
       type: 'plain',
       selected: getSeriesSelection(location),
@@ -267,7 +267,7 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
       grid: {
         left: 0,
         right: 0,
-        top: space(3),
+        top: '40px',
         bottom: 0,
       },
       seriesOptions: {
@@ -364,7 +364,6 @@ const ChartWrapper = styled('div')`
 const StyledSimpleTableChart = styled(SimpleTableChart)`
   /* align with other card charts */
   height: 216px;
-  font-size: ${p => p.theme.fontSizeMedium};
   margin-top: ${space(1.5)};
 `;
 

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
@@ -351,20 +351,21 @@ const LoadingScreen = ({loading}: {loading: boolean}) => {
 
 const BigNumber = styled('div')`
   font-size: 32px;
-  margin-top: ${space(1)};
-  padding: ${space(1)} ${space(2)} ${space(2)};
+  padding: ${space(1)} ${space(3)} ${space(3)} ${space(3)};
   * {
     text-align: left !important;
   }
 `;
 
 const ChartWrapper = styled('div')`
-  padding: 0 ${space(2)} ${space(2)};
+  padding: 0 ${space(3)} ${space(3)};
 `;
 
 const StyledSimpleTableChart = styled(SimpleTableChart)`
   /* align with other card charts */
   height: 216px;
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin-top: ${space(1.5)};
 `;
 
 export default WidgetCardChart;

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -131,7 +131,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     });
 
     // Click the add button
-    const add = wrapper.find('button[aria-label="Add Y-Axis"]');
+    const add = wrapper.find('button[aria-label="Add Overlay"]');
     add.simulate('click');
     wrapper.update();
 


### PR DESCRIPTION
**Updates:**
- Changed Add Y-Axis to Add Overlay
- Changed Add Add Overlay to New Query Overlay
- Changed Query Name to Legend Alias
- Added Display to Visualization Label
- Left aligned chart legend to be under header
- Condensed Big Number to match other features

**Before:** 
![Screen Shot 2021-02-09 at 12 33 44 PM](https://user-images.githubusercontent.com/4830259/107424898-10f3f800-6ad3-11eb-821f-9fdb8c9f2339.png)
![Screen Shot 2021-02-09 at 12 46 44 PM](https://user-images.githubusercontent.com/4830259/107426326-e99e2a80-6ad4-11eb-88ef-1f3c1fb8f9e1.png)
![Screen Shot 2021-02-09 at 12 34 26 PM](https://user-images.githubusercontent.com/4830259/107425286-a55e5a80-6ad3-11eb-801d-22bdcb6a62f9.png)

**After:**
![Screen Shot 2021-02-09 at 12 32 28 PM](https://user-images.githubusercontent.com/4830259/107424906-14877f00-6ad3-11eb-8e56-796942221aa2.png)
![Screen Shot 2021-02-09 at 12 45 45 PM](https://user-images.githubusercontent.com/4830259/107426347-ef940b80-6ad4-11eb-9a72-69079b99b1ad.png)
![Screen Shot 2021-02-09 at 12 37 45 PM](https://user-images.githubusercontent.com/4830259/107425297-a8f1e180-6ad3-11eb-8084-a3ad34002685.png)