### PR TITLE
fix(ui) Normalize select control font size

### DIFF
--- a/src/sentry/static/sentry/app/components/forms/selectControl.tsx
+++ b/src/sentry/static/sentry/app/components/forms/selectControl.tsx
@@ -139,7 +139,8 @@ function SelectControl<OptionType extends GeneralSelectValue = GeneralSelectValu
   const defaultStyles: StylesConfig = {
     control: (_, state: any) => ({
       height: '100%',
-      fontSize: '15px',
+      fontSize: theme.fontSizeLarge,
+      lineHeight: theme.text.lineHeightBody,
       display: 'flex',
       // @ts-ignore Ignore merge errors as only defining the property once
       // makes code harder to understand.


### PR DESCRIPTION
* Align the fontsize with the rest of our form inputs.
* Increase line height so that descenders are not clipped.