### PR TITLE
fix(issue_alerts): Make sure we track `created_by` when creating an issue alert async

### DIFF
--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -72,6 +72,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                 "conditions": conditions,
                 "actions": data.get("actions", []),
                 "frequency": data.get("frequency"),
+                "user_id": request.user.id,
             }
 
             if data.get("pending_save"):

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -1,4 +1,5 @@
 from django.core.urlresolvers import reverse
+from unittest.mock import patch
 
 from sentry.models import Environment, Integration, Rule, RuleActivity, RuleActivityType
 from sentry.testutils import APITestCase
@@ -412,3 +413,77 @@ class CreateProjectRuleTest(APITestCase):
         assert rule.created_by == self.user
 
         assert RuleActivity.objects.filter(rule=rule, type=RuleActivityType.CREATED.value).exists()
+
+    @patch(
+        "sentry.integrations.slack.notify_action.get_channel_id",
+        return_value=("#", None, True),
+    )
+    @patch("sentry.integrations.slack.tasks.find_channel_id_for_rule.apply_async")
+    @patch("sentry.integrations.slack.tasks.uuid4")
+    def test_kicks_off_slack_async_job(
+        self, mock_uuid4, mock_find_channel_id_for_alert_rule, mock_get_channel_id
+    ):
+        the_uuid = "abc123"
+
+        class uuid:
+            hex = the_uuid
+
+        project = self.create_project()
+
+        mock_uuid4.return_value = uuid
+        self.login_as(self.user)
+
+        integration = Integration.objects.create(
+            provider="slack",
+            name="Awesome Team",
+            external_id="TXXXXXXX1",
+            metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+        )
+        integration.add_organization(project.organization, self.user)
+
+        url = reverse(
+            "sentry-api-0-project-rules",
+            kwargs={
+                "organization_slug": project.organization.slug,
+                "project_slug": project.slug,
+            },
+        )
+        data = {
+            "name": "hello world",
+            "environment": None,
+            "actionMatch": "any",
+            "frequency": 5,
+            "actions": [
+                {
+                    "id": "sentry.integrations.slack.notify_action.SlackNotifyServiceAction",
+                    "name": "Send a notification to the funinthesun Slack workspace to #team-team-team and show tags [] in notification",
+                    "workspace": str(integration.id),
+                    "channel": "#team-team-team",
+                    "tags": "",
+                }
+            ],
+            "conditions": [
+                {"id": "sentry.rules.conditions.first_seen_event.FirstSeenEventCondition"}
+            ],
+        }
+        self.client.post(
+            url,
+            data=data,
+            format="json",
+        )
+
+        assert not Rule.objects.filter(label="hello world").exists()
+        kwargs = {
+            "name": data["name"],
+            "environment": data.get("environment"),
+            "action_match": data["actionMatch"],
+            "filter_match": data.get("filterMatch"),
+            "conditions": data.get("conditions", []) + data.get("filters", []),
+            "actions": data.get("actions", []),
+            "frequency": data.get("frequency"),
+            "user_id": self.user.id,
+            "uuid": the_uuid,
+        }
+        call_args = mock_find_channel_id_for_alert_rule.call_args[1]["kwargs"]
+        assert call_args.pop("project").id == project.id
+        assert call_args == kwargs

--- a/tests/sentry/integrations/slack/test_tasks.py
+++ b/tests/sentry/integrations/slack/test_tasks.py
@@ -94,6 +94,7 @@ class SlackTasksTest(TestCase):
             ],
             "frequency": 5,
             "uuid": self.uuid,
+            "user_id": self.user.id,
         }
 
         with self.tasks():
@@ -113,6 +114,7 @@ class SlackTasksTest(TestCase):
                 "workspace": self.integration.id,
             }
         ]
+        assert rule.created_by == self.user
 
     @responses.activate
     @patch.object(RedisRuleStatus, "set_value", return_value=None)


### PR DESCRIPTION
When we handle issue alert creation async (for slack, usually), we don't pass the request user
along as a param. So we end up not knowing which user created the alert.

This updates the task to accept a `user_id` param that is used to create the `RuleActivity` row that
tracks the rule creator, and passes the `user_id` through from the endpoint