### PR TITLE
feat(grouping): Do not flip stuff randomly to in_app false

### DIFF
--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -222,19 +222,14 @@ def _has_system_frames(frames):
     return bool(system_frames) and len(frames) != system_frames
 
 
-def _normalize_in_app(stacktrace, platform=None, sdk_info=None):
+def _normalize_in_app(stacktrace):
     """
     Ensures consistent values of in_app across a stacktrace.
     """
-    has_system_frames = _has_system_frames(stacktrace)
+    # Default to false in all cases where processors or grouping enhancers
+    # have not yet set in_app.
     for frame in stacktrace:
-        # If all frames are in_app, flip all of them. This is expected by the UI
-        if not has_system_frames:
-            set_in_app(frame, False)
-
-        # Default to false in all cases where processors or grouping enhancers
-        # have not yet set in_app.
-        elif frame.get("in_app") is None:
+        if frame.get("in_app") is None:
             set_in_app(frame, False)
 
 
@@ -286,7 +281,7 @@ def normalize_stacktraces_for_grouping(data, grouping_config=None):
 
     # normalize in-app
     for stacktrace in stacktraces:
-        _normalize_in_app(stacktrace, platform=platform)
+        _normalize_in_app(stacktrace)
 
 
 def should_process_for_stacktraces(data):

--- a/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_only_app_frames.pysnap
+++ b/tests/sentry/event_manager/interfaces/snapshots/test_exception/test_context_with_only_app_frames.pysnap
@@ -1,12 +1,12 @@
 ---
-created: '2019-06-05T20:07:56.986283Z'
+created: '2021-02-15T10:54:23.648255Z'
 creator: sentry
 source: tests/sentry/event_manager/interfaces/test_exception.py
 ---
 errors: null
 get_api_context:
   excOmitted: null
-  hasSystemFrames: false
+  hasSystemFrames: true
   values:
   - mechanism: null
     module: foo.bar
@@ -19,7 +19,7 @@ get_api_context:
         errors: null
         filename: foo/baz.py
         function: null
-        inApp: false
+        inApp: true
         instructionAddr: null
         lineNo: 1
         module: null
@@ -31,7 +31,7 @@ get_api_context:
         trust: null
         vars: null
       framesOmitted: null
-      hasSystemFrames: false
+      hasSystemFrames: true
       registers: null
     threadId: null
     type: ValueError
@@ -47,7 +47,7 @@ get_api_context:
         errors: null
         filename: foo/baz.py
         function: null
-        inApp: false
+        inApp: true
         instructionAddr: null
         lineNo: 1
         module: null
@@ -59,7 +59,7 @@ get_api_context:
         trust: null
         vars: null
       framesOmitted: null
-      hasSystemFrames: false
+      hasSystemFrames: true
       registers: null
     threadId: null
     type: ValueError
@@ -70,10 +70,8 @@ to_json:
     stacktrace:
       frames:
       - abs_path: foo/baz.py
-        data:
-          orig_in_app: 1
         filename: foo/baz.py
-        in_app: false
+        in_app: true
         lineno: 1
     type: ValueError
     value: hello world
@@ -81,10 +79,8 @@ to_json:
     stacktrace:
       frames:
       - abs_path: foo/baz.py
-        data:
-          orig_in_app: 1
         filename: foo/baz.py
-        in_app: false
+        in_app: true
         lineno: 1
     type: ValueError
     value: hello world

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:26.549863Z'
+created: '2021-02-15T10:11:48.660275Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
     app (exception of system takes precedence)
       exception (ignored because hash matches system variant)
         stacktrace*
-          frame* (frame considered in-app because no frame is in-app)
+          frame*
             filename*
               "foo/baz.py"
             lineno*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:26.566831Z'
+created: '2021-02-15T10:11:47.906066Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
     app (exception of system takes precedence)
       exception (ignored because hash matches system variant)
         stacktrace*
-          frame* (frame considered in-app because no frame is in-app)
+          frame*
             filename*
               "foo/baz.py"
             lineno*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/exception_compute_hashes_3.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:26.583065Z'
+created: '2021-02-15T10:11:47.604341Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
       chained-exception (ignored because hash matches system variant)
         exception*
           stacktrace*
-            frame* (frame considered in-app because no frame is in-app)
+            frame*
               filename*
                 "foo/baz.py"
               lineno*
@@ -21,7 +21,7 @@ app:
             "hello world"
         exception*
           stacktrace*
-            frame* (frame considered in-app because no frame is in-app)
+            frame*
               filename*
                 "foo/baz.py"
               lineno*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/python_exception_base.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:28.472520Z'
+created: '2021-02-15T10:11:48.466717Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -10,7 +10,7 @@ app:
       chained-exception (ignored because hash matches system variant)
         exception*
           stacktrace*
-            frame* (frame considered in-app because no frame is in-app)
+            frame*
               filename*
                 "foo/baz.py"
               lineno*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/legacy@2019_03_12/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-25T09:17:10.922310Z'
+created: '2021-02-15T10:11:48.993265Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -9,7 +9,7 @@ app:
     app (threads of system take precedence)
       threads (ignored because hash matches system variant)
         stacktrace*
-          frame* (frame considered in-app because no frame is in-app)
+          frame*
             filename*
               "foo/baz.c"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:30.029678Z'
+created: '2021-02-15T10:11:59.745958Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,9 +7,9 @@ app:
   hash: null
   component:
     app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.py"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:30.045131Z'
+created: '2021-02-15T10:11:58.986101Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,9 +7,9 @@ app:
   hash: null
   component:
     app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.py"
         type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/exception_compute_hashes_3.pysnap
@@ -1,23 +1,23 @@
 ---
-created: '2020-02-26T19:54:30.068024Z'
+created: '2021-02-15T10:11:58.690991Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "9c694b5c648e2e8a0822dcbd4c7f9c36"
+  hash: null
   component:
-    app*
-      chained-exception*
+    app (exception of system takes precedence)
+      chained-exception (ignored because hash matches system variant)
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/python_exception_base.pysnap
@@ -1,16 +1,16 @@
 ---
-created: '2020-02-26T19:54:32.243964Z'
+created: '2021-02-15T10:11:59.552171Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "9c694b5c648e2e8a0822dcbd4c7f9c36"
+  hash: "92816681b15788a8230e065fa299dc88"
   component:
     app*
       chained-exception*
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-25T09:17:14.769045Z'
+created: '2021-02-15T10:12:00.095344Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,9 +7,9 @@ app:
   hash: null
   component:
     app (threads of system take precedence)
-      threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      threads (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.c"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:33.771031Z'
+created: '2021-02-15T10:12:03.568671Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,14 +7,14 @@ app:
   hash: null
   component:
     app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.py"
         type*
           "ValueError"
-        value*
+        value (ignored because stacktrace takes precedence)
           "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:33.788300Z'
+created: '2021-02-15T10:12:02.703410Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,14 +7,14 @@ app:
   hash: null
   component:
     app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.py"
         type*
           "ValueError"
-        value*
+        value (ignored because stacktrace takes precedence)
           "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/exception_compute_hashes_3.pysnap
@@ -1,30 +1,30 @@
 ---
-created: '2020-02-26T19:54:33.806547Z'
+created: '2021-02-15T10:12:02.372386Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "b4c29e2a2a2681fbaf9fd8f5b09e4154"
+  hash: null
   component:
-    app*
-      chained-exception*
+    app (exception of system takes precedence)
+      chained-exception (ignored because hash matches system variant)
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/python_exception_base.pysnap
@@ -1,21 +1,21 @@
 ---
-created: '2020-02-26T19:54:36.177823Z'
+created: '2021-02-15T10:12:03.386674Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "b4c29e2a2a2681fbaf9fd8f5b09e4154"
+  hash: "c52ebcc2d9d0780a23c7d99831678830"
   component:
     app*
       chained-exception*
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
         exception*
           stacktrace

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-25T09:17:12.844476Z'
+created: '2021-02-15T10:12:03.907431Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,9 +7,9 @@ app:
   hash: null
   component:
     app (threads of system take precedence)
-      threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      threads (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.c"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.617221Z'
+created: '2021-02-15T10:11:52.210443Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,14 +7,14 @@ app:
   hash: null
   component:
     app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.py"
         type*
           "ValueError"
-        value*
+        value (ignored because stacktrace takes precedence)
           "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:37.634320Z'
+created: '2021-02-15T10:11:51.448335Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,14 +7,14 @@ app:
   hash: null
   component:
     app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.py"
         type*
           "ValueError"
-        value*
+        value (ignored because stacktrace takes precedence)
           "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_compute_hashes_3.pysnap
@@ -1,30 +1,30 @@
 ---
-created: '2020-02-26T19:54:37.652993Z'
+created: '2021-02-15T10:11:51.105902Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "b4c29e2a2a2681fbaf9fd8f5b09e4154"
+  hash: null
   component:
-    app*
-      chained-exception*
+    app (exception of system takes precedence)
+      chained-exception (ignored because hash matches system variant)
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/python_exception_base.pysnap
@@ -1,21 +1,21 @@
 ---
-created: '2020-02-26T19:54:39.627048Z'
+created: '2021-02-15T10:11:52.004400Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "b4c29e2a2a2681fbaf9fd8f5b09e4154"
+  hash: "c52ebcc2d9d0780a23c7d99831678830"
   component:
     app*
       chained-exception*
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
         exception*
           stacktrace

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-25T09:17:20.859593Z'
+created: '2021-02-15T10:11:52.576902Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,9 +7,9 @@ app:
   hash: null
   component:
     app (threads of system take precedence)
-      threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      threads (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.c"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.080865Z'
+created: '2021-02-15T10:11:55.845936Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,14 +7,14 @@ app:
   hash: null
   component:
     app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.py"
         type*
           "ValueError"
-        value*
+        value (ignored because stacktrace takes precedence)
           "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-02-26T19:54:41.097579Z'
+created: '2021-02-15T10:11:55.005190Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,14 +7,14 @@ app:
   hash: null
   component:
     app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.py"
         type*
           "ValueError"
-        value*
+        value (ignored because stacktrace takes precedence)
           "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_compute_hashes_3.pysnap
@@ -1,30 +1,30 @@
 ---
-created: '2020-02-26T19:54:41.122993Z'
+created: '2021-02-15T10:11:54.704396Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "b4c29e2a2a2681fbaf9fd8f5b09e4154"
+  hash: null
   component:
-    app*
-      chained-exception*
+    app (exception of system takes precedence)
+      chained-exception (ignored because hash matches system variant)
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/python_exception_base.pysnap
@@ -1,21 +1,21 @@
 ---
-created: '2020-02-26T19:54:43.010583Z'
+created: '2021-02-15T10:11:55.608178Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "b4c29e2a2a2681fbaf9fd8f5b09e4154"
+  hash: "c52ebcc2d9d0780a23c7d99831678830"
   component:
     app*
       chained-exception*
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
         exception*
           stacktrace

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-25T09:17:16.852190Z'
+created: '2021-02-15T10:11:56.222183Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,9 +7,9 @@ app:
   hash: null
   component:
     app (threads of system take precedence)
-      threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      threads (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.c"
             function*

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/exception_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/exception_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T17:38:22.964942Z'
+created: '2021-02-15T10:12:07.085635Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,14 +7,14 @@ app:
   hash: null
   component:
     app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.py"
         type*
           "ValueError"
-        value*
+        value (ignored because stacktrace takes precedence)
           "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/exception_compute_hashes_2.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/exception_compute_hashes_2.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-07-23T17:38:22.390367Z'
+created: '2021-02-15T10:12:06.296645Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,14 +7,14 @@ app:
   hash: null
   component:
     app (exception of system takes precedence)
-      exception (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      exception (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.py"
         type*
           "ValueError"
-        value*
+        value (ignored because stacktrace takes precedence)
           "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/exception_compute_hashes_3.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/exception_compute_hashes_3.pysnap
@@ -1,30 +1,30 @@
 ---
-created: '2020-07-23T17:38:22.137370Z'
+created: '2021-02-15T10:12:05.990300Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "b4c29e2a2a2681fbaf9fd8f5b09e4154"
+  hash: null
   component:
-    app*
-      chained-exception*
+    app (exception of system takes precedence)
+      chained-exception (ignored because hash matches system variant)
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
 --------------------------------------------------------------------------
 system:

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/python_exception_base.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/python_exception_base.pysnap
@@ -1,21 +1,21 @@
 ---
-created: '2020-07-23T17:38:22.808236Z'
+created: '2021-02-15T10:12:06.883362Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
 app:
-  hash: "b4c29e2a2a2681fbaf9fd8f5b09e4154"
+  hash: "c52ebcc2d9d0780a23c7d99831678830"
   component:
     app*
       chained-exception*
         exception*
-          stacktrace
-            frame (non app frame)
+          stacktrace*
+            frame*
               filename*
                 "baz.py"
           type*
             "ValueError"
-          value*
+          value (ignored because stacktrace takes precedence)
             "hello world"
         exception*
           stacktrace

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/threads_compute_hashes.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/threads_compute_hashes.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2020-08-25T09:17:08.996865Z'
+created: '2021-02-15T10:12:07.454125Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,9 +7,9 @@ app:
   hash: null
   component:
     app (threads of system take precedence)
-      threads (ignored because this variant does not have a contributing stacktrace, but the system variant does)
-        stacktrace
-          frame (non app frame)
+      threads (ignored because hash matches system variant)
+        stacktrace*
+          frame*
             filename*
               "baz.c"
             function*


### PR DESCRIPTION
This changes the grouping logic to no longer set all frames to not in app if all frames are in app. This change will create new groups but because the system hash never changes the changes is transparent to existing users. Any user who has one of the old app hashes will also have seen the system hash and thus an implicit merge into an already exist group will happen.