### PR TITLE
feat(ui): Hide unnecessary suggested assignees

### DIFF
--- a/src/sentry/static/sentry/app/components/assigneeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.tsx
@@ -245,8 +245,8 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
   renderSuggestedAssigneeNodes() {
     const {assignedTo} = this.state;
     return (
+      // filter out suggested assignees if a suggestion is already selected
       this.getSuggestedAssignees()
-        // filter out suggested assignees if one is already selected
         ?.filter(
           ({type, id}: SuggestedAssignee) =>
             !(assignedTo && type === assignedTo.type && id === assignedTo.id)

--- a/src/sentry/static/sentry/app/components/assigneeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.tsx
@@ -243,16 +243,27 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
   },
 
   renderSuggestedAssigneeNodes() {
-    return this.getSuggestedAssignees()?.map(({type, suggestedReason, assignee}) => {
-      const reason =
-        suggestedReason === 'suspectCommit' ? t('(Suspect Commit)') : t('(Issue Owner)');
-      if (type === 'user') {
-        return this.renderMemberNode(assignee, reason);
-      } else if (type === 'team') {
-        return this.renderTeamNode(assignee, reason);
-      }
-      return null;
-    });
+    const {assignedTo} = this.state;
+    return (
+      this.getSuggestedAssignees()
+        // filter out suggested assignees if one is already selected
+        ?.filter(
+          ({type, id}: SuggestedAssignee) =>
+            !(assignedTo && type === assignedTo.type && id === assignedTo.id)
+        )
+        .map(({type, suggestedReason, assignee}) => {
+          const reason =
+            suggestedReason === 'suspectCommit'
+              ? t('(Suspect Commit)')
+              : t('(Issue Owner)');
+          if (type === 'user') {
+            return this.renderMemberNode(assignee, reason);
+          } else if (type === 'team') {
+            return this.renderTeamNode(assignee, reason);
+          }
+          return null;
+        })
+    );
   },
 
   renderDropdownGroupLabel(label: string) {


### PR DESCRIPTION
If a suggested assignee is already selected it doesn't need to be shown in the suggested list for the assignee selector. This PR filters the list of suggested assignees to not include a suggestion if it is currently used as the assignee.

**Example where the suggestion is hidden after being used:**
![Kapture 2021-02-11 at 16 16 18](https://user-images.githubusercontent.com/9372512/107715599-7dfabf80-6c84-11eb-83cd-4f98aaf061b1.gif)

Fixes: WOR-526