### PR TITLE
ref(code-mappings): Migrate endpoints away from OrganizationIntegrationBaseEndpoint base class

### DIFF
--- a/src/sentry/api/endpoints/organization_integration_repository_project_path_config_details.py
+++ b/src/sentry/api/endpoints/organization_integration_repository_project_path_config_details.py
@@ -1,44 +1,54 @@
 from django.http import Http404
 
 from rest_framework import status
+from rest_framework.response import Response
 
-from sentry.api.bases.organization import OrganizationIntegrationsPermission
-from sentry.api.bases.organization_integrations import OrganizationIntegrationBaseEndpoint
+from sentry.api.bases.organization import OrganizationIntegrationsPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import RepositoryProjectPathConfig
 
 from .organization_integration_repository_project_path_configs import (
     RepositoryProjectPathConfigSerializer,
+    NullableOrganizationIntegrationMixin,
 )
 
 
 class OrganizationIntegrationRepositoryProjectPathConfigDetailsEndpoint(
-    OrganizationIntegrationBaseEndpoint
+    OrganizationEndpoint, NullableOrganizationIntegrationMixin
 ):
     permission_classes = (OrganizationIntegrationsPermission,)
 
-    def convert_args(self, request, organization_slug, integration_id, config_id, *args, **kwargs):
-        args, kwargs = super().convert_args(
-            request, organization_slug, integration_id, config_id, *args, **kwargs
-        )
-
-        org_integration = self.get_organization_integration(kwargs["organization"], integration_id)
-        kwargs["org_integration"] = org_integration
+    def convert_args(self, request, organization_slug, config_id, *args, **kwargs):
+        args, kwargs = super().convert_args(request, organization_slug, config_id, *args, **kwargs)
 
         try:
-            kwargs["config"] = RepositoryProjectPathConfig.objects.get(
+            kwargs["config"] = RepositoryProjectPathConfig.objects.all().get(
                 id=config_id,
-                organization_integration_id=org_integration.id,
             )
         except RepositoryProjectPathConfig.DoesNotExist:
             raise Http404
+
         return (args, kwargs)
 
-    def put(
-        self, request, organization_slug, integration_id, organization, org_integration, config
-    ):
+    def put(self, request, config_id, organization, config):
+        """
+        Update a repository project path config
+        ``````````````````
+
+        :pparam string organization_slug: the slug of the organization the
+                                          team should be created for.
+        :param int repository_id:
+        :param int project_id:
+        :param string stack_root:
+        :param string source_root:
+        :param string default_branch:
+        :auth: required
+        """
         serializer = RepositoryProjectPathConfigSerializer(
-            context={"organization_integration": org_integration},
+            context={
+                "organization": organization,
+                "organization_integration": config.organization_integration,
+            },
             instance=config,
             data=request.data,
         )
@@ -48,11 +58,13 @@ class OrganizationIntegrationRepositoryProjectPathConfigDetailsEndpoint(
                 serialize(repository_project_path_config, request.user),
                 status=status.HTTP_200_OK,
             )
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+    def delete(self, request, config_id, organization, config):
+        """
+        Delete a repository project path config
 
-    def delete(
-        self, request, organization_slug, integration_id, organization, org_integration, config
-    ):
+        :auth: required
+        """
         config.delete()
-        return self.respond(status=status.HTTP_204_NO_CONTENT)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/organization_integration_repository_project_path_config_details.py
+++ b/src/sentry/api/endpoints/organization_integration_repository_project_path_config_details.py
@@ -1,7 +1,6 @@
 from django.http import Http404
 
 from rest_framework import status
-from rest_framework.response import Response
 
 from sentry.api.bases.organization import OrganizationIntegrationsPermission, OrganizationEndpoint
 from sentry.api.serializers import serialize
@@ -22,7 +21,7 @@ class OrganizationIntegrationRepositoryProjectPathConfigDetailsEndpoint(
         args, kwargs = super().convert_args(request, organization_slug, config_id, *args, **kwargs)
 
         try:
-            kwargs["config"] = RepositoryProjectPathConfig.objects.all().get(
+            kwargs["config"] = RepositoryProjectPathConfig.objects.get(
                 id=config_id,
             )
         except RepositoryProjectPathConfig.DoesNotExist:
@@ -58,7 +57,7 @@ class OrganizationIntegrationRepositoryProjectPathConfigDetailsEndpoint(
                 serialize(repository_project_path_config, request.user),
                 status=status.HTTP_200_OK,
             )
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        return self.respond(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request, config_id, organization, config):
         """
@@ -67,4 +66,4 @@ class OrganizationIntegrationRepositoryProjectPathConfigDetailsEndpoint(
         :auth: required
         """
         config.delete()
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        return self.respond(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
+++ b/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
@@ -150,12 +150,12 @@ class OrganizationIntegrationRepositoryProjectPathConfigEndpoint(
         queryset = RepositoryProjectPathConfig.objects.all()
 
         if integration_id:
-            # Return early with 404
+            # get_organization_integration will raise a 404 if no org_integraiton is found
             org_integration = self.get_organization_integration(organization, integration_id)
             queryset = queryset.filter(organization_integration=org_integration)
 
         if project_id:
-            # Check that the project is apart of the organization.
+            # Check that the project is apart of the organization. get_project will raise 404 if project not found.
             project = self.get_project(organization, project_id)
             queryset = queryset.filter(project=project)
 

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -54,7 +54,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         # the ordering is deterministic
         # codepath mappings must have an associated integration for stacktrace linking.
         configs = RepositoryProjectPathConfig.objects.filter(
-            project=project, organization_integation__isnull=False
+            project=project, organization_integration__isnull=False
         )
         with configure_scope() as scope:
             for config in configs:

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -52,7 +52,10 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         # xxx(meredith): if there are ever any changes to this query, make
         # sure that we are still ordering by `id` because we want to make sure
         # the ordering is deterministic
-        configs = RepositoryProjectPathConfig.objects.filter(project=project)
+        # codepath mappings must have an associated integration for stacktrace linking.
+        configs = RepositoryProjectPathConfig.objects.filter(
+            project=project, organization_integation__isnull=False
+        )
         with configure_scope() as scope:
             for config in configs:
 

--- a/src/sentry/api/serializers/models/repository_project_path_config.py
+++ b/src/sentry/api/serializers/models/repository_project_path_config.py
@@ -6,16 +6,21 @@ from sentry.models import RepositoryProjectPathConfig
 @register(RepositoryProjectPathConfig)
 class RepositoryProjectPathConfigSerializer(Serializer):
     def serialize(self, obj, attrs, user):
-        integration = obj.organization_integration.integration
-        provider = integration.get_provider()
+        integration = (
+            obj.organization_integration.integration if obj.organization_integration else None
+        )
+        provider = integration.get_provider() if integration else None
+        serialized_provider = serialize_provider(provider) if provider else None
+        integration_id = str(integration.id) if integration else None
+
         return {
             "id": str(obj.id),
             "projectId": str(obj.project_id),
             "projectSlug": obj.project.slug,
             "repoId": str(obj.repository.id),
             "repoName": obj.repository.name,
-            "integrationId": str(integration.id),
-            "provider": serialize_provider(provider),
+            "integrationId": integration_id,
+            "provider": serialized_provider,
             "stackRoot": obj.stack_root,
             "sourceRoot": obj.source_root,
             "defaultBranch": obj.default_branch,

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -717,6 +717,17 @@ urlpatterns = [
                     ChunkUploadEndpoint.as_view(),
                     name="sentry-api-0-chunk-upload",
                 ),
+                # Code Path Mappings
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/repo-project-path-configs/$",
+                    OrganizationIntegrationRepositoryProjectPathConfigEndpoint.as_view(),
+                    name="sentry-api-0-organization-repository-project-path-config",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/repo-project-path-configs/(?P<config_id>[^\/]+)/$",
+                    OrganizationIntegrationRepositoryProjectPathConfigDetailsEndpoint.as_view(),
+                    name="sentry-api-0-organization-repository-project-path-config-details",
+                ),
                 # Discover
                 url(
                     r"^(?P<organization_slug>[^\/]+)/discover/query/$",
@@ -959,16 +970,6 @@ urlpatterns = [
                 url(
                     r"^(?P<organization_slug>[^\/]+)/integrations/(?P<integration_id>[^\/]+)/repos/$",
                     OrganizationIntegrationReposEndpoint.as_view(),
-                ),
-                url(
-                    r"^(?P<organization_slug>[^\/]+)/integrations/(?P<integration_id>[^\/]+)/repo-project-path-configs/$",
-                    OrganizationIntegrationRepositoryProjectPathConfigEndpoint.as_view(),
-                    name="sentry-api-0-organization-integration-repository-project-path-config",
-                ),
-                url(
-                    r"^(?P<organization_slug>[^\/]+)/integrations/(?P<integration_id>[^\/]+)/repo-project-path-configs/(?P<config_id>[^\/]+)/$",
-                    OrganizationIntegrationRepositoryProjectPathConfigDetailsEndpoint.as_view(),
-                    name="sentry-api-0-organization-integration-repository-project-path-config-details",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/integrations/(?P<integration_id>[^\/]+)/serverless-functions/$",

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -247,7 +247,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
     const {config} = this.match;
     const {organization} = this.props;
     const text = this.errorText;
-    const url = `/settings/${organization.slug}/integrations/${config?.provider.key}/${config?.integrationId}/?tab=codeMappings`;
+    const url = `/settings/${organization.slug}/integrations/${config?.provider?.key}/${config?.integrationId}/?tab=codeMappings`;
     return (
       <CodeMappingButtonContainer columnQuantity={2}>
         {text}
@@ -263,8 +263,8 @@ class StacktraceLink extends AsyncComponent<Props, State> {
       <OpenInContainer columnQuantity={2}>
         <div>{t('Open this line in')}</div>
         <OpenInLink onClick={() => this.onOpenLink()} href={url} openInNewTab>
-          {getIntegrationIcon(config.provider.key)}
-          <OpenInName>{config.provider.name}</OpenInName>
+          {getIntegrationIcon(config.provider?.key)}
+          <OpenInName>{config.provider?.name}</OpenInName>
         </OpenInLink>
       </OpenInContainer>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -13,7 +13,7 @@ import {
   Integration,
   Organization,
   Project,
-  RepositoryProjectPathConfig,
+  RepositoryProjectPathConfigWithIntegration,
 } from 'app/types';
 import {Event} from 'app/types/event';
 import {getIntegrationIcon, trackIntegrationEvent} from 'app/utils/integrationUtil';
@@ -35,7 +35,7 @@ type Props = AsyncComponent['props'] & {
 //format of the ProjectStacktraceLinkEndpoint response
 type StacktraceResultItem = {
   integrations: Integration[];
-  config?: RepositoryProjectPathConfig;
+  config?: RepositoryProjectPathConfigWithIntegration;
   sourceUrl?: string;
   error?: 'file_not_found' | 'stack_root_mismatch';
 };
@@ -247,7 +247,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
     const {config} = this.match;
     const {organization} = this.props;
     const text = this.errorText;
-    const url = `/settings/${organization.slug}/integrations/${config?.provider?.key}/${config?.integrationId}/?tab=codeMappings`;
+    const url = `/settings/${organization.slug}/integrations/${config?.provider.key}/${config?.integrationId}/?tab=codeMappings`;
     return (
       <CodeMappingButtonContainer columnQuantity={2}>
         {text}
@@ -257,14 +257,14 @@ class StacktraceLink extends AsyncComponent<Props, State> {
       </CodeMappingButtonContainer>
     );
   }
-  renderMatchWithUrl(config: RepositoryProjectPathConfig, url: string) {
+  renderMatchWithUrl(config: RepositoryProjectPathConfigWithIntegration, url: string) {
     url = `${url}#L${this.props.frame.lineNo}`;
     return (
       <OpenInContainer columnQuantity={2}>
         <div>{t('Open this line in')}</div>
         <OpenInLink onClick={() => this.onOpenLink()} href={url} openInNewTab>
-          {getIntegrationIcon(config.provider?.key)}
-          <OpenInName>{config.provider?.name}</OpenInName>
+          {getIntegrationIcon(config.provider.key)}
+          <OpenInName>{config.provider.name}</OpenInName>
         </OpenInLink>
       </OpenInContainer>
     );

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -73,10 +73,14 @@ class StacktraceLinkModal extends React.Component<Props, State> {
         },
       });
 
-      const configEndpoint = `/organizations/${organization.slug}/integrations/${configData.integrationId}/repo-project-path-configs/`;
+      const configEndpoint = `/organizations/${organization.slug}/repo-project-path-configs/`;
       await api.requestPromise(configEndpoint, {
         method: 'POST',
-        data: {...configData, projectId: project.id},
+        data: {
+          ...configData,
+          projectId: project.id,
+          integrationId: configData.integrationId,
+        },
       });
 
       addSuccessMessage(t('Stack trace configuration saved.'));

--- a/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
+++ b/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
@@ -26,12 +26,13 @@ type Props = {
 
 export default class RepositoryProjectPathConfigForm extends React.Component<Props> {
   get initialData() {
-    const {existingConfig} = this.props;
+    const {existingConfig, integration} = this.props;
     return {
       defaultBranch: 'master',
       stackRoot: '',
       sourceRoot: '',
       repositoryId: existingConfig?.repoId,
+      integrationId: integration.id,
       ...pick(existingConfig, ['projectId', 'defaultBranch', 'stackRoot', 'sourceRoot']),
     };
   }
@@ -105,16 +106,10 @@ export default class RepositoryProjectPathConfigForm extends React.Component<Pro
   }
 
   render() {
-    const {
-      organization,
-      integration,
-      onSubmitSuccess,
-      onCancel,
-      existingConfig,
-    } = this.props;
+    const {organization, onSubmitSuccess, onCancel, existingConfig} = this.props;
 
     // endpoint changes if we are making a new row or updating an existing one
-    const baseEndpoint = `/organizations/${organization.slug}/integrations/${integration.id}/repo-project-path-configs/`;
+    const baseEndpoint = `/organizations/${organization.slug}/repo-project-path-configs/`;
     const endpoint = existingConfig
       ? `${baseEndpoint}${existingConfig.id}/`
       : baseEndpoint;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1092,7 +1092,7 @@ export type RepositoryProjectPathConfig = {
   projectSlug: string;
   repoId: string;
   repoName: string;
-  integrationId: number | null;
+  integrationId: string | null;
   provider: BaseIntegrationProvider | null;
   stackRoot: string;
   sourceRoot: string;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1092,8 +1092,8 @@ export type RepositoryProjectPathConfig = {
   projectSlug: string;
   repoId: string;
   repoName: string;
-  integrationId: string;
-  provider: BaseIntegrationProvider;
+  integrationId: number | null;
+  provider: BaseIntegrationProvider | null;
   stackRoot: string;
   sourceRoot: string;
   defaultBranch?: string;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1086,17 +1086,25 @@ export enum RepositoryStatus {
   DELETION_IN_PROGRESS = 'deletion_in_progress',
 }
 
-export type RepositoryProjectPathConfig = {
+type BaseRepositoryProjectPathConfig = {
   id: string;
   projectId: string;
   projectSlug: string;
   repoId: string;
   repoName: string;
-  integrationId: string | null;
-  provider: BaseIntegrationProvider | null;
   stackRoot: string;
   sourceRoot: string;
   defaultBranch?: string;
+};
+
+export type RepositoryProjectPathConfig = BaseRepositoryProjectPathConfig & {
+  integrationId: string | null;
+  provider: BaseIntegrationProvider | null;
+};
+
+export type RepositoryProjectPathConfigWithIntegration = BaseRepositoryProjectPathConfig & {
+  integrationId: string;
+  provider: BaseIntegrationProvider;
 };
 
 export type PullRequest = {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -76,7 +76,8 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
     return [
       [
         'pathConfigs',
-        `/organizations/${orgSlug}/repo-project-path-configs/?integrationId=${this.integrationId}`,
+        `/organizations/${orgSlug}/repo-project-path-configs/`,
+        {query: {integrationId: this.integrationId}},
       ],
       ['repos', `/organizations/${orgSlug}/repos/`, {query: {status: 'active'}}],
     ];

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -76,7 +76,7 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
     return [
       [
         'pathConfigs',
-        `/organizations/${orgSlug}/integrations/${this.integrationId}/repo-project-path-configs/`,
+        `/organizations/${orgSlug}/repo-project-path-configs/?integrationId=${this.integrationId}`,
       ],
       ['repos', `/organizations/${orgSlug}/repos/`, {query: {status: 'active'}}],
     ];
@@ -103,8 +103,8 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
   }
 
   handleDelete = async (pathConfig: RepositoryProjectPathConfig) => {
-    const {organization, integration} = this.props;
-    const endpoint = `/organizations/${organization.slug}/integrations/${integration.id}/repo-project-path-configs/${pathConfig.id}/`;
+    const {organization} = this.props;
+    const endpoint = `/organizations/${organization.slug}/repo-project-path-configs/${pathConfig.id}/`;
     try {
       await this.api.requestPromise(endpoint, {
         method: 'DELETE',

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -432,6 +432,7 @@ class Factories:
     def create_code_mapping(project, repo=None, **kwargs):
         kwargs.setdefault("stack_root", "")
         kwargs.setdefault("source_root", "")
+        kwargs.setdefault("default_branch", "master")
 
         if not repo:
             repo = Factories.create_repo(project=project)

--- a/tests/js/spec/components/events/interfaces/stacktraceLinkModal.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/stacktraceLinkModal.spec.jsx
@@ -36,7 +36,7 @@ describe('StacktraceLinkModal', function () {
     });
 
     MockApiClient.addMockResponse({
-      url: `/organizations/${org.slug}/integrations/${integration.id}/repo-project-path-configs/`,
+      url: `/organizations/${org.slug}/repo-project-path-configs/`,
       method: 'POST',
       statusCode,
     });

--- a/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -69,7 +69,7 @@ describe('IntegrationCodeMappings', function () {
 
     mockResponse([
       [
-        `/organizations/${org.slug}/repo-project-path-configs/?integrationId=${integration.id}`,
+        `/organizations/${org.slug}/repo-project-path-configs/`,
         [pathConfig1, pathConfig2],
       ],
       [`/organizations/${org.slug}/repos/`, repos],
@@ -80,7 +80,7 @@ describe('IntegrationCodeMappings', function () {
     );
   });
 
-  it('shows the paths', () => {
+  it('shows the paths', async () => {
     expect(wrapper.find('RepoName').length).toEqual(2);
     expect(wrapper.find('RepoName').at(0).text()).toEqual(repos[0].name);
     expect(wrapper.find('RepoName').at(1).text()).toEqual(repos[1].name);

--- a/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationCodeMappings.spec.jsx
@@ -69,7 +69,7 @@ describe('IntegrationCodeMappings', function () {
 
     mockResponse([
       [
-        `/organizations/${org.slug}/integrations/${integration.id}/repo-project-path-configs/`,
+        `/organizations/${org.slug}/repo-project-path-configs/?integrationId=${integration.id}`,
         [pathConfig1, pathConfig2],
       ],
       [`/organizations/${org.slug}/repos/`, repos],
@@ -102,7 +102,7 @@ describe('IntegrationCodeMappings', function () {
     const stackRoot = 'my/root';
     const sourceRoot = 'hey/dude';
     const defaultBranch = 'release';
-    const url = `/organizations/${org.slug}/integrations/${integration.id}/repo-project-path-configs/`;
+    const url = `/organizations/${org.slug}/repo-project-path-configs/`;
     const createMock = Client.addMockResponse({
       url,
       method: 'POST',
@@ -133,13 +133,14 @@ describe('IntegrationCodeMappings', function () {
     expect(createMock).toHaveBeenCalledWith(
       url,
       expect.objectContaining({
-        data: {
+        data: expect.objectContaining({
           projectId: projects[1].id,
           repositoryId: repos[1].id,
           stackRoot,
           sourceRoot,
           defaultBranch,
-        },
+          integrationId: integration.id,
+        }),
       })
     );
   });
@@ -148,7 +149,7 @@ describe('IntegrationCodeMappings', function () {
     const stackRoot = 'new/root';
     const sourceRoot = 'source/root';
     const defaultBranch = 'master';
-    const url = `/organizations/${org.slug}/integrations/${integration.id}/repo-project-path-configs/${pathConfig1.id}/`;
+    const url = `/organizations/${org.slug}/repo-project-path-configs/${pathConfig1.id}/`;
     const editMock = Client.addMockResponse({
       url,
       method: 'PUT',
@@ -170,13 +171,13 @@ describe('IntegrationCodeMappings', function () {
     expect(editMock).toHaveBeenCalledWith(
       url,
       expect.objectContaining({
-        data: {
+        data: expect.objectContaining({
           defaultBranch,
           projectId: '2',
           repositoryId: '4',
           sourceRoot,
           stackRoot,
-        },
+        }),
       })
     );
   });

--- a/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_config_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_config_details.py
@@ -47,7 +47,7 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
         assert resp.status_code == 204
         assert not RepositoryProjectPathConfig.objects.filter(id=str(self.config.id)).exists()
 
-    def test_basic_edit_(self):
+    def test_basic_edit(self):
         resp = self.make_put({"sourceRoot": "newRoot"})
         assert resp.status_code == 200
         assert resp.data["id"] == str(self.config.id)

--- a/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_config_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_config_details.py
@@ -30,24 +30,24 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
         )
 
         self.url = reverse(
-            "sentry-api-0-organization-integration-repository-project-path-config-details",
-            args=[self.org.slug, self.integration.id, self.config.id],
+            "sentry-api-0-organization-repository-project-path-config-details",
+            args=[self.org.slug, self.config.id],
         )
 
     def make_put(self, data):
         # reconstruct the original object
         config_data = serialize(self.config, self.user)
-        config_data["repositoryId"] = str(self.repo.id)
-        # update with the new fields
-        config_data.update(data)
-        return self.client.put(self.url, config_data)
+        return self.client.put(
+            self.url,
+            {**config_data, **data, "repositoryId": self.repo.id},
+        )
 
     def test_basic_delete(self):
         resp = self.client.delete(self.url)
         assert resp.status_code == 204
         assert not RepositoryProjectPathConfig.objects.filter(id=str(self.config.id)).exists()
 
-    def test_basic_edit(self):
+    def test_basic_edit_(self):
         resp = self.make_put({"sourceRoot": "newRoot"})
         assert resp.status_code == 200
         assert resp.data["id"] == str(self.config.id)

--- a/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_config_details.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_config_details.py
@@ -5,7 +5,7 @@ from sentry.models import Integration, Repository, RepositoryProjectPathConfig
 from sentry.testutils import APITestCase
 
 
-class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
+class OrganizationIntegrationRepositoryProjectPathConfigDetailsTest(APITestCase):
     def setUp(self):
         super().setUp()
 

--- a/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
@@ -38,15 +38,14 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
         return self.client.post(self.url, data=config_data, format="json")
 
     def test_basic_get_with_integrationId(self):
-        path_config1 = RepositoryProjectPathConfig.objects.create(
+        path_config1 = self.create_code_mapping(
             organization_integration=self.org_integration,
             project=self.project1,
             repository=self.repo1,
             stack_root="stack/root",
             source_root="source/root",
-            default_branch="master",
         )
-        path_config2 = RepositoryProjectPathConfig.objects.create(
+        path_config2 = self.create_code_mapping(
             organization_integration=self.org_integration,
             project=self.project2,
             repository=self.repo1,

--- a/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
@@ -41,14 +41,14 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
         path_config1 = self.create_code_mapping(
             organization_integration=self.org_integration,
             project=self.project1,
-            repository=self.repo1,
+            repo=self.repo1,
             stack_root="stack/root",
             source_root="source/root",
         )
         path_config2 = self.create_code_mapping(
             organization_integration=self.org_integration,
             project=self.project2,
-            repository=self.repo1,
+            repo=self.repo1,
             stack_root="another/path",
             source_root="hey/there",
         )
@@ -97,7 +97,7 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
             "integrationId": str(self.integration.id),
             "stackRoot": "another/path",
             "sourceRoot": "hey/there",
-            "defaultBranch": None,
+            "defaultBranch": "master",
         }
 
     def test_basic_get_with_projectId(self):

--- a/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
@@ -21,8 +21,8 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
             name="example", organization_id=self.org.id, integration_id=self.integration.id
         )
         self.url = reverse(
-            "sentry-api-0-organization-integration-repository-project-path-config",
-            args=[self.org.slug, self.integration.id],
+            "sentry-api-0-organization-repository-project-path-config",
+            args=[self.org.slug],
         )
 
     def make_post(self, data=None):
@@ -37,7 +37,7 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
             config_data.update(data)
         return self.client.post(self.url, data=config_data, format="json")
 
-    def test_basic_get(self):
+    def test_basic_get_with_integrationId(self):
         path_config1 = RepositoryProjectPathConfig.objects.create(
             organization_integration=self.org_integration,
             project=self.project1,
@@ -53,7 +53,9 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
             stack_root="another/path",
             source_root="hey/there",
         )
-        response = self.client.get(self.url, format="json")
+
+        url_path = f"{self.url}?integrationId={self.integration.id}"
+        response = self.client.get(url_path, format="json")
 
         assert response.status_code == 200, response.content
 
@@ -99,8 +101,82 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
             "defaultBranch": None,
         }
 
-    def test_basic_post(self):
-        response = self.make_post()
+    def test_basic_get_with_projectId(self):
+        path_config1 = RepositoryProjectPathConfig.objects.create(
+            organization_integration=self.org_integration,
+            project=self.project1,
+            repository=self.repo1,
+            stack_root="stack/root",
+            source_root="source/root",
+            default_branch="master",
+        )
+
+        url_path = f"{self.url}?projectId={self.project1.id}"
+        response = self.client.get(url_path, format="json")
+
+        assert response.status_code == 200, response.content
+
+        assert response.data[0] == {
+            "id": str(path_config1.id),
+            "projectId": str(self.project1.id),
+            "projectSlug": self.project1.slug,
+            "repoId": str(self.repo1.id),
+            "repoName": self.repo1.name,
+            "provider": {
+                "aspects": {},
+                "features": ["commits", "issue-basic"],
+                "name": "GitHub",
+                "canDisable": False,
+                "key": "github",
+                "slug": "github",
+                "canAdd": True,
+            },
+            "integrationId": str(self.integration.id),
+            "stackRoot": "stack/root",
+            "sourceRoot": "source/root",
+            "defaultBranch": "master",
+        }
+
+    def test_basic_get_with_no_integrationId_and_projectId(self):
+        RepositoryProjectPathConfig.objects.create(
+            organization_integration=self.org_integration,
+            project=self.project1,
+            repository=self.repo1,
+            stack_root="stack/root",
+            source_root="source/root",
+            default_branch="master",
+        )
+
+        RepositoryProjectPathConfig.objects.create(
+            organization_integration=self.org_integration,
+            project=self.project2,
+            repository=self.repo1,
+            stack_root="another/path",
+            source_root="hey/there",
+        )
+
+        url_path = f"{self.url}"
+        response = self.client.get(url_path, format="json")
+
+        assert response.status_code == 400, response.content
+        assert response.data == {"detail": 'Missing valid "projectId" or "integrationId"'}
+
+    def test_basic_get_with_invalid_integrationId(self):
+
+        url_path = f"{self.url}?integrationId=100"
+        response = self.client.get(url_path, format="json")
+
+        assert response.status_code == 404, response.content
+
+    def test_basic_get_with_invalid_projectId(self):
+
+        url_path = f"{self.url}?projectId=100"
+        response = self.client.get(url_path, format="json")
+
+        assert response.status_code == 404, response.content
+
+    def test_basic_post_with_valid_integrationId(self):
+        response = self.make_post({"integrationId": self.integration.id})
         assert response.status_code == 201, response.content
         assert response.data == {
             "id": str(response.data["id"]),
@@ -123,6 +199,26 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
             "defaultBranch": "master",
         }
 
+    def test_basic_post_with_invalid_integrationId(self):
+        response = self.make_post({"integrationId": 100})
+        assert response.status_code == 404, response.content
+
+    def test_basic_post_with_no_integrationId(self):
+        response = self.make_post()
+        assert response.status_code == 201, response.content
+        assert response.data == {
+            "id": str(response.data["id"]),
+            "projectId": str(self.project1.id),
+            "projectSlug": self.project1.slug,
+            "repoId": str(self.repo1.id),
+            "repoName": self.repo1.name,
+            "provider": None,
+            "integrationId": None,
+            "stackRoot": "/stack/root",
+            "sourceRoot": "/source/root",
+            "defaultBranch": "master",
+        }
+
     def test_empty_roots_post(self):
         response = self.make_post({"stackRoot": "", "sourceRoot": ""})
         assert response.status_code == 201, response.content
@@ -134,11 +230,25 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
         assert response.status_code == 400
         assert response.data == {"projectId": ["Project does not exist"]}
 
-    def test_repo_does_not_exist(self):
+    def test_repo_does_not_exist_on_given_integrationId(self):
         bad_integration = Integration.objects.create(provider="github", external_id="radsfas")
         bad_integration.add_organization(self.org, self.user)
         bad_repo = Repository.objects.create(
             name="another", organization_id=self.org.id, integration_id=bad_integration.id
+        )
+        response = self.make_post(
+            {"repositoryId": bad_repo.id, "integrationId": self.integration.id}
+        )
+
+        assert response.status_code == 400
+        assert response.data == {"repositoryId": ["Repository does not exist"]}
+
+    def test_repo_does_not_exist_on_given_organization(self):
+        bad_org = self.create_organization(owner=self.user, name="foo")
+        bad_integration = Integration.objects.create(provider="github", external_id="radsfas")
+        bad_integration.add_organization(bad_org, self.user)
+        bad_repo = Repository.objects.create(
+            name="another", organization_id=bad_org.id, integration_id=bad_integration.id
         )
         response = self.make_post({"repositoryId": bad_repo.id})
 


### PR DESCRIPTION
## Objective:

In https://github.com/getsentry/sentry/pull/23673 , we created a migration to make `organization_integration_id` nullable. Yet we currently rely on `organization_integration_id` to find the code mappings for a project. 

The solution is to migrate away from the OrganizationIntegrationBaseEndpoint to the OrganizationEndpoint

## Test Plan
Add more python tests for query param validation logic. Updated frontend tests to mock the new endpoints.