### PR TITLE
fix(copy): changed alerts setting copy

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.tsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.tsx
@@ -72,7 +72,7 @@ const formGroups: JsonFormObject[] = [
       {
         name: 'alertsMemberWrite',
         type: 'boolean',
-        label: t('Grant Members Alerts Write'),
+        label: t('Let Members Create and Edit Alerts'),
         help: t(
           'Allow members to create, edit, and delete alert rules by granting them the `alerts:write` scope.'
         ),


### PR DESCRIPTION
### Before: clunky, hard to read

<img width="594" alt="Screen Shot 2021-02-11 at 9 41 31 AM" src="https://user-images.githubusercontent.com/1900676/107676048-96031c80-6c4d-11eb-9596-56a435be9b80.png">

### After: beautiful, poetic
<img width="627" alt="Screen Shot 2021-02-11 at 9 41 46 AM" src="https://user-images.githubusercontent.com/1900676/107687137-f6e52180-6c5a-11eb-89ca-49529a8baf61.png">


