### PR TITLE
fix(sdk-updates): Handling orgs without any projects

### DIFF
--- a/src/sentry/api/endpoints/organization_sdk_updates.py
+++ b/src/sentry/api/endpoints/organization_sdk_updates.py
@@ -63,6 +63,8 @@ class OrganizationSdkUpdatesEndpoint(OrganizationEventsEndpointBase):
 
         project_ids = self.get_requested_project_ids(request)
         projects = self.get_projects(request, organization, project_ids)
+        if len(projects) == 0:
+            return Response([])
 
         with self.handle_query_errors():
             result = discover.query(

--- a/tests/sentry/api/endpoints/test_organization_sdk_updates.py
+++ b/tests/sentry/api/endpoints/test_organization_sdk_updates.py
@@ -49,6 +49,18 @@ class OrganizationSdkUpdates(APITestCase, SnubaTestCase):
             "enables": [],
         }
 
+    def test_no_projects(self):
+        org = self.create_organization()
+        self.create_member(user=self.user, organization=org)
+
+        url = reverse(
+            "sentry-api-0-organization-sdk-updates",
+            kwargs={"organization_slug": org.slug},
+        )
+
+        response = self.client.get(url)
+        assert len(response.data) == 0
+
     def test_filtered_project(self):
         min_ago = iso_format(before_now(minutes=1))
         self.store_event(


### PR DESCRIPTION
- When an org has no projects, skip the attempt to make a snuba query
  and directly return an empty list