### PR TITLE
ref(stacktrace-link): Simple text changes

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -154,7 +154,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
     if (this.project && this.integrations.length > 0 && filename) {
       return (
         <CodeMappingButtonContainer columnQuantity={2}>
-          {t('Enable source code stack trace linking by setting up a code mapping.')}
+          {t('Link your stack trace to your source code.')}
           <Button
             onClick={() => {
               trackIntegrationEvent(

--- a/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
+++ b/src/sentry/static/sentry/app/components/repositoryProjectPathConfigForm.tsx
@@ -83,7 +83,7 @@ export default class RepositoryProjectPathConfigForm extends React.Component<Pro
         type: 'string',
         required: false,
         label: t('Source Code Root'),
-        placeholder: t('Type root path of your source code'),
+        placeholder: t('Type root path of your source code, e.g. `src/`.'),
         showHelpInTooltip: true,
         help: t(
           'When a rule matches, the stack trace root is replaced with this path to get the path in your repository. Leaving this empty means replacing the stack trace root with an empty string.'


### PR DESCRIPTION
This PR has two simple text changes:
* Updates the CTA to be more clear and concise
* Gives an explicit example of a source code root input. We've seen people put full urls (`https://github.com/...) here so this is to hopefully clarify that it's _not_ the full url. 

The Visuals
> <img width="334" alt="Screen Shot 2021-02-17 at 10 21 18 AM" src="https://user-images.githubusercontent.com/15368179/108250286-ea554300-710a-11eb-83c5-4a13528298cb.png">

> <img width="520" alt="Screen Shot 2021-02-17 at 10 21 50 AM" src="https://user-images.githubusercontent.com/15368179/108250279-e9bcac80-710a-11eb-8e29-baa57ec8aca8.png">

