### PR TITLE
build(ci): make install-py-dev to install wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,11 @@ install-js-dev: node-version-check
 	yarn check --verify-tree || yarn install --check-files
 
 install-py-dev: ensure-pinned-pip
+ifeq ($(shell command -v wheel 2> /dev/null),)
 	# The Python version installed via pyenv does not come with wheel pre-installed
 	# Installing wheel will speed up installation of Python dependencies
-	$(PIP) install wheel
+	@$(PIP) install wheel
+endif
 	@echo "--> Installing Sentry (for development)"
 ifdef BIG_SUR
 	# grpcio 1.35.0 is very painful to compile on Big Sur, and is not really surfaced in testing anyways.

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,9 @@ install-js-dev: node-version-check
 	yarn check --verify-tree || yarn install --check-files
 
 install-py-dev: ensure-pinned-pip
+	# The Python version installed via pyenv does not come with wheel pre-installed
+	# Installing wheel will speed up installation of Python dependencies
+	$(PIP) install wheel
 	@echo "--> Installing Sentry (for development)"
 ifdef BIG_SUR
 	# grpcio 1.35.0 is very painful to compile on Big Sur, and is not really surfaced in testing anyways.

--- a/scripts/pyenv_setup.sh
+++ b/scripts/pyenv_setup.sh
@@ -112,9 +112,6 @@ setup_pyenv() {
   eval "$(pyenv init -)"
   python_version=$(python -V | sed s/Python\ //g)
   [[ $python_version != $(cat .python-version) ]] && echo "Wrong Python version: $python_version" && exit 1
-  # The Python version installed via pyenv does not come with wheel pre-installed
-  # Installing wheel will speed up installation of Python dependencies
-  PIP_DISABLE_PIP_VERSION_CHECK=on pip install wheel
 }
 
 setup_pyenv

--- a/scripts/pyenv_setup.sh
+++ b/scripts/pyenv_setup.sh
@@ -108,10 +108,10 @@ setup_pyenv() {
 
   # If the script is called with the "dot space right" approach (. ./scripts/pyenv_setup.sh),
   # the effects of this will be persistent outside of this script
-  echo "Activating pyenv"
+  echo "Activating pyenv and validating Python version"
   eval "$(pyenv init -)"
   python_version=$(python -V | sed s/Python\ //g)
-  [[ $python_version != $(cat .python-version) ]] && echo "Wrong Python version: $python_version" && exit 1
+  [[ $python_version == $(cat .python-version) ]] || (echo "Wrong Python version: $python_version" && exit 1)
 }
 
 setup_pyenv


### PR DESCRIPTION
The Python version installed via pyenv does not come with `wheel` pre-installed.
Installing `wheel` will speed up installation of Python dependencies