### PR TITLE
ref(apm): Convert some transaction_start to SAMPLED_URL_NAMES

### DIFF
--- a/src/sentry/api/endpoints/group_integration_details.py
+++ b/src/sentry/api/endpoints/group_integration_details.py
@@ -9,7 +9,6 @@ from sentry.integrations import IntegrationFeatures
 from sentry.shared_integrations.exceptions import IntegrationError, IntegrationFormError
 from sentry.models import Activity, ExternalIssue, GroupLink, Integration
 from sentry.signals import integration_issue_created, integration_issue_linked
-from sentry.web.decorators import transaction_start
 
 
 MISSING_FEATURE_MESSAGE = "Your organization does not have access to this feature."
@@ -42,7 +41,6 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             data=issue_information,
         )
 
-    @transaction_start("GroupIntegrationDetailsEndpoint")
     def get(self, request, group, integration_id):
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
@@ -81,7 +79,6 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
             return Response({"detail": str(e)}, status=400)
 
     # was thinking put for link an existing issue, post for create new issue?
-    @transaction_start("GroupIntegrationDetailsEndpoint")
     def put(self, request, group, integration_id):
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
@@ -170,7 +167,6 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
-    @transaction_start("GroupIntegrationDetailsEndpoint")
     def post(self, request, group, integration_id):
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)
@@ -243,7 +239,6 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
         }
         return Response(context, status=201)
 
-    @transaction_start("GroupIntegrationDetailsEndpoint")
     def delete(self, request, group, integration_id):
         if not self._has_issue_feature(group.organization, request.user):
             return Response({"detail": MISSING_FEATURE_MESSAGE}, status=400)

--- a/src/sentry/api/endpoints/organization_release_details.py
+++ b/src/sentry/api/endpoints/organization_release_details.py
@@ -16,7 +16,6 @@ from sentry.models.release import UnsafeReleaseDeletion
 from sentry.snuba.sessions import STATS_PERIODS
 from sentry.api.endpoints.organization_releases import get_stats_period_detail
 from sentry.utils.sdk import configure_scope, bind_organization_context
-from sentry.web.decorators import transaction_start
 
 
 class OrganizationReleaseSerializer(ReleaseSerializer):
@@ -27,7 +26,6 @@ class OrganizationReleaseSerializer(ReleaseSerializer):
 
 
 class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnalyticsMixin):
-    @transaction_start("OrganizationReleaseDetailsEndpoint.get")
     def get(self, request, organization, version):
         """
         Retrieve an Organization's Release
@@ -74,7 +72,6 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint, Relea
             )
         )
 
-    @transaction_start("OrganizationReleaseDetailsEndpoint.put")
     def put(self, request, organization, version):
         """
         Update an Organization's Release
@@ -196,7 +193,6 @@ class OrganizationReleaseDetailsEndpoint(OrganizationReleasesBaseEndpoint, Relea
 
             return Response(serialize(release, request.user))
 
-    @transaction_start("OrganizationReleaseDetailsEndpoint.delete")
     def delete(self, request, organization, version):
         """
         Delete an Organization's Release

--- a/src/sentry/api/endpoints/project_release_details.py
+++ b/src/sentry/api/endpoints/project_release_details.py
@@ -15,13 +15,11 @@ from sentry.snuba.sessions import STATS_PERIODS
 from sentry.api.endpoints.organization_releases import get_stats_period_detail
 
 from sentry.utils.sdk import configure_scope, bind_organization_context
-from sentry.web.decorators import transaction_start
 
 
 class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
     permission_classes = (ProjectReleasePermission,)
 
-    @transaction_start("ProjectReleaseDetailsEndpoint.get")
     def get(self, request, project, version):
         """
         Retrieve a Project's Release
@@ -65,7 +63,6 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
             )
         )
 
-    @transaction_start("ProjectReleaseDetailsEndpoint.put")
     def put(self, request, project, version):
         """
         Update a Project's Release
@@ -143,7 +140,6 @@ class ProjectReleaseDetailsEndpoint(ProjectEndpoint, ReleaseAnalyticsMixin):
 
             return Response(serialize(release, request.user))
 
-    @transaction_start("ProjectReleaseDetailsEndpoint.delete")
     def delete(self, request, project, version):
         """
         Delete a Project's Release

--- a/src/sentry/api/endpoints/project_releases.py
+++ b/src/sentry/api/endpoints/project_releases.py
@@ -14,13 +14,11 @@ from sentry.models import Activity, Environment, Release, ReleaseStatus
 from sentry.plugins.interfaces.releasehook import ReleaseHook
 from sentry.signals import release_created
 from sentry.utils.sdk import configure_scope, bind_organization_context
-from sentry.web.decorators import transaction_start
 
 
 class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
     permission_classes = (ProjectReleasePermission,)
 
-    @transaction_start("ProjectReleasesEndpoint.get")
     def get(self, request, project):
         """
         List a Project's Releases
@@ -71,7 +69,6 @@ class ProjectReleasesEndpoint(ProjectEndpoint, EnvironmentMixin):
             ),
         )
 
-    @transaction_start("ProjectReleasesEndpoint.post")
     def post(self, request, project):
         """
         Create a New Release for a Project

--- a/src/sentry/api/endpoints/sentry_app_authorizations.py
+++ b/src/sentry/api/endpoints/sentry_app_authorizations.py
@@ -8,13 +8,11 @@ from sentry.api.bases import SentryAppAuthorizationsBaseEndpoint
 from sentry.coreapi import APIUnauthorized
 from sentry.mediators.token_exchange import GrantExchanger, Refresher, GrantTypes
 from sentry.api.serializers.models.apitoken import ApiTokenSerializer
-from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger(__name__)
 
 
 class SentryAppAuthorizationsEndpoint(SentryAppAuthorizationsBaseEndpoint):
-    @transaction_start("SentryAppAuthorizationsEndpoint")
     def post(self, request, installation):
         with sentry_sdk.configure_scope() as scope:
             scope.set_tag("organization", installation.organization_id)

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -395,7 +395,11 @@ GROUP_URLS = [
     ),
     url(r"^(?P<issue_id>[^\/]+)/attachments/$", GroupAttachmentsEndpoint.as_view()),
     url(r"^(?P<issue_id>[^\/]+)/similar/$", GroupSimilarIssuesEndpoint.as_view()),
-    url(r"^(?P<issue_id>[^\/]+)/external-issues/$", GroupExternalIssuesEndpoint.as_view()),
+    url(
+        r"^(?P<issue_id>[^\/]+)/external-issues/$",
+        GroupExternalIssuesEndpoint.as_view(),
+        name="external-issues",
+    ),
     url(
         r"^(?P<issue_id>[^\/]+)/external-issues/(?P<external_issue_id>\d+)/$",
         GroupExternalIssueDetailsEndpoint.as_view(),
@@ -404,6 +408,7 @@ GROUP_URLS = [
     url(
         r"^(?P<issue_id>[^\/]+)/integrations/(?P<integration_id>\d+)/$",
         GroupIntegrationDetailsEndpoint.as_view(),
+        name="integration-details",
     ),
     url(r"^(?P<issue_id>[^\/]+)/current-release/$", GroupCurrentReleaseEndpoint.as_view()),
     # Load plugin group urls
@@ -924,7 +929,10 @@ urlpatterns = [
                     OrganizationGroupIndexStatsEndpoint.as_view(),
                     name="sentry-api-0-organization-group-index-stats",
                 ),
-                url(r"^(?P<organization_slug>[^\/]+)/(?:issues|groups)/", include(GROUP_URLS)),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?:issues|groups)/",
+                    include(GROUP_URLS, namespace="sentry-api-0-organization-group"),
+                ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/integrations/$",
                     OrganizationIntegrationsEndpoint.as_view(),
@@ -1714,7 +1722,7 @@ urlpatterns = [
         ),
     ),
     # Groups
-    url(r"^(?:issues|groups)/", include(GROUP_URLS)),
+    url(r"^(?:issues|groups)/", include(GROUP_URLS, namespace="sentry-api-0-group")),
     url(
         r"^issues/(?P<issue_id>[^\/]+)/participants/$",
         GroupParticipantsEndpoint.as_view(),

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -23,8 +23,17 @@ UNSAFE_FILES = (
 
 # URLs that should always be sampled
 SAMPLED_URL_NAMES = {
+    # releases
     "sentry-api-0-organization-releases",
+    "sentry-api-0-organization-release-details",
+    "sentry-api-0-project-releases",
+    "sentry-api-0-project-release-details",
+    # integrations
     "sentry-extensions-jira-issue-hook",
+    "sentry-api-0-group-integration-details",
+    # integration platform
+    "sentry-api-0-group-external-issues",
+    "sentry-api-0-sentry-app-authorizations",
 }
 
 UNSAFE_TAG = "_unsafe"


### PR DESCRIPTION
**Context:**
There are couple things going in this PR, but they are all related to using the preferred way of gathering backend transactions by utilizing `SAMPLED_URL_NAMES`. This was added in https://github.com/getsentry/sentry/pull/22993 (there is more context in that pr) but basically we should be able to replace all the `@transaction_start` usage.

**Namespace Group URLs**
The original endpoint that I was looking to instrument was our `group_external_issues` endpoint. We are in the process of documenting some [new external issue endpoints](https://github.com/getsentry/sentry/pull/23784), but there are some inconsistencies (`groupId` vs `issueId`) that we want to solve before we do so. 

We want to get some metrics on our external issue endpoint (even tho it isn't documented) before making any potentially breaking change. 

[Namespacing](https://docs.djangoproject.com/en/1.11/topics/http/urls/#reversing-namespaced-urls) the group urls allows me to add them to the `SAMPLED_URL_NAMES` config. I added in the `group_integration_details` endpoint as well with this change.

This screenshot shows testing out hitting the `group_external_issues` endpoint with an internal integration api token:
<img width="1167" alt="Screen Shot 2021-02-19 at 10 12 42 AM" src="https://user-images.githubusercontent.com/15368179/108549123-9b8de180-72a1-11eb-8bcd-220a739ff952.png">


**Converting Releases Endpoints**
I used this PR as an opportunity to convert the rest of the releases endpoints that were originally instrumented in https://github.com/getsentry/sentry/pull/21651, since we already converted the `OrganizationReleasesEndpoint`. 