### PR TITLE
fix(performance): Removing measurements from issues query

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -491,26 +491,6 @@ export const FIELD_TAGS = Object.freeze(
 // Allows for a less strict field key definition in cases we are returning custom strings as fields
 export type LooseFieldKey = FieldKey | string | '';
 
-// This list contains fields/functions that are available with performance-view feature.
-export const TRACING_FIELDS = [
-  'avg',
-  'sum',
-  'transaction.duration',
-  'transaction.op',
-  'transaction.status',
-  'p50',
-  'p75',
-  'p95',
-  'p99',
-  'p100',
-  'percentile',
-  'failure_rate',
-  'apdex',
-  'user_misery',
-  'eps',
-  'epm',
-];
-
 export enum WebVital {
   FP = 'measurements.fp',
   FCP = 'measurements.fcp',
@@ -530,6 +510,27 @@ const MEASUREMENTS: Readonly<Record<WebVital, ColumnType>> = {
   [WebVital.TTFB]: 'duration',
   [WebVital.RequestTime]: 'duration',
 };
+
+// This list contains fields/functions that are available with performance-view feature.
+export const TRACING_FIELDS = [
+  'avg',
+  'sum',
+  'transaction.duration',
+  'transaction.op',
+  'transaction.status',
+  'p50',
+  'p75',
+  'p95',
+  'p99',
+  'p100',
+  'percentile',
+  'failure_rate',
+  'apdex',
+  'user_misery',
+  'eps',
+  'epm',
+  ...Object.keys(MEASUREMENTS),
+];
 
 export const MEASUREMENT_PATTERN = /^measurements\.([a-zA-Z0-9-_.]+)$/;
 


### PR DESCRIPTION
- The TRACING_FIELDS doesn't include measuerments, adding those too so
  when users add them to their query related issues doesn't break