### PR TITLE
feat(integrations): Prevent errors from integration providers from blowing up our UI

### DIFF
--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -93,6 +93,7 @@ class OrganizationIntegrationSerializer(Serializer):
         )
 
         dynamic_display_information = None
+        config_data = None
 
         try:
             installation = obj.integration.get_installation(obj.organization_id)
@@ -116,7 +117,7 @@ class OrganizationIntegrationSerializer(Serializer):
                 }
                 logger.info(name, extra=log_info)
 
-            integration.update({"configData": config_data})
+        integration.update({"configData": config_data})
 
         if dynamic_display_information:
             integration.update({"dynamicDisplayInformation": dynamic_display_information})

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -110,7 +110,7 @@ class OrganizationIntegrationSerializer(Serializer):
                 integration.update({"status": "disabled"})
                 name = "sentry.serializers.model.organizationintegration"
                 log_info = {
-                    "error": e,
+                    "error": str(e),
                     "integration_id": obj.integration.id,
                     "integration_provider": obj.integration.provider,
                 }

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1226,16 +1226,6 @@ export type Integration = {
   accountType: string;
   status: ObjectStatus;
   provider: BaseIntegrationProvider & {aspects: IntegrationAspects};
-  //TODO(Steve): move configData to IntegrationWithConfig when we no longer check
-  //for workspace apps
-  configData: object & {
-    //installationType is only for Slack migration and can be removed after migrations are done
-    installationType?:
-      | 'workspace_app'
-      | 'classic_bot'
-      | 'born_as_bot'
-      | 'migrated_to_bot';
-  };
   dynamicDisplayInformation?: {
     configure_integration?: {
       instructions: string[];
@@ -1249,6 +1239,7 @@ export type Integration = {
 // we include the configOrganization when we need it
 export type IntegrationWithConfig = Integration & {
   configOrganization: Field[];
+  configData: object | null;
 };
 
 export type IntegrationExternalIssue = {

--- a/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -136,7 +136,7 @@ class ConfigureIntegration extends AsyncView<Props, State> {
             saveOnBlur
             allowUndo
             apiMethod="POST"
-            initialData={integration.configData}
+            initialData={integration.configData || {}}
             apiEndpoint={`/organizations/${orgId}/integrations/${integration.id}/`}
           >
             <JsonForm


### PR DESCRIPTION
## Objective:
Currently if a user has a misconfiguration and we make a request to our integration providers, our API response will return a 500 even if all the other providers are 200. This prevents our Integration List Directory from loading for users.

If we cannot make a successful request, this PR will allow us to fail gracefully by setting it to disabled and allowing us to render the rest of the integrations/plugins. 

## UI:
_before_
![Screen Shot 2021-02-25 at 12 14 52 AM](https://user-images.githubusercontent.com/10491193/109123357-9a740e80-76fe-11eb-9ff7-4f10b095a5be.png)

_after_
![Screen Shot 2021-02-25 at 12 15 21 AM](https://user-images.githubusercontent.com/10491193/109123379-9fd15900-76fe-11eb-8922-37a03164d1c1.png)

![Screen Shot 2021-02-25 at 12 15 32 AM](https://user-images.githubusercontent.com/10491193/109123398-a4960d00-76fe-11eb-8c9e-675a697b1474.png)

## Future:
Might need design input on how to highlight that there is a problem with their configuration. 