### PR TITLE
fix(alerts): Incompatible Query Alert was using the wrong link

### DIFF
--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -89,7 +89,7 @@ function IncompatibleQueryAlert({
       <Link
         to={{
           pathname,
-          query: eventTypeError.generateQueryStringObject(),
+          query: eventTypeDefault.generateQueryStringObject(),
         }}
       />
     ),
@@ -97,7 +97,7 @@ function IncompatibleQueryAlert({
       <Link
         to={{
           pathname,
-          query: eventTypeDefault.generateQueryStringObject(),
+          query: eventTypeTransaction.generateQueryStringObject(),
         }}
       />
     ),


### PR DESCRIPTION
- Currently default adds `event.type:error` instead and transactions
  adds `event.type:default` instead