### PR TITLE
ref(workflow): Improving metrics around the workflow SLO

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -336,7 +336,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             )
             return Response(serialized, status=response.status_code)
         except client.ApiError as e:
-            logging.info(
+            logging.error(
                 "group_details:put client.ApiError",
                 exc_info=True,
             )

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -302,8 +302,6 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         :auth: required
         """
         try:
-            from sentry.utils import snuba
-
             discard = request.data.get("discard")
 
             # TODO(dcramer): we need to implement assignedTo in the bulk mutation
@@ -336,26 +334,18 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                     )
                 ),
             )
-            metrics.incr(
-                "group.update.http_response",
-                sample_rate=1.0,
-                tags={"status": response.status_code, "detail": "group_details:put:response"},
-            )
             return Response(serialized, status=response.status_code)
         except client.ApiError as e:
+            logging.info(
+                "group_details:put client.ApiError",
+                exc_info=True,
+            )
             metrics.incr(
-                "group.update.http_response",
+                "workflowslo.http_response",
                 sample_rate=1.0,
                 tags={"status": e.status_code, "detail": "group_details:put:client.ApiError"},
             )
             return Response(e.body, status=e.status_code)
-        except snuba.RateLimitExceeded:
-            metrics.incr(
-                "group.update.http_response",
-                sample_rate=1.0,
-                tags={"status": 429, "detail": "group_details:put:snuba.RateLimitExceeded"},
-            )
-            raise
         except Exception:
             metrics.incr(
                 "group.update.http_response",


### PR DESCRIPTION
It seems that we have been double reporting for this endpoint. Since this endpoint calls another endpoint which calls `update_groups` (which is already instrumented for our SLO), there is no need for it to also report some metrics.

So, I've removed the metrics from this endpoint that were being captured by the other endpoint.

Additionally, we want to be able to more closely represent our Datadog metrics within Sentry, so I've added an error that will track previously untracked client.ApiError's.