### PR TITLE
fix: Restore horizontal scrolling to the span view

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -8,6 +8,7 @@ import * as CursorGuideHandler from './cursorGuideHandler';
 import * as DividerHandlerManager from './dividerHandlerManager';
 import {DragManagerChildrenProps} from './dragManager';
 import MeasurementsPanel from './measurementsPanel';
+import * as ScrollbarManager from './scrollbarManager';
 import {zIndex} from './styles';
 import {
   ParsedTraceType,
@@ -358,7 +359,21 @@ class TraceViewHeader extends React.Component<PropType, State> {
                   // the width of this component is shrunk to compensate for half of the width of the divider line
                   width: `calc(${toPercent(dividerPosition)} - 0.5px)`,
                 }}
-              />
+              >
+                <ScrollbarManager.Consumer>
+                  {({virtualScrollbarRef, onDragStart}) => {
+                    return (
+                      <VirtualScrollBar
+                        data-type="virtual-scrollbar"
+                        ref={virtualScrollbarRef}
+                        onMouseDown={onDragStart}
+                      >
+                        <VirtualScrollBarGrip />
+                      </VirtualScrollBar>
+                    );
+                  }}
+                </ScrollbarManager.Consumer>
+              </ScrollBarContainer>
               <DividerSpacer />
               {hasMeasurements ? (
                 <MeasurementsPanel
@@ -872,6 +887,25 @@ const RightSidePane = styled('div')`
   height: ${MINIMAP_HEIGHT + TIME_AXIS_HEIGHT}px;
   position: absolute;
   top: 0;
+`;
+
+const VirtualScrollBar = styled('div')`
+  height: 8px;
+  width: 0;
+  padding-left: 4px;
+  padding-right: 4px;
+  position: relative;
+  top: 0;
+  left: 0;
+  cursor: grab;
+`;
+
+const VirtualScrollBarGrip = styled('div')`
+  height: 8px;
+  width: 100%;
+  border-radius: 20px;
+  transition: background-color 150ms ease;
+  background-color: rgba(48, 40, 57, 0.5);
 `;
 
 export default TraceViewHeader;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -871,7 +871,8 @@ const ScrollBarContainer = styled('div')`
   left: 0;
   bottom: 0;
   & > div[data-type='virtual-scrollbar'].dragging > div {
-    background-color: ${p => p.theme.gray500};
+    background-color: ${p => p.theme.textColor};
+    opacity: 0.8;
     cursor: grabbing;
   }
 `;
@@ -905,7 +906,8 @@ const VirtualScrollBarGrip = styled('div')`
   width: 100%;
   border-radius: 20px;
   transition: background-color 150ms ease;
-  background-color: rgba(48, 40, 57, 0.5);
+  background-color: ${p => p.theme.textColor};
+  opacity: 0.5;
 `;
 
 export default TraceViewHeader;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -120,7 +120,7 @@ export class Provider extends React.Component<Props, State> {
   }
 
   initializeScrollState = () => {
-    if (this.contentSpanBar.size === 0) {
+    if (this.contentSpanBar.size === 0 || !this.hasInteractiveLayer()) {
       return;
     }
 
@@ -175,14 +175,14 @@ export class Provider extends React.Component<Props, State> {
     const virtualScrollbarDOM = this.virtualScrollbar.current;
 
     const maxContentWidth = spanBar.getBoundingClientRect().width;
-    const {parentElement} = spanBar;
+    const interactiveLayer = this.props.interactiveLayerRef.current!;
 
-    if (maxContentWidth === undefined || maxContentWidth <= 0 || !parentElement) {
+    if (maxContentWidth === undefined || maxContentWidth <= 0) {
       virtualScrollbarDOM.style.width = '0';
       return;
     }
 
-    const visibleWidth = parentElement.getBoundingClientRect().width;
+    const visibleWidth = interactiveLayer.getBoundingClientRect().width;
 
     // This is the width of the content not visible.
     const maxScrollDistance = maxContentWidth - visibleWidth;
@@ -292,14 +292,12 @@ export class Provider extends React.Component<Props, State> {
     const virtualScrollPercentage = clamp(rawMouseX / maxVirtualScrollableArea, 0, 1);
 
     // Update scroll positions of all the span bars
+    const interactiveLayer = this.props.interactiveLayerRef.current!;
+    const interactiveLayerWidth = interactiveLayer.getBoundingClientRect().width;
 
     selectRefs(this.contentSpanBar, (spanBarDOM: HTMLDivElement) => {
-      if (!spanBarDOM.parentElement) {
-        return;
-      }
-
-      const parentWidth = spanBarDOM.parentElement.getBoundingClientRect().width;
-      const maxScrollDistance = spanBarDOM.getBoundingClientRect().width - parentWidth;
+      const maxScrollDistance =
+        spanBarDOM.getBoundingClientRect().width - interactiveLayerWidth;
 
       const left = -lerp(0, maxScrollDistance, virtualScrollPercentage);
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -71,29 +71,18 @@ export class Provider extends React.Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (this.props.dividerPosition !== prevProps.dividerPosition) {
-      // Find any span bar and adjust the virtual scroll bar's scroll position
-      // with respect to this span bar.
+    // Re-initialize the scroll state whenever:
+    // - the window was selected via the minimap or,
+    // - the divider was re-positioned.
 
-      if (this.contentSpanBar.size === 0) {
-        return;
-      }
-
-      const spanBarDOM = this.getReferenceSpanBar();
-      if (spanBarDOM) {
-        this.syncVirtualScrollbar(spanBarDOM);
-      }
-
-      return;
-    }
-
-    // If the window was selected via the minimap, then re-initialize the scroll state.
+    const dividerPositionChanged =
+      this.props.dividerPosition !== prevProps.dividerPosition;
 
     const viewWindowChanged =
       prevProps.dragProps.viewWindowStart !== this.props.dragProps.viewWindowStart ||
       prevProps.dragProps.viewWindowEnd !== this.props.dragProps.viewWindowEnd;
 
-    if (viewWindowChanged) {
+    if (dividerPositionChanged || viewWindowChanged) {
       this.initializeScrollState();
     }
   }

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/scrollbarManager.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/scrollbarManager.tsx
@@ -7,7 +7,6 @@ import {DragManagerChildrenProps} from './dragManager';
 import {clamp, rectOfContent, toPercent} from './utils';
 
 export type ScrollbarManagerChildrenProps = {
-  generateScrollableSpanBarRef: () => (instance: HTMLDivElement | null) => void;
   generateContentSpanBarRef: () => (instance: HTMLDivElement | null) => void;
   virtualScrollbarRef: React.RefObject<HTMLDivElement>;
   onDragStart: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -15,7 +14,6 @@ export type ScrollbarManagerChildrenProps = {
 };
 
 const ScrollbarManagerContext = React.createContext<ScrollbarManagerChildrenProps>({
-  generateScrollableSpanBarRef: () => () => undefined,
   generateContentSpanBarRef: () => () => undefined,
   virtualScrollbarRef: React.createRef<HTMLDivElement>(),
   onDragStart: () => {},
@@ -24,7 +22,7 @@ const ScrollbarManagerContext = React.createContext<ScrollbarManagerChildrenProp
 
 const selectRefs = (
   refs: Set<HTMLDivElement> | React.RefObject<HTMLDivElement>,
-  transform: (dividerDOM: HTMLDivElement) => void
+  transform: (element: HTMLDivElement) => void
 ) => {
   if (!(refs instanceof Set)) {
     if (refs.current) {
@@ -77,7 +75,7 @@ export class Provider extends React.Component<Props, State> {
       // Find any span bar and adjust the virtual scroll bar's scroll position
       // with respect to this span bar.
 
-      if (this.scrollableSpanBar.size === 0) {
+      if (this.contentSpanBar.size === 0) {
         return;
       }
 
@@ -104,14 +102,13 @@ export class Provider extends React.Component<Props, State> {
     this.cleanUpListeners();
   }
 
-  scrollableSpanBar: Set<HTMLDivElement> = new Set();
   contentSpanBar: Set<HTMLDivElement> = new Set();
   virtualScrollbar: React.RefObject<HTMLDivElement> = React.createRef<HTMLDivElement>();
   isDragging: boolean = false;
   previousUserSelect: UserSelectValues | null = null;
 
   getReferenceSpanBar() {
-    for (const currentSpanBar of this.scrollableSpanBar) {
+    for (const currentSpanBar of this.contentSpanBar) {
       const isHidden = currentSpanBar.offsetParent === null;
       if (!document.body.contains(currentSpanBar) || isHidden) {
         continue;
@@ -123,25 +120,21 @@ export class Provider extends React.Component<Props, State> {
   }
 
   initializeScrollState = () => {
-    if (this.scrollableSpanBar.size === 0 || this.contentSpanBar.size === 0) {
+    if (this.contentSpanBar.size === 0) {
       return;
     }
-
-    // set initial scroll state for all scrollable spanbars
-    selectRefs(this.scrollableSpanBar, (spanBarDOM: HTMLDivElement) => {
-      spanBarDOM.scrollLeft = 0;
-    });
 
     // reset all span bar content containers to their natural widths
     selectRefs(this.contentSpanBar, (spanBarDOM: HTMLDivElement) => {
       spanBarDOM.style.removeProperty('width');
       spanBarDOM.style.removeProperty('max-width');
       spanBarDOM.style.removeProperty('overflow');
+      spanBarDOM.style.removeProperty('transform');
     });
 
     // Find the maximum content width. We set each content spanbar to be this maximum width,
     // such that all content spanbar widths are uniform.
-    const maxContentWidth = Array.from(this.scrollableSpanBar).reduce(
+    const maxContentWidth = Array.from(this.contentSpanBar).reduce(
       (currentMaxWidth, currentSpanBar) => {
         const isHidden = currentSpanBar.offsetParent === null;
         if (!document.body.contains(currentSpanBar) || isHidden) {
@@ -165,71 +158,15 @@ export class Provider extends React.Component<Props, State> {
       spanBarDOM.style.overflow = 'hidden';
     });
 
-    this.scrollableSpanBar.forEach(currentSpanBarRef => {
-      this.unregisterEventListeners(currentSpanBarRef);
-    });
-
     const spanBarDOM = this.getReferenceSpanBar();
 
     if (spanBarDOM) {
       this.syncVirtualScrollbar(spanBarDOM);
     }
-
-    this.scrollableSpanBar.forEach(currentSpanBarRef => {
-      this.registerEventListeners(currentSpanBarRef);
-    });
   };
 
-  registerEventListeners = (spanbar: HTMLDivElement) => {
-    spanbar.onscroll = this.handleScroll.bind(this, spanbar);
-  };
-
-  unregisterEventListeners = (spanbar: HTMLDivElement) => {
-    spanbar.onscroll = null;
-  };
-
-  handleScroll = (spanbar: HTMLDivElement) => {
-    window.requestAnimationFrame(() => {
-      this.syncScrollPositions(spanbar);
-    });
-  };
-
-  syncScrollPositions = (scrolledSpanBar: HTMLDivElement) => {
-    // Sync scroll positions of all span bars with respect to scrolledSpanBar's
-    // scroll position
-
-    selectRefs(this.scrollableSpanBar, (spanBarDOM: HTMLDivElement) => {
-      if (scrolledSpanBar === spanBarDOM) {
-        // Don't sync scrolledSpanBar's scroll position with itself
-        return;
-      }
-
-      this.unregisterEventListeners(spanBarDOM);
-      this.syncScrollPosition(scrolledSpanBar, spanBarDOM);
-      this.syncVirtualScrollbar(scrolledSpanBar);
-
-      window.requestAnimationFrame(() => {
-        this.registerEventListeners(spanBarDOM);
-      });
-    });
-  };
-
-  syncScrollPosition = (scrolledSpanBar: HTMLDivElement, spanBarDOM: HTMLDivElement) => {
-    // sync spanBarDOM's scroll position with respect to scrolledSpanBar's
-    // scroll position
-
-    const {scrollLeft, scrollWidth, clientWidth} = scrolledSpanBar;
-
-    const scrollLeftOffset = scrollWidth - clientWidth;
-
-    if (scrollLeftOffset > 0) {
-      spanBarDOM.scrollLeft = scrollLeft;
-    }
-  };
-
-  syncVirtualScrollbar = (scrolledSpanBar: HTMLDivElement) => {
-    // sync the virtual scrollbar's scroll position with respect to scrolledSpanBar's
-    // scroll position
+  syncVirtualScrollbar = (spanBar: HTMLDivElement) => {
+    // sync the virtual scrollbar's width scrolledSpanBar's width
 
     if (!this.virtualScrollbar.current || !this.hasInteractiveLayer()) {
       return;
@@ -237,16 +174,18 @@ export class Provider extends React.Component<Props, State> {
 
     const virtualScrollbarDOM = this.virtualScrollbar.current;
 
-    const maxContentWidth = scrolledSpanBar.scrollWidth;
+    const maxContentWidth = spanBar.getBoundingClientRect().width;
+    const {parentElement} = spanBar;
 
-    if (maxContentWidth === undefined || maxContentWidth <= 0) {
+    if (maxContentWidth === undefined || maxContentWidth <= 0 || !parentElement) {
       virtualScrollbarDOM.style.width = '0';
       return;
     }
 
-    const visibleWidth = scrolledSpanBar.getBoundingClientRect().width;
-    // This is the scroll width of the content not visible on the screen due to overflow.
-    const maxScrollDistance = scrolledSpanBar.scrollWidth - scrolledSpanBar.clientWidth;
+    const visibleWidth = parentElement.getBoundingClientRect().width;
+
+    // This is the width of the content not visible.
+    const maxScrollDistance = maxContentWidth - visibleWidth;
 
     const virtualScrollbarWidth = visibleWidth / (visibleWidth + maxScrollDistance);
 
@@ -257,40 +196,7 @@ export class Provider extends React.Component<Props, State> {
 
     virtualScrollbarDOM.style.width = `max(50px, ${toPercent(virtualScrollbarWidth)})`;
 
-    const rect = rectOfContent(this.props.interactiveLayerRef.current!);
-    const virtualScrollBarRect = rectOfContent(virtualScrollbarDOM);
-    const maxVirtualScrollableArea = 1 - virtualScrollBarRect.width / rect.width;
-
-    // Assume scrollbarLeftOffset = lerp(0, maxScrollDistance, virtualScrollPercentage).
-    // Then solve for virtualScrollPercentage.
-    const virtualScrollPercentage = clamp(
-      scrolledSpanBar.scrollLeft / maxScrollDistance,
-      0,
-      1
-    );
-    const virtualScrollbarPosition = virtualScrollPercentage * maxVirtualScrollableArea;
-
-    virtualScrollbarDOM.style.left = `clamp(0%, calc(${toPercent(
-      virtualScrollbarPosition
-    )}), calc(100% - max(50px, ${toPercent(virtualScrollbarWidth)})))`;
-  };
-
-  generateScrollableSpanBarRef = () => {
-    let previousInstance: HTMLDivElement | null = null;
-
-    const addScrollableSpanBarRef = (instance: HTMLDivElement | null) => {
-      if (previousInstance) {
-        this.scrollableSpanBar.delete(previousInstance);
-        previousInstance = null;
-      }
-
-      if (instance) {
-        this.scrollableSpanBar.add(instance);
-        previousInstance = instance;
-      }
-    };
-
-    return addScrollableSpanBarRef;
+    virtualScrollbarDOM.style.left = '0';
   };
 
   generateContentSpanBarRef = () => {
@@ -348,8 +254,8 @@ export class Provider extends React.Component<Props, State> {
 
     this.isDragging = true;
 
-    selectRefs(this.virtualScrollbar, dividerDOM => {
-      dividerDOM.classList.add('dragging');
+    selectRefs(this.virtualScrollbar, scrollbarDOM => {
+      scrollbarDOM.classList.add('dragging');
     });
   };
 
@@ -387,16 +293,18 @@ export class Provider extends React.Component<Props, State> {
 
     // Update scroll positions of all the span bars
 
-    selectRefs(this.scrollableSpanBar, (spanBarDOM: HTMLDivElement) => {
-      this.unregisterEventListeners(spanBarDOM);
+    selectRefs(this.contentSpanBar, (spanBarDOM: HTMLDivElement) => {
+      if (!spanBarDOM.parentElement) {
+        return;
+      }
 
-      const maxScrollDistance = spanBarDOM.scrollWidth - spanBarDOM.clientWidth;
+      const parentWidth = spanBarDOM.parentElement.getBoundingClientRect().width;
+      const maxScrollDistance = spanBarDOM.getBoundingClientRect().width - parentWidth;
 
-      spanBarDOM.scrollLeft = lerp(0, maxScrollDistance, virtualScrollPercentage);
+      const left = -lerp(0, maxScrollDistance, virtualScrollPercentage);
 
-      window.requestAnimationFrame(() => {
-        this.registerEventListeners(spanBarDOM);
-      });
+      spanBarDOM.style.transform = `translate3d(${left}px, 0, 0)`;
+      spanBarDOM.style.transformOrigin = 'left';
     });
   };
 
@@ -420,8 +328,8 @@ export class Provider extends React.Component<Props, State> {
 
     this.isDragging = false;
 
-    selectRefs(this.virtualScrollbar, dividerDOM => {
-      dividerDOM.classList.remove('dragging');
+    selectRefs(this.virtualScrollbar, scrollbarDOM => {
+      scrollbarDOM.classList.remove('dragging');
     });
   };
 
@@ -435,7 +343,6 @@ export class Provider extends React.Component<Props, State> {
 
   render() {
     const childrenProps: ScrollbarManagerChildrenProps = {
-      generateScrollableSpanBarRef: this.generateScrollableSpanBarRef,
       generateContentSpanBarRef: this.generateContentSpanBarRef,
       onDragStart: this.onDragStart,
       virtualScrollbarRef: this.virtualScrollbar,

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -509,10 +509,7 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
   renderTitle(
     scrollbarManagerChildrenProps: ScrollbarManager.ScrollbarManagerChildrenProps
   ) {
-    const {
-      generateContentSpanBarRef,
-      generateScrollableSpanBarRef,
-    } = scrollbarManagerChildrenProps;
+    const {generateContentSpanBarRef} = scrollbarManagerChildrenProps;
     const {span, treeDepth, spanErrors} = this.props;
 
     const operationName = getSpanOperation(span) ? (
@@ -528,22 +525,23 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
     const left = treeDepth * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
 
     return (
-      <ScrollableSpanBar ref={generateScrollableSpanBarRef()}>
-        <SpanBarTitleContainer ref={generateContentSpanBarRef()}>
-          {this.renderSpanTreeToggler({left})}
-          <SpanBarTitle
-            style={{
-              left: `${left}px`,
-              width: '100%',
-            }}
-          >
-            <span>
-              {operationName}
-              {description}
-            </span>
-          </SpanBarTitle>
-        </SpanBarTitleContainer>
-      </ScrollableSpanBar>
+      <SpanBarTitleContainer
+        data-debug-id="SpanBarTitleContainer"
+        ref={generateContentSpanBarRef()}
+      >
+        {this.renderSpanTreeToggler({left})}
+        <SpanBarTitle
+          style={{
+            left: `${left}px`,
+            width: '100%',
+          }}
+        >
+          <span>
+            {operationName}
+            {description}
+          </span>
+        </SpanBarTitle>
+      </SpanBarTitleContainer>
     );
   }
 
@@ -1026,15 +1024,6 @@ export const SpanBarTitle = styled('div')`
   display: flex;
   flex: 1;
   align-items: center;
-`;
-
-const ScrollableSpanBar = styled('div')`
-  position: relative;
-  /* increase span bar height such that the horizontal scrollbar is out of view */
-  height: ${SPAN_ROW_HEIGHT + 50}px;
-  /* for virtual scrollbar */
-  overflow-y: hidden;
-  overflow-x: scroll;
 `;
 
 type TogglerTypes = OmitHtmlDivProps<{

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanGroup.tsx
@@ -4,11 +4,12 @@ import {Organization} from 'app/types';
 import {EventTransaction} from 'app/types/event';
 import {TableData, TableDataRow} from 'app/utils/discover/discoverQuery';
 
+import {ScrollbarManagerChildrenProps, withScrollbarManager} from './scrollbarManager';
 import SpanBar from './spanBar';
 import {ParsedTraceType, ProcessedSpanType, TreeDepthType} from './types';
 import {getSpanID, isGapSpan, SpanBoundsType, SpanGeneratedBoundsType} from './utils';
 
-type PropType = {
+type PropType = ScrollbarManagerChildrenProps & {
   orgId: string;
   organization: Organization;
   event: Readonly<EventTransaction>;
@@ -36,6 +37,14 @@ class SpanGroup extends React.Component<PropType, State> {
   state: State = {
     showSpanTree: true,
   };
+
+  componentDidUpdate(_prevProps: PropType, prevState: State) {
+    if (prevState.showSpanTree !== this.state.showSpanTree) {
+      // Update horizontal scroll states after this subtree was either hidden or
+      // revealed.
+      this.props.updateScrollState();
+    }
+  }
 
   toggleSpanTree = () => {
     this.setState(state => ({
@@ -125,4 +134,4 @@ class SpanGroup extends React.Component<PropType, State> {
   }
 }
 
-export default SpanGroup;
+export default withScrollbarManager(SpanGroup);


### PR DESCRIPTION

Restore horizontal scrolling that was disabled in https://github.com/getsentry/sentry/pull/22660 due to performance issues.

Previously the implementation allowed for each span bar to be scrollable, which allowed each span bar to scroll all other span bars, including the virtual scroll bar. This was the source of some of the performance issues, most notably when there are many spans.

This specific implementation detail has been removed in favour of controlling the scroll position only from the virtual scroll bar.

In addition, some performance optimizations included is the usage of `translate3d()` to compute x-axis positions which can help avoid repaints. 

https://user-images.githubusercontent.com/139499/107827484-e2854f80-6d54-11eb-884d-8ba3532fc799.mp4

