### PR TITLE
feat(workflow): Adding `module` support to ownership rules

### DIFF
--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -88,9 +88,9 @@ class Matcher(namedtuple("Matcher", "type pattern")):
         if self.type == "url":
             return self.test_url(data)
         elif self.type == "path":
-            return self.test_path(data)
+            return self.test_frames(data, ["filename", "abs_path"])
         elif self.type == "module":
-            return self.test_module(data)
+            return self.test_frames(data, ["module"])
         elif self.type.startswith("tags."):
             return self.test_tag(data)
         return False
@@ -102,26 +102,17 @@ class Matcher(namedtuple("Matcher", "type pattern")):
             return False
         return url and glob_match(url, self.pattern, ignorecase=True)
 
-    def test_path(self, data):
+    def test_frames(self, data, keys):
         for frame in _iter_frames(data):
-            filename = frame.get("filename") or frame.get("abs_path")
+            for key in keys:
+                value = frame.get(key)
+                if value:
+                    break
 
-            if not filename:
+            if not value:
                 continue
 
-            if glob_match(filename, self.pattern, ignorecase=True, path_normalize=True):
-                return True
-
-        return False
-
-    def test_module(self, data):
-        for frame in _iter_frames(data):
-            filename = frame.get("module")
-
-            if not filename:
-                continue
-
-            if glob_match(filename, self.pattern, ignorecase=True, path_normalize=True):
+            if glob_match(value, self.pattern, ignorecase=True, path_normalize=True):
                 return True
 
         return False

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -104,10 +104,7 @@ class Matcher(namedtuple("Matcher", "type pattern")):
 
     def test_frames(self, data, keys):
         for frame in _iter_frames(data):
-            for key in keys:
-                value = frame.get(key)
-                if value:
-                    break
+            value = next((frame.get(key) for key in keys if frame.get(key)), None)
 
             if not value:
                 continue

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -149,9 +149,13 @@ def test_matcher_test_module():
             ]
         },
     }
+    assert Matcher("module", "*os.Init").test(data)
     assert Matcher("module", "*somethinginthemiddle*").test(data)
     assert Matcher("module", "com.android.internal.os.RuntimeInit$MethodAndArgsCaller").test(data)
-    assert not Matcher("module", "*somethingattheend*").test(data)
+    assert Matcher("module", "com.android*").test(data)
+    assert not Matcher("module", "com.android").test(data)
+    assert not Matcher("module", "os.Init").test(data)
+    assert not Matcher("module", "*somethingattheend").test(data)
     assert not Matcher("module", "com.android.internal.os").test(data)
 
 

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -132,28 +132,19 @@ def test_matcher_test_module():
         "stacktrace": {
             "frames": [
                 {
-                    "function": "main",
                     "module": "com.android.internal.os.Init",
                     "filename": "Init.java",
                     "abs_path": "Init.java",
-                    "lineno": 964,
-                    "in_app": False,
                 },
                 {
-                    "function": "run",
                     "module": "com.android.internal.os.RuntimeInit$MethodAndArgsCaller",
                     "filename": "RuntimeInit.java",
                     "abs_path": "RuntimeInit.java",
-                    "lineno": 494,
-                    "in_app": False,
                 },
                 {
-                    "function": "run",
                     "module": "com.sentry.somethinginthemiddle.CustomModuleForMeowing",
                     "filename": "SourceFile",
                     "abs_path": "SourceFile",
-                    "lineno": 96,
-                    "in_app": False,
                 },
             ]
         },


### PR DESCRIPTION
Currently, ownership rules support 3 matcher types: `url`, `path`, and `tags`. This PR is adding a fourth: `module`.

This is a requested feature from a customer, and solves WOR-68.