### PR TITLE
feat: Add a link to discord in the help sidebar

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/help.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/help.tsx
@@ -41,6 +41,9 @@ const SidebarHelp = ({orientation, collapsed, hidePanel, organization}: Props) =
             <SidebarMenuItem href="https://forum.sentry.io/">
               {t('Community Discussions')}
             </SidebarMenuItem>
+            <SidebarMenuItem href="https://discord.com/invite/sentry/">
+              {t('Join the Sentry Discord')}
+            </SidebarMenuItem>
             <SidebarMenuItem href="https://status.sentry.io/">
               {t('Service Status')}
             </SidebarMenuItem>

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -153,7 +153,7 @@ describe('Sidebar', function () {
       const menu = wrapper.find('HelpMenu');
       expect(menu).toHaveLength(1);
       expect(menu).toSnapshot();
-      expect(menu.find('SidebarMenuItem')).toHaveLength(3);
+      expect(menu.find('SidebarMenuItem')).toHaveLength(4);
       wrapper.find('HelpActor').simulate('click');
       expect(wrapper.find('HelpMenu')).toHaveLength(0);
     });


### PR DESCRIPTION
<img width="271" alt="image" src="https://user-images.githubusercontent.com/4205004/107831601-6bec5000-6d5c-11eb-8578-f1db9a44767b.png">
<img width="263" alt="image" src="https://user-images.githubusercontent.com/4205004/107831621-760e4e80-6d5c-11eb-9173-8e87e6dbea15.png">
