### PR TITLE
fix(aws-lambda): prevent modifying external id that is used in cloudformation

### DIFF
--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -17,6 +17,7 @@ from sentry.integrations.serverless import ServerlessMixin
 from sentry.models import Project, OrganizationIntegration, ProjectStatus
 from sentry.pipeline import PipelineView
 from sentry.utils.compat import map
+from sentry.utils.sdk import capture_exception
 from sentry.utils import json
 
 from .client import gen_aws_client, ConfigurationError
@@ -262,6 +263,7 @@ class AwsLambdaCloudFormationPipelineView(PipelineView):
                 "error": error,
                 "initialStepNumber": curr_step,
                 "organization": serialized_organization,
+                "awsExternalId": pipeline.fetch_state("aws_external_id"),
             }
             return self.render_react_view(request, "awsLambdaCloudformation", context)
 
@@ -382,6 +384,7 @@ class AwsLambdaSetupLayerPipelineView(PipelineView):
                     if invalid_layer:
                         err_message = _(INVALID_LAYER_TEXT) % invalid_layer
                     else:
+                        capture_exception(e)
                         err_message = _("Unknown Error")
                     failures.append({"name": function["FunctionName"], "error": err_message})
                     logger.info(

--- a/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaCloudformation.tsx
+++ b/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaCloudformation.tsx
@@ -42,6 +42,7 @@ type Props = {
   accountNumber?: string;
   region?: string;
   error?: string;
+  awsExternalId?: string;
 };
 
 type State = {
@@ -56,7 +57,7 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
   state: State = {
     accountNumber: this.props.accountNumber,
     region: this.props.region,
-    awsExternalId: getAwsExternalId(),
+    awsExternalId: this.props.awsExternalId ?? getAwsExternalId(),
   };
 
   componentDidMount() {
@@ -81,7 +82,8 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
     // generarate the cloudformation URL using the params we get from the server
     // and the external id we generate
     const {baseCloudformationUrl, templateUrl, stackName} = this.props;
-    const {awsExternalId} = this.state;
+    //always us the generated AWS External ID in local storage
+    const awsExternalId = getAwsExternalId();
     const query = qs.stringify({
       templateURL: templateUrl,
       stackName,
@@ -97,11 +99,12 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
   handleSubmit = (e: React.MouseEvent) => {
     this.setState({submitting: true});
     e.preventDefault();
-    const {accountNumber, region} = this.state;
+    //use the external ID from the form on on the submission
+    const {accountNumber, region, awsExternalId} = this.state;
     const data = {
       accountNumber,
       region,
-      awsExternalId: getAwsExternalId(),
+      awsExternalId,
     };
     addLoadingMessage(t('Submitting\u2026'));
     const {
@@ -142,7 +145,6 @@ export default class AwsLambdaCloudformation extends React.Component<Props, Stat
   handleChangeExternalId = (awsExternalId: string) => {
     this.debouncedTrackValueChanged('awsExternalId');
     awsExternalId = awsExternalId.trim();
-    window.localStorage.setItem(ID_NAME, awsExternalId);
     this.setState({awsExternalId});
   };
 

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -68,6 +68,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
                 "error": None,
                 "initialStepNumber": 1,
                 "organization": serialize(self.organization),
+                "awsExternalId": None,
             },
         )
 
@@ -101,6 +102,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
                 "error": "Please validate the Cloudformation stack was created successfully",
                 "initialStepNumber": 1,
                 "organization": serialize(self.organization),
+                "awsExternalId": "my-id",
             },
         )
 


### PR DESCRIPTION
This PR changes how the externalID in the CloudFormation link is generated. Previously, we let the user type in values into the form input which get reflected in the URL for the CloudFormation link. However, AWS folks said this is a problem in case the user types in an insecure externalID that can be guessed. The fix here is that the link we generate that has the externalID as a query parameter is only determined by the random UUID Sentry generates. It is NOT based on the current value form field which could be anything except an empty string.

Note that there is still a form field for the externalID which is needed if a user is copying the external ID from a previously exsiting stack. 