### PR TITLE
feat(metric_alerts): Add threshold lines to chart

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -360,7 +360,17 @@ class DetailsBody extends React.Component<Props> {
       return this.renderLoading();
     }
 
-    const {query, environment, aggregate, projects: projectSlugs, timeWindow} = rule;
+    const {
+      query,
+      environment,
+      aggregate,
+      projects: projectSlugs,
+      timeWindow,
+      triggers,
+    } = rule;
+
+    const criticalTrigger = triggers.find(({label}) => label === 'critical');
+    const warningTrigger = triggers.find(({label}) => label === 'warning');
     const timePeriod = this.getTimePeriod();
     const queryWithTypeFilter = `${query} ${extractEventTypeFilterFromRule(rule)}`.trim();
 
@@ -403,7 +413,12 @@ class DetailsBody extends React.Component<Props> {
                     >
                       {({loading, timeseriesData}) =>
                         !loading && timeseriesData ? (
-                          <MetricChart data={timeseriesData} incidents={incidents} />
+                          <MetricChart
+                            data={timeseriesData}
+                            incidents={incidents}
+                            criticalTrigger={criticalTrigger}
+                            warningTrigger={warningTrigger}
+                          />
                         ) : (
                           <Placeholder height="200px" />
                         )

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -6,22 +6,43 @@ import LineChart, {LineChartSeries} from 'app/components/charts/lineChart';
 import space from 'app/styles/space';
 import {Series} from 'app/types/echarts';
 import theme from 'app/utils/theme';
+import {Trigger} from 'app/views/settings/incidentRules/types';
 
 import {Incident} from '../../types';
 
 type Props = {
   data: Series[];
   incidents?: Incident[];
+  warningTrigger?: Trigger;
+  criticalTrigger?: Trigger;
 };
 
-const MetricChart = ({data, incidents}: Props) => {
+function createThresholdSeries(color: string, threshold: number): LineChartSeries {
+  const criticalThresholdLine = {
+    seriesName: 'Threshold Line',
+    type: 'line',
+    markLine: MarkLine({
+      silent: true,
+      lineStyle: {color, type: 'dashed', width: 1},
+      data: [{yAxis: threshold} as any],
+    }),
+    data: [],
+  };
+  return criticalThresholdLine;
+}
+
+const MetricChart = ({data, incidents, warningTrigger, criticalTrigger}: Props) => {
   // Iterate through incidents to add markers to chart
   const series: LineChartSeries[] = [...data];
   const dataArr = data[0].data;
+  const maxSeriesValue = dataArr.reduce(
+    (currMax, coord2) => Math.max(currMax, coord2.value),
+    0
+  );
   const firstPoint = Number(dataArr[0].name);
   const lastPoint = dataArr[dataArr.length - 1].name;
   const resolvedArea = {
-    seriesName: 'Critical Area',
+    seriesName: 'Resolved Area',
     type: 'line',
     markLine: MarkLine({
       silent: true,
@@ -86,7 +107,22 @@ const MetricChart = ({data, incidents}: Props) => {
       }),
       data: [],
     };
-    series.push(incidentLinesSeries);
+    series.unshift(incidentLinesSeries);
+  }
+
+  let maxThresholdValue = 0;
+  if (warningTrigger?.alertThreshold) {
+    const {alertThreshold} = warningTrigger;
+    const warningThresholdLine = createThresholdSeries(theme.yellow300, alertThreshold);
+    series.unshift(warningThresholdLine);
+    maxThresholdValue = Math.max(maxThresholdValue, alertThreshold);
+  }
+
+  if (criticalTrigger?.alertThreshold) {
+    const {alertThreshold} = criticalTrigger;
+    const criticalThresholdLine = createThresholdSeries(theme.red300, alertThreshold);
+    series.unshift(criticalThresholdLine);
+    maxThresholdValue = Math.max(maxThresholdValue, alertThreshold);
   }
 
   return (
@@ -99,6 +135,7 @@ const MetricChart = ({data, incidents}: Props) => {
         top: space(2),
         bottom: 0,
       }}
+      yAxis={maxThresholdValue > maxSeriesValue ? {max: maxThresholdValue} : undefined}
       series={series}
     />
   );

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -36,7 +36,7 @@ const MetricChart = ({data, incidents, warningTrigger, criticalTrigger}: Props) 
   const series: LineChartSeries[] = [...data];
   const dataArr = data[0].data;
   const maxSeriesValue = dataArr.reduce(
-    (currMax, coord2) => Math.max(currMax, coord2.value),
+    (currMax, coord) => Math.max(currMax, coord.value),
     0
   );
   const firstPoint = Number(dataArr[0].name);


### PR DESCRIPTION
Adds warning/critical dashed threshold lines to the metric chart and ensures that they are rendered even if no data points reach the threshold.

<img width="839" alt="Screen Shot 2021-02-18 at 6 41 12 PM" src="https://user-images.githubusercontent.com/9372512/108450082-6938a180-7219-11eb-88dc-1b5671a0e453.png">

technically dependent on https://github.com/getsentry/sentry/pull/23968 (but not really, I just got lazy and didn't want to start off a fresh branch)