### PR TITLE
feat(ui): Sort teams alphabetically on project detail page

### DIFF
--- a/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
@@ -91,6 +91,11 @@ class ProjectCharts extends React.Component<Props, State> {
 
     return [
       {
+        value: DisplayModes.STABILITY,
+        label: t('Crash Free Sessions'),
+        disabled: this.otherActiveDisplayModes.includes(DisplayModes.STABILITY),
+      },
+      {
         value: DisplayModes.APDEX,
         label: t('Apdex'),
         disabled:
@@ -132,11 +137,6 @@ class ProjectCharts extends React.Component<Props, State> {
           this.otherActiveDisplayModes.includes(DisplayModes.TRANSACTIONS) ||
           !hasPerformance,
         tooltip: hasPerformance ? undefined : noPerformanceTooltip,
-      },
-      {
-        value: DisplayModes.STABILITY,
-        label: t('Crash Free Sessions'),
-        disabled: this.otherActiveDisplayModes.includes(DisplayModes.STABILITY),
       },
     ];
   }

--- a/src/sentry/static/sentry/app/views/projectDetail/projectTeamAccess.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectTeamAccess.tsx
@@ -56,14 +56,16 @@ function ProjectTeamAccess({organization, project}: Props) {
           </Button>
         )}
       >
-        {project.teams.map(team => (
-          <StyledLink
-            to={`/settings/${organization.slug}/teams/${team.slug}/`}
-            key={team.slug}
-          >
-            <IdBadge team={team} hideAvatar />
-          </StyledLink>
-        ))}
+        {project.teams
+          .sort((a, b) => a.slug.localeCompare(b.slug))
+          .map(team => (
+            <StyledLink
+              to={`/settings/${organization.slug}/teams/${team.slug}/`}
+              key={team.slug}
+            >
+              <IdBadge team={team} hideAvatar />
+            </StyledLink>
+          ))}
       </Collapsible>
     );
   }

--- a/tests/js/spec/views/projectDetail/projectTeamAccess.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectTeamAccess.spec.jsx
@@ -85,4 +85,24 @@ describe('ProjectDetail > ProjectTeamAccess', function () {
     wrapper.find('button[aria-label="Collapse"]').simulate('click');
     expect(wrapper.find('IdBadge').length).toBe(5);
   });
+
+  it('sorts teams alphabetically', function () {
+    const wrapper = mountWithTheme(
+      <ProjectTeamAccess
+        organization={organization}
+        project={TestStubs.Project({
+          teams: [
+            TestStubs.Team({slug: 'c'}),
+            TestStubs.Team({slug: 'z'}),
+            TestStubs.Team({slug: 'a'}),
+          ],
+        })}
+      />,
+      routerContext
+    );
+
+    expect(wrapper.find('IdBadge').at(0).text()).toBe('#a');
+    expect(wrapper.find('IdBadge').at(1).text()).toBe('#c');
+    expect(wrapper.find('IdBadge').at(2).text()).toBe('#z');
+  });
 });


### PR DESCRIPTION
Sort teams on the project detail page alphabetically.

I also moved the "Crash free sessions" chart display option to the top as it's the first chart preselected by default.