### PR TITLE
dev: unblock make install-py-dev on Big Sur by forcefully downloading grpcio wheel for older MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,11 @@ install-js-dev: node-version-check
 
 install-py-dev: ensure-pinned-pip
 	@echo "--> Installing Sentry (for development)"
+ifdef BIG_SUR
+	# grpcio 1.35.0 is very painful to compile on Big Sur, and is not really surfaced in testing anyways.
+	# So we set SYSTEM_VERSION_COMPAT=1 to get pip to download grpcio wheels for older MacOS.
+	SYSTEM_VERSION_COMPAT=1 $(PIP) install 'grpcio==1.35.0'
+endif
 	# SENTRY_LIGHT_BUILD=1 disables webpacking during setup.py.
 	# Webpacked assets are only necessary for devserver (which does it lazily anyways)
 	# and acceptance tests, which webpack automatically if run.


### PR DESCRIPTION
I recently had to upgrade grpcio, but turns out, it's a huge pain to build on Big Sur. I was able to, but it involves a painful command line that may not work on other people's computers depending on things (tm).

SYSTEM_VERSION_COMPAT=1 will get pip to download a wheel for older MacOS. This is fine for grpcio only, since it's not surfaced in local testing anyways.

For what it's worth, this is how I built it (however it takes a long, painful time):

```
$ LDFLAGS="-L/usr/local/opt/openssl@1.1/lib" PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig" CPPFLAGS="-I/usr/local/opt/openssl@1.1/include" GRPC_BUILD_WITH_BORING_SSL_ASM="" GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true GRPC_PYTHON_BUILD_SYSTEM_ZLIB=true pip install 'grpcio==1.35.0'
Collecting grpcio==1.35.0
  Using cached grpcio-1.35.0.tar.gz (21.2 MB)
Requirement already satisfied: six>=1.5.2 in ./.venv/lib/python3.6/site-packages (from grpcio==1.35.0) (1.11.0)
Building wheels for collected packages: grpcio
  Building wheel for grpcio (setup.py) ... done
  Created wheel for grpcio: filename=grpcio-1.35.0-cp36-cp36m-macosx_11_0_x86_64.whl size=2589928 sha256=100768fd387b02fe6452292f121ba7985a44283ce209a4ca5bbb73698fb1a07f
  Stored in directory: /Users/joshua.li/Library/Caches/pip/wheels/a9/3e/d4/1e979ea092d221fb1f6848eedd374fac9955a57c3109b055c4
Successfully built grpcio
Installing collected packages: grpcio
```

And this is what `SYSTEM_VERSION_COMPAT=1` does:

```
$ SYSTEM_VERSION_COMPAT=1 pip install grpcio
Collecting grpcio
  Downloading grpcio-1.35.0-cp38-cp38-macosx_10_10_x86_64.whl (3.8 MB)
     |████████████████████████████████| 3.8 MB 4.1 MB/s
Requirement already satisfied: six>=1.5.2 in ./.venv/lib/python3.8/site-packages (from grpcio) (1.15.0)
Installing collected packages: grpcio
```