### PR TITLE
dev_env(feat): Do not run JS tests when merging

### DIFF
--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -18,7 +18,9 @@ def main():
 
     files_modified = [text_type(f) for f in get_modified_files(os.getcwd()) if os.path.exists(f)]
 
-    return run(files_modified, test=True)
+    # Only run tests when the developer has this env variable defined
+    if os.environ.get("SENTRY_POST_MERGE_AUTO_UPDATE"):
+        return run(files_modified, test=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When I merge from master into my branch, I get a lot of JS tests being executed.
Unfortunately, these tests don't apply at all with my dev env work, thus,
I want to control this behaviour via a environment variable.