### PR TITLE
fix(ui): Fix chart dropdown control labels and related issue chart label

### DIFF
--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -216,7 +216,7 @@ class GroupList extends React.Component<Props, State> {
     return (
       <React.Fragment>
         <Panel>
-          <GroupListHeader withChart={!!withChart} statsPeriod={statsPeriod} />
+          <GroupListHeader withChart={!!withChart} />
           <PanelBody>
             {groups.map(({id, project}) => {
               const members = memberList?.hasOwnProperty(project.slug)

--- a/src/sentry/static/sentry/app/components/issues/groupListHeader.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupListHeader.tsx
@@ -8,10 +8,9 @@ import space from 'app/styles/space';
 
 type Props = {
   withChart: boolean;
-  statsPeriod?: '24h' | 'auto';
 };
 
-const GroupListHeader = ({withChart = true, statsPeriod = '24h'}: Props) => (
+const GroupListHeader = ({withChart = true}: Props) => (
   <PanelHeader disablePadding>
     <Box width={[8 / 12, 8 / 12, 6 / 12]} mx={2} flex="1">
       {t('Issue')}
@@ -23,10 +22,7 @@ const GroupListHeader = ({withChart = true, statsPeriod = '24h'}: Props) => (
         justifyContent="space-between"
         className="hidden-xs hidden-sm"
       >
-        {t('Graph: ')}
-        <StatsPeriodWrapper>
-          {statsPeriod === 'auto' ? t('Custom') : statsPeriod}
-        </StatsPeriodWrapper>
+        {t('Graph')}
       </Flex>
     )}
     <EventUserWrapper>{t('events')}</EventUserWrapper>
@@ -43,10 +39,6 @@ const GroupListHeader = ({withChart = true, statsPeriod = '24h'}: Props) => (
 );
 
 export default GroupListHeader;
-
-const StatsPeriodWrapper = styled('div')`
-  text-transform: none;
-`;
 
 const EventUserWrapper = styled('div')`
   display: flex;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -379,11 +379,13 @@ class DetailsBody extends React.Component<Props> {
                       </DropdownItem>
                     ))}
                   </DropdownControl>
-                  {timePeriod.custom && <StyledTimeRange>
-                    <DateTime date={timePeriod.start} timeAndDate />
-                    {' — '}
-                    <DateTime date={timePeriod.end} timeAndDate />
-                  </StyledTimeRange>}
+                  {timePeriod.custom && (
+                    <StyledTimeRange>
+                      <DateTime date={timePeriod.start} timeAndDate />
+                      {' — '}
+                      <DateTime date={timePeriod.end} timeAndDate />
+                    </StyledTimeRange>
+                  )}
                 </ChartControls>
                 <ChartPanel>
                   <PanelBody withPadding>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -11,6 +11,7 @@ import Button from 'app/components/button';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import {SectionHeading} from 'app/components/charts/styles';
 import {getInterval} from 'app/components/charts/utils';
+import DateTime from 'app/components/dateTime';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import Duration from 'app/components/duration';
 import * as Layout from 'app/components/layouts/thirds';
@@ -52,6 +53,7 @@ type Props = {
     start: string;
     end: string;
     label: string;
+    custom?: boolean;
   };
   organization: Organization;
   location: Location;
@@ -362,20 +364,27 @@ class DetailsBody extends React.Component<Props> {
           return initiallyLoaded ? (
             <Layout.Body>
               <Layout.Main>
-                <DropdownControl
-                  buttonProps={{prefix: t('Display')}}
-                  label={timePeriod.label}
-                >
-                  {TIME_OPTIONS.map(({label, value}) => (
-                    <DropdownItem
-                      key={value}
-                      eventKey={value}
-                      onSelect={this.handleTimePeriodChange}
-                    >
-                      {label}
-                    </DropdownItem>
-                  ))}
-                </DropdownControl>
+                <ChartControls>
+                  <DropdownControl
+                    buttonProps={{prefix: t('Display')}}
+                    label={timePeriod.label}
+                  >
+                    {TIME_OPTIONS.map(({label, value}) => (
+                      <DropdownItem
+                        key={value}
+                        eventKey={value}
+                        onSelect={this.handleTimePeriodChange}
+                      >
+                        {label}
+                      </DropdownItem>
+                    ))}
+                  </DropdownControl>
+                  {timePeriod.custom && <StyledTimeRange>
+                    <DateTime date={timePeriod.start} timeAndDate />
+                    {' — '}
+                    <DateTime date={timePeriod.end} timeAndDate />
+                  </StyledTimeRange>}
+                </ChartControls>
                 <ChartPanel>
                   <PanelBody withPadding>
                     <ChartHeader>
@@ -549,6 +558,16 @@ const AlertIconWrapper = styled('div')`
 const SidebarHeading = styled(SectionHeading)`
   display: flex;
   justify-content: space-between;
+`;
+
+const ChartControls = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const StyledTimeRange = styled('div')`
+  margin-left: ${space(2)};
 `;
 
 const ChartPanel = styled(Panel)`

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -365,10 +365,7 @@ class DetailsBody extends React.Component<Props> {
             <Layout.Body>
               <Layout.Main>
                 <ChartControls>
-                  <DropdownControl
-                    buttonProps={{prefix: t('Display')}}
-                    label={timePeriod.label}
-                  >
+                  <DropdownControl label={timePeriod.label}>
                     {TIME_OPTIONS.map(({label, value}) => (
                       <DropdownItem
                         key={value}

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {browserHistory, RouteComponentProps} from 'react-router';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {withTheme} from 'emotion-theming';
 import {Location} from 'history';
@@ -58,6 +58,7 @@ type Props = {
   organization: Organization;
   location: Location;
   theme: Theme;
+  handleTimePeriodChange: (value: string) => void;
 } & RouteComponentProps<{orgId: string}, {}>;
 
 class DetailsBody extends React.Component<Props> {
@@ -102,16 +103,6 @@ class DetailsBody extends React.Component<Props> {
 
     return getInterval({start, end}, true);
   }
-
-  handleTimePeriodChange = (value: string) => {
-    const {location} = this.props;
-    browserHistory.push({
-      pathname: location.pathname,
-      query: {
-        period: value,
-      },
-    });
-  };
 
   calculateSummaryPercentages(
     incidents: Incident[] | undefined,
@@ -370,7 +361,7 @@ class DetailsBody extends React.Component<Props> {
                       <DropdownItem
                         key={value}
                         eventKey={value}
-                        onSelect={this.handleTimePeriodChange}
+                        onSelect={this.props.handleTimePeriodChange}
                       >
                         {label}
                       </DropdownItem>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
@@ -3,10 +3,10 @@ import {SelectValue} from 'app/types';
 import {TimePeriod, TimeWindow} from 'app/views/settings/incidentRules/types';
 
 export const TIME_OPTIONS: SelectValue<string>[] = [
-  {label: t('6 hours'), value: TimePeriod.SIX_HOURS},
-  {label: t('24 hours'), value: TimePeriod.ONE_DAY},
-  {label: t('3 days'), value: TimePeriod.THREE_DAYS},
-  {label: t('7 days'), value: TimePeriod.SEVEN_DAYS},
+  {label: t('Last 6 hours'), value: TimePeriod.SIX_HOURS},
+  {label: t('Last 24 hours'), value: TimePeriod.ONE_DAY},
+  {label: t('Last 3 days'), value: TimePeriod.THREE_DAYS},
+  {label: t('Last 7 days'), value: TimePeriod.SEVEN_DAYS},
 ];
 
 export const ALERT_RULE_DETAILS_DEFAULT_PERIOD = TimePeriod.ONE_DAY;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -6,6 +6,7 @@ import moment from 'moment';
 import {fetchOrgMembers} from 'app/actionCreators/members';
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
+import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import withApi from 'app/utils/withApi';
@@ -41,7 +42,8 @@ class AlertRuleDetails extends React.Component<Props, State> {
       return {
         start: location.query.start,
         end: location.query.end,
-        label: 'Custom',
+        label: t('Custom time'),
+        custom: true,
       };
     }
 

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {RouteComponentProps} from 'react-router';
+import {browserHistory, RouteComponentProps} from 'react-router';
 import {Location} from 'history';
 import moment from 'moment';
 
@@ -95,6 +95,18 @@ class AlertRuleDetails extends React.Component<Props, State> {
     }
   };
 
+  handleTimePeriodChange = async (value: string) => {
+    const {location} = this.props;
+    browserHistory.push({
+      pathname: location.pathname,
+      query: {
+        period: value,
+      },
+    });
+
+    await this.fetchData();
+  };
+
   render() {
     const {rule, incidents, hasError} = this.state;
     const {params, organization} = this.props;
@@ -113,6 +125,7 @@ class AlertRuleDetails extends React.Component<Props, State> {
             rule={rule}
             incidents={incidents}
             timePeriod={timePeriod}
+            handleTimePeriodChange={this.handleTimePeriodChange}
           />
         </Feature>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -97,7 +97,7 @@ class AlertRuleDetails extends React.Component<Props, State> {
 
   handleTimePeriodChange = async (value: string) => {
     const {location} = this.props;
-    browserHistory.push({
+    await browserHistory.push({
       pathname: location.pathname,
       query: {
         period: value,


### PR DESCRIPTION
This changes the alert rule details interval picker labels and the graph title in the related issues.

Interval picker labels
[WOR-627](https://getsentry.atlassian.net/browse/WOR-627)
![Screen Shot 2021-02-23 at 4 08 03 PM](https://user-images.githubusercontent.com/15015880/108929275-952c9c00-75f8-11eb-91ae-e5f6d387504c.png)
![Screen Shot 2021-02-23 at 4 57 14 PM](https://user-images.githubusercontent.com/15015880/108929276-95c53280-75f8-11eb-8d76-2748245e1e95.png)



Graph title in the related issues:
([WOR-643](https://getsentry.atlassian.net/browse/WOR-643))
![Screen Shot 2021-02-23 at 4 39 49 PM](https://user-images.githubusercontent.com/15015880/108927756-c0fa5280-75f5-11eb-9784-011708bec11a.png)
