### PR TITLE
fix: Adjust some dark mode colours for the span view

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -676,7 +676,8 @@ const ViewHandle = styled('div')<{isDragging: boolean}>`
 `;
 
 const Fog = styled('div')`
-  background-color: rgba(108, 95, 199, 0.1);
+  background-color: ${p => p.theme.textColor};
+  opacity: 0.1;
   position: absolute;
   top: 0;
 `;
@@ -733,7 +734,8 @@ const WindowSelection = styled('div')`
   position: absolute;
   top: 0;
   height: ${MINIMAP_HEIGHT}px;
-  background-color: rgba(69, 38, 80, 0.1);
+  background-color: ${p => p.theme.textColor};
+  opacity: 0.1;
 `;
 
 const SecondaryHeader = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -749,7 +749,7 @@ const SecondaryHeader = styled('div')`
 
 const DividerSpacer = styled('div')`
   width: 1px;
-  background-color: ${p => p.theme.gray200};
+  background-color: ${p => p.theme.border};
 `;
 
 const ScrollBarContainer = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -943,7 +943,7 @@ const CursorGuide = styled('div')`
 `;
 
 export const DividerLine = styled('div')`
-  background-color: ${p => p.theme.gray200};
+  background-color: ${p => p.theme.border};
   position: absolute;
   height: 100%;
   width: 1px;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -12,7 +12,6 @@ import {Organization} from 'app/types';
 import {EventTransaction} from 'app/types/event';
 import {defined, OmitHtmlDivProps} from 'app/utils';
 import {TableDataRow} from 'app/utils/discover/discoverQuery';
-import globalTheme from 'app/utils/theme';
 
 import * as CursorGuideHandler from './cursorGuideHandler';
 import * as DividerHandlerManager from './dividerHandlerManager';
@@ -734,12 +733,9 @@ class SpanBar extends React.Component<SpanBarProps, SpanBarState> {
       // Mock component to preserve layout spacing
       return (
         <DividerLine
+          showDetail
           style={{
             position: 'relative',
-            backgroundColor: getBackgroundColor({
-              theme: globalTheme,
-              showDetail: true,
-            }),
           }}
         />
       );
@@ -942,8 +938,8 @@ const CursorGuide = styled('div')`
   height: 100%;
 `;
 
-export const DividerLine = styled('div')`
-  background-color: ${p => p.theme.border};
+export const DividerLine = styled('div')<{showDetail?: boolean}>`
+  background-color: ${p => (p.showDetail ? p.theme.textColor : p.theme.border)};
   position: absolute;
   height: 100%;
   width: 1px;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -25,7 +25,6 @@ import {TableDataRow} from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
 import {eventDetailsRoute, generateEventSlug} from 'app/utils/discover/urls';
 import getDynamicText from 'app/utils/getDynamicText';
-import theme from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 
 import * as SpanEntryContext from './context';
@@ -547,7 +546,7 @@ const StyledLoadingIndicator = styled(LoadingIndicator)`
 `;
 
 const StyledText = styled('p')`
-  font-size: ${theme.fontSizeMedium};
+  font-size: ${p => p.theme.fontSizeMedium};
   margin: ${space(2)} ${space(0)};
 `;
 


### PR DESCRIPTION
The fog and window selection of the minimap, and the divider line of the span view wasn't legible in dark mode. 

https://user-images.githubusercontent.com/139499/108262809-695e7180-7133-11eb-8811-2b91e18b70e2.mp4

