### PR TITLE
feat: stack trace lang logo

### DIFF
--- a/src/sentry/static/sentry/app/utils/fileExtension.tsx
+++ b/src/sentry/static/sentry/app/utils/fileExtension.tsx
@@ -17,10 +17,15 @@ const FILE_EXTENSION_TO_PLATFORM = {
   m: 'apple',
   mm: 'apple',
   M: 'apple',
-  cs: 'csharp',
   ex: 'elixir',
   exs: 'elixir',
+  cs: 'csharp',
   fs: 'fsharp',
+  kt: 'kotlin',
+  dart: 'dart',
+  sc: 'scala',
+  scala: 'scala',
+  clj: 'clojure',
 };
 
 /**


### PR DESCRIPTION
Flutter uses `dart`:

Currently it shows the default unknown logo:
![image](https://user-images.githubusercontent.com/1633368/108135433-167ab080-7086-11eb-9cb9-2bf0e55fda18.png)


Adding more known languages:
Kotlin: https://github.com/getsentry/platformicons/blob/b7a9a9fbab61335b22f5c2c3af3e65edbb3b6826/src/platformIcon.tsx#L54
Clojure: https://github.com/getsentry/platformicons/blob/b7a9a9fbab61335b22f5c2c3af3e65edbb3b6826/src/platformIcon.tsx#L7
Scala: https://github.com/getsentry/platformicons/blob/b7a9a9fbab61335b22f5c2c3af3e65edbb3b6826/src/platformIcon.tsx#L97

Likely not going to work for Android where there's always some `.java` mixed:
![image](https://user-images.githubusercontent.com/1633368/108135790-bf291000-7086-11eb-9ee6-493d9d38d95f.png)

With a `.kt` app.
![image](https://user-images.githubusercontent.com/1633368/108135760-b59fa800-7086-11eb-852c-e07197e4a3af.png)

Ideally we'd have up to 2 icons stacked up together.