### PR TITLE
fix(tests): Fix flaky test_assigned_me_or_none test

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -693,7 +693,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         for i in range(5):
             group = self.store_event(
                 data={
-                    "timestamp": iso_format(before_now(days=i)),
+                    "timestamp": iso_format(before_now(minutes=10, days=i)),
                     "fingerprint": [f"group-{i}"],
                 },
                 project_id=self.project.id,


### PR DESCRIPTION
This test is flaky because one of the events ends up not being created before the current
time. Just making sure all events are created a few mins beforehand