### PR TITLE
fix: remove response body on 204 response code

### DIFF
--- a/src/sentry/api/endpoints/project_servicehook_details.py
+++ b/src/sentry/api/endpoints/project_servicehook_details.py
@@ -114,4 +114,4 @@ class ProjectServiceHookDetailsEndpoint(ProjectEndpoint):
                 data=hook.get_audit_log_data(),
             )
 
-        return self.respond(serialize(hook, request.user), status=204)
+        return self.respond(status=204)


### PR DESCRIPTION
We shouldn't have any sort of response body when we send a 204 status code. Also, it's weird to return the deleted object when we delete a service hook.