### PR TITLE
feat(ui): allow setting a default category for project creation

### DIFF
--- a/src/sentry/static/sentry/app/components/platformPicker.tsx
+++ b/src/sentry/static/sentry/app/components/platformPicker.tsx
@@ -20,6 +20,8 @@ import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
 const PLATFORM_CATEGORIES = [...categoryList, {id: 'all', name: t('All')}] as const;
 
+type Category = typeof PLATFORM_CATEGORIES[number]['id'];
+
 type Props = {
   setPlatform: (key: PlatformKey | null) => void;
   platform?: string | null;
@@ -27,10 +29,11 @@ type Props = {
   listClassName?: string;
   listProps?: React.HTMLProps<HTMLDivElement>;
   noAutoFilter?: boolean;
+  category?: Category;
 };
 
 type State = {
-  category: typeof PLATFORM_CATEGORIES[number]['id'];
+  category: Category;
   filter: string;
 };
 
@@ -40,7 +43,7 @@ class PlatformPicker extends React.Component<Props, State> {
   };
 
   state: State = {
-    category: PLATFORM_CATEGORIES[0].id,
+    category: this.props.category ?? PLATFORM_CATEGORIES[0].id,
     filter: this.props.noAutoFilter ? '' : (this.props.platform || '').split('-')[0],
   };
 

--- a/src/sentry/static/sentry/app/components/platformPicker.tsx
+++ b/src/sentry/static/sentry/app/components/platformPicker.tsx
@@ -29,7 +29,7 @@ type Props = {
   listClassName?: string;
   listProps?: React.HTMLProps<HTMLDivElement>;
   noAutoFilter?: boolean;
-  category?: Category;
+  defaultCategory?: Category;
 };
 
 type State = {
@@ -43,7 +43,7 @@ class PlatformPicker extends React.Component<Props, State> {
   };
 
   state: State = {
-    category: this.props.category ?? PLATFORM_CATEGORIES[0].id,
+    category: this.props.defaultCategory ?? PLATFORM_CATEGORIES[0].id,
     filter: this.props.noAutoFilter ? '' : (this.props.platform || '').split('-')[0],
   };
 

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.tsx
@@ -28,10 +28,8 @@ import withOrganization from 'app/utils/withOrganization';
 import withTeams from 'app/utils/withTeams';
 import IssueAlertOptions from 'app/views/projectInstall/issueAlertOptions';
 
-const getCategoryName = (category?: string) => {
-  const matched = categoryList.find(({id}) => id === category);
-  return matched?.id;
-};
+const getCategoryName = (category?: string) =>
+  categoryList.find(({id}) => id === category)?.id;
 
 type RuleEventData = {
   eventKey: string;

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.tsx
@@ -13,6 +13,7 @@ import SelectControl from 'app/components/forms/selectControl';
 import PageHeading from 'app/components/pageHeading';
 import PlatformPicker from 'app/components/platformPicker';
 import Tooltip from 'app/components/tooltip';
+import categoryList from 'app/data/platformCategories';
 import {IconAdd} from 'app/icons';
 import {t} from 'app/locale';
 import {inputStyles} from 'app/styles/input';
@@ -26,6 +27,11 @@ import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
 import withTeams from 'app/utils/withTeams';
 import IssueAlertOptions from 'app/views/projectInstall/issueAlertOptions';
+
+const getCategoryName = (category?: string) => {
+  const matched = categoryList.find(({id}) => id === category);
+  return matched?.id;
+};
 
 type RuleEventData = {
   eventKey: string;
@@ -54,6 +60,7 @@ type State = {
   platform: PlatformName | null;
   inFlight: boolean;
   dataFragment: IssueAlertFragment | undefined;
+  category: ReturnType<typeof getCategoryName>;
 };
 
 class CreateProject extends React.Component<Props, State> {
@@ -70,12 +77,14 @@ class CreateProject extends React.Component<Props, State> {
 
     const team = query.team || (accessTeams.length && accessTeams[0].slug);
     const platform = getPlatformName(query.platform) ? query.platform : '';
+    const category = getCategoryName(query.category);
 
     this.state = {
       error: false,
       projectName: getPlatformName(platform) || '',
       team,
       platform,
+      category,
       inFlight: false,
       dataFragment: undefined,
     };
@@ -285,7 +294,7 @@ class CreateProject extends React.Component<Props, State> {
     }));
 
   render() {
-    const {platform, error} = this.state;
+    const {platform, category, error} = this.state;
 
     return (
       <React.Fragment>
@@ -301,7 +310,12 @@ class CreateProject extends React.Component<Props, State> {
             )}
           </HelpText>
           <PageHeading withMargins>{t('Choose a platform')}</PageHeading>
-          <PlatformPicker platform={platform} setPlatform={this.setPlatform} showOther />
+          <PlatformPicker
+            platform={platform}
+            category={category}
+            setPlatform={this.setPlatform}
+            showOther
+          />
           <IssueAlertOptions
             onChange={updatedData => {
               this.setState({dataFragment: updatedData});

--- a/src/sentry/static/sentry/app/views/projectInstall/createProject.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/createProject.tsx
@@ -60,7 +60,6 @@ type State = {
   platform: PlatformName | null;
   inFlight: boolean;
   dataFragment: IssueAlertFragment | undefined;
-  category: ReturnType<typeof getCategoryName>;
 };
 
 class CreateProject extends React.Component<Props, State> {
@@ -77,17 +76,20 @@ class CreateProject extends React.Component<Props, State> {
 
     const team = query.team || (accessTeams.length && accessTeams[0].slug);
     const platform = getPlatformName(query.platform) ? query.platform : '';
-    const category = getCategoryName(query.category);
 
     this.state = {
       error: false,
       projectName: getPlatformName(platform) || '',
       team,
       platform,
-      category,
       inFlight: false,
       dataFragment: undefined,
     };
+  }
+
+  get defaultCategory() {
+    const {query} = this.context.location;
+    return getCategoryName(query.category);
   }
 
   renderProjectForm() {
@@ -294,7 +296,7 @@ class CreateProject extends React.Component<Props, State> {
     }));
 
   render() {
-    const {platform, category, error} = this.state;
+    const {platform, error} = this.state;
 
     return (
       <React.Fragment>
@@ -312,7 +314,7 @@ class CreateProject extends React.Component<Props, State> {
           <PageHeading withMargins>{t('Choose a platform')}</PageHeading>
           <PlatformPicker
             platform={platform}
-            category={category}
+            defaultCategory={this.defaultCategory}
             setPlatform={this.setPlatform}
             showOther
           />

--- a/tests/js/spec/views/projectInstall/createProject.spec.jsx
+++ b/tests/js/spec/views/projectInstall/createProject.spec.jsx
@@ -125,6 +125,28 @@ describe('CreateProject', function () {
     expect(wrapper).toSnapshot();
   });
 
+  it('should fill in category name if its provided by url', function () {
+    const props = {
+      ...baseProps,
+    };
+
+    const wrapper = mountWithTheme(
+      <CreateProject {...props} />,
+      TestStubs.routerContext([
+        {
+          organization: {
+            id: '1',
+            slug: 'testOrg',
+            teams: [{slug: 'test', id: '1', name: 'test', hasAccess: true}],
+          },
+          location: {query: {category: 'mobile'}},
+        },
+      ])
+    );
+
+    expect(wrapper.find('PlatformPicker').state('category')).toBe('mobile');
+  });
+
   it('should deal with incorrect platform name if its provided by url', function () {
     const props = {
       ...baseProps,


### PR DESCRIPTION
We are going to be launching a program to get users to create mobile projects. To streamline the process, it would be helpful if we could add a query parameter on the project creation page to set the initial category to show.

Will add unit tests once I get confirmation this strategy is OK.