### PR TITLE
ref(stacktrace-link): Allow dismissing CTA

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -17,6 +17,7 @@ import {
 } from 'app/types';
 import {Event} from 'app/types/event';
 import {getIntegrationIcon, trackIntegrationEvent} from 'app/utils/integrationUtil';
+import {promptIsDismissed} from 'app/utils/promptIsDismissed';
 import withOrganization from 'app/utils/withOrganization';
 import withProjects from 'app/utils/withProjects';
 
@@ -92,7 +93,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
     });
 
     this.setState({
-      isDismissed: !prompt?.dismissedTime ? false : true,
+      isDismissed: promptIsDismissed(prompt),
     });
   }
 
@@ -199,39 +200,36 @@ class StacktraceLink extends AsyncComponent<Props, State> {
           {({hasAccess}) =>
             hasAccess && (
               <CodeMappingButtonContainer columnQuantity={2}>
-                {tct(
-                  'Link your stack trace to your source code. [link:Set Up Stack Trace Linking Now].',
-                  {
-                    link: (
-                      <a
-                        onClick={() => {
-                          trackIntegrationEvent(
-                            'integrations.stacktrace_start_setup',
-                            {
-                              view: 'stacktrace_issue_details',
-                              platform,
-                            },
-                            this.props.organization,
-                            {startSession: true}
-                          );
-                          openModal(
-                            deps =>
-                              this.project && (
-                                <StacktraceLinkModal
-                                  onSubmit={this.handleSubmit}
-                                  filename={filename}
-                                  project={this.project}
-                                  organization={organization}
-                                  integrations={this.integrations}
-                                  {...deps}
-                                />
-                              )
-                          );
-                        }}
-                      />
-                    ),
-                  }
-                )}
+                {tct('[link:Link your stack trace to your source code.]', {
+                  link: (
+                    <a
+                      onClick={() => {
+                        trackIntegrationEvent(
+                          'integrations.stacktrace_start_setup',
+                          {
+                            view: 'stacktrace_issue_details',
+                            platform,
+                          },
+                          this.props.organization,
+                          {startSession: true}
+                        );
+                        openModal(
+                          deps =>
+                            this.project && (
+                              <StacktraceLinkModal
+                                onSubmit={this.handleSubmit}
+                                filename={filename}
+                                project={this.project}
+                                organization={organization}
+                                integrations={this.integrations}
+                                {...deps}
+                              />
+                            )
+                        );
+                      }}
+                    />
+                  ),
+                })}
                 <StyledIconClose size="xs" onClick={() => this.dismissPrompt()} />
               </CodeMappingButtonContainer>
             )

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -42,7 +42,8 @@ type StacktraceResultItem = {
 
 type State = AsyncComponent['state'] & {
   match: StacktraceResultItem;
-  isDismissed: boolean | null;
+  isDismissed: boolean;
+  promptLoaded: boolean;
 };
 
 class StacktraceLink extends AsyncComponent<Props, State> {
@@ -94,6 +95,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
 
     this.setState({
       isDismissed: promptIsDismissed(prompt),
+      promptLoaded: true,
     });
   }
 
@@ -140,7 +142,8 @@ class StacktraceLink extends AsyncComponent<Props, State> {
       showModal: false,
       sourceCodeInput: '',
       match: {integrations: []},
-      isDismissed: null,
+      isDismissed: false,
+      promptLoaded: false,
     };
   }
 
@@ -268,7 +271,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
   }
   renderBody() {
     const {config, sourceUrl} = this.match || {};
-    const {isDismissed} = this.state;
+    const {isDismissed, promptLoaded} = this.state;
 
     if (config && sourceUrl) {
       return this.renderMatchWithUrl(config, sourceUrl);
@@ -277,7 +280,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
       return this.renderMatchNoUrl();
     }
 
-    if (isDismissed || isDismissed === null) {
+    if (!promptLoaded || (promptLoaded && isDismissed)) {
       return null;
     }
 

--- a/src/sentry/static/sentry/app/utils/integrationEvents.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationEvents.tsx
@@ -76,6 +76,7 @@ export type IntegrationEventParameters = {
   'integrations.index_viewed': MultipleIntegrationsEventParams;
   'integrations.directory_item_searched': IntegrationSearchEventParams;
   'integrations.directory_category_selected': IntegrationCategorySelectEventParams;
+  'integrations.stacktrace_link_cta_dismissed': IntegrationStacktraceLinkEventParams;
   'integrations.stacktrace_start_setup': IntegrationStacktraceLinkEventParams;
   'integrations.stacktrace_submit_config': IntegrationStacktraceLinkEventParams;
   'integrations.stacktrace_complete_setup': IntegrationStacktraceLinkEventParams;
@@ -113,6 +114,8 @@ export const integrationEventMap: Record<IntegrationAnalyticsKey, string> = {
   'integrations.index_viewed': 'Integrations: Index Page Viewed',
   'integrations.directory_item_searched': 'Integrations: Directory Item Searched',
   'integrations.directory_category_selected': 'Integrations: Directory Category Selected',
+  'integrations.stacktrace_link_cta_dismissed':
+    'Integrations: Stacktrace Link CTA Dismissed',
   'integrations.stacktrace_start_setup': 'Integrations: Stacktrace Start Setup',
   'integrations.stacktrace_submit_config': 'Integrations: Stacktrace Submit Config',
   'integrations.stacktrace_complete_setup': 'Integrations: Stacktrace Complete Setup',

--- a/src/sentry/utils/prompts.py
+++ b/src/sentry/utils/prompts.py
@@ -4,6 +4,7 @@ DEFAULT_PROMPTS = {
     "alert_stream": {"required_fields": ["organization_id"]},
     "sdk_updates": {"required_fields": ["organization_id"]},
     "suggest_mobile_project": {"required_fields": ["organization_id"]},
+    "stacktrace_link": {"required_fields": ["organization_id", "project_id"]},
 }
 
 


### PR DESCRIPTION
**Context:**
We have a CTA for users to set up Stack Trace Linking. Right now it will always show up you have both GitHub or GitLab installed AND no code mapping set up for the project the issue belongs to.

We don't currently check roles but we should, members can't edit integration settings so they shouldn't see this CTA. 

**CTA Updates**
I've changed a couple of things about the CTA:
* Check for `org:integrations` access (everything above members)
* Made the CTA dismissible using the `/prompts-activity/` endpoint
* Added analytics for when users decide to dismiss
* Update the UI to accommodate the dismiss action


![Screen Shot 2021-02-23 at 9 53 43 AM](https://user-images.githubusercontent.com/15368179/108885795-1403e380-75bd-11eb-828f-bf14de3c7cb9.png)
