### PR TITLE
ref(ui) Improve narrow viewport layout of chart footers

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/styles.tsx
+++ b/src/sentry/static/sentry/app/components/charts/styles.tsx
@@ -2,13 +2,6 @@ import styled from '@emotion/styled';
 
 import space from 'app/styles/space';
 
-export const ChartControls = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  padding: ${space(1)} ${space(3)};
-  border-top: 1px solid ${p => p.theme.border};
-`;
-
 export const SubHeading = styled('h3')`
   font-size: ${p => p.theme.fontSizeLarge};
   font-weight: normal;
@@ -47,6 +40,21 @@ export const InlineContainer = styled('div')`
 
   &:last-child {
     margin-right: 0;
+  }
+`;
+
+export const ChartControls = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  padding: ${space(1)} ${space(3)};
+  border-top: 1px solid ${p => p.theme.border};
+
+  @media (max-width: ${p => p.theme.breakpoints[0]}) {
+    flex-direction: column;
+
+    > ${/* sc-selector */ InlineContainer} + ${/* sc-selector */ InlineContainer} {
+      margin-top: ${space(1)};
+    }
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
@@ -151,7 +151,7 @@ const ReleaseChartControls = ({
   };
 
   return (
-    <StyledChartControls>
+    <ChartControls>
       <InlineContainer>
         <SectionHeading key="total-label">{getSummaryHeading()}</SectionHeading>
         <SectionValue key="total-value">{summary}</SectionValue>
@@ -178,7 +178,7 @@ const ReleaseChartControls = ({
           onChange={onYAxisChange as (value: string) => void}
         />
       </InlineContainer>
-    </StyledChartControls>
+    </ChartControls>
   );
 };
 
@@ -236,16 +236,5 @@ function SecondarySelector({
       return null;
   }
 }
-
-const StyledChartControls = styled(ChartControls)`
-  @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    display: grid;
-    grid-gap: ${space(1)};
-    padding-bottom: ${space(1.5)};
-    button {
-      font-size: ${p => p.theme.fontSizeSmall};
-    }
-  }
-`;
 
 export default ReleaseChartControls;

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/releaseChartControls.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styled from '@emotion/styled';
 
 import OptionSelector from 'app/components/charts/optionSelector';
 import {
@@ -11,7 +10,6 @@ import {
 import QuestionTooltip from 'app/components/questionTooltip';
 import NOT_AVAILABLE_MESSAGES from 'app/constants/notAvailableMessages';
 import {t} from 'app/locale';
-import space from 'app/styles/space';
 import {Organization, SelectValue} from 'app/types';
 import {WebVital} from 'app/utils/discover/fields';
 import {WEB_VITAL_DETAILS} from 'app/views/performance/transactionVitals/constants';


### PR DESCRIPTION
In small viewports vertically stack the InlineContainer elements within a ChartFooter. This reduces (but doesn't eliminate) the number of footer overflows we have.

Related to getsentry/getsentry#5055