### PR TITLE
fix (serverless): Better handling for missing role exception + fixed bug

### DIFF
--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -31,10 +31,9 @@ from .utils import (
     enable_single_lambda,
     disable_single_lambda,
     get_dsn_for_project,
-    get_invalid_layer_name,
     wrap_lambda_updater,
     ALL_AWS_REGIONS,
-    INVALID_LAYER_TEXT,
+    get_sentry_err_message,
 )
 
 logger = logging.getLogger("sentry.integrations.aws_lambda")
@@ -380,10 +379,8 @@ class AwsLambdaSetupLayerPipelineView(PipelineView):
                 else:
                     # need to make sure we catch any error to continue to the next function
                     err_message = str(e)
-                    invalid_layer = get_invalid_layer_name(err_message)
-                    if invalid_layer:
-                        err_message = _(INVALID_LAYER_TEXT) % invalid_layer
-                    else:
+                    is_custom_err, err_message = get_sentry_err_message(err_message)
+                    if not is_custom_err:
                         capture_exception(e)
                         err_message = _("Unknown Error")
                     failures.append({"name": function["FunctionName"], "error": err_message})

--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -23,6 +23,12 @@ SUPPORTED_RUNTIMES = [
 ]
 
 INVALID_LAYER_TEXT = "Invalid existing layer %s"
+MISSING_ROLE_TEXT = (
+    "An error occurred (InvalidParameterValueException) when "
+    "calling the UpdateFunctionConfiguration operation: "
+    "The role defined for the function cannot be "
+    "assumed by Lambda"
+)
 
 DEFAULT_NUM_RETRIES = 3
 
@@ -313,6 +319,15 @@ def get_invalid_layer_name(err_message):
     return None
 
 
+def get_missing_role_error(err_message):
+    """
+    Check to see if an error matches the missing role text
+    :param err_message: error string
+    :return boolean value if the error matches the missing role text
+    """
+    return err_message == MISSING_ROLE_TEXT
+
+
 def wrap_lambda_updater():
     """
     Wraps any function that updates a layer
@@ -330,6 +345,10 @@ def wrap_lambda_updater():
                 # only have one specific error to catch
                 if invalid_layer:
                     raise IntegrationError(_(INVALID_LAYER_TEXT) % invalid_layer)
+                # check if error raised is a missing role message
+                missing_role = get_missing_role_error(err_message)
+                if missing_role:
+                    raise IntegrationError(_(MISSING_ROLE_TEXT))
                 # otherwise, re-raise the original error
                 raise
 

--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -23,12 +23,7 @@ SUPPORTED_RUNTIMES = [
 ]
 
 INVALID_LAYER_TEXT = "Invalid existing layer %s"
-MISSING_ROLE_TEXT = (
-    "An error occurred (InvalidParameterValueException) when "
-    "calling the UpdateFunctionConfiguration operation: "
-    "The role defined for the function cannot be "
-    "assumed by Lambda"
-)
+MISSING_ROLE_TEXT = "Invalid role associated with the lambda function"
 
 DEFAULT_NUM_RETRIES = 3
 
@@ -325,7 +320,13 @@ def get_missing_role_error(err_message):
     :param err_message: error string
     :return boolean value if the error matches the missing role text
     """
-    return err_message == MISSING_ROLE_TEXT
+    missing_role_err = (
+        "An error occurred (InvalidParameterValueException) when "
+        "calling the UpdateFunctionConfiguration operation: "
+        "The role defined for the function cannot be "
+        "assumed by Lambda."
+    )
+    return err_message == missing_role_err
 
 
 def wrap_lambda_updater():

--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -214,8 +214,19 @@ def enable_single_lambda(lambda_client, function, sentry_project_dsn, retries_le
             {"NODE_OPTIONS": "-r @sentry/serverless/dist/awslambda-auto", **sentry_env_variables}
         )
     elif runtime.startswith("python"):
+        # This tries to set the `SENTRY_INITIAL_HANDLER` to the already existing
+        # value in env variables and if it does not exist it sets to the
+        # function handler. This is important in the case where we try
+        # to re-enable and already enabled lambda function so that the
+        # env variable `SENTRY_INITIAL_HANDLER` does not get overridden
+        # with an incorrect value
+        sentry_initial_handler = (
+            env_variables["SENTRY_INITIAL_HANDLER"]
+            if "SENTRY_INITIAL_HANDLER" in env_variables
+            else function["Handler"]
+        )
         env_variables.update(
-            {"SENTRY_INITIAL_HANDLER": function["Handler"], **sentry_env_variables}
+            {"SENTRY_INITIAL_HANDLER": sentry_initial_handler, **sentry_env_variables}
         )
         updated_handler = "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler"
 

--- a/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_serverless_functions.py
@@ -381,3 +381,71 @@ class OrganizationIntegrationServerlessFunctionsPostTest(AbstractServerlessTest)
                 "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
             ],
         )
+
+    @patch.object(AwsLambdaIntegration, "get_serialized_lambda_function")
+    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    def test_enable_python_layer_on_already_enabled(
+        self, mock_gen_aws_client, mock_get_serialized_lambda_function
+    ):
+        """
+        Test that ensures that if sentry-sdk is already enabled, then
+        re-enabling it should not override the env variables since it could be
+        problematic since the SENTRY_INITIAL_HANDLER env variable could be overriden
+        the second time with "sentry_sdk.integrations.init_serverless_sdk.
+        sentry_lambda_handler" and then disabling the sentry-sdk, would break
+        the function because the Handler will be updated with an incorrect
+        SENTRY_INITIAL_HANDLER value
+        """
+        mock_client = Mock()
+        mock_gen_aws_client.return_value = mock_client
+
+        mock_client.get_function = MagicMock(
+            return_value={
+                "Configuration": {
+                    "FunctionName": "lambdaZ",
+                    "Runtime": "python3.8",
+                    "Handler": "sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+                    "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaZ",
+                    "Layers": [
+                        "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                        "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
+                    ],
+                    "Environment": {
+                        "Variables": {
+                            "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
+                            "SENTRY_DSN": self.sentry_dsn,
+                            "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                        }
+                    },
+                },
+            }
+        )
+        mock_client.update_function_configuration = MagicMock()
+        return_value = {
+            "name": "lambdaZ",
+            "runtime": "python3.8",
+            "version": 3,
+            "outOfDate": False,
+            "enabled": True,
+        }
+        mock_get_serialized_lambda_function.return_value = return_value
+
+        assert self.get_response(action="enable", target="lambdaZ").data == return_value
+
+        mock_client.get_function.assert_called_with(FunctionName="lambdaZ")
+
+        mock_client.update_function_configuration.assert_called_with(
+            FunctionName="lambdaZ",
+            Layers=[
+                "arn:aws:lambda:us-east-2:1234:layer:something-else:2",
+                "arn:aws:lambda:us-east-2:1234:layer:my-python-layer:34",
+            ],
+            Environment={
+                "Variables": {
+                    "SENTRY_INITIAL_HANDLER": "lambda_handler.test_handler",
+                    "SENTRY_DSN": self.sentry_dsn,
+                    "SENTRY_TRACES_SAMPLE_RATE": "1.0",
+                }
+            },
+            Handler="sentry_sdk.integrations.init_serverless_sdk.sentry_lambda_handler",
+        )


### PR DESCRIPTION
This PR fixes two points:
- A fix for a bug discovered that loses the `SENTRY_INITIAL_HANDLER` value if I re-enable an already enabled AWS lambda python function
- Catch a known error that has to do with missing role when trying to enable a lambda function