### PR TITLE
fix(aws-lambda): adds missing sentry_assets

### DIFF
--- a/src/sentry/templates/sentry/bases/react_pipeline.html
+++ b/src/sentry/templates/sentry/bases/react_pipeline.html
@@ -1,4 +1,6 @@
 {% extends "sentry/base-react.html" %}
+{% load sentry_assets %}
+
 {% block body_app_boot %}
 {% script %}
 <script>


### PR DESCRIPTION
Adds the missing `{% load sentry_assets %}` bit that we have in the `react.html` file. 