### PR TITLE
feat(ui): Remove grouping settings moved alert

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectGeneralSettings.tsx
@@ -9,7 +9,6 @@ import {
   transferProject,
 } from 'app/actionCreators/projects';
 import ProjectActions from 'app/actions/projectActions';
-import AlertLink from 'app/components/alertLink';
 import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import {Panel, PanelAlert, PanelHeader} from 'app/components/panels';
@@ -276,18 +275,6 @@ class ProjectGeneralSettings extends AsyncView<Props, State> {
             title={t('Event Settings')}
             fields={[fields.resolveAge]}
           />
-
-          <AlertLink
-            to={`/settings/${organization.slug}/projects/${project.slug}/issue-grouping/`}
-            priority="info"
-          >
-            {tct(
-              "Looking for Grouping Settings? You'll find those in [underline: Issue Grouping].",
-              {
-                underline: <u />,
-              }
-            )}
-          </AlertLink>
 
           <JsonForm
             {...jsonFormProps}


### PR DESCRIPTION
Grouping settings have been moved ~3 months ago, we should be safe to remove the notice in the spirit of keeping things clean.