### PR TITLE
build(fix): Do not restrict using latest version of pip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ ensure-venv:
 	@./scripts/ensure-venv.sh
 
 ensure-pinned-pip: ensure-venv
-	$(PIP) install --no-cache-dir --upgrade "pip>=20.0.2,<20.3"
+	$(PIP) install --no-cache-dir --upgrade "pip>=20.0.2"
 
 setup-git-config:
 	@git config --local branch.autosetuprebase always


### PR DESCRIPTION
Unfortunately, the latest change has not been playing nicely for me and folks using Python 3.6 (see my output and Colleen's issue).

If you want, we can figure out a way to support you using a different range for your set up, however, I need to fix the current problem.

<img width="1167" alt="image" src="https://user-images.githubusercontent.com/44410/107563710-66053c00-6baf-11eb-9475-95f61af33a4e.png">


```
❯ pip install "psycopg2-binary<2.9.0,>=2.7.0"
Collecting psycopg2-binary<2.9.0,>=2.7.0
  Using cached psycopg2-binary-2.8.6.tar.gz (384 kB)
    ERROR: Command errored out with exit status 1:
     command: /Users/armenzg/code/sentry/.venv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/th/r04rfknj1056pf9tjxwdh6dr0000gn/T/pip-install-4kkisf68/psycopg2-binary/setup.py'"'"'; __file__='"'"'/private/var/folders/th/r04rfknj1056pf9tjxwdh6dr0000gn/T/pip-install-4kkisf68/psycopg2-binary/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/th/r04rfknj1056pf9tjxwdh6dr0000gn/T/pip-pip-egg-info-mmahx0lv
         cwd: /private/var/folders/th/r04rfknj1056pf9tjxwdh6dr0000gn/T/pip-install-4kkisf68/psycopg2-binary/
    Complete output (23 lines):
    running egg_info
    creating /private/var/folders/th/r04rfknj1056pf9tjxwdh6dr0000gn/T/pip-pip-egg-info-mmahx0lv/psycopg2_binary.egg-info
    writing /private/var/folders/th/r04rfknj1056pf9tjxwdh6dr0000gn/T/pip-pip-egg-info-mmahx0lv/psycopg2_binary.egg-info/PKG-INFO
    writing dependency_links to /private/var/folders/th/r04rfknj1056pf9tjxwdh6dr0000gn/T/pip-pip-egg-info-mmahx0lv/psycopg2_binary.egg-info/dependency_links.txt
    writing top-level names to /private/var/folders/th/r04rfknj1056pf9tjxwdh6dr0000gn/T/pip-pip-egg-info-mmahx0lv/psycopg2_binary.egg-info/top_level.txt
    writing manifest file '/private/var/folders/th/r04rfknj1056pf9tjxwdh6dr0000gn/T/pip-pip-egg-info-mmahx0lv/psycopg2_binary.egg-info/SOURCES.txt'

    Error: pg_config executable not found.

    pg_config is required to build psycopg2 from source.  Please add the directory
    containing pg_config to the $PATH or specify the full executable path with the
    option:

        python setup.py build_ext --pg-config /path/to/pg_config build ...

    or with the pg_config option in 'setup.cfg'.

    If you prefer to avoid building psycopg2 from source, please install the PyPI
    'psycopg2-binary' package instead.

    For further information please check the 'doc/src/install.rst' file (also at
    <https://www.psycopg.org/docs/install.html>).

    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
WARNING: You are using pip version 20.2.4; however, version 21.0.1 is available.
You should consider upgrading via the '/Users/armenzg/code/sentry/.venv/bin/python -m pip install --upgrade pip' command.

sentry on  master [$] via ⬢ v12.19.0 via 🐍 v3.6.10 (.venv)
❯ pip install --upgrade pip
Collecting pip
  Using cached pip-21.0.1-py3-none-any.whl (1.5 MB)
Installing collected packages: pip
  Attempting uninstall: pip
    Found existing installation: pip 20.2.4
    Uninstalling pip-20.2.4:
      Successfully uninstalled pip-20.2.4
Successfully installed pip-21.0.1

sentry on  master [$] via ⬢ v12.19.0 via 🐍 v3.6.10 (.venv)
❯ pip install "psycopg2-binary<2.9.0,>=2.7.0"
Collecting psycopg2-binary<2.9.0,>=2.7.0
  Using cached psycopg2_binary-2.8.6-cp36-cp36m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl (1.5 MB)
Installing collected packages: psycopg2-binary
Successfully installed psycopg2-binary-2.8.6
```