### PR TITLE
fix(storybook): reorganizing components

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -91,7 +91,19 @@ addParameters({
      * be the order they display
      * @type {Function}
      */
-    storySort: undefined,
+    storySort: {
+      order: [
+        'Core',
+        'Forms',
+        'UI',
+        'Layouts',
+        'Charts',
+        'DataVisualization',
+        'Features',
+        'Utilities',
+        'Deprecated',
+      ],
+    },
   },
 });
 

--- a/docs-ui/components/activity.stories.js
+++ b/docs-ui/components/activity.stories.js
@@ -15,7 +15,7 @@ const user = {
 };
 
 export default {
-  title: 'Core/_Activity/Item',
+  title: 'UI/Activity/Item',
 };
 
 export const DefaultActivityItem = ({hideDate}) => (

--- a/docs-ui/components/autoComplete.stories.js
+++ b/docs-ui/components/autoComplete.stories.js
@@ -15,7 +15,7 @@ const items = [
 ];
 
 export default {
-  title: 'Core/Forms/AutoComplete',
+  title: 'Forms/AutoComplete',
   parameters: {
     controls: {hideNoControlsWarning: true},
   },

--- a/docs-ui/components/avatar.stories.js
+++ b/docs-ui/components/avatar.stories.js
@@ -9,7 +9,7 @@ const USER = {
 };
 
 export default {
-  title: 'Core/Avatar',
+  title: 'Core/Style/Avatar',
   component: Avatar,
   args: {
     hasTooltip: false,

--- a/docs-ui/components/badge.stories.js
+++ b/docs-ui/components/badge.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import Badge from 'app/components/badge';
 
 export default {
-  title: 'Core/Badges+Tags/Badge',
+  title: 'Core/Tags/Badge',
   component: Badge,
   parameters: {
     controls: {hideNoControlsWarning: true},

--- a/docs-ui/components/charts-breakdownBars.stories.js
+++ b/docs-ui/components/charts-breakdownBars.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import BreakdownBars from 'app/components/charts/breakdownBars';
 
 export default {
-  title: 'Charts/BreakdownBars',
+  title: 'DataVisualization/Charts/BreakdownBars',
   component: BreakdownBars,
   parameters: {
     controls: {hideNoControlsWarning: true},

--- a/docs-ui/components/commandLine.stories.js
+++ b/docs-ui/components/commandLine.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import CommandLine from 'app/components/commandLine';
 
 export default {
-  title: 'Core/CommandLine',
+  title: 'Utilities/CommandLine',
   args: {
     children: 'sentry devserver --workers',
   },

--- a/docs-ui/components/deployBadge.stories.js
+++ b/docs-ui/components/deployBadge.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import DeployBadge from 'app/components/deployBadge';
 
 export default {
-  title: 'Core/Badges+Tags/DeployBadge',
+  title: 'Core/Tags/DeployBadge',
   component: DeployBadge,
   args: {
     deploy: {

--- a/docs-ui/components/dropdownAutoComplete.stories.js
+++ b/docs-ui/components/dropdownAutoComplete.stories.js
@@ -84,7 +84,7 @@ const groupedItems = [
 ];
 
 export default {
-  title: 'Core/Dropdowns/DropdownAutoComplete',
+  title: 'Core/Buttons/Dropdowns/DropdownAutoComplete',
   component: DropdownAutoComplete,
 };
 

--- a/docs-ui/components/dropdownControl.stories.js
+++ b/docs-ui/components/dropdownControl.stories.js
@@ -4,7 +4,7 @@ import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import MenuItem from 'app/components/menuItem';
 
 export default {
-  title: 'Core/Dropdowns/DropdownControl',
+  title: 'Core/Buttons/Dropdowns/DropdownControl',
 };
 
 export const BasicLabelKnobs = ({

--- a/docs-ui/components/dropdownLink.stories.js
+++ b/docs-ui/components/dropdownLink.stories.js
@@ -4,7 +4,7 @@ import DropdownLink from 'app/components/dropdownLink';
 import MenuItem from 'app/components/menuItem';
 
 export default {
-  title: 'Core/Dropdowns/DropdownLink',
+  title: 'Core/Buttons/Dropdowns/DropdownLink',
   component: DropdownLink,
 };
 

--- a/docs-ui/components/form-fields.stories.js
+++ b/docs-ui/components/form-fields.stories.js
@@ -17,7 +17,7 @@ import TextCopyInput from 'app/views/settings/components/forms/textCopyInput';
 import TextField from 'app/views/settings/components/forms/textField';
 
 export default {
-  title: 'Core/Forms/Fields',
+  title: 'Forms/Fields',
 };
 
 export const _TextField = () => (

--- a/docs-ui/components/form-old-fields.stories.js
+++ b/docs-ui/components/form-old-fields.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import {BooleanField, Form as LegacyForm, PasswordField} from 'app/components/forms';
 
 export default {
-  title: 'Core/Forms/Old/Fields',
+  title: 'Deprecated/Fields',
 };
 
 export const _PasswordField = () => (

--- a/docs-ui/components/form-old.stories.js
+++ b/docs-ui/components/form-old.stories.js
@@ -24,7 +24,7 @@ UndoButton.contextTypes = {
 };
 
 export default {
-  title: 'Core/Forms/Old/Form',
+  title: 'Deprecated/Form',
 };
 
 export const Empty = () => <LegacyForm onSubmit={action('submit')} />;

--- a/docs-ui/components/form.stories.js
+++ b/docs-ui/components/form.stories.js
@@ -8,7 +8,7 @@ import SelectField from 'app/views/settings/components/forms/selectField';
 import TextField from 'app/views/settings/components/forms/textField';
 
 export default {
-  title: 'Core/Forms/Form',
+  title: 'Forms/Form',
   args: {
     alignRight: false,
     required: false,

--- a/docs-ui/components/idBadge.stories.js
+++ b/docs-ui/components/idBadge.stories.js
@@ -19,7 +19,7 @@ const Header = styled('h2')`
 Header.displayName = 'Header';
 
 export default {
-  title: 'Core/Badges+Tags/IdBadge',
+  title: 'Core/Tags/IdBadge',
   components: IdBadge,
 };
 

--- a/docs-ui/components/multipleCheckbox.stories.js
+++ b/docs-ui/components/multipleCheckbox.stories.js
@@ -4,7 +4,7 @@ import {action} from '@storybook/addon-actions';
 import MultipleCheckbox from 'app/views/settings/components/forms/controls/multipleCheckbox';
 
 export default {
-  title: 'Core/Forms/Controls',
+  title: 'Forms/Controls',
   component: MultipleCheckbox,
   args: {
     choices: [

--- a/docs-ui/components/notAvailable.stories.js
+++ b/docs-ui/components/notAvailable.stories.js
@@ -4,7 +4,7 @@ import NotAvailable from 'app/components/notAvailable';
 import PanelTable from 'app/components/panels/panelTable';
 
 export default {
-  title: 'Core/NotAvailable',
+  title: 'UI/NotAvailable',
   component: NotAvailable,
 };
 

--- a/docs-ui/components/numberDragControl.stories.js
+++ b/docs-ui/components/numberDragControl.stories.js
@@ -5,7 +5,7 @@ import {action} from '@storybook/addon-actions';
 import NumberDragControl from 'app/components/numberDragControl';
 
 export default {
-  title: 'Core/Forms/Controls',
+  title: 'Forms/Controls',
   componet: NumberDragControl,
   args: {
     step: 1,

--- a/docs-ui/components/pagination.stories.js
+++ b/docs-ui/components/pagination.stories.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Pagination from 'app/components/pagination';
 
 export default {
-  title: 'Core/Pagination',
+  title: 'Core/Buttons/Pagination',
   component: Pagination,
 };
 

--- a/docs-ui/components/pills.stories.js
+++ b/docs-ui/components/pills.stories.js
@@ -4,7 +4,7 @@ import Pill from 'app/components/pill';
 import Pills from 'app/components/pills';
 
 export default {
-  title: 'Core/Badges+Tags/Pills',
+  title: 'Core/Tags/Pills',
 };
 
 export const Default = () => (

--- a/docs-ui/components/rangeSlider.stories.js
+++ b/docs-ui/components/rangeSlider.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import RangeSlider from 'app/views/settings/components/forms/controls/rangeSlider';
 
 export default {
-  title: 'Core/Forms/Controls',
+  title: 'Forms/Controls',
 };
 
 export const _RangeSlider = () => (

--- a/docs-ui/components/repoLabel.stories.js
+++ b/docs-ui/components/repoLabel.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import RepoLabel from 'app/components/repoLabel';
 
 export default {
-  title: 'Core/Badges+Tags/RepoLabel',
+  title: 'Core/Tags/RepoLabel',
 };
 
 export const Default = () => {

--- a/docs-ui/components/selectFields.stories.js
+++ b/docs-ui/components/selectFields.stories.js
@@ -6,7 +6,7 @@ import SelectCreatableField from 'app/components/forms/selectCreatableField';
 import SelectField from 'app/components/forms/selectField';
 
 export default {
-  title: 'Core/Forms/Fields/Old',
+  title: 'Forms/Fields/Old',
 };
 
 export const _SelectField = () => (

--- a/docs-ui/components/suggestedAvatarStack.stories.js
+++ b/docs-ui/components/suggestedAvatarStack.stories.js
@@ -33,7 +33,7 @@ const options = {
 };
 
 export default {
-  title: 'Core/Avatar',
+  title: 'Core/Style/Avatar/SuggestedAvatar',
   component: SuggestedAvatarStack,
 };
 

--- a/docs-ui/components/tag.stories.js
+++ b/docs-ui/components/tag.stories.js
@@ -7,7 +7,7 @@ import {toTitleCase} from 'app/utils';
 import theme from 'app/utils/theme';
 
 export default {
-  title: 'Core/Badges+Tags/Tag',
+  title: 'Core/Tags/Tag',
   component: Tag,
   argTypes: {
     tooltipText: {


### PR DESCRIPTION
Reorganizing Storybook here to make it easier to navigate: 

- Moved `Forms` out of `Core` into its own section so it's easier to jump to
- Reorganized folders in the left hand nav
- Moved `Activity` component out of `Core` because why
- Removed a bunch of other components out of `Core`

## Before

<img width="1327" alt="CleanShot 2021-02-16 at 21 35 38@2x" src="https://user-images.githubusercontent.com/1900676/108240548-ce986f80-70ff-11eb-9b36-112f558b9d82.png">

## After

<img width="1423" alt="CleanShot 2021-02-17 at 09 01 30@2x" src="https://user-images.githubusercontent.com/1900676/108240570-d3f5ba00-70ff-11eb-8cf4-68ee6853255a.png">
