### PR TITLE
build(ci): Re-enable "html to image" action

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -55,7 +55,7 @@ jobs:
           path: .artifacts/visual-snapshots/jest
 
       - name: Create Images from HTML
-        uses: getsentry/action-html-to-image@fix/puppeteer-image-libxss
+        uses: getsentry/action-html-to-image@main
         with:
           base-path: .artifacts/visual-snapshots/jest
           css-path: src/sentry/static/sentry/dist/sentry.css

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -54,11 +54,11 @@ jobs:
           name: jest-html
           path: .artifacts/visual-snapshots/jest
 
-      # - name: Create Images from HTML
-      #   uses: getsentry/action-html-to-image@main
-      #   with:
-      #     base-path: .artifacts/visual-snapshots/jest
-      #     css-path: src/sentry/static/sentry/dist/sentry.css
+      - name: Create Images from HTML
+        uses: getsentry/action-html-to-image@fix/puppeteer-image-libxss
+        with:
+          base-path: .artifacts/visual-snapshots/jest
+          css-path: src/sentry/static/sentry/dist/sentry.css
 
       - name: Save snapshots
         if: always()


### PR DESCRIPTION
This re-enables the action after pinning the action base image to the previous tag. Reverts #23941.

I believe this update to the image caused the issue: https://github.com/buildkite/docker-puppeteer/pull/141