### PR TITLE
test(unreal): Workaround a change in symbolic

### DIFF
--- a/tests/fixtures/native/unreal_crash.sym
+++ b/tests/fixtures/native/unreal_crash.sym
@@ -3165,3 +3165,4 @@ PUBLIC 7036a0 0 AOnlineBeacon::IsRelevancyOwnerFor(AActor const *,AActor const *
 PUBLIC 7036b0 0 FVoicePacketImpl::IsReliable()
 PUBLIC 7036c0 0 FOnlineVoiceImpl::IsRemotePlayerTalking(FUniqueNetId const &)
 PUBLIC 703700 0 FVoiceEngineImpl::IsRemotePlayerTalking(FUniqueNetId const &)
+FUNC 703800 1 0 <EOF>  # Original file was truncated. Added to prevent the last PUBLIC record covering the remainder of the file.


### PR DESCRIPTION
With getsentry/symbolic#320, we changed how trailing `PUBLIC` records in
incomplete Breakpad symbols are handled during native symbolication. The unreal
tests contain such incomplete symbols as fixtures to reduce their overall size,
which now creates changes in the snapshot.

We are not really interested in those additonal frames. By adding a phantom
function at the end, Symbolicator does not apply the trailing symbol to all
intermediate frames, which keeps the snapshots stable.

