### PR TITLE
feat(serverless): Python AWSLambdaserverless auto instrumentation

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -167,6 +167,8 @@ register("aws-lambda.cloudformation-url")
 register("aws-lambda.account-number", default="943013980633")
 register("aws-lambda.node.layer-name", default="SentryNodeServerlessSDK")
 register("aws-lambda.node.layer-version")
+register("aws-lambda.python.layer-name", default="SentryPythonServerlessSDK")
+register("aws-lambda.python.layer-version")
 # the region of the host account we use for assuming the role
 register("aws-lambda.host-region", default="us-east-2")
 

--- a/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
+++ b/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
@@ -85,8 +85,8 @@ export default class AwsLambdaFunctionSelect extends React.Component<Props, Stat
     return (
       <h4>
         {tn(
-          'We found %s function with a Node runtime',
-          'We found %s functions with Node runtimes',
+          'We found %s function with a Node/Python runtime',
+          'We found %s functions with Node/Python runtimes',
           count
         )}
       </h4>

--- a/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
+++ b/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
@@ -85,8 +85,8 @@ export default class AwsLambdaFunctionSelect extends React.Component<Props, Stat
     return (
       <h4>
         {tn(
-          'We found %s function with a Node/Python runtime',
-          'We found %s functions with Node/Python runtimes',
+          'We found %s function with a Node or Python runtime',
+          'We found %s functions with Node or Python runtimes',
           count
         )}
       </h4>

--- a/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaProjectSelect.tsx
+++ b/src/sentry/static/sentry/app/views/integrationPipeline/awsLambdaProjectSelect.tsx
@@ -58,7 +58,7 @@ export default class AwsLambdaProjectSelect extends React.Component<Props> {
                 stacked
               />
               <Alert type="info">
-                {t('Currently only supports Node Lambda functions')}
+                {t('Currently only supports Node and Python Lambda functions')}
               </Alert>
             </Form>
           </ListItem>

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationServerlessFunctions.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationServerlessFunctions.tsx
@@ -74,7 +74,7 @@ class IntegrationServerlessFunctions extends AsyncComponent<Props, State> {
       <React.Fragment>
         <Alert type="info">
           {t(
-            'Manage your AWS Lambda functions below. Only Node runtimes are currently supported.'
+            'Manage your AWS Lambda functions below. Only Node and Python runtimes are currently supported.'
           )}
         </Alert>
         <Panel>

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -134,6 +134,8 @@ def pytest_configure(config):
             "aws-lambda.account-number": "1234",
             "aws-lambda.node.layer-name": "my-layer",
             "aws-lambda.node.layer-version": "3",
+            "aws-lambda.python.layer-name": "my-python-layer",
+            "aws-lambda.python.layer-version": "34",
         }
     )
 

--- a/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
@@ -97,7 +97,7 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
 
     @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
     @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
-    def test_enable(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
+    def test_enable_node_layer(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
         mock_client = Mock()
         mock_gen_aws_client.return_value = mock_client
 
@@ -142,7 +142,54 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
 
     @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
     @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
-    def test_disable(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
+    def test_enable_python_layer(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
+        mock_client = Mock()
+        mock_gen_aws_client.return_value = mock_client
+
+        mock_client.get_function = MagicMock(
+            return_value={
+                "Configuration": {
+                    "FunctionName": "lambdaE",
+                    "Runtime": "python3.8",
+                    "Handler": "lambda_handler.test_handler",
+                    "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaE",
+                    "Layers": ["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
+                },
+            }
+        )
+        mock_client.update_function_configuration = MagicMock()
+        return_value = {
+            "name": "lambdaE",
+            "runtime": "python3.8",
+            "version": 3,
+            "outOfDate": False,
+            "enabled": True,
+        }
+        mock_get_serialized_lambda_function.return_value = return_value
+
+        assert self.get_response(action="enable", target="lambdaE").data == return_value
+
+        mock_client.get_function.assert_called_with(FunctionName="lambdaE")
+
+        mock_client.update_function_configuration.assert_called_with(
+            FunctionName="lambdaE",
+            Layers=[
+                "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
+            ],
+            Environment={
+                "Variables": {
+                    "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
+                    "SENTRY_DSN": self.sentry_dsn,
+                    "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                }
+            },
+            Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+        )
+
+    @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
+    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    def test_disable_node(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
         mock_client = Mock()
         mock_gen_aws_client.return_value = mock_client
 
@@ -189,7 +236,56 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
 
     @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
     @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
-    def test_update_version(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
+    def test_disable_python(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
+        mock_client = Mock()
+        mock_gen_aws_client.return_value = mock_client
+
+        mock_client.get_function = MagicMock(
+            return_value={
+                "Configuration": {
+                    "FunctionName": "lambdaF",
+                    "Runtime": "python3.6",
+                    "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaF",
+                    "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+                    "Layers": [
+                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
+                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34"},
+                    ],
+                    "Environment": {
+                        "Variables": {
+                            "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
+                            "SENTRY_DSN": self.sentry_dsn,
+                            "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                            "OTHER": "hi",
+                        }
+                    },
+                },
+            }
+        )
+        mock_client.update_function_configuration = MagicMock()
+        return_value = {
+            "name": "lambdaF",
+            "runtime": "python3.6",
+            "version": -1,
+            "outOfDate": False,
+            "enabled": False,
+        }
+        mock_get_serialized_lambda_function.return_value = return_value
+
+        assert self.get_response(action="disable", target="lambdaF").data == return_value
+
+        mock_client.get_function.assert_called_with(FunctionName="lambdaF")
+
+        mock_client.update_function_configuration.assert_called_with(
+            FunctionName="lambdaF",
+            Layers=["arn:aws:lambda:us-east-2:1234:layer:something-else:2"],
+            Environment={"Variables": {"OTHER": "hi"}},
+            Handler="lambda_handler.test_handler",
+        )
+
+    @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
+    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    def test_update_node_version(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
         mock_client = Mock()
         mock_gen_aws_client.return_value = mock_client
 
@@ -233,5 +329,55 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
             Layers=[
                 "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
                 "arn:aws:lambda:us-east-2:1234:layer:my-layer:3",
+            ],
+        )
+
+    @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
+    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    def test_update_python_version(self, mock_gen_aws_client, mock_get_serialized_lambda_function):
+        mock_client = Mock()
+        mock_gen_aws_client.return_value = mock_client
+
+        mock_client.get_function = MagicMock(
+            return_value={
+                "Configuration": {
+                    "FunctionName": "lambdaG",
+                    "Runtime": "python3.6",
+                    "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+                    "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaG",
+                    "Layers": [
+                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:something-else:2"},
+                        {"Arn": "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:2"},
+                    ],
+                    "Environment": {
+                        "Variables": {
+                            "SENTRY_INITIAL_HANDLER": "lambda_test.lambda_handler",
+                            "SENTRY_DSN": self.sentry_dsn,
+                            "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                            "OTHER": "hi",
+                        }
+                    },
+                },
+            }
+        )
+        mock_client.update_function_configuration = MagicMock()
+        return_value = {
+            "name": "lambdaG",
+            "runtime": "python3.8",
+            "version": 3,
+            "outOfDate": False,
+            "enabled": True,
+        }
+        mock_get_serialized_lambda_function.return_value = return_value
+
+        assert self.get_response(action="updateVersion", target="lambdaG").data == return_value
+
+        mock_client.get_function.assert_called_with(FunctionName="lambdaG")
+
+        mock_client.update_function_configuration.assert_called_with(
+            FunctionName="lambdaG",
+            Layers=[
+                "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
             ],
         )

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -228,7 +228,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
         mock_get_supported_functions.return_value = [
             {
                 "FunctionName": "lambdaA",
-                "Handler": "lambda_handler:test_handler",
+                "Handler": "lambda_handler.test_handler",
                 "Runtime": "python3.6",
                 "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaA",
             }
@@ -260,7 +260,7 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
             Layers=["arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34"],
             Environment={
                 "Variables": {
-                    "SENTRY_INITIAL_HANDLER": "lambda_handler:test_handler",
+                    "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
                     "SENTRY_DSN": sentry_project_dsn,
                     "SENTRY_TRACES_SAMPLE_RATE": "1.0",
                 }

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -113,6 +113,10 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
         mock_get_supported_functions.return_value = [
             {"FunctionName": "lambdaA", "Runtime": "nodejs12.x"},
             {"FunctionName": "lambdaB", "Runtime": "nodejs10.x"},
+            {"FunctionName": "lambdaC", "Runtime": "python3.6"},
+            {"FunctionName": "lambdaD", "Runtime": "python3.7"},
+            {"FunctionName": "lambdaE", "Runtime": "python3.8"},
+            {"FunctionName": "lambdaD", "Runtime": "python3.9"},
         ]
 
         aws_external_id = "12-323"
@@ -132,6 +136,10 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
                 "lambdaFunctions": [
                     {"FunctionName": "lambdaA", "Runtime": "nodejs12.x"},
                     {"FunctionName": "lambdaB", "Runtime": "nodejs10.x"},
+                    {"FunctionName": "lambdaC", "Runtime": "python3.6"},
+                    {"FunctionName": "lambdaD", "Runtime": "python3.7"},
+                    {"FunctionName": "lambdaE", "Runtime": "python3.8"},
+                    {"FunctionName": "lambdaD", "Runtime": "python3.9"},
                 ],
                 "initialStepNumber": 3,
             },
@@ -193,6 +201,71 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
                     "SENTRY_TRACES_SAMPLE_RATE": "1.0",
                 }
             },
+        )
+
+        integration = Integration.objects.get(provider=self.provider.key)
+        assert integration.name == "my_name us-east-2"
+        assert integration.external_id == "599817902985-us-east-2"
+        assert integration.metadata == {
+            "region": region,
+            "account_number": account_number,
+            "aws_external_id": aws_external_id,
+        }
+        assert OrganizationIntegration.objects.filter(
+            integration=integration, organization=self.organization
+        )
+
+    @patch("sentry.integrations.aws_lambda.integration.get_supported_functions")
+    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    def test_python_lambda_setup_layer_success(
+        self, mock_gen_aws_client, mock_get_supported_functions
+    ):
+        mock_client = Mock()
+        mock_gen_aws_client.return_value = mock_client
+        mock_client.update_function_configuration = MagicMock()
+        mock_client.describe_account = MagicMock(return_value={"Account": {"Name": "my_name"}})
+
+        mock_get_supported_functions.return_value = [
+            {
+                "FunctionName": "lambdaA",
+                "Handler": "lambda_handler:test_handler",
+                "Runtime": "python3.6",
+                "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaA",
+            }
+        ]
+
+        aws_external_id = "12-323"
+        self.pipeline.state.step_index = 2
+        self.pipeline.state.data = {
+            "region": region,
+            "account_number": account_number,
+            "aws_external_id": aws_external_id,
+            "project_id": self.projectA.id,
+        }
+
+        sentry_project_dsn = ProjectKey.get_default(project=self.projectA).get_dsn(public=True)
+
+        resp = self.client.post(
+            self.setup_path,
+            data={"lambdaA": True},
+            format="json",
+            HTTP_ACCEPT="application/json",
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+
+        assert resp.status_code == 200
+
+        mock_client.update_function_configuration.assert_called_once_with(
+            FunctionName="lambdaA",
+            Layers=["arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34"],
+            Environment={
+                "Variables": {
+                    "SENTRY_INITIAL_HANDLER": "lambda_handler:test_handler",
+                    "SENTRY_DSN": sentry_project_dsn,
+                    "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                }
+            },
+            Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
         )
 
         integration = Integration.objects.get(provider=self.provider.key)

--- a/tests/sentry/integrations/aws_lambda/test_utils.py
+++ b/tests/sentry/integrations/aws_lambda/test_utils.py
@@ -115,6 +115,7 @@ class GetSupportedFunctionsTest(TestCase):
         {"FunctionName": "lambdaA", "Runtime": "nodejs12.x"},
         {"FunctionName": "lambdaB", "Runtime": "nodejs10.x"},
         {"FunctionName": "lambdaC", "Runtime": "nodejs12.x"},
+        {"FunctionName": "lambdaD", "Runtime": "python3.6"},
     ]
 
     mock_client.get_paginator.assert_called_once_with("list_functions")
@@ -124,6 +125,10 @@ class GetOptionValueTest(TestCase):
     node_fn = {
         "Runtime": "nodejs10.x",
         "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaB",
+    }
+    python_fn = {
+        "Runtime": "python3.6",
+        "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaC",
     }
 
     cache_value = {
@@ -139,13 +144,29 @@ class GetOptionValueTest(TestCase):
                 {"region": "us-east-2", "version": "19"},
                 {"region": "us-west-1", "version": "17"},
             ],
-        }
+        },
+        "aws-layer:python": {
+            "name": "AWS Lambda Python Layer",
+            "canonical": "aws-layer:python",
+            "sdk_version": "0.20.3",
+            "account_number": "943013980633",
+            "layer_name": "SentryPythonServerlessSDK",
+            "repo_url": "https://github.com/getsentry/sentry-python",
+            "main_docs_url": "https://docs.sentry.io/platforms/python/guides/aws-lambda/",
+            "regions": [
+                {"region": "eu-west-1", "version": "2"},
+                {"region": "us-east-2", "version": "2"},
+            ],
+        },
     }
 
     def test_no_cache(self):
         assert get_option_value(self.node_fn, OPTION_VERSION) == "3"
         assert get_option_value(self.node_fn, OPTION_LAYER_NAME) == "my-layer"
         assert get_option_value(self.node_fn, OPTION_ACCOUNT_NUMBER) == "1234"
+        assert get_option_value(self.python_fn, OPTION_VERSION) == "34"
+        assert get_option_value(self.python_fn, OPTION_LAYER_NAME) == "my-python-layer"
+        assert get_option_value(self.python_fn, OPTION_ACCOUNT_NUMBER) == "1234"
 
     @patch.object(cache, "get")
     def test_with_cache(self, mock_get):
@@ -154,6 +175,11 @@ class GetOptionValueTest(TestCase):
             assert get_option_value(self.node_fn, OPTION_VERSION) == "19"
             assert get_option_value(self.node_fn, OPTION_LAYER_NAME) == "SentryNodeServerlessSDK"
             assert get_option_value(self.node_fn, OPTION_ACCOUNT_NUMBER) == "943013980633"
+            assert get_option_value(self.python_fn, OPTION_VERSION) == "2"
+            assert (
+                get_option_value(self.python_fn, OPTION_LAYER_NAME) == "SentryPythonServerlessSDK"
+            )
+            assert get_option_value(self.python_fn, OPTION_ACCOUNT_NUMBER) == "943013980633"
 
     @patch.object(cache, "get")
     def test_invalid_region(self, mock_get):


### PR DESCRIPTION
Issue: https://getsentry.atlassian.net/browse/GRW-30

- Sentry can install the Python layer on behalf of the user during the auto-instrumentation flow
- This layer updates the env variables to store the old handler and updates the handler of the function to have the sentry handler
- Disabling Sentry on a Python Lambda function will restore the original state of the Lambda by removing the layer, setting the handler function to the original value, and removing env variables we set
- The text in the integration flow reflects we support Python and Node