### PR TITLE
fix(mobile-prompt): bug with onSuccessCallback

### DIFF
--- a/src/sentry/static/sentry/app/components/modals/suggestProjectModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/suggestProjectModal.tsx
@@ -62,12 +62,12 @@ class SuggestProjectModal extends React.Component<Props, State> {
     this.setState({askTeammate: false});
   };
 
-  handleSubmitSuccess = ({targetUserEmail}: {targetUserEmail: string}) => {
+  handleSubmitSuccess = () => {
     const {matchedUserAgentString, organization, closeModal} = this.props;
     addSuccessMessage('Notified teammate successfully');
     trackAdvancedAnalyticsEvent(
       'growth.submitted_mobile_prompt_ask_teammate',
-      {email: targetUserEmail, matchedUserAgentString},
+      {matchedUserAgentString},
       organization
     );
     closeModal();

--- a/src/sentry/static/sentry/app/utils/growthAnalyticsEvents.tsx
+++ b/src/sentry/static/sentry/app/utils/growthAnalyticsEvents.tsx
@@ -16,9 +16,7 @@ export type GrowthEventParameters = {
   'growth.opened_mobile_project_suggest_modal': MobilePromptBannerParams;
   'growth.clicked_mobile_prompt_setup_project': MobilePromptBannerParams;
   'growth.clicked_mobile_prompt_ask_teammate': MobilePromptBannerParams;
-  'growth.submitted_mobile_prompt_ask_teammate': MobilePromptBannerParams & {
-    email: string;
-  };
+  'growth.submitted_mobile_prompt_ask_teammate': MobilePromptBannerParams;
 };
 
 type GrowthAnalyticsKey = keyof GrowthEventParameters;


### PR DESCRIPTION
I made a mistake thinking we would have the email in the `handleSubmitSuccess` callback but we don't. We don't really need the email so I just removed it from the analytics event.