### PR TITLE
fix(sessions): Avoid returning invalid JSON with literal NaN

### DIFF
--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import itertools
+import math
 
 from sentry.api.event_search import get_filter
 from sentry.api.utils import get_date_range_rollup_from_params
@@ -122,6 +123,12 @@ class UsersField:
         return 0
 
 
+def finite_or_none(val):
+    if not math.isfinite(val):
+        return None
+    return val
+
+
 class DurationAverageField:
     def get_snuba_columns(self, raw_groupby):
         return ["duration_avg"]
@@ -131,7 +138,7 @@ class DurationAverageField:
             return None
         status = group.get("session.status")
         if status is None or status == "healthy":
-            return row["duration_avg"]
+            return finite_or_none(row["duration_avg"])
         return None
 
 
@@ -147,7 +154,7 @@ class DurationQuantileField:
             return None
         status = group.get("session.status")
         if status is None or status == "healthy":
-            return row["duration_quantiles"][self.quantile_index]
+            return finite_or_none(row["duration_quantiles"][self.quantile_index])
         return None
 
 

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -1,3 +1,5 @@
+import math
+
 from freezegun import freeze_time
 from django.http import QueryDict
 
@@ -326,6 +328,56 @@ def test_massage_virtual_groupby_timeseries():
                 # so in the *whole* time window, that one user is not counted as healthy,
                 # so the `0` here is expected, as thats an example of the `count_unique` behavior.
                 "totals": {"count_unique(user)": 0, "sum(session)": 5},
+            },
+        ],
+    }
+
+    actual_result = result_sorted(massage_sessions_result(query, result_totals, result_timeseries))
+
+    assert actual_result == expected_result
+
+
+@freeze_time("2020-12-18T11:14:17.105Z")
+def test_nan_duration():
+    query = _make_query(
+        "statsPeriod=1d&interval=6h&field=avg(session.duration)&field=p50(session.duration)"
+    )
+
+    result_totals = [
+        {
+            "duration_avg": math.nan,
+            "duration_quantiles": [math.inf, math.inf, math.inf, math.inf, math.inf, math.inf],
+        },
+    ]
+    result_timeseries = [
+        {
+            "duration_avg": math.nan,
+            "duration_quantiles": [math.nan, math.nan, math.nan, math.nan, math.nan, math.nan],
+            "bucketed_started": "2020-12-17T12:00:00+00:00",
+        },
+        {
+            "duration_avg": math.inf,
+            "duration_quantiles": [math.inf, math.inf, math.inf, math.inf, math.inf, math.inf],
+            "bucketed_started": "2020-12-18T06:00:00+00:00",
+        },
+    ]
+
+    expected_result = {
+        "query": "",
+        "intervals": [
+            "2020-12-17T12:00:00Z",
+            "2020-12-17T18:00:00Z",
+            "2020-12-18T00:00:00Z",
+            "2020-12-18T06:00:00Z",
+        ],
+        "groups": [
+            {
+                "by": {},
+                "series": {
+                    "avg(session.duration)": [None, None, None, None],
+                    "p50(session.duration)": [None, None, None, None],
+                },
+                "totals": {"avg(session.duration)": None, "p50(session.duration)": None},
             },
         ],
     }


### PR DESCRIPTION
Snuba returns literal `NaN` values which python can parse without problems, but they
are not valid JSON and would therefore break JS. We just convert these non-finite
numbers to `null` instead.