### PR TITLE
fix: allow unauthorized users to click integration config

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/installedIntegration.tsx
@@ -106,23 +106,15 @@ export default class InstalledIntegration extends React.Component<Props> {
               <IntegrationItem integration={integration} />
             </IntegrationItemBox>
             <div>
-              <Tooltip
-                disabled={hasAccess}
-                position="left"
-                title={t(
-                  'You must be an organization owner, manager or admin to configure'
-                )}
+              <StyledButton
+                borderless
+                icon={<IconSettings />}
+                disabled={!hasAccess || integration.status !== 'active'}
+                to={`/settings/${organization.slug}/integrations/${provider.key}/${integration.id}/`}
+                data-test-id="integration-configure-button"
               >
-                <StyledButton
-                  borderless
-                  icon={<IconSettings />}
-                  disabled={!hasAccess || integration.status !== 'active'}
-                  to={`/settings/${organization.slug}/integrations/${provider.key}/${integration.id}/`}
-                  data-test-id="integration-configure-button"
-                >
-                  {t('Configure')}
-                </StyledButton>
-              </Tooltip>
+                {t('Configure')}
+              </StyledButton>
             </div>
             <div>
               <Tooltip


### PR DESCRIPTION
Some important information is available (read-only) through the integration
configuration, such as code path mapping for GitHub. Since the URL is still
accessible in the React props, this isn't actually a security feature.

This was quietly introduced in 2f91c4c49b4, and then the reauth button was quietly removed in f8359593f3, so I can't see any remaining reason to keep it.