### PR TITLE
meta(issue_templates): Remove "possible solution"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,8 @@ name: 🐞 Bug Report
 about: Report a bug to help improve Sentry
 ---
 
+<!-- WARNING: DO NOT remove any of the headers below or your issue will automatically be closed by our bot -->
+
 ## Important Details
 
 How are you running Sentry?
@@ -33,7 +35,3 @@ Good items to include here include:
 ### What you expected to happen
 
 [What you think should be happening]
-
-### Possible Solution
-
-[If you have an idea on how this could be solved include that detail here.]


### PR DESCRIPTION
In our bug reports, people tend to remove the "possible solution" section, causing the template enforcer bot to close valid issues. This PR removes that section as it is optional anyway (easier than adding optional header support to the bot).

It also adds a warning to the top, reminding people to not remove any headers.