### PR TITLE
fix: Use user.display instead of the user tag when opening an Issue in Discover

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
@@ -80,7 +80,7 @@ class Actions extends React.Component<Props, State> {
     const discoverQuery = {
       id: undefined,
       name: title || type,
-      fields: ['title', 'release', 'environment', 'user', 'timestamp'],
+      fields: ['title', 'release', 'environment', 'user.display', 'timestamp'],
       orderby: '-timestamp',
       query: `issue.id:${id}`,
       projects: [Number(project.id)],


### PR DESCRIPTION
`user.display` is more helpful than the `user` column.