### PR TITLE
ref(trace-view): Add more spans to the trace endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -1,4 +1,5 @@
 import logging
+import sentry_sdk
 
 from collections import deque
 
@@ -105,42 +106,46 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsEndpointBase):
             else:
                 break
         if extra_roots > 0:
-            warning_extra["extra_roots"] = extra_roots
             logger.warning(
                 "discover.trace-view.root.extra-found",
                 {"extra_roots": extra_roots, **warning_extra},
             )
 
         parent_map = {item["trace.parent_span"]: item for item in result["data"]}
-        return Response(self.serialize(parent_map, root, warning_extra, snuba_event, event_id))
+        return Response(
+            self.serialize(parent_map, root, warning_extra, params, snuba_event, event_id)
+        )
 
 
 class OrganizationEventsTraceLightEndpoint(OrganizationEventsTraceEndpointBase):
-    def serialize(self, parent_map, root, warning_extra, snuba_event, event_id=None):
+    def serialize(self, parent_map, root, warning_extra, params, snuba_event, event_id=None):
         """ Because the light endpoint could potentially have gaps between root and event we return a flattened list """
         trace_results = [self.serialize_event(root, None, 0, True)]
 
-        if root["id"] != event_id:
-            # Get the root event and see if the current event's span is in the root event
-            root_event = eventstore.get_event_by_id(root["project.id"], root["id"])
-            root_span = find_event(
-                root_event.data.get("spans", []),
-                lambda item: item["span_id"] == snuba_event["trace.parent_span"],
-            )
-
-            # For the light response, the parent will be unknown unless it is a direct descendent of the root
-            is_root_child = root_span is not None
-            trace_results.append(
-                self.serialize_event(
-                    snuba_event, root["id"] if is_root_child else None, 1 if is_root_child else None
+        with sentry_sdk.start_span(op="building.trace", description="light trace"):
+            if root["id"] != event_id:
+                # Get the root event and see if the current event's span is in the root event
+                root_event = eventstore.get_event_by_id(root["project.id"], root["id"])
+                root_span = find_event(
+                    root_event.data.get("spans", []),
+                    lambda item: item["span_id"] == snuba_event["trace.parent_span"],
                 )
-            )
 
-        event = eventstore.get_event_by_id(snuba_event["project.id"], event_id)
-        for span in event.data.get("spans", []):
-            if span["span_id"] in parent_map:
-                child_event = parent_map[span["span_id"]]
-                trace_results.append(self.serialize_event(child_event, event_id))
+                # For the light response, the parent will be unknown unless it is a direct descendent of the root
+                is_root_child = root_span is not None
+                trace_results.append(
+                    self.serialize_event(
+                        snuba_event,
+                        root["id"] if is_root_child else None,
+                        1 if is_root_child else None,
+                    )
+                )
+
+            event = eventstore.get_event_by_id(snuba_event["project.id"], event_id)
+            for span in event.data.get("spans", []):
+                if span["span_id"] in parent_map:
+                    child_event = parent_map[span["span_id"]]
+                    trace_results.append(self.serialize_event(child_event, event_id))
 
         return trace_results
 
@@ -151,37 +156,51 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
         event["children"] = []
         return event
 
-    def serialize(self, parent_map, root, warning_extra, snuba_event=None, event_id=None):
+    def serialize(self, parent_map, root, warning_extra, params, snuba_event=None, event_id=None):
         """ For the full event trace, we return the results as a graph instead of a flattened list """
         parent_events = {}
         result = parent_events[root["id"]] = self.serialize_event(root, None, 0, True)
-
-        to_check = deque([root])
-        iteration = 0
-        while to_check:
-            current_event = to_check.popleft()
-            event = eventstore.get_event_by_id(current_event["project.id"], current_event["id"])
-            previous_event = parent_events[current_event["id"]]
-            for child in event.data.get("spans", []):
-                if child["span_id"] not in parent_map:
-                    continue
-                # Avoid potential span loops by popping, so we don't traverse the same nodes twice
-                child_event = parent_map.pop(child["span_id"])
-
-                parent_events[child_event["id"]] = self.serialize_event(
-                    child_event, current_event["id"], previous_event["generation"] + 1
+        with sentry_sdk.start_span(
+            op="nodestore", description=f"retrieving {len(parent_map)} nodes"
+        ) as span:
+            span.set_data("total nodes", len(parent_map))
+            node_data = {
+                event.event_id: event
+                for event in eventstore.get_events(
+                    eventstore.Filter(
+                        project_ids=params["project_id"],
+                        event_ids=[event["id"] for event in parent_map.values()],
+                    )
                 )
-                # Add this event to its parent's children
-                previous_event["children"].append(parent_events[child_event["id"]])
+            }
 
-                to_check.append(child_event)
-            # Limit iterations just to be safe
-            iteration += 1
-            if iteration > MAX_TRACE_SIZE:
-                logger.warning(
-                    "discover.trace-view.surpassed-trace-limit",
-                    extra=warning_extra,
-                )
-                break
+        with sentry_sdk.start_span(op="building.trace", description="full trace"):
+            to_check = deque([root])
+            iteration = 0
+            while to_check:
+                current_event = to_check.popleft()
+                event = node_data.get(current_event["id"])
+                previous_event = parent_events[current_event["id"]]
+                for child in event.data.get("spans", []):
+                    if child["span_id"] not in parent_map:
+                        continue
+                    # Avoid potential span loops by popping, so we don't traverse the same nodes twice
+                    child_event = parent_map.pop(child["span_id"])
+
+                    parent_events[child_event["id"]] = self.serialize_event(
+                        child_event, current_event["id"], previous_event["generation"] + 1
+                    )
+                    # Add this event to its parent's children
+                    previous_event["children"].append(parent_events[child_event["id"]])
+
+                    to_check.append(child_event)
+                # Limit iterations just to be safe
+                iteration += 1
+                if iteration > MAX_TRACE_SIZE:
+                    logger.warning(
+                        "discover.trace-view.surpassed-trace-limit",
+                        extra=warning_extra,
+                    )
+                    break
 
         return result


### PR DESCRIPTION
- Also switching to the `eventstore.get_events` call, was originally `eventstore.get_event_by_id` to see if per event would be any faster