### PR TITLE
feat(external-user): PUT, POST, DELETE endpoints

### DIFF
--- a/src/sentry/api/endpoints/external_user.py
+++ b/src/sentry/api/endpoints/external_user.py
@@ -1,0 +1,83 @@
+import logging
+
+from django.db import IntegrityError
+from django.http import Http404
+
+from rest_framework import serializers, status
+from rest_framework.response import Response
+from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
+
+from sentry.api.bases.organization import OrganizationEndpoint
+
+from sentry.api.serializers import serialize
+from sentry.models import ExternalUser, EXTERNAL_PROVIDERS, OrganizationMember
+
+logger = logging.getLogger(__name__)
+
+
+class ExternalUserSerializer(CamelSnakeModelSerializer):
+    organizationmember_id = serializers.IntegerField(required=True)
+    external_name = serializers.CharField(required=True)
+    provider = serializers.ChoiceField(choices=list(EXTERNAL_PROVIDERS.values()))
+
+    class Meta:
+        model = ExternalUser
+        fields = ["organizationmember_id", "external_name", "provider"]
+
+    def validate_provider(self, provider):
+        if provider not in EXTERNAL_PROVIDERS.values():
+            raise serializers.ValidationError(
+                f'The provider "{provider}" is not supported. We currently accept Github and Gitlab user identities.'
+            )
+        return ExternalUser.get_provider_enum(provider)
+
+    def create(self, validated_data):
+        return ExternalUser.objects.get_or_create(**validated_data)
+
+    def update(self, instance, validated_data):
+        if "id" in validated_data:
+            validated_data.pop("id")
+        for key, value in validated_data.items():
+            setattr(self.instance, key, value)
+        try:
+            self.instance.save()
+            return self.instance
+        except IntegrityError:
+            raise serializers.ValidationError(
+                "There already exists an external user association with this external_name and provider."
+            )
+
+
+class ExternalUserEndpoint(OrganizationEndpoint):
+    def convert_args(self, request, organization_slug, user_id, *args, **kwargs):
+        args, kwargs = super().convert_args(request, organization_slug, *args, **kwargs)
+        try:
+            kwargs["organization_member"] = OrganizationMember.objects.get(
+                id=user_id, organization=kwargs["organization"]
+            )
+        except OrganizationMember.DoesNotExist:
+            raise Http404
+
+        return (args, kwargs)
+
+    def post(self, request, organization, organization_member):
+        """
+        Create an External User
+        `````````````
+
+        :pparam string organization_slug: the slug of the organization the
+                                          user belongs to.
+        :pparam string user_id: the organization_member id.
+        :param required string provider: enum("github", "gitlab")
+        :param required string external_name: the associated Github/Gitlab user name.
+        :auth: required
+        """
+        serializer = ExternalUserSerializer(
+            data={**request.data, "organizationmember_id": organization_member.id}
+        )
+        if serializer.is_valid():
+            external_user, created = serializer.save()
+            status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+            return Response(serialize(external_user, request.user), status=status_code)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/external_user_details.py
+++ b/src/sentry/api/endpoints/external_user_details.py
@@ -41,7 +41,7 @@ class ExternalUserDetailsEndpoint(OrganizationEndpoint):
 
         serializer = ExternalUserSerializer(
             instance=external_user,
-            data={**request.data},
+            data=request.data,
             context={"organization": organization},
             partial=True,
         )

--- a/src/sentry/api/endpoints/external_user_details.py
+++ b/src/sentry/api/endpoints/external_user_details.py
@@ -1,0 +1,65 @@
+import logging
+from django.http import Http404
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.serializers import serialize
+from sentry.models import ExternalUser, OrganizationMember
+
+from .external_user import ExternalUserSerializer
+
+logger = logging.getLogger(__name__)
+
+
+class ExternalUserDetailsEndpoint(OrganizationEndpoint):
+    def convert_args(self, request, organization_slug, user_id, external_user_id, *args, **kwargs):
+        args, kwargs = super().convert_args(request, organization_slug, *args, **kwargs)
+        try:
+            kwargs["organization_member"] = OrganizationMember.objects.get(
+                id=user_id, organization=kwargs["organization"]
+            )
+            kwargs["external_user"] = ExternalUser.objects.get(
+                id=external_user_id,
+            )
+        except ExternalUser.DoesNotExist:
+            raise Http404
+
+        return (args, kwargs)
+
+    def put(self, request, organization, organization_member, external_user):
+        """
+        Update an External User
+        `````````````
+
+        :pparam string organization_slug: the slug of the organization the
+                                          user belongs to.
+        :pparam int user_id: the organization_member id.
+        :pparam string external_user_id: id of external_user object
+        :param string external_name: the Github/Gitlab user name.
+        :param string provider: enum("github","gitlab")
+        :auth: required
+        """
+
+        serializer = ExternalUserSerializer(
+            instance=external_user,
+            data={**request.data, "organizationmember_id": organization_member.id},
+            partial=True,
+        )
+        if serializer.is_valid():
+            updated_external_user = serializer.save()
+
+            return Response(
+                serialize(updated_external_user, request.user), status=status.HTTP_200_OK
+            )
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, organization, organization_member, external_user):
+        """
+        Delete an External Team
+        """
+
+        external_user.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -959,6 +959,16 @@ urlpatterns = [
                     name="sentry-api-0-organization-member-index",
                 ),
                 url(
+                    r"^(?P<organization_slug>[^\/]+)/members/externaluser/$",
+                    ExternalUserEndpoint.as_view(),
+                    name="sentry-api-0-organization-external-user",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/members/externaluser/(?P<external_user_id>[^\/]+)/$",
+                    ExternalUserDetailsEndpoint.as_view(),
+                    name="sentry-api-0-organization-external-user-details",
+                ),
+                url(
                     r"^(?P<organization_slug>[^\/]+)/integration-requests/$",
                     OrganizationIntegrationRequestEndpoint.as_view(),
                     name="sentry-api-0-organization-integration-request",
@@ -1166,16 +1176,6 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/users/(?P<user_id>[^\/]+)/$",
                     OrganizationUserDetailsEndpoint.as_view(),
                     name="sentry-api-0-organization-user-details",
-                ),
-                url(
-                    r"^(?P<organization_slug>[^\/]+)/users/(?P<user_id>[^\/]+)/externaluser/$",
-                    ExternalUserEndpoint.as_view(),
-                    name="sentry-api-0-external-user",
-                ),
-                url(
-                    r"^(?P<organization_slug>[^\/]+)/users/(?P<user_id>[^\/]+)/externaluser/(?P<external_user_id>[^\/]+)/$",
-                    ExternalUserDetailsEndpoint.as_view(),
-                    name="sentry-api-0-external-user-details",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/sentry-app-installations/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -32,6 +32,8 @@ from .endpoints.event_grouping_info import EventGroupingInfoEndpoint
 from .endpoints.event_owners import EventOwnersEndpoint
 from .endpoints.external_team import ExternalTeamEndpoint
 from .endpoints.external_team_details import ExternalTeamDetailsEndpoint
+from .endpoints.external_user import ExternalUserEndpoint
+from .endpoints.external_user_details import ExternalUserDetailsEndpoint
 from .endpoints.filechange import CommitFileChangeEndpoint
 from .endpoints.group_attachments import GroupAttachmentsEndpoint
 from .endpoints.group_current_release import GroupCurrentReleaseEndpoint
@@ -1164,6 +1166,16 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/users/(?P<user_id>[^\/]+)/$",
                     OrganizationUserDetailsEndpoint.as_view(),
                     name="sentry-api-0-organization-user-details",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/users/(?P<user_id>[^\/]+)/externaluser/$",
+                    ExternalUserEndpoint.as_view(),
+                    name="sentry-api-0-external-user",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/users/(?P<user_id>[^\/]+)/externaluser/(?P<external_user_id>[^\/]+)/$",
+                    ExternalUserDetailsEndpoint.as_view(),
+                    name="sentry-api-0-external-user-details",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/sentry-app-installations/$",

--- a/tests/sentry/api/endpoints/test_external_user.py
+++ b/tests/sentry/api/endpoints/test_external_user.py
@@ -1,0 +1,60 @@
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+from sentry.models import OrganizationMember, ExternalUser
+
+
+class ExternalUserTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.org = self.create_organization(owner=self.user, name="baz")
+        self.organization_member = OrganizationMember.objects.get(user=self.user)
+        self.url = reverse(
+            "sentry-api-0-external-user",
+            args=[self.org.slug, self.organization_member.id],
+        )
+
+    def test_basic_post(self):
+        data = {"externalName": "@NisanthanNanthakumar", "provider": "github"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 201, response.content
+        assert response.data == {
+            "id": str(response.data["id"]),
+            "teamId": str(self.team.id),
+            **data,
+        }
+
+    def test_missing_provider(self):
+        response = self.client.post(self.url, {"externalName": "@NisanthanNanthakumar"})
+        assert response.status_code == 400
+        assert response.data == {"provider": ["This field is required."]}
+
+    def test_missing_externalName(self):
+        response = self.client.post(self.url, {"provider": "gitlab"})
+        assert response.status_code == 400
+        assert response.data == {"externalName": ["This field is required."]}
+
+    def test_invalid_provider(self):
+        data = {"externalName": "@NisanthanNanthakumar", "provider": "git"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 400
+        assert response.data == {"provider": ['"git" is not a valid choice.']}
+
+    def test_create_existing_association(self):
+        self.external_user = ExternalUser.objects.create(
+            organizationmember_id=str(self.organization_member.id),
+            provider=ExternalUser.get_provider_enum("github"),
+            external_name="@NisanthanNanthakumar",
+        )
+        data = {
+            "externalName": self.external_user.external_name,
+            "provider": ExternalUser.get_provider_string(self.external_user.provider),
+        }
+        response = self.client.post(self.url, data)
+        assert response.status_code == 200
+        assert response.data == {
+            "id": str(self.external_user.id),
+            "organizationMemberId": str(self.external_user.organizationmember_id),
+            **data,
+        }

--- a/tests/sentry/api/endpoints/test_external_user_details.py
+++ b/tests/sentry/api/endpoints/test_external_user_details.py
@@ -1,0 +1,32 @@
+from django.core.urlresolvers import reverse
+from sentry.models import ExternalUser
+from sentry.testutils import APITestCase
+
+
+class ExternalUserDetailsTest(APITestCase):
+    def setUp(self):
+        super().setUp()
+        self.login_as(user=self.user)
+        self.external_user = self.create_external_user(
+            self.user, self.organization, external_name="@NisanthanNanthakumar"
+        )
+        self.url = reverse(
+            "sentry-api-0-organization-external-user-details",
+            args=[self.organization.slug, self.external_user.id],
+        )
+
+    def test_basic_delete(self):
+        resp = self.client.delete(self.url)
+        assert resp.status_code == 204
+        assert not ExternalUser.objects.filter(id=str(self.external_user.id)).exists()
+
+    def test_basic_update(self):
+        resp = self.client.put(self.url, {"externalName": "@new_username"})
+        assert resp.status_code == 200
+        assert resp.data["id"] == str(self.external_user.id)
+        assert resp.data["externalName"] == "@new_username"
+
+    def test_invalid_provider_update(self):
+        resp = self.client.put(self.url, {"provider": "unknown"})
+        assert resp.status_code == 400
+        assert resp.data == {"provider": ['"unknown" is not a valid choice.']}


### PR DESCRIPTION
## Objective:
We just create migration to create the `sentry_externaluser` table. We will need to create createOne, deleteOne and updateOne endpoints for `sentry_externaluser` model

We can get the id of an `externalUser` object from https://github.com/getsentry/sentry/pull/23935

The endpoints will return `{id: int, provider: enum(“github”, “gitlab”), memberId: int, externalName: string}`

## Test Plan:
Added tests for all the new endpoints.
