### PR TITLE
fix: Return empty projects query set if given sentry app install token cannot be found

### DIFF
--- a/src/sentry/api/endpoints/project_index.py
+++ b/src/sentry/api/endpoints/project_index.py
@@ -1,4 +1,6 @@
 from django.db.models import Q
+from django.db.models.query import EmptyQuerySet
+from rest_framework.exceptions import AuthenticationFailed
 
 from sentry.api.base import Endpoint
 from sentry.api.bases.project import ProjectPermission
@@ -43,6 +45,8 @@ class ProjectIndexEndpoint(Endpoint):
         elif not (is_active_superuser(request) and request.GET.get("show") == "all"):
             if request.user.is_sentry_app:
                 queryset = SentryAppInstallationToken.get_projects(request.auth)
+                if isinstance(queryset, EmptyQuerySet):
+                    raise AuthenticationFailed("Token not found")
             else:
                 queryset = queryset.filter(teams__organizationmember__user=request.user)
 

--- a/src/sentry/models/sentryappinstallation.py
+++ b/src/sentry/models/sentryappinstallation.py
@@ -70,7 +70,7 @@ class SentryAppInstallationToken(Model):
                 api_token=token
             )
         except cls.DoesNotExist:
-            return False
+            return Project.objects.none()
 
         return Project.objects.filter(
             organization_id=install_token.sentry_app_installation.organization_id

--- a/tests/sentry/api/endpoints/test_project_index.py
+++ b/tests/sentry/api/endpoints/test_project_index.py
@@ -149,3 +149,21 @@ class ProjectsListTest(APITestCase):
             f"{self.path}", HTTP_AUTHORIZATION=f"Bearer {token.api_token.token}"
         )
         assert project.name.encode("utf-8") in response.content
+
+    def test_deleted_token_with_internal_integration(self):
+        self.create_internal_integration(
+            name="my_app",
+            organization=self.organization,
+            scopes=("project:read",),
+            webhook_url="http://example.com",
+        )
+        # there should only be one record created so just grab the first one
+        token = SentryAppInstallationToken.objects.first()
+        token = token.api_token.token
+
+        # Delete the token
+        SentryAppInstallationToken.objects.all().delete()
+
+        response = self.client.get(f"{self.path}", HTTP_AUTHORIZATION=f"Bearer {token}")
+        assert response.status_code == 200
+        assert len(response.data) == 0

--- a/tests/sentry/api/endpoints/test_project_index.py
+++ b/tests/sentry/api/endpoints/test_project_index.py
@@ -165,5 +165,4 @@ class ProjectsListTest(APITestCase):
         SentryAppInstallationToken.objects.all().delete()
 
         response = self.client.get(f"{self.path}", HTTP_AUTHORIZATION=f"Bearer {token}")
-        assert response.status_code == 200
-        assert len(response.data) == 0
+        assert response.status_code == 401


### PR DESCRIPTION
Regression from https://github.com/getsentry/sentry/pull/19169

Fixes SENTRY-K6M