### PR TITLE
fix(dashboards): Pass project ids based on user's permissions for widget validation/creation

### DIFF
--- a/src/sentry/api/endpoints/organization_dashboard_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_details.py
@@ -86,7 +86,11 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardEndpoint):
         serializer = DashboardDetailsSerializer(
             data=request.data,
             instance=dashboard,
-            context={"organization": organization, "request": request},
+            context={
+                "organization": organization,
+                "request": request,
+                "projects": self.get_projects(request, organization),
+            },
         )
 
         if not serializer.is_valid():

--- a/src/sentry/api/endpoints/organization_dashboard_widget_details.py
+++ b/src/sentry/api/endpoints/organization_dashboard_widget_details.py
@@ -22,7 +22,11 @@ class OrganizationDashboardWidgetDetailsEndpoint(OrganizationEndpoint):
             return Response(status=404)
 
         serializer = DashboardWidgetSerializer(
-            data=request.data, context={"organization": organization}
+            data=request.data,
+            context={
+                "organization": organization,
+                "projects": self.get_projects(request, organization),
+            },
         )
         if not serializer.is_valid():
             return Response(serializer.errors, status=400)

--- a/src/sentry/api/endpoints/organization_dashboards.py
+++ b/src/sentry/api/endpoints/organization_dashboards.py
@@ -79,7 +79,12 @@ class OrganizationDashboardsEndpoint(OrganizationEndpoint):
             return Response(status=404)
 
         serializer = DashboardSerializer(
-            data=request.data, context={"organization": organization, "request": request}
+            data=request.data,
+            context={
+                "organization": organization,
+                "request": request,
+                "projects": self.get_projects(request, organization),
+            },
         )
 
         if not serializer.is_valid():

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -77,6 +77,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
             params = {
                 "start": datetime.now() - timedelta(days=1),
                 "end": datetime.now(),
+                "project_id": [p.id for p in self.context.get("projects")],
             }
 
             snuba_filter = get_filter(conditions, params=params)

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -17,11 +17,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type:error", "fields": ["count()"]}
             ],
         }
-        response = self.do_request(
-            "post",
-            self.url(),
-            data=data,
-        )
+        response = self.do_request("post", self.url(), data=data,)
         assert response.status_code == 200, response.data
 
     def test_valid_widget_permissions(self):
@@ -36,11 +32,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type: tag:foo", "fields": ["count()"]}
             ],
         }
-        response = self.do_request(
-            "post",
-            self.url(),
-            data=data,
-        )
+        response = self.do_request("post", self.url(), data=data,)
         assert response.status_code == 400, response.data
         assert "queries" in response.data, response.data
         assert response.data["queries"][0]["conditions"], response.data
@@ -57,11 +49,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type:error", "fields": ["p95(user)"]}
             ],
         }
-        response = self.do_request(
-            "post",
-            self.url(),
-            data=data,
-        )
+        response = self.do_request("post", self.url(), data=data,)
         assert response.status_code == 400, response.data
         assert "queries" in response.data, response.data
         assert response.data["queries"][0]["fields"], response.data
@@ -74,11 +62,7 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type:error", "fields": ["count()"]}
             ],
         }
-        response = self.do_request(
-            "post",
-            self.url(),
-            data=data,
-        )
+        response = self.do_request("post", self.url(), data=data,)
         assert response.status_code == 400, response.data
         assert "displayType" in response.data, response.data
 
@@ -88,9 +72,25 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             "displayType": "big_number",
             "queries": [{"name": "", "fields": ["epm()"], "conditions": "", "orderby": ""}],
         }
-        response = self.do_request(
-            "post",
-            self.url(),
-            data=data,
-        )
+        response = self.do_request("post", self.url(), data=data,)
+        assert response.status_code == 200, response.data
+
+    def test_project_search_condition(self):
+        team = self.create_team(organization=self.org)
+        self.project = self.create_project(name="foo", organization=self.org, teams=[team])
+
+        self.create_member(teams=[team], user=self.user, organization=self.org)
+        data = {
+            "title": "EPM Big Number",
+            "displayType": "big_number",
+            "queries": [
+                {
+                    "name": "",
+                    "fields": ["epm()"],
+                    "conditions": f"project:{self.project.name}",
+                    "orderby": "",
+                }
+            ],
+        }
+        response = self.do_request("post", self.url(), data=data,)
         assert response.status_code == 200, response.data

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -96,10 +96,14 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert response.status_code == 200, response.data
 
     def test_project_search_condition(self):
-        team = self.create_team(organization=self.organization)
-        self.project = self.create_project(name="foo", organization=self.organization, teams=[team])
-
-        self.create_member(teams=[team], user=self.user, organization=self.organization)
+        self.user = self.create_user(is_superuser=False)
+        self.project = self.create_project(
+            name="foo", organization=self.organization, teams=[self.team]
+        )
+        self.create_member(
+            user=self.user, organization=self.organization, role="member", teams=[self.team]
+        )
+        self.login_as(self.user)
         data = {
             "title": "EPM Big Number",
             "displayType": "big_number",

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -96,10 +96,10 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
         assert response.status_code == 200, response.data
 
     def test_project_search_condition(self):
-        team = self.create_team(organization=self.org)
-        self.project = self.create_project(name="foo", organization=self.org, teams=[team])
+        team = self.create_team(organization=self.organization)
+        self.project = self.create_project(name="foo", organization=self.organization, teams=[team])
 
-        self.create_member(teams=[team], user=self.user, organization=self.org)
+        self.create_member(teams=[team], user=self.user, organization=self.organization)
         data = {
             "title": "EPM Big Number",
             "displayType": "big_number",

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -17,7 +17,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type:error", "fields": ["count()"]}
             ],
         }
-        response = self.do_request("post", self.url(), data=data,)
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 200, response.data
 
     def test_valid_widget_permissions(self):
@@ -32,7 +36,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type: tag:foo", "fields": ["count()"]}
             ],
         }
-        response = self.do_request("post", self.url(), data=data,)
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert "queries" in response.data, response.data
         assert response.data["queries"][0]["conditions"], response.data
@@ -49,7 +57,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type:error", "fields": ["p95(user)"]}
             ],
         }
-        response = self.do_request("post", self.url(), data=data,)
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert "queries" in response.data, response.data
         assert response.data["queries"][0]["fields"], response.data
@@ -62,7 +74,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 {"name": "errors", "conditions": "event.type:error", "fields": ["count()"]}
             ],
         }
-        response = self.do_request("post", self.url(), data=data,)
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 400, response.data
         assert "displayType" in response.data, response.data
 
@@ -72,7 +88,11 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             "displayType": "big_number",
             "queries": [{"name": "", "fields": ["epm()"], "conditions": "", "orderby": ""}],
         }
-        response = self.do_request("post", self.url(), data=data,)
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 200, response.data
 
     def test_project_search_condition(self):
@@ -92,5 +112,9 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
                 }
             ],
         }
-        response = self.do_request("post", self.url(), data=data,)
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
         assert response.status_code == 200, response.data


### PR DESCRIPTION
Using `project:<project-name>` search condition borks the dashboard widget serialization. This PR fixes that.

![Screen Shot 2021-02-24 at 10 50 32 AM](https://user-images.githubusercontent.com/139499/109072392-fa4cc400-76c2-11eb-8de1-8c79beefbda5.png)
