### PR TITLE
ref(perf): Fix charts UI for large number of releases

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -10,7 +10,7 @@ import BarChart from 'app/components/charts/barChart';
 import ChartZoom, {ZoomRenderProps} from 'app/components/charts/chartZoom';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LineChart from 'app/components/charts/lineChart';
-import ReleaseSeries, {ReleaseSeriesData} from 'app/components/charts/releaseSeries';
+import ReleaseSeries from 'app/components/charts/releaseSeries';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getInterval} from 'app/components/charts/utils';
@@ -33,7 +33,7 @@ type ChartProps = {
   legendOptions?: EChartOption.Legend;
   chartOptions?: EChartOption;
   currentSeriesName?: string;
-  releaseSeries?: ReleaseSeriesData[];
+  releaseSeries?: Series[];
   previousTimeseriesData?: Series | null;
   previousSeriesName?: string;
   /**
@@ -159,8 +159,8 @@ class Chart extends React.Component<ChartProps, State> {
     const releases = releaseSeries && releaseSeries[0];
     const hideReleasesByDefault =
       Array.isArray(releaseSeries) &&
-      releases?.markLine?.data &&
-      (releases.markLine.data as any).length >= 1000;
+      (releases as any)?.markLine?.data &&
+      (releases as any).markLine.data.length >= 1000;
 
     const selected = !Array.isArray(releaseSeries)
       ? seriesSelection

--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -10,7 +10,7 @@ import BarChart from 'app/components/charts/barChart';
 import ChartZoom, {ZoomRenderProps} from 'app/components/charts/chartZoom';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LineChart from 'app/components/charts/lineChart';
-import ReleaseSeries from 'app/components/charts/releaseSeries';
+import ReleaseSeries, {ReleaseSeriesData} from 'app/components/charts/releaseSeries';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
 import {getInterval} from 'app/components/charts/utils';
@@ -33,7 +33,7 @@ type ChartProps = {
   legendOptions?: EChartOption.Legend;
   chartOptions?: EChartOption;
   currentSeriesName?: string;
-  releaseSeries?: Series[];
+  releaseSeries?: ReleaseSeriesData[];
   previousTimeseriesData?: Series | null;
   previousSeriesName?: string;
   /**
@@ -156,8 +156,11 @@ class Chart extends React.Component<ChartProps, State> {
 
     // Temporary fix to improve performance on pages with a high number of releases.
     // Picked 1000 as it is the size of the first page
+    const releases = releaseSeries && releaseSeries[0];
     const hideReleasesByDefault =
-      Array.isArray(releaseSeries) && releaseSeries.length >= 1000;
+      Array.isArray(releaseSeries) &&
+      releases?.markLine?.data &&
+      (releases.markLine.data as any).length >= 1000;
 
     const selected = !Array.isArray(releaseSeries)
       ? seriesSelection

--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -148,16 +148,29 @@ class Chart extends React.Component<ChartProps, State> {
     const {seriesSelection} = this.state;
 
     const data = [currentSeriesName ?? t('Current'), previousSeriesName ?? t('Previous')];
+
+    const releasesLegend = t('Releases');
     if (Array.isArray(releaseSeries)) {
-      data.push(t('Releases'));
+      data.push(releasesLegend);
     }
+
+    // Temporary fix to improve performance on pages with a high number of releases.
+    // Picked 1000 as it is the size of the first page
+    const hideReleasesByDefault =
+      Array.isArray(releaseSeries) && releaseSeries.length >= 1000;
+
+    const selected = !Array.isArray(releaseSeries)
+      ? seriesSelection
+      : Object.keys(seriesSelection).length === 0 && hideReleasesByDefault
+      ? {[releasesLegend]: false}
+      : seriesSelection;
 
     const legend = showLegend
       ? {
           right: 16,
           top: 12,
           data,
-          selected: seriesSelection,
+          selected,
           ...(legendOptions ?? {}),
         }
       : undefined;

--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.tsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.tsx
@@ -35,10 +35,6 @@ type ReleaseConditions = {
   cursor?: string;
 };
 
-export type ReleaseSeriesData = Series & {
-  markLine: EChartOption.SeriesLine['markLine'];
-};
-
 // This is not an exported action/function because releases list uses AsyncComponent
 // and this is not re-used anywhere else afaict
 function getOrganizationReleases(
@@ -184,7 +180,7 @@ class ReleaseSeries extends React.Component<Props, State> {
 
   setReleasesWithSeries(releases) {
     const {emphasizeReleases = []} = this.props;
-    const releaseSeries: ReleaseSeriesData[] = [];
+    const releaseSeries: Series[] = [];
 
     if (emphasizeReleases.length) {
       const [unemphasizedReleases, emphasizedReleases] = partition(

--- a/src/sentry/static/sentry/app/components/charts/releaseSeries.tsx
+++ b/src/sentry/static/sentry/app/components/charts/releaseSeries.tsx
@@ -35,6 +35,10 @@ type ReleaseConditions = {
   cursor?: string;
 };
 
+export type ReleaseSeriesData = Series & {
+  markLine: EChartOption.SeriesLine['markLine'];
+};
+
 // This is not an exported action/function because releases list uses AsyncComponent
 // and this is not re-used anywhere else afaict
 function getOrganizationReleases(
@@ -180,7 +184,7 @@ class ReleaseSeries extends React.Component<Props, State> {
 
   setReleasesWithSeries(releases) {
     const {emphasizeReleases = []} = this.props;
-    const releaseSeries: Series[] = [];
+    const releaseSeries: ReleaseSeriesData[] = [];
 
     if (emphasizeReleases.length) {
       const [unemphasizedReleases, emphasizedReleases] = partition(


### PR DESCRIPTION
### Summary
Users can potentially have thousands of releases in a view, which echarts can take quite a bit of CPU to display. This will disable releases by default if they have 1000 or greater (more than one page worth).