### PR TITLE
feat(trace-view): Add parent_span_id to the trace response

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -27,6 +27,8 @@ def serialize_event(event, parent, is_root_event=False):
         "transaction.duration": event["transaction.duration"],
         "project_id": event["project_id"],
         "parent_event_id": parent,
+        # Avoid empty string for root events
+        "parent_span_id": event["trace.parent_span"] or None,
         "is_root": is_root_event,
     }
 

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -39,7 +39,7 @@ class OrganizationEventsTrendsLightEndpointTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
 
         self.day_ago = before_now(days=1).replace(hour=10, minute=0, second=0, microsecond=0)
-        root_span_ids = [uuid4().hex[:16] for _ in range(3)]
+        self.root_span_ids = [uuid4().hex[:16] for _ in range(3)]
         self.trace_id = uuid4().hex
         self.root_event = self.create_event(
             trace=self.trace_id,
@@ -52,14 +52,14 @@ class OrganizationEventsTrendsLightEndpointTest(APITestCase, SnubaTestCase):
                     "span_id": root_span_id,
                     "trace_id": self.trace_id,
                 }
-                for i, root_span_id in enumerate(root_span_ids)
+                for i, root_span_id in enumerate(self.root_span_ids)
             ],
             parent_span_id=None,
             project_id=self.project.id,
         )
 
         # First Generation
-        gen1_span_ids = [uuid4().hex[:16] for _ in range(3)]
+        self.gen1_span_ids = [uuid4().hex[:16] for _ in range(3)]
         self.gen1_events = [
             self.create_event(
                 trace=self.trace_id,
@@ -76,11 +76,13 @@ class OrganizationEventsTrendsLightEndpointTest(APITestCase, SnubaTestCase):
                 parent_span_id=root_span_id,
                 project_id=self.create_project(organization=self.organization).id,
             )
-            for i, (root_span_id, gen1_span_id) in enumerate(zip(root_span_ids, gen1_span_ids))
+            for i, (root_span_id, gen1_span_id) in enumerate(
+                zip(self.root_span_ids, self.gen1_span_ids)
+            )
         ]
 
         # Second Generation
-        gen2_span_ids = [uuid4().hex[:16] for _ in range(3)]
+        self.gen2_span_ids = [uuid4().hex[:16] for _ in range(3)]
         self.gen2_events = [
             self.create_event(
                 trace=self.trace_id,
@@ -97,7 +99,9 @@ class OrganizationEventsTrendsLightEndpointTest(APITestCase, SnubaTestCase):
                 parent_span_id=gen1_span_id,
                 project_id=self.create_project(organization=self.organization).id,
             )
-            for i, (gen1_span_id, gen2_span_id) in enumerate(zip(gen1_span_ids, gen2_span_ids))
+            for i, (gen1_span_id, gen2_span_id) in enumerate(
+                zip(self.gen1_span_ids, self.gen2_span_ids)
+            )
         ]
 
         # Third generation
@@ -105,7 +109,7 @@ class OrganizationEventsTrendsLightEndpointTest(APITestCase, SnubaTestCase):
             trace=self.trace_id,
             transaction="/transaction/gen3-0",
             spans=[],
-            parent_span_id=gen2_span_ids[0],
+            parent_span_id=self.gen2_span_ids[0],
             project_id=self.create_project(organization=self.organization).id,
         )
 
@@ -218,13 +222,15 @@ class OrganizationEventsTrendsLightEndpointTest(APITestCase, SnubaTestCase):
         event = events[root_event_id]
         assert event["is_root"]
         assert event["parent_event_id"] is None
+        assert event["parent_span_id"] is None
 
-        for child_event in self.gen1_events:
+        for i, child_event in enumerate(self.gen1_events):
             child_event_id = child_event.event_id
             assert child_event_id in events
             event = events[child_event_id]
             assert not event["is_root"]
             assert event["parent_event_id"] == root_event_id
+            assert event["parent_span_id"] == self.root_span_ids[i]
 
     def test_direct_parent_with_children(self):
         root_event_id = self.root_event.event_id
@@ -247,16 +253,19 @@ class OrganizationEventsTrendsLightEndpointTest(APITestCase, SnubaTestCase):
         event = events[root_event_id]
         assert event["is_root"]
         assert event["parent_event_id"] is None
+        assert event["parent_span_id"] is None
 
         assert current_event in events
         event = events[current_event]
         assert not event["is_root"]
         assert event["parent_event_id"] == root_event_id
+        assert event["parent_span_id"] == self.root_span_ids[0]
 
         assert child_event_id in events
         event = events[child_event_id]
         assert not event["is_root"]
         assert event["parent_event_id"] == current_event
+        assert event["parent_span_id"] == self.gen1_span_ids[0]
 
     def test_second_generation_with_children(self):
         root_event_id = self.root_event.event_id
@@ -279,17 +288,21 @@ class OrganizationEventsTrendsLightEndpointTest(APITestCase, SnubaTestCase):
         event = events[root_event_id]
         assert event["is_root"]
         assert event["parent_event_id"] is None
+        assert event["parent_span_id"] is None
 
         assert current_event in events
         event = events[current_event]
         assert not event["is_root"]
         # Parent is unknown in this case
         assert event["parent_event_id"] is None
+        # But we still know the parent_span
+        assert event["parent_span_id"] == self.gen1_span_ids[0]
 
         assert child_event_id in events
         event = events[child_event_id]
         assert not event["is_root"]
         assert event["parent_event_id"] == current_event
+        assert event["parent_span_id"] == self.gen2_span_ids[0]
 
     def test_third_generation_no_children(self):
         root_event_id = self.root_event.event_id
@@ -311,9 +324,12 @@ class OrganizationEventsTrendsLightEndpointTest(APITestCase, SnubaTestCase):
         event = events[root_event_id]
         assert event["is_root"]
         assert event["parent_event_id"] is None
+        assert event["parent_span_id"] is None
 
         assert current_event in events
         event = events[current_event]
         assert not event["is_root"]
         # Parent is unknown in this case
         assert event["parent_event_id"] is None
+        # But we still know the parent_span
+        assert event["parent_span_id"] == self.gen2_span_ids[0]


### PR DESCRIPTION
- This is so that we can associate child spans with this endpoint
  instead of making a request whenever we open a span.
- This is to help with VIS-636