### PR TITLE
ref: migrate to ComingSoon

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/comingSoon.tsx
+++ b/src/sentry/static/sentry/app/components/acl/comingSoon.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 
 import Alert from 'app/components/alert';
-import {IconInfo} from 'app/icons';
+import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 
+export const comingSoonText = t(
+  'This feature has not been enabled for the current user, project, organization, or Sentry instance.'
+);
+
 const ComingSoon = () => (
-  <Alert type="info" icon={<IconInfo size="md" />}>
-    {t('This feature is coming soon!')}
+  <Alert type="warning" icon={<IconWarning size="md" />}>
+    {comingSoonText}
   </Alert>
 );
 

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -5,8 +5,8 @@ import flatten from 'lodash/flatten';
 import omit from 'lodash/omit';
 
 import {promptsCheck, promptsUpdate} from 'app/actionCreators/prompts';
+import ComingSoon from 'app/components/acl/comingSoon';
 import Feature from 'app/components/acl/feature';
-import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
@@ -324,7 +324,7 @@ class IncidentsListContainer extends React.Component<Props> {
     return (
       <Layout.Body>
         <Layout.Main fullWidth>
-          <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+          <ComingSoon />
         </Layout.Main>
       </Layout.Body>
     );

--- a/src/sentry/static/sentry/app/views/discover/index.tsx
+++ b/src/sentry/static/sentry/app/views/discover/index.tsx
@@ -3,9 +3,8 @@ import DocumentTitle from 'react-document-title';
 import {browserHistory, WithRouterProps} from 'react-router';
 
 import {updateDateTime, updateProjects} from 'app/actionCreators/globalSelection';
+import ComingSoon from 'app/components/acl/comingSoon';
 import Feature from 'app/components/acl/feature';
-import Alert from 'app/components/alert';
-import {t} from 'app/locale';
 import {GlobalSelection, Organization} from 'app/types';
 import {getUserTimezone, getUtcToLocalDateObject} from 'app/utils/dates';
 import {getDiscoverLandingUrl} from 'app/utils/discover/urls';
@@ -213,7 +212,7 @@ class DiscoverContainer extends React.Component<Props, State> {
     ) {
       return <Redirect router={router} to={getDiscoverLandingUrl(organization)} />;
     } else {
-      return <Alert type="warning">{t("You don't have access to this feature")}</Alert>;
+      return <ComingSoon />;
     }
   };
 

--- a/src/sentry/static/sentry/app/views/eventsV2/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
+import ComingSoon from 'app/components/acl/comingSoon';
 import Feature from 'app/components/acl/feature';
-import Alert from 'app/components/alert';
-import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
 import {Organization} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
@@ -15,7 +14,7 @@ class DiscoverContainer extends React.Component<Props> {
   renderNoAccess() {
     return (
       <PageContent>
-        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+        <ComingSoon />
       </PageContent>
     );
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -7,8 +7,8 @@ import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import {stringify} from 'query-string';
 
+import ComingSoon from 'app/components/acl/comingSoon';
 import Feature from 'app/components/acl/feature';
-import Alert from 'app/components/alert';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
@@ -312,7 +312,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
   renderNoAccess() {
     return (
       <PageContent>
-        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+        <ComingSoon />
       </PageContent>
     );
   }

--- a/src/sentry/static/sentry/app/views/performance/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
+import ComingSoon from 'app/components/acl/comingSoon';
 import Feature from 'app/components/acl/feature';
-import Alert from 'app/components/alert';
-import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
 import {Organization} from 'app/types';
 import withOrganization from 'app/utils/withOrganization';
@@ -15,7 +14,7 @@ class PerformanceContainer extends React.Component<Props> {
   renderNoAccess() {
     return (
       <PageContent>
-        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+        <ComingSoon />
       </PageContent>
     );
   }

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/index.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import Feature from 'app/components/acl/feature';
-import Alert from 'app/components/alert';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
@@ -65,10 +64,6 @@ class TransactionVitals extends React.Component<Props> {
     return [t('Summary'), t('Vitals')].join(' \u2014 ');
   }
 
-  renderNoAccess = () => {
-    return <Alert type="warning">{t("You don't have access to this feature")}</Alert>;
-  };
-
   render() {
     const {organization, projects, location} = this.props;
     const {eventView} = this.state;
@@ -98,7 +93,7 @@ class TransactionVitals extends React.Component<Props> {
         <Feature
           features={['performance-view']}
           organization={organization}
-          renderDisabled={this.renderNoAccess}
+          renderDisabled
         >
           <GlobalSelectionHeader
             lockedMessageSubject={t('transaction')}

--- a/src/sentry/static/sentry/app/views/projectDetail/index.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
+import ComingSoon from 'app/components/acl/comingSoon';
 import Feature from 'app/components/acl/feature';
-import Alert from 'app/components/alert';
-import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -17,7 +16,7 @@ function ProjectDetailContainer(
   function renderNoAccess() {
     return (
       <PageContent>
-        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+        <ComingSoon />
       </PageContent>
     );
   }

--- a/src/sentry/static/sentry/app/views/projectDetail/projectQuickLinks.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectQuickLinks.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
+import {comingSoonText} from 'app/components/acl/comingSoon';
 import {SectionHeading} from 'app/components/charts/styles';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
 import Tooltip from 'app/components/tooltip';
@@ -73,10 +74,7 @@ function ProjectQuickLinks({organization, project, location}: Props) {
         .sort((link1, link2) => Number(!!link1.disabled) - Number(!!link2.disabled))
         .map(({title, to, disabled}) => (
           <div key={title}>
-            <Tooltip
-              title={t("You don't have access to this feature")}
-              disabled={!disabled}
-            >
+            <Tooltip title={comingSoonText} disabled={!disabled}>
               <QuickLink to={to} disabled={disabled}>
                 <IconLink />
                 <QuickLinkText>{title}</QuickLinkText>

--- a/src/sentry/static/sentry/app/views/settings/account/mobileApp/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/mobileApp/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
-import Alert from 'app/components/alert';
-import {t} from 'app/locale';
+import ComingSoon from 'app/components/acl/comingSoon';
 import ConfigStore from 'app/stores/configStore';
 import {PageContent} from 'app/styles/organization';
 
@@ -11,7 +10,7 @@ class MobileAppContainer extends React.Component<MobileApp['props']> {
   renderNoAccess() {
     return (
       <PageContent>
-        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+        <ComingSoon />
       </PageContent>
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/projectProguard/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectProguard/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
+import ComingSoon from 'app/components/acl/comingSoon';
 import Feature from 'app/components/acl/feature';
-import Alert from 'app/components/alert';
-import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -12,7 +11,7 @@ class ProjectProguardContainer extends React.Component<ProjectProguard['props']>
   renderNoAccess() {
     return (
       <PageContent>
-        <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+        <ComingSoon />
       </PageContent>
     );
   }

--- a/tests/js/spec/views/discover/index.spec.jsx
+++ b/tests/js/spec/views/discover/index.spec.jsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 
+import {comingSoonText} from 'app/components/acl/comingSoon';
 import DiscoverContainerWithStore, {DiscoverContainer} from 'app/views/discover';
 
 describe('DiscoverContainer', function () {
@@ -315,7 +316,7 @@ describe('DiscoverContainer', function () {
         />,
         TestStubs.routerContext()
       );
-      expect(wrapper.text()).toBe("You don't have access to this feature");
+      expect(wrapper.text()).toBe(comingSoonText);
     });
   });
 });

--- a/tests/js/spec/views/eventsV2/index.spec.jsx
+++ b/tests/js/spec/views/eventsV2/index.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 
+import {comingSoonText} from 'app/components/acl/comingSoon';
 import {DiscoverLanding} from 'app/views/eventsV2/landing';
 
 describe('EventsV2 > Landing', function () {
@@ -86,6 +87,6 @@ describe('EventsV2 > Landing', function () {
     );
 
     const content = wrapper.find('PageContent');
-    expect(content.text()).toContain("You don't have access to this feature");
+    expect(content.text()).toContain(comingSoonText);
   });
 });

--- a/tests/js/spec/views/performance/transactionVitals.spec.jsx
+++ b/tests/js/spec/views/performance/transactionVitals.spec.jsx
@@ -4,6 +4,7 @@ import {browserHistory} from 'react-router';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
+import {comingSoonText} from 'app/components/acl/comingSoon';
 import ProjectsStore from 'app/stores/projectsStore';
 import TransactionVitals from 'app/views/performance/transactionVitals';
 import {VITAL_GROUPS, ZOOM_KEYS} from 'app/views/performance/transactionVitals/constants';
@@ -121,7 +122,7 @@ describe('Performance > Web Vitals', function () {
     await tick();
     wrapper.update();
 
-    expect(wrapper.text()).toEqual("You don't have access to this feature");
+    expect(wrapper.text()).toEqual(comingSoonText);
   });
 
   it('renders the basic UI components', async function () {

--- a/tests/js/spec/views/projectDetail/projectQuickLinks.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectQuickLinks.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
+import {comingSoonText} from 'app/components/acl/comingSoon';
 import ProjectQuickLinks from 'app/views/projectDetail/projectQuickLinks';
 
 describe('ProjectDetail > ProjectQuickLinks', function () {
@@ -64,7 +65,7 @@ describe('ProjectDetail > ProjectQuickLinks', function () {
 
     expect(keyTransactions.prop('disabled')).toBeTruthy();
     expect(keyTransactions.find('a').exists()).toBeFalsy();
-    expect(tooltip.prop('title')).toBe("You don't have access to this feature");
+    expect(tooltip.prop('title')).toBe(comingSoonText);
     expect(tooltip.prop('disabled')).toBeFalsy();
   });
 });


### PR DESCRIPTION
Currently, behavior when a feature flag is not available is inconsistent. Some
features show "You don't have access to this feature", some show "This feature
is coming soon". The former message was confusing to me as a new Sentry
self-hoster, leading me to suspect that something was wrong with my UI setup,
when in fact the feature wasn't enabled at all on the server.

Therefore, change the message, and refactor along the way to reduce string
duplication.