### PR TITLE
fix(alerts): Add filters to incidents for alert rule details

### DIFF
--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -59,11 +59,12 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
             incidents = incidents.filter(alert_rule__snuba_query__dataset=Dataset.Events.value)
 
         query_detailed = request.GET.get("detailed")
+
         def serialize_results(results):
             if query_detailed:
                 return serialize(results, request.user, DetailedIncidentSerializer())
             else:
-                return serialize(results, request.user),
+                return (serialize(results, request.user),)
 
         return self.paginate(
             request,

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -38,7 +38,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
         query_start = request.GET.get("start")
         query_end = request.GET.get("end")
         if query_start is not None and query_end is not None:
-            incidents = incidents.filter(start=query_start, end=query_end)
+            incidents = incidents.filter(date_started__lte=query_end, date_closed__gte=query_start)
 
         query_status = request.GET.get("status")
         if query_status is not None:

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -34,6 +34,14 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
         if query_alert_rule is not None:
             incidents = incidents.filter(alert_rule=query_alert_rule)
 
+        query_start = request.GET.get("start")
+        if query_start is not None:
+            incidents = incidents.filter(start=query_start)
+
+        query_end = request.GET.get("end")
+        if query_end is not None:
+            incidents = incidents.filter(end=query_end)
+
         query_status = request.GET.get("status")
         if query_status is not None:
             if query_status == "open":

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -36,9 +36,14 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
             incidents = incidents.filter(alert_rule=query_alert_rule)
 
         query_start = request.GET.get("start")
+        if query_start is not None:
+            # exclude incidents closed before the window
+            incidents = incidents.exclude(date_closed__lte=query_start)
+
         query_end = request.GET.get("end")
-        if query_start is not None and query_end is not None:
-            incidents = incidents.filter(date_started__lte=query_end, date_closed__gte=query_start)
+        if query_end is not None:
+            # exclude incidents started after the window
+            incidents = incidents.exclude(date_started__gte=query_end)
 
         query_status = request.GET.get("status")
         if query_status is not None:

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -37,11 +37,11 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
 
         query_start = request.GET.get("start")
         if query_start is not None:
-            incidents = incidents.filter(start=query_start)
+            incidents = incidents.filter(start__gte=query_start)
 
         query_end = request.GET.get("end")
         if query_end is not None:
-            incidents = incidents.filter(end=query_end)
+            incidents = incidents.filter(end__gte=query_end)
 
         query_status = request.GET.get("status")
         if query_status is not None:

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -64,7 +64,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
             if query_detailed:
                 return serialize(results, request.user, DetailedIncidentSerializer())
             else:
-                return (serialize(results, request.user),)
+                return serialize(results, request.user)
 
         return self.paginate(
             request,

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -36,12 +36,9 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
             incidents = incidents.filter(alert_rule=query_alert_rule)
 
         query_start = request.GET.get("start")
-        if query_start is not None:
-            incidents = incidents.filter(start__gte=query_start)
-
         query_end = request.GET.get("end")
-        if query_end is not None:
-            incidents = incidents.filter(end__gte=query_end)
+        if query_start is not None and query_end is not None:
+            incidents = incidents.filter(start=query_start, end=query_end)
 
         query_status = request.GET.get("status")
         if query_status is not None:

--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -179,6 +179,7 @@ class GroupList extends React.Component<Props, State> {
       renderEmptyMessage,
       withPagination,
       useFilteredStats,
+      queryParams,
     } = this.props;
     const {loading, error, groups, memberList, pageLinks} = this.state;
 
@@ -205,6 +206,10 @@ class GroupList extends React.Component<Props, State> {
       );
     }
 
+    const statsPeriod = typeof queryParams?.groupStatsPeriod === 'string'
+      ? queryParams?.groupStatsPeriod
+      : undefined;
+
     return (
       <React.Fragment>
         <Panel>
@@ -223,6 +228,7 @@ class GroupList extends React.Component<Props, State> {
                   withChart={withChart}
                   memberList={members}
                   useFilteredStats={useFilteredStats}
+                  statsPeriod={statsPeriod}
                 />
               );
             })}

--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -206,9 +206,10 @@ class GroupList extends React.Component<Props, State> {
       );
     }
 
-    const statsPeriod = typeof queryParams?.groupStatsPeriod === 'string'
-      ? queryParams?.groupStatsPeriod
-      : undefined;
+    const statsPeriod =
+      typeof queryParams?.groupStatsPeriod === 'string'
+        ? queryParams?.groupStatsPeriod
+        : undefined;
 
     return (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -61,12 +61,21 @@ const TIME_OPTIONS: SelectValue<string>[] = [
   {label: t('7 days'), value: TimePeriod.SEVEN_DAYS},
 ];
 
+export const ALERT_RULE_DETAILS_DEFAULT_PERIOD = TimePeriod.ONE_DAY;
+
 const TIME_WINDOWS = {
   [TimePeriod.SIX_HOURS]: TimeWindow.ONE_HOUR * 6 * 60 * 1000,
   [TimePeriod.ONE_DAY]: TimeWindow.ONE_DAY * 60 * 1000,
   [TimePeriod.THREE_DAYS]: TimeWindow.ONE_DAY * 3 * 60 * 1000,
   [TimePeriod.SEVEN_DAYS]: TimeWindow.ONE_DAY * 7 * 60 * 1000,
 };
+
+export const getStartEndTimesFromPeriod = (period: string): {start: string, end: string} => {
+  return {
+    start: getUtcDateString(moment(moment.utc().diff(TIME_WINDOWS[period]))),
+    end: getUtcDateString(moment.utc()),
+  }
+}
 
 class DetailsBody extends React.Component<Props> {
   get metricPreset() {
@@ -94,16 +103,14 @@ class DetailsBody extends React.Component<Props> {
 
   getTimePeriod() {
     const {location} = this.props;
-    const now = moment.utc();
 
-    const timePeriod = location.query.period ?? TimePeriod.ONE_DAY;
+    const timePeriod = location.query.period ?? ALERT_RULE_DETAILS_DEFAULT_PERIOD;
     const timeOption =
       TIME_OPTIONS.find(item => item.value === timePeriod) ?? TIME_OPTIONS[1];
 
     return {
       ...timeOption,
-      start: getUtcDateString(moment(now.diff(TIME_WINDOWS[timeOption.value]))),
-      end: getUtcDateString(now),
+      ...getStartEndTimesFromPeriod(timeOption.value),
     };
   }
 

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -70,12 +70,14 @@ const TIME_WINDOWS = {
   [TimePeriod.SEVEN_DAYS]: TimeWindow.ONE_DAY * 7 * 60 * 1000,
 };
 
-export const getStartEndTimesFromPeriod = (period: string): {start: string, end: string} => {
+export const getStartEndTimesFromPeriod = (
+  period: string
+): {start: string; end: string} => {
   return {
     start: getUtcDateString(moment(moment.utc().diff(TIME_WINDOWS[period]))),
     end: getUtcDateString(moment.utc()),
-  }
-}
+  };
+};
 
 class DetailsBody extends React.Component<Props> {
   get metricPreset() {

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/header.tsx
@@ -39,7 +39,7 @@ export default class DetailsHeader extends React.Component<Props> {
           <AlertBreadcrumbs
             crumbs={[
               {label: t('Alerts'), to: `/organizations/${params.orgId}/alerts/`},
-              {label: rule && `Alert Rule Details #${rule.id}`},
+              {label: t('Alert Rule')},
             ]}
           />
           <Controls>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import {Location} from 'history';
 import {RouteComponentProps} from 'react-router';
+import {Location} from 'history';
 
 import {fetchOrgMembers} from 'app/actionCreators/members';
 import {Client} from 'app/api';
@@ -12,7 +12,10 @@ import {IncidentRule} from 'app/views/settings/incidentRules/types';
 import {Incident} from '../../types';
 import {fetchAlertRule, fetchIncidentsForRule} from '../../utils';
 
-import DetailsBody, {ALERT_RULE_DETAILS_DEFAULT_PERIOD, getStartEndTimesFromPeriod} from './body';
+import DetailsBody, {
+  ALERT_RULE_DETAILS_DEFAULT_PERIOD,
+  getStartEndTimesFromPeriod,
+} from './body';
 import DetailsHeader from './header';
 
 type Props = {
@@ -46,15 +49,20 @@ class AlertRuleDetails extends React.Component<Props, State> {
       params: {orgId, ruleId},
     } = this.props;
 
-    const {start, end} = getStartEndTimesFromPeriod(location.query.period ?? ALERT_RULE_DETAILS_DEFAULT_PERIOD);
+    const {start, end} = getStartEndTimesFromPeriod(
+      location.query.period ?? ALERT_RULE_DETAILS_DEFAULT_PERIOD
+    );
 
     try {
       const rulePromise = fetchAlertRule(orgId, ruleId).then(rule =>
         this.setState({rule})
       );
-      const incidentsPromise = fetchIncidentsForRule(orgId, ruleId, start, end).then(incidents =>
-        this.setState({incidents})
-      );
+      const incidentsPromise = fetchIncidentsForRule(
+        orgId,
+        ruleId,
+        start,
+        end
+      ).then(incidents => this.setState({incidents}));
       await Promise.all([rulePromise, incidentsPromise]);
       this.setState({isLoading: false, hasError: false});
     } catch (_err) {

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
@@ -16,7 +16,6 @@ type Props = {
   rule: IncidentRule;
   projects: Project[];
   filter: string;
-  statsPeriod?: string;
   start?: string;
   end?: string;
 };
@@ -35,13 +34,13 @@ class RelatedIssues extends React.Component<Props> {
   };
 
   render() {
-    const {rule, projects, filter, organization, start, end, statsPeriod} = this.props;
+    const {rule, projects, filter, organization, start, end} = this.props;
 
     const path = `/organizations/${organization.slug}/issues/`;
     const queryParams = {
       start,
       end,
-      statsPeriod,
+      groupStatsPeriod: 'auto',
       limit: 5,
       sort: 'new',
       query: `${rule.query} ${filter}`,
@@ -66,10 +65,10 @@ class RelatedIssues extends React.Component<Props> {
             orgId={organization.slug}
             endpointPath={path}
             queryParams={queryParams}
-            query=""
+            query={`start=${start}&end=${end}&groupStatsPeriod=auto`}
             canSelectGroups={false}
             renderEmptyMessage={this.renderEmptyMessage}
-            withChart={false}
+            withChart={true}
             withPagination={false}
             useFilteredStats={false}
           />

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
@@ -68,7 +68,7 @@ class RelatedIssues extends React.Component<Props> {
             query={`start=${start}&end=${end}&groupStatsPeriod=auto`}
             canSelectGroups={false}
             renderEmptyMessage={this.renderEmptyMessage}
-            withChart={true}
+            withChart
             withPagination={false}
             useFilteredStats={false}
           />

--- a/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
@@ -28,10 +28,12 @@ export function fetchAlertRule(orgId: string, ruleId: string): Promise<IncidentR
 
 export function fetchIncidentsForRule(
   orgId: string,
-  alertRule: string
+  alertRule: string,
+  start: string,
+  end: string,
 ): Promise<Incident[]> {
   return uncancellableApi.requestPromise(`/organizations/${orgId}/incidents/`, {
-    query: {alertRule},
+    query: {alertRule, start, end},
   });
 }
 

--- a/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
@@ -30,7 +30,7 @@ export function fetchIncidentsForRule(
   orgId: string,
   alertRule: string,
   start: string,
-  end: string,
+  end: string
 ): Promise<Incident[]> {
   return uncancellableApi.requestPromise(`/organizations/${orgId}/incidents/`, {
     query: {alertRule, start, end, detailed: true},

--- a/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
@@ -33,7 +33,7 @@ export function fetchIncidentsForRule(
   end: string,
 ): Promise<Incident[]> {
   return uncancellableApi.requestPromise(`/organizations/${orgId}/incidents/`, {
-    query: {alertRule, start, end},
+    query: {alertRule, start, end, detailed: true},
   });
 }
 

--- a/tests/sentry/incidents/endpoints/test_organization_incident_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_index.py
@@ -100,7 +100,7 @@ class IncidentListEndpointTest(APITestCase):
         update_incident_status(
             incident=old_incident,
             status=IncidentStatus.CLOSED,
-            date_closed=timezone.now() - timedelta(hours=25)
+            date_closed=timezone.now() - timedelta(hours=25),
         )
         new_incident = self.create_incident(date_started=timezone.now() - timedelta(hours=2))
         update_incident_status(

--- a/tests/sentry/incidents/endpoints/test_organization_incident_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_index.py
@@ -95,14 +95,28 @@ class IncidentListEndpointTest(APITestCase):
 
     def test_filter_start_end_times(self):
         self.create_team(organization=self.organization, members=[self.user])
-        new_incident = self.create_incident(date_started=timezone.now() - timedelta(hours=2), date_closed=timezone.now() - timedelta(hours=1))
-        old_incident = self.create_incident(date_started=timezone.now() - timedelta(hours=26), date_closed=timezone.now() - timedelta(hours=25))
+        new_incident = self.create_incident(
+            date_started=timezone.now() - timedelta(hours=2),
+            date_closed=timezone.now() - timedelta(hours=1),
+        )
+        old_incident = self.create_incident(
+            date_started=timezone.now() - timedelta(hours=26),
+            date_closed=timezone.now() - timedelta(hours=25),
+        )
 
         self.login_as(self.user)
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
             resp_all = self.get_valid_response(self.organization.slug)
-            resp_new = self.get_valid_response(self.organization.slug, start=timezone.now() - timedelta(hours=12), end=timezone.now())
-            resp_old = self.get_valid_response(self.organization.slug, start=timezone.now() - timedelta(hours=36), end=timezone.now() - timedelta(hours=24))
+            resp_new = self.get_valid_response(
+                self.organization.slug,
+                start=timezone.now() - timedelta(hours=12),
+                end=timezone.now(),
+            )
+            resp_old = self.get_valid_response(
+                self.organization.slug,
+                start=timezone.now() - timedelta(hours=36),
+                end=timezone.now() - timedelta(hours=24),
+            )
 
         assert resp_old.data == serialize([old_incident])
         assert resp_new.data == serialize([new_incident])


### PR DESCRIPTION
This adds start/end and detailed parameters to the incidents endpoint for the alert rule details page. Also added `groupStatsPeriod: 'auto' ` to related issues and changed the breadcrumbs in alert rule details.