### PR TITLE
feat: make percents display above vitals

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/vitalCard.tsx
@@ -640,6 +640,7 @@ const PercentContainer = styled('div')`
   top: ${space(2)};
   right: ${space(3)};
   z-index: 2;
+  background-color: ${p => p.theme.background};
 `;
 
 const StyledTag = styled(Tag)`


### PR DESCRIPTION
otherwise the lines (particularly the baseline) can draw over the percents,
which looks ugly.