### PR TITLE
ref(ui) Remove deprecatedSelect from FieldFromConfig

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/fieldFromConfig.tsx
@@ -65,10 +65,6 @@ export default class FieldFromConfig extends React.Component<Props> {
         if (props.multiline) {
           return <TextareaField {...props} />;
         }
-
-        // TODO(billy): Handle `props.choices` with a "creatable" SelectField
-        // if (props.choices) return <Select2TextField {...props} />;
-
         return <TextField {...props} />;
       case 'number':
         return <NumberField {...props} />;
@@ -77,12 +73,7 @@ export default class FieldFromConfig extends React.Component<Props> {
       case 'choice':
       case 'select':
       case 'array':
-        // TODO(billy): Handle `props.has_autocomplete` with an "async" SelectField
-        // if (props.has_autocomplete) {
-        // return <SelectAsyncField {...props} />;
-        // }
-
-        return <SelectField deprecatedSelectControl {...props} />;
+        return <SelectField {...props} />;
       case 'choice_mapper':
         // TODO(ts) The switch on field.type is not resolving
         // the Field union for this component. The union might be 'too big'.


### PR DESCRIPTION
This picks up the work started in #22901. The other changes from that pull request have already been merged in via smaller pull requests.

This change could be risky as it change the default mode for plugin select controls. These controls are being defined in server code and thus lack the ability to define behavior that could complicate the upgrade.