### PR TITLE
fix(thread-selector): Fix option description

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/index.tsx
@@ -126,6 +126,7 @@ class Threads extends React.Component<Props, State> {
                     activeThread={activeThread}
                     event={event}
                     onChange={this.handleSelectNewThread}
+                    exception={exception}
                   />
                 )
               }

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/filterThreadInfo.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/filterThreadInfo.tsx
@@ -1,20 +1,42 @@
 import {trimPackage} from 'app/components/events/interfaces/frame/utils';
-import {Frame} from 'app/types';
+import {EntryData, ExceptionType, Frame} from 'app/types';
+import {Event} from 'app/types/event';
 import {Thread} from 'app/types/events';
+import {StacktraceType} from 'app/types/stacktrace';
 
 import getRelevantFrame from './getRelevantFrame';
+import getThreadException from './getThreadException';
 import getThreadStacktrace from './getThreadStacktrace';
 import trimFilename from './trimFilename';
 
 type ThreadInfo = {
   label?: string;
   filename?: string;
+  crashedInfo?: EntryData;
 };
 
-function filterThreadInfo(thread: Thread): ThreadInfo {
-  const stacktrace = getThreadStacktrace(false, thread);
-
+function filterThreadInfo(
+  event: Event,
+  thread: Thread,
+  exception?: Required<ExceptionType>
+): ThreadInfo {
   const threadInfo: ThreadInfo = {};
+
+  let stacktrace: StacktraceType | undefined = getThreadStacktrace(false, thread);
+
+  if (thread.crashed) {
+    const threadException = exception ?? getThreadException(event, thread);
+
+    const matchedStacktraceAndExceptionThread = threadException?.values.find(
+      exceptionDataValue => exceptionDataValue.threadId === thread.id
+    );
+
+    if (matchedStacktraceAndExceptionThread) {
+      stacktrace = matchedStacktraceAndExceptionThread.stacktrace ?? undefined;
+    }
+
+    threadInfo.crashedInfo = threadException;
+  }
 
   if (!stacktrace) {
     return threadInfo;

--- a/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/threads/threadSelector/index.tsx
@@ -5,13 +5,12 @@ import partition from 'lodash/partition';
 import DropdownAutoComplete from 'app/components/dropdownAutoComplete';
 import DropdownButton from 'app/components/dropdownButton';
 import {t} from 'app/locale';
-import {EntryData} from 'app/types';
+import {ExceptionType} from 'app/types';
 import {Event} from 'app/types/event';
 import {Thread} from 'app/types/events';
 import theme from 'app/utils/theme';
 
 import filterThreadInfo from './filterThreadInfo';
-import getThreadException from './getThreadException';
 import Header from './header';
 import Option from './option';
 import SelectedOption from './selectedOption';
@@ -20,24 +19,18 @@ type Props = {
   threads: Array<Thread>;
   activeThread: Thread;
   event: Event;
+  exception?: Required<ExceptionType>;
   onChange?: (thread: Thread) => void;
 };
 
 const DROPDOWN_MAX_HEIGHT = 400;
 
-const ThreadSelector = ({threads, event, activeThread, onChange}: Props) => {
+const ThreadSelector = ({threads, event, exception, activeThread, onChange}: Props) => {
   const getDropDownItem = (thread: Thread) => {
-    const threadInfo = filterThreadInfo(thread);
-
-    const dropDownValue = `#${thread.id}: ${thread.name} ${threadInfo.label} ${threadInfo.filename}`;
-    let crashedInfo: undefined | EntryData;
-
-    if (thread.crashed) {
-      crashedInfo = getThreadException(event, thread);
-    }
-
+    const {label, filename, crashedInfo} = filterThreadInfo(event, thread, exception);
+    const threadInfo = {label, filename};
     return {
-      value: dropDownValue,
+      value: `#${thread.id}: ${thread.name} ${label} ${filename}`,
       threadInfo,
       thread,
       label: (
@@ -87,7 +80,7 @@ const ThreadSelector = ({threads, event, activeThread, onChange}: Props) => {
           ) : (
             <SelectedOption
               id={activeThread.id}
-              details={filterThreadInfo(activeThread)}
+              details={filterThreadInfo(event, activeThread, exception)}
             />
           )}
         </StyledDropdownButton>


### PR DESCRIPTION


After merging the PR https://github.com/getsentry/sentry/pull/23890 the thread selector option started to appear as unknown in the case of crashed thread. This PR fixes the issue.

**Before:**

![image](https://user-images.githubusercontent.com/29228205/109132403-16e50c80-7754-11eb-94e4-1a052f9d7836.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/109132491-2fedbd80-7754-11eb-96d7-f09aac7d8815.png)
