### PR TITLE
fix(images-loaded): Fix candidates list height

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
@@ -17,7 +17,6 @@ import {CandidateDownloadStatus, Image} from 'app/types/debugImage';
 import {defined} from 'app/utils';
 
 import Filter from '../filter';
-import {IMAGE_AND_CANDIDATE_LIST_MAX_HEIGHT} from '../utils';
 
 import Status from './candidate/status';
 import Candidate from './candidate';
@@ -405,8 +404,6 @@ const StyledSearchBar = styled(SearchBar)`
 `;
 
 const StyledPanelTable = styled(PanelTable)`
-  overflow: auto;
-  max-height: ${IMAGE_AND_CANDIDATE_LIST_MAX_HEIGHT}px;
   grid-template-columns: 0.5fr minmax(300px, 2fr) 1fr 1fr;
 
   > *:nth-child(5n) {


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/29228205/108495761-78673000-72a9-11eb-87aa-e3e767e089f7.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/108495822-8ddc5a00-72a9-11eb-9322-d603d64b07c8.png)


P.S: max-height with overflow auto will still be implemented, but atm it is better to remove it, as some issues need to be fixed