### PR TITLE
fix(api): Don't return any HTTP body with a 204 on recent-searches

### DIFF
--- a/src/sentry/api/endpoints/organization_recent_searches.py
+++ b/src/sentry/api/endpoints/organization_recent_searches.py
@@ -70,5 +70,5 @@ class OrganizationRecentSearchesEndpoint(OrganizationEndpoint):
                 remove_excess_recent_searches(organization, request.user, result["type"])
             status = 201 if created else 204
 
-            return Response("", status=status)
+            return Response(status=status)
         return Response(serializer.errors, status=400)


### PR DESCRIPTION
This is changing the response body for both the 201 and the 204, but the
body being returned on 201 was an empty string so there's no value in it
there.

According to the HTTP spec, it's considered incorrect to send back any
body on a 204 since the response means literally "No Content". This is
bad for any HTTP client that actually respects this.

We didn't see any issues because nginx silently sorta fixes this, but
itself ends up yielding a different malformed HTTP response. nginx chops
off the body, but maintains the incorrect `Content-Length: 2` header but
with no body.

This came up since we're attempting to swap in envoy internally for http
routing, and envoy is a little more strict. Instead of silently
"fixing", it actually errors and yields a 503 on these response bodies.

Alternatively, I have no idea why we're returning a "204 No Content"
here when the search is a duplicate, but I don't care to investigate
this or suggest anything different.