### PR TITLE
fix(metric_alerts): Paint metric series data over other metric indicators

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -107,7 +107,6 @@ const MetricChart = ({data, incidents, warningTrigger, criticalTrigger}: Props) 
         } as any,
       }),
       data: [],
-      z: -100,
     };
     series.push(incidentLinesSeries);
   }

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -32,8 +32,9 @@ function createThresholdSeries(color: string, threshold: number): LineChartSerie
 }
 
 const MetricChart = ({data, incidents, warningTrigger, criticalTrigger}: Props) => {
-  // Iterate through incidents to add markers to chart
   const series: LineChartSeries[] = [...data];
+  // Ensure series data appears above incident lines
+  series[0].z = 100;
   const dataArr = data[0].data;
   const maxSeriesValue = dataArr.reduce(
     (currMax, coord) => Math.max(currMax, coord.value),
@@ -106,22 +107,23 @@ const MetricChart = ({data, incidents, warningTrigger, criticalTrigger}: Props) 
         } as any,
       }),
       data: [],
+      z: -100,
     };
-    series.unshift(incidentLinesSeries);
+    series.push(incidentLinesSeries);
   }
 
   let maxThresholdValue = 0;
   if (warningTrigger?.alertThreshold) {
     const {alertThreshold} = warningTrigger;
     const warningThresholdLine = createThresholdSeries(theme.yellow300, alertThreshold);
-    series.unshift(warningThresholdLine);
+    series.push(warningThresholdLine);
     maxThresholdValue = Math.max(maxThresholdValue, alertThreshold);
   }
 
   if (criticalTrigger?.alertThreshold) {
     const {alertThreshold} = criticalTrigger;
     const criticalThresholdLine = createThresholdSeries(theme.red300, alertThreshold);
-    series.unshift(criticalThresholdLine);
+    series.push(criticalThresholdLine);
     maxThresholdValue = Math.max(maxThresholdValue, alertThreshold);
   }
 


### PR DESCRIPTION
Paints the metric series data over the incident indicator lines.

**Before:**
<img width="414" alt="Screen Shot 2021-02-24 at 12 45 11 PM" src="https://user-images.githubusercontent.com/9372512/109063761-6a951e80-769e-11eb-9dab-ce92f42d1924.png">

**After:**
<img width="517" alt="Screen Shot 2021-02-24 at 12 44 42 PM" src="https://user-images.githubusercontent.com/9372512/109063772-6d900f00-769e-11eb-9021-dd476b89b17a.png">
