### PR TITLE
feat(perf): Add links to quick trace pills

### DIFF
--- a/src/sentry/static/sentry/app/components/tag.tsx
+++ b/src/sentry/static/sentry/app/components/tag.tsx
@@ -139,7 +139,7 @@ const IconWrapper = styled('span')`
   display: inline-flex;
 `;
 
-export const Text = styled('span')<{maxWidth: number; type: keyof Theme['tag']}>`
+const Text = styled('span')<{maxWidth: number; type: keyof Theme['tag']}>`
   color: ${p => (p.type === 'black' ? p.theme.white : p.theme.gray500)};
   max-width: ${p => p.maxWidth}px;
   overflow: hidden;

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceQuery.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceQuery.tsx
@@ -14,7 +14,7 @@ import withApi from 'app/utils/withApi';
 
 import {isTransaction} from './utils';
 
-type TransactionLite = {
+export type EventLite = {
   event_id: string;
   span_id: string;
   transaction: string;
@@ -23,7 +23,7 @@ type TransactionLite = {
   is_root: boolean;
 };
 
-export type TraceLite = TransactionLite[];
+export type TraceLite = EventLite[];
 
 type QuickTraceProps = {
   event: Event;


### PR DESCRIPTION
The quick trace pills should link to the corresponding event when possible and link to a discover query otherwise. This change adds this interaction.

- The `Root` pill will link to the span details of the root transaction
- The `Ancestors` pill will link to a discover query containing all the transactions in the trace
- The `This Event` pill has no additional interactions
- The `1 Child` pill will link to the span details of the only direct child
- The `X Children` pill will link to a discover query containing all the child transactions in the trace
- The `Descendants` pill will link to a discover query containing all the transactions in the trace