### PR TITLE
fix(discover): Fix drilldowns when generating search conditions from array value fields

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -366,7 +366,7 @@ function generateExpandedConditions(
     const value = conditions[key];
 
     if (Array.isArray(value)) {
-      parsedQuery.addTagValues(key, value);
+      parsedQuery.setTagValues(key, value);
       continue;
     }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -366,19 +366,7 @@ function generateExpandedConditions(
     const value = conditions[key];
 
     if (Array.isArray(value)) {
-      parsedQuery.addOp('(');
-
-      const lastIndex = value.length - 1;
-
-      value.forEach((tagValue, index) => {
-        parsedQuery.addTagValues(key, [tagValue]);
-
-        if (lastIndex !== index) {
-          parsedQuery.addOp('OR');
-        }
-      });
-
-      parsedQuery.addOp(')');
+      parsedQuery.addTagValues(key, value);
       continue;
     }
 

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -400,6 +400,25 @@ describe('getExpandedResults()', function () {
     expect(result.query).toEqual('event.type:error custom_tag:tag_value');
   });
 
+  it('applies array value conditions from event data', () => {
+    const view = new EventView({
+      ...state,
+      fields: [...state.fields, {field: 'error.type'}],
+    });
+    const event = {
+      type: 'error',
+      tags: [
+        {key: 'nope', value: 'nope'},
+        {key: 'custom_tag', value: 'tag_value'},
+      ],
+      'error.type': ['DeadSystem Exception', 'RuntimeException', 'RuntimeException'],
+    };
+    const result = getExpandedResults(view, {}, event);
+    expect(result.query).toEqual(
+      'event.type:error custom_tag:tag_value ( error.type:"DeadSystem Exception" OR error.type:RuntimeException OR error.type:RuntimeException )'
+    );
+  });
+
   it('applies project condition to project property', () => {
     const view = new EventView(state);
 

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -415,7 +415,7 @@ describe('getExpandedResults()', function () {
     };
     const result = getExpandedResults(view, {}, event);
     expect(result.query).toEqual(
-      'event.type:error custom_tag:tag_value ( error.type:"DeadSystem Exception" OR error.type:RuntimeException OR error.type:RuntimeException )'
+      'event.type:error custom_tag:tag_value error.type:"DeadSystem Exception" error.type:RuntimeException error.type:RuntimeException'
     );
   });
 


### PR DESCRIPTION
Discover drilldowns need to support fields that can be array values. 