### PR TITLE
fix(ui): Allow ownership rules to be blank

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ownerInput.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ownerInput.tsx
@@ -10,6 +10,7 @@ import MemberListStore from 'app/stores/memberListStore';
 import ProjectsStore from 'app/stores/projectsStore';
 import {inputStyles} from 'app/styles/input';
 import {Organization, Project, Team} from 'app/types';
+import {defined} from 'app/utils';
 import theme from 'app/utils/theme';
 
 import RuleBuilder from './ruleBuilder';
@@ -28,7 +29,7 @@ type Props = {
 
 type State = {
   hasChanges: boolean;
-  text: string;
+  text: string | null;
   error: null | {
     raw: string[];
   };
@@ -39,7 +40,7 @@ class OwnerInput extends React.Component<Props, State> {
 
   state: State = {
     hasChanges: false,
-    text: '',
+    text: null,
     error: null,
   };
 
@@ -173,7 +174,7 @@ class OwnerInput extends React.Component<Props, State> {
             }
             onChange={this.handleChange}
             disabled={disabled}
-            value={text || initialText}
+            value={defined(text) ? text : initialText}
             spellCheck="false"
             autoComplete="off"
             autoCorrect="off"


### PR DESCRIPTION
When trying to delete all ownership rules in settings, due to the logic in the component, the value within the input field will reset to the initial value of the ownership rule input field:

**example:**
![Kapture 2021-02-11 at 23 46 31](https://user-images.githubusercontent.com/9372512/107742343-b4a3fa80-6cc3-11eb-9d3b-7ada48ae68cc.gif)

This PR changes the component to allow the text field to be empty without "resetting" to its initial value.

Fixes: WOR-561