### PR TITLE
fix(metric_alerts): Return a useful error message when people attempt to create a metric alert with a project id.

### DIFF
--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -402,6 +402,8 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
                     "end": timezone.now(),
                 },
             )
+            if any(cond[0] == "project_id" for cond in snuba_filter.conditions):
+                raise serializers.ValidationError({"query": "Project is an invalid search term"})
         except (InvalidSearchQuery, ValueError) as e:
             raise serializers.ValidationError("Invalid Query or Metric: {}".format(force_text(e)))
         else:

--- a/tests/sentry/incidents/endpoints/test_serializers.py
+++ b/tests/sentry/incidents/endpoints/test_serializers.py
@@ -192,6 +192,12 @@ class TestAlertRuleSerializer(TestCase):
         assert alert_rule.snuba_query.dataset == QueryDatasets.TRANSACTIONS.value
         assert alert_rule.snuba_query.aggregate == "count()"
 
+    def test_query_project(self):
+        self.run_fail_validation_test(
+            {"query": f"project:{self.project.slug}"},
+            {"query": ["Project is an invalid search term"]},
+        )
+
     def test_decimal(self):
         params = self.valid_transaction_params.copy()
         alert_threshold = 0.8


### PR DESCRIPTION
Currently we throw an error and return a 500 if a user includes `project` in their query. Return a
400 and a useful error message instead.

Fixes ISSUE-1136