### PR TITLE
fix: change order by for organization_has_mobile_app_events

### DIFF
--- a/src/sentry/api/endpoints/organization_has_mobile_app_events.py
+++ b/src/sentry/api/endpoints/organization_has_mobile_app_events.py
@@ -43,8 +43,8 @@ class OrganizationHasMobileAppEvents(OrganizationEventsEndpointBase):
             # TODO: update discover query for null browser and client_os_name is android or ios
             result = discover.query(
                 query=query,
-                orderby="browser.name",
-                selected_columns=["browser.name", "project", "id", "client_os.name"],
+                orderby="-timestamp",
+                selected_columns=["browser.name", "client_os.name", "timestamp"],
                 limit=1,
                 params={
                     "start": timezone.now() - timedelta(days=1),
@@ -59,15 +59,6 @@ class OrganizationHasMobileAppEvents(OrganizationEventsEndpointBase):
                 return None
 
             one_result = data[0]
-            # log the info so we can debug this later
-            logger.info(
-                "result_found",
-                extra={
-                    "organization_id": organization.id,
-                    "organization_slug": organization.slug,
-                    **one_result,
-                },
-            )
             # only send back browserName and clientOsName for now
             return {
                 "browserName": one_result["browser.name"],


### PR DESCRIPTION
1. Order by timestamp to make the query more efficient
2. Remove log statement