### PR TITLE
chore: Refactor field renderers to enable additional options

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/simpleTableChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/simpleTableChart.tsx
@@ -32,7 +32,7 @@ class SimpleTableChart extends React.Component<Props> {
 
     return columns.map(column => {
       const fieldRenderer = getFieldRenderer(column.name, tableMeta);
-      const rendered = fieldRenderer(row, {organization, location});
+      const rendered = fieldRenderer({data: row}, {organization, location});
       return <div key={`${index}:${column.name}`}>{rendered}</div>;
     });
   }

--- a/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
+++ b/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
@@ -440,7 +440,7 @@ class TransactionsTable extends React.PureComponent<TableProps> {
       const fieldType = tableMeta[fieldName];
 
       const fieldRenderer = getFieldRenderer(field, tableMeta);
-      let rendered = fieldRenderer(row, {organization, location});
+      let rendered = fieldRenderer({data: row}, {organization, location});
 
       const target = generateLink?.[tableTitles[index]]?.(
         organization,

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -443,7 +443,6 @@ export function getFieldRenderer(
     return SPECIAL_FIELDS[field].renderFunc;
   }
   const fieldName = getAggregateAlias(field);
-  const fieldType = meta[fieldName];
 
   for (const alias in SPECIAL_FUNCTIONS) {
     if (fieldName.startsWith(alias)) {
@@ -451,14 +450,7 @@ export function getFieldRenderer(
     }
   }
 
-  if (FIELD_FORMATTERS.hasOwnProperty(fieldType)) {
-    return function (props) {
-      return FIELD_FORMATTERS[fieldType].renderFunc({field: fieldName, ...props});
-    };
-  }
-  return function (props) {
-    return FIELD_FORMATTERS.string.renderFunc({field: fieldName, ...props});
-  };
+  return getFieldFormatter(field, meta);
 }
 
 type FieldTypeFormatterRenderFunction = (

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -41,7 +41,7 @@ type RenderFunctionBaggage = {
 type FieldFormatterRenderFunctionProps = {
   field: string;
   data: EventData;
-  alignNumbers?: boolean;
+  align?: 'left' | 'right';
 };
 
 type FieldFormatterRenderFunction = (
@@ -86,9 +86,9 @@ const emptyValue = <EmptyValueContainer>{t('n/a')}</EmptyValueContainer>;
 const FIELD_FORMATTERS: FieldFormatters = {
   boolean: {
     isSortable: true,
-    renderFunc: ({field, data}) => {
+    renderFunc: ({field, data, align}) => {
       const value = data[field] ? t('true') : t('false');
-      return <Container>{value}</Container>;
+      return <Container align={align}>{value}</Container>;
     },
   },
   date: {
@@ -106,8 +106,8 @@ const FIELD_FORMATTERS: FieldFormatters = {
   },
   duration: {
     isSortable: true,
-    renderFunc: ({field, data, alignNumbers}) => (
-      <NumberContainer alignNumbers={alignNumbers}>
+    renderFunc: ({field, data, align}) => (
+      <NumberContainer align={align}>
         {typeof data[field] === 'number' ? (
           <Duration seconds={data[field] / 1000} fixedDigits={2} abbreviation />
         ) : (
@@ -118,38 +118,38 @@ const FIELD_FORMATTERS: FieldFormatters = {
   },
   integer: {
     isSortable: true,
-    renderFunc: ({field, data, alignNumbers}) => (
-      <NumberContainer alignNumbers={alignNumbers}>
+    renderFunc: ({field, data, align}) => (
+      <NumberContainer align={align}>
         {typeof data[field] === 'number' ? <Count value={data[field]} /> : emptyValue}
       </NumberContainer>
     ),
   },
   number: {
     isSortable: true,
-    renderFunc: ({field, data, alignNumbers}) => (
-      <NumberContainer alignNumbers={alignNumbers}>
+    renderFunc: ({field, data, align}) => (
+      <NumberContainer align={align}>
         {typeof data[field] === 'number' ? formatFloat(data[field], 4) : emptyValue}
       </NumberContainer>
     ),
   },
   percentage: {
     isSortable: true,
-    renderFunc: ({field, data, alignNumbers}) => (
-      <NumberContainer alignNumbers={alignNumbers}>
+    renderFunc: ({field, data, align}) => (
+      <NumberContainer align={align}>
         {typeof data[field] === 'number' ? formatPercentage(data[field]) : emptyValue}
       </NumberContainer>
     ),
   },
   string: {
     isSortable: true,
-    renderFunc: ({field, data}) => {
+    renderFunc: ({field, data, align}) => {
       // Some fields have long arrays in them, only show the tail of the data.
       const value = Array.isArray(data[field])
         ? data[field].slice(-1)
         : defined(data[field])
         ? data[field]
         : emptyValue;
-      return <Container>{value}</Container>;
+      return <Container align={align}>{value}</Container>;
     },
   },
   array: {

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -285,7 +285,7 @@ const SPECIAL_FIELDS: SpecialFields = {
   },
   'user.display': {
     sortField: 'user.display',
-    renderFunc: data => {
+    renderFunc: ({data}) => {
       if (data['user.display']) {
         const userObj = {
           id: '',

--- a/src/sentry/static/sentry/app/utils/discover/styles.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/styles.tsx
@@ -16,8 +16,8 @@ export const VersionContainer = styled('div')`
   display: flex;
 `;
 
-export const NumberContainer = styled('div')`
-  text-align: right;
+export const NumberContainer = styled('div')<{alignNumbers?: boolean}>`
+  text-align: ${p => (p.alignNumbers === false ? 'left' : 'right')};
   ${overflowEllipsis};
 `;
 

--- a/src/sentry/static/sentry/app/utils/discover/styles.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/styles.tsx
@@ -8,12 +8,12 @@ import overflowEllipsis from 'app/styles/overflowEllipsis';
 /**
  * Styled components used to render discover result sets.
  */
-export const Container = styled('div')`
+export const Container = styled('div')<{align?: 'left' | 'right'}>`
+  text-align: ${p => p.align ?? 'left'};
   ${overflowEllipsis};
 `;
 
-export const VersionContainer = styled('div')<{align?: 'left' | 'right'}>`
-  text-align: ${p => p.align ?? 'left'};
+export const VersionContainer = styled('div')`
   display: flex;
 `;
 

--- a/src/sentry/static/sentry/app/utils/discover/styles.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/styles.tsx
@@ -12,12 +12,13 @@ export const Container = styled('div')`
   ${overflowEllipsis};
 `;
 
-export const VersionContainer = styled('div')`
+export const VersionContainer = styled('div')<{align?: 'left' | 'right'}>`
+  text-align: ${p => p.align ?? 'left'};
   display: flex;
 `;
 
-export const NumberContainer = styled('div')<{alignNumbers?: boolean}>`
-  text-align: ${p => (p.alignNumbers === false ? 'left' : 'right')};
+export const NumberContainer = styled('div')<{align?: 'left' | 'right'}>`
+  text-align: ${p => p.align ?? 'right'};
   ${overflowEllipsis};
 `;
 

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedTransactions.tsx
@@ -65,7 +65,7 @@ class Table extends React.Component<TableProps, TableState> {
 
     const field = String(column.key);
     const fieldRenderer = getFieldRenderer(field, tableMeta);
-    const rendered = fieldRenderer(dataRow, {organization, location});
+    const rendered = fieldRenderer({data: dataRow}, {organization, location});
 
     if (field === 'transaction') {
       const projectID = getProjectID(dataRow, projects);

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
@@ -132,7 +132,7 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
       const dataRow = result.data[0];
       const fieldRenderer = getFieldFormatter(field, tableMeta);
 
-      const rendered = fieldRenderer({data: dataRow});
+      const rendered = fieldRenderer({data: dataRow, alignNumbers: false});
 
       return <BigNumber key={`big_number:${result.title}`}>{rendered}</BigNumber>;
     });
@@ -354,9 +354,6 @@ const LoadingScreen = ({loading}: {loading: boolean}) => {
 const BigNumber = styled('div')`
   font-size: 32px;
   padding: ${space(1)} ${space(3)} ${space(3)} ${space(3)};
-  * {
-    text-align: left !important;
-  }
 `;
 
 const ChartWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
@@ -132,7 +132,7 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
       const dataRow = result.data[0];
       const fieldRenderer = getFieldFormatter(field, tableMeta);
 
-      const rendered = fieldRenderer(dataRow);
+      const rendered = fieldRenderer({data: dataRow});
 
       return <BigNumber key={`big_number:${result.title}`}>{rendered}</BigNumber>;
     });

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
@@ -132,7 +132,7 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
       const dataRow = result.data[0];
       const fieldRenderer = getFieldFormatter(field, tableMeta);
 
-      const rendered = fieldRenderer({data: dataRow, alignNumbers: false});
+      const rendered = fieldRenderer({data: dataRow, align: 'left'});
 
       return <BigNumber key={`big_number:${result.title}`}>{rendered}</BigNumber>;
     });

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -215,7 +215,7 @@ class TableView extends React.Component<TableViewProps> {
 
     const count = Math.min(tableData?.data?.length ?? TOP_N, TOP_N);
 
-    let cell = fieldRenderer(dataRow, {organization, location});
+    let cell = fieldRenderer({data: dataRow}, {organization, location});
 
     if (columnKey === 'id') {
       const eventSlug = generateEventSlug(dataRow);

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -87,7 +87,7 @@ class TableView extends React.Component<TableViewProps> {
 
   _renderPrependColumns = (
     isHeader: boolean,
-    dataRow?: any,
+    dataRow?: TableDataRow,
     rowIndex?: number
   ): React.ReactNode[] => {
     const {organization, eventView, tableData, location} = this.props;
@@ -133,12 +133,12 @@ class TableView extends React.Component<TableViewProps> {
           </Link>
         </Tooltip>,
       ];
-    } else if (!hasIdField) {
-      let value = dataRow.id;
+    } else if (!hasIdField && dataRow) {
+      let value: React.ReactNode = dataRow.id;
 
       if (tableData && tableData.meta) {
         const fieldRenderer = getFieldRenderer('id', tableData.meta);
-        value = fieldRenderer(dataRow, {organization, location});
+        value = fieldRenderer({data: dataRow}, {organization, location});
       }
 
       const eventSlug = generateEventSlug(dataRow);
@@ -411,7 +411,7 @@ class TableView extends React.Component<TableViewProps> {
           renderHeadCell: this._renderGridHeaderCell as any,
           renderBodyCell: this._renderGridBodyCell as any,
           onResizeColumn: this._resizeColumn as any,
-          renderPrependColumns: this._renderPrependColumns as any,
+          renderPrependColumns: this._renderPrependColumns,
           prependColumnWidths,
         }}
         headerButtons={this.renderHeaderButtons}

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -101,7 +101,7 @@ class Table extends React.Component<Props, State> {
 
     const field = String(column.key);
     const fieldRenderer = getFieldRenderer(field, tableMeta);
-    const rendered = fieldRenderer(dataRow, {organization, location});
+    const rendered = fieldRenderer({data: dataRow}, {organization, location});
 
     const allowActions = [
       Actions.ADD,

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -56,7 +56,7 @@ function UserStats({eventView, totals, location, organization, transactionName}:
 
     const apdexKey = `apdex_${threshold}`;
     const formatter = getFieldRenderer(apdexKey, {[apdexKey]: 'number'});
-    apdex = formatter(totals, {organization, location});
+    apdex = formatter({data: totals}, {organization, location});
 
     const [vitalsPassed, vitalsTotal] = VITAL_GROUPS.map(({vitals: vs}) => vs).reduce(
       ([passed, total], vs) => {

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/table.tsx
@@ -162,7 +162,7 @@ class Table extends React.Component<Props, State> {
     }
 
     const fieldRenderer = getFieldRenderer(field, tableMeta);
-    const rendered = fieldRenderer(dataRow, {organization, location});
+    const rendered = fieldRenderer({data: dataRow}, {organization, location});
 
     const allowActions = [
       Actions.ADD,

--- a/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
+++ b/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
@@ -50,21 +50,21 @@ describe('getFieldRenderer', function () {
 
   it('can render string fields', function () {
     const renderer = getFieldRenderer('url', {url: 'string'});
-    const wrapper = mount(renderer(data, {location, organization}));
+    const wrapper = mount(renderer({data}, {location, organization}));
     const text = wrapper.find('Container');
     expect(text.text()).toEqual(data.url);
   });
 
   it('can render boolean fields', function () {
     const renderer = getFieldRenderer('boolValue', {boolValue: 'boolean'});
-    const wrapper = mount(renderer(data, {location, organization}));
+    const wrapper = mount(renderer({data}, {location, organization}));
     const text = wrapper.find('Container');
     expect(text.text()).toEqual('true');
   });
 
   it('can render integer fields', function () {
     const renderer = getFieldRenderer('numeric', {numeric: 'integer'});
-    const wrapper = mount(renderer(data, {location, organization}));
+    const wrapper = mount(renderer({data}, {location, organization}));
 
     const value = wrapper.find('Count');
     expect(value).toHaveLength(1);
@@ -74,7 +74,7 @@ describe('getFieldRenderer', function () {
   it('can render date fields', function () {
     const renderer = getFieldRenderer('createdAt', {createdAt: 'date'});
     expect(renderer).toBeInstanceOf(Function);
-    const wrapper = mount(renderer(data, {location, organization}));
+    const wrapper = mount(renderer({data}, {location, organization}));
 
     const value = wrapper.find('StyledDateTime');
     expect(value).toHaveLength(1);
@@ -83,7 +83,7 @@ describe('getFieldRenderer', function () {
 
   it('can render null date fields', function () {
     const renderer = getFieldRenderer('nope', {nope: 'date'});
-    const wrapper = mount(renderer(data, {location, organization}));
+    const wrapper = mount(renderer({data}, {location, organization}));
 
     const value = wrapper.find('StyledDateTime');
     expect(value).toHaveLength(0);
@@ -94,29 +94,35 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('error.handled', {'error.handled': 'boolean'});
 
     // Should render the last value.
-    let wrapper = mount(renderer({'error.handled': [0, 1]}, {location, organization}));
+    let wrapper = mount(
+      renderer({data: {'error.handled': [0, 1]}}, {location, organization})
+    );
     expect(wrapper.text()).toEqual('true');
 
-    wrapper = mount(renderer({'error.handled': [0, 0]}, {location, organization}));
+    wrapper = mount(
+      renderer({data: {'error.handled': [0, 0]}}, {location, organization})
+    );
     expect(wrapper.text()).toEqual('false');
 
     // null = true for error.handled data.
-    wrapper = mount(renderer({'error.handled': [null]}, {location, organization}));
+    wrapper = mount(
+      renderer({data: {'error.handled': [null]}}, {location, organization})
+    );
     expect(wrapper.text()).toEqual('true');
 
     // Default events won't have error.handled and will return an empty list.
-    wrapper = mount(renderer({'error.handled': []}, {location, organization}));
+    wrapper = mount(renderer({data: {'error.handled': []}}, {location, organization}));
     expect(wrapper.text()).toEqual('n/a');
 
     // Transactions will have null for error.handled as the 'tag' won't be set.
-    wrapper = mount(renderer({'error.handled': null}, {location, organization}));
+    wrapper = mount(renderer({data: {'error.handled': null}}, {location, organization}));
     expect(wrapper.text()).toEqual('n/a');
   });
 
   it('can render user fields with aliased user', function () {
     const renderer = getFieldRenderer('user', {user: 'string'});
 
-    const wrapper = mount(renderer(data, {location, organization}));
+    const wrapper = mount(renderer({data}, {location, organization}));
 
     const badge = wrapper.find('UserBadge');
     expect(badge).toHaveLength(1);
@@ -130,7 +136,7 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('user', {user: 'string'});
 
     delete data.user;
-    const wrapper = mount(renderer(data, {location, organization}));
+    const wrapper = mount(renderer({data}, {location, organization}));
 
     const badge = wrapper.find('UserBadge');
     expect(badge).toHaveLength(0);
@@ -144,7 +150,7 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('release', {release: 'string'});
 
     delete data.release;
-    const wrapper = mount(renderer(data, {location, organization}));
+    const wrapper = mount(renderer({data}, {location, organization}));
 
     const value = wrapper.find('EmptyValueContainer');
     expect(value).toHaveLength(1);
@@ -155,7 +161,7 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('project', {project: 'string'});
 
     const wrapper = mountWithTheme(
-      renderer(data, {location, organization}),
+      renderer({data}, {location, organization}),
       context.routerContext
     );
 
@@ -169,7 +175,7 @@ describe('getFieldRenderer', function () {
     delete data.project;
 
     const wrapper = mountWithTheme(
-      renderer(data, {location, organization}),
+      renderer({data}, {location, organization}),
       context.routerContext
     );
 
@@ -185,7 +191,7 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('key_transaction', {key_transaction: 'boolean'});
 
     const wrapper = mountWithTheme(
-      renderer(data, {location, organization}),
+      renderer({data}, {location, organization}),
       context.routerContext
     );
     await tick();


### PR DESCRIPTION
For Dashboards v2, we'd like to left-align numbers for the Big Number widget. Currently we're doing this using `text-align: left !important;` which isn't ideal.

Thus, field renderers and their types are refactored to enable this.

I've updated its usage across the product app. 