### PR TITLE
feat(ui): check customComponent is undefined in ErrorBoundary

### DIFF
--- a/src/sentry/static/sentry/app/components/errorBoundary.tsx
+++ b/src/sentry/static/sentry/app/components/errorBoundary.tsx
@@ -88,7 +88,7 @@ class ErrorBoundary extends React.Component<Props, State> {
 
     const {customComponent, mini, message, className} = this.props;
 
-    if (customComponent) {
+    if (typeof customComponent !== 'undefined') {
       return customComponent;
     }
 


### PR DESCRIPTION
Sometimes we might want to render nothing when an error happens in `ErrorBoundary`. In order to pass in `null` for `customComponent`, I am adding a check to see if `customComponent` is undefined instead of just falsy.