### PR TITLE
fix(ui) Normalize OptionSelector item height

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
+++ b/src/sentry/static/sentry/app/components/charts/optionSelector.tsx
@@ -123,6 +123,7 @@ const StyledDropdownBubble = styled(DropdownBubble)<{
 `;
 
 const StyledDropdownItem = styled(DropdownItem)`
+  line-height: ${p => p.theme.text.lineHeightBody};
   white-space: nowrap;
 `;
 


### PR DESCRIPTION
The `SettingsLayout` page sets `line-height:1` which makes the dropdown items too small. With this change the dropdown items are sized consistently.