### PR TITLE
fix: reduce epm minimum

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1985,7 +1985,7 @@ FUNCTIONS = {
         ),
         Function(
             "epm",
-            optional_args=[IntervalDefault("interval", 60, None)],
+            optional_args=[IntervalDefault("interval", 1, None)],
             transform="divide(count(), divide({interval:g}, 60))",
             default_result_type="number",
         ),

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2389,9 +2389,14 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["groupby"] == []
 
         with pytest.raises(InvalidSearchQuery) as err:
-            fields = ["epm(30)"]
+            fields = ["epm(0)"]
             resolve_field_list(fields, eventstore.Filter())
-        assert "epm(30): interval argument invalid: 30 must be greater than or equal to 60" in str(
+        assert "epm(0): interval argument invalid: 0 must be greater than or equal to 1" in str(err)
+
+        with pytest.raises(InvalidSearchQuery) as err:
+            fields = ["epm(-1)"]
+            resolve_field_list(fields, eventstore.Filter())
+        assert "epm(-1): interval argument invalid: -1 must be greater than or equal to 1" in str(
             err
         )
 


### PR DESCRIPTION
currently, sub-minute queries fail badly on the default performance landing
page, since tpm requires minimum 60 seconds. I think this metric is perfectly
well-defined for smaller durations, as long as t!=0.

this was discussed at https://github.com/getsentry/sentry/pull/17113/commits/977bca2311a967fa740ae92ad0f69281ef6f54b6#r381016144, but I'm not convinced of the logic. if you drive 10 km in 10 minutes, your average speed is 60 km/h over the 10-minute period. you don't need to drive for an hour to figure out what your speed is in km/h.