### PR TITLE
fix: Set overflow: hidden to the Dashboard widget

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -170,6 +170,7 @@ const StyledPanel = styled(Panel, {
   /* If a panel overflows due to a long title stretch its grid sibling */
   height: 100%;
   min-height: 96px;
+  overflow: hidden;
 `;
 
 const ToolbarPanel = styled('div')`


### PR DESCRIPTION
This ensures that widget content isn't clipping outside of its borders, especially at the corners. 