### PR TITLE
Revert "fix(workflow): Use `ReleaseProjectEnvironment` data to limit date range in `tagstore.get_release_tags`"

### DIFF
--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 
 from sentry import options
 from sentry.api.event_search import FIELD_ALIASES, PROJECT_ALIAS, USER_DISPLAY_ALIAS
-from sentry.models import Project, ReleaseProjectEnvironment
+from sentry.models import Project
 from sentry.api.utils import default_start_end_dates
 from sentry.snuba.dataset import Dataset
 from sentry.tagstore import TagKeyStatus
@@ -558,9 +558,8 @@ class SnubaTagStorage(TagStorage):
             ["min", SEEN_COLUMN, "first_seen"],
             ["max", SEEN_COLUMN, "last_seen"],
         ]
-        start = self.get_min_start_date(project_ids, environment_id, versions)
+
         result = snuba.query(
-            start=start,
             groupby=["project_id", col],
             conditions=conditions,
             filter_keys=filters,
@@ -575,20 +574,6 @@ class SnubaTagStorage(TagStorage):
                 values.append(TagValue(key=tag, value=value, **fix_tag_value_data(data)))
 
         return set(values)
-
-    def get_min_start_date(self, project_ids, environment_id, versions):
-        rpe = ReleaseProjectEnvironment.objects.filter(
-            project_id__in=project_ids, release__version__in=versions
-        ).order_by("first_seen")
-
-        if environment_id:
-            rpe = rpe.filter(environment_id=environment_id)
-
-        rpe = rpe.first()
-        if rpe:
-            return rpe.first_seen
-
-        return None
 
     def get_group_ids_for_users(self, project_ids, event_users, limit=100):
         filters = {"project_id": project_ids}

--- a/tests/snuba/tagstore/test_tagstore_backend.py
+++ b/tests/snuba/tagstore/test_tagstore_backend.py
@@ -3,7 +3,7 @@ import pytest
 
 from django.utils import timezone
 
-from sentry.models import Environment, EventUser, ReleaseProjectEnvironment, Release
+from sentry.models import Environment, EventUser
 from sentry.tagstore.exceptions import (
     GroupTagKeyNotFound,
     GroupTagValueNotFound,
@@ -24,9 +24,7 @@ class TagStorageTest(TestCase, SnubaTestCase):
         self.proj1 = self.create_project()
         env1 = "test"
         env2 = "test2"
-        self.env3 = Environment.objects.create(
-            organization_id=self.proj1.organization_id, name="test3"
-        )
+
         self.now = timezone.now().replace(microsecond=0)
 
         exception = {
@@ -383,65 +381,6 @@ class TagStorageTest(TestCase, SnubaTestCase):
         assert tags[0].first_seen == one_second_ago
         assert tags[0].times_seen == 1
         assert tags[0].key == "sentry:release"
-
-    def test_get_release_tags_uses_release_project_environment(self):
-        tags = list(self.ts.get_release_tags([self.proj1.id], None, ["100"]))
-
-        assert len(tags) == 1
-        one_second_ago = self.now - timedelta(seconds=1)
-        assert tags[0].last_seen == one_second_ago
-        assert tags[0].first_seen == one_second_ago
-        assert tags[0].times_seen == 1
-
-        one_day_ago = self.now - timedelta(days=1)
-        two_days_ago = self.now - timedelta(days=2)
-        self.store_event(
-            data={
-                "event_id": "5" * 32,
-                "message": "message3",
-                "platform": "python",
-                "environment": None,
-                "fingerprint": ["group-1"],
-                "timestamp": iso_format(one_day_ago),
-                "tags": {
-                    "sentry:release": 100,
-                },
-            },
-            project_id=self.proj1.id,
-        )
-        self.store_event(
-            data={
-                "event_id": "6" * 32,
-                "message": "message3",
-                "platform": "python",
-                "environment": None,
-                "fingerprint": ["group-1"],
-                "timestamp": iso_format(two_days_ago),
-                "tags": {
-                    "sentry:release": 100,
-                },
-            },
-            project_id=self.proj1.id,
-        )
-
-        tags = list(self.ts.get_release_tags([self.proj1.id], None, ["100"]))
-        assert tags[0].last_seen == one_second_ago
-        assert tags[0].first_seen == two_days_ago
-        assert tags[0].times_seen == 3
-
-        release = Release.objects.create(version="100", organization=self.organization)
-        ReleaseProjectEnvironment.objects.create(
-            release_id=release.id,
-            project_id=self.proj1.id,
-            environment_id=self.env3.id,
-            first_seen=one_day_ago,
-        )
-        tags = list(self.ts.get_release_tags([self.proj1.id], None, ["100"]))
-        assert tags[0].last_seen == one_second_ago
-        assert tags[0].first_seen == one_day_ago
-        assert (
-            tags[0].times_seen == 2
-        )  # Isn't 3 because start was limited by the ReleaseProjectEnvironment entry
 
     def test_get_group_event_filter(self):
         assert self.ts.get_group_event_filter(


### PR DESCRIPTION
Reverts getsentry/sentry#23848