### PR TITLE
fix(discover): Handle events out of retention

### DIFF
--- a/src/sentry/api/endpoints/organization_event_details.py
+++ b/src/sentry/api/endpoints/organization_event_details.py
@@ -25,7 +25,8 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
 
         # We return the requested event if we find a match regardless of whether
         # it occurred within the range specified
-        event = eventstore.get_event_by_id(project.id, event_id)
+        with self.handle_query_errors():
+            event = eventstore.get_event_by_id(project.id, event_id)
 
         if event is None:
             return Response({"detail": "Event not found"}, status=404)

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -227,7 +227,7 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
             data={
                 "event_id": "d" * 32,
                 "message": "oh no",
-                "timestamp": iso_format(before_now(days=1)),
+                "timestamp": iso_format(before_now(days=2)),
                 "fingerprint": ["group-1"],
             },
             project_id=self.project.id,

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -221,3 +221,31 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert response.data["id"] == "a" * 32
         assert response.data["projectSlug"] == self.project.slug
+
+    def test_out_of_retention(self):
+        self.store_event(
+            data={
+                "event_id": "d" * 32,
+                "message": "oh no",
+                "timestamp": iso_format(before_now(days=1)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+
+        url = reverse(
+            "sentry-api-0-organization-event-details",
+            kwargs={
+                "organization_slug": self.project.organization.slug,
+                "project_slug": self.project.slug,
+                "event_id": "d" * 32,
+            },
+        )
+
+        with self.options({"system.event-retention-days": 1}):
+            response = self.client.get(
+                url,
+                format="json",
+            )
+
+        assert response.status_code == 400, response.content


### PR DESCRIPTION
- When an event is out of retention get_event_by_id errors because the
  calculated date params are invalid