### PR TITLE
fix: Remove ~/ from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,3 @@ package-lock.json
 .webpack.meta
 pip-wheel-metadata/
 Brewfile.lock.json
-~/


### PR DESCRIPTION
It looks like this rule was checked in by accident.