### PR TITLE
ci(feat): Do not invalidate CI cache for patch Python version uprades

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Set python version output
         id: python-version
         run: |
-          echo "::set-output name=python-version::$(cat .python-version)"
+          echo "::set-output name=python-version::$(cat .python-version | sed -r 's/^([0-9]+.[0-9]+)(\.[0-9]+)$/\1/')"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2

--- a/.github/workflows/api-docs-test.yml
+++ b/.github/workflows/api-docs-test.yml
@@ -30,7 +30,7 @@ jobs:
         id: python-version
         if: steps.changes.outputs.api_docs == 'true'
         run: |
-          echo "::set-output name=python-version::$(cat .python-version)"
+          echo "::set-output name=python-version::$(cat .python-version | sed -r 's/^([0-9]+.[0-9]+)(\.[0-9]+)$/\1/')"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2

--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -42,7 +42,7 @@ jobs:
         id: python-version
         if: steps.changes.outputs.backend == 'true'
         run: |
-          echo "::set-output name=python-version::$(cat .python-version)"
+          echo "::set-output name=python-version::$(cat .python-version | sed -r 's/^([0-9]+.[0-9]+)(\.[0-9]+)$/\1/')"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -40,7 +40,7 @@ jobs:
         id: python-version
         if: steps.changes.outputs.backend == 'true'
         run: |
-          echo "::set-output name=python-version::$(cat .python-version)"
+          echo "::set-output name=python-version::$(cat .python-version | sed -r 's/^([0-9]+.[0-9]+)(\.[0-9]+)$/\1/')"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2

--- a/.github/workflows/check-if-migration-is-required.yml
+++ b/.github/workflows/check-if-migration-is-required.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set python version output
         id: python-version
         run: |
-          echo "::set-output name=python-version::$(cat .python-version)"
+          echo "::set-output name=python-version::$(cat .python-version | sed -r 's/^([0-9]+.[0-9]+)(\.[0-9]+)$/\1/')"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2

--- a/.github/workflows/command-line-test.yml
+++ b/.github/workflows/command-line-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set python version output
         id: python-version
         run: |
-          echo "::set-output name=python-version::$(cat .python-version)"
+          echo "::set-output name=python-version::$(cat .python-version | sed -r 's/^([0-9]+.[0-9]+)(\.[0-9]+)$/\1/')"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set python version output
         id: python-version
         run: |
-          echo "::set-output name=python-version::$(cat .python-version)"
+          echo "::set-output name=python-version::$(cat .python-version | sed -r 's/^([0-9]+.[0-9]+)(\.[0-9]+)$/\1/')"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2

--- a/.github/workflows/plugins-test.yml
+++ b/.github/workflows/plugins-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set python version output
         id: python-version
         run: |
-          echo "::set-output name=python-version::$(cat .python-version)"
+          echo "::set-output name=python-version::$(cat .python-version | sed -r 's/^([0-9]+.[0-9]+)(\.[0-9]+)$/\1/')"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2

--- a/.github/workflows/relay-integration-test.yml
+++ b/.github/workflows/relay-integration-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set python version output
         id: python-version
         run: |
-          echo "::set-output name=python-version::$(cat .python-version)"
+          echo "::set-output name=python-version::$(cat .python-version | sed -r 's/^([0-9]+.[0-9]+)(\.[0-9]+)$/\1/')"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2

--- a/.github/workflows/snuba-integration-test.yml
+++ b/.github/workflows/snuba-integration-test.yml
@@ -41,7 +41,7 @@ jobs:
         id: python-version
         if: steps.changes.outputs.backend == 'true'
         run: |
-          echo "::set-output name=python-version::$(cat .python-version)"
+          echo "::set-output name=python-version::$(cat .python-version | sed -r 's/^([0-9]+.[0-9]+)(\.[0-9]+)$/\1/')"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2

--- a/.github/workflows/symbolicator-integration-test.yml
+++ b/.github/workflows/symbolicator-integration-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set python version output
         id: python-version
         run: |
-          echo "::set-output name=python-version::$(cat .python-version)"
+          echo "::set-output name=python-version::$(cat .python-version | sed -r 's/^([0-9]+.[0-9]+)(\.[0-9]+)$/\1/')"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2


### PR DESCRIPTION
This change sets the Python version for the cache key to be "major.minor" and drops
the "patch" from the version. This prevents cache invalidation in the CI.

This won't work without first landing #24005