### PR TITLE
feat(alerts): Add timeline view to alert rule details

### DIFF
--- a/src/sentry/static/sentry/app/icons/iconEllipse.tsx
+++ b/src/sentry/static/sentry/app/icons/iconEllipse.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import SvgIcon from './svgIcon';
+
+type Props = React.ComponentProps<typeof SvgIcon>;
+
+const IconEllipse = React.forwardRef(function IconEllipse(
+  props: Props,
+  ref: React.Ref<SVGSVGElement>
+) {
+  return (
+    <SvgIcon {...props} ref={ref}>
+      <circle cx="8" cy="8" r="4" />
+    </SvgIcon>
+  );
+});
+
+IconEllipse.displayName = 'IconEllipse';
+
+export {IconEllipse};

--- a/src/sentry/static/sentry/app/icons/index.tsx
+++ b/src/sentry/static/sentry/app/icons/index.tsx
@@ -25,6 +25,7 @@ export {IconDelete} from './iconDelete';
 export {IconDocs} from './iconDocs';
 export {IconDownload} from './iconDownload';
 export {IconEdit} from './iconEdit';
+export {IconEllipse} from './iconEllipse';
 export {IconEllipsis} from './iconEllipsis';
 export {IconEvent} from './iconEvent';
 export {IconFile} from './iconFile';

--- a/src/sentry/static/sentry/app/views/alerts/details/activity/statusItem.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/activity/statusItem.tsx
@@ -104,7 +104,7 @@ const StatusValue = styled('span')`
   font-weight: bold;
 `;
 
-function getTriggerName(value: string | null) {
+export function getTriggerName(value: string | null) {
   if (value === `${IncidentStatus.WARNING}`) {
     return t('Warning');
   }

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -31,7 +31,7 @@ import {
   IncidentStatus,
   IncidentStatusMethod,
 } from '../types';
-import {DATA_SOURCE_LABELS, getIncidentMetricPreset} from '../utils';
+import {DATA_SOURCE_LABELS, getIncidentMetricPreset, isIssueAlert} from '../utils';
 
 import Activity from './activity';
 import Chart from './chart';
@@ -212,7 +212,10 @@ export default class DetailsBody extends React.Component<Props> {
   render() {
     const {params, incident, organization, stats} = this.props;
 
-    const hasRedesign = organization.features.includes('alert-details-redesign');
+    const hasRedesign =
+      incident?.alertRule &&
+      !isIssueAlert(incident?.alertRule) &&
+      organization.features.includes('alert-details-redesign');
     const alertRuleLink = hasRedesign
       ? `/organizations/${organization.slug}/alerts/rules/details/${incident?.alertRule?.id}/`
       : `/organizations/${params.orgId}/alerts/metric-rules/${incident?.projects[0]}/${incident?.alertRule?.id}/`;

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -16,7 +16,7 @@ import {IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
 import space from 'app/styles/space';
-import {Project} from 'app/types';
+import {Organization, Project} from 'app/types';
 import {defined} from 'app/utils';
 import Projects from 'app/utils/projects';
 import theme from 'app/utils/theme';
@@ -38,6 +38,7 @@ import Chart from './chart';
 
 type Props = {
   incident?: Incident;
+  organization: Organization;
   stats?: IncidentStats;
 } & RouteComponentProps<{alertId: string; orgId: string}, {}>;
 
@@ -209,7 +210,12 @@ export default class DetailsBody extends React.Component<Props> {
   }
 
   render() {
-    const {params, incident, stats} = this.props;
+    const {params, incident, organization, stats} = this.props;
+
+    const hasRedesign = organization.features.includes('alert-details-redesign');
+    const alertRuleLink = hasRedesign
+      ? `/organizations/${organization.slug}/alerts/rules/details/${incident?.alertRule?.id}/`
+      : `/organizations/${params.orgId}/alerts/metric-rules/${incident?.projects[0]}/${incident?.alertRule?.id}/`;
 
     return (
       <StyledPageContent>
@@ -271,13 +277,14 @@ export default class DetailsBody extends React.Component<Props> {
             <Sidebar>
               <SidebarHeading>
                 <span>{t('Alert Rule')}</span>
-                {incident?.alertRule?.status !== AlertRuleStatus.SNAPSHOT && (
+                {(incident?.alertRule?.status !== AlertRuleStatus.SNAPSHOT ||
+                  hasRedesign) && (
                   <SideHeaderLink
                     disabled={!!incident?.id}
                     to={
                       incident?.id
                         ? {
-                            pathname: `/organizations/${params.orgId}/alerts/metric-rules/${incident?.projects[0]}/${incident?.alertRule?.id}/`,
+                            pathname: alertRuleLink,
                           }
                         : ''
                     }

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -26,6 +26,7 @@ import {defined} from 'app/utils';
 import {getUtcDateString} from 'app/utils/dates';
 import Projects from 'app/utils/projects';
 import {Theme} from 'app/utils/theme';
+import Timeline from 'app/views/alerts/rules/details/timeline';
 import {DATASET_EVENT_TYPE_FILTERS} from 'app/views/settings/incidentRules/constants';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {
@@ -439,6 +440,7 @@ class DetailsBody extends React.Component<Props> {
                         filter={DATASET_EVENT_TYPE_FILTERS[rule.dataset]}
                       />
                     )}
+                    <Timeline api={api} orgId={orgId} rule={rule} incidents={incidents} />
                   </ActivityWrapper>
                 </DetailWrapper>
               </Layout.Main>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
@@ -76,7 +76,7 @@ class TimelineIncident extends React.Component<IncidentProps, IncidentState> {
     }
   }
 
-  renderActivity(activity: ActivityType, idx) {
+  renderActivity(activity: ActivityType, idx: number) {
     const {incident, rule} = this.props;
     const {activities} = this.state;
     const last = this.state.activities && idx === this.state.activities.length - 1;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
@@ -198,23 +198,21 @@ class TimelineIncident extends React.Component<IncidentProps, IncidentState> {
     let color: string = theme.green300;
 
     if (
-      activities &&
-      activities.find(
-        activity =>
-          activity.type === IncidentActivityType.DETECTED ||
-          (activity.type === IncidentActivityType.STATUS_CHANGE &&
-            activity.value === `${IncidentStatus.CRITICAL}`)
+      activities?.find(
+        ({type, value}) =>
+          type === IncidentActivityType.DETECTED ||
+          (type === IncidentActivityType.STATUS_CHANGE &&
+            value === `${IncidentStatus.CRITICAL}`)
       )
     ) {
       Icon = IconFire;
       color = theme.red300;
     } else if (
-      activities &&
-      activities.find(
-        activity =>
-          activity.type === IncidentActivityType.STARTED ||
-          (activity.type === IncidentActivityType.STATUS_CHANGE &&
-            activity.value === `${IncidentStatus.CRITICAL}`)
+      activities?.find(
+        ({type, value}) =>
+          type === IncidentActivityType.STARTED ||
+          (type === IncidentActivityType.STATUS_CHANGE &&
+            value === `${IncidentStatus.CRITICAL}`)
       )
     ) {
       Icon = IconWarning;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
@@ -369,7 +369,7 @@ const ActivityTime = styled('li')`
   align-items: center;
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeSmall};
-  margin-bottom: ${space(1)};
+  margin-bottom: ${space(0.75)};
 `;
 
 const StyledTimeSince = styled(TimeSince)`
@@ -377,13 +377,15 @@ const StyledTimeSince = styled(TimeSince)`
 `;
 
 const ActivityText = styled('div')`
-  margin-bottom: ${space(2)};
+  flex-direction: row;
+  margin-bottom: ${space(1.5)};
 `;
 
-const ActivitySubText = styled('div')`
-  display: flex;
+const ActivitySubText = styled('span')`
+  display: inline-block;
   color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
+  margin-left: ${space(0.5)};
 `;
 
 const HorizontalDivider = styled('div')`

--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -47,7 +47,8 @@ class RuleListRow extends React.Component<Props, State> {
       isIssueAlert(rule) ? 'rules' : 'metric-rules'
     }/${slug}/${rule.id}/`;
 
-    const hasRedesign = organization.features.includes('alert-details-redesign');
+    const hasRedesign =
+      !isIssueAlert(rule) && organization.features.includes('alert-details-redesign');
     const detailsLink = `/organizations/${orgId}/alerts/rules/details/${rule.id}/`;
 
     return (


### PR DESCRIPTION
This adds a timeline of incidents to the alert rule details page.
Currently all incidents are shown in the timeline but they might be limited by the chart window as well in the future.
Also will need to include `seenBy` results in the incidents query.

[Jira - WOR-595](https://getsentry.atlassian.net/browse/WOR-595)
[Design](https://www.figma.com/file/9bqoJ1hNQZWudZUNjf72qe/Handover%3A-Metric-Alerts-Detail?node-id=27%3A10)

Multiple Incidents:
![Screen Shot 2021-02-11 at 2 38 41 AM](https://user-images.githubusercontent.com/15015880/107628144-13f70180-6c15-11eb-879f-e31e5ced3461.png)

Random Incident with weird activity:
![Screen Shot 2021-02-11 at 2 36 42 AM](https://user-images.githubusercontent.com/15015880/107628185-21ac8700-6c15-11eb-99a9-93515764689a.png)
