### PR TITLE
fix(workflow): Fix active/hover saved search text colors

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/savedSearchMenu.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchMenu.tsx
@@ -146,8 +146,14 @@ const StyledMenuItem = styled(MenuItem)<{isActive: boolean; last: boolean}>`
   ${SearchTitle}, ${SearchQuery}, ${SearchSort} {
     color: ${p.theme.white};
   }
+  ${SearchSort}:before {
+    color: ${p.theme.white};
+  }
   &:hover {
-    ${SearchTitle}, ${SearchQuery} {
+    ${SearchTitle}, ${SearchQuery}, ${SearchSort} {
+      color: ${p.theme.black};
+    }
+    ${SearchSort}:before {
       color: ${p.theme.black};
     }
   }


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/1400464/108441729-9b8ed280-720a-11eb-9134-135741e52a06.png)


after:

https://user-images.githubusercontent.com/1400464/108441687-83b74e80-720a-11eb-893e-c17e561daaf1.mp4

