### PR TITLE
feat: Update wizard flow to support mobile app

### DIFF
--- a/src/sentry/api/endpoints/setup_wizard.py
+++ b/src/sentry/api/endpoints/setup_wizard.py
@@ -49,7 +49,12 @@ class SetupWizard(Endpoint):
             if rate_limited:
                 logger.info("setup-wizard.rate-limit")
                 return Response({"Too many wizard requests"}, status=403)
+
             wizard_hash = get_random_string(64, allowed_chars="abcdefghijklmnopqrstuvwxyz012345679")
+
+            mobile_hash = request.GET.get("mobile", None)
+            if mobile_hash is not None:
+                wizard_hash = "mobile-" + wizard_hash
 
             key = f"{SETUP_WIZARD_CACHE_KEY}{wizard_hash}"
             default_cache.set(key, "empty", SETUP_WIZARD_CACHE_TIMEOUT)

--- a/src/sentry/static/sentry/app/components/setupWizard.tsx
+++ b/src/sentry/static/sentry/app/components/setupWizard.tsx
@@ -38,6 +38,9 @@ class SetupWizard extends React.Component<Props, State> {
             // On mobile we don't wait for the App to connect here
             // We just tell the user everything is alright
             this.setState({finished: true});
+            setTimeout(() => {
+              window.location.href = 'sentryiomobile://auth-success';
+            }, 1000);
           } else {
             setTimeout(() => this.pollFinished(), 1000);
           }
@@ -74,7 +77,14 @@ class SetupWizard extends React.Component<Props, State> {
   renderMobileSuccess() {
     return (
       <div className="row">
-        <h5>{t('Return to the App')}</h5>
+        <button
+          className="btn btn-default"
+          onClick={() => {
+            window.location.href = 'sentryiomobile://auth-success';
+          }}
+        >
+          {t('Return to the App')}
+        </button>
       </div>
     );
   }

--- a/src/sentry/static/sentry/app/components/setupWizard.tsx
+++ b/src/sentry/static/sentry/app/components/setupWizard.tsx
@@ -8,6 +8,7 @@ import withApi from 'app/utils/withApi';
 type Props = {
   api: Client;
   hash?: boolean | string;
+  mobile?: boolean;
 };
 
 type State = {
@@ -17,6 +18,7 @@ type State = {
 class SetupWizard extends React.Component<Props, State> {
   static defaultProps = {
     hash: false,
+    mobile: false,
   };
 
   state: State = {
@@ -32,7 +34,13 @@ class SetupWizard extends React.Component<Props, State> {
       this.props.api.request(`/wizard/${this.props.hash}/`, {
         method: 'GET',
         success: () => {
-          setTimeout(() => this.pollFinished(), 1000);
+          if (this.props.mobile) {
+            // On mobile we don't wait for the App to connect here
+            // We just tell the user everything is alright
+            this.setState({finished: true});
+          } else {
+            setTimeout(() => this.pollFinished(), 1000);
+          }
         },
         error: () => {
           resolve();
@@ -63,13 +71,36 @@ class SetupWizard extends React.Component<Props, State> {
     );
   }
 
+  renderMobileSuccess() {
+    return (
+      <div className="row">
+        <h5>{t('Return to the App')}</h5>
+      </div>
+    );
+  }
+
+  renderMobileLoading() {
+    return (
+      <div className="row">
+        <h5>{t('Waiting for your App to connect')}</h5>
+      </div>
+    );
+  }
+
   render() {
     const {finished} = this.state;
+    const {mobile} = this.props;
 
+    let success = this.renderSuccess;
+    let loading = this.renderLoading;
+    if (mobile) {
+      success = this.renderMobileSuccess;
+      loading = this.renderMobileLoading;
+    }
     return (
       <div className="container">
         <LoadingIndicator style={{margin: '2em auto'}} finished={finished}>
-          {finished ? this.renderSuccess() : this.renderLoading()}
+          {finished ? success() : loading()}
         </LoadingIndicator>
       </div>
     );

--- a/src/sentry/templates/sentry/setup-wizard.html
+++ b/src/sentry/templates/sentry/setup-wizard.html
@@ -12,7 +12,8 @@
   {% script %}
   <script>
     ReactDOM.render(React.createElement(SentryApp.SetupWizard, {
-      hash: {{ hash|to_json|safe }}
+      hash: {{ hash|to_json|safe }},
+      mobile: {{ hash|to_json|safe }},
     }), document.getElementById('setup-wizard-container'));
   </script>
   {% endscript %}

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -45,6 +45,7 @@ class SetupWizardView(BaseView):
         mobile_scope = [
             "project:releases",
             "project:read",
+            "project:write",
             "event:read",
             "team:read",
             "org:read",

--- a/src/sentry/web/frontend/setup_wizard.py
+++ b/src/sentry/web/frontend/setup_wizard.py
@@ -30,7 +30,7 @@ class SetupWizardView(BaseView):
         if wizard_data is None:
             return self.redirect_to_org(request)
 
-        if wizard_hash.startswith('mobile-'):
+        if wizard_hash.startswith("mobile-"):
             context = {"hash": wizard_hash, "mobile": True}
             result = self.mobile_wizard(request, wizard_data)
         else:
@@ -42,7 +42,15 @@ class SetupWizardView(BaseView):
         return render_to_response("sentry/setup-wizard.html", context, request)
 
     def mobile_wizard(self, request, wizard_data):
-        mobile_scope = ["project:releases", "project:read", "event:read", "team:read", "org:read", "member:read", "alerts:read"]
+        mobile_scope = [
+            "project:releases",
+            "project:read",
+            "event:read",
+            "team:read",
+            "org:read",
+            "member:read",
+            "alerts:read",
+        ]
         # Fetching or creating a token
         token = None
         tokens = [
@@ -61,7 +69,6 @@ class SetupWizardView(BaseView):
             token = tokens[0]
 
         return {"token": serialize(token).get("token")}
-
 
     def setup_wizard(self, request, wizard_data):
         orgs = Organization.objects.filter(


### PR DESCRIPTION
This PR updates our Setup Wizard capabilities to also support the login flow for Mobile.
The motivation for this change can be found in this issue.
Ref: https://github.com/getsentry/sentry-mobile/issues/116

I am aware of this not being the best solution to this problem, but we wanted something that works reliably and is not too complicated. Keep in mind the first version of the App is an EA version, for that, I feel like this is good enough.

Success screen for mobile:
![image](https://user-images.githubusercontent.com/363802/108175250-d4db1b80-7100-11eb-83ba-133532468a1c.png)

---

### How the flow works

- `GET https://sentry.io/api/0/wizard/?mobile=1` returns a random string.
<details>
<summary>Response</summary>
```json
{
    "hash": "random-string-hash"
}
```
</details>
This hash is stored in the cache and is valid for 10 mins.

- The `hash` can be used to poll this URL: `GET https://sentry.io/api/0/wizard/${hash}/`
  - This endpoint will return `400`, which is expected. That means no one authenticated yet.
  - Keep polling until you receive `200`. In order to receive `200` a logged-in user needs to visit `https://sentry.io/account/settings/wizard/random-string-hash/`. When opening this page, a user auth token with the required scopes for the mobile app will be created and put into the cache.
  The response to the API call `GET https://sentry.io/api/0/wizard/${hash}/` will contain the auth token.

<details>
<summary>Response</summary>
```json
{
    "token": "abcd"
}
```
</details>

- Call `DELETE https://sentry.io/api/0/wizard/${hash}/` to clean the cache and invalidate the hash.