### PR TITLE
fix(api-docs): 409 on this page means the project slug already exists

### DIFF
--- a/api-docs/paths/teams/projects.json
+++ b/api-docs/paths/teams/projects.json
@@ -190,7 +190,7 @@
         "description": "Team not found"
       },
       "409": {
-        "description": "Team already exists"
+        "description": "A project with the given slug already exists"
       }
     },
     "security": [


### PR DESCRIPTION
For the `/api/0/teams/{organization_slug}/{team_slug}/projects/` endpoint, when it finds that the user is trying to create a project using a slug that already exists, it returns a 409: https://github.com/getsentry/sentry/blob/master/src/sentry/api/endpoints/team_projects.py#L122-L125

The docs currently say that a 409 means the team slug [already exists](https://docs.sentry.io/api/teams/create-a-new-project/). This PR changes the docs to say a 409 means the project slug already exists.

## Test plan
* Ran the docs site locally and here's the results
![Screen Shot 2021-02-18 at 9 24 44 AM](https://user-images.githubusercontent.com/1417849/108396488-be4dc680-71cb-11eb-8216-1c1dff98333f.png)
