### PR TITLE
ref(perf): Include project slug in events-trace response

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -18,7 +18,7 @@ import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import {IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
-import {Organization, Project} from 'app/types';
+import {Organization} from 'app/types';
 import {EventTransaction} from 'app/types/event';
 import {assert} from 'app/types/utils';
 import {TableDataRow} from 'app/utils/discover/discoverQuery';
@@ -27,7 +27,6 @@ import {eventDetailsRoute, generateEventSlug} from 'app/utils/discover/urls';
 import getDynamicText from 'app/utils/getDynamicText';
 import {QuickTraceContextChildrenProps} from 'app/utils/performance/quickTrace/quickTraceContext';
 import withApi from 'app/utils/withApi';
-import withProjects from 'app/utils/withProjects';
 
 import * as SpanEntryContext from './context';
 import InlineDocs from './inlineDocs';
@@ -47,7 +46,6 @@ type Props = {
   api: Client;
   orgId: string;
   organization: Organization;
-  projects: Project[];
   event: Readonly<EventTransaction>;
   span: Readonly<ProcessedSpanType>;
   isRoot: boolean;
@@ -92,7 +90,7 @@ class SpanDetail extends React.Component<Props, State> {
     spanID: string,
     traceID: string
   ): Promise<{data: TransactionResult[]}> {
-    const {api, organization, projects, quickTrace, trace, event} = this.props;
+    const {api, organization, quickTrace, trace, event} = this.props;
 
     // Skip doing a request if the results will be behind a disabled button.
     if (!organization.features.includes('discover-basic')) {
@@ -105,19 +103,16 @@ class SpanDetail extends React.Component<Props, State> {
       const traceLite = quickTrace.trace;
       const child = traceLite.find(transaction => transaction.parent_span_id === spanID);
       if (child) {
-        const project = projects.find(proj => parseInt(proj.id, 10) === child.project_id);
-        if (project) {
-          return Promise.resolve({
-            data: [
-              {
-                'project.name': project.slug,
-                transaction: child.transaction,
-                'trace.span': child.span_id,
-                id: child.event_id,
-              },
-            ],
-          });
-        }
+        return Promise.resolve({
+          data: [
+            {
+              'project.name': child.project_slug,
+              transaction: child.transaction,
+              'trace.span': child.span_id,
+              id: child.event_id,
+            },
+          ],
+        });
       }
       return Promise.resolve({data: []});
     }
@@ -650,4 +645,4 @@ function generateSlug(result: TransactionResult): string {
   });
 }
 
-export default withProjects(withApi(SpanDetail));
+export default withApi(SpanDetail);

--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/quickTraceQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/quickTraceQuery.tsx
@@ -20,6 +20,7 @@ export type EventLite = {
   transaction: string;
   'transaction.duration': number;
   project_id: number;
+  project_slug: string;
   parent_event_id: string | null;
   parent_span_id: string | null;
   is_root: boolean;

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
@@ -164,7 +164,6 @@ const QuickTraceLite = withProjects(
         event,
         children,
         organization,
-        projects,
         location
       );
       nodes.push(<TraceConnector key="children-connector" />);
@@ -239,7 +238,6 @@ type NodeProps = {
 function EventNodeDropdown({
   location,
   organization,
-  projects,
   children,
   events = [],
   numEvents = 5,
@@ -258,12 +256,7 @@ function EventNodeDropdown({
       {events.length === 0
         ? null
         : events.slice(0, numEvents).map((event, i) => {
-            const target = generateSingleEventTarget(
-              event,
-              organization,
-              projects,
-              location
-            );
+            const target = generateSingleEventTarget(event, organization, location);
             return (
               <DropdownItem key={event.event_id} to={target} first={i === 0}>
                 <Truncate

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
@@ -7,7 +7,7 @@ import Placeholder from 'app/components/placeholder';
 import Tooltip from 'app/components/tooltip';
 import Truncate from 'app/components/truncate';
 import {t, tn} from 'app/locale';
-import {OrganizationSummary, Project} from 'app/types';
+import {OrganizationSummary} from 'app/types';
 import {Event} from 'app/types/event';
 import {getShortEventId} from 'app/utils/events';
 import {getDuration} from 'app/utils/formatters';
@@ -17,7 +17,6 @@ import {
   TraceLite,
 } from 'app/utils/performance/quickTrace/quickTraceQuery';
 import {isTransaction} from 'app/utils/performance/quickTrace/utils';
-import withProjects from 'app/utils/withProjects';
 
 import {
   DropdownItem,
@@ -90,143 +89,135 @@ type QuickTraceLiteProps = {
   trace: TraceLite;
   location: Location;
   organization: OrganizationSummary;
-  projects: Project[];
 };
 
-const QuickTraceLite = withProjects(
-  ({event, trace, location, organization, projects}: QuickTraceLiteProps) => {
-    // non transaction events are currently unsupported
-    if (!isTransaction(event)) {
-      return null;
-    }
+function QuickTraceLite({event, trace, location, organization}: QuickTraceLiteProps) {
+  // non transaction events are currently unsupported
+  if (!isTransaction(event)) {
+    return null;
+  }
 
-    const {root, current, children} = parseTraceLite(trace, event);
-    const nodes: React.ReactNode[] = [];
+  const {root, current, children} = parseTraceLite(trace, event);
+  const nodes: React.ReactNode[] = [];
 
-    if (root) {
-      nodes.push(
-        <EventNodeDropdown
-          key="root-node"
-          organization={organization}
-          projects={projects}
-          location={location}
-          events={[root]}
-        >
-          <Tooltip
-            position="top"
-            containerDisplayMode="inline-flex"
-            title={t('View the root transaction in this trace.')}
-          >
-            <EventNode type="white" pad="right" icon={null}>
-              {t('Root')}
-            </EventNode>
-          </Tooltip>
-        </EventNodeDropdown>
-      );
-      nodes.push(<TraceConnector key="root-connector" />);
-    }
-
-    const traceTarget = generateTraceTarget(event, organization);
-
-    if (root && current && root.event_id !== current.parent_event_id) {
-      nodes.push(
-        <EventNodeDropdown
-          key="ancestors-node"
-          comingSoon
-          organization={organization}
-          projects={projects}
-          location={location}
-          seeMoreText={t('See trace in Discover')}
-          seeMoreLink={traceTarget}
-        >
-          <Tooltip
-            position="top"
-            containerDisplayMode="inline-flex"
-            title={t('View all transactions in this trace.')}
-          >
-            <EventNode type="white" pad="right" icon={null}>
-              {t('Ancestors')}
-            </EventNode>
-          </Tooltip>
-        </EventNodeDropdown>
-      );
-      nodes.push(<TraceConnector key="ancestors-connector" />);
-    }
-
+  if (root) {
     nodes.push(
-      <EventNode key="current-node" type="black">
-        {t('This Event')}
-      </EventNode>
+      <EventNodeDropdown
+        key="root-node"
+        organization={organization}
+        location={location}
+        events={[root]}
+      >
+        <Tooltip
+          position="top"
+          containerDisplayMode="inline-flex"
+          title={t('View the root transaction in this trace.')}
+        >
+          <EventNode type="white" pad="right" icon={null}>
+            {t('Root')}
+          </EventNode>
+        </Tooltip>
+      </EventNodeDropdown>
+    );
+    nodes.push(<TraceConnector key="root-connector" />);
+  }
+
+  const traceTarget = generateTraceTarget(event, organization);
+
+  if (root && current && root.event_id !== current.parent_event_id) {
+    nodes.push(
+      <EventNodeDropdown
+        key="ancestors-node"
+        comingSoon
+        organization={organization}
+        location={location}
+        seeMoreText={t('See trace in Discover')}
+        seeMoreLink={traceTarget}
+      >
+        <Tooltip
+          position="top"
+          containerDisplayMode="inline-flex"
+          title={t('View all transactions in this trace.')}
+        >
+          <EventNode type="white" pad="right" icon={null}>
+            {t('Ancestors')}
+          </EventNode>
+        </Tooltip>
+      </EventNodeDropdown>
+    );
+    nodes.push(<TraceConnector key="ancestors-connector" />);
+  }
+
+  nodes.push(
+    <EventNode key="current-node" type="black">
+      {t('This Event')}
+    </EventNode>
+  );
+
+  if (children.length) {
+    const childrenTarget = generateChildrenEventTarget(
+      event,
+      children,
+      organization,
+      location
+    );
+    nodes.push(<TraceConnector key="children-connector" />);
+    nodes.push(
+      <EventNodeDropdown
+        key="children-node"
+        organization={organization}
+        location={location}
+        events={children.sort(
+          (a, b) => b['transaction.duration'] - a['transaction.duration']
+        )}
+        seeMoreText={t('See %s children in Discover', children.length)}
+        seeMoreLink={childrenTarget}
+      >
+        <Tooltip
+          position="top"
+          containerDisplayMode="inline-flex"
+          title={tn(
+            'View the child transaction of this event.',
+            'View all child transactions of this event.',
+            children.length
+          )}
+        >
+          <EventNode type="white" pad="left" icon={null}>
+            {tn('%s Child', '%s Children', children.length)}
+          </EventNode>
+        </Tooltip>
+      </EventNodeDropdown>
     );
 
-    if (children.length) {
-      const childrenTarget = generateChildrenEventTarget(
-        event,
-        children,
-        organization,
-        location
-      );
-      nodes.push(<TraceConnector key="children-connector" />);
-      nodes.push(
-        <EventNodeDropdown
-          key="children-node"
-          organization={organization}
-          projects={projects}
-          location={location}
-          events={children.sort(
-            (a, b) => b['transaction.duration'] - a['transaction.duration']
-          )}
-          seeMoreText={t('See %s children in Discover', children.length)}
-          seeMoreLink={childrenTarget}
+    nodes.push(<TraceConnector key="descendants-connector" />);
+    nodes.push(
+      <EventNodeDropdown
+        key="descendants-node"
+        comingSoon
+        organization={organization}
+        location={location}
+        seeMoreText={t('See trace in Discover')}
+        seeMoreLink={traceTarget}
+      >
+        <Tooltip
+          position="top"
+          containerDisplayMode="inline-flex"
+          title={t('View all transactions in this trace.')}
         >
-          <Tooltip
-            position="top"
-            containerDisplayMode="inline-flex"
-            title={tn(
-              'View the child transaction of this event.',
-              'View all child transactions of this event.',
-              children.length
-            )}
-          >
-            <EventNode type="white" pad="left" icon={null}>
-              {tn('%s Child', '%s Children', children.length)}
-            </EventNode>
-          </Tooltip>
-        </EventNodeDropdown>
-      );
-
-      nodes.push(<TraceConnector key="descendants-connector" />);
-      nodes.push(
-        <EventNodeDropdown
-          key="descendants-node"
-          comingSoon
-          organization={organization}
-          projects={projects}
-          location={location}
-          seeMoreText={t('See trace in Discover')}
-          seeMoreLink={traceTarget}
-        >
-          <Tooltip
-            position="top"
-            containerDisplayMode="inline-flex"
-            title={t('View all transactions in this trace.')}
-          >
-            <EventNode type="white" pad="left" icon={null}>
-              <StyledIconEllipsis size="xs" />
-            </EventNode>
-          </Tooltip>
-        </EventNodeDropdown>
-      );
-    }
-
-    return <QuickTraceContainer>{nodes}</QuickTraceContainer>;
+          <EventNode type="white" pad="left" icon={null}>
+            <StyledIconEllipsis size="xs" />
+          </EventNode>
+        </Tooltip>
+      </EventNodeDropdown>
+    );
   }
-);
+
+  return <QuickTraceContainer>{nodes}</QuickTraceContainer>;
+}
 
 type NodeProps = {
   location: Location;
   organization: OrganizationSummary;
-  projects: Project[];
   children: React.ReactNode;
   events?: EventLite[];
   numEvents?: number;

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/utils.tsx
@@ -2,7 +2,7 @@ import {Location, LocationDescriptor} from 'history';
 
 import {getTraceDateTimeRange} from 'app/components/events/interfaces/spans/utils';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
-import {OrganizationSummary, Project} from 'app/types';
+import {OrganizationSummary} from 'app/types';
 import {Event, EventTransaction} from 'app/types/event';
 import EventView from 'app/utils/discover/eventView';
 import {generateEventSlug} from 'app/utils/discover/urls';
@@ -25,17 +25,11 @@ export function parseTraceLite(trace: TraceLite, event: Event) {
 export function generateSingleEventTarget(
   event: EventLite,
   organization: OrganizationSummary,
-  projects: Project[],
   location: Location
-): LocationDescriptor | undefined {
-  const project = projects.find(p => parseInt(p.id, 10) === event.project_id);
-  if (project === undefined) {
-    return undefined;
-  }
-
+): LocationDescriptor {
   const eventSlug = generateEventSlug({
     id: event.event_id,
-    project: project.slug,
+    project: event.project_slug,
   });
   return getTransactionDetailsUrl(
     organization,
@@ -49,11 +43,10 @@ export function generateChildrenEventTarget(
   event: EventTransaction,
   children: EventLite[],
   organization: OrganizationSummary,
-  projects: Project[],
   location: Location
-): LocationDescriptor | undefined {
+): LocationDescriptor {
   if (children.length === 1) {
-    return generateSingleEventTarget(children[0], organization, projects, location);
+    return generateSingleEventTarget(children[0], organization, location);
   }
 
   const queryResults = new QueryResults([]);


### PR DESCRIPTION
The events-trace response also includes the project slug now. This change makes
use of this field to simplify some existing logic.