### PR TITLE
feat: Return default operation breakdown list from project options

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -567,6 +567,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:fingerprinting_rules",
             "sentry:relay_pii_config",
             "sentry:dynamic_sampling",
+            "sentry:breakdowns",
             "feedback:branding",
             "digests:mail:minimum_delay",
             "digests:mail:maximum_delay",
@@ -698,6 +699,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
                 "builtinSymbolSources": get_value_with_default("sentry:builtin_symbol_sources"),
                 "symbolSources": attrs["options"].get("sentry:symbol_sources"),
                 "dynamicSampling": get_value_with_default("sentry:dynamic_sampling"),
+                "breakdowns": get_value_with_default("sentry:breakdowns"),
             }
         )
         return data

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -62,3 +62,16 @@ register(key="filters:localhost", epoch_defaults={1: "0"})
 
 # Default dynamic sampling rules
 register(key="sentry:dynamicSampling", epoch_defaults={1: []})
+
+# Default breakdowns config
+register(
+    key="sentry:breakdowns",
+    epoch_defaults={
+        1: {
+            "span_ops": {
+                "type": "span_operations",
+                "matches": ["http", "db", "browser", "resource"],
+            }
+        },
+    },
+)

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -138,6 +138,11 @@ def get_project_config(project, full_config=True, project_keys=None):
         if dynamic_sampling is not None:
             cfg["config"]["dynamicSampling"] = dynamic_sampling
 
+    if features.has("organizations:performance-ops-breakdown", project.organization):
+        breakdowns_config = project.get_option("sentry:breakdowns")
+        if breakdowns_config is not None:
+            cfg["config"]["breakdowns"] = breakdowns_config
+
     if not full_config:
         # This is all we need for external Relay processors
         return ProjectConfig(project, **cfg)

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/no_ops_breakdown/full_config.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/no_ops_breakdown/full_config.pysnap
@@ -1,0 +1,117 @@
+---
+created: '2021-03-24T22:52:16.803444Z'
+creator: sentry
+source: tests/sentry/relay/test_config.py
+---
+config:
+  allowedDomains:
+  - '*'
+  breakdowns:
+    span_ops:
+      matches:
+      - http
+      - db
+      - browser
+      - resource
+      type: span_operations
+  datascrubbingSettings:
+    excludeFields: []
+    scrubData: true
+    scrubDefaults: true
+    scrubIpAddresses: false
+    sensitiveFields: []
+  eventRetention: null
+  filterSettings:
+    browserExtensions:
+      isEnabled: false
+    csp:
+      disallowedSources:
+      - about
+      - ms-browser-extension
+      - chrome://*
+      - chrome-extension://*
+      - chromeinvokeimmediate://*
+      - chromenull://*
+      - data:text/html,chromewebdata
+      - safari-extension://*
+      - mxaddon-pkg://*
+      - jar://*
+      - webviewprogressproxy://*
+      - ms-browser-extension://*
+      - tmtbff://*
+      - mbinit://*
+      - symres://*
+      - resource://*
+      - moz-extension://*
+      - '*.metrext.com'
+      - static.image2play.com
+      - '*.tlscdn.com'
+      - 73a5b0806e464be8bd4e694c744624f0.com
+      - 020dfefc4ac745dab7594f2f771c1ded.com
+      - '*.superfish.com'
+      - addons.mozilla.org
+      - v.zilionfast.in
+      - widgets.amung.us
+      - '*.superfish.com'
+      - xls.searchfun.in
+      - istatic.datafastguru.info
+      - v.zilionfast.in
+      - localhost
+      - resultshub-a.akamaihd.net
+      - pulseadnetwork.com
+      - gateway.zscalertwo.net
+      - www.passpack.com
+      - middlerush-a.akamaihd.net
+      - www.websmartcenter.com
+      - a.linkluster.com
+      - saveyoutime.ru
+      - cdncache-a.akamaihd.net
+      - x.rafomedia.com
+      - savingsslider-a.akamaihd.net
+      - injections.adguard.com
+      - icontent.us
+      - amiok.org
+      - connectionstrenth.com
+      - siteheart.net
+      - netanalitics.space
+      - printapplink.com
+      - godlinkapp.com
+      - devappstor.com
+      - hoholikik.club
+      - smartlink.cool
+      - promfflinkdev.com
+    legacyBrowsers:
+      isEnabled: false
+    localhost:
+      isEnabled: false
+    webCrawlers:
+      isEnabled: false
+  groupingConfig:
+    enhancements: eJybzDhxY3J-bm5-npWRgaGlroGxrpHxBABcTQcY
+    id: newstyle:2019-10-29
+  piiConfig:
+    applications:
+      $string:
+      - organization:remove_ips_and_macs
+      - project:remove_ips_and_macs
+    rules:
+      organization:remove_ips_and_macs:
+        hide_rule: false
+        redaction:
+          method: remove
+        rules:
+        - '@ip'
+        - '@mac'
+        type: multiple
+      project:remove_ips_and_macs:
+        hide_rule: false
+        redaction:
+          method: remove
+        rules:
+        - '@ip'
+        - '@mac'
+        type: multiple
+  quotas: []
+  trustedRelays: []
+disabled: false
+slug: bar

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/no_ops_breakdown/slim_config.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/no_ops_breakdown/slim_config.pysnap
@@ -1,0 +1,47 @@
+---
+created: '2021-03-24T22:52:16.674401Z'
+creator: sentry
+source: tests/sentry/relay/test_config.py
+---
+config:
+  allowedDomains:
+  - '*'
+  breakdowns:
+    span_ops:
+      matches:
+      - http
+      - db
+      - browser
+      - resource
+      type: span_operations
+  datascrubbingSettings:
+    excludeFields: []
+    scrubData: true
+    scrubDefaults: true
+    scrubIpAddresses: false
+    sensitiveFields: []
+  piiConfig:
+    applications:
+      $string:
+      - organization:remove_ips_and_macs
+      - project:remove_ips_and_macs
+    rules:
+      organization:remove_ips_and_macs:
+        hide_rule: false
+        redaction:
+          method: remove
+        rules:
+        - '@ip'
+        - '@mac'
+        type: multiple
+      project:remove_ips_and_macs:
+        hide_rule: false
+        redaction:
+          method: remove
+        rules:
+        - '@ip'
+        - '@mac'
+        type: multiple
+  trustedRelays: []
+disabled: false
+slug: bar

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/full_config.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/full_config.pysnap
@@ -1,0 +1,109 @@
+---
+created: '2021-03-24T22:52:16.551136Z'
+creator: sentry
+source: tests/sentry/relay/test_config.py
+---
+config:
+  allowedDomains:
+  - '*'
+  datascrubbingSettings:
+    excludeFields: []
+    scrubData: true
+    scrubDefaults: true
+    scrubIpAddresses: false
+    sensitiveFields: []
+  eventRetention: null
+  filterSettings:
+    browserExtensions:
+      isEnabled: false
+    csp:
+      disallowedSources:
+      - about
+      - ms-browser-extension
+      - chrome://*
+      - chrome-extension://*
+      - chromeinvokeimmediate://*
+      - chromenull://*
+      - data:text/html,chromewebdata
+      - safari-extension://*
+      - mxaddon-pkg://*
+      - jar://*
+      - webviewprogressproxy://*
+      - ms-browser-extension://*
+      - tmtbff://*
+      - mbinit://*
+      - symres://*
+      - resource://*
+      - moz-extension://*
+      - '*.metrext.com'
+      - static.image2play.com
+      - '*.tlscdn.com'
+      - 73a5b0806e464be8bd4e694c744624f0.com
+      - 020dfefc4ac745dab7594f2f771c1ded.com
+      - '*.superfish.com'
+      - addons.mozilla.org
+      - v.zilionfast.in
+      - widgets.amung.us
+      - '*.superfish.com'
+      - xls.searchfun.in
+      - istatic.datafastguru.info
+      - v.zilionfast.in
+      - localhost
+      - resultshub-a.akamaihd.net
+      - pulseadnetwork.com
+      - gateway.zscalertwo.net
+      - www.passpack.com
+      - middlerush-a.akamaihd.net
+      - www.websmartcenter.com
+      - a.linkluster.com
+      - saveyoutime.ru
+      - cdncache-a.akamaihd.net
+      - x.rafomedia.com
+      - savingsslider-a.akamaihd.net
+      - injections.adguard.com
+      - icontent.us
+      - amiok.org
+      - connectionstrenth.com
+      - siteheart.net
+      - netanalitics.space
+      - printapplink.com
+      - godlinkapp.com
+      - devappstor.com
+      - hoholikik.club
+      - smartlink.cool
+      - promfflinkdev.com
+    legacyBrowsers:
+      isEnabled: false
+    localhost:
+      isEnabled: false
+    webCrawlers:
+      isEnabled: false
+  groupingConfig:
+    enhancements: eJybzDhxY3J-bm5-npWRgaGlroGxrpHxBABcTQcY
+    id: newstyle:2019-10-29
+  piiConfig:
+    applications:
+      $string:
+      - organization:remove_ips_and_macs
+      - project:remove_ips_and_macs
+    rules:
+      organization:remove_ips_and_macs:
+        hide_rule: false
+        redaction:
+          method: remove
+        rules:
+        - '@ip'
+        - '@mac'
+        type: multiple
+      project:remove_ips_and_macs:
+        hide_rule: false
+        redaction:
+          method: remove
+        rules:
+        - '@ip'
+        - '@mac'
+        type: multiple
+  quotas: []
+  trustedRelays: []
+disabled: false
+slug: bar

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/slim_config.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/slim_config.pysnap
@@ -1,0 +1,39 @@
+---
+created: '2021-03-24T22:52:16.337094Z'
+creator: sentry
+source: tests/sentry/relay/test_config.py
+---
+config:
+  allowedDomains:
+  - '*'
+  datascrubbingSettings:
+    excludeFields: []
+    scrubData: true
+    scrubDefaults: true
+    scrubIpAddresses: false
+    sensitiveFields: []
+  piiConfig:
+    applications:
+      $string:
+      - organization:remove_ips_and_macs
+      - project:remove_ips_and_macs
+    rules:
+      organization:remove_ips_and_macs:
+        hide_rule: false
+        redaction:
+          method: remove
+        rules:
+        - '@ip'
+        - '@mac'
+        type: multiple
+      project:remove_ips_and_macs:
+        hide_rule: false
+        redaction:
+          method: remove
+        rules:
+        - '@ip'
+        - '@mac'
+        type: multiple
+  trustedRelays: []
+disabled: false
+slug: bar

--- a/tests/sentry/relay/test_config.py
+++ b/tests/sentry/relay/test_config.py
@@ -28,27 +28,31 @@ PII_CONFIG = """
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("full", [False, True])
-def test_get_project_config(default_project, insta_snapshot, full):
+@pytest.mark.parametrize("full", [False, True], ids=["slim_config", "full_config"])
+@pytest.mark.parametrize(
+    "has_ops_breakdown", [False, True], ids=["ops_breakdown", "no_ops_breakdown"]
+)
+def test_get_project_config(default_project, insta_snapshot, full, has_ops_breakdown):
     # We could use the default_project fixture here, but we would like to avoid 1) hitting the db 2) creating a mock
     default_project.update_option("sentry:relay_pii_config", PII_CONFIG)
     default_project.organization.update_option("sentry:relay_pii_config", PII_CONFIG)
     keys = ProjectKey.objects.filter(project=default_project)
 
-    cfg = get_project_config(default_project, full_config=full, project_keys=keys)
-    cfg = cfg.to_dict()
+    with Feature({"organizations:performance-ops-breakdown": has_ops_breakdown}):
+        cfg = get_project_config(default_project, full_config=full, project_keys=keys)
+        cfg = cfg.to_dict()
 
-    # Remove keys that change everytime
-    cfg.pop("lastChange")
-    cfg.pop("lastFetch")
-    cfg.pop("rev")
+        # Remove keys that change everytime
+        cfg.pop("lastChange")
+        cfg.pop("lastFetch")
+        cfg.pop("rev")
 
-    # public keys change every time
-    assert cfg.pop("projectId") == default_project.id
-    assert len(cfg.pop("publicKeys")) == len(keys)
-    assert cfg.pop("organizationId") == default_project.organization.id
+        # public keys change every time
+        assert cfg.pop("projectId") == default_project.id
+        assert len(cfg.pop("publicKeys")) == len(keys)
+        assert cfg.pop("organizationId") == default_project.organization.id
 
-    insta_snapshot(cfg)
+        insta_snapshot(cfg)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Add `sentry:breakdowns` project options which will be consumed by Relay in https://github.com/getsentry/relay/pull/934

These project options are hardcoded to a predefined list of span ops: `"http", "db", "browser", "resource"`

Reference: https://getsentry.atlassian.net/browse/VIS-617 and https://getsentry.atlassian.net/browse/VIS-698

The default config will be:

```
{
    "span_ops": {
        "type": "span_operations",
        "matches": ["http", "db", "browser", "resource"],
    }
}
```

## TODO

- [x] add feature flag from https://github.com/getsentry/sentry/pull/24013