### PR TITLE
fix: add threshold to vital percents

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalPercents.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/vitalPercents.tsx
@@ -25,15 +25,15 @@ function getVitalStateText(vital, vitalState) {
     case VitalState.POOR:
       return Array.isArray(vital)
         ? t('Poor')
-        : tct('Poor: >[threshold]ms', webVitalPoor[vital]);
+        : tct('Poor: >[threshold]ms', {threshold: webVitalPoor[vital]});
     case VitalState.MEH:
       return Array.isArray(vital)
         ? t('Needs improvement')
-        : tct('Needs improvement: >[threshold]ms', webVitalMeh[vital]);
+        : tct('Needs improvement: >[threshold]ms', {threshold: webVitalMeh[vital]});
     case VitalState.GOOD:
       return Array.isArray(vital)
         ? t('Good')
-        : tct('Good: <[threshold]ms', webVitalMeh[vital]);
+        : tct('Good: <[threshold]ms', {threshold: webVitalMeh[vital]});
     default:
       return null;
   }


### PR DESCRIPTION
tct was passed a raw number, which doesn't work. it needs to be {threshold:
num}. this was done correctly in my initial version and then screwed up after
the refactor.