### PR TITLE
fix(images-loaded-v2): Fix filter visibility logic

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -482,7 +482,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
       filteredImagesByFilter: images,
     } = this.state;
 
-    const displayFilter = Object.values(filterOptions).length > 1;
+    const displayFilter = (Object.values(filterOptions ?? {})[0] ?? []).length > 1;
 
     return (
       <StyledEventDataSection


### PR DESCRIPTION
The filter was not showing, although there were options