### PR TITLE
feat(discover): Show configuration / upsell popovers for Open Discover button

### DIFF
--- a/src/sentry/static/sentry/app/components/discoverButton.tsx
+++ b/src/sentry/static/sentry/app/components/discoverButton.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
 import Feature from 'app/components/acl/feature';
+import FeatureDisabled from 'app/components/acl/featureDisabled';
 import Button from 'app/components/button';
+import Hovercard from 'app/components/hovercard';
+import {t} from 'app/locale';
 
 type Props = React.PropsWithChildren<{
   className?: string;
@@ -13,8 +16,29 @@ type Props = React.PropsWithChildren<{
  * doesn't have access to discover results.
  */
 function DiscoverButton({children, ...buttonProps}: Props) {
+  const noFeatureMessage = t('Requires discover feature.');
+
+  const renderDisabled = p => (
+    <Hovercard
+      body={
+        <FeatureDisabled
+          features={p.features}
+          hideHelpToggle
+          message={noFeatureMessage}
+          featureName={noFeatureMessage}
+        />
+      }
+    >
+      {p.children(p)}
+    </Hovercard>
+  );
+
   return (
-    <Feature features={['organizations:discover-basic']}>
+    <Feature
+      hookName="feature-disabled:open-discover"
+      features={['organizations:discover-basic']}
+      renderDisabled={renderDisabled}
+    >
       {({hasFeature}) => (
         <Button disabled={!hasFeature} {...buttonProps}>
           {children}

--- a/src/sentry/static/sentry/app/stores/hookStore.tsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.tsx
@@ -29,6 +29,7 @@ const validHookNames = new Set<HookName>([
   'feature-disabled:events-page',
   'feature-disabled:events-sidebar-item',
   'feature-disabled:grid-editable-actions',
+  'feature-disabled:open-discover',
   'feature-disabled:incidents-sidebar-item',
   'feature-disabled:performance-new-project',
   'feature-disabled:performance-page',

--- a/src/sentry/static/sentry/app/types/hooks.tsx
+++ b/src/sentry/static/sentry/app/types/hooks.tsx
@@ -100,6 +100,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:events-page': FeatureDisabledHook;
   'feature-disabled:events-sidebar-item': FeatureDisabledHook;
   'feature-disabled:grid-editable-actions': FeatureDisabledHook;
+  'feature-disabled:open-discover': FeatureDisabledHook;
   'feature-disabled:incidents-sidebar-item': FeatureDisabledHook;
   'feature-disabled:performance-new-project': FeatureDisabledHook;
   'feature-disabled:performance-page': FeatureDisabledHook;


### PR DESCRIPTION
We'd like to show these popovers for the "Open Discover" button wherever they're used. 

## On-premise

<img width="1404" alt="Screen Shot 2021-02-23 at 7 47 48 PM" src="https://user-images.githubusercontent.com/139499/108928520-4b4fb000-7610-11eb-8c9f-c368a264ab1c.png">


## Sentry SaaS

<img width="1004" alt="Screen Shot 2021-02-23 at 7 42 31 PM" src="https://user-images.githubusercontent.com/139499/108928512-48ed5600-7610-11eb-8b3f-380e6ead35d6.png">
<img width="1398" alt="Screen Shot 2021-02-23 at 7 42 44 PM" src="https://user-images.githubusercontent.com/139499/108928517-4ab71980-7610-11eb-87df-5eb3deabea60.png">
