### PR TITLE
fix(slack): Don't uninstall classic bot apps

### DIFF
--- a/src/sentry/migrations/0152_remove_slack_workspace_orgintegrations.py
+++ b/src/sentry/migrations/0152_remove_slack_workspace_orgintegrations.py
@@ -21,6 +21,10 @@ def remove_slack_workspace_apps(apps, schema_editor):
         Integration.objects.filter(provider="slack")
     ):
         if not integration.metadata.get("installation_type"):
+            # classic bot apps use the `user_access_token` but
+            # may be missing the installation_type. Don't delete these
+            if "user_access_token" in integration.metadata:
+                continue
             for org_integration in OrganizationIntegration.objects.filter(
                 integration_id=integration.id
             ):


### PR DESCRIPTION
The original PR, https://github.com/getsentry/sentry/pull/23211 has more information about why this was done in the first place. However, for on-prem users it is possible for them to have an integration that does not have the `installation_type` set AND not have a workspace app. This would be the case if they have the **classic bot** app. The classic bot app is an outdated version of the bot apps, [these docs](https://api.slack.com/authentication/quickstart) go into more detail about the difference between the two bot app types. 

The classic bot apps use the `bot` scope which has all the scopes and is also valid for the new `conversations.list` endpoints that workspace apps couldn't use. So if someone has the classic bot installed, it should continue to work. This is why we don't want to uninstall integrations that are bot apps. 

This update to the migration wouldn't have changed the outcome for sentry.io (since we wouldn't have had any classic bot installations)