### PR TITLE
fix(Vercel): Handle env already exists errors

### DIFF
--- a/src/sentry/api/client.py
+++ b/src/sentry/api/client.py
@@ -105,6 +105,9 @@ class ApiClient:
     def get(self, *args, **kwargs):
         return self.request("GET", *args, **kwargs)
 
+    def patch(self, *args, **kwargs):
+        return self.request("PATCH", *args, **kwargs)
+
     def post(self, *args, **kwargs):
         return self.request("POST", *args, **kwargs)
 

--- a/src/sentry/api/client.py
+++ b/src/sentry/api/client.py
@@ -105,9 +105,6 @@ class ApiClient:
     def get(self, *args, **kwargs):
         return self.request("GET", *args, **kwargs)
 
-    def patch(self, *args, **kwargs):
-        return self.request("PATCH", *args, **kwargs)
-
     def post(self, *args, **kwargs):
         return self.request("POST", *args, **kwargs)
 

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -101,6 +101,7 @@ class VercelClient(ApiClient):
             raise
 
     def update_env_variable(self, vercel_project_id, key, value, data):
+
         env_var_id = [
             env_var["id"]
             for env_var in self.get(self.GET_ENV_VAR_URL % vercel_project_id)["envs"]

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -84,7 +84,7 @@ class VercelClient(ApiClient):
     def get_env_vars(self, vercel_project_id):
         return self.get(self.GET_ENV_VAR_URL % vercel_project_id)
 
-    def create_secret(self, vercel_project_id, name, value):
+    def create_secret(self, name, value):
         data = {"name": name, "value": value}
         response = self.post(self.SECRETS_URL, data=data)["uid"]
         return response

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -89,25 +89,8 @@ class VercelClient(ApiClient):
         response = self.post(self.SECRETS_URL, data=data)["uid"]
         return response
 
-    def create_env_variable(self, vercel_project_id, key, value):
-        data = {"key": key, "value": value, "target": ["production"], "type": "secret"}
-        try:
-            return self.post(self.ENV_VAR_URL % vercel_project_id, data=data)
-        except ApiError as e:
-            if e.json:
-                if e.json["error"]:
-                    if e.json["error"]["code"] == "ENV_ALREADY_EXISTS":
-                        return self.update_env_variable(vercel_project_id, key, value, data)
-            raise
+    def create_env_variable(self, vercel_project_id, key, value, data):
+        return self.post(self.ENV_VAR_URL % vercel_project_id, data=data)
 
-    def update_env_variable(self, vercel_project_id, key, value, data):
-
-        env_var_id = [
-            env_var["id"]
-            for env_var in self.get(self.GET_ENV_VAR_URL % vercel_project_id)["envs"]
-            if env_var["key"] == key
-        ]
-        if env_var_id:
-            return self.patch(
-                self.UPDATE_ENV_VAR_URL % (vercel_project_id, env_var_id[0]), data=data
-            )
+    def update_env_variable(self, vercel_project_id, env_var_id, data):
+        return self.patch(self.UPDATE_ENV_VAR_URL % (vercel_project_id, env_var_id), data=data)

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -89,7 +89,7 @@ class VercelClient(ApiClient):
         response = self.post(self.SECRETS_URL, data=data)["uid"]
         return response
 
-    def create_env_variable(self, vercel_project_id, key, value, data):
+    def create_env_variable(self, vercel_project_id, data):
         return self.post(self.ENV_VAR_URL % vercel_project_id, data=data)
 
     def update_env_variable(self, vercel_project_id, env_var_id, data):

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -255,12 +255,14 @@ class VercelIntegration(IntegrationInstallation):
                 "SENTRY_PROJECT_%s" % uuid,
                 dsn_secret_name % uuid,
                 "SENTRY_AUTH_TOKEN_%s" % uuid,
+                f"VERCEL_{source_code_provider.upper()}_COMMIT_SHA_{uuid}",
             ]
             values = [
                 sentry_project.organization.slug,
                 sentry_project.slug,
                 sentry_project_dsn,
                 sentry_auth_token,
+                source_code_provider,
             ]
 
             dsn_env_name = "NEXT_PUBLIC_SENTRY_DSN" if is_next_js else "SENTRY_DSN"
@@ -277,7 +279,6 @@ class VercelIntegration(IntegrationInstallation):
             for name, val in zip(secret_names, values):
                 secrets.append(vercel_client.create_secret(vercel_project_id, name, val))
 
-            secrets.append("")
             for secret, env_var in zip(secrets, env_var_names):
                 self.create_env_var(vercel_client, vercel_project_id, env_var, secret)
 
@@ -285,7 +286,7 @@ class VercelIntegration(IntegrationInstallation):
         self.org_integration.update(config=config)
 
     def create_env_var(self, client, vercel_project_id, key, value):
-        return client.update_env_variable(vercel_project_id, key, value, retry_update=0)
+        return client.create_env_variable(vercel_project_id, key, value)
 
 
 class VercelIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -288,17 +288,18 @@ class VercelIntegration(IntegrationInstallation):
             raise
 
     def update_env_variable(self, client, vercel_project_id, data):
+        key = data["key"]
         try:
             envs = client.get_env_vars(vercel_project_id)["envs"]
-        except Exception:
-            raise
+        except ApiError:
+            message = f"Failed to get ID for environment variable {key} in Vercel project {vercel_project_id}."
+            raise IntegrationError(message)
 
         env_var_ids = [env_var["id"] for env_var in envs if env_var["key"] == data["key"]]
         if env_var_ids:
             try:
                 return client.update_env_variable(vercel_project_id, env_var_ids[0], data)
             except ApiError:
-                key = data["key"]
                 message = f"Could not update environment variable {key} in Vercel project {vercel_project_id}."
                 raise IntegrationError(message)
 

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -206,6 +206,7 @@ class VercelIntegration(IntegrationInstallation):
 
     def update_organization_config(self, data):
         # data = {"project_mappings": [[sentry_project_id, vercel_project_id]]}
+
         vercel_client = self.get_client()
         config = self.org_integration.config
         try:
@@ -262,13 +263,10 @@ class VercelIntegration(IntegrationInstallation):
                 if details["type"] == "secret":
                     secret_name = env_var + "_%s" % uuid
                     secret_value = vercel_client.create_secret(secret_name, details["value"])
-                    self.create_env_var(
-                        vercel_client, vercel_project_id, env_var, secret_value, details["type"]
-                    )
-                else:
-                    self.create_env_var(
-                        vercel_client, vercel_project_id, env_var, details["value"], details["type"]
-                    )
+                    details["value"] = secret_value
+                self.create_env_var(
+                    vercel_client, vercel_project_id, env_var, details["value"], details["type"]
+                )
 
         config.update(data)
         self.org_integration.update(config=config)
@@ -295,10 +293,9 @@ class VercelIntegration(IntegrationInstallation):
             return client.update_env_variable(vercel_project_id, env_var_ids[0], data)
 
         key = data["key"]
-        message = (
+        raise IntegrationError(
             f"Could not update environment variable {key} in Vercel project {vercel_project_id}."
         )
-        raise IntegrationError(message)
 
 
 class VercelIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -288,20 +288,18 @@ class VercelIntegration(IntegrationInstallation):
             raise
 
     def update_env_variable(self, client, vercel_project_id, data):
-        key = data["key"]
         try:
             envs = client.get_env_vars(vercel_project_id)["envs"]
         except ApiError:
-            message = f"Failed to get ID for environment variable {key} in Vercel project {vercel_project_id}."
-            raise IntegrationError(message)
+            raise
 
         env_var_ids = [env_var["id"] for env_var in envs if env_var["key"] == data["key"]]
         if env_var_ids:
             try:
                 return client.update_env_variable(vercel_project_id, env_var_ids[0], data)
             except ApiError:
-                message = f"Could not update environment variable {key} in Vercel project {vercel_project_id}."
-                raise IntegrationError(message)
+                raise
+        raise
 
 
 class VercelIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -284,19 +284,8 @@ class VercelIntegration(IntegrationInstallation):
         config.update(data)
         self.org_integration.update(config=config)
 
-    def env_var_already_exists(self, client, vercel_project_id, name):
-        return any(
-            [
-                env_var
-                for env_var in client.get_env_vars(vercel_project_id)
-                if env_var["key"] == name
-            ]
-        )
-
     def create_env_var(self, client, vercel_project_id, key, value):
-        if not self.env_var_already_exists(client, vercel_project_id, key):
-            return client.create_env_variable(vercel_project_id, key, value)
-        client.update_env_variable(vercel_project_id, key, value)
+        return client.update_env_variable(vercel_project_id, key, value, retry_update=0)
 
 
 class VercelIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -258,12 +258,12 @@ class VercelIntegration(IntegrationInstallation):
                 "VERCEL_GIT_COMMIT_SHA": {"type": "system", "value": "VERCEL_GIT_COMMIT_SHA"},
             }
 
-            for env_var, data in env_var_map.items():
-                if data["type"] == "secret":
+            for env_var, details in env_var_map.items():
+                if details["type"] == "secret":
                     secret_name = env_var + "_%s" % uuid
-                    data["value"] = vercel_client.create_secret(secret_name, data["value"])
+                    details["value"] = vercel_client.create_secret(secret_name, details["value"])
                 self.create_env_var(
-                    vercel_client, vercel_project_id, env_var, data["value"], data["type"]
+                    vercel_client, vercel_project_id, env_var, details["value"], details["type"]
                 )
 
         config.update(data)
@@ -293,11 +293,10 @@ class VercelIntegration(IntegrationInstallation):
         if env_var_id:
             return client.update_env_variable(vercel_project_id, env_var_id[0], data)
 
-        logger.warn(
-            "vercel.update_env_var.failed",
-            extra={"env_var": key, "vercel_project_id": vercel_project_id},
+        message = "Could not update environment variable {} in Vercel project {}.".format(
+            key,
+            vercel_project_id,
         )
-        message = "Could not update environment variable %s in Vercel." % key
         raise IntegrationError(message)
 
 

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -293,7 +293,12 @@ class VercelIntegration(IntegrationInstallation):
         env_var_ids = [env_var["id"] for env_var in envs if env_var["key"] == data["key"]]
         if env_var_ids:
             return client.update_env_variable(vercel_project_id, env_var_ids[0], data)
-        raise
+
+        key = data["key"]
+        message = (
+            f"Could not update environment variable {key} in Vercel project {vercel_project_id}."
+        )
+        raise IntegrationError(message)
 
 
 class VercelIntegrationProvider(IntegrationProvider):

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -288,17 +288,11 @@ class VercelIntegration(IntegrationInstallation):
             raise
 
     def update_env_variable(self, client, vercel_project_id, data):
-        try:
-            envs = client.get_env_vars(vercel_project_id)["envs"]
-        except ApiError:
-            raise
+        envs = client.get_env_vars(vercel_project_id)["envs"]
 
         env_var_ids = [env_var["id"] for env_var in envs if env_var["key"] == data["key"]]
         if env_var_ids:
-            try:
-                return client.update_env_variable(vercel_project_id, env_var_ids[0], data)
-            except ApiError:
-                raise
+            return client.update_env_variable(vercel_project_id, env_var_ids[0], data)
         raise
 
 

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -207,15 +207,15 @@ class VercelIntegrationTest(IntegrationTestCase):
             json={"link": {"type": "github"}, "framework": "nextjs"},
         )
 
-        # mock create the secret for the auth token
-        responses.add(
-            responses.POST,
-            "https://api.vercel.com/v2/now/secrets",
-            json={"uid": "sec_0"},
-        )
-
         # mock create the env vars
         for env_var, details in env_var_map.items():
+            if details["type"] == "secret":
+                # mock create the secret for the auth token
+                responses.add(
+                    responses.POST,
+                    "https://api.vercel.com/v2/now/secrets",
+                    json={"uid": "sec_0"},
+                )
             responses.add(
                 responses.POST,
                 "https://api.vercel.com/v6/projects/%s/env"
@@ -335,11 +335,6 @@ class VercelIntegrationTest(IntegrationTestCase):
                 "https://api.vercel.com/v6/projects/%s/env"
                 % "Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H",
                 json={"envs": [{"id": count, "key": env_var}]},
-            )
-            print("update url2")
-            print(
-                "https://api.vercel.com/v6/projects/%s/env/%s"
-                % ("Qme9NXBpguaRxcXssZ1NWHVaM98MAL6PHDXUs1jPrgiM8H", count)
             )
             # mock update env var
             responses.add(


### PR DESCRIPTION
This is another pass at fixing the problem outlined in https://github.com/getsentry/sentry/pull/23709

**Before**
When creating the mappings between a Sentry and Vercel project, we create a few environment variables in Vercel. For each environment variable we'd check to see if it already existed in Vercel or not, and if it didn't, we'd create it. If it did, we'd delete and create it. 

**Problem**
In the last PR we had run into an issue where the endpoint we were using to get the existing environment variables was only returning 20 results, so I implemented pagination to get all of the results. This appeared to fix it (it resolved it when I reproduced it locally) at first, but the issue came up again.

**New Solution**
Try to create the env var, if it already exists, get the env var ID and update it using [this endpoint](https://vercel.com/docs/api#endpoints/projects/edit-a-project-environment-variable). I also updated the `ENV_VAR_URL` (create an env var) endpoint to use v6 but had to make some changes like making `target` a list, adding in a `type`, and not passing an empty string as the secret for `VERCEL_GITHUB_COMMIT_SHA`. 


Fixes [SENTRY-JW3](https://sentry.io/organizations/sentry/issues/2069926640/events/e0b5b53f718b4e2baa7af67cda35c1ce/?project=1)