### PR TITLE
feat(perf): Add quick trace to transaction details

### DIFF
--- a/src/sentry/static/sentry/app/components/tag.tsx
+++ b/src/sentry/static/sentry/app/components/tag.tsx
@@ -67,7 +67,9 @@ function Tag({
       <Background type={type}>
         {tagIcon()}
 
-        <Text maxWidth={textMaxWidth}>{children}</Text>
+        <Text type={type} maxWidth={textMaxWidth}>
+          {children}
+        </Text>
 
         {defined(onDismiss) && (
           <DismissButton
@@ -137,8 +139,8 @@ const IconWrapper = styled('span')`
   display: inline-flex;
 `;
 
-export const Text = styled('span')<{maxWidth: number}>`
-  color: ${p => p.theme.gray500};
+export const Text = styled('span')<{maxWidth: number; type: keyof Theme['tag']}>`
+  color: ${p => (p.type === 'black' ? p.theme.white : p.theme.gray500)};
   max-width: ${p => p.maxWidth}px;
   overflow: hidden;
   white-space: nowrap;

--- a/src/sentry/static/sentry/app/components/tag.tsx
+++ b/src/sentry/static/sentry/app/components/tag.tsx
@@ -123,7 +123,7 @@ const TagWrapper = styled('span')`
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 
-const Background = styled('div')<{type: keyof Theme['tag']}>`
+export const Background = styled('div')<{type: keyof Theme['tag']}>`
   display: inline-flex;
   align-items: center;
   height: ${TAG_HEIGHT};
@@ -137,7 +137,7 @@ const IconWrapper = styled('span')`
   display: inline-flex;
 `;
 
-const Text = styled('span')<{maxWidth: number}>`
+export const Text = styled('span')<{maxWidth: number}>`
   color: ${p => p.theme.gray500};
   max-width: ${p => p.maxWidth}px;
   overflow: hidden;

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -267,6 +267,10 @@ const tag = {
     background: colors.white,
     iconColor: colors.gray500,
   },
+  black: {
+    background: colors.gray500,
+    iconColor: colors.white,
+  },
 };
 
 const generateButtonTheme = alias => ({

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
@@ -149,14 +149,17 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
           </Layout.HeaderActions>
         </Layout.Header>
         <Layout.Body>
-          <Layout.Main fullWidth={!isSidebarVisible}>
-            {hasQuickTraceView && (
+          {hasQuickTraceView && (
+            <Layout.Main fullWidth>
               <EventMetas
                 event={event}
                 organization={organization}
                 projectId={this.projectId}
+                location={location}
               />
-            )}
+            </Layout.Main>
+          )}
+          <Layout.Main fullWidth={!isSidebarVisible}>
             <Projects orgId={organization.slug} slugs={[this.projectId]}>
               {({projects}) => (
                 <SpanEntryContext.Provider

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/eventMetas.tsx
@@ -1,26 +1,29 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import {Location} from 'history';
 
-import {SectionHeading} from 'app/components/charts/styles';
-import DateTime from 'app/components/dateTime';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
-import QuestionTooltip from 'app/components/questionTooltip';
+import TimeSince from 'app/components/timeSince';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {OrganizationSummary} from 'app/types';
-import {Event, EventTransaction} from 'app/types/event';
+import {Event} from 'app/types/event';
 import {getShortEventId} from 'app/utils/events';
 import {getDuration} from 'app/utils/formatters';
-import getDynamicText from 'app/utils/getDynamicText';
 import Projects from 'app/utils/projects';
+
+import QuickTrace from './quickTrace';
+import {MetaData} from './styles';
+import {isTransaction} from './utils';
 
 type Props = {
   event: Event;
   organization: OrganizationSummary;
   projectId: string;
+  location: Location;
 };
 
-function EventMetas({event, organization, projectId}: Props) {
+function EventMetas({event, organization, projectId, location}: Props) {
   if (!isTransaction(event)) {
     return null;
   }
@@ -37,18 +40,13 @@ function EventMetas({event, organization, projectId}: Props) {
   );
 
   const timestamp = (
-    <DateTime
-      date={getDynamicText({
-        value: event.dateCreated || (event.endTimestamp || 0) * 1000,
-        fixed: 'Dummy timestamp',
-      })}
-    />
+    <TimeSince date={event.dateCreated || (event.endTimestamp || 0) * 1000} />
   );
 
   const httpStatus = <HttpStatus event={event} />;
 
   return (
-    <MetaDatasContainer>
+    <Container>
       <MetaData
         headingText={t('Event ID')}
         tooltipText={t('The unique ID assigned to this transaction.')}
@@ -71,9 +69,20 @@ function EventMetas({event, organization, projectId}: Props) {
         bodyText={event.contexts?.trace?.status ?? '\u2014'}
         subtext={httpStatus}
       />
-    </MetaDatasContainer>
+      <QuickTrace event={event} organization={organization} location={location} />
+    </Container>
   );
 }
+
+const Container = styled('div')`
+  display: grid;
+  grid-column-gap: ${space(2)};
+  grid-template-columns: repeat(3, 2fr);
+
+  @media (min-width: ${p => p.theme.breakpoints[2]}) {
+    grid-template-columns: repeat(3, 2fr) 5fr;
+  }
+`;
 
 function HttpStatus({event}: {event: Event}) {
   const {tags} = event;
@@ -92,55 +101,5 @@ function HttpStatus({event}: {event: Event}) {
 
   return <React.Fragment>HTTP {tag.value}</React.Fragment>;
 }
-
-function isTransaction(event: Event): event is EventTransaction {
-  return event.type === 'transaction';
-}
-
-const MetaDatasContainer = styled('div')`
-  display: grid;
-  grid-column-gap: ${space(2)};
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-`;
-
-type MetaDataProps = {
-  headingText: string;
-  tooltipText: string;
-  bodyText: string;
-  subtext: React.ReactNode;
-};
-
-function MetaData({headingText, tooltipText, bodyText, subtext}: MetaDataProps) {
-  return (
-    <div>
-      <StyledSectionHeading>
-        {headingText}
-        <QuestionTooltip
-          position="top"
-          size="sm"
-          containerDisplayMode="block"
-          title={tooltipText}
-        />
-      </StyledSectionHeading>
-      <SectionBody>{bodyText}</SectionBody>
-      <SectionSubtext>{subtext}</SectionSubtext>
-    </div>
-  );
-}
-
-const StyledSectionHeading = styled(SectionHeading)`
-  color: ${p => p.theme.textColor};
-`;
-
-const SectionBody = styled('p')`
-  color: ${p => p.theme.textColor};
-  font-size: ${p => p.theme.headerFontSize};
-  margin-bottom: ${space(1)};
-`;
-
-const SectionSubtext = styled('div')`
-  margin-bottom: ${space(3)};
-  color: ${p => p.theme.subText};
-`;
 
 export default EventMetas;

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import Placeholder from 'app/components/placeholder';
+import {t, tn} from 'app/locale';
+import {OrganizationSummary} from 'app/types';
+import {Event} from 'app/types/event';
+import {getShortEventId} from 'app/utils/events';
+
+import QuickTraceQuery, {TraceLite} from './quickTraceQuery';
+import {EventNode, MetaData, NodesContainer} from './styles';
+import {isTransaction, parseTraceLite} from './utils';
+
+type Props = {
+  event: Event;
+  organization: OrganizationSummary;
+  location: Location;
+};
+
+export default function QuickTrace({event, organization, location}: Props) {
+  // non transaction events are currently unsupported
+  if (!isTransaction(event)) {
+    return null;
+  }
+
+  const traceId = event.contexts?.trace?.trace_id ?? '';
+
+  return (
+    <QuickTraceQuery event={event} location={location} orgSlug={organization.slug}>
+      {({isLoading, error, trace}) => {
+        const body = isLoading ? (
+          <Placeholder height="33px" />
+        ) : error || trace === null ? (
+          '\u2014'
+        ) : (
+          <QuickTraceLite event={event} trace={trace} />
+        );
+
+        return (
+          <MetaData
+            headingText={t('Quick Trace')}
+            tooltipText={t('The unique ID assigned to this transaction.')}
+            bodyText={body}
+            subtext={t('Trace ID: %s', getShortEventId(traceId))}
+          />
+        );
+      }}
+    </QuickTraceQuery>
+  );
+}
+
+type QuickTraceLiteProps = {
+  event: Event;
+  trace: TraceLite;
+};
+
+function QuickTraceLite({event, trace}: QuickTraceLiteProps) {
+  const {root, current, children} = parseTraceLite(trace, event);
+  const nodes: React.ReactNode[] = [];
+
+  if (root) {
+    nodes.push(
+      <EventNode key="root" type="white">
+        {t('Root')}
+      </EventNode>
+    );
+  }
+
+  if (root && current && root.event_id !== current.parent_event_id) {
+    nodes.push(
+      <EventNode key="ancestors" type="white">
+        {t('Ancestors')}
+      </EventNode>
+    );
+  }
+
+  nodes.push(
+    <EventNode key="current" type="black">
+      {t('This Event')}
+    </EventNode>
+  );
+
+  if (children.length) {
+    nodes.push(
+      <EventNode key="children" type="white">
+        {tn('%s Child', '%s Children', children.length)}
+      </EventNode>
+    );
+    nodes.push(
+      <EventNode key="descendents" type="white">
+        {t('Descendents')}
+      </EventNode>
+    );
+  }
+
+  return (
+    <Container>
+      <NodesContainer>{nodes}</NodesContainer>
+    </Container>
+  );
+}
+
+const Container = styled('div')`
+  position: relative;
+  height: 33px;
+`;

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceQuery.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceQuery.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import omit from 'lodash/omit';
+
+import {Client} from 'app/api';
+import {getTraceDateTimeRange} from 'app/components/events/interfaces/spans/utils';
+import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
+import {Event, EventTransaction} from 'app/types/event';
+import EventView from 'app/utils/discover/eventView';
+import GenericDiscoverQuery, {
+  DiscoverQueryProps,
+  GenericChildrenProps,
+} from 'app/utils/discover/genericDiscoverQuery';
+import withApi from 'app/utils/withApi';
+
+import {isTransaction} from './utils';
+
+type TransactionLite = {
+  event_id: string;
+  span_id: string;
+  transaction: string;
+  project_id: number;
+  parent_event_id: string | null;
+  is_root: boolean;
+};
+
+export type TraceLite = TransactionLite[];
+
+type QuickTraceProps = {
+  event: Event;
+};
+
+type RequestProps = DiscoverQueryProps & QuickTraceProps;
+
+type ChildrenProps = Omit<GenericChildrenProps<QuickTraceProps>, 'tableData'> & {
+  trace: TraceLite | null;
+};
+
+type QueryProps = Omit<RequestProps, 'eventView'> & {
+  children: (props: ChildrenProps) => React.ReactNode;
+};
+
+function getQuickTraceRequestPayload({eventView, event, location}: RequestProps) {
+  const additionalApiPayload = omit(eventView.getEventsAPIPayload(location), [
+    'field',
+    'sort',
+    'per_page',
+  ]);
+  return Object.assign({event_id: event.id}, additionalApiPayload);
+}
+
+function beforeFetch(api: Client) {
+  api.clear();
+}
+
+function makeEventView(event: EventTransaction) {
+  // TODO: increase the time range here for a buffer around the start/end of
+  // the current transactions to find other transactions in the trace better
+  const {start, end} = getTraceDateTimeRange({
+    start: event.startTimestamp,
+    end: event.endTimestamp,
+  });
+
+  return EventView.fromSavedQuery({
+    id: undefined,
+    version: 2,
+    name: '',
+    // This field doesn't actually do anything,
+    // just here to satify a constraint in EventView.
+    fields: ['transaction.duration'],
+    projects: [ALL_ACCESS_PROJECTS],
+    query: '',
+    environment: [],
+    range: '',
+    start,
+    end,
+  });
+}
+
+function EmptyTrace({children}: Pick<QueryProps, 'children'>) {
+  return (
+    <React.Fragment>
+      {children({
+        isLoading: true,
+        error: null,
+        pageLinks: null,
+        trace: null,
+      })}
+    </React.Fragment>
+  );
+}
+
+function QuickTraceQuery({event, children, ...props}: QueryProps) {
+  // non transaction events are currently unsupported
+  if (!isTransaction(event)) {
+    return <EmptyTrace>{children}</EmptyTrace>;
+  }
+
+  const traceId = event.contexts?.trace?.trace_id;
+  if (!traceId) {
+    return <EmptyTrace>{children}</EmptyTrace>;
+  }
+
+  const eventView = makeEventView(event);
+
+  return (
+    <GenericDiscoverQuery<TraceLite, QuickTraceProps>
+      event={event}
+      route={`events-trace-light/${traceId}`}
+      getRequestPayload={getQuickTraceRequestPayload}
+      beforeFetch={beforeFetch}
+      eventView={eventView}
+      {...props}
+    >
+      {({tableData, ...rest}) => {
+        return children({trace: tableData, ...rest});
+      }}
+    </GenericDiscoverQuery>
+  );
+}
+
+export default withApi(QuickTraceQuery);

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceQuery.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceQuery.tsx
@@ -53,8 +53,6 @@ function beforeFetch(api: Client) {
 }
 
 function makeEventView(event: EventTransaction) {
-  // TODO: increase the time range here for a buffer around the start/end of
-  // the current transactions to find other transactions in the trace better
   const {start, end} = getTraceDateTimeRange({
     start: event.startTimestamp,
     end: event.endTimestamp,
@@ -111,9 +109,7 @@ function QuickTraceQuery({event, children, ...props}: QueryProps) {
       eventView={eventView}
       {...props}
     >
-      {({tableData, ...rest}) => {
-        return children({trace: tableData, ...rest});
-      }}
+      {({tableData, ...rest}) => children({trace: tableData ?? null, ...rest})}
     </GenericDiscoverQuery>
   );
 }

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {SectionHeading} from 'app/components/charts/styles';
+import QuestionTooltip from 'app/components/questionTooltip';
+import Tag, {Background, Text} from 'app/components/tag';
+import space from 'app/styles/space';
+import {Theme} from 'app/utils/theme';
+
+type MetaDataProps = {
+  headingText: string;
+  tooltipText: string;
+  bodyText: React.ReactNode;
+  subtext: React.ReactNode;
+};
+
+export function MetaData({headingText, tooltipText, bodyText, subtext}: MetaDataProps) {
+  return (
+    <Container>
+      <StyledSectionHeading>
+        {headingText}
+        <QuestionTooltip
+          position="top"
+          size="sm"
+          containerDisplayMode="block"
+          title={tooltipText}
+        />
+      </StyledSectionHeading>
+      <SectionBody>{bodyText}</SectionBody>
+      <SectionSubtext>{subtext}</SectionSubtext>
+    </Container>
+  );
+}
+
+const Container = styled('div')`
+  min-width: 150px;
+`;
+
+const StyledSectionHeading = styled(SectionHeading)`
+  color: ${p => p.theme.textColor};
+`;
+
+const SectionBody = styled('p')`
+  color: ${p => p.theme.textColor};
+  font-size: ${p => p.theme.headerFontSize};
+  margin-bottom: ${space(1)};
+`;
+
+const SectionSubtext = styled('div')`
+  color: ${p => p.theme.subText};
+`;
+
+export const NodesContainer = styled('div')`
+  position: absolute;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  height: 33px;
+  gap: ${space(1)};
+
+  &:before {
+    content: '';
+    border-bottom: 1px solid ${p => p.theme.gray500};
+    height: 33px;
+    position: absolute;
+    width: 100%;
+    transform: translateY(-50%);
+    z-index: ${p => p.theme.zIndex.initial};
+  }
+`;
+
+export const EventNode = styled(Tag)<{type: keyof Theme['tag']}>`
+  z-index: ${p => p.theme.zIndex.initial};
+
+  & ${/* sc-selector */ Background} {
+    border: 1px solid ${p => p.theme.gray500};
+    height: 24px;
+  }
+
+  & ${/* sc-selector */ Text} {
+    color: ${p => (p.type === 'black' ? p.theme.white : p.theme.gray500)};
+  }
+`;

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import {SectionHeading} from 'app/components/charts/styles';
 import QuestionTooltip from 'app/components/questionTooltip';
-import Tag, {Background, Text} from 'app/components/tag';
+import Tag, {Background} from 'app/components/tag';
 import space from 'app/styles/space';
 import {Theme} from 'app/utils/theme';
 
@@ -75,9 +75,6 @@ export const EventNode = styled(Tag)<{type: keyof Theme['tag']}>`
   & ${/* sc-selector */ Background} {
     border: 1px solid ${p => p.theme.gray500};
     height: 24px;
-  }
-
-  & ${/* sc-selector */ Text} {
-    color: ${p => (p.type === 'black' ? p.theme.white : p.theme.gray500)};
+    border-radius: 24px;
   }
 `;

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/utils.tsx
@@ -1,0 +1,18 @@
+import {Event, EventTransaction} from 'app/types/event';
+
+import {TraceLite} from './quickTraceQuery';
+
+export function isTransaction(event: Event): event is EventTransaction {
+  return event.type === 'transaction';
+}
+
+export function parseTraceLite(trace: TraceLite, event: Event) {
+  const root = trace.find(e => e.is_root && e.event_id !== event.id) ?? null;
+  const current = trace.find(e => e.event_id === event.id) ?? null;
+  const children = trace.filter(e => e.parent_event_id === event.id);
+  return {
+    root,
+    current,
+    children,
+  };
+}


### PR DESCRIPTION
This change adds the quick trace pills to the transaction details page. The quick trace will show if there is a root event in the trace, the current event, and if there are any ancestors or children.

These pills are currently not interactable but will be addressed in an upcoming change. Additionally, we have no way of knowing how many ancestors/descendants there are today. We only have guarantees (to some degree) that there will be a root event, the current event, and some (perhaps all) direct children.

# Screenshot

![image](https://user-images.githubusercontent.com/10239353/107584386-59421180-6bca-11eb-8106-f5360b78d8df.png)
