### PR TITLE
feat(ui): add info to "No results found"

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -368,7 +368,7 @@ class GridEditable<
       <GridRow>
         <GridBodyCellStatus>
           <EmptyStateWarning>
-            <p>{t('No results found for the given query')}</p>
+            <p>{t('No results found for your query')}</p>
           </EmptyStateWarning>
         </GridBodyCellStatus>
       </GridRow>

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -368,7 +368,7 @@ class GridEditable<
       <GridRow>
         <GridBodyCellStatus>
           <EmptyStateWarning>
-            <p>{t('No results found')}</p>
+            <p>{t('No results found for the given query')}</p>
           </EmptyStateWarning>
         </GridBodyCellStatus>
       </GridRow>


### PR DESCRIPTION
Currently, the Performance Summary defaults to a 24-hour filter. The "No
results found" message made me think that the data had disappeared when
in fact it was simply filtered out.

Renaming this to "No results found for the given query" is an easy way
to give users a hint that they should investigate the filters.

I only tested this for the performance page, not the other uses of
GridEditable, but I think it applies for all of them.