### PR TITLE
feat(ui): Remove Key Transactions from project quick links

### DIFF
--- a/src/sentry/static/sentry/app/views/projectDetail/projectQuickLinks.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectQuickLinks.tsx
@@ -51,14 +51,6 @@ function ProjectQuickLinks({organization, project, location}: Props) {
       },
     },
     {
-      title: t('Key Transactions'),
-      to: {
-        pathname: getPerformanceLandingUrl(organization),
-        query: {project: project?.id},
-      },
-      disabled: !organization.features.includes('performance-view'),
-    },
-    {
       title: t('Most Improved/Regressed Transactions'),
       to: getTrendsLink(),
       disabled: !organization.features.includes('performance-view'),

--- a/tests/js/spec/views/projectDetail/projectQuickLinks.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectQuickLinks.spec.jsx
@@ -20,21 +20,14 @@ describe('ProjectDetail > ProjectQuickLinks', function () {
     );
 
     expect(wrapper.find('SectionHeading').text()).toBe('Quick Links');
-    expect(wrapper.find('QuickLink a').length).toBe(3);
+    expect(wrapper.find('QuickLink a').length).toBe(2);
 
     const userFeedback = wrapper.find('QuickLink').at(0);
-    const keyTransactions = wrapper.find('QuickLink').at(1);
-    const mostChangedTransactions = wrapper.find('QuickLink').at(2);
+    const mostChangedTransactions = wrapper.find('QuickLink').at(1);
 
     expect(userFeedback.text()).toBe('User Feedback');
     expect(userFeedback.prop('to')).toEqual({
       pathname: '/organizations/org-slug/user-feedback/',
-      query: {project: '2'},
-    });
-
-    expect(keyTransactions.text()).toBe('Key Transactions');
-    expect(keyTransactions.prop('to')).toEqual({
-      pathname: '/organizations/org-slug/performance/',
       query: {project: '2'},
     });
 
@@ -59,11 +52,11 @@ describe('ProjectDetail > ProjectQuickLinks', function () {
       />
     );
 
-    const keyTransactions = wrapper.find('QuickLink').at(1);
+    const mostChangedTransactions = wrapper.find('QuickLink').at(1);
     const tooltip = wrapper.find('Tooltip').at(1);
 
-    expect(keyTransactions.prop('disabled')).toBeTruthy();
-    expect(keyTransactions.find('a').exists()).toBeFalsy();
+    expect(mostChangedTransactions.prop('disabled')).toBeTruthy();
+    expect(mostChangedTransactions.find('a').exists()).toBeFalsy();
     expect(tooltip.prop('title')).toBe("You don't have access to this feature");
     expect(tooltip.prop('disabled')).toBeFalsy();
   });


### PR DESCRIPTION
Key transactions are now part of a performance main page. It does not make sense to have a Performance quick link as it would be the same as clicking Performance in the main nav sidebar.