### PR TITLE
feat(ui): Hide Releases series by default if there are more than 50 lines

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/eventsChart.tsx
@@ -13,7 +13,7 @@ import LineChart from 'app/components/charts/lineChart';
 import ReleaseSeries from 'app/components/charts/releaseSeries';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
-import {getInterval} from 'app/components/charts/utils';
+import {getInterval, RELEASE_LINES_THRESHOLD} from 'app/components/charts/utils';
 import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
 import {DateString, OrganizationSummary} from 'app/types';
@@ -155,12 +155,11 @@ class Chart extends React.Component<ChartProps, State> {
     }
 
     // Temporary fix to improve performance on pages with a high number of releases.
-    // Picked 1000 as it is the size of the first page
     const releases = releaseSeries && releaseSeries[0];
     const hideReleasesByDefault =
       Array.isArray(releaseSeries) &&
       (releases as any)?.markLine?.data &&
-      (releases as any).markLine.data.length >= 1000;
+      (releases as any).markLine.data.length >= RELEASE_LINES_THRESHOLD;
 
     const selected = !Array.isArray(releaseSeries)
       ? seriesSelection

--- a/src/sentry/static/sentry/app/components/charts/utils.tsx
+++ b/src/sentry/static/sentry/app/components/charts/utils.tsx
@@ -19,6 +19,11 @@ export const ONE_WEEK = 10080;
 export const TWENTY_FOUR_HOURS = 1440;
 export const ONE_HOUR = 60;
 
+/**
+ * If there are more releases than this number we hide "Releases" series by default
+ */
+export const RELEASE_LINES_THRESHOLD = 50;
+
 export type DateTimeObject = Partial<GlobalSelection['datetime']>;
 
 export function truncationFormatter(

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectStabilityChart.tsx
@@ -11,6 +11,7 @@ import ReleaseSeries from 'app/components/charts/releaseSeries';
 import {HeaderTitleLegend} from 'app/components/charts/styles';
 import TransitionChart from 'app/components/charts/transitionChart';
 import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
+import {RELEASE_LINES_THRESHOLD} from 'app/components/charts/utils';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
@@ -195,8 +196,16 @@ class Chart extends React.Component<ChartProps, ChartState> {
   };
 
   get legend() {
-    const {theme} = this.props;
+    const {theme, releaseSeries} = this.props;
     const {seriesSelection} = this.state;
+
+    const hideReleasesByDefault =
+      (releaseSeries[0] as any)?.markLine?.data.length >= RELEASE_LINES_THRESHOLD;
+
+    const selected =
+      Object.keys(seriesSelection).length === 0 && hideReleasesByDefault
+        ? {[t('Releases')]: false}
+        : seriesSelection;
 
     return {
       right: 10,
@@ -213,7 +222,7 @@ class Chart extends React.Component<ChartProps, ChartState> {
         fontFamily: theme.text.family,
       },
       data: [t('This Period'), t('Previous Period'), t('Releases')],
-      selected: seriesSelection,
+      selected,
     };
   }
 


### PR DESCRIPTION
We will start to hide "Releases" series by default if there are more than 50 lines. At that point, it's often too noisy to provide any value. The series will still be there if you need it, it will just be hidden by default.

Relates to https://github.com/getsentry/sentry/pull/23888