### PR TITLE
perf(files): Ensure an upload isn't destined for failure before accepting it

### DIFF
--- a/src/sentry/api/endpoints/organization_release_files.py
+++ b/src/sentry/api/endpoints/organization_release_files.py
@@ -127,6 +127,16 @@ class OrganizationReleaseFilesEndpoint(OrganizationReleasesBaseEndpoint):
         if dist_name:
             dist = release.add_dist(dist_name)
 
+        # Quickly check for the presence of this file before continuing with
+        # the costly file upload process.
+        if ReleaseFile.objects.filter(
+            organization_id=release.organization_id,
+            release=release,
+            name=full_name,
+            dist=dist,
+        ).exists():
+            return Response({"detail": ERR_FILE_EXISTS}, status=409)
+
         headers = {"Content-Type": fileobj.content_type}
         for headerval in request.data.getlist("header") or ():
             try:

--- a/src/sentry/api/endpoints/project_release_files.py
+++ b/src/sentry/api/endpoints/project_release_files.py
@@ -125,6 +125,16 @@ class ProjectReleaseFilesEndpoint(ProjectEndpoint):
         if dist_name:
             dist = release.add_dist(dist_name)
 
+        # Quickly check for the presence of this file before continuing with
+        # the costly file upload process.
+        if ReleaseFile.objects.filter(
+            organization_id=release.organization_id,
+            release=release,
+            name=full_name,
+            dist=dist,
+        ).exists():
+            return Response({"detail": ERR_FILE_EXISTS}, status=409)
+
         headers = {"Content-Type": fileobj.content_type}
         for headerval in request.data.getlist("header") or ():
             try:


### PR DESCRIPTION
`File` records have a lot of associated overhead. We should not accept them if we know we are going to reject them later anyway.