### PR TITLE
feat(metric_alerts): Widen incident window in metric alert details 

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
@@ -19,3 +19,4 @@ export const TIME_WINDOWS = {
 };
 
 export const API_INTERVAL_POINTS_LIMIT = 10000;
+export const API_INTERVAL_POINTS_MIN = 150;


### PR DESCRIPTION
Implement new logic to ensure that there are at least 150 data points to show in the incident viewing graph, but also no more than 10,000 data points. Previously, the range was determined by evaluating a function based on the incident duration, but if the incident duration was very short, say 3 minutes, then the total time period may only be 9 minutes which could possibly be only 1 data point.

**Example incident with 150 data points:**
![image](https://user-images.githubusercontent.com/9372512/108785442-43b3dc80-7526-11eb-9afc-aaa28d8d6ca3.png)
