### PR TITLE
fix(sessions-api): Support filtering environment by query string

### DIFF
--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -31,13 +31,12 @@ class OrganizationSessionsEndpoint(OrganizationEventsEndpointBase):
             return Response(result, status=200)
 
     def build_sessions_query(self, request, organization):
-        # validate and default all `project` params.
-        projects = self.get_projects(request, organization)
-        if projects is None or len(projects) == 0:
-            raise NoProjects("No projects available")
-        project_ids = [p.id for p in projects]
+        try:
+            params = self.get_filter_params(request, organization, date_filter_optional=True)
+        except NoProjects:
+            raise NoProjects("No projects available")  # give it a description
 
-        return QueryDefinition(request.GET, project_ids)
+        return QueryDefinition(request.GET, params)
 
     @contextmanager
     def handle_query_errors(self):

--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -4,7 +4,7 @@ import itertools
 from sentry.api.event_search import get_filter
 from sentry.api.utils import get_date_range_rollup_from_params
 from sentry.utils.dates import to_timestamp
-from sentry.utils.snuba import Dataset, raw_query
+from sentry.utils.snuba import Dataset, raw_query, resolve_condition
 
 """
 The new Sessions API defines a "metrics"-like interface which is can be used in
@@ -190,12 +190,22 @@ class SessionStatusGroupBy:
         return [("session.status", key) for key in ["healthy", "abnormal", "crashed", "errored"]]
 
 
+# NOTE: in the future we might add new `user_agent` and `os` fields
+
 GROUPBY_MAP = {
     "project": SimpleGroupBy("project_id", "project"),
     "environment": SimpleGroupBy("environment"),
     "release": SimpleGroupBy("release"),
     "session.status": SessionStatusGroupBy(),
 }
+
+CONDITION_COLUMNS = ["project", "environment", "release"]
+
+
+def resolve_column(col):
+    if col in CONDITION_COLUMNS:
+        return col
+    raise InvalidField(f'Invalid query field: "{col}"')
 
 
 class InvalidField(Exception):
@@ -209,7 +219,7 @@ class QueryDefinition:
     `fields` and `groupby` definitions as [`ColumnDefinition`] objects.
     """
 
-    def __init__(self, query, project_ids=None):
+    def __init__(self, query, params):
         self.query = query.get("query", "")
         raw_fields = query.getlist("field", [])
         raw_groupby = query.getlist("groupBy", [])
@@ -246,11 +256,17 @@ class QueryDefinition:
             query_groupby.update(groupby.get_snuba_groupby())
         self.query_groupby = list(query_groupby)
 
-        params = {"project_id": project_ids or []}
+        # the `params` are:
+        # project_id, organization_id, environment;
+        # also: start, end; but we got those ourselves.
         snuba_filter = get_filter(self.query, params)
 
+        # this makes sure that literals in complex queries are properly quoted,
+        # and unknown fields are raised as errors
+        conditions = [resolve_condition(c, resolve_column) for c in snuba_filter.conditions]
+
         self.aggregations = snuba_filter.aggregations
-        self.conditions = snuba_filter.conditions
+        self.conditions = conditions
         self.filter_keys = snuba_filter.filter_keys
 
 

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -10,7 +10,7 @@ from sentry.snuba.sessions_v2 import (
 
 
 def _make_query(qs):
-    return QueryDefinition(QueryDict(qs), [])
+    return QueryDefinition(QueryDict(qs), {})
 
 
 def result_sorted(result):


### PR DESCRIPTION
The second commit properly quotes literals in combined conditions, thus making `release:foo or release:bar` work properly.
Fixes SENTRY-NAF

CC @matejminar 