### PR TITLE
fix(perf): Quick trace query can result in an empty string

### DIFF
--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/quickTraceQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/quickTraceQuery.tsx
@@ -116,11 +116,11 @@ function QuickTraceQuery({event, children, ...props}: QueryProps) {
     >
       {({tableData, ...rest}) =>
         children({
-          // Without casting this to include undefined as a possible value,
-          // the compiled js only coalesces null values to null.
-          // Changing the type in GenericDiscoverQuery to TraceLite | undefined
-          // does not work either.
-          trace: (tableData as TraceLite | null | undefined) ?? null,
+          // This is using '||` instead of '??` here because
+          // the client returns a empty string when the response
+          // is 204. And we want the empty string, undefined and
+          // null to be converted to null.
+          trace: tableData || null,
           ...rest,
         })
       }

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {Location, LocationDescriptor} from 'history';
 
 import DropdownLink from 'app/components/dropdownLink';
+import ErrorBoundary from 'app/components/errorBoundary';
 import Link from 'app/components/links/link';
 import Placeholder from 'app/components/placeholder';
 import Tooltip from 'app/components/tooltip';
@@ -60,12 +61,14 @@ export default function QuickTrace({
   ) : error || trace === null ? (
     '\u2014'
   ) : (
-    <QuickTraceLite
-      event={event}
-      trace={trace}
-      location={location}
-      organization={organization}
-    />
+    <ErrorBoundary mini>
+      <QuickTraceLite
+        event={event}
+        trace={trace}
+        location={location}
+        organization={organization}
+      />
+    </ErrorBoundary>
   );
 
   return (


### PR DESCRIPTION
The change in #24050 made it so that when the response is a 204, the data is an
empty string. This change makes sure to handle it so that `undefined`, `null`,
and the empty string aare all coalesced to `null`. Will require further
investigation to assess the impact of #24050 on other parts of the app.