### PR TITLE
ref(ui) Convert more deprecated select controls

### DIFF
--- a/src/sentry/static/sentry/app/data/forms/accountPreferences.tsx
+++ b/src/sentry/static/sentry/app/data/forms/accountPreferences.tsx
@@ -17,7 +17,8 @@ const formGroups: JsonFormObject[] = [
     fields: [
       {
         name: 'theme',
-        type: 'choice',
+        type: 'select',
+        deprecatedSelectControl: false,
         label: t('Theme'),
         help: t(
           "Select your theme preference. It can be synced to your system's theme, always light mode, or always dark mode."
@@ -31,7 +32,8 @@ const formGroups: JsonFormObject[] = [
       },
       {
         name: 'stacktraceOrder',
-        type: 'choice',
+        type: 'select',
+        deprecatedSelectControl: false,
         required: false,
         choices: [
           ['-1', t('Default (let Sentry decide)')],
@@ -44,14 +46,16 @@ const formGroups: JsonFormObject[] = [
       },
       {
         name: 'language',
-        type: 'choice',
+        type: 'select',
+        deprecatedSelectControl: false,
         label: t('Language'),
         choices: languages,
         getData: transformOptions,
       },
       {
         name: 'timezone',
-        type: 'choice',
+        type: 'select',
+        deprecatedSelectControl: false,
         label: t('Timezone'),
         choices: timezones,
         getData: transformOptions,

--- a/src/sentry/static/sentry/app/data/forms/accountPreferences.tsx
+++ b/src/sentry/static/sentry/app/data/forms/accountPreferences.tsx
@@ -36,9 +36,9 @@ const formGroups: JsonFormObject[] = [
         deprecatedSelectControl: false,
         required: false,
         choices: [
-          ['-1', t('Default (let Sentry decide)')],
-          ['1', t('Most recent call last')],
-          ['2', t('Most recent call first')],
+          [-1, t('Default (let Sentry decide)')],
+          [1, t('Most recent call last')],
+          [2, t('Most recent call first')],
         ],
         label: t('Stack Trace Order'),
         help: t('Choose the default ordering of frames in stack traces'),

--- a/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.tsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationGeneralSettings.tsx
@@ -45,7 +45,8 @@ const formGroups: JsonFormObject[] = [
     fields: [
       {
         name: 'defaultRole',
-        type: 'array',
+        type: 'select',
+        deprecatedSelectControl: false,
         required: true,
         label: t('Default Role'),
         // seems weird to have choices in initial form data
@@ -79,7 +80,8 @@ const formGroups: JsonFormObject[] = [
       },
       {
         name: 'attachmentsRole',
-        type: 'array',
+        type: 'select',
+        deprecatedSelectControl: false,
         choices: ({initialData = {}}) =>
           initialData?.availableRoles?.map((r: MemberRole) => [r.id, r.name]) ?? [],
         label: t('Attachments Access'),
@@ -90,7 +92,8 @@ const formGroups: JsonFormObject[] = [
       },
       {
         name: 'debugFilesRole',
-        type: 'array',
+        type: 'select',
+        deprecatedSelectControl: false,
         choices: ({initialData = {}}) =>
           initialData?.availableRoles?.map((r: MemberRole) => [r.id, r.name]) ?? [],
         label: t('Debug Files Access'),

--- a/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacyGroups.tsx
+++ b/src/sentry/static/sentry/app/data/forms/organizationSecurityAndPrivacyGroups.tsx
@@ -66,7 +66,8 @@ export default [
       },
       {
         name: 'storeCrashReports',
-        type: 'array',
+        type: 'select',
+        deprecatedSelectControl: false,
         label: t('Store Native Crash Reports'),
         help: t(
           'Store native crash reports such as Minidumps for improved processing and download in issue details'

--- a/src/sentry/static/sentry/app/data/forms/projectDebugFiles.tsx
+++ b/src/sentry/static/sentry/app/data/forms/projectDebugFiles.tsx
@@ -46,6 +46,7 @@ export const fields: Record<string, Field> = {
   builtinSymbolSources: {
     name: 'builtinSymbolSources',
     type: 'select',
+    deprecatedSelectControl: false,
     multiple: true,
     label: t('Built-in Repositories'),
     help: t(

--- a/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.tsx
+++ b/src/sentry/static/sentry/app/data/forms/projectGeneralSettings.tsx
@@ -56,7 +56,8 @@ export const fields: Record<string, Field> = {
 
   platform: {
     name: 'platform',
-    type: 'array',
+    type: 'select',
+    deprecatedSelectControl: false,
     label: t('Platform'),
     choices: () =>
       platforms.map(({id, name}) => [

--- a/src/sentry/static/sentry/app/data/forms/projectIssueGrouping.tsx
+++ b/src/sentry/static/sentry/app/data/forms/projectIssueGrouping.tsx
@@ -101,7 +101,8 @@ stack.function:mylibrary_* +app`}
   },
   groupingConfig: {
     name: 'groupingConfig',
-    type: 'array',
+    type: 'select',
+    deprecatedSelectControl: false,
     label: t('Grouping Config'),
     saveOnBlur: false,
     saveMessageAlertType: 'info',
@@ -136,7 +137,8 @@ stack.function:mylibrary_* +app`}
   },
   groupingEnhancementsBase: {
     name: 'groupingEnhancementsBase',
-    type: 'array',
+    type: 'select',
+    deprecatedSelectControl: false,
     label: t('Stack Trace Rules Base'),
     saveOnBlur: false,
     saveMessageAlertType: 'info',

--- a/src/sentry/static/sentry/app/data/forms/projectSecurityAndPrivacyGroups.tsx
+++ b/src/sentry/static/sentry/app/data/forms/projectSecurityAndPrivacyGroups.tsx
@@ -26,7 +26,8 @@ export default [
     fields: [
       {
         name: 'storeCrashReports',
-        type: 'array',
+        type: 'select',
+        deprecatedSelectControl: false,
         label: t('Store Native Crash Reports'),
         help: ({organization}) =>
           tct(

--- a/tests/js/spec/components/forms/jsonForm.spec.tsx
+++ b/tests/js/spec/components/forms/jsonForm.spec.tsx
@@ -130,7 +130,7 @@ describe('JsonForm', function () {
       // slug and platform have no visible prop, that means they will be always visible
       const wrapper = mountWithTheme(<JsonForm fields={jsonFormFields} />);
       expect(wrapper.find('FormPanel')).toHaveLength(1);
-      expect(wrapper.find('input')).toHaveLength(2);
+      expect(wrapper.find('input[type="text"]')).toHaveLength(2);
     });
 
     it('should NOT hide panel, if at least one field has visible set to true -  visible prop is of type boolean', function () {
@@ -139,7 +139,7 @@ describe('JsonForm', function () {
         <JsonForm fields={jsonFormFields.map(field => ({...field, visible: true}))} />
       );
       expect(wrapper.find('FormPanel')).toHaveLength(1);
-      expect(wrapper.find('input')).toHaveLength(2);
+      expect(wrapper.find('input[type="text"]')).toHaveLength(2);
     });
 
     it('should NOT hide panel, if at least one field has visible set to true -  visible prop is of type func', function () {
@@ -150,7 +150,7 @@ describe('JsonForm', function () {
         />
       );
       expect(wrapper.find('FormPanel')).toHaveLength(1);
-      expect(wrapper.find('input')).toHaveLength(2);
+      expect(wrapper.find('input[type="text"]')).toHaveLength(2);
     });
 
     it('should ALWAYS hide panel, if all fields have visible set to false -  visible prop is of type boolean', function () {

--- a/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
+++ b/tests/js/spec/views/settings/projectGeneralSettings.spec.jsx
@@ -3,7 +3,7 @@ import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {mountGlobalModal} from 'sentry-test/modal';
-import {selectByValue} from 'sentry-test/select';
+import {selectByValue} from 'sentry-test/select-new';
 
 import ProjectsStore from 'app/stores/projectsStore';
 import ProjectContext from 'app/views/projects/projectContext';


### PR DESCRIPTION
These should all be simple as they don't replace any components and rely on basic behavior. I've also normalized the type on `select` as I'd like to remove `choice` and `array` soon.