### PR TITLE
fix(ui) Fix legend and title alignment

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -86,7 +86,7 @@ class DurationChart extends React.Component<Props> {
 
     const legend = {
       right: 10,
-      top: 0,
+      top: 5,
       selected: getSeriesSelection(location),
     };
 


### PR DESCRIPTION
Fix legend and title alignment so they have a common baseline.

![Screen Shot 2021-02-12 at 11 46 50 AM](https://user-images.githubusercontent.com/24086/107796712-2a41b200-6d28-11eb-8728-68cf34005924.png)
