### PR TITLE
feat(codeowners): POST, PUT, DELETE endpoints

### DIFF
--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -1,11 +1,144 @@
+import logging
+
+from django.db import IntegrityError
+from django.utils import timezone
+
+from rest_framework import serializers, status
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import ProjectCodeOwners
+from sentry.models import (
+    ProjectCodeOwners,
+    ExternalUser,
+    ExternalTeam,
+    RepositoryProjectPathConfig,
+    User,
+)
+from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
+from sentry.ownership.grammar import (
+    parse_code_owners,
+    convert_codeowners_syntax,
+)
+
+from sentry.api.endpoints.project_ownership import ProjectOwnershipSerializer, ProjectOwnershipMixin
+
+logger = logging.getLogger(__name__)
 
 
-class ProjectCodeOwnersEndpoint(ProjectEndpoint):
+class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
+    code_mapping_id = serializers.IntegerField(required=True)
+    raw = serializers.CharField(required=True)
+    organization_integration_id = serializers.IntegerField(required=False)
+
+    class Meta:
+        model = ProjectCodeOwners
+        fields = ["raw", "code_mapping_id", "organization_integration_id"]
+
+    def validate(self, attrs):
+        # If it already exists, set default attrs with existing values
+        if self.instance:
+            attrs = {
+                "raw": self.instance.raw,
+                "code_mapping_id": self.instance.repository_project_path_config,
+                **attrs,
+            }
+
+        if not attrs.get("raw", "").strip():
+            return attrs
+        external_association_err = ""
+        # Get list of team/user names from CODEOWNERS file
+        teamnames, usernames, emails = parse_code_owners(attrs["raw"])
+
+        # Check if there exists Sentry users with the emails listed in CODEOWNERS
+        users = User.objects.filter(email__in=emails)
+        users_emails = [user.email for user in users]
+        users_emails_diff = [email for email in emails if email not in users_emails]
+
+        if len(users_emails_diff):
+            external_association_err += f'The following emails do not have an user associated in Sentry: {", ".join(users_emails_diff)}.'
+
+        # Check if the usernames have an association
+        external_users = ExternalUser.objects.filter(external_name__in=usernames)
+
+        external_users_names = [user.external_name for user in external_users]
+        external_users_diff = [name for name in usernames if name not in external_users_names]
+
+        if len(external_users_diff):
+            external_association_err += f'The following usernames do not have an association in Sentry: {", ".join(external_users_diff)}.'
+
+        # Check if the team names have an association
+        external_teams = ExternalTeam.objects.filter(external_name__in=teamnames)
+
+        external_teams_names = [team.external_name for team in external_teams]
+        external_teams_diff = [name for name in teamnames if name not in external_teams_names]
+
+        if len(external_teams_diff):
+            external_association_err += f'The following team names do not have an association in Sentry: {", ".join(external_teams_diff)}.'
+
+        if len(external_association_err):
+            raise serializers.ValidationError({"raw": external_association_err})
+
+        # Convert CODEOWNERS into IssueOwner syntax
+        users_dict = {
+            user.external_name: user.organizationmember.user.email for user in external_users
+        }
+        teams_dict = {team.external_name: f"#{team.team.slug}" for team in external_teams}
+        emails_dict = {email: email for email in emails}
+        associations = {**users_dict, **teams_dict, **emails_dict}
+
+        issue_owner_rules = convert_codeowners_syntax(
+            attrs["raw"], associations, attrs["code_mapping_id"]
+        )
+
+        # Convert IssueOwner syntax into schema syntax
+        validated_data = ProjectOwnershipSerializer(context=self.context).validate(
+            {"raw": issue_owner_rules}
+        )
+
+        return {**validated_data, **attrs}
+
+    def validate_code_mapping_id(self, code_mapping_id):
+        try:
+            return RepositoryProjectPathConfig.objects.get(
+                id=code_mapping_id, project=self.context["project"]
+            )
+        except RepositoryProjectPathConfig.DoesNotExist:
+            raise serializers.ValidationError("This code mapping does not exist.")
+
+    def create(self, validated_data):
+        # Create a project_ownership record with default values if none exists.
+        ownership = self.context["ownership"]
+        if ownership.id is None:
+            now = timezone.now()
+            ownership.date_created = now
+            ownership.last_updated = now
+            ownership.save()
+
+        # Save projectcodeowners record
+        repository_project_path_config = validated_data.pop("code_mapping_id", None)
+        project = self.context["project"]
+        return ProjectCodeOwners.objects.create(
+            repository_project_path_config=repository_project_path_config,
+            project=project,
+            **validated_data,
+        )
+
+    def update(self, instance, validated_data):
+        if "id" in validated_data:
+            validated_data.pop("id")
+        for key, value in validated_data.items():
+            setattr(self.instance, key, value)
+        try:
+            self.instance.save()
+            return self.instance
+        except IntegrityError:
+            raise serializers.ValidationError(
+                "There already exists an external user association with this external_name and provider."
+            )
+
+
+class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
     def get(self, request, project):
         """
         Retrieve List of CODEOWNERS configurations for a project
@@ -17,4 +150,28 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint):
         """
         codeowners = list(ProjectCodeOwners.objects.filter(project=project))
 
-        return Response(serialize(codeowners, request.user))
+        return Response(serialize(codeowners, request.user), status.HTTP_200_OK)
+
+    def post(self, request, project):
+        """
+        Upload a CODEWONERS for project
+        `````````````
+
+        :pparam string organization_slug: the slug of the organization the
+                                          file belongs to.
+        :pparam string project_slug: the slug of the project to get.
+        :param string raw: the raw CODEOWNERS text
+        :param string codeMappingId: id of the RepositoryProjectPathConfig object
+        :auth: required
+        """
+        serializer = ProjectCodeOwnerSerializer(
+            context={"ownership": self.get_ownership(project), "project": project},
+            data={**request.data},
+        )
+        if serializer.is_valid():
+            project_codeowners = serializer.save()
+            return Response(
+                serialize(project_codeowners, request.user), status=status.HTTP_201_CREATED
+            )
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -53,8 +53,7 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
         user_emails = UserEmail.objects.filter(email__in=emails)
         user_emails_diff = self._validate_association(emails, user_emails, "emails")
 
-        if len(user_emails_diff):
-            external_association_err.extend(user_emails_diff)
+        external_association_err.extend(user_emails_diff)
 
         # Check if the usernames have an association
         external_users = ExternalUser.objects.filter(
@@ -64,8 +63,7 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
 
         external_users_diff = self._validate_association(usernames, external_users, "usernames")
 
-        if len(external_users_diff):
-            external_association_err.extend(external_users_diff)
+        external_association_err.extend(external_users_diff)
 
         # Check if the team names have an association
         external_teams = ExternalTeam.objects.filter(
@@ -75,8 +73,7 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
 
         external_teams_diff = self._validate_association(teamnames, external_teams, "team names")
 
-        if len(external_teams_diff):
-            external_association_err.extend(external_teams_diff)
+        external_association_err.extend(external_teams_diff)
 
         if len(external_association_err):
             raise serializers.ValidationError({"raw": "\n".join(external_association_err)})

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.db import IntegrityError
 from django.utils import timezone
 
 from rest_framework import serializers, status
@@ -149,13 +148,8 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
             validated_data.pop("id")
         for key, value in validated_data.items():
             setattr(self.instance, key, value)
-        try:
-            self.instance.save()
-            return self.instance
-        except IntegrityError:
-            raise serializers.ValidationError(
-                "There already exists an external user association with this external_name and provider."
-            )
+        self.instance.save()
+        return self.instance
 
 
 class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin):

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -169,8 +169,7 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
         Upload a CODEWONERS for project
         `````````````
 
-        :pparam string organization_slug: the slug of the organization the
-                                          file belongs to.
+        :pparam string organization_slug: the slug of the organization.
         :pparam string project_slug: the slug of the project to get.
         :param string raw: the raw CODEOWNERS text
         :param string codeMappingId: id of the RepositoryProjectPathConfig object

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -61,7 +61,10 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
             )
 
         # Check if the usernames have an association
-        external_users = ExternalUser.objects.filter(external_name__in=usernames)
+        external_users = ExternalUser.objects.filter(
+            external_name__in=usernames,
+            organizationmember__organization=self.context["project"].organization,
+        )
 
         external_users_names = [user.external_name for user in external_users]
         external_users_diff = [name for name in usernames if name not in external_users_names]
@@ -74,7 +77,7 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
         # Check if the team names have an association
         external_teams = ExternalTeam.objects.filter(
             external_name__in=teamnames,
-            organizationmember__organization=self.context["project"].organization,
+            team__organization=self.context["project"].organization,
         )
 
         external_teams_names = [team.external_name for team in external_teams]

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -13,7 +13,7 @@ from sentry.models import (
     ExternalUser,
     ExternalTeam,
     RepositoryProjectPathConfig,
-    User,
+    UserEmail,
 )
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.ownership.grammar import (
@@ -51,12 +51,12 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
         teamnames, usernames, emails = parse_code_owners(attrs["raw"])
 
         # Check if there exists Sentry users with the emails listed in CODEOWNERS
-        users = User.objects.filter(email__in=emails)
-        users_emails = [user.email for user in users]
-        users_emails_diff = [email for email in emails if email not in users_emails]
+        user_emails = UserEmail.objects.filter(email__in=emails)
+        user_emails = [user.email for user in user_emails]
+        user_emails_diff = [email for email in emails if email not in user_emails]
 
-        if len(users_emails_diff):
-            external_association_err += f'The following emails do not have an user associated in Sentry: {", ".join(users_emails_diff)}.'
+        if len(user_emails_diff):
+            external_association_err += f'The following emails do not have an user associated in Sentry: {", ".join(user_emails_diff)}.'
 
         # Check if the usernames have an association
         external_users = ExternalUser.objects.filter(external_name__in=usernames)

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -65,7 +65,8 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
         external_users_diff = [name for name in usernames if name not in external_users_names]
 
         if len(external_users_diff):
-            external_association_err += f'The following usernames do not have an association in Sentry: {", ".join(external_users_diff)}.'
+            nl = "\n" if len(external_association_err) else ""
+            external_association_err += f'{nl}The following usernames do not have an association in Sentry: {", ".join(external_users_diff)}.'
 
         # Check if the team names have an association
         external_teams = ExternalTeam.objects.filter(external_name__in=teamnames)
@@ -74,7 +75,8 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
         external_teams_diff = [name for name in teamnames if name not in external_teams_names]
 
         if len(external_teams_diff):
-            external_association_err += f'The following team names do not have an association in Sentry: {", ".join(external_teams_diff)}.'
+            nl = "\n" if len(external_association_err) else ""
+            external_association_err += f'{nl}The following team names do not have an association in Sentry: {", ".join(external_teams_diff)}.'
 
         if len(external_association_err):
             raise serializers.ValidationError({"raw": external_association_err})

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -72,7 +72,10 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
             )
 
         # Check if the team names have an association
-        external_teams = ExternalTeam.objects.filter(external_name__in=teamnames)
+        external_teams = ExternalTeam.objects.filter(
+            external_name__in=teamnames,
+            organizationmember__organization=self.context["project"].organization,
+        )
 
         external_teams_names = [team.external_name for team in external_teams]
         external_teams_diff = [name for name in teamnames if name not in external_teams_names]

--- a/src/sentry/api/endpoints/project_codeowners_details.py
+++ b/src/sentry/api/endpoints/project_codeowners_details.py
@@ -1,0 +1,66 @@
+import logging
+from django.http import Http404
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from sentry.api.bases.project import ProjectEndpoint
+from sentry.api.serializers import serialize
+from sentry.models import ProjectCodeOwners
+
+from .project_codeowners import ProjectCodeOwnerSerializer
+
+from sentry.api.endpoints.project_ownership import ProjectOwnershipMixin
+
+logger = logging.getLogger(__name__)
+
+
+class ProjectCodeOwnersDetailsEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
+    def convert_args(
+        self, request, organization_slug, project_slug, codeowners_id, *args, **kwargs
+    ):
+        args, kwargs = super().convert_args(
+            request, organization_slug, project_slug, *args, **kwargs
+        )
+        try:
+            kwargs["codeowners"] = ProjectCodeOwners.objects.get(
+                id=codeowners_id,
+            )
+        except ProjectCodeOwners.DoesNotExist:
+            raise Http404
+
+        return (args, kwargs)
+
+    def put(self, request, project, codeowners):
+        """
+        Update a CodeOwners
+        `````````````
+
+        :pparam string organization_slug: the slug of the organization the
+                                          file belongs to.
+        :pparam string project_slug: the slug of the project to get.
+        :pparam string codeowners_id: id of codeowners object
+        :param string raw: the raw CODEOWNERS text
+        :param string codeMappingId: id of the RepositoryProjectPathConfig object
+        :auth: required
+        """
+        serializer = ProjectCodeOwnerSerializer(
+            instance=codeowners,
+            context={"ownership": self.get_ownership(project), "project": project},
+            partial=True,
+            data={**request.data},
+        )
+        if serializer.is_valid():
+            updated_codeowners = serializer.save()
+
+            return Response(serialize(updated_codeowners, request.user), status=status.HTTP_200_OK)
+
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+    def delete(self, request, project, codeowners):
+        """
+        Delete a CodeOwners
+        """
+
+        codeowners.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/project_codeowners_details.py
+++ b/src/sentry/api/endpoints/project_codeowners_details.py
@@ -24,7 +24,7 @@ class ProjectCodeOwnersDetailsEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
         )
         try:
             kwargs["codeowners"] = ProjectCodeOwners.objects.get(
-                id=codeowners_id,
+                id=codeowners_id, project=kwargs["project"]
             )
         except ProjectCodeOwners.DoesNotExist:
             raise Http404

--- a/src/sentry/api/endpoints/project_codeowners_details.py
+++ b/src/sentry/api/endpoints/project_codeowners_details.py
@@ -1,9 +1,8 @@
 import logging
-from django.http import Http404
 
 from rest_framework import status
 from rest_framework.response import Response
-
+from rest_framework.exceptions import NotFound
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import ProjectCodeOwners
@@ -27,7 +26,7 @@ class ProjectCodeOwnersDetailsEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
                 id=codeowners_id, project=kwargs["project"]
             )
         except ProjectCodeOwners.DoesNotExist:
-            raise Http404
+            raise NotFound(detail=f"Cannot find a ProjectCodeOwners with id {codeowners_id}")
 
         return (args, kwargs)
 
@@ -36,8 +35,7 @@ class ProjectCodeOwnersDetailsEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
         Update a CodeOwners
         `````````````
 
-        :pparam string organization_slug: the slug of the organization the
-                                          file belongs to.
+        :pparam string organization_slug: the slug of the organization.
         :pparam string project_slug: the slug of the project to get.
         :pparam string codeowners_id: id of codeowners object
         :param string raw: the raw CODEOWNERS text

--- a/src/sentry/api/endpoints/project_codeowners_details.py
+++ b/src/sentry/api/endpoints/project_codeowners_details.py
@@ -2,10 +2,10 @@ import logging
 
 from rest_framework import status
 from rest_framework.response import Response
-from rest_framework.exceptions import NotFound
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import ProjectCodeOwners
+from sentry.api.exceptions import ResourceDoesNotExist
 
 from .project_codeowners import ProjectCodeOwnerSerializer
 
@@ -26,7 +26,7 @@ class ProjectCodeOwnersDetailsEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
                 id=codeowners_id, project=kwargs["project"]
             )
         except ProjectCodeOwners.DoesNotExist:
-            raise NotFound(detail=f"Cannot find a ProjectCodeOwners with id {codeowners_id}")
+            raise ResourceDoesNotExist
 
         return (args, kwargs)
 

--- a/src/sentry/api/endpoints/project_ownership.py
+++ b/src/sentry/api/endpoints/project_ownership.py
@@ -95,13 +95,19 @@ class ProjectOwnershipSerializer(serializers.Serializer):
         return changed
 
 
-class ProjectOwnershipEndpoint(ProjectEndpoint):
+class ProjectOwnershipMixin:
     def get_ownership(self, project):
         try:
             return ProjectOwnership.objects.get(project=project)
         except ProjectOwnership.DoesNotExist:
-            return ProjectOwnership(project=project, date_created=None, last_updated=None)
+            return ProjectOwnership(
+                project=project,
+                date_created=None,
+                last_updated=None,
+            )
 
+
+class ProjectOwnershipEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
     def get(self, request, project):
         """
         Retrieve a Project's Ownership configuration

--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -23,6 +23,7 @@ class ProjectCodeOwnersSerializer(Serializer):
 
     def serialize(self, obj, attrs, user):
         data = {
+            "id": str(obj.id),
             "raw": obj.raw,
             "dateCreated": obj.date_added,
             "dateUpdated": obj.date_updated,

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -222,6 +222,7 @@ from .endpoints.project_keys import ProjectKeysEndpoint
 from .endpoints.project_member_index import ProjectMemberIndexEndpoint
 from .endpoints.project_ownership import ProjectOwnershipEndpoint
 from .endpoints.project_codeowners import ProjectCodeOwnersEndpoint
+from .endpoints.project_codeowners_details import ProjectCodeOwnersDetailsEndpoint
 from .endpoints.project_platforms import ProjectPlatformsEndpoint
 from .endpoints.project_plugin_details import ProjectPluginDetailsEndpoint
 from .endpoints.project_plugins import ProjectPluginsEndpoint
@@ -1696,6 +1697,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/codeowners/$",
                     ProjectCodeOwnersEndpoint.as_view(),
                     name="sentry-api-0-project-codeowners",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<project_slug>[^\/]+)/codeowners/(?P<codeowners_id>[^\/]+)/$",
+                    ProjectCodeOwnersDetailsEndpoint.as_view(),
+                    name="sentry-api-0-project-codeowners-details",
                 ),
                 # Load plugin project urls
                 url(

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -70,6 +70,8 @@ from sentry.models import (
     RepositoryProjectPathConfig,
     Rule,
     ExternalUser,
+    ExternalTeam,
+    ProjectCodeOwners,
 )
 from sentry.models.integrationfeature import Feature, IntegrationFeature
 from sentry.signals import project_created
@@ -955,3 +957,18 @@ class Factories:
         kwargs.setdefault("external_name", "")
 
         return ExternalUser.objects.create(organizationmember=organizationmember, **kwargs)
+
+    @staticmethod
+    def create_external_team(team, **kwargs):
+        kwargs.setdefault("provider", ExternalTeam.get_provider_enum("github"))
+        kwargs.setdefault("external_name", "@getsentry/ecosystem")
+
+        return ExternalTeam.objects.create(team=team, **kwargs)
+
+    @staticmethod
+    def create_codeowners(project, code_mapping, **kwargs):
+        kwargs.setdefault("raw", "")
+
+        return ProjectCodeOwners.objects.create(
+            project=project, repository_project_path_config=code_mapping, **kwargs
+        )

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -302,6 +302,20 @@ class Fixtures:
         organizationmember = OrganizationMember.objects.get(user=user, organization=organization)
         return Factories.create_external_user(organizationmember=organizationmember, **kwargs)
 
+    def create_external_team(self, team=None, **kwargs):
+        if not team:
+            team = self.team
+        return Factories.create_external_team(team=team, **kwargs)
+
+    def create_codeowners(self, project=None, code_mapping=None, **kwargs):
+        if not project:
+            project = self.project
+        if not code_mapping:
+            self.repo = self.create_repo(self.project)
+            code_mapping = self.create_code_mapping(self.project, self.repo)
+
+        return Factories.create_codeowners(project=project, code_mapping=code_mapping, **kwargs)
+
     @pytest.fixture(autouse=True)
     def _init_insta_snapshot(self, insta_snapshot):
         self.insta_snapshot = insta_snapshot

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -1,13 +1,14 @@
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase
-from sentry.models import Integration, ProjectCodeOwners
+from sentry.models import Integration, ProjectCodeOwners, ProjectOwnership
 
 
 class ProjectCodeOwnersEndpointTestCase(APITestCase):
     def setUp(self):
-        self.login_as(user=self.user)
+        self.user = self.create_user("admin@sentry.io", is_superuser=True)
 
+        self.login_as(user=self.user)
         self.team = self.create_team(
             organization=self.organization, slug="tiger-team", members=[self.user]
         )
@@ -15,11 +16,17 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         self.project = self.project = self.create_project(
             organization=self.organization, teams=[self.team], slug="bengal"
         )
-
-        self.path = reverse(
+        self.code_mapping = self.create_code_mapping(project=self.project)
+        self.external_user = self.create_external_user(external_name="@NisanthanNanthakumar")
+        self.external_team = self.create_external_team()
+        self.url = reverse(
             "sentry-api-0-project-codeowners",
             kwargs={"organization_slug": self.organization.slug, "project_slug": self.project.slug},
         )
+        self.data = {
+            "raw": "docs/*    @NisanthanNanthakumar   @getsentry/ecosystem\n",
+            "codeMappingId": self.code_mapping.id,
+        }
 
     def _create_codeowner_with_integration(self):
         self.integration = Integration.objects.create(
@@ -36,8 +43,11 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             integration_id=self.integration.id,
             url="https://github.com/getsentry/sentry",
         )
-        self.code_mapping = self.create_code_mapping(
-            project=self.project, repo=self.repo, organization_integration=self.oi
+        self.code_mapping_with_integration = self.create_code_mapping(
+            project=self.project,
+            repo=self.repo,
+            organization_integration=self.oi,
+            stack_root="webpack://",
         )
         self.code_owner = ProjectCodeOwners.objects.create(
             project=self.project,
@@ -46,33 +56,155 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         )
 
     def test_no_codeowners(self):
-        resp = self.client.get(self.path)
+        resp = self.client.get(self.url)
         assert resp.status_code == 200
         assert resp.data == []
 
     def test_codeowners_without_integrations(self):
-        code_mapping = self.create_code_mapping(project=self.project)
         code_owner = ProjectCodeOwners.objects.create(
             project=self.project,
             raw="*.js @tiger-team",
-            repository_project_path_config=code_mapping,
+            repository_project_path_config=self.code_mapping,
         )
-        resp = self.client.get(self.path)
+        resp = self.client.get(self.url)
         assert resp.status_code == 200
         resp_data = resp.data[0]
         assert resp_data["raw"] == code_owner.raw
         assert resp_data["dateCreated"] == code_owner.date_added
         assert resp_data["dateUpdated"] == code_owner.date_updated
-        assert resp_data["codeMappingId"] == str(code_mapping.id)
+        assert resp_data["codeMappingId"] == str(self.code_mapping.id)
         assert resp_data["provider"] == "unknown"
 
     def test_codeowners_with_integration(self):
         self._create_codeowner_with_integration()
-        resp = self.client.get(self.path)
+        resp = self.client.get(self.url)
         assert resp.status_code == 200
         resp_data = resp.data[0]
         assert resp_data["raw"] == self.code_owner.raw
         assert resp_data["dateCreated"] == self.code_owner.date_added
         assert resp_data["dateUpdated"] == self.code_owner.date_updated
-        assert resp_data["codeMappingId"] == str(self.code_mapping.id)
+        assert resp_data["codeMappingId"] == str(self.code_mapping_with_integration.id)
         assert resp_data["provider"] == self.integration.provider
+
+    def test_basic_post(self):
+
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 201, response.content
+        assert response.data["id"]
+        assert {
+            "raw": "docs/*    @NisanthanNanthakumar   @getsentry/ecosystem",
+            "codeMappingId": str(self.code_mapping.id),
+            "provider": "unknown",
+        }.items() <= response.data.items()
+
+    def test_cannot_find_external_user_name_association(self):
+        self.data["raw"] = "docs/*  @MeredithAnya "
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 400
+        assert response.data == {
+            "raw": ["The following usernames do not have an association in Sentry: @MeredithAnya."]
+        }
+
+    def test_cannot_find_sentry_user_with_email(self):
+        self.data["raw"] = "docs/*  someuser@sentry.io"
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 400
+        assert response.data == {
+            "raw": [
+                "The following emails do not have an user associated in Sentry: someuser@sentry.io."
+            ]
+        }
+
+    def test_cannot_find_external_team_name_association(self):
+        self.data["raw"] = "docs/*  @getsentry/frontend"
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 400
+        assert response.data == {
+            "raw": [
+                "The following team names do not have an association in Sentry: @getsentry/frontend."
+            ]
+        }
+
+    def test_cannot_find__multiple_external_name_association(self):
+        self.data["raw"] = "docs/*  @AnotherUser @getsentry/frontend @getsentry/docs"
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 400
+        assert response.data == {
+            "raw": [
+                "The following usernames do not have an association in Sentry: @AnotherUser.The following team names do not have an association in Sentry: @getsentry/frontend, @getsentry/docs."
+            ]
+        }
+
+    def test_missing_code_mapping_id(self):
+        self.data.pop("codeMappingId")
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 400
+        assert response.data == {"codeMappingId": ["This field is required."]}
+
+    def test_invalid_code_mapping_id(self):
+        self.data["codeMappingId"] = 500
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 400
+        assert response.data == {"codeMappingId": ["This code mapping does not exist."]}
+
+    def test_default_project_ownership_record_created(self):
+        assert ProjectOwnership.objects.filter(project=self.project).exists() is False
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 201, response.content
+        assert ProjectOwnership.objects.filter(project=self.project).exists() is True
+
+    def test_schema_is_correct(self):
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 201, response.content
+        assert response.data["id"]
+        project_codeowners = ProjectCodeOwners.objects.get(id=response.data["id"])
+        assert project_codeowners.schema == {
+            "$version": 1,
+            "rules": [
+                {
+                    "matcher": {"pattern": "docs/*", "type": "path"},
+                    "owners": [
+                        {"identifier": self.user.email, "type": "user"},
+                        {"identifier": self.team.slug, "type": "team"},
+                    ],
+                }
+            ],
+        }
+
+    def test_schema_preserves_comments(self):
+        self.data["raw"] = "docs/*    @NisanthanNanthakumar   @getsentry/ecosystem\n"
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 201, response.content
+        assert response.data["id"]
+        project_codeowners = ProjectCodeOwners.objects.get(id=response.data["id"])
+        assert project_codeowners.schema == {
+            "$version": 1,
+            "rules": [
+                {
+                    "matcher": {"pattern": "docs/*", "type": "path"},
+                    "owners": [
+                        {"identifier": self.user.email, "type": "user"},
+                        {"identifier": self.team.slug, "type": "team"},
+                    ],
+                }
+            ],
+        }
+
+    def test_raw_email_correct_schema(self):
+        self.data["raw"] = f"docs/*    {self.user.email}   @getsentry/ecosystem\n"
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 201, response.content
+        assert response.data["id"]
+        project_codeowners = ProjectCodeOwners.objects.get(id=response.data["id"])
+        assert project_codeowners.schema == {
+            "$version": 1,
+            "rules": [
+                {
+                    "matcher": {"pattern": "docs/*", "type": "path"},
+                    "owners": [
+                        {"identifier": self.user.email, "type": "user"},
+                        {"identifier": self.team.slug, "type": "team"},
+                    ],
+                }
+            ],
+        }

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -143,7 +143,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert response.status_code == 400
         assert response.data == {
             "raw": [
-                "The following usernames do not have an association in Sentry: @AnotherUser.The following team names do not have an association in Sentry: @getsentry/frontend, @getsentry/docs."
+                "The following usernames do not have an association in Sentry: @AnotherUser.\nThe following team names do not have an association in Sentry: @getsentry/frontend, @getsentry/docs."
             ]
         }
 

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -117,7 +117,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert response.status_code == 400
         assert response.data == {
             "raw": [
-                "The following emails do not have an user associated in Sentry: someuser@sentry.io."
+                "The following emails do not have an association in Sentry: someuser@sentry.io."
             ]
         }
 

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -97,6 +97,18 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             "provider": "unknown",
         }.items() <= response.data.items()
 
+    def test_empty_codeowners_text(self):
+        self.data["raw"] = ""
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 400
+        assert response.data == {"raw": ["This field may not be blank."]}
+
+    def test_invalid_codeowners_text(self):
+        self.data["raw"] = "docs/*"
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 400
+        assert response.data == {"raw": ["Parse error: 'ownership' (line 1, column 1)"]}
+
     def test_cannot_find_external_user_name_association(self):
         self.data["raw"] = "docs/*  @MeredithAnya "
         response = self.client.post(self.url, self.data)

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -49,10 +49,8 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             organization_integration=self.oi,
             stack_root="webpack://",
         )
-        self.code_owner = ProjectCodeOwners.objects.create(
-            project=self.project,
-            raw="*.js @tiger-team",
-            repository_project_path_config=self.code_mapping,
+        self.code_owner = self.create_codeowners(
+            self.project, self.code_mapping_with_integration, raw="*.js @tiger-team"
         )
 
     def test_no_codeowners(self):
@@ -61,11 +59,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert resp.data == []
 
     def test_codeowners_without_integrations(self):
-        code_owner = ProjectCodeOwners.objects.create(
-            project=self.project,
-            raw="*.js @tiger-team",
-            repository_project_path_config=self.code_mapping,
-        )
+        code_owner = self.create_codeowners(self.project, self.code_mapping, raw="*.js @tiger-team")
         resp = self.client.get(self.url)
         assert resp.status_code == 200
         resp_data = resp.data[0]

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -51,6 +51,20 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         assert response.data["id"] == str(self.codeowners.id)
         assert response.data["raw"] == data["raw"].strip()
 
+    def test_wrong_codeowners_id(self):
+        self.url = reverse(
+            "sentry-api-0-project-codeowners-details",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "codeowners_id": 1000,
+            },
+        )
+
+        response = self.client.put(self.url, self.data)
+        assert response.status_code == 404
+        assert response.data == {"detail": "Cannot find a ProjectCodeOwners with id 1000"}
+
     def test_missing_external_associations_update(self):
         data = {
             "raw": "\n# cool stuff comment\n*.js                    @getsentry/frontend @NisanthanNanthakumar\n# good comment\n\n\n  docs/*  @getsentry/docs @getsentry/ecosystem\nsrc/sentry/*       @AnotherUser\n\n"

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -59,7 +59,7 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         assert response.status_code == 400
         assert response.data == {
             "raw": [
-                "The following usernames do not have an association in Sentry: @AnotherUser.The following team names do not have an association in Sentry: @getsentry/frontend, @getsentry/docs."
+                "The following usernames do not have an association in Sentry: @AnotherUser.\nThe following team names do not have an association in Sentry: @getsentry/frontend, @getsentry/docs."
             ]
         }
 

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -1,0 +1,75 @@
+from django.core.urlresolvers import reverse
+
+from sentry.testutils import APITestCase
+from sentry.models import ProjectCodeOwners
+
+
+class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
+    def setUp(self):
+        self.user = self.create_user("admin@sentry.io", is_superuser=True)
+
+        self.login_as(user=self.user)
+
+        self.team = self.create_team(
+            organization=self.organization, slug="tiger-team", members=[self.user]
+        )
+
+        self.project = self.project = self.create_project(
+            organization=self.organization, teams=[self.team], slug="bengal"
+        )
+        self.code_mapping = self.create_code_mapping(project=self.project)
+        self.external_user = self.create_external_user(external_name="@NisanthanNanthakumar")
+        self.external_team = self.create_external_team()
+        self.data = {
+            "raw": "docs/*    @NisanthanNanthakumar   @getsentry/ecosystem\n",
+        }
+        self.codeowners = self.create_codeowners(
+            project=self.project, code_mapping=self.code_mapping
+        )
+        self.url = reverse(
+            "sentry-api-0-project-codeowners-details",
+            kwargs={
+                "organization_slug": self.organization.slug,
+                "project_slug": self.project.slug,
+                "codeowners_id": self.codeowners.id,
+            },
+        )
+
+    def test_basic_delete(self):
+        response = self.client.delete(self.url)
+        assert response.status_code == 204
+        assert not ProjectCodeOwners.objects.filter(id=str(self.codeowners.id)).exists()
+
+    def test_basic_update(self):
+        self.create_external_team(external_name="@getsentry/frontend")
+        self.create_external_team(external_name="@getsentry/docs")
+        data = {
+            "raw": "\n# cool stuff comment\n*.js                    @getsentry/frontend @NisanthanNanthakumar\n# good comment\n\n\n  docs/*  @getsentry/docs @getsentry/ecosystem\n\n"
+        }
+        response = self.client.put(self.url, data)
+        assert response.status_code == 200
+        assert response.data["id"] == str(self.codeowners.id)
+        assert response.data["raw"] == data["raw"].strip()
+
+    def test_missing_external_associations_update(self):
+        data = {
+            "raw": "\n# cool stuff comment\n*.js                    @getsentry/frontend @NisanthanNanthakumar\n# good comment\n\n\n  docs/*  @getsentry/docs @getsentry/ecosystem\nsrc/sentry/*       @AnotherUser\n\n"
+        }
+        response = self.client.put(self.url, data)
+        assert response.status_code == 400
+        assert response.data == {
+            "raw": [
+                "The following usernames do not have an association in Sentry: @AnotherUser.The following team names do not have an association in Sentry: @getsentry/frontend, @getsentry/docs."
+            ]
+        }
+
+    def test_invalid_code_mapping_id_update(self):
+        response = self.client.put(self.url, {"codeMappingId": 500})
+        assert response.status_code == 400
+        assert response.data == {"codeMappingId": ["This code mapping does not exist."]}
+
+    def test_codeowners_email_update(self):
+        data = {"raw": f"\n# cool stuff comment\n*.js {self.user.email}\n# good comment\n\n\n"}
+        response = self.client.put(self.url, data)
+        assert response.status_code == 200
+        assert response.data["raw"] == "# cool stuff comment\n*.js admin@sentry.io\n# good comment"

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -63,7 +63,7 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
 
         response = self.client.put(self.url, self.data)
         assert response.status_code == 404
-        assert response.data == {"detail": "Cannot find a ProjectCodeOwners with id 1000"}
+        assert response.data == {"detail": "The requested resource does not exist"}
 
     def test_missing_external_associations_update(self):
         data = {

--- a/tests/sentry/ownership/test_grammar.py
+++ b/tests/sentry/ownership/test_grammar.py
@@ -35,7 +35,7 @@ codeowners_fixture_data = """
 
   docs/*  @getsentry/docs @getsentry/ecosystem
 src/sentry/*       @AnotherUser
-
+api/*    nisanthan.nanthakumar@sentry.io
 """
 
 
@@ -189,6 +189,7 @@ def test_parse_code_owners():
     assert parse_code_owners(codeowners_fixture_data) == (
         ["@getsentry/frontend", "@getsentry/docs", "@getsentry/ecosystem"],
         ["@NisanthanNanthakumar", "@AnotherUser"],
+        ["nisanthan.nanthakumar@sentry.io"],
     )
 
 
@@ -205,8 +206,9 @@ def test_convert_codeowners_syntax():
                 "@getsentry/ecosystem": "ecosystem",
                 "@NisanthanNanthakumar": "nisanthan.nanthakumar@sentry.io",
                 "@AnotherUser": "anotheruser@sentry.io",
+                "nisanthan.nanthakumar@sentry.io": "nisanthan.nanthakumar@sentry.io",
             },
             code_mapping,
         )
-        == "\n# cool stuff comment\npath:*.js front-sentry nisanthan.nanthakumar@sentry.io\n# good comment\n\n\npath:webpack://docs/* docs-sentry ecosystem\npath:src/sentry/* anotheruser@sentry.io\n\n"
+        == "\n# cool stuff comment\npath:*.js front-sentry nisanthan.nanthakumar@sentry.io\n# good comment\n\n\npath:webpack://docs/* docs-sentry ecosystem\npath:src/sentry/* anotheruser@sentry.io\npath:api/* nisanthan.nanthakumar@sentry.io\n"
     )


### PR DESCRIPTION
## Objective:
Before saving a record in the `sentry_projectcodeowners` table, we need to do some validation/transformations.
- we need to transform CODEOWNERS syntax into IssueOwner syntax. Then we can reuse existing logic to tranform IssueOwner syntax into the schema.
- we need to validate that all the usernames, team names and emails in the CODEOWNERS file has an association in Sentry.
- we need to transform the file paths in CODEOWNERS with the code path mappings in Sentry.
- we need to create a default record in `sentry_projectownership` table if none exists, to create default settings

## Test Plan:
I wrote unit tests for the grammar functions and endpoint integration tests

## Future:
We need to create a migration to remove the `organization_integration` column from `sentry_projectcodeowners` table. We already have a reference to it from `repository_project_path_config` foreignkey column and it is possible to update both tables independantly, increasing the chances of a drift in consistency.