### PR TITLE
fix(metric_alerts): Make sure we track `created_by` when creating an alert rule async (2/2)

### DIFF
--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -43,6 +43,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
                     "uuid": client.uuid,
                     "data": data,
                     "alert_rule_id": alert_rule.id,
+                    "user_id": request.user.id,
                 }
                 tasks.find_channel_id_for_alert_rule.apply_async(kwargs=task_args)
                 return Response({"uuid": client.uuid}, status=202)

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -102,6 +102,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
                     "organization_id": project.organization_id,
                     "uuid": client.uuid,
                     "data": data,
+                    "user_id": request.user.id,
                 }
                 tasks.find_channel_id_for_alert_rule.apply_async(kwargs=task_args)
                 return Response({"uuid": client.uuid}, status=202)

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -240,6 +240,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
             "uuid": "abc123",
             "alert_rule_id": self.alert_rule.id,
             "data": test_params,
+            "user_id": self.user.id,
         }
         mock_find_channel_id_for_alert_rule.assert_called_once_with(kwargs=kwargs)
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -193,6 +193,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
             "organization_id": self.organization.id,
             "uuid": "abc123",
             "data": valid_alert_rule,
+            "user_id": self.user.id,
         }
         mock_find_channel_id_for_alert_rule.assert_called_once_with(kwargs=kwargs)
 


### PR DESCRIPTION
When we handle metric alert creation async (for slack, usually), we don't pass the request user
along as a param. So we end up not knowing which user created the metric alert.

This updates the endpoints to pass the user id along to the task.

Fixes ISSUE-1146