### PR TITLE
Revert "ref(chart): Simplify BaseChart to a functional component"

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/baseChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/baseChart.tsx
@@ -29,7 +29,6 @@ import Tooltip from './components/tooltip';
 import XAxis from './components/xAxis';
 import YAxis from './components/yAxis';
 import LineSeries from './series/lineSeries';
-import {getColorPalette} from './utils';
 
 // If dimension is a number convert it to pixels, otherwise use dimension without transform
 const getDimensionValue = (dimension?: ReactEChartOpts['height']) => {
@@ -228,199 +227,225 @@ type Props = {
   style?: React.CSSProperties;
 };
 
-function BaseChartUnwrapped({
-  theme,
+class BaseChart extends React.Component<Props> {
+  static defaultProps = {
+    height: 200,
+    width: 'auto',
+    renderer: 'svg',
+    notMerge: true,
+    lazyUpdate: false,
+    onChartReady: () => {},
+    options: {},
 
-  colors,
-  grid,
-  tooltip,
-  legend,
-  dataZoom,
-  toolBox,
-  graphic,
-  axisPointer,
-  previousPeriod,
-  echartsTheme,
-  devicePixelRatio,
+    series: [],
+    xAxis: {},
+    yAxis: {},
+    isGroupedByDate: false,
+    transformSinglePointToBar: false,
+  };
 
-  showTimeInTooltip,
-  useShortDate,
-  start,
-  end,
-  period,
-  utc,
-  yAxes,
-  xAxes,
+  getEventsMap: ReactEchartProps['onEvents'] = {
+    click: (props, instance) => {
+      this.handleClick(props, instance);
+      this.props.onClick?.(props, instance);
+    },
+    highlight: (props, instance) => this.props.onHighlight?.(props, instance),
+    mouseover: (props, instance) => this.props.onMouseOver?.(props, instance),
+    datazoom: (props, instance) => this.props.onDataZoom?.(props, instance),
+    restore: (props, instance) => this.props.onRestore?.(props, instance),
+    finished: (props, instance) => this.props.onFinished?.(props, instance),
+    rendered: (props, instance) => this.props.onRendered?.(props, instance),
+    legendselectchanged: (props, instance) =>
+      this.props.onLegendSelectChanged?.(props, instance),
+  };
 
-  style,
-  forwardedRef,
-
-  onClick,
-  onLegendSelectChanged,
-  onHighlight,
-  onMouseOver,
-  onDataZoom,
-  onRestore,
-  onFinished,
-  onRendered,
-
-  options = {},
-  series = [],
-  yAxis = {},
-  xAxis = {},
-
-  height = 200,
-  width = 'auto',
-  renderer = 'svg',
-  notMerge = true,
-  lazyUpdate = false,
-  isGroupedByDate = false,
-  transformSinglePointToBar = false,
-  onChartReady = () => {},
-}: Props) {
   // TODO(ts): What is the series type? EChartOption.Series's data cannot have
   // `onClick` since it's typically an array.
-  //
-  // Handle series item clicks (e.g. Releases mark line or a single series
-  // item) This is different than when you hover over an "axis" line on a chart
-  // (e.g.  if there are 2 series for an axis and you're not directly hovered
-  // over an item)
-  //
-  // Calls "onClick" inside of series data
-  const handleClick = (clickSeries: any, instance: ECharts) => {
-    if (clickSeries.data) {
-      clickSeries.data.onClick?.(clickSeries, instance);
+  /**
+   * Handle series item clicks (e.g. Releases mark line or a single series item)
+   * This is different than when you hover over an "axis" line on a chart (e.g.
+   * if there are 2 series for an axis and you're not directly hovered over an item)
+   *
+   * Calls "onClick" inside of series data
+   */
+  handleClick = (series: any, instance: ECharts) => {
+    if (series.data) {
+      series.data.onClick?.(series, instance);
     }
   };
 
-  const getEventsMap: ReactEchartProps['onEvents'] = {
-    click: (props, instance) => {
-      handleClick(props, instance);
-      onClick?.(props, instance);
-    },
-    highlight: (props, instance) => onHighlight?.(props, instance),
-    mouseover: (props, instance) => onMouseOver?.(props, instance),
-    datazoom: (props, instance) => onDataZoom?.(props, instance),
-    restore: (props, instance) => onRestore?.(props, instance),
-    finished: (props, instance) => onFinished?.(props, instance),
-    rendered: (props, instance) => onRendered?.(props, instance),
-    legendselectchanged: (props, instance) => onLegendSelectChanged?.(props, instance),
-  };
+  getColorPalette() {
+    const {theme, series} = this.props;
 
-  const hasSinglePoints = (series as EChartOption.SeriesLine[] | undefined)?.every(
-    s => Array.isArray(s.data) && s.data.length === 1
-  );
+    const palette = series?.length
+      ? theme.charts.getColorPalette(series.length)
+      : theme.charts.colors;
 
-  const transformedSeries =
-    (hasSinglePoints && transformSinglePointToBar
-      ? (series as EChartOption.SeriesLine[] | undefined)?.map(s => ({
-          ...s,
-          type: 'bar',
-          barWidth: 40,
-          barGap: 0,
-        }))
-      : series) ?? [];
+    return (palette as unknown) as string[];
+  }
 
-  const transformedPreviousPeriod =
-    previousPeriod?.map(previous =>
-      LineSeries({
-        name: previous.seriesName,
-        data: previous.data.map(({name, value}) => [name, value]),
-        lineStyle: {color: theme.gray200, type: 'dotted'},
-        itemStyle: {color: theme.gray200},
-      })
-    ) ?? [];
+  getSeries() {
+    const {previousPeriod, series, theme, transformSinglePointToBar} = this.props;
 
-  const resolvedSeries = !previousPeriod
-    ? transformedSeries
-    : [...transformedSeries, ...transformedPreviousPeriod];
+    const hasSinglePoints = (series as EChartOption.SeriesLine[] | undefined)?.every(
+      s => Array.isArray(s.data) && s.data.length === 1
+    );
 
-  const defaultAxesProps = {theme};
+    const transformedSeries =
+      (hasSinglePoints && transformSinglePointToBar
+        ? (series as EChartOption.SeriesLine[] | undefined)?.map(s => ({
+            ...s,
+            type: 'bar',
+            barWidth: 40,
+            barGap: 0,
+          }))
+        : series) ?? [];
 
-  const yAxisOrCustom = !yAxes
-    ? yAxis !== null
-      ? YAxis({theme, ...yAxis})
-      : undefined
-    : Array.isArray(yAxes)
-    ? yAxes.map(axis => YAxis({...axis, theme}))
-    : [YAxis(defaultAxesProps), YAxis(defaultAxesProps)];
-
-  const xAxisOrCustom = !xAxes
-    ? xAxis !== null
-      ? XAxis({
-          ...xAxis,
-          theme,
-          useShortDate,
-          start,
-          end,
-          period,
-          isGroupedByDate,
-          utc,
+    const transformedPreviousPeriod =
+      previousPeriod?.map(previous =>
+        LineSeries({
+          name: previous.seriesName,
+          data: previous.data.map(({name, value}) => [name, value]),
+          lineStyle: {
+            color: theme.gray200,
+            type: 'dotted',
+          },
+          itemStyle: {
+            color: theme.gray200,
+          },
         })
-      : undefined
-    : Array.isArray(xAxes)
-    ? xAxes.map(axis =>
-        XAxis({...axis, theme, useShortDate, start, end, period, isGroupedByDate, utc})
-      )
-    : [XAxis(defaultAxesProps), XAxis(defaultAxesProps)];
+      ) ?? [];
 
-  // Maybe changing the series type to types/echarts Series[] would be a better
-  // solution and can't use ignore for multiline blocks
-  // @ts-expect-error
-  const seriesValid = series && series[0]?.data && series[0].data.length > 1;
-  // @ts-expect-error
-  const seriesData = seriesValid ? series[0].data : undefined;
-  const bucketSize = seriesData ? seriesData[1][0] - seriesData[0][0] : undefined;
+    if (!previousPeriod) {
+      return transformedSeries;
+    }
 
-  return (
-    <ChartContainer>
-      <ReactEchartsCore
-        ref={forwardedRef}
-        echarts={echarts}
-        notMerge={notMerge}
-        lazyUpdate={lazyUpdate}
-        theme={echartsTheme}
-        onChartReady={onChartReady}
-        onEvents={getEventsMap}
-        opts={{
-          height,
-          width,
-          renderer,
-          devicePixelRatio,
-        }}
-        style={{
-          height: getDimensionValue(height),
-          width: getDimensionValue(width),
-          ...style,
-        }}
-        option={{
-          animation: IS_ACCEPTANCE_TEST ? false : true,
-          ...options,
-          useUTC: utc,
-          color: colors || getColorPalette(theme, series?.length),
-          grid: Array.isArray(grid) ? grid.map(Grid) : Grid(grid),
-          tooltip:
-            tooltip !== null
-              ? Tooltip({
-                  showTimeInTooltip,
-                  isGroupedByDate,
-                  utc,
-                  bucketSize,
-                  ...tooltip,
-                })
-              : undefined,
-          legend: legend ? Legend({theme, ...legend}) : undefined,
-          yAxis: yAxisOrCustom,
-          xAxis: xAxisOrCustom,
-          series: resolvedSeries,
-          axisPointer,
-          dataZoom,
-          toolbox: toolBox,
-          graphic,
-        }}
-      />
-    </ChartContainer>
-  );
+    return [...transformedSeries, ...transformedPreviousPeriod];
+  }
+
+  render() {
+    const {
+      theme,
+
+      options,
+      colors,
+      grid,
+      tooltip,
+      legend,
+      series,
+      yAxis,
+      xAxis,
+      dataZoom,
+      toolBox,
+      graphic,
+      axisPointer,
+
+      isGroupedByDate,
+      showTimeInTooltip,
+      useShortDate,
+      start,
+      end,
+      period,
+      utc,
+      yAxes,
+      xAxes,
+
+      devicePixelRatio,
+      height,
+      width,
+      renderer,
+      notMerge,
+      lazyUpdate,
+      style,
+      forwardedRef,
+      onChartReady,
+    } = this.props;
+
+    const defaultAxesProps = {theme};
+    const yAxisOrCustom = !yAxes
+      ? yAxis !== null
+        ? YAxis({theme, ...yAxis})
+        : undefined
+      : Array.isArray(yAxes)
+      ? yAxes.map(axis => YAxis({...axis, theme}))
+      : [YAxis(defaultAxesProps), YAxis(defaultAxesProps)];
+    const xAxisOrCustom = !xAxes
+      ? xAxis !== null
+        ? XAxis({
+            ...xAxis,
+            theme,
+            useShortDate,
+            start,
+            end,
+            period,
+            isGroupedByDate,
+            utc,
+          })
+        : undefined
+      : Array.isArray(xAxes)
+      ? xAxes.map(axis =>
+          XAxis({...axis, theme, useShortDate, start, end, period, isGroupedByDate, utc})
+        )
+      : [XAxis(defaultAxesProps), XAxis(defaultAxesProps)];
+
+    // Maybe changing the series type to types/echarts Series[] would be a better solution
+    // and can't use ignore for multiline blocks
+    // @ts-expect-error
+    const seriesValid = series && series[0]?.data && series[0].data.length > 1;
+    // @ts-expect-error
+    const seriesData = seriesValid ? series[0].data : undefined;
+    const bucketSize = seriesData ? seriesData[1][0] - seriesData[0][0] : undefined;
+
+    return (
+      <ChartContainer>
+        <ReactEchartsCore
+          ref={forwardedRef}
+          echarts={echarts}
+          notMerge={notMerge}
+          lazyUpdate={lazyUpdate}
+          theme={this.props.echartsTheme}
+          onChartReady={onChartReady}
+          onEvents={this.getEventsMap}
+          opts={{
+            height,
+            width,
+            renderer,
+            devicePixelRatio,
+          }}
+          style={{
+            height: getDimensionValue(height),
+            width: getDimensionValue(width),
+            ...style,
+          }}
+          option={{
+            animation: IS_ACCEPTANCE_TEST ? false : true,
+            ...options,
+            useUTC: utc,
+            color: colors || this.getColorPalette(),
+            grid: Array.isArray(grid) ? grid.map(Grid) : Grid(grid),
+            tooltip:
+              tooltip !== null
+                ? Tooltip({
+                    showTimeInTooltip,
+                    isGroupedByDate,
+                    utc,
+                    bucketSize,
+                    ...tooltip,
+                  })
+                : undefined,
+            legend: legend ? Legend({theme, ...legend}) : undefined,
+            yAxis: yAxisOrCustom,
+            xAxis: xAxisOrCustom,
+            series: this.getSeries(),
+            axisPointer,
+            dataZoom,
+            toolbox: toolBox,
+            graphic,
+          }}
+        />
+      </ChartContainer>
+    );
+  }
 }
 
 // Contains styling for chart elements as we can't easily style those
@@ -506,11 +531,11 @@ const ChartContainer = styled('div')`
   }
 `;
 
-const BaseChartWithTheme = withTheme(BaseChartUnwrapped);
+const BaseChartWithTheme = withTheme(BaseChart);
 
-const BaseChart = React.forwardRef<ReactEchartsRef, Omit<Props, 'theme'>>(
+const BaseChartRef = React.forwardRef<ReactEchartsRef, Omit<Props, 'theme'>>(
   (props, ref) => <BaseChartWithTheme forwardedRef={ref} {...props} />
 );
-BaseChart.displayName = 'forwardRef(BaseChart)';
+BaseChartRef.displayName = 'forwardRef(BaseChart)';
 
-export default BaseChart;
+export default BaseChartRef;

--- a/src/sentry/static/sentry/app/components/charts/chartZoom.tsx
+++ b/src/sentry/static/sentry/app/components/charts/chartZoom.tsx
@@ -58,7 +58,7 @@ type Props = {
   onDataZoom?: EChartDataZoomHandler;
   onFinished?: EChartFinishedHandler;
   onRestore?: EChartRestoreHandler;
-  onZoom?: (period: Period) => void;
+  onZoom?: (Period) => void;
 };
 
 /**

--- a/src/sentry/static/sentry/app/components/charts/utils.tsx
+++ b/src/sentry/static/sentry/app/components/charts/utils.tsx
@@ -7,7 +7,6 @@ import {EventsStats, GlobalSelection, MultiSeriesEventsStats} from 'app/types';
 import {escape} from 'app/utils';
 import {parsePeriodToHours} from 'app/utils/dates';
 import {decodeList} from 'app/utils/queryString';
-import {Theme} from 'app/utils/theme';
 
 const DEFAULT_TRUNCATE_LENGTH = 80;
 
@@ -140,16 +139,4 @@ export function isMultiSeriesStats(
   data: MultiSeriesEventsStats | EventsStats | null
 ): data is MultiSeriesEventsStats {
   return data !== null && data.data === undefined && data.totals === undefined;
-}
-
-/**
- * Constructs the color palette for a chart given the Theme and optionally a
- * series length
- */
-export function getColorPalette(theme: Theme, seriesLength: number | undefined | null) {
-  const palette = seriesLength
-    ? theme.charts.getColorPalette(seriesLength)
-    : theme.charts.colors;
-
-  return (palette as unknown) as string[];
 }


### PR DESCRIPTION
Reverts getsentry/sentry#23906

This conversion to a functional component is causing errors in the rendering. Specifically, when clicking on the legend to toggle a series on and off, we're seeing the following

```javascript
Uncaught TypeError: api.getZr().storage is null
```

It is unclear to me why exactly this is happening, but the simplest reproducible example would be to convert this back into a class component and moving `getEventsMap` inside the `render` method. My best guess right now is that it is related to React life cycles for a class vs functional component.

Fixes JAVASCRIPT-23BR, JAVASCRIPT-23RV, JAVASCRIPT-23RT