### PR TITLE
feat(codeowners): Add ProjectCodeOwners GET endpoint

### DIFF
--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -1,0 +1,20 @@
+from rest_framework.response import Response
+
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.serializers import serialize
+from sentry.models import ProjectCodeOwners
+
+
+class ProjectCodeOwnersEndpoint(ProjectEndpoint):
+    def get(self, request, project):
+        """
+        Retrieve List of CODEOWNERS configurations for a project
+        ````````````````````````````````````````````
+
+        Return a list of a project's CODEOWNERS configuration.
+
+        :auth: required
+        """
+        codeowners = list(ProjectCodeOwners.objects.filter(project=project))
+
+        return Response(serialize(codeowners, request.user))

--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -1,0 +1,17 @@
+from sentry.api.serializers import Serializer, register
+from sentry.models import ProjectCodeOwners
+
+
+@register(ProjectCodeOwners)
+class ProjectCodeOwnersSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        data = {
+            "raw": obj.raw,
+            "dateCreated": obj.date_added,
+            "dateUpdated": obj.date_updated,
+            "provider": "unknown",
+        }
+        if obj.organization_integration:
+            data["provider"] = obj.organization_integration.integration.provider
+
+        return data

--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -9,6 +9,7 @@ class ProjectCodeOwnersSerializer(Serializer):
             "raw": obj.raw,
             "dateCreated": obj.date_added,
             "dateUpdated": obj.date_updated,
+            "codeMappingId": str(obj.repository_project_path_config_id),
             "provider": "unknown",
         }
         if obj.organization_integration:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -212,6 +212,7 @@ from .endpoints.project_key_stats import ProjectKeyStatsEndpoint
 from .endpoints.project_keys import ProjectKeysEndpoint
 from .endpoints.project_member_index import ProjectMemberIndexEndpoint
 from .endpoints.project_ownership import ProjectOwnershipEndpoint
+from .endpoints.project_codeowners import ProjectCodeOwnersEndpoint
 from .endpoints.project_platforms import ProjectPlatformsEndpoint
 from .endpoints.project_plugin_details import ProjectPluginDetailsEndpoint
 from .endpoints.project_plugins import ProjectPluginsEndpoint
@@ -1637,6 +1638,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/ownership/$",
                     ProjectOwnershipEndpoint.as_view(),
                     name="sentry-api-0-project-ownership",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/codeowners/$",
+                    ProjectCodeOwnersEndpoint.as_view(),
+                    name="sentry-api-0-project-codeowners",
                 ),
                 # Load plugin project urls
                 url(

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -67,6 +67,7 @@ from sentry.models import (
     ExternalIssue,
     GroupLink,
     ReleaseFile,
+    RepositoryProjectPathConfig,
     Rule,
 )
 from sentry.models.integrationfeature import Feature, IntegrationFeature
@@ -425,6 +426,18 @@ class Factories:
                         zipfile.write(fullpath, relpath)
 
         return bundle.getvalue()
+
+    @staticmethod
+    def create_code_mapping(project, repo=None, **kwargs):
+        kwargs.setdefault("stack_root", "")
+        kwargs.setdefault("source_root", "")
+
+        if not repo:
+            repo = Factories.create_repo(project=project)
+
+        return RepositoryProjectPathConfig.objects.create(
+            project=project, repository=repo, **kwargs
+        )
 
     @staticmethod
     def create_repo(project, name=None, provider=None, integration_id=None, url=None):

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -152,6 +152,11 @@ class Fixtures:
             release = self.release.version
         return Factories.create_artifact_bundle(org, release, *args, **kwargs)
 
+    def create_code_mapping(self, project=None, repo=None, **kwargs):
+        if project is None:
+            project = self.project
+        return Factories.create_code_mapping(project, repo, **kwargs)
+
     def create_repo(self, project=None, *args, **kwargs):
         if project is None:
             project = self.project

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -1,0 +1,77 @@
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+from sentry.models import Integration, ProjectCodeOwners
+
+
+class ProjectOwnershipEndpointTestCase(APITestCase):
+    def setUp(self):
+        self.login_as(user=self.user)
+
+        self.team = self.create_team(
+            organization=self.organization, slug="tiger-team", members=[self.user]
+        )
+
+        self.project = self.project = self.create_project(
+            organization=self.organization, teams=[self.team], slug="bengal"
+        )
+
+        self.path = reverse(
+            "sentry-api-0-project-codeowners",
+            kwargs={"organization_slug": self.organization.slug, "project_slug": self.project.slug},
+        )
+
+    def _create_codeowner_with_integration(self):
+        self.integration = Integration.objects.create(
+            provider="github",
+            name="getsentry",
+            external_id="1234",
+            metadata={"domain_name": "github.com/getsentry"},
+        )
+        self.oi = self.integration.add_organization(self.organization, self.user)
+        self.repo = self.create_repo(
+            project=self.project,
+            name="getsentry/sentry",
+            provider="integrations:github",
+            integration_id=self.integration.id,
+            url="https://github.com/getsentry/sentry",
+        )
+        self.code_mapping = self.create_code_mapping(
+            project=self.project, repo=self.repo, organization_integration=self.oi
+        )
+        self.code_owner = ProjectCodeOwners.objects.create(
+            project=self.project,
+            raw="*.js @tiger-team",
+            organization_integration=self.oi,
+            repository_project_path_config=self.code_mapping,
+        )
+
+    def test_no_codeowners(self):
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        assert resp.data == []
+
+    def test_codeowners_without_integrations(self):
+        code_mapping = self.create_code_mapping(project=self.project)
+        code_owner = ProjectCodeOwners.objects.create(
+            project=self.project,
+            raw="*.js @tiger-team",
+            repository_project_path_config=code_mapping,
+        )
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        resp_data = resp.data[0]
+        assert resp_data["raw"] == code_owner.raw
+        assert resp_data["dateCreated"] == code_owner.date_added
+        assert resp_data["dateUpdated"] == code_owner.date_updated
+        assert resp_data["provider"] == "unknown"
+
+    def test_codeowners_with_integration(self):
+        self._create_codeowner_with_integration()
+        resp = self.client.get(self.path)
+        assert resp.status_code == 200
+        resp_data = resp.data[0]
+        assert resp_data["raw"] == self.code_owner.raw
+        assert resp_data["dateCreated"] == self.code_owner.date_added
+        assert resp_data["dateUpdated"] == self.code_owner.date_updated
+        assert resp_data["provider"] == self.integration.provider

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -4,7 +4,7 @@ from sentry.testutils import APITestCase
 from sentry.models import Integration, ProjectCodeOwners
 
 
-class ProjectOwnershipEndpointTestCase(APITestCase):
+class ProjectCodeOwnersEndpointTestCase(APITestCase):
     def setUp(self):
         self.login_as(user=self.user)
 
@@ -64,6 +64,7 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         assert resp_data["raw"] == code_owner.raw
         assert resp_data["dateCreated"] == code_owner.date_added
         assert resp_data["dateUpdated"] == code_owner.date_updated
+        assert resp_data["codeMappingId"] == str(code_mapping.id)
         assert resp_data["provider"] == "unknown"
 
     def test_codeowners_with_integration(self):
@@ -74,4 +75,5 @@ class ProjectOwnershipEndpointTestCase(APITestCase):
         assert resp_data["raw"] == self.code_owner.raw
         assert resp_data["dateCreated"] == self.code_owner.date_added
         assert resp_data["dateUpdated"] == self.code_owner.date_updated
+        assert resp_data["codeMappingId"] == str(self.code_mapping.id)
         assert resp_data["provider"] == self.integration.provider


### PR DESCRIPTION
**Context:**
The table for codeowners was added https://github.com/getsentry/sentry/pull/23715. This is similar to issues owners, but there are a few differences worth noting:
1. There can be multiple codeowners for one project because you can have multiple repositories for a single project. An example of this would be `getsentry` and `sentry` repositories (which each have a CODEOWNERS file) for the `sentry` project.
2. For now, the `raw` field in codeowners is the syntax of the original file, e.g. GitHub. For issue owners, `raw` is our own issue owners syntax

**`ProjectCodeOwnersEndpoint`**
This PR adds the `GET` for the list of codeowners you have for any given project. 

I've added the `provider` in the response because we use the provider often to determine what to display, we can change this if need, or even add more information (like the `integration_id`), but since we are focused on the non-integration codeowners first, I just wanted some simple testing between the two.