### PR TITLE
Drop py2 from .craft.yml

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -13,27 +13,15 @@ statusProvider:
 targets:
   - name: github
   - name: pypi
-  - id: py3-release
+  - id: release
     name: docker
     source: us.gcr.io/sentryio/sentry
     target: getsentry/sentry
-  - id: py3-latest
+  - id: latest
     name: docker
     source: us.gcr.io/sentryio/sentry
     target: getsentry/sentry
     targetFormat: '{{{target}}}:latest'
-  - id: py2-release
-    name: docker
-    source: us.gcr.io/sentryio/sentry
-    sourceFormat: '{{{source}}}:{{{revision}}}-py2'
-    target: getsentry/sentry
-    targetFormat: '{{{target}}}:{{{version}}}-py2'
-  - id: py2-latest
-    name: docker
-    source: us.gcr.io/sentryio/sentry
-    sourceFormat: '{{{source}}}:{{{revision}}}-py2'
-    target: getsentry/sentry
-    targetFormat: '{{{target}}}:latest-py2'
 
 requireNames:
-  - /^sentry-.+-py2.py3-none-any.whl$/
+  - /^sentry-.+-py3\d?-none-any.whl$/


### PR DESCRIPTION
Now that we're done making py2 builds, we need to stop telling Craft to expect them.

Became an issue with https://github.com/getsentry/sentry/pull/23187/files#diff-f49283ec41267b987e1a57bdc126e96259398a31acdf7a12049f183839f4e8baL15.