### PR TITLE
fix: __iter__ audit

### DIFF
--- a/src/sentry/eventtypes/manager.py
+++ b/src/sentry/eventtypes/manager.py
@@ -4,7 +4,7 @@ class EventTypeManager:
         self.__lookup = {}
 
     def __iter__(self):
-        return self.__values.values()
+        yield from self.__values
 
     def __contains__(self, key):
         return key in self.__lookup

--- a/src/sentry/roles/manager.py
+++ b/src/sentry/roles/manager.py
@@ -41,7 +41,7 @@ class RoleManager:
         self._top_dog = role_list[-1]
 
     def __iter__(self):
-        return self._roles.values()
+        yield from self._roles.values()
 
     def can_manage(self, role, other):
         return self.get(role).priority >= self.get(other).priority


### PR DESCRIPTION
This is a long overdue followup to https://github.com/getsentry/sentry/pull/23741. I haven't seen these crop up in Sentry, though. The `sentry.eventtypes.default_manager` is fundamentally just incorrect, so these codepaths are likely just not touched. Anyway, fixed.

I used `rg -tpy -A5 __iter__` and looked for anything that seemed wrong.

```py
>>> iter(sentry.roles.default_manager)
Traceback (most recent call last):
  File "/Users/joshua.li/.local/share/pyenv/versions/3.6.10/lib/python3.6/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
TypeError: iter() returned non-iterator of type 'odict_values'

>>> iter(sentry.eventtypes.default_manager)
Traceback (most recent call last):
  File "/Users/joshua.li/.local/share/pyenv/versions/3.6.10/lib/python3.6/code.py", line 91, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/Users/joshua.li/dev/sentry/sentry/src/sentry/eventtypes/manager.py", line 7, in __iter__
    return self.__values.values()
AttributeError: 'list' object has no attribute 'values'
```
