### PR TITLE
fix(metric_alerts): Make sure we track `created_by` when creating an alert rule async (1/2)

### DIFF
--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -211,6 +211,7 @@ class SlackTasksTest(TestCase):
             "data": alert_rule_data,
             "uuid": self.uuid,
             "organization_id": self.org.id,
+            "user_id": self.user.id,
         }
 
         with self.tasks():
@@ -218,6 +219,7 @@ class SlackTasksTest(TestCase):
                 find_channel_id_for_alert_rule(**data)
 
         rule = AlertRule.objects.get(name="New Rule")
+        assert rule.created_by == self.user
         mock_set_value.assert_called_with("success", rule.id)
         mock_get_channel_id.assert_called_with(self.integration, "my-channel", 180)
 


### PR DESCRIPTION
When we handle metric alert creation async (for slack, usually), we don't pass the request user
along as a param. So we end up not knowing which user created the metric alert.

This updates the task to accept a `user_id` param and to pass it to the serializer so that we're
able to track who created it. This is split into two parts so that we can deploy the task change
first, then the change to caller, so that we don't have any issues during deploy.

Part of ISSUE-1146