### PR TITLE
ref(apm): Only use url_name when namespacing urls

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -32,7 +32,7 @@ SAMPLED_URL_NAMES = {
     "sentry-extensions-jira-issue-hook",
     "sentry-api-0-group-integration-details",
     # integration platform
-    "sentry-api-0-group-external-issues",
+    "external-issues",
     "sentry-api-0-sentry-app-authorizations",
 }
 


### PR DESCRIPTION
Added some new backend transactions in https://github.com/getsentry/sentry/pull/23987, including one that I added namespacing for, the `group_external_issues.py` endpoint.

I assumed I could add the name as so:
https://github.com/getsentry/sentry/blob/ad40a73163531ce478453f9e15c5fd85f6f956a1/src/sentry/utils/sdk.py#L35

but turns out that's **not** what it will resolve to:

```python
>>> resolve("/api/0/issues/123123/external-issues/")
ResolverMatch(func=sentry.api.endpoints.group_external_issues.GroupExternalIssuesEndpoint, args=(), kwargs={'issue_id': '123123'}, url_name=external-issues, app_names=[], namespaces=['sentry-api-0-group'])
```

This PR just updates the name to be `external-issues`, so that it will resolve correctly. The reason that I was able to get results locally in https://github.com/getsentry/sentry/pull/23987 was because we fall back on the `SENTRY_BACKEND_APM_SAMPLING` if we can't resolve the url. I had this set to `1` locally 🙃 
