### PR TITLE
fix(discover):  Avoid returning invalid JSON with literal NaN

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -1,3 +1,5 @@
+import numbers
+import math
 from contextlib import contextmanager
 import sentry_sdk
 from django.utils.http import urlquote
@@ -201,6 +203,11 @@ class OrganizationEventsV2EndpointBase(OrganizationEventsEndpointBase):
             for result in results:
                 if has_issues and "issue.id" in result:
                     result["issue"] = issues.get(result["issue.id"], "unknown")
+
+        for result in results:
+            for key in result:
+                if isinstance(result[key], numbers.Number) and not math.isfinite(result[key]):
+                    result[key] = None
 
         if not ("project.id" in first_row or "projectid" in first_row):
             return results

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2934,3 +2934,17 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200
         assert len(response.data["data"]) == 1
         assert "Link" not in response
+
+    def test_aggregates_in_empty_project(self):
+        self.create_project()
+        features = {"organizations:discover-basic": True, "organizations:global-views": True}
+        query = {"field": ["p50()", "p75()", "p95()", "percentile(transaction.duration, 0.99)"]}
+        response = self.do_request(query, features=features)
+        assert response.status_code == 200, response.content
+
+        data = response.data["data"]
+        assert len(data) == 1
+        assert data[0]["p50"] is None
+        assert data[0]["p75"] is None
+        assert data[0]["p95"] is None
+        assert data[0]["percentile_transaction_duration_0_99"] is None


### PR DESCRIPTION
Some Discover functions may return `nan` if there are no events to aggregate on. These `nan`s may propagate to the frontend where `JSON.parse()` will be unable to parse them.

This is a stopgap solution until they're well handled from within Snuba.

## TODO

- [ ] check perf change