### PR TITLE
feat(discover): Add support for an Any Function

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1528,6 +1528,19 @@ class CountColumn(FunctionArg):
         return value
 
 
+class FieldColumn(CountColumn):
+    """ Allow any field column, of any type """
+
+    def get_type(self, value):
+        if is_duration_measurement(value):
+            return "duration"
+        elif value == "transaction.duration":
+            return "duration"
+        elif value == "timestamp":
+            return "date"
+        return "string"
+
+
 class StringArg(FunctionArg):
     def __init__(self, name, unquote=False, unescape_quotes=False):
         super().__init__(name)
@@ -2152,6 +2165,13 @@ FUNCTIONS = {
             aggregate=["sum", ArgValue("column"), None],
             result_type_fn=reflective_result_type(),
             default_result_type="duration",
+        ),
+        Function(
+            "any",
+            required_args=[FieldColumn("column")],
+            aggregate=["min", ArgValue("column"), None],
+            result_type_fn=reflective_result_type(),
+            redundant_grouping=True,
         ),
         # Currently only being used by the baseline PoC
         Function(

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -148,6 +148,17 @@ export const AGGREGATIONS = {
     isSortable: true,
     multiPlotType: 'area',
   },
+  any: {
+    parameters: [
+      {
+        kind: 'column',
+        columnTypes: ['string', 'integer', 'number', 'duration', 'date', 'boolean'],
+        required: true,
+      },
+    ],
+    outputType: null,
+    isSortable: true,
+  },
   last_seen: {
     parameters: [],
     outputType: 'date',

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -3147,6 +3147,7 @@ class ResolveFieldListTest(unittest.TestCase):
             ["min(timestamp)", "timestamp"],
             ["max(timestamp)", "timestamp"],
             ["p95()", "transaction.duration"],
+            ["any(measurements.fcp)", "measurements.fcp"],
         ]
         for field in fields:
             with pytest.raises(InvalidSearchQuery) as error:

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -508,6 +508,24 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
                 use_aggregate_conditions=True,
             )
 
+    def test_any_function(self):
+        data = load_data("transaction", timestamp=before_now(seconds=3))
+        data["transaction"] = "a" * 32
+        self.store_event(data=data, project_id=self.project.id)
+
+        results = discover.query(
+            selected_columns=["count()", "any(transaction)", "any(user.id)"],
+            query="",
+            params={"project_id": [self.project.id]},
+            use_aggregate_conditions=True,
+        )
+
+        data = results["data"]
+        assert len(data) == 1
+        assert data[0]["any_transaction"] == "a" * 32
+        assert data[0]["any_user_id"] == "99"
+        assert data[0]["count"] == 2
+
 
 class QueryTransformTest(TestCase):
     """


### PR DESCRIPTION
- This adds a function that will just return the first encountered value, we don't want to actually use [clickhouse's](https://clickhouse.tech/docs/en/sql-reference/aggregate-functions/reference/any/) `any` function since it is indeterminate, so "any" is actually "min" for consistent results