### PR TITLE
feat(alerts): Alert rule details related transactions sort and time query

### DIFF
--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -38,12 +38,12 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
         query_start = request.GET.get("start")
         if query_start is not None:
             # exclude incidents closed before the window
-            incidents = incidents.exclude(date_closed__lte=query_start)
+            incidents = incidents.exclude(date_closed__lt=query_start)
 
         query_end = request.GET.get("end")
         if query_end is not None:
             # exclude incidents started after the window
-            incidents = incidents.exclude(date_started__gte=query_end)
+            incidents = incidents.exclude(date_started__gt=query_end)
 
         query_status = request.GET.get("status")
         if query_status is not None:

--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -12,7 +12,9 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody} from 'app/components/panels';
-import StreamGroup, {DEFAULT_STREAM_GROUP_STATS_PERIOD} from 'app/components/stream/group';
+import StreamGroup, {
+  DEFAULT_STREAM_GROUP_STATS_PERIOD,
+} from 'app/components/stream/group';
 import {t} from 'app/locale';
 import GroupStore from 'app/stores/groupStore';
 import {Group} from 'app/types';

--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -12,7 +12,7 @@ import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody} from 'app/components/panels';
-import StreamGroup from 'app/components/stream/group';
+import StreamGroup, {DEFAULT_STREAM_GROUP_STATS_PERIOD} from 'app/components/stream/group';
 import {t} from 'app/locale';
 import GroupStore from 'app/stores/groupStore';
 import {Group} from 'app/types';
@@ -207,14 +207,14 @@ class GroupList extends React.Component<Props, State> {
     }
 
     const statsPeriod =
-      typeof queryParams?.groupStatsPeriod === 'string'
+      queryParams?.groupStatsPeriod === 'auto'
         ? queryParams?.groupStatsPeriod
-        : undefined;
+        : DEFAULT_STREAM_GROUP_STATS_PERIOD;
 
     return (
       <React.Fragment>
         <Panel>
-          <GroupListHeader withChart={!!withChart} />
+          <GroupListHeader withChart={!!withChart} statsPeriod={statsPeriod} />
           <PanelBody>
             {groups.map(({id, project}) => {
               const members = memberList?.hasOwnProperty(project.slug)

--- a/src/sentry/static/sentry/app/components/issues/groupListHeader.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupListHeader.tsx
@@ -8,7 +8,7 @@ import space from 'app/styles/space';
 
 type Props = {
   withChart: boolean;
-  statsPeriod: '24h' | 'auto';
+  statsPeriod?: '24h' | 'auto';
 };
 
 const GroupListHeader = ({withChart = true, statsPeriod = '24h'}: Props) => (

--- a/src/sentry/static/sentry/app/components/issues/groupListHeader.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupListHeader.tsx
@@ -17,19 +17,20 @@ const GroupListHeader = ({withChart = true, statsPeriod = '24h'}: Props) => (
       {t('Issue')}
     </Box>
     {withChart && (
-      <Flex width={160} mx={2} justifyContent="space-between" className="hidden-xs hidden-sm">
+      <Flex
+        width={160}
+        mx={2}
+        justifyContent="space-between"
+        className="hidden-xs hidden-sm"
+      >
         {t('Graph: ')}
         <StatsPeriodWrapper>
           {statsPeriod === 'auto' ? t('Custom') : statsPeriod}
         </StatsPeriodWrapper>
       </Flex>
     )}
-    <EventUserWrapper>
-      {t('events')}
-    </EventUserWrapper>
-    <EventUserWrapper>
-      {t('users')}
-    </EventUserWrapper>
+    <EventUserWrapper>{t('events')}</EventUserWrapper>
+    <EventUserWrapper>{t('users')}</EventUserWrapper>
     <Flex
       width={80}
       mx={2}
@@ -58,4 +59,3 @@ const EventUserWrapper = styled('div')`
     width: 80px;
   }
 `;
-

--- a/src/sentry/static/sentry/app/components/issues/groupListHeader.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupListHeader.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
+import styled from '@emotion/styled';
 import {Box, Flex} from 'reflexbox'; // eslint-disable-line no-restricted-imports
 
 import {PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
-import styled from 'app/styled';
 import space from 'app/styles/space';
 
 type Props = {

--- a/src/sentry/static/sentry/app/components/issues/groupListHeader.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupListHeader.tsx
@@ -3,27 +3,33 @@ import {Box, Flex} from 'reflexbox'; // eslint-disable-line no-restricted-import
 
 import {PanelHeader} from 'app/components/panels';
 import {t} from 'app/locale';
+import styled from 'app/styled';
+import space from 'app/styles/space';
 
 type Props = {
   withChart: boolean;
+  statsPeriod: '24h' | 'auto';
 };
 
-const GroupListHeader = ({withChart = true}: Props) => (
+const GroupListHeader = ({withChart = true, statsPeriod = '24h'}: Props) => (
   <PanelHeader disablePadding>
-    <Box width={[8 / 12, 8 / 12, 6 / 12]} mx={2} flex="1" className="toolbar-header">
+    <Box width={[8 / 12, 8 / 12, 6 / 12]} mx={2} flex="1">
       {t('Issue')}
     </Box>
     {withChart && (
-      <Box width={160} mx={2} className="toolbar-header hidden-xs hidden-sm">
-        {t('Last 24 hours')}
-      </Box>
+      <Flex width={160} mx={2} justifyContent="space-between" className="hidden-xs hidden-sm">
+        {t('Graph: ')}
+        <StatsPeriodWrapper>
+          {statsPeriod === 'auto' ? t('Custom') : statsPeriod}
+        </StatsPeriodWrapper>
+      </Flex>
     )}
-    <Flex width={80} mx={2} justifyContent="flex-end" className="toolbar-header">
+    <EventUserWrapper>
       {t('events')}
-    </Flex>
-    <Flex width={80} mx={2} justifyContent="flex-end" className="toolbar-header">
+    </EventUserWrapper>
+    <EventUserWrapper>
       {t('users')}
-    </Flex>
+    </EventUserWrapper>
     <Flex
       width={80}
       mx={2}
@@ -36,3 +42,20 @@ const GroupListHeader = ({withChart = true}: Props) => (
 );
 
 export default GroupListHeader;
+
+const StatsPeriodWrapper = styled('div')`
+  text-transform: none;
+`;
+
+const EventUserWrapper = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  align-self: center;
+  width: 60px;
+  margin: 0 ${space(2)};
+
+  @media (min-width: ${p => p.theme.breakpoints[3]}) {
+    width: 80px;
+  }
+`;
+

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -59,8 +59,10 @@ const DiscoveryExclusionFields: string[] = [
   '__text',
 ];
 
+export const DEFAULT_STREAM_GROUP_STATS_PERIOD = '24h';
+
 const defaultProps = {
-  statsPeriod: '24h',
+  statsPeriod: DEFAULT_STREAM_GROUP_STATS_PERIOD,
   canSelect: true,
   withChart: true,
   useFilteredStats: false,

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -191,9 +191,7 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
 
   renderList() {
     const {loading, incidentList, incidentListPageLinks, hasAlertRule} = this.state;
-    const {
-      params: {orgId},
-    } = this.props;
+    const {params: {orgId}, organization} = this.props;
 
     const allProjectsFromIncidents = new Set(
       flatten(incidentList?.map(({projects}) => projects))
@@ -238,6 +236,7 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
                           incident={incident}
                           orgId={orgId}
                           filteredStatus={status}
+                          organization={organization}
                         />
                       ))
                     }

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -191,7 +191,10 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
 
   renderList() {
     const {loading, incidentList, incidentListPageLinks, hasAlertRule} = this.state;
-    const {params: {orgId}, organization} = this.props;
+    const {
+      params: {orgId},
+      organization,
+    } = this.props;
 
     const allProjectsFromIncidents = new Set(
       flatten(incidentList?.map(({projects}) => projects))

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -64,6 +64,19 @@ class AlertListRow extends AsyncComponent<Props, State> {
     projects.find(project => project.slug === slug)
   );
 
+  getRuleDetailsQuery(): {start: string, end: string} {
+    const {incident} = this.props;
+    const now = moment.utc();
+    const startDate = moment.utc(incident.dateStarted);
+    const endDate = incident.dateClosed ? moment.utc(incident.dateClosed) : now;
+    const halfDuration = moment.duration(endDate.diff(startDate) / 2);
+
+    return {
+      start: getUtcDateString(startDate.subtract(halfDuration)),
+      end: getUtcDateString(moment.min(endDate.add(halfDuration), now)),
+    }
+  };
+
   renderLoading() {
     return this.renderBody();
   }
@@ -112,17 +125,14 @@ class AlertListRow extends AsyncComponent<Props, State> {
     const slug = incident.projects[0];
 
     const hasRedesign =
-      incident?.alertRule &&
-      !isIssueAlert(incident?.alertRule) &&
+      incident.alertRule &&
+      !isIssueAlert(incident.alertRule) &&
       organization.features.includes('alert-details-redesign');
 
     const alertLink = hasRedesign
       ? {
-          pathname: `/organizations/${orgId}/alerts/rules/details/${incident?.alertRule?.id}/`,
-          query: {
-            start: incident.dateStarted,
-            end: incident.dateClosed ?? getUtcDateString(moment.utc()),
-          },
+          pathname: `/organizations/${orgId}/alerts/rules/details/${incident.alertRule?.id}/`,
+          query: this.getRuleDetailsQuery(),
         }
       : {
           pathname: `/organizations/${orgId}/alerts/${incident.identifier}/`,

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -64,7 +64,7 @@ class AlertListRow extends AsyncComponent<Props, State> {
     projects.find(project => project.slug === slug)
   );
 
-  getRuleDetailsQuery(): {start: string, end: string} {
+  getRuleDetailsQuery(): {start: string; end: string} {
     const {incident} = this.props;
     const now = moment.utc();
     const startDate = moment.utc(incident.dateStarted);
@@ -74,8 +74,8 @@ class AlertListRow extends AsyncComponent<Props, State> {
     return {
       start: getUtcDateString(startDate.subtract(halfDuration)),
       end: getUtcDateString(moment.min(endDate.add(halfDuration), now)),
-    }
-  };
+    };
+  }
 
   renderLoading() {
     return this.renderBody();

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -16,6 +16,7 @@ import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
+import {getUtcDateString} from 'app/utils/dates';
 import getDynamicText from 'app/utils/getDynamicText';
 import theme from 'app/utils/theme';
 
@@ -24,7 +25,6 @@ import {getIncidentMetricPreset, isIssueAlert} from '../utils';
 
 import SparkLine from './sparkLine';
 import {TableLayout, TitleAndSparkLine} from './styles';
-import {getUtcDateString} from 'app/utils/dates';
 
 type Props = {
   incident: Incident;
@@ -96,7 +96,14 @@ class AlertListRow extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    const {incident, orgId, projectsLoaded, projects, filteredStatus, organization} = this.props;
+    const {
+      incident,
+      orgId,
+      projectsLoaded,
+      projects,
+      filteredStatus,
+      organization,
+    } = this.props;
     const {error, stats} = this.state;
     const started = moment(incident.dateStarted);
     const duration = moment
@@ -109,15 +116,17 @@ class AlertListRow extends AsyncComponent<Props, State> {
       !isIssueAlert(incident?.alertRule) &&
       organization.features.includes('alert-details-redesign');
 
-    const alertLink = hasRedesign ? {
-        pathname: `/organizations/${orgId}/alerts/rules/details/${incident?.alertRule?.id}/`,
-        query: {
-          start: incident.dateStarted,
-          end: incident.dateClosed ?? getUtcDateString(moment.utc()),
+    const alertLink = hasRedesign
+      ? {
+          pathname: `/organizations/${orgId}/alerts/rules/details/${incident?.alertRule?.id}/`,
+          query: {
+            start: incident.dateStarted,
+            end: incident.dateClosed ?? getUtcDateString(moment.utc()),
+          },
         }
-      } : {
-        pathname: `/organizations/${orgId}/alerts/${incident.identifier}/`,
-      }
+      : {
+          pathname: `/organizations/${orgId}/alerts/${incident.identifier}/`,
+        };
 
     return (
       <ErrorBoundary>
@@ -126,9 +135,7 @@ class AlertListRow extends AsyncComponent<Props, State> {
             <TitleAndSparkLine status={filteredStatus}>
               <Title>
                 {this.renderStatusIndicator()}
-                <IncidentLink to={alertLink}>
-                  Alert #{incident.id}
-                </IncidentLink>
+                <IncidentLink to={alertLink}>Alert #{incident.id}</IncidentLink>
                 {incident.title}
               </Title>
 

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -39,19 +39,19 @@ import {extractEventTypeFilterFromRule} from 'app/views/settings/incidentRules/u
 import {Incident, IncidentStatus} from '../../types';
 import {DATA_SOURCE_LABELS, getIncidentRuleMetricPreset} from '../../utils';
 
+import {TIME_OPTIONS} from './constants';
 import MetricChart from './metricChart';
 import RelatedIssues from './relatedIssues';
 import RelatedTransactions from './relatedTransactions';
-import {TIME_OPTIONS} from './constants';
 
 type Props = {
   api: Client;
   rule?: IncidentRule;
   incidents?: Incident[];
   timePeriod: {
-    start: string,
-    end: string,
-    label: string,
+    start: string;
+    end: string;
+    label: string;
   };
   organization: Organization;
   location: Location;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -39,7 +39,7 @@ import {extractEventTypeFilterFromRule} from 'app/views/settings/incidentRules/u
 import {Incident, IncidentStatus} from '../../types';
 import {DATA_SOURCE_LABELS, getIncidentRuleMetricPreset} from '../../utils';
 
-import {TIME_OPTIONS, API_INTERVAL_POINTS_LIMIT} from './constants';
+import {API_INTERVAL_POINTS_LIMIT, TIME_OPTIONS} from './constants';
 import MetricChart from './metricChart';
 import RelatedIssues from './relatedIssues';
 import RelatedTransactions from './relatedTransactions';
@@ -83,12 +83,18 @@ class DetailsBody extends React.Component<Props> {
   }
 
   getInterval() {
-    const {timePeriod: {start, end}, rule} = this.props
+    const {
+      timePeriod: {start, end},
+      rule,
+    } = this.props;
     const startDate = moment.utc(start);
     const endDate = moment.utc(end);
     const timeWindow = rule?.timeWindow;
 
-    if (timeWindow && endDate.diff(startDate) < (API_INTERVAL_POINTS_LIMIT * timeWindow * 60 * 1000)) {
+    if (
+      timeWindow &&
+      endDate.diff(startDate) < API_INTERVAL_POINTS_LIMIT * timeWindow * 60 * 1000
+    ) {
       return `${timeWindow}m`;
     }
 
@@ -346,13 +352,7 @@ class DetailsBody extends React.Component<Props> {
       return this.renderLoading();
     }
 
-    const {
-      query,
-      environment,
-      aggregate,
-      projects: projectSlugs,
-      triggers,
-    } = rule;
+    const {query, environment, aggregate, projects: projectSlugs, triggers} = rule;
 
     const criticalTrigger = triggers.find(({label}) => label === 'critical');
     const warningTrigger = triggers.find(({label}) => label === 'warning');

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -10,6 +10,7 @@ import Feature from 'app/components/acl/feature';
 import Button from 'app/components/button';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import {SectionHeading} from 'app/components/charts/styles';
+import {getInterval} from 'app/components/charts/utils';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import Duration from 'app/components/duration';
 import * as Layout from 'app/components/layouts/thirds';
@@ -44,7 +45,6 @@ import {DATA_SOURCE_LABELS, getIncidentRuleMetricPreset} from '../../utils';
 import MetricChart from './metricChart';
 import RelatedIssues from './relatedIssues';
 import RelatedTransactions from './relatedTransactions';
-import {getInterval} from 'app/components/charts/utils';
 
 type Props = {
   api: Client;
@@ -108,8 +108,11 @@ class DetailsBody extends React.Component<Props> {
     const {location} = this.props;
 
     const timePeriod = location.query.period ?? ALERT_RULE_DETAILS_DEFAULT_PERIOD;
-    const timeOption = TIME_OPTIONS.find(item => item.value === timePeriod) ?? TIME_OPTIONS[1];
-    const {start: periodStart, end: periodEnd} = getStartEndTimesFromPeriod(timeOption.value);
+    const timeOption =
+      TIME_OPTIONS.find(item => item.value === timePeriod) ?? TIME_OPTIONS[1];
+    const {start: periodStart, end: periodEnd} = getStartEndTimesFromPeriod(
+      timeOption.value
+    );
 
     const useQueryTimes = location.query.start && location.query.end;
 
@@ -155,9 +158,7 @@ class DetailsBody extends React.Component<Props> {
       for (const incident of filteredIncidents) {
         // use the larger of the start of the incident or the start of the time period
         const incidentStart = moment.max(moment(incident.dateStarted), startDate);
-        const incidentClose = incident.dateClosed
-          ? moment(incident.dateClosed)
-          : endDate;
+        const incidentClose = incident.dateClosed ? moment(incident.dateClosed) : endDate;
         criticalDuration += incidentClose.diff(incidentStart);
       }
       criticalPercent = ((criticalDuration / totalTime) * 100).toFixed(2);
@@ -279,7 +280,7 @@ class DetailsBody extends React.Component<Props> {
     const percentages = this.calculateSummaryPercentages(
       incidents,
       timePeriod.start,
-      timePeriod.end,
+      timePeriod.end
     );
 
     return (
@@ -423,7 +424,10 @@ class DetailsBody extends React.Component<Props> {
                       query={queryWithTypeFilter}
                       environment={environment ? [environment] : undefined}
                       project={(projects as Project[]).map(project => Number(project.id))}
-                      interval={getInterval({start: timePeriod.start, end: timePeriod.end}, true)}
+                      interval={getInterval(
+                        {start: timePeriod.start, end: timePeriod.end},
+                        true
+                      )}
                       start={timePeriod.start}
                       end={timePeriod.end}
                       yAxis={aggregate}

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
@@ -1,0 +1,20 @@
+import {SelectValue} from 'app/types';
+import {t} from 'app/locale';
+import {TimePeriod, TimeWindow} from 'app/views/settings/incidentRules/types';
+
+export const TIME_OPTIONS: SelectValue<string>[] = [
+  {label: t('6 hours'), value: TimePeriod.SIX_HOURS},
+  {label: t('24 hours'), value: TimePeriod.ONE_DAY},
+  {label: t('3 days'), value: TimePeriod.THREE_DAYS},
+  {label: t('7 days'), value: TimePeriod.SEVEN_DAYS},
+];
+
+export const ALERT_RULE_DETAILS_DEFAULT_PERIOD = TimePeriod.ONE_DAY;
+
+export const TIME_WINDOWS = {
+  [TimePeriod.SIX_HOURS]: TimeWindow.ONE_HOUR * 6 * 60 * 1000,
+  [TimePeriod.ONE_DAY]: TimeWindow.ONE_DAY * 60 * 1000,
+  [TimePeriod.THREE_DAYS]: TimeWindow.ONE_DAY * 3 * 60 * 1000,
+  [TimePeriod.SEVEN_DAYS]: TimeWindow.ONE_DAY * 7 * 60 * 1000,
+};
+

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
@@ -17,3 +17,5 @@ export const TIME_WINDOWS = {
   [TimePeriod.THREE_DAYS]: TimeWindow.ONE_DAY * 3 * 60 * 1000,
   [TimePeriod.SEVEN_DAYS]: TimeWindow.ONE_DAY * 7 * 60 * 1000,
 };
+
+export const API_INTERVAL_POINTS_LIMIT = 10000;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
@@ -1,5 +1,5 @@
-import {SelectValue} from 'app/types';
 import {t} from 'app/locale';
+import {SelectValue} from 'app/types';
 import {TimePeriod, TimeWindow} from 'app/views/settings/incidentRules/types';
 
 export const TIME_OPTIONS: SelectValue<string>[] = [
@@ -17,4 +17,3 @@ export const TIME_WINDOWS = {
   [TimePeriod.THREE_DAYS]: TimeWindow.ONE_DAY * 3 * 60 * 1000,
   [TimePeriod.SEVEN_DAYS]: TimeWindow.ONE_DAY * 7 * 60 * 1000,
 };
-

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -7,6 +7,7 @@ import {fetchOrgMembers} from 'app/actionCreators/members';
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import {Organization} from 'app/types';
+import {getUtcDateString} from 'app/utils/dates';
 import withApi from 'app/utils/withApi';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
@@ -14,9 +15,8 @@ import {Incident} from '../../types';
 import {fetchAlertRule, fetchIncidentsForRule} from '../../utils';
 
 import DetailsBody from './body';
+import {ALERT_RULE_DETAILS_DEFAULT_PERIOD, TIME_OPTIONS, TIME_WINDOWS} from './constants';
 import DetailsHeader from './header';
-import {getUtcDateString} from 'app/utils/dates';
-import {TIME_OPTIONS, TIME_WINDOWS, ALERT_RULE_DETAILS_DEFAULT_PERIOD} from './constants';
 
 type Props = {
   api: Client;
@@ -42,12 +42,15 @@ class AlertRuleDetails extends React.Component<Props, State> {
         start: location.query.start,
         end: location.query.end,
         label: 'Custom',
-      }
+      };
     }
 
     const timePeriod = location.query.period ?? ALERT_RULE_DETAILS_DEFAULT_PERIOD;
-    const timeOption = TIME_OPTIONS.find(item => item.value === timePeriod) ?? TIME_OPTIONS[1];
-    const start = getUtcDateString(moment(moment.utc().diff(TIME_WINDOWS[timeOption.value])));
+    const timeOption =
+      TIME_OPTIONS.find(item => item.value === timePeriod) ?? TIME_OPTIONS[1];
+    const start = getUtcDateString(
+      moment(moment.utc().diff(TIME_WINDOWS[timeOption.value]))
+    );
     const end = getUtcDateString(moment.utc());
 
     return {
@@ -103,7 +106,12 @@ class AlertRuleDetails extends React.Component<Props, State> {
             params={params}
             rule={rule}
           />
-          <DetailsBody {...this.props} rule={rule} incidents={incidents} timePeriod={timePeriod}/>
+          <DetailsBody
+            {...this.props}
+            rule={rule}
+            incidents={incidents}
+            timePeriod={timePeriod}
+          />
         </Feature>
       </React.Fragment>
     );

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -83,9 +83,9 @@ const MetricChart = ({data, incidents, warningTrigger, criticalTrigger}: Props) 
     series.push(criticalArea);
 
     const incidentValueMap: Record<number, string> = {};
-    const incidentLines = filteredIncidents.map(({dateStarted, id}) => {
+    const incidentLines = filteredIncidents.map(({dateStarted, identifier}) => {
       const incidentStart = moment(dateStarted).valueOf();
-      incidentValueMap[incidentStart] = id;
+      incidentValueMap[incidentStart] = identifier;
       return {xAxis: incidentStart};
     });
     const incidentLinesSeries = {

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
@@ -42,7 +42,7 @@ class RelatedIssues extends React.Component<Props> {
       end,
       groupStatsPeriod: 'auto',
       limit: 5,
-      sort: 'new',
+      sort: rule.aggregate === 'count_unique(user)' ? 'user' : 'freq',
       query: `${rule.query} ${filter}`,
       project: projects.map(project => project.id),
     };

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
@@ -197,7 +197,16 @@ class TimelineIncident extends React.Component<IncidentProps, IncidentState> {
     let Icon = IconCheckmark;
     let color: string = theme.green300;
 
-    if (
+    if (!incident.dateClosed && incident.status === IncidentStatus.CRITICAL) {
+      // active incident is critical
+      Icon = IconFire;
+      color = theme.red300;
+    } else if (!incident.dateClosed && incident.status === IncidentStatus.WARNING) {
+      // active incident is warning
+      Icon = IconWarning;
+      color = theme.yellow300;
+    } else if (
+      // closed incident was at max critical
       activities?.find(
         ({type, value}) =>
           type === IncidentActivityType.DETECTED ||
@@ -208,6 +217,7 @@ class TimelineIncident extends React.Component<IncidentProps, IncidentState> {
       Icon = IconFire;
       color = theme.red300;
     } else if (
+      // closed incident was at max warning
       activities?.find(
         ({type, value}) =>
           type === IncidentActivityType.STARTED ||


### PR DESCRIPTION
This adds a sort to the related issues in the alert rule details page and adds start/end as a query to the page. Can now open rule details instead of incidents details for metric alerts if the org has the feature.

Also changed the `GroupList` `StreamGroup` chart to bring it more inline with the `IssueListOverview` `StreamGroup` chart:
- Changed the variable width of the chart headers to snap to details
- Changed the graph header to reflect the graph duration 

[WOR-627](https://getsentry.atlassian.net/browse/WOR-627)
[WOR-628](https://getsentry.atlassian.net/browse/WOR-628)