### PR TITLE
fix(inbox): Add color back to inbox query count

### DIFF
--- a/src/sentry/static/sentry/app/components/queryCount.tsx
+++ b/src/sentry/static/sentry/app/components/queryCount.tsx
@@ -10,6 +10,7 @@ type Props = {
   hideIfEmpty?: boolean;
   hideParens?: boolean;
   isTag?: boolean;
+  tagProps?: React.ComponentProps<typeof Tag>;
 };
 
 /**
@@ -25,6 +26,7 @@ const QueryCount = ({
   hideIfEmpty = true,
   hideParens = false,
   isTag = false,
+  tagProps = {},
 }: Props) => {
   const countOrMax = defined(count) && defined(max) && count >= max ? `${max}+` : count;
 
@@ -33,7 +35,7 @@ const QueryCount = ({
   }
 
   if (isTag) {
-    return <Tag>{countOrMax}</Tag>;
+    return <Tag {...tagProps}>{countOrMax}</Tag>;
   }
 
   return (

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -137,6 +137,13 @@ function IssueListHeader({
                           {queryCounts[tabQuery] && (
                             <StyledQueryCount
                               isTag
+                              tagProps={{
+                                type:
+                                  isForReviewQuery(tabQuery) &&
+                                  queryCounts[tabQuery].count > 0
+                                    ? 'warning'
+                                    : 'default',
+                              }}
                               count={queryCounts[tabQuery].count}
                               max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
                             />


### PR DESCRIPTION
We've had a change of heart, adds color to the inbox tab when issues > 0.

![image](https://user-images.githubusercontent.com/1400464/108927595-6eb93180-75f5-11eb-9d39-4cb18a0f85be.png)
