### PR TITLE
ref(ui) Move chart title components

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/styles.tsx
+++ b/src/sentry/static/sentry/app/components/charts/styles.tsx
@@ -49,3 +49,26 @@ export const InlineContainer = styled('div')`
     margin-right: 0;
   }
 `;
+
+// Header element for charts within panels.
+export const HeaderTitle = styled('div')`
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-gap: ${space(1)};
+  font-size: ${p => p.theme.fontSizeLarge};
+  color: ${p => p.theme.textColor};
+  align-items: center;
+`;
+
+// Header element for charts within panels
+// This header can be rendered while the chart is still loading
+export const HeaderTitleLegend = styled(HeaderTitle)`
+  background-color: ${p => p.theme.background};
+  border-bottom-right-radius: ${p => p.theme.borderRadius};
+  position: absolute;
+  z-index: 1;
+`;
+
+export const ChartContainer = styled('div')`
+  padding: ${space(2)} ${space(3)};
+`;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -6,6 +6,7 @@ import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 
 import {Client} from 'app/api';
+import {HeaderTitle} from 'app/components/charts/styles';
 import ErrorBoundary from 'app/components/errorBoundary';
 import {isSelectionEqual} from 'app/components/organizations/globalSelectionHeader/utils';
 import {Panel} from 'app/components/panels';
@@ -17,8 +18,6 @@ import {GlobalSelection, Organization} from 'app/types';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
-
-import {HeaderTitle} from '../performance/styles';
 
 import {Widget} from './types';
 import WidgetCardChart from './widgetCardChart';

--- a/src/sentry/static/sentry/app/views/performance/charts/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/charts/index.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 import {Client} from 'app/api';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import LoadingPanel from 'app/components/charts/loadingPanel';
+import {HeaderTitle} from 'app/components/charts/styles';
 import {getInterval} from 'app/components/charts/utils';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel} from 'app/components/panels';
@@ -18,7 +19,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import withApi from 'app/utils/withApi';
 
 import {getAxisOptions} from '../data';
-import {DoubleHeaderContainer, ErrorPanel, HeaderTitle} from '../styles';
+import {DoubleHeaderContainer, ErrorPanel} from '../styles';
 
 import Chart from './chart';
 import Footer from './footer';

--- a/src/sentry/static/sentry/app/views/performance/landing/chart/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/chart/durationChart.tsx
@@ -7,6 +7,7 @@ import {Location} from 'history';
 import {Client} from 'app/api';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getInterval} from 'app/components/charts/utils';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
@@ -21,7 +22,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import withApi from 'app/utils/withApi';
 
 import Chart from '../../charts/chart';
-import {DoubleHeaderContainer, HeaderTitleLegend} from '../../styles';
+import {DoubleHeaderContainer} from '../../styles';
 
 type Props = {
   api: Client;

--- a/src/sentry/static/sentry/app/views/performance/landing/chart/histogramChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/chart/histogramChart.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 import BarChart from 'app/components/charts/barChart';
 import BarChartZoom from 'app/components/charts/barChartZoom';
 import ErrorPanel from 'app/components/charts/errorPanel';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import Placeholder from 'app/components/placeholder';
 import QuestionTooltip from 'app/components/questionTooltip';
@@ -18,7 +19,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import theme from 'app/utils/theme';
 
 import {computeBuckets, formatHistogramData} from '../../charts/utils';
-import {DoubleHeaderContainer, HeaderTitleLegend} from '../../styles';
+import {DoubleHeaderContainer} from '../../styles';
 import HistogramQuery from '../../transactionVitals/histogramQuery';
 
 const NUM_BUCKETS = 50;

--- a/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/vitalsCards.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 import {Client} from 'app/api';
 import Card from 'app/components/card';
 import EventsRequest from 'app/components/charts/eventsRequest';
+import {HeaderTitle} from 'app/components/charts/styles';
 import {getInterval} from 'app/components/charts/utils';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import Link from 'app/components/links/link';
@@ -29,7 +30,6 @@ import VitalsCardsDiscoverQuery, {
   VitalsData,
 } from 'app/views/performance/vitalDetail/vitalsCardsDiscoverQuery';
 
-import {HeaderTitle} from '../styles';
 import ColorBar from '../vitalDetail/colorBar';
 import {
   vitalAbbreviations,

--- a/src/sentry/static/sentry/app/views/performance/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/styles.tsx
@@ -17,26 +17,6 @@ export const DoubleHeaderContainer = styled('div')`
   grid-gap: ${space(3)};
 `;
 
-export const HeaderTitle = styled('div')`
-  display: inline-grid;
-  grid-auto-flow: column;
-  grid-gap: ${space(1)};
-  font-size: ${p => p.theme.fontSizeLarge};
-  color: ${p => p.theme.textColor};
-  align-items: center;
-`;
-
-export const HeaderTitleLegend = styled(HeaderTitle)`
-  background-color: ${p => p.theme.background};
-  border-bottom-right-radius: ${p => p.theme.borderRadius};
-  position: absolute;
-  z-index: 1;
-`;
-
-export const ChartContainer = styled('div')`
-  padding: ${space(2)} ${space(3)};
-`;
-
 export const ErrorPanel = styled('div')`
   display: flex;
   justify-content: center;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
@@ -4,6 +4,7 @@ import {Location} from 'history';
 
 import OptionSelector from 'app/components/charts/optionSelector';
 import {
+  ChartContainer,
   ChartControls,
   InlineContainer,
   SectionHeading,
@@ -17,7 +18,6 @@ import {decodeScalar} from 'app/utils/queryString';
 import {TransactionsListOption} from 'app/views/releases/detail/overview';
 import {YAxis} from 'app/views/releases/detail/overview/chart/releaseChartControls';
 
-import {ChartContainer} from '../styles';
 import {TrendColumnField, TrendFunctionField} from '../trends/types';
 import {
   generateTrendFunctionAsString,

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -9,6 +9,7 @@ import ChartZoom from 'app/components/charts/chartZoom';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getInterval, getSeriesSelection} from 'app/components/charts/utils';
@@ -24,8 +25,6 @@ import getDynamicText from 'app/utils/getDynamicText';
 import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
-
-import {HeaderTitleLegend} from '../styles';
 
 const QUERY_KEYS = [
   'environment',

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
@@ -7,6 +7,7 @@ import AsyncComponent from 'app/components/asyncComponent';
 import AreaChart from 'app/components/charts/areaChart';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LoadingPanel from 'app/components/charts/loadingPanel';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
@@ -15,8 +16,6 @@ import {axisLabelFormatter} from 'app/utils/discover/charts';
 import EventView from 'app/utils/discover/eventView';
 import {getDuration} from 'app/utils/formatters';
 import theme from 'app/utils/theme';
-
-import {HeaderTitleLegend} from '../styles';
 
 const QUERY_KEYS = [
   'environment',

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
@@ -5,6 +5,7 @@ import BarChart from 'app/components/charts/barChart';
 import BarChartZoom from 'app/components/charts/barChartZoom';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LoadingPanel from 'app/components/charts/loadingPanel';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
@@ -15,7 +16,6 @@ import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 
 import {computeBuckets, formatHistogramData} from '../charts/utils';
-import {HeaderTitleLegend} from '../styles';
 import HistogramQuery from '../transactionVitals/histogramQuery';
 import {HistogramData} from '../transactionVitals/types';
 

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/trendChart.tsx
@@ -9,6 +9,7 @@ import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import LineChart from 'app/components/charts/lineChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getInterval, getSeriesSelection} from 'app/components/charts/utils';
@@ -25,7 +26,6 @@ import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 
-import {HeaderTitleLegend} from '../styles';
 import {transformEventStatsSmoothed} from '../trends/utils';
 
 const QUERY_KEYS = [

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/vitalsChart.tsx
@@ -9,6 +9,7 @@ import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import LineChart from 'app/components/charts/lineChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getInterval, getSeriesSelection} from 'app/components/charts/utils';
@@ -26,8 +27,6 @@ import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 import {TransactionsListOption} from 'app/views/releases/detail/overview';
-
-import {HeaderTitleLegend} from '../styles';
 
 const QUERY_KEYS = [
   'environment',

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -6,6 +6,7 @@ import {Location, Query} from 'history';
 import {Client} from 'app/api';
 import ProjectAvatar from 'app/components/avatar/projectAvatar';
 import Button from 'app/components/button';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import Count from 'app/components/count';
 import DropdownLink from 'app/components/dropdownLink';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
@@ -30,7 +31,6 @@ import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
 import {RadioLineItem} from 'app/views/settings/components/forms/controls/radioGroup';
 
-import {HeaderTitleLegend} from '../styles';
 import {DisplayModes} from '../transactionSummary/charts';
 import {transactionSummaryRouteWithQuery} from '../transactionSummary/utils';
 

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalChart.tsx
@@ -10,6 +10,7 @@ import ErrorPanel from 'app/components/charts/errorPanel';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import LineChart from 'app/components/charts/lineChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
+import {ChartContainer, HeaderTitleLegend} from 'app/components/charts/styles';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getInterval, getSeriesSelection} from 'app/components/charts/utils';
@@ -27,7 +28,6 @@ import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 
-import {ChartContainer, HeaderTitleLegend} from '../styles';
 import {replaceSeriesName, transformEventStatsSmoothed} from '../trends/utils';
 
 import {getMaxOfSeries, vitalNameFromLocation, webVitalMeh, webVitalPoor} from './utils';

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -4,6 +4,7 @@ import {withTheme} from 'emotion-theming';
 
 import {fetchTotalCount} from 'app/actionCreators/events';
 import EventsChart from 'app/components/charts/eventsChart';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {isSelectionEqual} from 'app/components/organizations/globalSelectionHeader/utils';
 import QuestionTooltip from 'app/components/questionTooltip';
@@ -13,7 +14,6 @@ import {axisLabelFormatter} from 'app/utils/discover/charts';
 import getDynamicText from 'app/utils/getDynamicText';
 import {Theme} from 'app/utils/theme';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
-import {HeaderTitleLegend} from 'app/views/performance/styles';
 
 type Props = Omit<
   EventsChart['props'],

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
@@ -8,6 +8,7 @@ import ChartZoom, {ZoomRenderProps} from 'app/components/charts/chartZoom';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LineChart from 'app/components/charts/lineChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import QuestionTooltip from 'app/components/questionTooltip';
@@ -18,7 +19,6 @@ import {EChartEventHandler, Series} from 'app/types/echarts';
 import getDynamicText from 'app/utils/getDynamicText';
 import {Theme} from 'app/utils/theme';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
-import {HeaderTitleLegend} from 'app/views/performance/styles';
 import {displayCrashFreePercent} from 'app/views/releases/utils';
 import {
   getSessionTermDescription,

--- a/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectCharts.tsx
@@ -7,6 +7,7 @@ import {Location} from 'history';
 import {Client} from 'app/api';
 import OptionSelector from 'app/components/charts/optionSelector';
 import {
+  ChartContainer,
   ChartControls,
   InlineContainer,
   SectionHeading,
@@ -23,7 +24,6 @@ import {Theme} from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 
 import {getTermHelp, PERFORMANCE_TERM} from '../performance/data';
-import {ChartContainer} from '../performance/styles';
 
 import ProjectBaseEventsChart from './charts/projectBaseEventsChart';
 import ProjectStabilityChart from './charts/projectStabilityChart';

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/healthChart.tsx
@@ -7,6 +7,7 @@ import AreaChart from 'app/components/charts/areaChart';
 import {ZoomRenderProps} from 'app/components/charts/chartZoom';
 import LineChart from 'app/components/charts/lineChart';
 import StackedAreaChart from 'app/components/charts/stackedAreaChart';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import {getSeriesSelection} from 'app/components/charts/utils';
 import {parseStatsPeriod} from 'app/components/organizations/timeRangeSelector/utils';
 import QuestionTooltip from 'app/components/questionTooltip';
@@ -18,7 +19,6 @@ import {axisDuration} from 'app/utils/discover/charts';
 import {getExactDuration} from 'app/utils/formatters';
 import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
-import {HeaderTitleLegend} from 'app/views/performance/styles';
 
 import {
   getSessionTermDescription,

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 
 import {Client} from 'app/api';
 import EventsChart from 'app/components/charts/eventsChart';
+import {ChartContainer, HeaderTitleLegend} from 'app/components/charts/styles';
 import {Panel} from 'app/components/panels';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {PlatformKey} from 'app/data/platformCategories';
@@ -15,7 +16,6 @@ import {WebVital} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
 import {Theme} from 'app/utils/theme';
 import {getTermHelp, PERFORMANCE_TERM} from 'app/views/performance/data';
-import {ChartContainer, HeaderTitleLegend} from 'app/views/performance/styles';
 
 import {ReleaseStatsRequestRenderProps} from '../releaseStatsRequest';
 

--- a/src/sentry/static/sentry/app/views/releases/list/releasesStabilityChart.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releasesStabilityChart.tsx
@@ -4,6 +4,7 @@ import {Location} from 'history';
 
 import {Client} from 'app/api';
 import {
+  ChartContainer,
   ChartControls,
   InlineContainer,
   SectionHeading,
@@ -13,7 +14,6 @@ import {Panel} from 'app/components/panels';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import withApi from 'app/utils/withApi';
-import {ChartContainer} from 'app/views/performance/styles';
 import ProjectStabilityChart from 'app/views/projectDetail/charts/projectStabilityChart';
 
 type Props = {


### PR DESCRIPTION
I would like to use these in getsentry for the new subscription charts. Importing from the views directories feels like bad hygiene. Moving these components also lets us have fewer cross view imports as well.