### PR TITLE
fix(workflow): Set metric alert event types from discover query

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -99,6 +99,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       ...super.getDefaultState(),
 
       dataset: rule.dataset,
+      eventTypes: rule.eventTypes,
       aggregate: rule.aggregate,
       query: rule.query || '',
       timeWindow: rule.timeWindow,

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -75,6 +75,7 @@ describe('Incident Rules Form', function () {
         rule: {
           ...rule,
           id: undefined,
+          eventTypes: ['default'],
         },
       });
 
@@ -90,6 +91,7 @@ describe('Incident Rules Form', function () {
           data: expect.objectContaining({
             name: 'Incident Rule',
             projects: ['project-slug'],
+            eventTypes: ['default'],
           }),
         })
       );


### PR DESCRIPTION
fixes eventTypes not being sent correctly until changed