### PR TITLE
fix(discover): Has issue filter for transactions was incorrect

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -844,7 +844,7 @@ def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
         # Handle "has" queries
         if search_filter.value.raw_value == "":
             if search_filter.operator == "=":
-                # The state os having no issues is represented differently on transactions vs
+                # The state of having no issues is represented differently on transactions vs
                 # other events. On the transactions table, it is represented by 0 whereas it is
                 # represented by NULL everywhere else. This means we have to check for both 0
                 # or NULL.

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -844,10 +844,18 @@ def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
         # Handle "has" queries
         if search_filter.value.raw_value == "":
             if search_filter.operator == "=":
-                # Use isNull to get events with no issue (transactions)
-                return [["isNull", [name]], search_filter.operator, 1]
+                # The state os having no issues is represented differently on transactions vs
+                # other events. On the transactions table, it is represented by 0 whereas it is
+                # represented by NULL everywhere else. This means we have to check for both 0
+                # or NULL.
+                return [
+                    [["isNull", [name]], search_filter.operator, 1],
+                    [name, search_filter.operator, 0],
+                ]
             else:
-                # Compare to 0 as group_id is not nullable on issues.
+                # Based the reasoning above, we should be checking that it is not 0 and not NULL.
+                # However, because NULL != 0 evaluates to NULL in Clickhouse, we can simplify it
+                # to check just not 0.
                 return [name, search_filter.operator, 0]
 
         # Skip isNull check on group_id value as we want to

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1739,6 +1739,18 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_not_has(self):
         assert get_filter("!has:release").conditions == [[["isNull", ["release"]], "=", 1]]
 
+    def test_has_issue(self):
+        has_issue_filter = get_filter("has:issue")
+        assert has_issue_filter.group_ids == []
+        assert has_issue_filter.conditions == [["issue.id", "!=", 0]]
+
+    def test_not_has_issue(self):
+        has_issue_filter = get_filter("!has:issue")
+        assert has_issue_filter.group_ids == []
+        assert has_issue_filter.conditions == [
+            [[["isNull", ["issue.id"]], "=", 1], ["issue.id", "=", 0]]
+        ]
+
     def test_has_issue_id(self):
         has_issue_filter = get_filter("has:issue.id")
         assert has_issue_filter.group_ids == []
@@ -1747,7 +1759,9 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_not_has_issue_id(self):
         has_issue_filter = get_filter("!has:issue.id")
         assert has_issue_filter.group_ids == []
-        assert has_issue_filter.conditions == [[["isNull", ["issue.id"]], "=", 1]]
+        assert has_issue_filter.conditions == [
+            [[["isNull", ["issue.id"]], "=", 1], ["issue.id", "=", 0]]
+        ]
 
     def test_message_empty(self):
         assert get_filter("has:message").conditions == [[["equals", ["message", ""]], "!=", 1]]
@@ -1818,7 +1832,7 @@ class GetSnubaQueryArgsTest(TestCase):
 
     def test_unknown_issue_filter(self):
         _filter = get_filter("issue:unknown", {"organization_id": self.organization.id})
-        assert _filter.conditions == [[["isNull", ["issue.id"]], "=", 1]]
+        assert _filter.conditions == [[[["isNull", ["issue.id"]], "=", 1], ["issue.id", "=", 0]]]
         assert _filter.filter_keys == {}
         assert _filter.group_ids == []
 


### PR DESCRIPTION
The has:issue filter for transactions was incorrect. The issue column on
transactions is inconsistent. It returns NULL on the events table and 0 on the
transactions table. This change updates the condition to account for this.