### PR TITLE
fix(ui): Issue stream issue chart stats period selector bug

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/timeRangeSelector/index.tsx
@@ -251,7 +251,7 @@ class TimeRangeSelector extends React.PureComponent<Props, State> {
     const {onChange} = this.props;
 
     const newDateTime: ChangeData = {
-      relative: null,
+      relative: DEFAULT_STATS_PERIOD,
       start: null,
       end: null,
       utc: null,

--- a/src/sentry/static/sentry/app/views/issueList/actions/headers.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/headers.tsx
@@ -48,12 +48,14 @@ function Headers({
           >
             <GraphHeader>
               <StyledToolbarHeader>{t('Graph:')}</StyledToolbarHeader>
-              <GraphToggle
-                active={statsPeriod === '24h'}
-                onClick={() => onSelectStatsPeriod('24h')}
-              >
-                {t('24h')}
-              </GraphToggle>
+              {selection.datetime.period !== '24h' && (
+                <GraphToggle
+                  active={statsPeriod === '24h'}
+                  onClick={() => onSelectStatsPeriod('24h')}
+                >
+                  {t('24h')}
+                </GraphToggle>
+              )}
               <GraphToggle
                 active={statsPeriod === 'auto'}
                 onClick={() => onSelectStatsPeriod('auto')}


### PR DESCRIPTION
This fixes an issue where the chart dateRange selector in the issue stream would show `24h / 24h`. Added a special case for hiding the default `'24h'` when `'24h'` is selected from the global selection header. Also when global selection header is cleaned now it sets the selection to `'14d'`, this is the default period and all other behavior is consistent with `'14d'` except for `selection.datetime.period`. It is now consistent.
![CleanShot 2021-02-12 at 14 59 57](https://user-images.githubusercontent.com/15015880/107835717-5290d700-6d4f-11eb-9b39-53945539fe12.png)
