### PR TITLE
feat(http): Add domain_blacklisted key to error for blacklisted urls

### DIFF
--- a/src/sentry/http.py
+++ b/src/sentry/http.py
@@ -153,7 +153,6 @@ def fetch_file(
         if domain_result:
             domain_result = dict(domain_result)
             domain_result["url"] = url
-            domain_result["domain_blacklisted"] = True
             raise CannotFetch(domain_result)
 
     logger.debug("Fetching %r from the internet", url)
@@ -230,6 +229,7 @@ def fetch_file(
 
                 # TODO(dcramer): we want to be less aggressive on disabling domains
                 if domain_lock_enabled:
+                    error["domain_blacklisted"] = True
                     cache.set(domain_key, error or "", 300)
                     logger.warning("source.disabled", extra=error)
                 raise CannotFetch(error)

--- a/src/sentry/http.py
+++ b/src/sentry/http.py
@@ -151,7 +151,9 @@ def fetch_file(
         domain_key = "source:blacklist:v2:{}".format(md5_text(domain).hexdigest())
         domain_result = cache.get(domain_key)
         if domain_result:
+            domain_result = dict(domain_result)
             domain_result["url"] = url
+            domain_result["domain_blacklisted"] = True
             raise CannotFetch(domain_result)
 
     logger.debug("Fetching %r from the internet", url)


### PR DESCRIPTION
When a fetch is failing because of the domain blacklist we now add an information to the URL error so that users can understand why the fetch is failing.