### PR TITLE
feat(external-team): PUT, POST, DELETE endpoints

### DIFF
--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -35,6 +35,7 @@ class ExternalTeamSerializer(CamelSnakeModelSerializer):
             return ExternalTeam.objects.create(**validated_data)
         except IntegrityError:
             # swallow the error and find and return the object.
+            # we currently expect this endpoint to be hit by start-up scripts, so if the association already exists, we'll just return it.
             return list(ExternalTeam.objects.filter(**validated_data))
 
     def update(self, instance, validated_data):

--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -1,7 +1,10 @@
 import logging
 
+from django.db import IntegrityError
+
 from rest_framework import serializers, status
 from rest_framework.response import Response
+from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.serializers import serialize
@@ -10,7 +13,9 @@ from sentry.models import ExternalTeam, EXTERNAL_PROVIDERS
 logger = logging.getLogger(__name__)
 
 
-class ExternalTeamSerializer(serializers.ModelSerializer):
+class ExternalTeamSerializer(CamelSnakeModelSerializer):
+    team_id = serializers.IntegerField(required=True)
+    external_id = serializers.CharField(required=True)
     provider = serializers.ChoiceField(choices=list(EXTERNAL_PROVIDERS.values()))
 
     class Meta:
@@ -26,15 +31,24 @@ class ExternalTeamSerializer(serializers.ModelSerializer):
         return inv_providers_map[provider].value
 
     def create(self, validated_data):
-        return ExternalTeam.objects.create(team=self.context["team"], **validated_data)
+        try:
+            return ExternalTeam.objects.create(**validated_data)
+        except IntegrityError:
+            # swallow the error and find and return the object.
+            return list(ExternalTeam.objects.filter(**validated_data))
 
     def update(self, instance, validated_data):
         if "id" in validated_data:
             validated_data.pop("id")
         for key, value in validated_data.items():
             setattr(self.instance, key, value)
-        self.instance.save()
-        return self.instance
+        try:
+            self.instance.save()
+            return self.instance
+        except IntegrityError:
+            raise serializers.ValidationError(
+                "There already exists an external team association with this external_id and provider."
+            )
 
 
 class ExternalTeamEndpoint(TeamEndpoint):
@@ -53,9 +67,15 @@ class ExternalTeamEndpoint(TeamEndpoint):
         :param required string external_id: the associated Github/Gitlab team name.
         :auth: required
         """
-        serializer = ExternalTeamSerializer(context={"team": team}, data=request.data)
+        serializer = ExternalTeamSerializer(data={**request.data, "team_id": team.id})
         if serializer.is_valid():
             external_team = serializer.save()
+
+            if isinstance(external_team, list):
+                return Response(
+                    serialize(external_team[0], request.user), status=status.HTTP_200_OK
+                )
+
             return Response(serialize(external_team, request.user), status=status.HTTP_201_CREATED)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -1,0 +1,61 @@
+import logging
+
+from rest_framework import serializers, status
+from rest_framework.response import Response
+
+from sentry.api.bases.team import TeamEndpoint
+from sentry.api.serializers import serialize
+from sentry.models import ExternalTeam, EXTERNAL_PROVIDERS
+
+logger = logging.getLogger(__name__)
+
+
+class ExternalTeamSerializer(serializers.ModelSerializer):
+    provider = serializers.ChoiceField(choices=list(EXTERNAL_PROVIDERS.values()))
+
+    class Meta:
+        model = ExternalTeam
+        fields = ["team_id", "external_id", "provider"]
+
+    def validate_provider(self, provider):
+        if provider not in EXTERNAL_PROVIDERS.values():
+            raise serializers.ValidationError(
+                f'The provider "{provider}" is not supported. We currently accept Github and Gitlab team identities.'
+            )
+        inv_providers_map = {v: k for k, v in EXTERNAL_PROVIDERS.items()}
+        return inv_providers_map[provider].value
+
+    def create(self, validated_data):
+        return ExternalTeam.objects.create(team=self.context["team"], **validated_data)
+
+    def update(self, instance, validated_data):
+        if "id" in validated_data:
+            validated_data.pop("id")
+        for key, value in validated_data.items():
+            setattr(self.instance, key, value)
+        self.instance.save()
+        return self.instance
+
+
+class ExternalTeamEndpoint(TeamEndpoint):
+    def post(self, request, team):
+        """
+        Create an External Team
+        `````````````
+
+        Update various attributes and configurable settings for the given
+        team.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          team belongs to.
+        :pparam string team_slug: the slug of the team to get.
+        :param required string provider: enum("github", "gitlab")
+        :param required string external_id: the associated Github/Gitlab team name.
+        :auth: required
+        """
+        serializer = ExternalTeamSerializer(context={"team": team}, data=request.data)
+        if serializer.is_valid():
+            external_team = serializer.save()
+            return Response(serialize(external_team, request.user), status=status.HTTP_201_CREATED)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -62,10 +62,7 @@ class ExternalTeamEndpoint(TeamEndpoint):
         serializer = ExternalTeamSerializer(data={**request.data, "team_id": team.id})
         if serializer.is_valid():
             external_team, created = serializer.save()
-
-            if not created:
-                return Response(serialize(external_team, request.user), status=status.HTTP_200_OK)
-
-            return Response(serialize(external_team, request.user), status=status.HTTP_201_CREATED)
+            status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+            return Response(serialize(external_team, request.user), status=status_code)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -58,9 +58,6 @@ class ExternalTeamEndpoint(TeamEndpoint):
         Create an External Team
         `````````````
 
-        Update various attributes and configurable settings for the given
-        team.
-
         :pparam string organization_slug: the slug of the organization the
                                           team belongs to.
         :pparam string team_slug: the slug of the team to get.

--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -27,8 +27,7 @@ class ExternalTeamSerializer(CamelSnakeModelSerializer):
             raise serializers.ValidationError(
                 f'The provider "{provider}" is not supported. We currently accept Github and Gitlab team identities.'
             )
-        inv_providers_map = {v: k for k, v in EXTERNAL_PROVIDERS.items()}
-        return inv_providers_map[provider].value
+        return ExternalTeam.get_provider_enum(provider)
 
     def create(self, validated_data):
         try:

--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -45,7 +45,7 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint):
         """
 
         serializer = ExternalTeamSerializer(
-            context={"team": team}, instance=external_team, data=request.data, partial=True
+            instance=external_team, data={**request.data, "team_id": team.id}, partial=True
         )
         if serializer.is_valid():
             updated_external_team = serializer.save()

--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -1,0 +1,65 @@
+import logging
+from django.http import Http404
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from sentry.api.bases.team import TeamEndpoint
+from sentry.api.serializers import serialize
+from sentry.models import ExternalTeam
+
+from .external_team import ExternalTeamSerializer
+
+logger = logging.getLogger(__name__)
+
+
+class ExternalTeamDetailsEndpoint(TeamEndpoint):
+    def convert_args(
+        self, request, organization_slug, team_slug, external_team_id, *args, **kwargs
+    ):
+        args, kwargs = super().convert_args(request, organization_slug, team_slug, *args, **kwargs)
+        try:
+            kwargs["external_team"] = ExternalTeam.objects.get(
+                id=external_team_id,
+            )
+        except ExternalTeam.DoesNotExist:
+            raise Http404
+
+        return (args, kwargs)
+
+    def put(self, request, team, external_team):
+        """
+        Update an External Team
+        `````````````
+
+        Update various attributes and configurable settings for the given
+        team.
+
+        :pparam string organization_slug: the slug of the organization the
+                                          team belongs to.
+        :pparam string team_slug: the slug of the team to get.
+        :pparam string external_team_id: id of external_team object
+        :param string external_id: the Github/Gitlab team name.
+        :param string provider: enum("github","gitlab")
+        :auth: required
+        """
+
+        serializer = ExternalTeamSerializer(
+            context={"team": team}, instance=external_team, data=request.data, partial=True
+        )
+        if serializer.is_valid():
+            updated_external_team = serializer.save()
+
+            return Response(
+                serialize(updated_external_team, request.user), status=status.HTTP_200_OK
+            )
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, team, external_team):
+        """
+        Delete an External Team
+        """
+
+        external_team.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -32,9 +32,6 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint):
         Update an External Team
         `````````````
 
-        Update various attributes and configurable settings for the given
-        team.
-
         :pparam string organization_slug: the slug of the organization the
                                           team belongs to.
         :pparam string team_slug: the slug of the team to get.

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -213,9 +213,9 @@ class ExternalTeamSerializer(Serializer):
         provider = self.get_provider_string(obj.provider)
         return {
             "id": obj.id,
-            "team_id": obj.team_id,
+            "teamId": obj.team_id,
             "provider": provider,
-            "external_id": obj.external_id,
+            "externalId": obj.external_id,
         }
 
     def get_provider_string(self, provider):

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -9,8 +9,6 @@ from sentry.models import (
     Integration,
     OrganizationIntegration,
     ExternalTeam,
-    EXTERNAL_PROVIDERS,
-    ExternalProviders,
 )
 
 
@@ -210,13 +208,10 @@ class IntegrationIssueSerializer(IntegrationSerializer):
 @register(ExternalTeam)
 class ExternalTeamSerializer(Serializer):
     def serialize(self, obj, attrs, user):
-        provider = self.get_provider_string(obj.provider)
+        provider = ExternalTeam.get_provider_string(obj.provider)
         return {
-            "id": obj.id,
-            "teamId": obj.team_id,
+            "id": str(obj.id),
+            "teamId": str(obj.team_id),
             "provider": provider,
             "externalId": obj.external_id,
         }
-
-    def get_provider_string(self, provider):
-        return EXTERNAL_PROVIDERS.get(ExternalProviders(provider), "unknown")

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -30,6 +30,8 @@ from .endpoints.event_attachments import EventAttachmentsEndpoint
 from .endpoints.event_file_committers import EventFileCommittersEndpoint
 from .endpoints.event_grouping_info import EventGroupingInfoEndpoint
 from .endpoints.event_owners import EventOwnersEndpoint
+from .endpoints.external_team import ExternalTeamEndpoint
+from .endpoints.external_team_details import ExternalTeamDetailsEndpoint
 from .endpoints.filechange import CommitFileChangeEndpoint
 from .endpoints.group_attachments import GroupAttachmentsEndpoint
 from .endpoints.group_current_release import GroupCurrentReleaseEndpoint
@@ -1292,6 +1294,16 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/avatar/$",
                     TeamAvatarEndpoint.as_view(),
                     name="sentry-api-0-team-avatar",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/externalteam/$",
+                    ExternalTeamEndpoint.as_view(),
+                    name="sentry-api-0-external-team",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/externalteam/(?P<external_team_id>[^\/]+)/$",
+                    ExternalTeamDetailsEndpoint.as_view(),
+                    name="sentry-api-0-external-team-details",
                 ),
             ]
         ),

--- a/src/sentry/models/integration.py
+++ b/src/sentry/models/integration.py
@@ -92,6 +92,13 @@ class ExternalTeam(DefaultFieldsModel):
         db_table = "sentry_externalteam"
         unique_together = (("team", "provider", "external_id"),)
 
+    def get_provider_string(provider_int):
+        return EXTERNAL_PROVIDERS.get(ExternalProviders(provider_int), "unknown")
+
+    def get_provider_enum(provider_str):
+        inv_providers_map = {v: k for k, v in EXTERNAL_PROVIDERS.items()}
+        return inv_providers_map[provider_str].value if inv_providers_map[provider_str] else None
+
 
 class ExternalUser(DefaultFieldsModel):
     __core__ = False

--- a/tests/sentry/api/endpoints/test_external_team.py
+++ b/tests/sentry/api/endpoints/test_external_team.py
@@ -1,0 +1,42 @@
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+
+
+class ExternalTeamTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user, name="baz")
+        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+
+        self.url = reverse(
+            "sentry-api-0-external-team",
+            args=[self.org.slug, self.team.slug],
+        )
+
+    def test_basic_post(self):
+        data = {"externalId": "@getsentry/ecosystem", "provider": "github"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 201, response.content
+        assert response.data == {
+            "id": str(response.data["id"]),
+            "teamId": str(self.team.id),
+            **data,
+        }
+
+    def test_missing_provider(self):
+        response = self.client.post(self.url, {"externalId": "@getsentry/ecosystem"})
+        assert response.status_code == 400
+        assert response.data == {"provider": ["This field is required."]}
+
+    def test_missing_externalId(self):
+        response = self.client.post(self.url, {"provider": "gitlab"})
+        assert response.status_code == 400
+        assert response.data == {"externalId": ["This field is required."]}
+
+    def test_invalid_provider(self):
+        data = {"externalId": "@getsentry/ecosystem", "provider": "git"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 400
+        assert response.data == {"provider": ['"git" is not a valid choice.']}

--- a/tests/sentry/api/endpoints/test_external_team_details.py
+++ b/tests/sentry/api/endpoints/test_external_team_details.py
@@ -1,0 +1,36 @@
+from django.core.urlresolvers import reverse
+from sentry.models import ExternalTeam
+from sentry.testutils import APITestCase
+
+
+class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user, name="baz")
+        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+        self.external_team = ExternalTeam.objects.create(
+            team_id=str(self.team.id),
+            provider=ExternalTeam.get_provider_enum("github"),
+            external_id="@getsentry/ecosystem",
+        )
+        self.url = reverse(
+            "sentry-api-0-external-team-details",
+            args=[self.org.slug, self.team.slug, self.external_team.id],
+        )
+
+    def test_basic_delete(self):
+        resp = self.client.delete(self.url)
+        assert resp.status_code == 204
+        assert not ExternalTeam.objects.filter(id=str(self.external_team.id)).exists()
+
+    def test_basic_update(self):
+        resp = self.client.put(self.url, {"externalId": "@getsentry/growth"})
+        assert resp.status_code == 200
+        assert resp.data["id"] == str(self.external_team.id)
+        assert resp.data["externalId"] == "@getsentry/growth"
+
+    def test_invalid_provider_update(self):
+        resp = self.client.put(self.url, {"provider": "git"})
+        assert resp.status_code == 400
+        assert resp.data == {"provider": ['"git" is not a valid choice.']}


### PR DESCRIPTION
## Objective:
We just create migration to create the `sentry_externalteam` table. We will need to create createOne, deleteOne and updateOne endpoints for sentry_externalteam model

We can get the id of and externalTeam object from https://github.com/getsentry/sentry/pull/23721

The endpoints will return `{id: int, provider: enum(“github”, “gitlab”, team_id: int, external_id: string}`

## Test Plan:
Added tests for all the new endpoints.

## Future:
We may add a `getList` endpoint for externalteams