### PR TITLE
ci: Temporarily disable creating images for frontend workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -54,11 +54,11 @@ jobs:
           name: jest-html
           path: .artifacts/visual-snapshots/jest
 
-      - name: Create Images from HTML
-        uses: getsentry/action-html-to-image@main
-        with:
-          base-path: .artifacts/visual-snapshots/jest
-          css-path: src/sentry/static/sentry/dist/sentry.css
+      # - name: Create Images from HTML
+      #   uses: getsentry/action-html-to-image@main
+      #   with:
+      #     base-path: .artifacts/visual-snapshots/jest
+      #     css-path: src/sentry/static/sentry/dist/sentry.css
 
       - name: Save snapshots
         if: always()


### PR DESCRIPTION
This morning, the frontend workflow started failing with:

> Error: Failed to launch the browser process!
> /node_modules/puppeteer/.local-chromium/linux-782078/chrome-linux/chrome: error while
  loading shared libraries: libXss.so.1: cannot open shared object file: No such file or directory

We're going to temporarily disable it until we can investigate what's causing it.