### PR TITLE
ref(ts) Update MultiSelectControl to typescript and fix types

### DIFF
--- a/src/sentry/static/sentry/app/components/contextPickerModal.tsx
+++ b/src/sentry/static/sentry/app/components/contextPickerModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ReactSelect, {components, StylesConfig} from 'react-select';
+import {components, StylesConfig} from 'react-select';
 import styled from '@emotion/styled';
 import createReactClass from 'create-react-class';
 import Reflux from 'reflux';
@@ -100,8 +100,10 @@ class ContextPickerModal extends React.Component<Props> {
     }
   }
 
-  orgSelect: ReactSelect | null = null;
-  projectSelect: ReactSelect | null = null;
+  // TODO(ts) The various generics in react-select types make getting this
+  // right hard.
+  orgSelect: any | null = null;
+  projectSelect: any | null = null;
 
   // Performs checks to see if we need to prompt user
   // i.e. When there is only 1 org and no project is needed or
@@ -148,7 +150,7 @@ class ContextPickerModal extends React.Component<Props> {
     );
   };
 
-  doFocus = (ref: ReactSelect | null) => {
+  doFocus = (ref: any | null) => {
     if (!ref || this.props.loading) {
       return;
     }
@@ -264,7 +266,7 @@ class ContextPickerModal extends React.Component<Props> {
     }
     return (
       <StyledSelectControl
-        ref={(ref: ReactSelect) => {
+        ref={(ref: any) => {
           this.projectSelect = ref;
           this.focusProjectSelector();
         }}
@@ -310,7 +312,7 @@ class ContextPickerModal extends React.Component<Props> {
           {loading && <StyledLoadingIndicator overlay />}
           {needOrg && (
             <StyledSelectControl
-              ref={(ref: ReactSelect) => {
+              ref={(ref: any) => {
                 this.orgSelect = ref;
                 if (shouldShowProjectSelector) {
                   return;

--- a/src/sentry/static/sentry/app/components/forms/multiSelectControl.jsx
+++ b/src/sentry/static/sentry/app/components/forms/multiSelectControl.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-import SelectControl from 'app/components/forms/selectControl';
-
-export default React.forwardRef(function MultiSelectControl(props, ref) {
-  return <SelectControl forwardedRef={ref} {...props} multiple />;
-});

--- a/src/sentry/static/sentry/app/components/forms/multiSelectControl.tsx
+++ b/src/sentry/static/sentry/app/components/forms/multiSelectControl.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactSelect from 'react-select';
+
+import SelectControl, {ControlProps} from 'app/components/forms/selectControl';
+import {SelectValue} from 'app/types';
+
+type Props = Omit<ControlProps, 'onChange'> & {
+  /**
+   * Triggered when values change.
+   */
+  onChange?: (value: SelectValue<any>[] | null | undefined) => void;
+};
+
+export default React.forwardRef<ReactSelect, Props>(function MultiSelectControl(
+  props,
+  ref
+) {
+  return <SelectControl forwardedRef={ref} {...props} multiple />;
+});

--- a/src/sentry/static/sentry/app/components/forms/multiSelectControl.tsx
+++ b/src/sentry/static/sentry/app/components/forms/multiSelectControl.tsx
@@ -8,7 +8,7 @@ type Props = Omit<ControlProps, 'onChange'> & {
   /**
    * Triggered when values change.
    */
-  onChange?: (value: SelectValue<any>[] | null | undefined) => void;
+  onChange?: (value?: SelectValue<any>[] | null) => void;
 };
 
 export default React.forwardRef<ReactSelect, Props>(function MultiSelectControl(

--- a/src/sentry/static/sentry/app/components/forms/selectControl.tsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import ReactSelect, {
   components as selectComponents,
+  GroupedOptionsType,
   mergeStyles,
+  OptionsType,
+  Props as ReactSelectProps,
   StylesConfig,
 } from 'react-select';
 import Async from 'react-select/async';
@@ -11,11 +14,24 @@ import {withTheme} from 'emotion-theming';
 
 import {IconChevron, IconClose} from 'app/icons';
 import space from 'app/styles/space';
-import {Choices} from 'app/types';
+import {Choices, SelectValue} from 'app/types';
 import convertFromSelect2Choices from 'app/utils/convertFromSelect2Choices';
 import {Theme} from 'app/utils/theme';
 
 import SelectControlLegacy from './selectControlLegacy';
+
+function isGroupedOptions<OptionType>(
+  maybe:
+    | ReturnType<typeof convertFromSelect2Choices>
+    | GroupedOptionsType<OptionType>
+    | OptionType[]
+    | OptionsType<OptionType>
+): maybe is GroupedOptionsType<OptionType> {
+  if (!maybe || maybe.length === 0) {
+    return false;
+  }
+  return (maybe as GroupedOptionsType<OptionType>)[0].options !== undefined;
+}
 
 const ClearIndicator = (
   props: React.ComponentProps<typeof selectComponents.ClearIndicator>
@@ -41,13 +57,10 @@ const MultiValueRemove = (
   </selectComponents.MultiValueRemove>
 );
 
-type ControlProps = React.ComponentProps<typeof ReactSelect> & {
-  theme: Theme;
-  /**
-   * Ref forwarded into ReactSelect component.
-   * The any is inherited from react-select.
-   */
-  forwardedRef: React.Ref<ReactSelect>;
+export type ControlProps<OptionType = GeneralSelectValue> = Omit<
+  ReactSelectProps<OptionType>,
+  'onChange' | 'value'
+> & {
   /**
    * Set to true to prefix selected values with content
    */
@@ -55,16 +68,51 @@ type ControlProps = React.ComponentProps<typeof ReactSelect> & {
   /**
    * Backwards compatible shim to work with select2 style choice type.
    */
-  choices?: Choices | ((props: ControlProps) => Choices);
+  choices?: Choices | ((props: ControlProps<OptionType>) => Choices);
   /**
    * Use react-select v2. Deprecated, don't make more of this.
    */
   deprecatedSelectControl?: boolean;
+  /**
+   * Used by MultiSelectControl.
+   */
+  multiple?: boolean;
+  /**
+   * Handler for changes. Narrower than the types in react-select.
+   */
+  onChange?: (value: OptionType | null | undefined) => void;
+  /**
+   * Unlike react-select which expects an OptionType as its value
+   * we accept the option.value and resolve the option object.
+   * Because this type is embedded in the OptionType generic we
+   * can't have a good type here.
+   */
+  value?: any;
+};
+
+/**
+ * Additional props provided by forwardRef and withTheme()
+ */
+type WrappedControlProps<OptionType> = ControlProps<OptionType> & {
+  theme: Theme;
+  /**
+   * Ref forwarded into ReactSelect component.
+   * The any is inherited from react-select.
+   */
+  forwardedRef: React.Ref<ReactSelect>;
 };
 
 type LegacyProps = React.ComponentProps<typeof SelectControlLegacy>;
 
-function SelectControl(props: ControlProps) {
+// TODO(ts) The exported component uses forwardRef.
+// This means we cannot fill the SelectValue generic
+// at the call site. We use `any` here to avoid type errors with select
+// controls that have custom option structures
+type GeneralSelectValue = SelectValue<any>;
+
+function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValue>(
+  props: WrappedControlProps<OptionType>
+) {
   // TODO(epurkhiser): We should remove all SelectControls (and SelectFields,
   // SelectAsyncFields, etc) that are using this prop, before we can remove the
   // v1 react-select component.
@@ -262,7 +310,15 @@ function SelectControl(props: ControlProps) {
      * because the select component fetches the options finding the mappedValue will fail
      * and the component won't work
      */
-    const flatOptions = choicesOrOptions.flatMap(option => option.options || option);
+    let flatOptions: any[] = [];
+    if (isGroupedOptions<OptionType>(choicesOrOptions)) {
+      flatOptions = choicesOrOptions.flatMap(option => option.options);
+    } else {
+      // @ts-ignore The types used in react-select generics (OptionType) don't
+      // line up well with our option type (SelectValue). We need to do more work
+      // to get these types to align.
+      flatOptions = choicesOrOptions.flatMap(option => option);
+    }
     mappedValue =
       props.multiple && Array.isArray(value)
         ? value.map(val => flatOptions.find(option => option.value === val))
@@ -299,7 +355,7 @@ function SelectControl(props: ControlProps) {
   };
 
   return (
-    <SelectPicker
+    <SelectPicker<OptionType>
       styles={mappedStyles}
       components={{...replacedComponents, ...components}}
       async={async}
@@ -309,7 +365,7 @@ function SelectControl(props: ControlProps) {
       value={mappedValue}
       isMulti={props.multiple || props.multi}
       isDisabled={props.isDisabled || props.disabled}
-      options={choicesOrOptions}
+      options={options || (choicesOrOptions as OptionsType<OptionType>)}
       openMenuOnFocus={props.openMenuOnFocus === undefined ? true : props.openMenuOnFocus}
       {...rest}
     />
@@ -319,7 +375,7 @@ SelectControl.propTypes = SelectControlLegacy.propTypes;
 
 const SelectControlWithTheme = withTheme(SelectControl);
 
-type PickerProps = ControlProps & {
+type PickerProps<OptionType> = ControlProps<OptionType> & {
   /**
    * Enable async option loading.
    */
@@ -334,7 +390,12 @@ type PickerProps = ControlProps & {
   clearable?: boolean;
 };
 
-function SelectPicker({async, creatable, forwardedRef, ...props}: PickerProps) {
+function SelectPicker<OptionType>({
+  async,
+  creatable,
+  forwardedRef,
+  ...props
+}: PickerProps<OptionType>) {
   // Pick the right component to use
   // Using any here as react-select types also use any
   let Component: React.ComponentType<any> | undefined;
@@ -353,11 +414,13 @@ function SelectPicker({async, creatable, forwardedRef, ...props}: PickerProps) {
 
 SelectPicker.propTypes = SelectControl.propTypes;
 
-const RefForwardedSelectControl = React.forwardRef<ReactSelect, ControlProps>(
-  function RefForwardedSelectControl(props, ref) {
-    return <SelectControlWithTheme forwardedRef={ref} {...props} />;
-  }
-);
+// The generics need to be filled here as forwardRef can't expose generics.
+const RefForwardedSelectControl = React.forwardRef<
+  ReactSelect<GeneralSelectValue>,
+  ControlProps<GeneralSelectValue>
+>(function RefForwardedSelectControl(props, ref) {
+  return <SelectControlWithTheme forwardedRef={ref} {...props} />;
+});
 
 // TODO(ts): Needed because <SelectField> uses this
 RefForwardedSelectControl.propTypes = SelectControl.propTypes;

--- a/src/sentry/static/sentry/app/components/forms/selectControl.tsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.tsx
@@ -80,7 +80,7 @@ export type ControlProps<OptionType = GeneralSelectValue> = Omit<
   /**
    * Handler for changes. Narrower than the types in react-select.
    */
-  onChange?: (value: OptionType | null | undefined) => void;
+  onChange?: (value?: OptionType | null) => void;
   /**
    * Unlike react-select which expects an OptionType as its value
    * we accept the option.value and resolve the option object.

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/index.tsx
@@ -364,7 +364,7 @@ class InviteMembersModal extends AsyncComponent<Props, State> {
                 i
               )
             }
-            onChangeRole={({value}) => this.setRole(value, i)}
+            onChangeRole={value => this.setRole(value?.value, i)}
             onChangeTeams={opts => this.setTeams(opts ? opts.map(v => v.value) : [], i)}
             disableRemove={disableInputs || pendingInvites.length === 1}
           />

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -10,6 +10,8 @@ import {MemberRole, SelectValue, Team} from 'app/types';
 import renderEmailValue from './renderEmailValue';
 import {InviteStatus} from './types';
 
+type SelectOption = SelectValue<string>;
+
 type Props = {
   className?: string;
   disabled: boolean;
@@ -23,9 +25,9 @@ type Props = {
   inviteStatus: InviteStatus;
   onRemove: () => void;
 
-  onChangeEmails: (emails: SelectValue<string>[]) => void;
-  onChangeRole: (role: SelectValue<string>) => void;
-  onChangeTeams: (teams: null | SelectValue<string>[]) => void;
+  onChangeEmails: (emails: SelectOption[]) => void;
+  onChangeRole: (role: SelectOption) => void;
+  onChangeTeams: (teams: SelectOption[] | null | undefined) => void;
 };
 
 const InviteRowControl = ({

--- a/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
+++ b/src/sentry/static/sentry/app/components/modals/inviteMembersModal/inviteRowControl.tsx
@@ -27,7 +27,7 @@ type Props = {
 
   onChangeEmails: (emails: SelectOption[]) => void;
   onChangeRole: (role: SelectOption) => void;
-  onChangeTeams: (teams: SelectOption[] | null | undefined) => void;
+  onChangeTeams: (teams?: SelectOption[] | null) => void;
 };
 
 const InviteRowControl = ({

--- a/src/sentry/static/sentry/app/components/roleSelectControl.tsx
+++ b/src/sentry/static/sentry/app/components/roleSelectControl.tsx
@@ -2,22 +2,26 @@ import React from 'react';
 import {components, OptionProps} from 'react-select';
 import styled from '@emotion/styled';
 
-import SelectControl from 'app/components/forms/selectControl';
+import SelectControl, {ControlProps} from 'app/components/forms/selectControl';
 import space from 'app/styles/space';
 import {MemberRole} from 'app/types';
 import theme from 'app/utils/theme';
-
-type Props = React.ComponentProps<typeof SelectControl> & {
-  roles: MemberRole[];
-  disableUnallowed: boolean;
-  value?: string;
-};
 
 type OptionType = {
   label: string;
   value: string;
   disabled: boolean;
   description: string;
+};
+
+type Props = Omit<ControlProps<OptionType>, 'onChange' | 'value'> & {
+  roles: MemberRole[];
+  disableUnallowed: boolean;
+  value?: string;
+  /**
+   * Narrower type than SelectControl because there is no empty value
+   */
+  onChange?: (value: OptionType) => void;
 };
 
 function RoleSelectControl({roles, disableUnallowed, ...props}: Props) {

--- a/src/sentry/static/sentry/app/components/selectMembers/index.tsx
+++ b/src/sentry/static/sentry/app/components/selectMembers/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactSelect from 'react-select';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
 
@@ -87,7 +86,8 @@ class SelectMembers extends React.Component<Props, State> {
     this.unlisteners.forEach(callIfFunction);
   }
 
-  selectRef = React.createRef<ReactSelect>();
+  // TODO(ts) This type could be improved when react-select types are better.
+  selectRef = React.createRef<any>();
 
   unlisteners = [
     MemberListStore.listen(() => {

--- a/src/sentry/static/sentry/app/utils/convertFromSelect2Choices.tsx
+++ b/src/sentry/static/sentry/app/utils/convertFromSelect2Choices.tsx
@@ -8,12 +8,14 @@ function isStringList(maybe: string[] | Choices): maybe is string[] {
 
 /**
  * Converts arg from a `select2` choices array to a `react-select` `options` array
+ * This contains some any hacks as this is creates type errors with the generics
+ * used in SelectControl as the generics conflict with the concrete types here.
  */
-const convertFromSelect2Choices = (choices: Input): SelectValue<any>[] | null => {
+const convertFromSelect2Choices = (choices: Input): SelectValue<any>[] | undefined => {
   // TODO(ts): This is to make sure that this function is backwards compatible, ideally,
   // this function only accepts arrays
   if (!Array.isArray(choices)) {
-    return null;
+    return undefined;
   }
   if (isStringList(choices)) {
     return choices.map(choice => ({value: choice, label: choice}));

--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -1,17 +1,16 @@
 import React, {CSSProperties} from 'react';
-// eslint import checks can't find types in the flow code.
-// eslint-disable-next-line import/named
 import {components, OptionProps, SingleValueProps} from 'react-select';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
-import SelectControl from 'app/components/forms/selectControl';
+import SelectControl, {ControlProps} from 'app/components/forms/selectControl';
 import Tag from 'app/components/tag';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {SelectValue} from 'app/types';
 import {
   AggregateParameter,
+  AggregationKey,
   ColumnType,
   QueryFieldValue,
   ValidateColumnTypes,
@@ -20,7 +19,9 @@ import Input from 'app/views/settings/components/forms/controls/input';
 
 import {FieldValue, FieldValueColumns, FieldValueKind} from './types';
 
-type FieldOptions = Record<string, SelectValue<FieldValue>>;
+type FieldValueOption = SelectValue<FieldValue>;
+
+type FieldOptions = Record<string, FieldValueOption>;
 
 // Intermediate type that combines the current column
 // data with the AggregateParameter type.
@@ -34,7 +35,7 @@ type ParameterDescription =
   | {
       kind: 'column';
       value: FieldValue | null;
-      options: SelectValue<FieldValue>[];
+      options: FieldValueOption[];
       required: boolean;
     };
 
@@ -55,7 +56,7 @@ type Props = {
    * NOTE: This is different from passing an already filtered fieldOptions
    * list, as tag items in the list may be used as parameters to functions.
    */
-  filterPrimaryOptions?: (option: SelectValue<FieldValue>) => boolean;
+  filterPrimaryOptions?: (option: FieldValueOption) => boolean;
   /**
    * Whether or not to add labels inside of the input fields, currently only
    * used for the metric alert builder.
@@ -76,7 +77,11 @@ type OptionType = {
 };
 
 class QueryField extends React.Component<Props> {
-  handleFieldChange = ({value}) => {
+  handleFieldChange = (selected: FieldValueOption | null | undefined) => {
+    if (!selected) {
+      return;
+    }
+    const {value} = selected;
     const current = this.props.fieldValue;
     let fieldValue: QueryFieldValue = cloneDeep(this.props.fieldValue);
 
@@ -88,11 +93,18 @@ class QueryField extends React.Component<Props> {
         break;
       case FieldValueKind.FUNCTION:
         if (current.kind === 'field') {
-          fieldValue = {kind: 'function', function: [value.meta.name, '', undefined]};
+          fieldValue = {
+            kind: 'function',
+            function: [value.meta.name as AggregationKey, '', undefined],
+          };
         } else if (current.kind === 'function') {
           fieldValue = {
             kind: 'function',
-            function: [value.meta.name, current.function[1], current.function[2]],
+            function: [
+              value.meta.name as AggregationKey,
+              current.function[1],
+              current.function[2],
+            ],
           };
         }
         break;
@@ -407,7 +419,7 @@ class QueryField extends React.Component<Props> {
       ? Object.values(fieldOptions).filter(filterPrimaryOptions)
       : Object.values(fieldOptions);
 
-    const selectProps: React.ComponentProps<typeof SelectControl> = {
+    const selectProps: ControlProps<FieldValueOption> = {
       name: 'field',
       options: Object.values(allFieldOptions),
       placeholder: t('(Required)'),

--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -77,7 +77,7 @@ type OptionType = {
 };
 
 class QueryField extends React.Component<Props> {
-  handleFieldChange = (selected: FieldValueOption | null | undefined) => {
+  handleFieldChange = (selected?: FieldValueOption | null) => {
     if (!selected) {
       return;
     }

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/index.tsx
@@ -85,7 +85,7 @@ class Form extends React.Component<Props<Values, KeysOfUnion<Values>>, State> {
                 value,
               }))}
               value={method}
-              onChange={({value}) => onChange('method', value)}
+              onChange={value => onChange('method', value?.value)}
             />
           </Field>
           {values.method === MethodType.REPLACE && (
@@ -128,7 +128,7 @@ class Form extends React.Component<Props<Values, KeysOfUnion<Values>>, State> {
                 value,
               }))}
               value={type}
-              onChange={({value}) => onChange('type', value)}
+              onChange={value => onChange('type', value?.value)}
             />
           </Field>
           {values.type === RuleType.PATTERN && (

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/selectField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/selectField.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import ReactSelect, {components, OptionProps} from 'react-select';
+import {components, OptionProps} from 'react-select';
 import styled from '@emotion/styled';
 
-import SelectControl from 'app/components/forms/selectControl';
+import SelectControl, {ControlProps} from 'app/components/forms/selectControl';
 import space from 'app/styles/space';
 
-type SelectControlProps = React.ComponentProps<typeof SelectControl>;
-
 type Props = Pick<
-  SelectControlProps,
+  ControlProps,
   'value' | 'placeholder' | 'name' | 'onChange' | 'options'
 >;
 
@@ -19,12 +17,12 @@ class SelectField extends React.Component<Props> {
     }
 
     if (this.selectRef.current?.select?.inputRef) {
-      // @ts-ignore The react-select types have inputRef as any.
       this.selectRef.current.select.inputRef.autocomplete = 'off';
     }
   }
 
-  selectRef = React.createRef<ReactSelect>();
+  // TODO(ts) The generics in react-select make getting a good type here hard.
+  selectRef = React.createRef<any>();
 
   render() {
     return (

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/selectOwners.tsx
@@ -71,7 +71,7 @@ class SelectOwners extends React.Component<Props, State> {
     }
   }
 
-  private selectRef = React.createRef<React.ReactInstance>();
+  private selectRef = React.createRef<any>();
 
   renderUserBadge = (user: User) => (
     <IdBadge avatarSize={24} user={user} hideEmail useLink={false} />

--- a/tests/js/spec/utils/convertFromSelect2Choices.spec.jsx
+++ b/tests/js/spec/utils/convertFromSelect2Choices.spec.jsx
@@ -42,9 +42,9 @@ describe('convertFromSelect2Choices', function () {
   });
 
   it('returns null on invalid values', function () {
-    expect(convertFromSelect2Choices('test')).toEqual(null);
-    expect(convertFromSelect2Choices(1)).toEqual(null);
-    expect(convertFromSelect2Choices({})).toEqual(null);
-    expect(convertFromSelect2Choices(undefined)).toEqual(null);
+    expect(convertFromSelect2Choices('test')).toBeUndefined();
+    expect(convertFromSelect2Choices(1)).toBeUndefined();
+    expect(convertFromSelect2Choices({})).toBeUndefined();
+    expect(convertFromSelect2Choices(undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
When converting MultiSelectControl to typescript I discovered that the types for `SelectControl` were all wrong. The default export of the type stubs for `react-select` are not for the component, but for the state manager. This meant that our types were all wrong. Fixing those types required numerous generics. I had to use a few `any` values as `forwardRef` doesn't let expose generic types. I also had to use `any` on all the refs we take on react-select because the `StateManager` requires multiple layers of generics and even when those generics are filled we still need to use `any`.