### PR TITLE
fix: Enable backdrop option for Discover column editor modal. 

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
@@ -55,7 +55,15 @@ class ColumnEditModal extends React.Component<Props, State> {
   };
 
   render() {
-    const {Header, Body, Footer, tagKeys, measurementKeys, organization} = this.props;
+    const {
+      Header,
+      Body,
+      Footer,
+      tagKeys,
+      measurementKeys,
+      organization,
+      closeModal,
+    } = this.props;
     const fieldOptions = generateFieldOptions({
       organization,
       tagKeys,
@@ -63,7 +71,7 @@ class ColumnEditModal extends React.Component<Props, State> {
     });
     return (
       <React.Fragment>
-        <Header>
+        <Header closeButton onHide={closeModal}>
           <h4>{t('Edit Columns')}</h4>
         </Header>
         <Body>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -265,7 +265,7 @@ class TableView extends React.Component<TableViewProps> {
           onApply={this.handleUpdateColumns}
         />
       ),
-      {modalCss}
+      {modalCss, backdrop: 'static'}
     );
   };
 


### PR DESCRIPTION
Enable backdrop option for Discover column editor modal. This is to prevent accidental dismissal of the modal.

I also added a close button on the top right-hand corner of the modal so that users can dismiss the modal without applying changes.

Option based on https://getbootstrap.com/docs/3.4/javascript/#modals-options

<img width="809" alt="Screen Shot 2021-02-11 at 4 50 58 PM" src="https://user-images.githubusercontent.com/139499/107703333-7f7ab680-6c89-11eb-9a70-9a1c5ff1328f.png">


