### PR TITLE
fix(ui): Override team avatar tooltip with tooltip prop

### DIFF
--- a/src/sentry/static/sentry/app/components/assigneeSelector.tsx
+++ b/src/sentry/static/sentry/app/components/assigneeSelector.tsx
@@ -352,7 +352,7 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
     const suggestedReasons: Record<SuggestedOwnerReason, React.ReactNode> = {
       suspectCommit: tct('Based on [commit:commit data]', {
         commit: (
-          <ExternalLink href="https://docs.sentry.io/product/sentry-basics/guides/integrate-frontend/configure-scms/" />
+          <TooltipSubExternalLink href="https://docs.sentry.io/product/sentry-basics/guides/integrate-frontend/configure-scms/" />
         ),
       }),
       ownershipRule: t('Matching Issue Owners Rule'),
@@ -442,6 +442,7 @@ const AssigneeSelectorComponent = createReactClass<Props, State>({
                   <SuggestedAvatarStack
                     size={24}
                     owners={suggestedActors}
+                    tooltipOptions={{isHoverable: true}}
                     tooltip={
                       <TooltipWrapper>
                         <div>
@@ -603,10 +604,6 @@ const TooltipWrapper = styled('div')`
 
 const TooltipSubtext = styled('div')`
   color: ${p => p.theme.subText};
-
-  & > a {
-    color: ${p => p.theme.subText};
-  }
 `;
 
 const TooltipSubExternalLink = styled(ExternalLink)`

--- a/src/sentry/static/sentry/app/components/avatar/actorAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/actorAvatar.tsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react';
 
 import TeamAvatar from 'app/components/avatar/teamAvatar';
 import UserAvatar from 'app/components/avatar/userAvatar';
+import Tooltip from 'app/components/tooltip';
 import MemberListStore from 'app/stores/memberListStore';
 import TeamStore from 'app/stores/teamStore';
 import {Actor} from 'app/types';
@@ -21,6 +22,7 @@ type Props = DefaultProps & {
   onClick?: () => void;
   suggested?: boolean;
   tooltip?: React.ReactNode;
+  tooltipOptions?: Omit<Tooltip['props'], 'children' | 'title'>;
 };
 
 class ActorAvatar extends React.Component<Props> {

--- a/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/baseAvatar.tsx
@@ -60,7 +60,7 @@ type Props = {
   /**
    * Additional props for the tooltip
    */
-  tooltipOptions?: Tooltip['props'];
+  tooltipOptions?: Omit<Tooltip['props'], 'children' | 'title'>;
 
   className?: string;
 

--- a/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/suggestedAvatarStack.tsx
@@ -14,7 +14,7 @@ type Props = {
 // Constrain the number of visible suggestions
 const MAX_SUGGESTIONS = 5;
 
-const SuggestedAvatarStack = ({owners, tooltip, ...props}: Props) => {
+const SuggestedAvatarStack = ({owners, tooltip, tooltipOptions, ...props}: Props) => {
   const backgroundAvatarProps = {
     ...props,
     round: owners[0].type === 'user',
@@ -38,6 +38,7 @@ const SuggestedAvatarStack = ({owners, tooltip, ...props}: Props) => {
         actor={owners[0]}
         index={numAvatars - 1}
         tooltip={tooltip}
+        tooltipOptions={{...tooltipOptions, skipWrapper: true}}
       />
     </AvatarStack>
   );

--- a/src/sentry/static/sentry/app/components/avatar/teamAvatar.tsx
+++ b/src/sentry/static/sentry/app/components/avatar/teamAvatar.tsx
@@ -10,13 +10,13 @@ type Props = {
 
 class TeamAvatar extends React.Component<Props> {
   render() {
-    const {team, ...props} = this.props;
+    const {team, tooltip: tooltipProp, ...props} = this.props;
     if (!team) {
       return null;
     }
     const slug = (team && team.slug) || '';
     const title = explodeSlug(slug);
-    const tooltip = `#${title}`;
+    const tooltip = tooltipProp ?? `#${title}`;
 
     return (
       <BaseAvatar


### PR DESCRIPTION
Skip tooltip wrapper on suggested avatar stack
Fix one tooltip link color
Allow avatar tooltips with links to be "hoverable"