### PR TITLE
fix(metric_alerts): Fix metric alerts to support `issue.id` in the query

### DIFF
--- a/src/sentry/snuba/tasks.py
+++ b/src/sentry/snuba/tasks.py
@@ -172,6 +172,8 @@ def build_snuba_filter(dataset, query, aggregate, environment, event_types, para
     snuba_filter = get_filter(query, params=params)
     snuba_filter.update_with(resolve_field_list([aggregate], snuba_filter, auto_fields=False))
     snuba_filter = resolve_snuba_aliases(snuba_filter, resolve_func)[0]
+    if snuba_filter.group_ids:
+        snuba_filter.conditions.append(["group_id", "IN", list(map(int, snuba_filter.group_ids))])
     if environment:
         snuba_filter.conditions.append(["environment", "=", environment.name])
     return snuba_filter


### PR DESCRIPTION
This fixes a bug where metric alerts would silently ignore `issue.id` filters in the query. This is
because the query parser extracts them to a separate variable (`group_ids` and `filter_keys`), which
metric alerts doesn't use.

In practice, this meant that we'd end up overcounting these alerts and showing values much too high
in our alert integrations.