### PR TITLE
feat(users): Include list of external user associations

### DIFF
--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -9,6 +9,7 @@ from sentry import roles, features
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models import OrganizationMemberWithExternalUsersSerializer
 from sentry.api.serializers.rest_framework import ListField
 from sentry.api.validators import AllowedEmailField
 from sentry.models import (
@@ -162,7 +163,9 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
         return self.paginate(
             request=request,
             queryset=queryset,
-            on_results=lambda x: serialize(x, request.user),
+            on_results=lambda x: serialize(
+                x, request.user, serializer=OrganizationMemberWithExternalUsersSerializer()
+            ),
             paginator_cls=OffsetPaginator,
         )
 

--- a/src/sentry/api/endpoints/organization_member_index.py
+++ b/src/sentry/api/endpoints/organization_member_index.py
@@ -159,18 +159,18 @@ class OrganizationMemberIndexEndpoint(OrganizationEndpoint):
                 else:
                     queryset = queryset.none()
 
-        is_detailed = request.GET.get("detailed", "0") != "0"
-
-        serializer = (
-            organization_member_serializers.OrganizationMemberWithExternalUsersSerializer
-            if is_detailed
-            else organization_member_serializers.OrganizationMemberSerializer
-        )
+        expand = request.GET.getlist("expand", [])
 
         return self.paginate(
             request=request,
             queryset=queryset,
-            on_results=lambda x: serialize(x, request.user, serializer=serializer()),
+            on_results=lambda x: serialize(
+                x,
+                request.user,
+                serializer=organization_member_serializers.OrganizationMemberSerializer(
+                    expand=expand
+                ),
+            ),
             paginator_cls=OffsetPaginator,
         )
 

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -224,7 +224,7 @@ class ExternalUserSerializer(Serializer):
         provider = ExternalUser.get_provider_string(obj.provider)
         return {
             "id": str(obj.id),
-            "organizationMemberId": str(obj.organizationmember_id),
+            "memberId": str(obj.organizationmember_id),
             "provider": provider,
             "externalName": obj.external_name,
         }

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -9,6 +9,7 @@ from sentry.models import (
     Integration,
     OrganizationIntegration,
     ExternalTeam,
+    ExternalUser,
 )
 
 
@@ -212,6 +213,18 @@ class ExternalTeamSerializer(Serializer):
         return {
             "id": str(obj.id),
             "teamId": str(obj.team_id),
+            "provider": provider,
+            "externalName": obj.external_name,
+        }
+
+
+@register(ExternalUser)
+class ExternalUserSerializer(Serializer):
+    def serialize(self, obj, attrs, user):
+        provider = ExternalUser.get_provider_string(obj.provider)
+        return {
+            "id": str(obj.id),
+            "organizationMemberId": str(obj.organizationmember_id),
             "provider": provider,
             "externalName": obj.external_name,
         }

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -7,13 +7,33 @@ from sentry.models import OrganizationMember, OrganizationMemberTeam, Team, Team
 
 @register(OrganizationMember)
 class OrganizationMemberSerializer(Serializer):
+    def __init__(
+        self,
+        expand=None,
+    ):
+        self.expand = expand or []
+
     def get_attrs(self, item_list, user):
         # TODO(dcramer): assert on relations
         users = {d["id"]: d for d in serialize({i.user for i in item_list if i.user_id}, user)}
+        external_users_map = defaultdict(list)
 
-        return {
-            item: {"user": users[str(item.user_id)] if item.user_id else None} for item in item_list
+        if "externalUsers" in self.expand:
+            external_users = list(ExternalUser.objects.filter(organizationmember__in=item_list))
+
+            for external_user in external_users:
+                serialized = serialize(external_user, user)
+                external_users_map[external_user.organizationmember_id].append(serialized)
+
+        attrs = {
+            item: {
+                "user": users[str(item.user_id)] if item.user_id else None,
+                "externalUsers": external_users_map[item.id],
+            }
+            for item in item_list
         }
+
+        return attrs
 
     def serialize(self, obj, attrs, user):
         d = {
@@ -33,6 +53,10 @@ class OrganizationMemberSerializer(Serializer):
             "inviteStatus": obj.get_invite_status_name(),
             "inviterName": obj.inviter.get_display_name() if obj.inviter else None,
         }
+
+        if "externalUsers" in self.expand:
+            d["externalUsers"] = attrs.get("externalUsers", [])
+
         return d
 
 
@@ -108,28 +132,4 @@ class OrganizationMemberWithProjectsSerializer(OrganizationMemberSerializer):
     def serialize(self, obj, attrs, user):
         d = super().serialize(obj, attrs, user)
         d["projects"] = attrs.get("projects", [])
-        return d
-
-
-class OrganizationMemberWithExternalUsersSerializer(OrganizationMemberSerializer):
-    def get_attrs(self, item_list, user):
-        attrs = super().get_attrs(item_list, user)
-
-        external_users = list(ExternalUser.objects.filter(organizationmember__in=item_list))
-
-        external_users_map = defaultdict(list)
-        for external_user in external_users:
-            serialized = serialize(external_user, user)
-            external_users_map[external_user.organizationmember_id].append(serialized)
-
-        for org_member in item_list:
-            attrs[org_member]["externalUsers"] = external_users_map[org_member.id]
-
-        return attrs
-
-    def serialize(self, obj, attrs, user):
-        d = super().serialize(obj, attrs, user)
-
-        d["externalUsers"] = attrs.get("externalUsers", [])
-
         return d

--- a/src/sentry/models/integration.py
+++ b/src/sentry/models/integration.py
@@ -74,7 +74,16 @@ EXTERNAL_PROVIDERS = {
 }
 
 
-class ExternalTeam(DefaultFieldsModel):
+class ExternalProviderMixin:
+    def get_provider_string(provider_int):
+        return EXTERNAL_PROVIDERS.get(ExternalProviders(provider_int), "unknown")
+
+    def get_provider_enum(provider_str):
+        inv_providers_map = {v: k for k, v in EXTERNAL_PROVIDERS.items()}
+        return inv_providers_map[provider_str].value if inv_providers_map[provider_str] else None
+
+
+class ExternalTeam(DefaultFieldsModel, ExternalProviderMixin):
     __core__ = False
 
     team = FlexibleForeignKey("sentry.Team")
@@ -92,15 +101,8 @@ class ExternalTeam(DefaultFieldsModel):
         db_table = "sentry_externalteam"
         unique_together = (("team", "provider", "external_name"),)
 
-    def get_provider_string(provider_int):
-        return EXTERNAL_PROVIDERS.get(ExternalProviders(provider_int), "unknown")
 
-    def get_provider_enum(provider_str):
-        inv_providers_map = {v: k for k, v in EXTERNAL_PROVIDERS.items()}
-        return inv_providers_map[provider_str].value if inv_providers_map[provider_str] else None
-
-
-class ExternalUser(DefaultFieldsModel):
+class ExternalUser(DefaultFieldsModel, ExternalProviderMixin):
     __core__ = False
 
     organizationmember = FlexibleForeignKey("sentry.OrganizationMember")

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -69,6 +69,7 @@ from sentry.models import (
     ReleaseFile,
     RepositoryProjectPathConfig,
     Rule,
+    ExternalUser,
 )
 from sentry.models.integrationfeature import Feature, IntegrationFeature
 from sentry.signals import project_created
@@ -946,3 +947,10 @@ class Factories:
         return create_alert_rule_trigger_action(
             trigger, type, target_type, target_identifier, integration, sentry_app
         )
+
+    @staticmethod
+    def create_external_user(organizationmember, **kwargs):
+        kwargs.setdefault("provider", ExternalUser.get_provider_enum("github"))
+        kwargs.setdefault("external_name", "")
+
+        return ExternalUser.objects.create(organizationmember=organizationmember, **kwargs)

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -293,6 +293,15 @@ class Fixtures:
             alert_rule_trigger, target_identifier=target_identifier, **kwargs
         )
 
+    def create_external_user(self, user=None, organization=None, **kwargs):
+        if not user:
+            user = self.user
+        if not organization:
+            organization = self.organization
+
+        organizationmember = OrganizationMember.objects.get(user=user, organization=organization)
+        return Factories.create_external_user(organizationmember=organizationmember, **kwargs)
+
     @pytest.fixture(autouse=True)
     def _init_insta_snapshot(self, insta_snapshot):
         self.insta_snapshot = insta_snapshot

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -476,7 +476,7 @@ class OrganizationMemberListTest(APITestCase):
         assert len(mail.outbox) == 1
 
     def test_user_has_external_user_association(self):
-        response = self.get_valid_response(self.org.slug, qs_params={"detailed": "1"})
+        response = self.get_valid_response(self.org.slug, qs_params={"expand": "externalUsers"})
         assert len(response.data) == 2
         member = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
         assert member
@@ -487,7 +487,7 @@ class OrganizationMemberListTest(APITestCase):
     def test_user_has_external_user_associations_across_multiple_orgs(self):
         self.org_2 = self.create_organization(owner=self.user_2)
         self.external_user_2 = self.create_external_user(self.user_2, self.org_2)
-        response = self.get_valid_response(self.org.slug, qs_params={"detailed": "1"})
+        response = self.get_valid_response(self.org.slug, qs_params={"expand": "externalUsers"})
         assert len(response.data) == 2
         member = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
         assert member

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -476,7 +476,7 @@ class OrganizationMemberListTest(APITestCase):
         assert len(mail.outbox) == 1
 
     def test_user_has_external_user_association(self):
-        response = self.get_valid_response(self.org.slug)
+        response = self.get_valid_response(self.org.slug, qs_params={"detailed": "1"})
         assert len(response.data) == 2
         member = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
         assert member
@@ -487,7 +487,7 @@ class OrganizationMemberListTest(APITestCase):
     def test_user_has_external_user_associations_across_multiple_orgs(self):
         self.org_2 = self.create_organization(owner=self.user_2)
         self.external_user_2 = self.create_external_user(self.user_2, self.org_2)
-        response = self.get_valid_response(self.org.slug)
+        response = self.get_valid_response(self.org.slug, qs_params={"detailed": "1"})
         assert len(response.data) == 2
         member = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
         assert member

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -54,6 +54,8 @@ class OrganizationMemberSerializerTest(TestCase):
 
 
 class OrganizationMemberListTest(APITestCase):
+    endpoint = "sentry-api-0-organization-member-index"
+
     def setUp(self):
         self.owner_user = self.create_user("foo@localhost", username="foo")
         self.user_2 = self.create_user("bar@localhost", username="bar")
@@ -62,6 +64,7 @@ class OrganizationMemberListTest(APITestCase):
         self.org = self.create_organization(owner=self.owner_user)
         self.org.member_set.create(user=self.user_2)
         self.team = self.create_team(organization=self.org)
+        self.external_user = self.create_external_user(self.user_2, self.org)
 
         self.login_as(user=self.owner_user)
 
@@ -471,6 +474,26 @@ class OrganizationMemberListTest(APITestCase):
         assert not OrganizationMember.objects.filter(id=join_request.id).exists()
         assert OrganizationMember.objects.filter(organization=self.org, email=email).exists()
         assert len(mail.outbox) == 1
+
+    def test_user_has_external_user_association(self):
+        response = self.get_valid_response(self.org.slug)
+        assert len(response.data) == 2
+        member = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
+        assert member
+        assert len(member["externalUsers"]) == 1
+        assert member["externalUsers"][0]["id"] == str(self.external_user.id)
+        assert member["externalUsers"][0]["memberId"] == member["id"]
+
+    def test_user_has_external_user_associations_across_multiple_orgs(self):
+        self.org_2 = self.create_organization(owner=self.user_2)
+        self.external_user_2 = self.create_external_user(self.user_2, self.org_2)
+        response = self.get_valid_response(self.org.slug)
+        assert len(response.data) == 2
+        member = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
+        assert member
+        assert len(member["externalUsers"]) == 1
+        assert member["externalUsers"][0]["id"] == str(self.external_user.id)
+        assert member["externalUsers"][0]["memberId"] == member["id"]
 
 
 class OrganizationMemberListPostTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_users.py
+++ b/tests/sentry/api/endpoints/test_organization_users.py
@@ -12,17 +12,19 @@ class OrganizationMemberListTest(APITestCase):
 
         self.org = self.create_organization(owner=self.owner_user)
         self.org.member_set.create(user=self.user_2)
-        self.team = self.create_team(organization=self.org, members=[self.owner_user, self.user_2])
+        self.team_1 = self.create_team(
+            organization=self.org, members=[self.owner_user, self.user_2]
+        )
         self.team_2 = self.create_team(organization=self.org, members=[self.user_2])
         self.team_3 = self.create_team(organization=self.org, members=[self.user_3])
-        self.project = self.create_project(teams=[self.team])
+        self.project_1 = self.create_project(teams=[self.team_1])
         self.project_2 = self.create_project(teams=[self.team_2])
         self.project_3 = self.create_project(teams=[self.team_3])
-
+        self.external_user = self.create_external_user(self.user_2, self.org)
         self.login_as(user=self.user_2)
 
     def test_simple(self):
-        projects_ids = [self.project.id, self.project_2.id]
+        projects_ids = [self.project_1.id, self.project_2.id]
         response = self.get_valid_response(self.org.slug, project=projects_ids)
         expected = serialize(
             list(
@@ -43,3 +45,15 @@ class OrganizationMemberListTest(APITestCase):
             OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
         )
         assert response.data == expected
+
+    def test_user_has_external_user_association(self):
+        response = self.get_valid_response(self.org.slug, project=[self.project_2.id])
+        assert len(response.data) == 1
+        assert response.data[0]["externalUsers"] == [serialize(self.external_user, self.user_2)]
+
+    def test_user_has_external_user_associations_across_multiple_orgs(self):
+        self.org_2 = self.create_organization(owner=self.user_2)
+        self.external_user_2 = self.create_external_user(self.user_2, self.org_2)
+        response = self.get_valid_response(self.org.slug, project=[self.project_2.id])
+        assert len(response.data) == 1
+        assert response.data[0]["externalUsers"] == [serialize(self.external_user, self.user_2)]

--- a/tests/sentry/api/endpoints/test_organization_users.py
+++ b/tests/sentry/api/endpoints/test_organization_users.py
@@ -20,7 +20,6 @@ class OrganizationMemberListTest(APITestCase):
         self.project_1 = self.create_project(teams=[self.team_1])
         self.project_2 = self.create_project(teams=[self.team_2])
         self.project_3 = self.create_project(teams=[self.team_3])
-        self.external_user = self.create_external_user(self.user_2, self.org)
         self.login_as(user=self.user_2)
 
     def test_simple(self):
@@ -45,15 +44,3 @@ class OrganizationMemberListTest(APITestCase):
             OrganizationMemberWithProjectsSerializer(project_ids=projects_ids),
         )
         assert response.data == expected
-
-    def test_user_has_external_user_association(self):
-        response = self.get_valid_response(self.org.slug, project=[self.project_2.id])
-        assert len(response.data) == 1
-        assert response.data[0]["externalUsers"] == [serialize(self.external_user, self.user_2)]
-
-    def test_user_has_external_user_associations_across_multiple_orgs(self):
-        self.org_2 = self.create_organization(owner=self.user_2)
-        self.external_user_2 = self.create_external_user(self.user_2, self.org_2)
-        response = self.get_valid_response(self.org.slug, project=[self.project_2.id])
-        assert len(response.data) == 1
-        assert response.data[0]["externalUsers"] == [serialize(self.external_user, self.user_2)]


### PR DESCRIPTION
## Objective:
We already have a `getList` of OrganizationMembers endpoint: `/api/0/organizations/{organization_slug}/members/`

We will need to add `externalUsers` to the getList response schema if there exists a `expand` query param `externalUsers`.  `externalUsers` will come from sentry_externaluser table.

`externalUsers` will have a type of `{id: int, provider: enum(“github”, “gitlab”), memberId: int, externalName: string}[]`

## Test Plan
Added tests.