### PR TITLE
fix: Adjust dndkit configuration for dashboard widgets

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import LazyLoad from 'react-lazyload';
-import {DndContext} from '@dnd-kit/core';
-import {arrayMove, rectSwappingStrategy, SortableContext} from '@dnd-kit/sortable';
+import {closestCenter, DndContext} from '@dnd-kit/core';
+import {arrayMove, rectSortingStrategy, SortableContext} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 
 import {openAddDashboardWidgetModal} from 'app/actionCreators/modal';
@@ -129,6 +129,7 @@ class Dashboard extends React.Component<Props> {
 
     return (
       <DndContext
+        collisionDetection={closestCenter}
         onDragEnd={({over, active}) => {
           const activeDragId = active.id;
           const getIndex = items.indexOf.bind(items);
@@ -144,7 +145,7 @@ class Dashboard extends React.Component<Props> {
         }}
       >
         <WidgetContainer>
-          <SortableContext items={items} strategy={rectSwappingStrategy}>
+          <SortableContext items={items} strategy={rectSortingStrategy}>
             {widgets.map((widget, index) => this.renderWidget(widget, index))}
             {isEditing && <AddWidget onClick={this.handleStartAdd} />}
           </SortableContext>

--- a/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
@@ -57,8 +57,9 @@ function SortableWidget(props: Props) {
       displayType={widget.displayType}
       layoutId={dragId}
       style={{
-        // Origin is set to top right-hand corner where the drag handle is placed
-        originX: 1,
+        // Origin is set to top right-hand corner where the drag handle is placed.
+        // Otherwise, set the origin to be the top left-hand corner when swapping widgets.
+        originX: currentWidgetDragging ? 1 : 0,
         originY: 0,
         boxShadow: currentWidgetDragging ? theme.dropShadowHeavy : 'none',
         borderRadius: currentWidgetDragging ? theme.borderRadius : undefined,

--- a/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/sortableWidget.tsx
@@ -57,7 +57,8 @@ function SortableWidget(props: Props) {
       displayType={widget.displayType}
       layoutId={dragId}
       style={{
-        originX: 0,
+        // Origin is set to top right-hand corner where the drag handle is placed
+        originX: 1,
         originY: 0,
         boxShadow: currentWidgetDragging ? theme.dropShadowHeavy : 'none',
         borderRadius: currentWidgetDragging ? theme.borderRadius : undefined,


### PR DESCRIPTION
For widgets being dragged, set their transform origins to be the top right-hand corner; since this is where the drag handle is located. For widgets not being dragged, their transform origins will remain to be the top left-hand corner.

This addresses a UI issue when dragging a line-chart sized widget into a big number sized widget.

Also adjust the collision detection and swap strategy as suggested in the dndkit's sortable docs: https://docs.dndkit.com/presets/sortable


Before:


https://user-images.githubusercontent.com/139499/108271202-6fa61b00-713e-11eb-8d30-deceb2f1d8bf.mp4

After:

https://user-images.githubusercontent.com/139499/108271214-72a10b80-713e-11eb-938d-8fa15da309f4.mp4

