### PR TITLE
feat(discover): Track errors with no details in discover

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
 
 import {doEventsRequest} from 'app/actionCreators/events';
@@ -207,6 +208,11 @@ class WidgetQueries extends React.Component<Props, State> {
       } catch (err) {
         const errorMessage = err?.responseJSON?.detail || t('An unknown error occurred.');
         this.setState({errorMessage});
+
+        // We always want to make sure an useful error message is set.
+        if (!err?.responseJSON?.detail) {
+          Sentry.captureException(err);
+        }
       }
     });
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -136,11 +136,6 @@ class Table extends React.PureComponent<TableProps, TableState> {
           },
         });
 
-        // We always want to make sure an useful error message is set.
-        if (!err?.responseJSON?.detail) {
-          Sentry.captureException(err);
-        }
-
         const message = err?.responseJSON?.detail || t('An unknown error occurred.');
         this.setState({
           isLoading: false,
@@ -150,6 +145,11 @@ class Table extends React.PureComponent<TableProps, TableState> {
           tableData: null,
         });
         setError(message, err.status);
+
+        // We always want to make sure an useful error message is set.
+        if (!err?.responseJSON?.detail) {
+          Sentry.captureException(err);
+        }
       });
   };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import {Location} from 'history';
 
 import {Client} from 'app/api';
@@ -134,6 +135,12 @@ class Table extends React.PureComponent<TableProps, TableState> {
             status: err.status,
           },
         });
+
+        // We always want to make sure an useful error message is set.
+        if (!err?.responseJSON?.detail) {
+          Sentry.captureException(err);
+        }
+
         const message = err?.responseJSON?.detail || t('An unknown error occurred.');
         this.setState({
           isLoading: false,


### PR DESCRIPTION
Discover errors should always have a helpful error message attached. This helps
us track down ones without the appropriate message by sending them to sentry.