### PR TITLE
fix(pii): Fix wrong Pii replacement

### DIFF
--- a/src/sentry/static/sentry/app/components/events/meta/annotatedText/valueElement.tsx
+++ b/src/sentry/static/sentry/app/components/events/meta/annotatedText/valueElement.tsx
@@ -31,14 +31,6 @@ const ValueElement = ({value, meta}: Props) => {
     );
   }
 
-  if (!value) {
-    return (
-      <Redaction withoutBackground>
-        <i>{`<${t('invalid')}>`}</i>
-      </Redaction>
-    );
-  }
-
   if (React.isValidElement(value)) {
     return value;
   }

--- a/src/sentry/static/sentry/app/components/events/meta/annotatedText/valueElement.tsx
+++ b/src/sentry/static/sentry/app/components/events/meta/annotatedText/valueElement.tsx
@@ -10,6 +10,10 @@ type Props = {
   meta?: Meta;
 };
 
+// If you find yourself modifying this component to fix some tooltip bug,
+// consider that `meta` is not properly passed into this component in the
+// first place. It's much more likely that `withMeta` is buggy or improperly
+// used than that this component has a bug.
 const ValueElement = ({value, meta}: Props) => {
   if (value && meta) {
     return <Redaction>{value}</Redaction>;

--- a/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/selectField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/dataScrubbing/modals/form/selectField.tsx
@@ -48,7 +48,7 @@ class SelectField extends React.Component<Props> {
             description?: string;
           }>) => (
             <components.Option isSelected={isSelected} data={data} {...props}>
-              <Wrapper isSelected={isSelected}>
+              <Wrapper>
                 <div data-test-id="label">{label}</div>
                 {description && <Description>{`(${description})`}</Description>}
               </Wrapper>
@@ -67,17 +67,8 @@ const Description = styled('div')`
   color: ${p => p.theme.gray300};
 `;
 
-const Wrapper = styled('div')<{isSelected?: boolean}>`
+const Wrapper = styled('div')`
   display: grid;
   grid-template-columns: 1fr auto;
   grid-gap: ${space(1)};
-  ${p =>
-    p.isSelected &&
-    `
-      ${Description} {
-        :not(:hover) {
-          color: ${p.theme.white};
-        }
-      }
-    `}
 `;


### PR DESCRIPTION
Atm when a string is empty and there is no "data scrubbing rule" for it,  the UI replaces the string with `<invalid>`, which is not correct.

closes: https://forum.sentry.io/t/advanced-data-scrubbing-not-understanding/12773/3

This PR also removes a custom style from the selected item to make it consistent with other select components present in the application.