### PR TITLE
fix: make perf marklines visible on dark theme

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import {withTheme} from 'emotion-theming';
 import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 import throttle from 'lodash/throttle';
@@ -27,7 +28,7 @@ import {
   getDuration,
 } from 'app/utils/formatters';
 import getDynamicText from 'app/utils/getDynamicText';
-import theme from 'app/utils/theme';
+import {Theme} from 'app/utils/theme';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
 import {VitalData} from 'app/views/performance/vitalDetail/vitalsCardsDiscoverQuery';
 
@@ -46,6 +47,7 @@ import {HistogramData, Rectangle, Vital} from './types';
 import {asPixelRect, findNearestBucketIndex, getRefRect, mapPoint} from './utils';
 
 type Props = {
+  theme: Theme;
   location: Location;
   organization: Organization;
   isLoading: boolean;
@@ -250,6 +252,7 @@ class VitalCard extends React.Component<Props, State> {
 
   renderHistogram() {
     const {
+      theme,
       location,
       isLoading,
       chartData,
@@ -399,7 +402,7 @@ class VitalCard extends React.Component<Props, State> {
   }
 
   getBaselineSeries() {
-    const {chartData} = this.props;
+    const {theme, chartData} = this.props;
     const summary = this.summary;
     if (summary === null || this.state.refPixelRect === null) {
       return null;
@@ -472,7 +475,7 @@ class VitalCard extends React.Component<Props, State> {
   }
 
   getFailureSeries() {
-    const {chartData, vitalDetails: vital} = this.props;
+    const {theme, chartData, vitalDetails: vital} = this.props;
     const failureRate = this.failureRate;
     const {failureThreshold, type} = vital;
     if (this.state.refDataRect === null || this.state.refPixelRect === null) {
@@ -648,4 +651,4 @@ const StyledTag = styled(Tag)`
   }
 `;
 
-export default VitalCard;
+export default withTheme(VitalCard);

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -96,7 +96,7 @@ class VitalCard extends React.Component<Props, State> {
     refPixelRect: null,
   };
 
-  static getDerivedStateFromProps(nextProps: Props, prevState: State) {
+  static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State) {
     const {isLoading, error, chartData} = nextProps;
 
     if (isLoading || error === null) {

--- a/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/chart.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {browserHistory, withRouter} from 'react-router';
 import {WithRouterProps} from 'react-router/lib/withRouter';
+import {withTheme} from 'emotion-theming';
 
 import {Client} from 'app/api';
 import ChartZoom from 'app/components/charts/chartZoom';
@@ -15,7 +16,7 @@ import {axisLabelFormatter, tooltipFormatter} from 'app/utils/discover/charts';
 import EventView from 'app/utils/discover/eventView';
 import getDynamicText from 'app/utils/getDynamicText';
 import {decodeList, decodeScalar} from 'app/utils/queryString';
-import theme from 'app/utils/theme';
+import {Theme} from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 import {YAxis} from 'app/views/releases/detail/overview/chart/releaseChartControls';
 
@@ -42,6 +43,7 @@ type ViewProps = Pick<EventView, typeof QUERY_KEYS[number]>;
 
 type Props = WithRouterProps &
   ViewProps & {
+    theme: Theme;
     api: Client;
     location: Location;
     organization: OrganizationSummary;
@@ -89,6 +91,7 @@ function getLegend(trendFunction: string) {
 }
 
 function getIntervalLine(
+  theme: Theme,
   series: Series[],
   intervalRatio: number,
   transaction?: NormalizedTrendsTransaction
@@ -221,6 +224,7 @@ class Chart extends React.Component<Props> {
     const props = this.props;
 
     const {
+      theme,
       trendChangeType,
       router,
       statsPeriod,
@@ -325,7 +329,12 @@ class Chart extends React.Component<Props> {
               })
             : [];
 
-          const intervalSeries = getIntervalLine(smoothedResults || [], 0.5, transaction);
+          const intervalSeries = getIntervalLine(
+            theme,
+            smoothedResults || [],
+            0.5,
+            transaction
+          );
 
           return (
             <ReleaseSeries
@@ -375,4 +384,4 @@ class Chart extends React.Component<Props> {
   }
 }
 
-export default withApi(withRouter(Chart));
+export default withTheme(withApi(withRouter(Chart)));


### PR DESCRIPTION
Trend and vitals lines were using the global theme.colors, not the current
version. Convert them to withTheme instead, so they fetch the context theme.

I got this error:

```
ERROR in [...]/sentry/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx(654,26):
TS2345: Argument of type 'typeof VitalCard' is not assignable to parameter of type 'ComponentType<any>'.
  Type 'typeof VitalCard' is not assignable to type 'ComponentClass<any, any>'.
    Types of property 'getDerivedStateFromProps' are incompatible.
      Type '(nextProps: Props, prevState: State) => { refDataRect: Rectangle | null; refPixelRect: Rectangle | null; }' is not assignable to type 'GetDerivedStateFromProps<any, any>'.
        Types of parameters 'nextProps' and 'nextProps' are incompatible.
          Type 'Readonly<any>' is missing the following properties from type 'Props': theme, location, organization, isLoading, and 7 more.
```

`@ts-ignore` works, but I have no idea what's actually wrong here.