### PR TITLE
fix: Various fixes for Dashboards

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
@@ -8,12 +8,12 @@ import {Widget} from './types';
 import WidgetCard from './widgetCard';
 import WidgetWrapper from './widgetWrapper';
 
-const initialStyles = {
+const initialStyles: React.ComponentProps<typeof WidgetWrapper>['animate'] = {
   x: 0,
   y: 0,
   scaleX: 1,
   scaleY: 1,
-  zIndex: 0,
+  zIndex: 'auto',
 };
 
 type Props = {
@@ -69,7 +69,7 @@ function SortableWidget(props: Props) {
               y: transform.y,
               scaleX: transform?.scaleX && transform.scaleX <= 1 ? transform.scaleX : 1,
               scaleY: transform?.scaleY && transform.scaleY <= 1 ? transform.scaleY : 1,
-              zIndex: currentWidgetDragging ? theme.zIndex.modal : 0,
+              zIndex: currentWidgetDragging ? theme.zIndex.modal : 'auto',
             }
           : initialStyles
       }

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCard.tsx
@@ -168,7 +168,6 @@ const StyledPanel = styled(Panel, {
   /* If a panel overflows due to a long title stretch its grid sibling */
   height: 100%;
   min-height: 96px;
-  overflow: hidden;
 `;
 
 const ToolbarPanel = styled('div')`
@@ -185,6 +184,7 @@ const ToolbarPanel = styled('div')`
   align-items: flex-start;
 
   background-color: rgba(255, 255, 255, 0.7);
+  border-radius: ${p => p.theme.borderRadius};
 `;
 
 const IconContainer = styled('div')`

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
@@ -367,6 +367,8 @@ const StyledSimpleTableChart = styled(SimpleTableChart)`
   /* align with other card charts */
   height: 216px;
   margin-top: ${space(1.5)};
+  border-bottom-left-radius: ${p => p.theme.borderRadius};
+  border-bottom-right-radius: ${p => p.theme.borderRadius};
 `;
 
 export default WidgetCardChart;


### PR DESCRIPTION
- Fix tooltips being shown below other dashboard widgets.
- Accidentally applied `overflow: hidden` to the entire widget container. Instead reverted it in favour of applying a border radius.
- Apply border radius to the bottom corners of the dashboard table widget.