### PR TITLE
fix(dashboards) Fix incorrect permissions check on dashboards

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/index.tsx
@@ -22,7 +22,6 @@ class DashboardsV2Container extends React.Component<Props> {
     return (
       <Feature
         features={['dashboards-basic']}
-        requireAll={false}
         organization={organization}
         renderDisabled={this.renderNoAccess}
       >


### PR DESCRIPTION
Require permissions so that accounts without dashboards can't directly
navigate to the view.