### PR TITLE
fix(stacktrace-link): use arrow function

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -179,9 +179,9 @@ class StacktraceLink extends AsyncComponent<Props, State> {
     }
   }
 
-  handleSubmit() {
+  handleSubmit = () => {
     this.reloadData();
-  }
+  };
 
   // let the ErrorBoundary handle errors by raising it
   renderError(): React.ReactNode {


### PR DESCRIPTION
We don't have an error in Sentry because we catch it [here](https://github.com/getsentry/sentry/blob/master/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx#L98) but we are getting:

```
TypeError: Cannot read property 'reloadData' of undefined
```