### PR TITLE
ci: Do not use yarn eslint against yml file

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -9,7 +9,6 @@ frontend_lintable: &frontend_lintable
   - *frontend_components_lintable
   - '**/tsconfig*.json'
   - '{package,now,vercel}.json'
-  - '.github/workflows/js-*.yml'
 
 frontend: &frontend
   - *frontend_lintable
@@ -19,6 +18,7 @@ frontend: &frontend
   - 'docs-ui/**'
   - 'src/sentry/static/sentry/**'
   - 'tests/js/**'
+  - '.github/workflows/js-*.yml'
 
 frontend_modified_lintable:
   - added|modified: *frontend_lintable


### PR DESCRIPTION
Changes to `js-build-andlint.yml` should cause the workflow to trigger but it should
not try to lint it.