### PR TITLE
fix: Update server configuration docs URL

### DIFF
--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -243,7 +243,7 @@ export const ORGANIZATION_FETCH_ERROR_TYPES = {
   ORG_NOT_FOUND: 'ORG_NOT_FOUND',
 };
 
-export const CONFIG_DOCS_URL = 'https://docs.sentry.io/server/config/';
+export const CONFIG_DOCS_URL = 'https://develop.sentry.dev/config/';
 export const DISCOVER2_DOCS_URL = 'https://docs.sentry.io/product/discover-queries/';
 
 export const IS_ACCEPTANCE_TEST = !!process.env.IS_ACCEPTANCE_TEST;


### PR DESCRIPTION
https://docs.sentry.io/server/config/ now redirects to https://develop.sentry.dev/config/ 

This url is used for features that are disabled. For example:

<img width="1404" alt="Screen Shot 2021-02-23 at 7 47 48 PM" src="https://user-images.githubusercontent.com/139499/108930359-ce263a00-7613-11eb-9b24-cbd250164e4c.png">
