### PR TITLE
fix(ui): Reset issue stream manager between queries

### DIFF
--- a/src/sentry/static/sentry/app/utils/streamManager.tsx
+++ b/src/sentry/static/sentry/app/utils/streamManager.tsx
@@ -23,6 +23,10 @@ class StreamManager {
     this.limit = options.limit || 100;
   }
 
+  reset() {
+    this.idList = [];
+  }
+
   trim() {
     if (this.limit > this.idList.length) {
       return;

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -494,6 +494,7 @@ class IssueListOverview extends React.Component<Props, State> {
 
   fetchData = (selectionChanged?: boolean) => {
     GroupStore.loadInitialData([]);
+    this._streamManager.reset();
 
     this.setState({
       issuesLoading: true,


### PR DESCRIPTION
Fixes an issue with items being out of order when stream manager push preserves ids that are shared between two queries.