### PR TITLE
feat(alerts): Update permissions tooltip (WOR-611)

### DIFF
--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -25,7 +25,7 @@ type Props = {
   to?: string | object;
   href?: string;
   icon?: React.ReactNode;
-  title?: string | React.ReactNode;
+  title?: React.ReactNode;
   external?: boolean;
   borderless?: boolean;
   label?: string;

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -218,11 +218,20 @@ const getColors = ({priority, disabled, borderless, theme}: StyledButtonProps) =
 
 const StyledButton = styled(
   React.forwardRef<any, ButtonProps>(
-    ({forwardRef, size: _size, external, to, href, ...props}: Props, forwardRefAlt) => {
+    (
+      {forwardRef, size: _size, external, to, href, ...otherProps}: Props,
+      forwardRefAlt
+    ) => {
       // XXX: There may be two forwarded refs here, one potentially passed from a
       // wrapped Tooltip, another from callers of Button.
 
       const ref = mergeRefs([forwardRef, forwardRefAlt]);
+
+      // only pass down title to child element if it is a string
+      const {title, ...props} = otherProps;
+      if (typeof title === 'string') {
+        props[title] = title;
+      }
 
       // Get component to use based on existence of `to` or `href` properties
       // Can be react-router `Link`, `a`, or `button`

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -25,7 +25,7 @@ type Props = {
   to?: string | object;
   href?: string;
   icon?: React.ReactNode;
-  title?: React.ReactNode;
+  title?: React.ComponentProps<typeof Tooltip>['title'];
   external?: boolean;
   borderless?: boolean;
   label?: string;

--- a/src/sentry/static/sentry/app/components/button.tsx
+++ b/src/sentry/static/sentry/app/components/button.tsx
@@ -25,7 +25,7 @@ type Props = {
   to?: string | object;
   href?: string;
   icon?: React.ReactNode;
-  title?: string;
+  title?: string | React.ReactNode;
   external?: boolean;
   borderless?: boolean;
   label?: string;

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -335,22 +335,37 @@ const CreateAlertButton = withRouter(
       );
     }
 
+    const permissionTooltipText = tct(
+      'Users with admin permission or higher can create alert rules. Owners and managers can [settingsLink] for you.',
+      {
+        settingsLink: (
+          <StyledLink to={`/settings/${organization.slug}`}>
+            {t('change this setting')}
+          </StyledLink>
+        ),
+      }
+    );
+
     return (
       <Access organization={organization} access={['alerts:write']}>
         {({hasAccess}) => (
           <Button
             disabled={!hasAccess}
-            title={
-              !hasAccess
-                ? t('Users with admin permission or higher can create alert rules.')
-                : undefined
-            }
+            title={!hasAccess ? permissionTooltipText : undefined}
             icon={!hideIcon && <IconSiren {...iconProps} />}
             to={
               projectSlug
                 ? `/organizations/${organization.slug}/alerts/${projectSlug}/new/`
                 : undefined
             }
+            tooltipProps={{
+              isHoverable: true,
+              position: 'top',
+              popperStyle: {
+                maxWidth: '270px',
+                fontWeight: 'normal',
+              },
+            }}
             onClick={projectSlug ? undefined : handleClickWithoutProject}
             {...buttonProps}
           >
@@ -389,5 +404,15 @@ const StyledCloseButton = styled(Button)`
   &:focus {
     background-color: transparent;
     opacity: 1;
+  }
+`;
+
+const StyledLink = styled(Link)`
+  color: ${p => p.theme.bodyBackground};
+  text-decoration: underline;
+
+  &:hover {
+    color: ${p => p.theme.bodyBackground};
+    text-decoration: underline;
   }
 `;

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -336,14 +336,8 @@ const CreateAlertButton = withRouter(
     }
 
     const permissionTooltipText = tct(
-      'Users with admin permission or higher can create alert rules. Owners and managers can [settingsLink] for you.',
-      {
-        settingsLink: (
-          <StyledLink to={`/settings/${organization.slug}`}>
-            {t('change this setting')}
-          </StyledLink>
-        ),
-      }
+      'Users with admin permission or higher can create alert rules. Owners and managers can [settingsLink:change this setting] for you.',
+      {settingsLink: <Link to={`/settings/${organization.slug}`} />}
     );
 
     return (
@@ -404,15 +398,5 @@ const StyledCloseButton = styled(Button)`
   &:focus {
     background-color: transparent;
     opacity: 1;
-  }
-`;
-
-const StyledLink = styled(Link)`
-  color: ${p => p.theme.bodyBackground};
-  text-decoration: underline;
-
-  &:hover {
-    color: ${p => p.theme.bodyBackground};
-    text-decoration: underline;
   }
 `;

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -336,7 +336,7 @@ const CreateAlertButton = withRouter(
     }
 
     const permissionTooltipText = tct(
-      'Users with admin permission or higher can create alert rules. Owners and managers can [settingsLink:change this setting] for you.',
+      'Ask your organization owner or manager to [settingsLink:enable alerts access] for you.',
       {settingsLink: <Link to={`/settings/${organization.slug}`} />}
     );
 

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -357,7 +357,6 @@ const CreateAlertButton = withRouter(
               position: 'top',
               popperStyle: {
                 maxWidth: '270px',
-                fontWeight: 'normal',
               },
             }}
             onClick={projectSlug ? undefined : handleClickWithoutProject}

--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -337,6 +337,11 @@ const TooltipContent = styled(motion.div)<{hide: boolean} & Pick<Props, 'popperS
   text-align: center;
   ${p => p.popperStyle as any};
   ${p => p.hide && `display: none`};
+
+  a {
+    color: ${p => p.theme.bodyBackground};
+    text-decoration: underline;
+  }
 `;
 
 const TooltipArrow = styled('span')<{background: string | number}>`

--- a/src/sentry/static/sentry/app/components/tooltip.tsx
+++ b/src/sentry/static/sentry/app/components/tooltip.tsx
@@ -337,11 +337,6 @@ const TooltipContent = styled(motion.div)<{hide: boolean} & Pick<Props, 'popperS
   text-align: center;
   ${p => p.popperStyle as any};
   ${p => p.hide && `display: none`};
-
-  a {
-    color: ${p => p.theme.bodyBackground};
-    text-decoration: underline;
-  }
 `;
 
 const TooltipArrow = styled('span')<{background: string | number}>`


### PR DESCRIPTION
Updates the permission tooltip for when members try to create an alert.

<img width="285" alt="Screen Shot 2021-02-18 at 4 09 39 PM" src="https://user-images.githubusercontent.com/9372512/108438982-397f9e80-7205-11eb-9590-9ac2bde07f3b.png">

**The link takes them to the organization settings**

This will increase the visibility of the new option we give orgs to allow their members to create their own alerts.