### PR TITLE
feat(workflow): Owner search onboarding (WOR-609)

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -22,4 +22,5 @@ GUIDES = {
     "for_review_guide": {"id": 9, "required_targets": ["for_review_guide_tab"]},
     "alerts_write_member": {"id": 10, "required_targets": ["alerts_write_member"]},
     "alerts_write_owner": {"id": 11, "required_targets": ["alerts_write_owner"]},
+    "assigned_or_suggested_guide": {"id": 10, "required_targets": ["assigned_or_suggested_query"]},
 }

--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -22,5 +22,5 @@ GUIDES = {
     "for_review_guide": {"id": 9, "required_targets": ["for_review_guide_tab"]},
     "alerts_write_member": {"id": 10, "required_targets": ["alerts_write_member"]},
     "alerts_write_owner": {"id": 11, "required_targets": ["alerts_write_owner"]},
-    "assigned_or_suggested_guide": {"id": 10, "required_targets": ["assigned_or_suggested_query"]},
+    "assigned_or_suggested_guide": {"id": 12, "required_targets": ["assigned_or_suggested_query"]},
 }

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -162,7 +162,7 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
         {
           target: 'assigned_or_suggested_query',
           description: tct(
-            "Tip: use [assignedOrSuggested] to include issues based on your [ownership:ownership rules] and [committed:code you've committed].",
+            "Tip: use [assignedOrSuggested] to include search results based on your [ownership:ownership rules] and [committed:code you've committed].",
             {
               assignedOrSuggested: <code>assigned_or_suggested</code>,
               ownership: (

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -156,15 +156,21 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
       ],
     },
     {
-      guide: 'alerts_write_member',
-      requiredTargets: ['alerts_write_member'],
+      guide: 'assigned_or_suggested_guide',
+      requiredTargets: ['assigned_or_suggested_query'],
       steps: [
         {
-          target: 'alerts_write_member',
+          target: 'assigned_or_suggested_query',
           description: tct(
-            `Members can now create and edit alert rules. Ask your organization owner or manager to [link:enable this setting].`,
+            "Tip: use [assignedOrSuggested] to include issues based on your [ownership:ownership rules] and [committed:code you've committed].",
             {
-              link: <Link to={orgSlug ? `/settings/${orgSlug}` : `/settings`} />,
+              assignedOrSuggested: <code>assigned_or_suggested</code>,
+              ownership: (
+                <ExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
+              ),
+              committed: (
+                <ExternalLink href="https://docs.sentry.io/product/sentry-basics/guides/integrate-frontend/configure-scms/" />
+              ),
             }
           ),
         },

--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
@@ -31,6 +31,8 @@ type Props = {
     query: Query;
   };
   onFinish?: () => void;
+  /** Hovercard renders the container */
+  containerClassName?: string;
 };
 
 type State = {
@@ -182,7 +184,7 @@ const GuideAnchor = createReactClass<Props, State>({
   },
 
   render() {
-    const {disabled, children, position, offset} = this.props;
+    const {disabled, children, position, offset, containerClassName} = this.props;
     const {active} = this.state;
 
     if (!active || disabled) {
@@ -196,6 +198,7 @@ const GuideAnchor = createReactClass<Props, State>({
         tipColor={theme.purple300}
         position={position}
         offset={offset}
+        containerClassName={containerClassName}
       >
         <span ref={el => (this.containerElement = el)}>{children}</span>
       </StyledHovercard>

--- a/src/sentry/static/sentry/app/views/issueList/filters.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/filters.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import {ClassNames} from '@emotion/core';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import PageHeading from 'app/components/pageHeading';
 import QueryCount from 'app/components/queryCount';
 import {t} from 'app/locale';
@@ -76,6 +78,7 @@ class IssueListFilters extends React.Component<Props> {
       tags,
       isInbox,
     } = this.props;
+    const isAssignedQuery = /\bassigned:/.test(query);
 
     return (
       <PageHeader>
@@ -100,19 +103,30 @@ class IssueListFilters extends React.Component<Props> {
               />
             )}
 
-            <IssueListSearchBar
-              organization={organization}
-              query={query || ''}
-              sort={sort}
-              onSearch={onSearch}
-              disabled={isSearchDisabled}
-              excludeEnvironment
-              supportedTags={tags}
-              tagValueLoader={tagValueLoader}
-              savedSearch={savedSearch}
-              onSidebarToggle={onSidebarToggle}
-              isInbox={isInbox}
-            />
+            <ClassNames>
+              {({css}) => (
+                <GuideAnchor
+                  target="assigned_or_suggested_query"
+                  disabled={!isAssignedQuery}
+                  containerClassName={css`
+                    width: 100%;
+                  `}
+                >
+                  <IssueListSearchBar
+                    organization={organization}
+                    query={query || ''}
+                    onSearch={onSearch}
+                    disabled={isSearchDisabled}
+                    excludeEnvironment
+                    supportedTags={tags}
+                    tagValueLoader={tagValueLoader}
+                    savedSearch={savedSearch}
+                    onSidebarToggle={onSidebarToggle}
+                    isInbox={isInbox}
+                  />
+                </GuideAnchor>
+              )}
+            </ClassNames>
           </SearchSelectorContainer>
         </SearchContainer>
       </PageHeader>

--- a/src/sentry/static/sentry/app/views/issueList/filters.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/filters.tsx
@@ -115,6 +115,7 @@ class IssueListFilters extends React.Component<Props> {
                   <IssueListSearchBar
                     organization={organization}
                     query={query || ''}
+                    sort={sort}
                     onSearch={onSearch}
                     disabled={isSearchDisabled}
                     excludeEnvironment

--- a/src/sentry/static/sentry/app/views/issueList/searchBar.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/searchBar.tsx
@@ -33,8 +33,8 @@ const SEARCH_ITEMS: SearchItem[] = [
   },
   {
     title: t('Assigned'),
-    desc: 'assigned:[me|user@example.com|#team-example]',
-    value: 'assigned:',
+    desc: 'assigned, assigned_or_suggested:[me|user@example.com|#team-example]',
+    value: '',
     type: 'default',
   },
   {

--- a/src/sentry/static/sentry/app/views/issueList/searchBar.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/searchBar.tsx
@@ -33,7 +33,8 @@ const SEARCH_ITEMS: SearchItem[] = [
   },
   {
     title: t('Assigned'),
-    desc: 'assigned, assigned_or_suggested:[me|user@example.com|#team-example]',
+    desc:
+      'assigned, assigned_or_suggested:[me|me_or_none|user@example.com|#team-example]',
     value: '',
     type: 'default',
   },


### PR DESCRIPTION
Adds a guide that will display the first time a user uses `assigned:` in a query
![image](https://user-images.githubusercontent.com/1400464/108422798-db928d00-71eb-11eb-9564-65db1d40b1d1.png)

Adjusts text in common search terms