### PR TITLE
feat(alerts): Nudge users to enable alert creation for members (WOR-611)

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -20,4 +20,6 @@ GUIDES = {
     "issue_stream": {"id": 3, "required_targets": ["issue_stream"]},
     "inbox_guide": {"id": 8, "required_targets": ["inbox_guide"]},
     "for_review_guide": {"id": 9, "required_targets": ["for_review_guide_tab"]},
+    "alerts_write_member": {"id": 10, "required_targets": ["alerts_write_member"]},
+    "alerts_write_owner": {"id": 11, "required_targets": ["alerts_write_owner"]},
 }

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 
 import {GuidesContent} from 'app/components/assistant/types';
 import ExternalLink from 'app/components/links/externalLink';
+import Link from 'app/components/links/link';
 import {t, tct} from 'app/locale';
 
-export default function getGuidesContent(): GuidesContent {
+export default function getGuidesContent(orgSlug: string | null): GuidesContent {
   return [
     {
       guide: 'issue',
@@ -156,6 +157,38 @@ export default function getGuidesContent(): GuidesContent {
             issues from piling up and you from losing your damn mind.`
           ),
           nextText: t(`Make It Stop Already`),
+        },
+      ],
+    },
+    {
+      guide: 'alerts_write_member',
+      requiredTargets: ['alerts_write_member'],
+      steps: [
+        {
+          target: 'alerts_write_member',
+          description: tct(
+            `Members can now create and edit alert rules. Ask your organization owner or manager to [link:enable this setting].`,
+            {
+              link: <Link to={orgSlug ? `/settings/${orgSlug}` : `/settings`} />,
+            }
+          ),
+        },
+      ],
+    },
+    {
+      guide: 'alerts_write_owner',
+      requiredTargets: ['alerts_write_owner'],
+      steps: [
+        {
+          target: 'alerts_write_owner',
+          description: tct(
+            `Today only admins in your organization can create alert rules but we recommend [link:allowing members to create alerts], too.`,
+            {
+              link: <Link to={orgSlug ? `/settings/${orgSlug}` : `/settings`} />,
+            }
+          ),
+          nextText: t(`Allow`),
+          hasNextGuide: true,
         },
       ],
     },

--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
@@ -30,6 +30,7 @@ type Props = {
     pathname: string;
     query: Query;
   };
+  onFinish?: () => void;
 };
 
 type State = {
@@ -100,6 +101,10 @@ const GuideAnchor = createReactClass<Props, State>({
    */
   handleFinish(e: React.MouseEvent) {
     e.stopPropagation();
+    const {onFinish} = this.props;
+    if (onFinish) {
+      onFinish();
+    }
     const {currentGuide, orgId} = this.state;
     recordFinish(currentGuide.guide, orgId);
     closeGuide();
@@ -126,6 +131,17 @@ const GuideAnchor = createReactClass<Props, State>({
     const lastStep = currentStepCount === totalStepCount;
     const hasManySteps = totalStepCount > 1;
 
+    const dismissButton = (
+      <DismissButton
+        size="small"
+        href="#" // to clear `#assistant` from the url
+        onClick={this.handleDismiss}
+        priority="link"
+      >
+        {currentStep.dismissText || t('Dismiss')}
+      </DismissButton>
+    );
+
     return (
       <GuideContainer>
         <GuideContent>
@@ -136,15 +152,6 @@ const GuideAnchor = createReactClass<Props, State>({
           <div>
             {lastStep ? (
               <React.Fragment>
-                {currentStep.hasNextGuide && (
-                  <DismissButton
-                    size="small"
-                    href="#" // to clear `#assistant` from the url
-                    onClick={this.handleFinish}
-                  >
-                    {currentStep.dismissText || t('Dismiss')}
-                  </DismissButton>
-                )}
                 <StyledButton
                   size="small"
                   href={currentGuide.carryAssistantForward ? '#assistant' : '#'} // to clear `#assistant` from the url
@@ -154,23 +161,14 @@ const GuideAnchor = createReactClass<Props, State>({
                   {currentStep.nextText ||
                     (hasManySteps ? t('Enough Already') : t('Got It'))}
                 </StyledButton>
+                {currentStep.hasNextGuide && dismissButton}
               </React.Fragment>
             ) : (
               <React.Fragment>
-                {!currentStep.cantDismiss && (
-                  <DismissButton
-                    priority="primary"
-                    size="small"
-                    href="#" // to clear `#assistant` from the url
-                    to={to}
-                    onClick={this.handleDismiss}
-                  >
-                    {currentStep.dismissText || t('Dismiss')}
-                  </DismissButton>
-                )}
                 <StyledButton size="small" onClick={this.handleNextStep} to={to}>
                   {currentStep.nextText || t('Next')}
                 </StyledButton>
+                {!currentStep.cantDismiss && dismissButton}
               </React.Fragment>
             )}
           </div>
@@ -248,18 +246,19 @@ const GuideAction = styled('div')`
 `;
 
 const StyledButton = styled(Button)`
-  border-color: ${p => p.theme.border};
+  font-size: ${p => p.theme.fontSizeMedium};
   min-width: 40%;
 `;
 
 const DismissButton = styled(StyledButton)`
-  margin-right: ${space(1)};
+  margin-left: ${space(1)};
 
   &:hover,
   &:focus,
   &:active {
-    border-color: ${p => p.theme.border};
+    color: ${p => p.theme.white};
   }
+  color: ${p => p.theme.white};
 `;
 
 const StepCount = styled('div')`
@@ -273,6 +272,7 @@ const StyledHovercard = styled(Hovercard)`
     background-color: ${theme.purple300};
     margin: -1px;
     border-radius: ${theme.borderRadius};
+    width: 300px;
   }
 `;
 

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -2,9 +2,16 @@ import React from 'react';
 import {withRouter, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
 
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'app/actionCreators/indicator';
 import {navigateTo} from 'app/actionCreators/navigation';
+import {Client} from 'app/api';
 import Access from 'app/components/acl/access';
 import Alert from 'app/components/alert';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import Button from 'app/components/button';
 import Link from 'app/components/links/link';
 import {IconClose, IconInfo, IconSiren} from 'app/icons';
@@ -12,6 +19,7 @@ import {t, tct} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import {Aggregation, AGGREGATIONS, explodeFieldString} from 'app/utils/discover/fields';
+import withApi from 'app/utils/withApi';
 import {getQueryDatasource} from 'app/views/alerts/utils';
 import {
   errorFieldConfig,
@@ -311,63 +319,102 @@ type Props = {
   iconProps?: React.ComponentProps<typeof IconSiren>;
   referrer?: string;
   hideIcon?: boolean;
+  api: Client;
 } & WithRouterProps &
   React.ComponentProps<typeof Button>;
 
-const CreateAlertButton = withRouter(
-  ({
-    organization,
-    projectSlug,
-    iconProps,
-    referrer,
-    router,
-    hideIcon,
-    ...buttonProps
-  }: Props) => {
-    function handleClickWithoutProject(event: React.MouseEvent) {
-      event.preventDefault();
+const CreateAlertButton = withApi(
+  withRouter(
+    ({
+      organization,
+      projectSlug,
+      iconProps,
+      referrer,
+      router,
+      hideIcon,
+      api,
+      ...buttonProps
+    }: Props) => {
+      function handleClickWithoutProject(event: React.MouseEvent) {
+        event.preventDefault();
 
-      navigateTo(
-        `/organizations/${organization.slug}/alerts/:projectId/new/${
-          referrer ? `?referrer=${referrer}` : ''
-        }`,
-        router
+        navigateTo(
+          `/organizations/${organization.slug}/alerts/:projectId/new/${
+            referrer ? `?referrer=${referrer}` : ''
+          }`,
+          router
+        );
+      }
+
+      async function enableAlertsMemberWrite() {
+        const settingsEndpoint = `/organizations/${organization.slug}/`;
+        addLoadingMessage();
+        try {
+          await api.requestPromise(settingsEndpoint, {
+            method: 'PUT',
+            data: {
+              alertsMemberWrite: true,
+            },
+          });
+          addSuccessMessage(t('Successfully updated organization settings'));
+        } catch (err) {
+          addErrorMessage(t('Unable to update organization settings'));
+        }
+      }
+
+      const permissionTooltipText = tct(
+        'Ask your organization owner or manager to [settingsLink:enable alerts access] for you.',
+        {settingsLink: <Link to={`/settings/${organization.slug}`} />}
+      );
+
+      const renderButton = (hasAccess: boolean) => (
+        <Button
+          disabled={!hasAccess}
+          title={!hasAccess ? permissionTooltipText : undefined}
+          icon={!hideIcon && <IconSiren {...iconProps} />}
+          to={
+            projectSlug
+              ? `/organizations/${organization.slug}/alerts/${projectSlug}/new/`
+              : undefined
+          }
+          tooltipProps={{
+            isHoverable: true,
+            position: 'top',
+            popperStyle: {
+              maxWidth: '270px',
+            },
+          }}
+          onClick={projectSlug ? undefined : handleClickWithoutProject}
+          {...buttonProps}
+        >
+          {buttonProps.children ?? t('Create Alert')}
+        </Button>
+      );
+
+      const showGuide = !organization.alertsMemberWrite;
+
+      return (
+        <Access organization={organization} access={['alerts:write']}>
+          {({hasAccess}) =>
+            showGuide ? (
+              <Access organization={organization} access={['org:write']}>
+                {({hasAccess: isOrgAdmin}) => (
+                  <GuideAnchor
+                    target={isOrgAdmin ? 'alerts_write_owner' : 'alerts_write_member'}
+                    onFinish={isOrgAdmin ? enableAlertsMemberWrite : undefined}
+                  >
+                    {renderButton(hasAccess)}
+                  </GuideAnchor>
+                )}
+              </Access>
+            ) : (
+              renderButton(hasAccess)
+            )
+          }
+        </Access>
       );
     }
-
-    const permissionTooltipText = tct(
-      'Ask your organization owner or manager to [settingsLink:enable alerts access] for you.',
-      {settingsLink: <Link to={`/settings/${organization.slug}`} />}
-    );
-
-    return (
-      <Access organization={organization} access={['alerts:write']}>
-        {({hasAccess}) => (
-          <Button
-            disabled={!hasAccess}
-            title={!hasAccess ? permissionTooltipText : undefined}
-            icon={!hideIcon && <IconSiren {...iconProps} />}
-            to={
-              projectSlug
-                ? `/organizations/${organization.slug}/alerts/${projectSlug}/new/`
-                : undefined
-            }
-            tooltipProps={{
-              isHoverable: true,
-              position: 'top',
-              popperStyle: {
-                maxWidth: '270px',
-              },
-            }}
-            onClick={projectSlug ? undefined : handleClickWithoutProject}
-            {...buttonProps}
-          >
-            {buttonProps.children ?? t('Create Alert')}
-          </Button>
-        )}
-      </Access>
-    );
-  }
+  )
 );
 
 export {CreateAlertFromViewButton};

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -9,8 +9,6 @@ import {Guide, GuidesContent, GuidesServerData} from 'app/components/assistant/t
 import ConfigStore from 'app/stores/configStore';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 
-const guidesContent: GuidesContent = getGuidesContent();
-
 export type GuideStoreState = {
   /**
    * All tooltip guides
@@ -33,6 +31,10 @@ export type GuideStoreState = {
    */
   orgId: string | null;
   /**
+   * Current organization slug
+   */
+  orgSlug: string | null;
+  /**
    * We force show a guide if the URL contains #assistant
    */
   forceShow: boolean;
@@ -48,6 +50,7 @@ const defaultState: GuideStoreState = {
   currentGuide: null,
   currentStep: 0,
   orgId: null,
+  orgSlug: null,
   forceShow: false,
   prevGuide: null,
 };
@@ -88,6 +91,7 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
 
   onSetActiveOrganization(data) {
     this.state.orgId = data ? data.id : null;
+    this.state.orgSlug = data ? data.slug : null;
     this.updateCurrentGuide();
   },
 
@@ -100,6 +104,7 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
       return;
     }
 
+    const guidesContent: GuidesContent = getGuidesContent(this.state.orgSlug);
     // map server guide state (i.e. seen status) with guide content
     const guides = guidesContent.reduce((acc: Guide[], content) => {
       const serverGuide = data.find(guide => guide.guide === content.guide);

--- a/tests/js/spec/components/createAlertButton.spec.jsx
+++ b/tests/js/spec/components/createAlertButton.spec.jsx
@@ -188,4 +188,35 @@ describe('CreateAlertFromViewButton', () => {
     const button = wrapper.find('button[aria-label="Create Alert"]');
     expect(button.props()['aria-disabled']).toBe(true);
   });
+
+  it('shows a guide for members', async () => {
+    const eventView = EventView.fromSavedQuery({
+      ...DEFAULT_EVENT_VIEW,
+    });
+    const noAccessOrg = {
+      ...organization,
+      access: [],
+    };
+
+    const wrapper = generateWrappedComponent(noAccessOrg, eventView);
+
+    const guide = wrapper.find('GuideAnchor');
+    expect(guide.props().target).toBe('alerts_write_member');
+  });
+
+  it('shows a guide for owners/admins', async () => {
+    const eventView = EventView.fromSavedQuery({
+      ...DEFAULT_EVENT_VIEW,
+    });
+    const adminAccessOrg = {
+      ...organization,
+      access: ['org:write'],
+    };
+
+    const wrapper = generateWrappedComponent(adminAccessOrg, eventView);
+
+    const guide = wrapper.find('GuideAnchor');
+    expect(guide.props().target).toBe('alerts_write_owner');
+    expect(guide.props().onFinish).toBeDefined();
+  });
 });


### PR DESCRIPTION
Many users have been requesting the ability to give members the permissions necessary to create/edit alerts. We went ahead and did that https://github.com/getsentry/sentry/pull/22924, but most orgs have no idea that this feature exists and have still been requesting/discovering this on their own.

To increase visibility of our new `Let members edit alerts` setting we have two guides (for members, and admins).

The **member guide** just has a link to the settings page:
<img width="323" alt="Screen Shot 2021-02-18 at 2 46 27 PM" src="https://user-images.githubusercontent.com/9372512/108431721-1ac6db00-71f8-11eb-8e84-fb23a3c43683.png">

The **owner guide** has an option to turn on the organization setting without leaving the page by pressing allow:
<img width="320" alt="Screen Shot 2021-02-18 at 2 45 08 PM" src="https://user-images.githubusercontent.com/9372512/108431658-0682de00-71f8-11eb-856b-c42566382374.png">

**This PR also includes style changes to all guides that Robin requested**