### PR TITLE
feat(trace-view): Improve how we call eventstore.get_events

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -6,6 +6,7 @@ from collections import deque
 from rest_framework.response import Response
 
 from sentry import features, eventstore
+from sentry.eventstore.models import Event
 from sentry.api.bases import OrganizationEventsEndpointBase, NoProjects
 from sentry.snuba import discover
 
@@ -168,9 +169,14 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
                 event.event_id: event
                 for event in eventstore.get_events(
                     eventstore.Filter(
+                        start=params["start"],
+                        end=params["end"],
                         project_ids=params["project_id"],
-                        event_ids=[event["id"] for event in parent_map.values()],
-                    )
+                    ),
+                    event_list=[
+                        Event(project_id=event["project.id"], event_id=event["id"])
+                        for event in parent_map.values()
+                    ],
                 )
             }
 

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -136,6 +136,7 @@ class EventStorage(Service):
         limit=100,
         offset=0,
         referrer="eventstore.get_events",  # NOQA
+        event_list=None,
     ):
         """
         Fetches a list of events given a set of criteria.
@@ -146,6 +147,7 @@ class EventStorage(Service):
         limit (int): Query limit - default 100
         offset (int): Query offset - default 0
         referrer (string): Referrer - default "eventstore.get_events"
+        event_list (Sequence[Event]): List of events to get
         """
         raise NotImplementedError
 

--- a/src/sentry/eventstore/base.py
+++ b/src/sentry/eventstore/base.py
@@ -21,6 +21,7 @@ class Filter:
     project_ids (Sequence[int]): List of project IDs to fetch - default None
     group_ids (Sequence[int]): List of group IDs to fetch - default None
     event_ids (Sequence[int]): List of event IDs to fetch - default None
+    event_identifiers (Sequence[EventIdentifier]): List of event identifiers to fetch - default None
 
     selected_columns (Sequence[str]): List of columns to select
     aggregations (Sequence[Any, str|None, str]): Aggregate functions to fetch.
@@ -41,6 +42,7 @@ class Filter:
         project_ids=None,
         group_ids=None,
         event_ids=None,
+        event_identifiers=None,
         selected_columns=None,
         aggregations=None,
         rollup=None,
@@ -58,6 +60,15 @@ class Filter:
         self.project_ids = project_ids
         self.group_ids = group_ids
         self.event_ids = event_ids
+        self.event_identifiers = event_identifiers
+
+        if event_identifiers is not None:
+            # Even with the specific event identifiers, if we surpass the event limit we will fallback to getting
+            # everything, so need to make sure these attributes still get set.
+            if self.event_ids is None:
+                self.event_ids = [event.event_id for event in event_identifiers]
+            if self.project_ids is None:
+                self.project_ids = list({event.project_id for event in event_identifiers})
 
         self.rollup = rollup
         self.selected_columns = selected_columns if selected_columns is not None else []
@@ -136,7 +147,6 @@ class EventStorage(Service):
         limit=100,
         offset=0,
         referrer="eventstore.get_events",  # NOQA
-        event_list=None,
     ):
         """
         Fetches a list of events given a set of criteria.
@@ -147,7 +157,6 @@ class EventStorage(Service):
         limit (int): Query limit - default 100
         offset (int): Query offset - default 0
         referrer (string): Referrer - default "eventstore.get_events"
-        event_list (Sequence[Event]): List of events to get
         """
         raise NotImplementedError
 

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -29,6 +29,21 @@ def ref_func(x):
     return x.project_id or x.project.id
 
 
+class EventIdentifier:
+    """
+    Identifier for an event to be retrieved
+    """
+
+    __slots__ = ["project_id", "event_id"]
+
+    def __init__(self, project_id, event_id):
+        self.project_id = project_id
+        self.event_id = event_id
+
+    def to_event(self):
+        return Event(self.project_id, self.event_id)
+
+
 class Event:
     """
     Event backed by nodestore and Snuba.


### PR DESCRIPTION
- This allows eventstore.get_events to directly take a list of events
  to retrieve, currently get_events takes a filter of project and
  event ids.
  - This is problematic for the trace view where we already know the
    project to event_id mapping, and so we're not getting the
    optimization mentioned in the get_events function.