### PR TITLE
ref(images-loaded): Add 'Search in Settings' button 

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -257,7 +257,7 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
             </GeneralInfo>
             {debugFilesSettingsLink && (
               <SearchInSettingsAction>
-                <Tooltip title={t('Search for this debug file in settings')}>
+                <Tooltip title={t('Search for this debug file in all images for the %s project', projectId)}>
                   <Button to={debugFilesSettingsLink} size="small">
                     {t('Search in Settings')}
                   </Button>

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -257,7 +257,12 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
             </GeneralInfo>
             {debugFilesSettingsLink && (
               <SearchInSettingsAction>
-                <Tooltip title={t('Search for this debug file in all images for the %s project', projectId)}>
+                <Tooltip
+                  title={t(
+                    'Search for this debug file in all images for the %s project',
+                    projectId
+                  )}
+                >
                   <Button to={debugFilesSettingsLink} size="small">
                     {t('Search in Settings')}
                   </Button>

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -9,6 +9,7 @@ import {ModalRenderProps} from 'app/actionCreators/modal';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import NotAvailable from 'app/components/notAvailable';
+import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
@@ -182,6 +183,18 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
     return this.sortCandidates(convertedCandidates, unAppliedCandidates);
   }
 
+  getDebugFilesSettingsLink() {
+    const {organization, projectId, image} = this.props;
+    const orgSlug = organization.slug;
+    const debugId = image?.debug_id;
+
+    if (!orgSlug || !projectId || !debugId) {
+      return undefined;
+    }
+
+    return `/settings/${orgSlug}/projects/${projectId}/debug-symbols/?query=${debugId}`;
+  }
+
   handleDelete = async (debugId: string) => {
     const {organization, projectId} = this.props;
 
@@ -214,6 +227,7 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
 
     const title = getFileName(code_file);
     const imageAddress = image ? <Address image={image} /> : undefined;
+    const debugFilesSettingsLink = this.getDebugFilesSettingsLink();
 
     return (
       <React.Fragment>
@@ -241,6 +255,15 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
               <Label coloredBg>{t('Architecture')}</Label>
               <Value coloredBg>{architecture ?? <NotAvailable />}</Value>
             </GeneralInfo>
+            {debugFilesSettingsLink && (
+              <SearchInSettingsAction>
+                <Tooltip title={t('Search for this debug file in settings')}>
+                  <Button to={debugFilesSettingsLink} size="small">
+                    {t('Search in Settings')}
+                  </Button>
+                </Tooltip>
+              </SearchInSettingsAction>
+            )}
             <Candidates
               candidates={candidates}
               organization={organization}
@@ -269,8 +292,13 @@ export default DebugImageDetails;
 
 const Content = styled('div')`
   display: grid;
-  grid-gap: ${space(4)};
+  grid-gap: ${space(3)};
   font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const SearchInSettingsAction = styled('div')`
+  display: flex;
+  justify-content: flex-end;
 `;
 
 const GeneralInfo = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -86,7 +86,11 @@ class DebugMeta extends React.PureComponent<Props, State> {
   };
 
   componentDidMount() {
-    this.unsubscribeFromStore = DebugMetaStore.listen(this.onStoreChange, undefined);
+    this.unsubscribeFromDebugMetaStore = DebugMetaStore.listen(
+      this.onDebugMetaStoreChange,
+      undefined
+    );
+
     cache.clearAll();
     this.getRelevantImages();
     this.openImageDetailsModal();
@@ -101,17 +105,17 @@ class DebugMeta extends React.PureComponent<Props, State> {
   }
 
   componentWillUnmount() {
-    if (this.unsubscribeFromStore) {
-      this.unsubscribeFromStore();
+    if (this.unsubscribeFromDebugMetaStore) {
+      this.unsubscribeFromDebugMetaStore();
     }
   }
 
-  unsubscribeFromStore: any;
+  unsubscribeFromDebugMetaStore: any;
 
   panelTableRef = React.createRef<HTMLDivElement>();
   listRef: List | null = null;
 
-  onStoreChange = (store: {filter: string}) => {
+  onDebugMetaStoreChange = (store: {filter: string}) => {
     const {searchTerm} = this.state;
 
     if (store.filter !== searchTerm) {

--- a/src/sentry/static/sentry/app/components/globalModal.tsx
+++ b/src/sentry/static/sentry/app/components/globalModal.tsx
@@ -61,7 +61,7 @@ class GlobalModal extends React.Component<Props> {
     const renderedChild =
       typeof children === 'function'
         ? children({
-            closeModal,
+            closeModal: this.handleCloseModal,
             Header: Modal.Header,
             Body: Modal.Body,
             Footer: Modal.Footer,

--- a/src/sentry/static/sentry/app/stores/modalStore.tsx
+++ b/src/sentry/static/sentry/app/stores/modalStore.tsx
@@ -25,13 +25,6 @@ const ModalStore = Reflux.createStore({
   },
 
   onCloseModal() {
-    const onClose = this.state?.options?.onClose;
-
-    // Trigger the options.onClose callback
-    if (typeof onClose === 'function') {
-      onClose();
-    }
-
     this.reset();
     this.trigger(this.state);
   },


### PR DESCRIPTION
The Images loaded table in version 1 shows a search button that we ended up removing in version 2:

Images Loaded - V1: 
![image](https://user-images.githubusercontent.com/29228205/109024750-5bbe6400-76be-11eb-8538-aeec69922238.png)



As this button proved to be very useful, we decided to add it again, but this time as part of the details modal:

![image](https://user-images.githubusercontent.com/29228205/109024500-21ed5d80-76be-11eb-926e-d812aadfff87.png)


