### PR TITLE
fix(perf): Fix bad null coalescing in quick trace

### DIFF
--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/quickTraceQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/quickTraceQuery.tsx
@@ -114,7 +114,16 @@ function QuickTraceQuery({event, children, ...props}: QueryProps) {
       eventView={eventView}
       {...props}
     >
-      {({tableData, ...rest}) => children({trace: tableData ?? null, ...rest})}
+      {({tableData, ...rest}) =>
+        children({
+          // Without casting this to include undefined as a possible value,
+          // the compiled js only coalesces null values to null.
+          // Changing the type in GenericDiscoverQuery to TraceLite | undefined
+          // does not work either.
+          trace: (tableData as TraceLite | null | undefined) ?? null,
+          ...rest,
+        })
+      }
     </GenericDiscoverQuery>
   );
 }


### PR DESCRIPTION
The null coalescing is only coalescing nulls here in the compiled JS, leaving
possible undefined values as undefined. This change explicitly casts the type to
include undefined to ensure that undefined is correctly coalesced to null as
well.

Fixes JAVASCRIPT-23WT
FIxes JAVASCRIPT-23WF