### PR TITLE
ref: WIP inline compat list wrap

### DIFF
--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -1,4 +1,3 @@
-from sentry.utils.compat import map
 
 __all__ = ("Attribute", "Event", "Map")
 

--- a/src/sentry/analytics/event.py
+++ b/src/sentry/analytics/event.py
@@ -1,4 +1,3 @@
-
 __all__ = ("Attribute", "Event", "Map")
 
 from uuid import uuid1
@@ -58,7 +57,9 @@ class Map(Attribute):
             data[attr.name] = attr.extract(nv)
 
         if items:
-            raise ValueError("Unknown attributes: {}".format(", ".join(map(str, items.keys()))))
+            raise ValueError(
+                "Unknown attributes: {}".format(", ".join(list(map(str, items.keys()))))
+            )
 
         return data
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -21,7 +21,6 @@ from sentry.models import (
 from sentry.utils import auth
 from sentry.utils.hashlib import hash_values
 from sentry.utils.sdk import bind_organization_context
-from sentry.utils.compat import map
 
 
 class NoProjects(Exception):

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -158,7 +158,7 @@ class OrganizationEndpoint(Endpoint):
         permission checking, use ``get_projects``, instead.
         """
         try:
-            return set(map(int, request.GET.getlist("project")))
+            return set(list(map(int, request.GET.getlist("project"))))
         except ValueError:
             raise ParseError(detail="Invalid project parameter. Values must be numbers.")
 

--- a/src/sentry/api/endpoints/assistant.py
+++ b/src/sentry/api/endpoints/assistant.py
@@ -17,7 +17,7 @@ VALID_STATUSES = frozenset(("viewed", "dismissed"))
 class AssistantSerializer(serializers.Serializer):
     guide = serializers.CharField(required=False)
     guide_id = serializers.IntegerField(required=False)
-    status = serializers.ChoiceField(choices=zip(VALID_STATUSES, VALID_STATUSES))
+    status = serializers.ChoiceField(choices=list(zip(VALID_STATUSES, VALID_STATUSES)))
     useful = serializers.BooleanField(required=False)
 
     def validate_guide_id(self, value):

--- a/src/sentry/api/endpoints/assistant.py
+++ b/src/sentry/api/endpoints/assistant.py
@@ -10,7 +10,6 @@ from rest_framework.response import Response
 from sentry.api.base import Endpoint
 from sentry.models import AssistantActivity
 from sentry.assistant import manager
-from sentry.utils.compat import zip
 
 VALID_STATUSES = frozenset(("viewed", "dismissed"))
 

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -114,7 +114,9 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             return Response({"error": "Too many chunks"}, status=status.HTTP_400_BAD_REQUEST)
 
         try:
-            FileBlob.from_files(zip(files, checksums), organization=organization, logger=logger)
+            FileBlob.from_files(
+                list(zip(files, checksums)), organization=organization, logger=logger
+            )
         except OSError as err:
             logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response({"error": str(err)}, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -12,7 +12,6 @@ from sentry import options
 from sentry.models import FileBlob
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationReleasePermission
 from sentry.utils.files import get_max_file_size
-from sentry.utils.compat import zip
 
 
 MAX_CHUNKS_PER_REQUEST = 64

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -26,7 +26,6 @@ from sentry.plugins.bases import IssueTrackingPlugin2
 from sentry.signals import issue_deleted
 from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
-from sentry.utils.compat import zip
 from sentry.models.groupinbox import get_inbox_details
 
 delete_logger = logging.getLogger("sentry.deletions.api")

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -141,7 +141,7 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         # Default to a dictionary if the release object wasn't found and not serialized
         return [
             item if item is not None else {"version": version}
-            for item, version in zip(serialized_releases, versions)
+            for item, version in list(zip(serialized_releases, versions))
         ]
 
     @rate_limit_endpoint(limit=5, window=1)

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -3,7 +3,6 @@ import logging
 from rest_framework.response import Response
 
 from sentry import features as feature_flags
-from sentry.utils.compat import zip
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import Group

--- a/src/sentry/api/endpoints/group_similar_issues.py
+++ b/src/sentry/api/endpoints/group_similar_issues.py
@@ -54,7 +54,7 @@ class GroupSimilarIssuesEndpoint(GroupEndpoint):
 
         # We need to preserve the ordering of the Redis results, as that
         # ordering is directly shown in the UI
-        for group_id, scores in zip(group_ids, group_scores):
+        for group_id, scores in list(zip(group_ids, group_scores)):
             group = serialized_groups.get(group_id)
             if group is None:
                 # TODO(tkaemming): This should log when we filter out a group that is

--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -13,7 +13,7 @@ class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):
             feature_flag_name = "organizations:integrations-%s" % provider.key
             return features.has(feature_flag_name, organization, actor=request.user)
 
-        providers = filter(is_provider_enabled, list(integrations.all()))
+        providers = list(filter(is_provider_enabled, list(integrations.all())))
 
         providers.sort(key=lambda i: i.key)
 

--- a/src/sentry/api/endpoints/organization_config_integrations.py
+++ b/src/sentry/api/endpoints/organization_config_integrations.py
@@ -3,7 +3,6 @@ from rest_framework.response import Response
 from sentry import integrations, features
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize, IntegrationProviderSerializer
-from sentry.utils.compat import filter
 
 
 class OrganizationConfigIntegrationsEndpoint(OrganizationEndpoint):

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -284,7 +284,7 @@ class OrganizationGroupIndexEndpoint(OrganizationEventsEndpointBase):
 
         # If group ids specified, just ignore any query components
         try:
-            group_ids = set(map(int, request.GET.getlist("group")))
+            group_ids = set(list(map(int, request.GET.getlist("group"))))
         except ValueError:
             return Response({"detail": "Group ids must be integers"}, status=400)
 

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -35,7 +35,6 @@ from sentry.search.snuba.executors import (
     PostgresSnubaQueryExecutor,
 )
 from sentry.snuba import discover
-from sentry.utils.compat import map
 from sentry.utils.cursors import Cursor, CursorResult
 
 from sentry.utils.validators import normalize_event_id

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -61,7 +61,7 @@ class OrganizationGroupIndexStatsEndpoint(OrganizationEventsEndpointBase):
         project_ids = [p.id for p in projects]
 
         try:
-            group_ids = set(map(int, request.GET.getlist("groups")))
+            group_ids = set(list(map(int, request.GET.getlist("groups"))))
         except ValueError:
             raise ParseError(detail="Group ids must be integers")
 

--- a/src/sentry/api/endpoints/organization_group_index_stats.py
+++ b/src/sentry/api/endpoints/organization_group_index_stats.py
@@ -12,7 +12,6 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import get_date_range_from_params, InvalidParams
 from sentry.models import Group
-from sentry.utils.compat import map
 from sentry.api.endpoints.organization_group_index import ERR_INVALID_STATS_PERIOD
 
 

--- a/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
+++ b/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
@@ -160,7 +160,7 @@ class OrganizationIntegrationRepositoryProjectPathConfigEndpoint(
 
         # front end handles ordering
         # TODO: Add pagination
-        data = map(lambda x: serialize(x, request.user), queryset)
+        data = list(map(lambda x: serialize(x, request.user), queryset))
         return self.respond(data)
 
     def post(self, request, organization):

--- a/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
+++ b/src/sentry/api/endpoints/organization_integration_repository_project_path_configs.py
@@ -11,7 +11,6 @@ from sentry.models import (
     Repository,
     OrganizationIntegration,
 )
-from sentry.utils.compat import map
 
 
 def gen_path_regex_field():

--- a/src/sentry/api/endpoints/organization_member_unreleased_commits.py
+++ b/src/sentry/api/endpoints/organization_member_unreleased_commits.py
@@ -3,7 +3,6 @@ from django.db import connections
 from sentry.api.bases import OrganizationMemberEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import Commit, Repository, UserEmail
-from sentry.utils.compat import zip
 
 # TODO(dcramer): once LatestRepoReleaseEnvironment is backfilled, change this query to use the new
 # schema [performance]

--- a/src/sentry/api/endpoints/organization_member_unreleased_commits.py
+++ b/src/sentry/api/endpoints/organization_member_unreleased_commits.py
@@ -70,7 +70,7 @@ class OrganizationMemberUnreleasedCommitsEndpoint(OrganizationMemberEndpoint):
                     for c in results
                 ],
                 "repositories": {
-                    str(r.id): d for r, d in zip(repos, serialize(repos, request.user))
+                    str(r.id): d for r, d in list(zip(repos, serialize(repos, request.user)))
                 },
             }
         )

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -23,7 +23,7 @@ class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):
         :auth: required
         """
         is_member = request.GET.get("is_member")
-        project_ids = set(map(int, request.GET.getlist("project")))
+        project_ids = set(list(map(int, request.GET.getlist("project"))))
         queryset = Project.objects.filter(organization=organization, first_event__isnull=False)
         if is_member:
             queryset = queryset.filter(teams__organizationmember__user=request.user)

--- a/src/sentry/api/endpoints/organization_projects_sent_first_event.py
+++ b/src/sentry/api/endpoints/organization_projects_sent_first_event.py
@@ -3,7 +3,6 @@ from rest_framework.response import Response
 from sentry.models import Project
 from sentry.api.serializers import serialize
 from sentry.api.bases.organization import OrganizationEndpoint
-from sentry.utils.compat import map
 
 
 class OrganizationProjectsSentFirstEventEndpoint(OrganizationEndpoint):

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -80,7 +80,7 @@ def debounce_update_release_health_data(organization, project_ids):
     should_update = {}
     cache_keys = ["debounce-health:%d" % id for id in project_ids]
     cache_data = cache.get_many(cache_keys)
-    for project_id, cache_key in zip(project_ids, cache_keys):
+    for project_id, cache_key in list(zip(project_ids, cache_keys)):
         if cache_data.get(cache_key) is None:
             should_update[project_id] = cache_key
 
@@ -129,7 +129,7 @@ def debounce_update_release_health_data(organization, project_ids):
         release.add_project(project)
 
     # Debounce updates for a minute
-    cache.set_many(dict(zip(should_update.values(), [True] * len(should_update))), 60)
+    cache.set_many(dict(list(zip(should_update.values(), [True] * len(should_update)))), 60)
 
 
 class OrganizationReleasesEndpoint(

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -35,7 +35,6 @@ from sentry.snuba.sessions import (
     STATS_PERIODS,
 )
 from sentry.utils.cache import cache
-from sentry.utils.compat import zip as izip
 from sentry.utils.sdk import configure_scope, bind_organization_context
 
 
@@ -81,7 +80,7 @@ def debounce_update_release_health_data(organization, project_ids):
     should_update = {}
     cache_keys = ["debounce-health:%d" % id for id in project_ids]
     cache_data = cache.get_many(cache_keys)
-    for project_id, cache_key in izip(project_ids, cache_keys):
+    for project_id, cache_key in zip(project_ids, cache_keys):
         if cache_data.get(cache_key) is None:
             should_update[project_id] = cache_key
 
@@ -130,7 +129,7 @@ def debounce_update_release_health_data(organization, project_ids):
         release.add_project(project)
 
     # Debounce updates for a minute
-    cache.set_many(dict(izip(should_update.values(), [True] * len(should_update))), 60)
+    cache.set_many(dict(zip(should_update.values(), [True] * len(should_update))), 60)
 
 
 class OrganizationReleasesEndpoint(

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -50,7 +50,7 @@ class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMix
             raise ValueError("Invalid group: %s" % group)
 
         if "id" in request.GET:
-            id_filter_set = frozenset(map(int, request.GET.getlist("id")))
+            id_filter_set = frozenset(list(map(int, request.GET.getlist("id"))))
             keys = [k for k in keys if k in id_filter_set]
 
         if not keys:

--- a/src/sentry/api/endpoints/organization_stats.py
+++ b/src/sentry/api/endpoints/organization_stats.py
@@ -5,7 +5,6 @@ from sentry.api.base import EnvironmentMixin, StatsMixin
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.models import Environment, Project, Team
-from sentry.utils.compat import map
 
 
 class OrganizationStatsEndpoint(OrganizationEndpoint, EnvironmentMixin, StatsMixin):

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -193,7 +193,7 @@ class ProjectAdminSerializer(ProjectMemberSerializer):
         return data
 
     def validate_allowedDomains(self, value):
-        value = filter(bool, value)
+        value = list(filter(bool, value))
         if len(value) == 0:
             raise serializers.ValidationError(
                 "Empty value will block all requests, use * to accept from all domains"
@@ -347,7 +347,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         """
         data = serialize(project, request.user, DetailedProjectSerializer())
 
-        include = set(filter(bool, request.GET.get("include", "").split(",")))
+        include = set(list(filter(bool, request.GET.get("include", "").split(","))))
         if "stats" in include:
             data["stats"] = {"unresolved": self._get_unresolved_count(project)}
 

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -37,7 +37,6 @@ from sentry.grouping.enhancer import Enhancements, InvalidEnhancerConfig
 from sentry.grouping.fingerprinting import FingerprintingRules, InvalidFingerprintingConfig
 from sentry.tasks.deletion import delete_project
 from sentry.utils import json
-from sentry.utils.compat import filter
 
 delete_logger = logging.getLogger("sentry.deletions.api")
 

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -347,7 +347,7 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         """
         data = serialize(project, request.user, DetailedProjectSerializer())
 
-        include = set(list(filter(bool, request.GET.get("include", "").split(","))))
+        include = set(filter(bool, request.GET.get("include", "").split(",")))
         if "stats" in include:
             data["stats"] = {"unresolved": self._get_unresolved_count(project)}
 

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -40,8 +40,8 @@ class PathMappingSerializer(CamelSnakeSerializer):
     @property
     def providers(self):
         # TODO: use feature flag in the future
-        providers = filter(lambda x: x.has_stacktrace_linking, list(integrations.all()))
-        return map(lambda x: x.key, providers)
+        providers = list(filter(lambda x: x.has_stacktrace_linking, list(integrations.all())))
+        return list(map(lambda x: x.key, providers))
 
     @property
     def org_id(self):
@@ -69,7 +69,7 @@ class PathMappingSerializer(CamelSnakeSerializer):
             organizations=self.org_id, provider__in=self.providers
         )
 
-        matching_integrations = filter(integration_match, integrations)
+        matching_integrations = list(filter(integration_match, integrations))
         if not matching_integrations:
             raise serializers.ValidationError("Could not find integration")
 
@@ -77,7 +77,7 @@ class PathMappingSerializer(CamelSnakeSerializer):
 
         # now find the matching repo
         repos = Repository.objects.filter(integration_id=self.integration.id)
-        matching_repos = filter(repo_match, repos)
+        matching_repos = list(filter(repo_match, repos))
         if not matching_repos:
             raise serializers.ValidationError("Could not find repo")
 

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -4,7 +4,6 @@ from sentry import integrations
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.models import Integration, Repository
-from sentry.utils.compat import filter, map
 
 
 def find_roots(stack_path, source_path):

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -4,7 +4,6 @@ from sentry import analytics
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.models import Integration, RepositoryProjectPathConfig
 from sentry.api.serializers import serialize
-from sentry.utils.compat import filter
 
 from sentry_sdk import configure_scope
 

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -45,7 +45,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         # no longer feature gated and is added as an IntegrationFeature
         result["integrations"] = [
             serialize(i, request.user)
-            for i in filter(lambda i: i.get_provider().has_stacktrace_linking, integrations)
+            for i in list(filter(lambda i: i.get_provider().has_stacktrace_linking, integrations))
         ]
 
         # xxx(meredith): if there are ever any changes to this query, make

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -15,7 +15,9 @@ VALID_STATUSES = frozenset(("snoozed", "dismissed"))
 
 class PromptsActivitySerializer(serializers.Serializer):
     feature = serializers.CharField(required=True)
-    status = serializers.ChoiceField(choices=zip(VALID_STATUSES, VALID_STATUSES), required=True)
+    status = serializers.ChoiceField(
+        choices=list(zip(VALID_STATUSES, VALID_STATUSES)), required=True
+    )
 
     def validate_feature(self, value):
         if value is None:

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -8,7 +8,6 @@ from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
 from sentry.models import Organization, PromptsActivity, Project
-from sentry.utils.compat import zip
 from sentry.utils.prompts import prompt_config
 
 VALID_STATUSES = frozenset(("snoozed", "dismissed"))

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -35,7 +35,6 @@ from sentry.utils.snuba import (
     SNUBA_AND,
     SNUBA_OR,
 )
-from sentry.utils.compat import filter, map, zip
 
 
 WILDCARD_CHARS = re.compile(r"[\*]")

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -245,7 +245,7 @@ class ParenExpression(namedtuple("ParenExpression", "children")):
 
 class SearchFilter(namedtuple("SearchFilter", "key operator value")):
     def __str__(self):
-        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
+        return "".join(list(map(str, (self.key.name, self.operator, self.value.raw_value))))
 
     @cached_property
     def is_negation(self):
@@ -274,7 +274,7 @@ class SearchKey(namedtuple("SearchKey", "name")):
 
 class AggregateFilter(namedtuple("AggregateFilter", "key operator value")):
     def __str__(self):
-        return "".join(map(str, (self.key.name, self.operator, self.value.raw_value)))
+        return "".join(list(map(str, (self.key.name, self.operator, self.value.raw_value))))
 
 
 class AggregateKey(namedtuple("AggregateKey", "name")):
@@ -364,13 +364,13 @@ class SearchVisitor(NodeVisitor):
         def is_not_optional(child):
             return not (isinstance(child, Node) and isinstance(child.expr, Optional))
 
-        return filter(is_not_optional, children)
+        return list(filter(is_not_optional, children))
 
     def remove_space(self, children):
         def is_not_space(child):
             return not (isinstance(child, Node) and child.text == " " * len(child.text))
 
-        return filter(is_not_space, children)
+        return list(filter(is_not_space, children))
 
     def is_numeric_key(self, key):
         return key in self.numeric_keys or is_measurement(key)
@@ -1189,7 +1189,7 @@ def convert_search_boolean_to_snuba_query(terms, params=None):
 
     condition, having = None, None
     if lhs_condition or rhs_condition:
-        args = filter(None, [lhs_condition, rhs_condition])
+        args = list(filter(None, [lhs_condition, rhs_condition]))
         if not args:
             condition = None
         elif len(args) == 1:
@@ -1198,7 +1198,7 @@ def convert_search_boolean_to_snuba_query(terms, params=None):
             condition = [operator, args]
 
     if lhs_having or rhs_having:
-        args = filter(None, [lhs_having, rhs_having])
+        args = list(filter(None, [lhs_having, rhs_having]))
         if not args:
             having = None
         elif len(args) == 1:
@@ -1835,7 +1835,7 @@ class Function:
         arguments = {}
 
         # normalize the arguments before putting them in a dict
-        for argument, column in zip(self.args, columns):
+        for argument, column in list(zip(self.args, columns)):
             try:
                 arguments[argument.name] = argument.normalize(column, params)
             except InvalidFunctionArgument as e:

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -65,7 +65,7 @@ class Actor(namedtuple("Actor", "id type")):
             for instance in type.objects.filter(id__in=[a.id for a in _actors]):
                 results[(type, instance.id)] = instance
 
-        return list(list(filter(None, [results.get((actor.type, actor.id)) for actor in actors])))
+        return list(filter(None, [results.get((actor.type, actor.id)) for actor in actors]))
 
     @classmethod
     def resolve_dict(cls, actor_dict):

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -65,7 +65,7 @@ class Actor(namedtuple("Actor", "id type")):
             for instance in type.objects.filter(id__in=[a.id for a in _actors]):
                 results[(type, instance.id)] = instance
 
-        return list(filter(None, [results.get((actor.type, actor.id)) for actor in actors]))
+        return list(list(filter(None, [results.get((actor.type, actor.id)) for actor in actors])))
 
     @classmethod
     def resolve_dict(cls, actor_dict):

--- a/src/sentry/api/fields/actor.py
+++ b/src/sentry/api/fields/actor.py
@@ -2,7 +2,6 @@ from collections import defaultdict, namedtuple
 from rest_framework import serializers
 from sentry.models import User, Team
 from sentry.utils.auth import find_users
-from sentry.utils.compat import filter
 
 
 class Actor(namedtuple("Actor", "id type")):

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -65,7 +65,6 @@ from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.cursors import Cursor
 from sentry.utils.functional import extract_lazy_object
-from sentry.utils.compat import zip
 
 delete_logger = logging.getLogger("sentry.deletions.api")
 

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -236,7 +236,7 @@ class GroupValidator(serializers.Serializer):
     inbox = serializers.BooleanField()
     inboxDetails = InboxDetailsValidator()
     status = serializers.ChoiceField(
-        choices=zip(STATUS_UPDATE_CHOICES.keys(), STATUS_UPDATE_CHOICES.keys())
+        choices=list(zip(STATUS_UPDATE_CHOICES.keys(), STATUS_UPDATE_CHOICES.keys()))
     )
     statusDetails = StatusDetailsValidator()
     hasSeen = serializers.BooleanField()

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -18,7 +18,6 @@ from sentry.search.utils import (
     parse_release,
     parse_status_value,
 )
-from sentry.utils.compat import map
 
 
 class IssueSearchVisitor(SearchVisitor):

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -144,4 +144,4 @@ def convert_query_values(search_filters, projects, user, environments):
             )
         return search_filter
 
-    return map(convert_search_filter, search_filters)
+    return list(map(convert_search_filter, search_filters))

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -355,7 +355,7 @@ def reverse_bisect_left(a, x, lo=0, hi=None):
 class SequencePaginator:
     def __init__(self, data, reverse=False, max_limit=MAX_LIMIT, on_results=None):
         self.scores, self.values = (
-            map(list, zip(*sorted(data, reverse=reverse))) if data else ([], [])
+            list(map(list, list(zip(*sorted(data, reverse=reverse))))) if data else ([], [])
         )
         self.reverse = reverse
         self.search = functools.partial(

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -9,8 +9,6 @@ from django.db.models.sql.datastructures import EmptyResultSet
 from django.utils import timezone
 
 from sentry.utils.cursors import build_cursor, Cursor, CursorResult
-from sentry.utils.compat import map
-from sentry.utils.compat import zip
 
 quote_name = connections["default"].ops.quote_name
 

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -19,7 +19,9 @@ class ActivitySerializer(Serializer):
         }
         if commit_ids:
             commit_list = list(Commit.objects.filter(id__in=commit_ids))
-            commits_by_id = {c.id: d for c, d in zip(commit_list, serialize(commit_list, user))}
+            commits_by_id = {
+                c.id: d for c, d in list(zip(commit_list, serialize(commit_list, user)))
+            }
             commits = {
                 i: commits_by_id.get(i.data["commit"])
                 for i in item_list
@@ -36,7 +38,7 @@ class ActivitySerializer(Serializer):
         if pull_request_ids:
             pull_request_list = list(PullRequest.objects.filter(id__in=pull_request_ids))
             pull_requests_by_id = {
-                c.id: d for c, d in zip(pull_request_list, serialize(pull_request_list, user))
+                c.id: d for c, d in list(zip(pull_request_list, serialize(pull_request_list, user)))
             }
             pull_requests = {
                 i: pull_requests_by_id.get(i.data["pull_request"])

--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -3,7 +3,6 @@ import functools
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import Activity, Commit, Group, PullRequest
 from sentry.utils.functional import apply_values
-from sentry.utils.compat import zip
 
 
 @register(Activity)

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -25,7 +25,7 @@ class AlertRuleSerializer(Serializer):
         result = defaultdict(dict)
         triggers = AlertRuleTrigger.objects.filter(alert_rule__in=item_list).order_by("label")
         serialized_triggers = serialize(list(triggers))
-        for trigger, serialized in zip(triggers, serialized_triggers):
+        for trigger, serialized in list(zip(triggers, serialized_triggers)):
             alert_rule_triggers = result[alert_rules[trigger.alert_rule_id]].setdefault(
                 "triggers", []
             )

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -13,7 +13,6 @@ from sentry.incidents.logic import translate_aggregate_field
 from sentry.snuba.models import SnubaQueryEventType
 
 from sentry.models import Rule
-from sentry.utils.compat import zip
 from sentry.utils.db import attach_foreignkey
 
 

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -22,7 +22,7 @@ class AlertRuleTriggerSerializer(Serializer):
             "id"
         )
         serialized_actions = serialize(list(actions))
-        for trigger, serialized in zip(actions, serialized_actions):
+        for trigger, serialized in list(zip(actions, serialized_actions)):
             triggers_actions = result[triggers[trigger.alert_rule_trigger_id]].setdefault(
                 "actions", []
             )

--- a/src/sentry/api/serializers/models/alert_rule_trigger.py
+++ b/src/sentry/api/serializers/models/alert_rule_trigger.py
@@ -7,7 +7,6 @@ from sentry.incidents.models import (
     AlertRuleTriggerAction,
     AlertRuleTriggerExclusion,
 )
-from sentry.utils.compat import zip
 from sentry.utils.db import attach_foreignkey
 
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -169,7 +169,7 @@ class EventSerializer(Serializer):
         crash_files = get_crash_files(item_list)
         serialized_files = {
             file.event_id: serialized
-            for file, serialized in zip(crash_files, serialize(crash_files, user=user))
+            for file, serialized in list(zip(crash_files, serialize(crash_files, user=user)))
         }
         results = {}
         for item in item_list:
@@ -347,7 +347,7 @@ class SimpleEventSerializer(EventSerializer):
         crash_files = get_crash_files(item_list)
         serialized_files = {
             file.event_id: serialized
-            for file, serialized in zip(crash_files, serialize(crash_files, user=user))
+            for file, serialized in list(zip(crash_files, serialize(crash_files, user=user)))
         }
         return {event: {"crash_file": serialized_files.get(event.event_id)} for event in item_list}
 

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -7,7 +7,6 @@ from sentry.eventstore.models import Event
 from sentry.models import EventAttachment, EventError, Release, UserReport
 from sentry.sdk_updates import get_suggested_updates, SdkSetupState
 from sentry.search.utils import convert_user_tag_to_query
-from sentry.utils.compat import zip
 from sentry.utils.json import prune_empty_keys
 from sentry.utils.safe import get_path
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -50,7 +50,6 @@ from sentry.tsdb.snuba import SnubaTSDB
 from sentry.utils import snuba
 from sentry.utils.db import attach_foreignkey
 from sentry.utils.safe import safe_execute
-from sentry.utils.compat import map, zip
 from sentry.utils.snuba import Dataset, raw_query
 from sentry.reprocessing2 import get_progress
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -196,12 +196,14 @@ class GroupSerializerBase(Serializer):
             for subscription in GroupSubscription.objects.filter(
                 group__in=list(
                     itertools.chain.from_iterable(
-                        map(
-                            lambda project__groups: project__groups[1]
-                            if not options.get(project__groups[0].id, options.get(None))
-                            == UserOptionValue.no_conversations
-                            else [],
-                            projects.items(),
+                        list(
+                            map(
+                                lambda project__groups: project__groups[1]
+                                if not options.get(project__groups[0].id, options.get(None))
+                                == UserOptionValue.no_conversations
+                                else [],
+                                projects.items(),
+                            )
                         )
                     )
                 ),
@@ -293,7 +295,7 @@ class GroupSerializerBase(Serializer):
                 )
             )
             commit_resolutions = {
-                i.group_id: d for i, d in zip(commit_results, serialize(commit_results, user))
+                i.group_id: d for i, d in list(zip(commit_results, serialize(commit_results, user)))
             }
         else:
             release_resolutions = {}
@@ -303,7 +305,7 @@ class GroupSerializerBase(Serializer):
         actor_ids.update(r.actor_id for r in ignore_items.values())
         if actor_ids:
             users = list(User.objects.filter(id__in=actor_ids, is_active=True))
-            actors = {u.id: d for u, d in zip(users, serialize(users, user))}
+            actors = {u.id: d for u, d in list(zip(users, serialize(users, user)))}
         else:
             actors = {}
 
@@ -849,7 +851,7 @@ class GroupSerializerSnuba(GroupSerializerBase):
         )
         seen_data = {
             issue["group_id"]: fix_tag_value_data(
-                dict(filter(lambda key: key[0] != "group_id", issue.items()))
+                dict(list(filter(lambda key: key[0] != "group_id", issue.items())))
             )
             for issue in result["data"]
         }

--- a/src/sentry/api/serializers/models/grouprelease.py
+++ b/src/sentry/api/serializers/models/grouprelease.py
@@ -13,7 +13,7 @@ StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))
 class GroupReleaseSerializer(Serializer):
     def get_attrs(self, item_list, user):
         release_list = list(Release.objects.filter(id__in=[i.release_id for i in item_list]))
-        releases = {r.id: d for r, d in zip(release_list, serialize(release_list, user))}
+        releases = {r.id: d for r, d in list(zip(release_list, serialize(release_list, user)))}
 
         result = {}
         for item in item_list:

--- a/src/sentry/api/serializers/models/grouprelease.py
+++ b/src/sentry/api/serializers/models/grouprelease.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 from sentry.app import tsdb
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import GroupRelease, Release
-from sentry.utils.compat import zip
 
 StatsPeriod = namedtuple("StatsPeriod", ("segments", "interval"))
 

--- a/src/sentry/api/serializers/models/grouptombstone.py
+++ b/src/sentry/api/serializers/models/grouptombstone.py
@@ -1,7 +1,6 @@
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.constants import LOG_LEVELS
 from sentry.models import GroupTombstone, User
-from sentry.utils.compat import zip
 
 
 @register(GroupTombstone)

--- a/src/sentry/api/serializers/models/grouptombstone.py
+++ b/src/sentry/api/serializers/models/grouptombstone.py
@@ -7,7 +7,7 @@ from sentry.models import GroupTombstone, User
 class GroupTombstoneSerializer(Serializer):
     def get_attrs(self, item_list, user):
         user_list = list(User.objects.filter(id__in=[item.actor_id for item in item_list]))
-        users = {u.id: d for u, d in zip(user_list, serialize(user_list, user))}
+        users = {u.id: d for u, d in list(zip(user_list, serialize(user_list, user)))}
 
         attrs = {}
         for item in item_list:

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -33,7 +33,6 @@ from sentry.models import (
 )
 from sentry.snuba import discover
 from sentry.ingest.inbound_filters import FilterTypes
-from sentry.utils.compat import zip
 
 STATUS_LABELS = {
     ProjectStatus.VISIBLE: "active",

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -599,7 +599,7 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
         latest_release_list = bulk_fetch_project_latest_releases(item_list)
         latest_releases = {
             r.actual_project_id: d
-            for r, d in zip(latest_release_list, serialize(latest_release_list, user))
+            for r, d in list(zip(latest_release_list, serialize(latest_release_list, user)))
         }
 
         for item in item_list:

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -20,7 +20,6 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.utils import metrics
-from sentry.utils.compat import zip
 from sentry.utils.hashlib import md5_text
 
 

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -158,7 +158,7 @@ class ReleaseSerializer(Serializer):
         commit_ids = {o.last_commit_id for o in item_list if o.last_commit_id}
         if commit_ids:
             commit_list = list(Commit.objects.filter(id__in=commit_ids).select_related("author"))
-            commits = {c.id: d for c, d in zip(commit_list, serialize(commit_list, user))}
+            commits = {c.id: d for c, d in list(zip(commit_list, serialize(commit_list, user)))}
         else:
             commits = {}
 
@@ -194,7 +194,7 @@ class ReleaseSerializer(Serializer):
         deploy_ids = {o.last_deploy_id for o in item_list if o.last_deploy_id}
         if deploy_ids:
             deploy_list = list(Deploy.objects.filter(id__in=deploy_ids))
-            deploys = {d.id: c for d, c in zip(deploy_list, serialize(deploy_list, user))}
+            deploys = {d.id: c for d, c in list(zip(deploy_list, serialize(deploy_list, user)))}
         else:
             deploys = {}
 

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -1,6 +1,5 @@
 from sentry.api.serializers import Serializer, register
 from sentry.models import Environment, Rule, RuleActivity, RuleActivityType
-from sentry.utils.compat import filter
 
 
 def _generate_rule_label(project, rule, data):

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -56,9 +56,9 @@ class RuleSerializer(Serializer):
             # as part of the rule editor
             "id": str(obj.id) if obj.id else None,
             # conditions pertain to criteria that can trigger an alert
-            "conditions": filter(lambda condition: not _is_filter(condition), all_conditions),
+            "conditions": list(filter(lambda condition: not _is_filter(condition), all_conditions)),
             # filters are not new conditions but are the subset of conditions that pertain to event attributes
-            "filters": filter(lambda condition: _is_filter(condition), all_conditions),
+            "filters": list(filter(lambda condition: _is_filter(condition), all_conditions)),
             "actions": [
                 dict(list(o.items()) + [("name", _generate_rule_label(obj.project, obj, o))])
                 for o in obj.data.get("actions", [])

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -4,7 +4,6 @@ from sentry.auth.superuser import is_active_superuser
 from sentry.constants import SentryAppStatus
 from sentry.models import IntegrationFeature, SentryApp
 from sentry.models.sentryapp import MASKED_VALUE
-from sentry.utils.compat import map
 
 
 @register(SentryApp)

--- a/src/sentry/api/serializers/models/sentry_app.py
+++ b/src/sentry/api/serializers/models/sentry_app.py
@@ -32,7 +32,7 @@ class SentryAppSerializer(Serializer):
 
         if obj.status != SentryAppStatus.INTERNAL:
             features = IntegrationFeature.objects.filter(sentry_app_id=obj.id)
-            data["featureData"] = map(lambda x: serialize(x, user), features)
+            data["featureData"] = list(map(lambda x: serialize(x, user), features))
 
         if obj.status == SentryAppStatus.PUBLISHED and obj.date_published:
             data.update({"datePublished": obj.date_published})

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -144,7 +144,7 @@ class TeamWithProjectsSerializer(TeamSerializer):
 
         projects = [pt.project for pt in project_teams]
         projects_by_id = {
-            project.id: data for project, data in zip(projects, serialize(projects, user))
+            project.id: data for project, data in list(zip(projects, serialize(projects, user)))
         }
 
         project_map = defaultdict(list)

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -17,7 +17,6 @@ from sentry.models import (
     TeamAvatar,
     ExternalTeam,
 )
-from sentry.utils.compat import zip
 
 
 def get_team_memberships(team_list, user):

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -11,7 +11,7 @@ class UserReportSerializer(Serializer):
         # for event_user_id to be None.
         if event_user_ids:
             queryset = list(EventUser.objects.filter(id__in=event_user_ids))
-            event_users = {e.id: d for e, d in zip(queryset, serialize(queryset, user))}
+            event_users = {e.id: d for e, d in list(zip(queryset, serialize(queryset, user)))}
         else:
             event_users = {}
 

--- a/src/sentry/api/serializers/models/userreport.py
+++ b/src/sentry/api/serializers/models/userreport.py
@@ -1,6 +1,5 @@
 from sentry.api.serializers import register, serialize, Serializer
 from sentry.models import EventUser, Group, UserReport
-from sentry.utils.compat import zip
 
 
 @register(UserReport)

--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -6,7 +6,6 @@ from rest_framework import serializers
 from sentry.models import MonitorStatus, MonitorType, ScheduleType
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers.rest_framework.project import ProjectField
-from sentry.utils.compat import zip
 
 
 SCHEDULE_TYPES = OrderedDict(

--- a/src/sentry/api/validators/monitor.py
+++ b/src/sentry/api/validators/monitor.py
@@ -38,7 +38,7 @@ class ObjectField(serializers.Field):
 
 class CronJobValidator(serializers.Serializer):
     schedule_type = serializers.ChoiceField(
-        choices=zip(SCHEDULE_TYPES.keys(), SCHEDULE_TYPES.keys())
+        choices=list(zip(SCHEDULE_TYPES.keys(), SCHEDULE_TYPES.keys()))
     )
     schedule = ObjectField()
     checkin_margin = EmptyIntegerField(required=False, default=None)
@@ -85,9 +85,9 @@ class MonitorValidator(serializers.Serializer):
     project = ProjectField()
     name = serializers.CharField()
     status = serializers.ChoiceField(
-        choices=zip(MONITOR_STATUSES.keys(), MONITOR_STATUSES.keys()), default="active"
+        choices=list(zip(MONITOR_STATUSES.keys(), MONITOR_STATUSES.keys())), default="active"
     )
-    type = serializers.ChoiceField(choices=zip(MONITOR_TYPES.keys(), MONITOR_TYPES.keys()))
+    type = serializers.ChoiceField(choices=list(zip(MONITOR_TYPES.keys(), MONITOR_TYPES.keys())))
     config = ObjectField()
 
     def validate(self, attrs):

--- a/src/sentry/auth/providers/google/views.py
+++ b/src/sentry/auth/providers/google/views.py
@@ -25,7 +25,7 @@ class FetchUser(AuthView):
             return helper.error(ERR_INVALID_RESPONSE)
 
         try:
-            _, payload, _ = map(urlsafe_b64decode, id_token.split(".", 2))
+            _, payload, _ = list(map(urlsafe_b64decode, id_token.split(".", 2)))
         except Exception as exc:
             logger.error("Unable to decode id_token: %s" % exc, exc_info=True)
             return helper.error(ERR_INVALID_RESPONSE)

--- a/src/sentry/auth/providers/google/views.py
+++ b/src/sentry/auth/providers/google/views.py
@@ -5,7 +5,6 @@ from sentry.utils import json
 from sentry.utils.signing import urlsafe_b64decode
 
 from .constants import DOMAIN_BLOCKLIST, ERR_INVALID_DOMAIN, ERR_INVALID_RESPONSE
-from sentry.utils.compat import map
 
 logger = logging.getLogger("sentry.auth.google")
 

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -32,7 +32,7 @@ class DataExportQuerySerializer(serializers.Serializer):
             get_projects_by_id = self.context["get_projects_by_id"]
             # Coerce the query into a set
             if isinstance(project_query, list):
-                projects = get_projects_by_id(set(map(int, project_query)))
+                projects = get_projects_by_id(set(list(map(int, project_query))))
             else:
                 projects = get_projects_by_id({int(project_query)})
             query_info["project"] = [project.id for project in projects]

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -9,7 +9,6 @@ from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params
 from sentry.models import Environment
 from sentry.utils import metrics
-from sentry.utils.compat import map
 from sentry.utils.snuba import MAX_FIELDS
 
 from ..base import ExportQueryType

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -27,7 +27,7 @@ class DataExportDetailsEndpoint(OrganizationEndpoint):
             data_export = ExportedData.objects.get(id=kwargs["data_export_id"])
             # Check data export permissions
             if data_export.query_info.get("project"):
-                project_ids = map(int, data_export.query_info.get("project", []))
+                project_ids = list(map(int, data_export.query_info.get("project", [])))
                 projects = Project.objects.filter(organization=organization, id__in=project_ids)
                 if any(p for p in projects if not request.access.has_project_access(p)):
                     raise PermissionDenied(

--- a/src/sentry/data_export/endpoints/data_export_details.py
+++ b/src/sentry/data_export/endpoints/data_export_details.py
@@ -7,7 +7,6 @@ from sentry.api.bases.organization import OrganizationEndpoint, OrganizationData
 from sentry.api.serializers import serialize
 from sentry.models import Project
 from sentry.utils import metrics
-from sentry.utils.compat import map
 
 from ..models import ExportedData
 

--- a/src/sentry/data_export/processors/discover.py
+++ b/src/sentry/data_export/processors/discover.py
@@ -29,7 +29,7 @@ class DiscoverProcessor:
         # an empty list DOES NOT work
         if self.environments:
             self.params["environment"] = self.environments
-        self.header_fields = map(lambda x: get_function_alias(x), discover_query["field"])
+        self.header_fields = list(map(lambda x: get_function_alias(x), discover_query["field"]))
         self.data_fn = self.get_data_fn(
             fields=discover_query["field"], query=discover_query["query"], params=self.params
         )

--- a/src/sentry/data_export/processors/discover.py
+++ b/src/sentry/data_export/processors/discover.py
@@ -4,7 +4,6 @@ from sentry.api.event_search import get_function_alias
 from sentry.api.utils import get_date_range_from_params
 from sentry.models import Environment, Group, Project
 from sentry.snuba import discover
-from sentry.utils.compat import map
 
 from ..base import ExportError
 

--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -107,7 +107,7 @@ class BulkDeleteQuery:
                         if position is not None:
                             where.append((f"{quote_name(order_field)} >= %s", [position]))
 
-                    conditions, parameters = zip(*where)
+                    conditions, parameters = list(zip(*where))
                     parameters = list(itertools.chain.from_iterable(parameters))
 
                     query = """

--- a/src/sentry/db/deletion.py
+++ b/src/sentry/db/deletion.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 from datetime import timedelta
 from django.db import connections, router
 from django.utils import timezone
-from sentry.utils.compat import zip
 
 
 class BulkDeleteQuery:

--- a/src/sentry/db/models/fields/array.py
+++ b/src/sentry/db/models/fields/array.py
@@ -40,4 +40,4 @@ class ArrayField(models.Field):
             value = []
         if isinstance(value, str):
             value = json.loads(value)
-        return map(self.of.to_python, value)
+        return list(map(self.of.to_python, value))

--- a/src/sentry/db/models/fields/array.py
+++ b/src/sentry/db/models/fields/array.py
@@ -2,7 +2,6 @@ from django.db import models
 
 from sentry.db.models.utils import Creator
 from sentry.utils import json
-from sentry.utils.compat import map
 
 
 # Adapted from django-pgfields

--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -379,7 +379,7 @@ class BaseManager(Manager):
         nested_lookup_cache_keys = []
         nested_lookup_values = []
 
-        for cache_key, value in zip(cache_lookup_cache_keys, cache_lookup_values):
+        for cache_key, value in list(zip(cache_lookup_cache_keys, cache_lookup_values)):
             cache_result = cache_results.get(cache_key)
             if cache_result is None:
                 db_lookup_cache_keys.append(cache_key)
@@ -425,7 +425,7 @@ class BaseManager(Manager):
         cache_writes = []
 
         db_results = {getattr(x, key): x for x in self.filter(**{key + "__in": db_lookup_values})}
-        for cache_key, value in zip(db_lookup_cache_keys, db_lookup_values):
+        for cache_key, value in list(zip(db_lookup_cache_keys, db_lookup_values)):
             db_result = db_results.get(value)
             if db_result is None:
                 continue  # This model ultimately does not exist

--- a/src/sentry/db/models/manager.py
+++ b/src/sentry/db/models/manager.py
@@ -17,7 +17,6 @@ from sentry.utils.cache import cache
 from sentry.utils.hashlib import md5_text
 
 from .query import create_or_update
-from sentry.utils.compat import zip
 
 __all__ = ("BaseManager", "OptionManager")
 

--- a/src/sentry/debug/utils/packages.py
+++ b/src/sentry/debug/utils/packages.py
@@ -1,5 +1,4 @@
 import sys
-from sentry.utils.compat import map
 
 try:
     import pkg_resources

--- a/src/sentry/debug/utils/packages.py
+++ b/src/sentry/debug/utils/packages.py
@@ -40,7 +40,7 @@ def get_package_version(module_name, app):
         return None
 
     if isinstance(version, (list, tuple)):
-        version = ".".join(map(str, version))
+        version = ".".join(list(map(str, version)))
 
     return str(version)
 

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -201,15 +201,17 @@ class RedisBackend(Backend):
                 else:
                     raise
 
-            records = map(
-                lambda key__value__timestamp: Record(
-                    key__value__timestamp[0].decode("utf-8"),
-                    self.codec.decode(key__value__timestamp[1])
-                    if key__value__timestamp[1] is not None
-                    else None,
-                    float(key__value__timestamp[2]),
-                ),
-                response,
+            records = list(
+                map(
+                    lambda key__value__timestamp: Record(
+                        key__value__timestamp[0].decode("utf-8"),
+                        self.codec.decode(key__value__timestamp[1])
+                        if key__value__timestamp[1] is not None
+                        else None,
+                        float(key__value__timestamp[2]),
+                    ),
+                    response,
+                )
             )
 
             # If the record value is `None`, this means the record data was

--- a/src/sentry/digests/backends/redis.py
+++ b/src/sentry/digests/backends/redis.py
@@ -10,7 +10,6 @@ from sentry.utils.locking.backends.redis import RedisLockBackend
 from sentry.utils.locking.manager import LockManager
 from sentry.utils.redis import check_cluster_versions, get_cluster_from_options, load_script
 from sentry.utils.versioning import Version
-from sentry.utils.compat import map
 
 logger = logging.getLogger("sentry.digests")
 

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -12,7 +12,6 @@ from sentry.discover.utils import transform_aliases_and_query
 from sentry import features
 
 from .serializers import DiscoverQuerySerializer
-from sentry.utils.compat import map
 
 
 class DiscoverQueryPermission(OrganizationPermission):

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -105,7 +105,7 @@ class DiscoverQueryEndpoint(OrganizationEndpoint):
             return Response(status=404)
 
         try:
-            requested_projects = set(map(int, request.data.get("projects", [])))
+            requested_projects = set(list(map(int, request.data.get("projects", []))))
         except (ValueError, TypeError):
             raise ResourceDoesNotExist()
         projects = self._get_projects_by_id(requested_projects, request, organization)

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -67,7 +67,6 @@ from sentry.utils.outcomes import Outcome, track_outcome
 from sentry.utils.safe import safe_execute, trim, get_path, setdefault_path
 from sentry.stacktraces.processing import normalize_stacktraces_for_grouping
 from sentry.culprit import generate_culprit
-from sentry.utils.compat import map
 from sentry.reprocessing2 import save_unprocessed_event, is_reprocessed_event
 
 logger = logging.getLogger("sentry.events")

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1381,8 +1381,8 @@ def save_attachments(cache_key, attachments, job):
 
 
 def _find_hashes(project, hash_list):
-    return map(
-        lambda hash: GroupHash.objects.get_or_create(project=project, hash=hash)[0], hash_list
+    return list(
+        map(lambda hash: GroupHash.objects.get_or_create(project=project, hash=hash)[0], hash_list)
     )
 
 

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -123,7 +123,7 @@ class Event:
             keys = self._snuba_data[tags_key_column]
             values = self._snuba_data[tags_value_column]
             if keys and values and len(keys) == len(values):
-                return sorted(zip(keys, values))
+                return sorted(list(zip(keys, values)))
             else:
                 return []
         # Nodestore implementation

--- a/src/sentry/eventstore/models.py
+++ b/src/sentry/eventstore/models.py
@@ -18,7 +18,6 @@ from sentry.utils.cache import memoize
 from sentry.utils.canonical import CanonicalKeyView
 from sentry.utils.safe import get_path, trim
 from sentry.utils.strings import truncatechars
-from sentry.utils.compat import zip
 
 
 # Keys in the event payload we do not want to send to the event stream / snuba.

--- a/src/sentry/grouping/enhancer.py
+++ b/src/sentry/grouping/enhancer.py
@@ -266,7 +266,7 @@ class FlagAction(Action):
 
         sliced_components = self._slice_to_range(components, idx)
         sliced_frames = self._slice_to_range(frames, idx)
-        for component, frame in zip(sliced_components, sliced_frames):
+        for component, frame in list(zip(sliced_components, sliced_frames)):
             if self.key == "group" and self.flag != component.contributes:
                 component.update(
                     contributes=self.flag,
@@ -349,7 +349,7 @@ class Enhancements:
 
         # Apply direct frame actions and update the stack state alongside
         for rule in self.iter_rules():
-            for idx, (component, frame) in enumerate(zip(components, frames)):
+            for idx, (component, frame) in enumerate(list(zip(components, frames))):
                 actions = rule.get_matching_frame_actions(frame, platform)
                 for action in actions or ():
                     action.update_frame_components_contributions(components, frames, idx, rule=rule)

--- a/src/sentry/grouping/enhancer.py
+++ b/src/sentry/grouping/enhancer.py
@@ -14,7 +14,6 @@ from sentry.grouping.component import GroupingComponent
 from sentry.grouping.utils import get_rule_bool
 from sentry.utils.glob import glob_match
 from sentry.utils.safe import get_path
-from sentry.utils.compat import zip
 from sentry.utils.strings import unescape_string
 
 

--- a/src/sentry/identity/google/provider.py
+++ b/src/sentry/identity/google/provider.py
@@ -4,7 +4,6 @@ from sentry.auth.exceptions import IdentityNotValid
 from sentry.utils import json
 from sentry.utils.signing import urlsafe_b64decode
 from sentry.auth.provider import MigratingIdentityId
-from sentry.utils.compat import map
 
 
 # When no hosted domain is in use for the authenticated user, we default to the

--- a/src/sentry/identity/google/provider.py
+++ b/src/sentry/identity/google/provider.py
@@ -37,7 +37,7 @@ class GoogleIdentityProvider(OAuth2Provider):
             raise IdentityNotValid("Missing id_token in OAuth response: %s" % data)
 
         try:
-            _, payload, _ = map(urlsafe_b64decode, id_token.split(".", 2))
+            _, payload, _ = list(map(urlsafe_b64decode, id_token.split(".", 2)))
         except Exception as exc:
             raise IdentityNotValid("Unable to decode id_token: %s" % exc)
 

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -43,7 +43,6 @@ from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QueryDatasets, SnubaQueryEventType
 from sentry.snuba.tasks import build_snuba_filter
 from sentry.utils.snuba import raw_query
-from sentry.utils.compat import zip
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -448,7 +448,7 @@ class AlertRuleSerializer(CamelSnakeModelSerializer):
             )
 
         for i, (trigger, expected_label) in enumerate(
-            zip(triggers, (CRITICAL_TRIGGER_LABEL, WARNING_TRIGGER_LABEL))
+            list(zip(triggers, (CRITICAL_TRIGGER_LABEL, WARNING_TRIGGER_LABEL)))
         ):
             if trigger.get("label", None) != expected_label:
                 raise serializers.ValidationError(

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -486,7 +486,7 @@ def get_incident_event_stats(incident, start=None, end=None, windowed_stats=Fals
     results = bulk_raw_query(snuba_params, referrer="incidents.get_incident_event_stats")
     # Once we receive the results, if we requested extra buckets we now need to label
     # them with timestamp data, since the query we ran only returns the count.
-    for extra_start, result in zip(extra_buckets, results[1:]):
+    for extra_start, result in list(zip(extra_buckets, results[1:])):
         result["data"][0]["time"] = int(to_timestamp(extra_start))
     merged_data = list(chain(*[r["data"] for r in results]))
     merged_data.sort(key=lambda row: row["time"])

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -45,7 +45,6 @@ from sentry.snuba.subscriptions import (
     update_snuba_query,
 )
 from sentry.snuba.tasks import build_snuba_filter
-from sentry.utils.compat import zip
 from sentry.utils.dates import to_timestamp
 from sentry.utils.snuba import bulk_raw_query, is_measurement, SnubaQueryParams, SnubaTSResult
 from sentry.shared_integrations.exceptions import (

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -31,7 +31,6 @@ from sentry.incidents.tasks import handle_trigger_action
 from sentry.models import Project
 from sentry.utils import metrics, redis
 from sentry.utils.dates import to_datetime, to_timestamp
-from sentry.utils.compat import zip
 
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/incidents/subscription_processor.py
+++ b/src/sentry/incidents/subscription_processor.py
@@ -446,7 +446,7 @@ def partition(iterable, n):
     """
     assert len(iterable) % n == 0
     args = [iter(iterable)] * n
-    return zip(*args)
+    return list(zip(*args))
 
 
 def get_alert_rule_stats(alert_rule, subscription, triggers):
@@ -469,8 +469,8 @@ def get_alert_rule_stats(alert_rule, subscription, triggers):
     trigger_results = results[1:]
     trigger_alert_counts = {}
     trigger_resolve_counts = {}
-    for trigger, trigger_result in zip(
-        triggers, partition(trigger_results, len(ALERT_RULE_TRIGGER_STAT_KEYS))
+    for trigger, trigger_result in list(
+        zip(triggers, partition(trigger_results, len(ALERT_RULE_TRIGGER_STAT_KEYS)))
     ):
         trigger_alert_counts[trigger.id] = trigger_result[0]
         trigger_resolve_counts[trigger.id] = trigger_result[1]
@@ -484,7 +484,7 @@ def update_alert_rule_stats(alert_rule, subscription, last_update, alert_counts,
     """
     pipeline = get_redis_client().pipeline()
 
-    counts_with_stat_keys = zip(ALERT_RULE_TRIGGER_STAT_KEYS, (alert_counts, resolve_counts))
+    counts_with_stat_keys = list(zip(ALERT_RULE_TRIGGER_STAT_KEYS, (alert_counts, resolve_counts)))
     for stat_key, trigger_counts in counts_with_stat_keys:
         for trigger_id, alert_count in trigger_counts.items():
             pipeline.set(

--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -16,7 +16,6 @@ from sentry.integrations import (
 from sentry.integrations.serverless import ServerlessMixin
 from sentry.models import Project, OrganizationIntegration, ProjectStatus
 from sentry.pipeline import PipelineView
-from sentry.utils.compat import map
 from sentry.utils.sdk import capture_exception
 from sentry.utils import json
 

--- a/src/sentry/integrations/aws_lambda/integration.py
+++ b/src/sentry/integrations/aws_lambda/integration.py
@@ -121,7 +121,7 @@ class AwsLambdaIntegration(IntegrationInstallation, ServerlessMixin):
         functions = get_supported_functions(self.client)
         functions.sort(key=lambda x: x["FunctionName"].lower())
 
-        return map(self.serialize_lambda_function, functions)
+        return list(map(self.serialize_lambda_function, functions))
 
     @wrap_lambda_updater()
     def enable_function(self, target):
@@ -238,7 +238,7 @@ class AwsLambdaProjectSelectPipelineView(PipelineView):
             pipeline.bind_state("project_id", projects[0].id)
             return pipeline.next_step()
 
-        serialized_projects = map(lambda x: serialize(x, request.user), projects)
+        serialized_projects = list(map(lambda x: serialize(x, request.user), projects))
         return self.render_react_view(
             request, "awsLambdaProjectSelect", {"projects": serialized_projects}
         )
@@ -353,7 +353,7 @@ class AwsLambdaSetupLayerPipelineView(PipelineView):
             # check to see if the user wants to enable this function
             return enabled_lambdas.get(name)
 
-        lambda_functions = filter(is_lambda_enabled, lambda_functions)
+        lambda_functions = list(filter(is_lambda_enabled, lambda_functions))
 
         def _enable_lambda(function):
             try:

--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -102,7 +102,7 @@ def get_option_value(function, option):
     # special lookup for the version since it depends on the region
     if option == OPTION_VERSION:
         region_release_list = cache_value.get("regions", [])
-        matched_regions = filter(lambda x: x["region"] == region, region_release_list)
+        matched_regions = list(filter(lambda x: x["region"] == region, region_release_list))
         # see if there is the specific region in our list
         if matched_regions:
             version = matched_regions[0]["version"]
@@ -134,7 +134,7 @@ def _get_arn_from_layer(layer):
 
 def get_function_layer_arns(function):
     layers = function.get("Layers", [])
-    return map(_get_arn_from_layer, layers)
+    return list(map(_get_arn_from_layer, layers))
 
 
 def get_latest_layer_for_function(function):
@@ -174,9 +174,11 @@ def get_supported_functions(lambda_client):
     for page in response_iterator:
         functions += page["Functions"]
 
-    return filter(
-        lambda x: x.get("Runtime") in SUPPORTED_RUNTIMES,
-        functions,
+    return list(
+        filter(
+            lambda x: x.get("Runtime") in SUPPORTED_RUNTIMES,
+            functions,
+        )
     )
 
 

--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -11,7 +11,6 @@ from sentry import options
 from sentry.models import Project, ProjectKey
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.tasks.release_registry import LAYER_INDEX_CACHE_KEY
-from sentry.utils.compat import filter, map
 
 SUPPORTED_RUNTIMES = [
     "nodejs12.x",

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -15,7 +15,6 @@ from sentry.integrations import (
 from urllib.parse import urlparse
 from sentry.integrations.repositories import RepositoryMixin
 from sentry.pipeline import PipelineView
-from sentry.utils.compat import filter
 from django.utils.translation import ugettext_lazy as _
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.models.repository import Repository

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -272,7 +272,7 @@ class BitbucketServerIntegration(IntegrationInstallation, RepositoryMixin):
 
         accessible_repos = [r["identifier"] for r in self.get_repositories()]
 
-        return filter(lambda repo: repo.name not in accessible_repos, repos)
+        return list(filter(lambda repo: repo.name not in accessible_repos, repos))
 
     def reinstall(self):
         self.reinstall_repositories()

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -7,7 +7,6 @@ from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 from sentry.models import Activity, ExternalIssue, Group, GroupLink, GroupStatus, Organization
 from sentry.utils.http import absolute_uri
 from sentry.utils.safe import safe_execute
-from sentry.utils.compat import filter
 
 logger = logging.getLogger("sentry.integrations.issues")
 

--- a/src/sentry/integrations/issues.py
+++ b/src/sentry/integrations/issues.py
@@ -265,7 +265,7 @@ class IssueBasicMixin:
         # group annotations by group id
         annotations_by_group_id = defaultdict(list)
         for group_link in group_links:
-            issues_for_group = filter(lambda x: x.id == group_link.linked_id, external_issues)
+            issues_for_group = list(filter(lambda x: x.id == group_link.linked_id, external_issues))
             annotations = self.map_external_issues_to_annotations(issues_for_group)
             annotations_by_group_id[group_link.group_id].extend(annotations)
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -22,7 +22,6 @@ from sentry.shared_integrations.exceptions import (
 )
 from sentry.integrations.issues import IssueSyncMixin
 from sentry.models import IntegrationExternalProject, Organization, OrganizationIntegration, User
-from sentry.utils.compat import filter
 from sentry.utils.http import absolute_uri
 from sentry.utils.decorators import classproperty
 

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -243,8 +243,10 @@ class JiraIntegration(IntegrationInstallation, IssueSyncMixin):
             # accidentally use newlines, so we explicitly handle that case. On page
             # refresh, they will see how it got interpreted as `get_config_data` will
             # re-serialize the config as a comma-separated list.
-            ignored_fields_list = filter(
-                None, [field.strip() for field in re.split(r"[,\n\r]+", ignored_fields_text)]
+            ignored_fields_list = list(
+                filter(
+                    None, [field.strip() for field in re.split(r"[,\n\r]+", ignored_fields_text)]
+                )
             )
             data[self.issues_ignored_fields_key] = ignored_fields_list
 

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -54,8 +54,11 @@ class JiraSearchEndpoint(IntegrationEndpoint):
             except (ApiUnauthorized, ApiError):
                 return Response({"detail": "Unable to fetch users from Jira"}, status=400)
 
-            user_tuples = filter(
-                None, [build_user_choice(user, jira_client.user_id_field()) for user in response]
+            user_tuples = list(
+                filter(
+                    None,
+                    [build_user_choice(user, jira_client.user_id_field()) for user in response],
+                )
             )
             users = [{"value": user_id, "label": display} for user_id, display in user_tuples]
             return Response(users)

--- a/src/sentry/integrations/jira/search.py
+++ b/src/sentry/integrations/jira/search.py
@@ -4,7 +4,6 @@ from rest_framework.response import Response
 from sentry.api.bases.integration import IntegrationEndpoint
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError
 from sentry.models import Integration
-from sentry.utils.compat import filter
 
 from .utils import build_user_choice
 

--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -6,7 +6,6 @@ from sentry.models import (
     Team,
 )
 from sentry.utils.assets import get_asset_url
-from sentry.utils.compat import map
 from sentry.utils.http import absolute_uri
 
 from .utils import ACTION_TYPE

--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -19,7 +19,7 @@ logo = {
 
 
 def generate_action_payload(action_type, event, rules, integration):
-    rule_ids = map(lambda x: x.id, rules)
+    rule_ids = list(map(lambda x: x.id, rules))
     # we need nested data or else Teams won't handle the payload correctly
     return {
         "payload": {

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -49,7 +49,7 @@ def get_channel_id(organization, integration_id, name):
 
     # handle searching for channels first
     channel_list = client.get_channel_list(team_id)
-    filtered_channels = list(filter(lambda x: channel_filter(x, name), channel_list))
+    filtered_channels = list(list(filter(lambda x: channel_filter(x, name), channel_list)))
     if len(filtered_channels) > 0:
         return filtered_channels[0].get("id")
 
@@ -60,7 +60,7 @@ def get_channel_id(organization, integration_id, name):
         continuation_token = members.get("continuationToken")
 
         filtered_members = list(
-            filter(lambda x: x.get("name").lower() == name.lower(), member_list)
+            list(filter(lambda x: x.get("name").lower() == name.lower(), member_list))
         )
         if len(filtered_members) > 0:
             # TODO: handle duplicate username case

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -9,7 +9,6 @@ from sentry.models import (
     IdentityProvider,
 )
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.utils.compat import filter
 
 from .client import MsTeamsClient, MsTeamsPreInstallClient, get_token_data
 

--- a/src/sentry/integrations/msteams/utils.py
+++ b/src/sentry/integrations/msteams/utils.py
@@ -49,7 +49,7 @@ def get_channel_id(organization, integration_id, name):
 
     # handle searching for channels first
     channel_list = client.get_channel_list(team_id)
-    filtered_channels = list(list(filter(lambda x: channel_filter(x, name), channel_list)))
+    filtered_channels = list(filter(lambda x: channel_filter(x, name), channel_list))
     if len(filtered_channels) > 0:
         return filtered_channels[0].get("id")
 
@@ -60,7 +60,7 @@ def get_channel_id(organization, integration_id, name):
         continuation_token = members.get("continuationToken")
 
         filtered_members = list(
-            list(filter(lambda x: x.get("name").lower() == name.lower(), member_list))
+            filter(lambda x: x.get("name").lower() == name.lower(), member_list)
         )
         if len(filtered_members) > 0:
             # TODO: handle duplicate username case

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -20,7 +20,6 @@ from sentry.models import (
 )
 from sentry.utils import json
 from sentry.utils.audit import create_audit_entry
-from sentry.utils.compat import filter
 from sentry.utils.signing import sign
 from sentry.web.decorators import transaction_start
 

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -180,7 +180,7 @@ class MsTeamsWebhookEndpoint(Endpoint):
     def handle_personal_member_add(self, request):
         data = request.data
         # only care if our bot is the new member added
-        matches = filter(lambda x: x["id"] == data["recipient"]["id"], data["membersAdded"])
+        matches = list(filter(lambda x: x["id"] == data["recipient"]["id"], data["membersAdded"]))
         if not matches:
             return self.respond(status=204)
 
@@ -195,7 +195,7 @@ class MsTeamsWebhookEndpoint(Endpoint):
         data = request.data
         channel_data = data["channelData"]
         # only care if our bot is the new member added
-        matches = filter(lambda x: x["id"] == data["recipient"]["id"], data["membersAdded"])
+        matches = list(filter(lambda x: x["id"] == data["recipient"]["id"], data["membersAdded"]))
         if not matches:
             return self.respond(status=204)
 
@@ -221,7 +221,7 @@ class MsTeamsWebhookEndpoint(Endpoint):
         data = request.data
         channel_data = data["channelData"]
         # only care if our bot is the new member removed
-        matches = filter(lambda x: x["id"] == data["recipient"]["id"], data["membersRemoved"])
+        matches = list(filter(lambda x: x["id"] == data["recipient"]["id"], data["membersRemoved"]))
         if not matches:
             return self.respond(status=204)
 
@@ -425,9 +425,11 @@ class MsTeamsWebhookEndpoint(Endpoint):
             # check the ids of the mentions in the entities
             mentioned = (
                 len(
-                    filter(
-                        lambda x: x.get("mentioned", {}).get("id") == recipient_id,
-                        data.get("entities", []),
+                    list(
+                        filter(
+                            lambda x: x.get("mentioned", {}).get("id") == recipient_id,
+                            data.get("entities", []),
+                        )
                     )
                 )
                 > 0

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -4,7 +4,6 @@ from django.db import transaction
 from sentry import options
 
 from sentry.utils import json
-from sentry.utils.compat import filter
 from sentry.utils.http import absolute_uri
 from sentry.integrations.base import (
     IntegrationInstallation,

--- a/src/sentry/integrations/pagerduty/integration.py
+++ b/src/sentry/integrations/pagerduty/integration.py
@@ -80,7 +80,9 @@ class PagerDutyIntegration(IntegrationInstallation):
         if "service_table" in data:
             service_rows = data["service_table"]
             # validate fields
-            bad_rows = filter(lambda x: not x["service"] or not x["integration_key"], service_rows)
+            bad_rows = list(
+                filter(lambda x: not x["service"] or not x["integration_key"], service_rows)
+            )
             if bad_rows:
                 raise IntegrationError("Name and key are required")
 
@@ -91,7 +93,7 @@ class PagerDutyIntegration(IntegrationInstallation):
 
                 for service_item in exising_service_items:
                     # find the matching row from the input
-                    matched_rows = filter(lambda x: x["id"] == service_item.id, service_rows)
+                    matched_rows = list(filter(lambda x: x["id"] == service_item.id, service_rows))
                     if matched_rows:
                         matched_row = matched_rows[0]
                         service_item.integration_key = matched_row["integration_key"]
@@ -101,7 +103,7 @@ class PagerDutyIntegration(IntegrationInstallation):
                         service_item.delete()
 
                 # new rows don't have an id
-                new_rows = filter(lambda x: not x["id"], service_rows)
+                new_rows = list(filter(lambda x: not x["id"], service_rows))
                 for row in new_rows:
                     service_name = row["service"]
                     key = row["integration_key"]

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -27,7 +27,6 @@ from sentry.models import (
     SentryAppInstallation,
     SentryAppInstallationForProvider,
 )
-from sentry.utils.compat import map
 from sentry.shared_integrations.exceptions import IntegrationError, ApiError
 from sentry.mediators.sentry_apps import InternalCreator
 

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -170,15 +170,17 @@ class VercelIntegration(IntegrationInstallation):
         ]
 
         proj_fields = ["id", "platform", "name", "slug"]
-        sentry_projects = map(
-            lambda proj: {key: proj[key] for key in proj_fields},
-            (
-                Project.objects.filter(
-                    organization_id=self.organization_id, status=ObjectStatus.VISIBLE
-                )
-                .order_by("slug")
-                .values(*proj_fields)
-            ),
+        sentry_projects = list(
+            map(
+                lambda proj: {key: proj[key] for key in proj_fields},
+                (
+                    Project.objects.filter(
+                        organization_id=self.organization_id, status=ObjectStatus.VISIBLE
+                    )
+                    .order_by("slug")
+                    .values(*proj_fields)
+                ),
+            )
         )
 
         fields = [

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -148,7 +148,7 @@ class VercelWebhookEndpoint(Endpoint):
         # for each org integration, search the configs to find one that matches the vercel project of the webhook
         for org_integration in org_integrations:
             project_mappings = org_integration.config.get("project_mappings") or []
-            matched_mappings = filter(lambda x: x[1] == vercel_project_id, project_mappings)
+            matched_mappings = list(filter(lambda x: x[1] == vercel_project_id, project_mappings))
             if matched_mappings:
                 organization = org_integration.organization
                 sentry_project_id = matched_mappings[0][0]

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -15,7 +15,6 @@ from sentry.models import (
 )
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
-from sentry.utils.compat import filter
 from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger("sentry.integrations.vercel.webhooks")

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -1,4 +1,3 @@
-from sentry.utils.compat import map
 
 __all__ = ("Http",)
 

--- a/src/sentry/interfaces/http.py
+++ b/src/sentry/interfaces/http.py
@@ -1,4 +1,3 @@
-
 __all__ = ("Http",)
 
 import re
@@ -55,7 +54,7 @@ def format_cookies(value):
     if isinstance(value, dict):
         value = value.items()
 
-    return [map(fix_broken_encoding, (k.strip(), v)) for k, v in value]
+    return [list(map(fix_broken_encoding, (k.strip(), v))) for k, v in value]
 
 
 def fix_broken_encoding(value):

--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -6,7 +6,6 @@ from sentry.lang.native.utils import image_name
 from sentry.utils.safe import get_path
 
 from symbolic import parse_addr
-from sentry.utils.compat import map
 
 REPORT_VERSION = "104"
 

--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -159,9 +159,11 @@ class AppleCrashReport:
         # We dont need binary images on symbolicated crashreport
         if self.symbolicated or self.debug_images is None:
             return ""
-        binary_images = map(
-            lambda i: self._convert_debug_meta_to_binary_image_row(debug_image=i),
-            sorted(self.debug_images, key=lambda i: parse_addr(i["image_addr"])),
+        binary_images = list(
+            map(
+                lambda i: self._convert_debug_meta_to_binary_image_row(debug_image=i),
+                sorted(self.debug_images, key=lambda i: parse_addr(i["image_addr"])),
+            )
         )
         return "Binary Images:\n" + "\n".join(binary_images)
 

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -19,7 +19,6 @@ from sentry.utils.in_app import is_known_third_party, is_optional_package
 from sentry.utils.safe import get_path, set_path, setdefault_path, trim
 from sentry.stacktraces.functions import trim_function_name
 from sentry.stacktraces.processing import find_stacktraces_in_data
-from sentry.utils.compat import zip
 
 from symbolic import normalize_debug_id, ParseDebugIdError
 

--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -368,12 +368,12 @@ def process_payload(data):
 
     sdk_info = get_sdk_from_event(data)
 
-    for raw_image, complete_image in zip(modules, response["modules"]):
+    for raw_image, complete_image in list(zip(modules, response["modules"])):
         _merge_image(raw_image, complete_image, sdk_info, data)
 
     assert len(stacktraces) == len(response["stacktraces"]), (stacktraces, response)
 
-    for sinfo, complete_stacktrace in zip(stacktrace_infos, response["stacktraces"]):
+    for sinfo, complete_stacktrace in list(zip(stacktrace_infos, response["stacktraces"])):
         complete_frames_by_idx = {}
         for complete_frame in complete_stacktrace.get("frames") or ():
             complete_frames_by_idx.setdefault(complete_frame["original_index"], []).append(

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -7,7 +7,6 @@ from pkg_resources import parse_version
 import sentry
 from django.conf import settings
 from sentry.utils import json
-from sentry.utils.compat import map
 
 logger = logging.getLogger("sentry")
 

--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -29,7 +29,7 @@ def load_registry(path):
 def get_highest_browser_sdk_version(versions):
     full_versions = [x for x in versions if _version_regexp.match(x)]
     return (
-        str(max(map(parse_version, full_versions)))
+        str(max(list(map(parse_version, full_versions))))
         if full_versions
         else settings.JS_SDK_LOADER_SDK_VERSION
     )

--- a/src/sentry/mail/activity/release.py
+++ b/src/sentry/mail/activity/release.py
@@ -218,7 +218,7 @@ class ReleaseActivityEmail(ActivityEmail):
 
         resolved_issue_counts = [self.group_counts_by_project.get(p.id, 0) for p in projects]
         return {
-            "projects": zip(projects, release_links, resolved_issue_counts),
+            "projects": list(zip(projects, release_links, resolved_issue_counts)),
             "project_count": len(projects),
         }
 

--- a/src/sentry/mail/activity/release.py
+++ b/src/sentry/mail/activity/release.py
@@ -25,7 +25,6 @@ from sentry.models import (
 from sentry.utils.http import absolute_uri
 
 from .base import ActivityEmail
-from sentry.utils.compat import zip
 
 
 class ReleaseActivityEmail(ActivityEmail):

--- a/src/sentry/management/commands/collectstatic.py
+++ b/src/sentry/management/commands/collectstatic.py
@@ -6,8 +6,6 @@ from operator import itemgetter
 from hashlib import md5
 from django.contrib.staticfiles.management.commands.collectstatic import Command as BaseCommand
 
-from sentry.utils.compat import map
-from sentry.utils.compat import zip
 
 BUFFER_SIZE = 65536
 VERSION_PATH = "version"

--- a/src/sentry/management/commands/collectstatic.py
+++ b/src/sentry/management/commands/collectstatic.py
@@ -23,7 +23,7 @@ def checksum(file_):
 
 def get_bundle_version(files):
     hasher = md5()
-    for (short, _), sum in zip(files, map(checksum, files)):
+    for (short, _), sum in list(zip(files, list(map(checksum, files)))):
         echo(f"{sum}  {short}")
         hasher.update(f"{sum}  {short}\n".encode("utf-8"))
     return hasher.hexdigest()
@@ -38,8 +38,8 @@ class Command(BaseCommand):
 
         collected = super().collect()
         paths = sorted(set(chain(*itemgetter(*collected.keys())(collected))))
-        abs_paths = map(self.storage.path, paths)
-        version = get_bundle_version(zip(paths, abs_paths))
+        abs_paths = list(map(self.storage.path, paths))
+        version = get_bundle_version(list(zip(paths, abs_paths)))
         echo("-----------------")
         echo(version)
         with open(self.storage.path(VERSION_PATH), "wb") as fp:

--- a/src/sentry/middleware/health.py
+++ b/src/sentry/middleware/health.py
@@ -1,7 +1,6 @@
 import itertools
 
 from django.http import HttpResponse
-from sentry.utils.compat import filter
 
 
 class HealthCheck:

--- a/src/sentry/middleware/health.py
+++ b/src/sentry/middleware/health.py
@@ -21,7 +21,9 @@ class HealthCheck:
         from sentry.utils import json
 
         threshold = Problem.threshold(Problem.SEVERITY_CRITICAL)
-        results = {check: filter(threshold, problems) for check, problems in check_all().items()}
+        results = {
+            check: list(filter(threshold, problems)) for check, problems in check_all().items()
+        }
         problems = list(itertools.chain.from_iterable(results.values()))
 
         return HttpResponse(

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -12,7 +12,6 @@ from sentry.db.models import (
     FlexibleForeignKey,
     sane_repr,
 )
-from sentry.utils.compat import filter
 
 
 # TODO(dcramer): pull in enum library

--- a/src/sentry/models/apikey.py
+++ b/src/sentry/models/apikey.py
@@ -82,7 +82,7 @@ class ApiKey(Model):
     def get_allowed_origins(self):
         if not self.allowed_origins:
             return []
-        return filter(bool, self.allowed_origins.split("\n"))
+        return list(filter(bool, self.allowed_origins.split("\n")))
 
     def get_audit_log_data(self):
         return {

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -6,7 +6,6 @@ from django.db import models
 from django.utils import timezone
 
 from sentry.db.models import FlexibleForeignKey, Model
-from sentry.utils.compat import filter
 
 
 class GroupOwnerType(Enum):

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -44,7 +44,7 @@ class GroupOwner(Model):
         db_table = "sentry_groupowner"
 
     def save(self, *args, **kwargs):
-        keys = list(list(filter(None, [self.user_id, self.team_id])))
+        keys = list(filter(None, [self.user_id, self.team_id]))
         assert len(keys) == 1, "Must have team or user, not both"
         super().save(*args, **kwargs)
 

--- a/src/sentry/models/groupowner.py
+++ b/src/sentry/models/groupowner.py
@@ -44,7 +44,7 @@ class GroupOwner(Model):
         db_table = "sentry_groupowner"
 
     def save(self, *args, **kwargs):
-        keys = list(filter(None, [self.user_id, self.team_id]))
+        keys = list(list(filter(None, [self.user_id, self.team_id])))
         assert len(keys) == 1, "Must have team or user, not both"
         super().save(*args, **kwargs)
 

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -23,7 +23,7 @@ Note: To configure webhooks over multiple projects, we recommend setting up an
 def split_urls(value):
     if not value:
         return ()
-    return filter(bool, (url.strip() for url in value.splitlines()))
+    return list(filter(bool, (url.strip() for url in value.splitlines())))
 
 
 def validate_urls(value, **kwargs):

--- a/src/sentry/plugins/sentry_webhooks/plugin.py
+++ b/src/sentry/plugins/sentry_webhooks/plugin.py
@@ -11,7 +11,6 @@ from sentry.plugins.bases import notify
 from sentry.http import is_valid_url, safe_urlopen
 from sentry.utils.safe import safe_execute
 from sentry.integrations import FeatureDescription, IntegrationFeatures
-from sentry.utils.compat import filter
 
 DESCRIPTION = """
 Trigger outgoing HTTP POST requests from Sentry.

--- a/src/sentry/quotas/redis.py
+++ b/src/sentry/quotas/redis.py
@@ -9,8 +9,6 @@ from sentry.utils.redis import (
     validate_dynamic_cluster,
     load_script,
 )
-from sentry.utils.compat import map
-from sentry.utils.compat import zip
 
 is_rate_limited = load_script("quotas/is_rate_limited.lua")
 

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -43,31 +43,33 @@ def cli(ctx, config):
 
 # TODO(mattrobenolt): Autodiscover commands?
 list(
-    map(
-        lambda cmd: cli.add_command(import_string(cmd)),
-        (
-            "sentry.runner.commands.backup.export",
-            "sentry.runner.commands.backup.import_",
-            "sentry.runner.commands.cleanup.cleanup",
-            "sentry.runner.commands.config.config",
-            "sentry.runner.commands.createuser.createuser",
-            "sentry.runner.commands.devserver.devserver",
-            "sentry.runner.commands.django.django",
-            "sentry.runner.commands.exec.exec_",
-            "sentry.runner.commands.files.files",
-            "sentry.runner.commands.help.help",
-            "sentry.runner.commands.init.init",
-            "sentry.runner.commands.migrations.migrations",
-            "sentry.runner.commands.plugins.plugins",
-            "sentry.runner.commands.queues.queues",
-            "sentry.runner.commands.repair.repair",
-            "sentry.runner.commands.run.run",
-            "sentry.runner.commands.start.start",
-            "sentry.runner.commands.tsdb.tsdb",
-            "sentry.runner.commands.upgrade.upgrade",
-            "sentry.runner.commands.permissions.permissions",
-            "sentry.runner.commands.devservices.devservices",
-        ),
+    list(
+        map(
+            lambda cmd: cli.add_command(import_string(cmd)),
+            (
+                "sentry.runner.commands.backup.export",
+                "sentry.runner.commands.backup.import_",
+                "sentry.runner.commands.cleanup.cleanup",
+                "sentry.runner.commands.config.config",
+                "sentry.runner.commands.createuser.createuser",
+                "sentry.runner.commands.devserver.devserver",
+                "sentry.runner.commands.django.django",
+                "sentry.runner.commands.exec.exec_",
+                "sentry.runner.commands.files.files",
+                "sentry.runner.commands.help.help",
+                "sentry.runner.commands.init.init",
+                "sentry.runner.commands.migrations.migrations",
+                "sentry.runner.commands.plugins.plugins",
+                "sentry.runner.commands.queues.queues",
+                "sentry.runner.commands.repair.repair",
+                "sentry.runner.commands.run.run",
+                "sentry.runner.commands.start.start",
+                "sentry.runner.commands.tsdb.tsdb",
+                "sentry.runner.commands.upgrade.upgrade",
+                "sentry.runner.commands.permissions.permissions",
+                "sentry.runner.commands.devservices.devservices",
+            ),
+        )
     )
 )
 
@@ -95,9 +97,11 @@ def make_django_command(name, django_command=None, help=None):
 
 
 list(
-    map(
-        cli.add_command,
-        (make_django_command("shell", help="Run a Python interactive interpreter."),),
+    list(
+        map(
+            cli.add_command,
+            (make_django_command("shell", help="Run a Python interactive interpreter."),),
+        )
     )
 )
 

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -4,7 +4,6 @@ import sys
 import sentry
 import datetime
 from sentry.utils.imports import import_string
-from sentry.utils.compat import map
 
 # We need to run this here because of a concurrency bug in Python's locale
 # with the lazy initialization.

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -3,7 +3,6 @@ import signal
 import os
 import click
 
-from sentry.utils.compat import map
 
 
 # Work around a stupid docker issue: https://github.com/docker/for-mac/issues/5025

--- a/src/sentry/runner/commands/devservices.py
+++ b/src/sentry/runner/commands/devservices.py
@@ -4,7 +4,6 @@ import os
 import click
 
 
-
 # Work around a stupid docker issue: https://github.com/docker/for-mac/issues/5025
 RAW_SOCKET_HACK_PATH = os.path.expanduser(
     "~/Library/Containers/com.docker.docker/Data/docker.raw.sock"
@@ -286,7 +285,7 @@ def _start_service(
 
     listening = ""
     if options["ports"]:
-        listening = "(listening: %s)" % ", ".join(map(str, options["ports"].values()))
+        listening = "(listening: %s)" % ", ".join(list(map(str, options["ports"].values())))
 
     # If a service is associated with the devserver, then do not run the created container.
     # This was mainly added since it was not desirable for nginx to occupy port 8000 on the

--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -7,7 +7,6 @@ from dateutil.parser import parse
 
 from sentry.runner.decorators import configuration
 from sentry.utils.iterators import chunked
-from sentry.utils.compat import map
 
 
 class DateTimeParamType(click.ParamType):

--- a/src/sentry/runner/commands/tsdb.py
+++ b/src/sentry/runner/commands/tsdb.py
@@ -101,5 +101,5 @@ def organizations(metrics, since, until):
                 values.append(aggregate(results[metric][key]))
 
             stdout.write(
-                "{} {} {}\n".format(instance.id, instance.slug, " ".join(map(str, values)))
+                "{} {} {}\n".format(instance.id, instance.slug, " ".join(list(map(str, values))))
             )

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -271,7 +271,7 @@ def show_big_error(message):
         lines = message.strip().splitlines()
     else:
         lines = message
-    maxline = max(map(len, lines))
+    maxline = max(list(map(len, lines)))
     click.echo("", err=True)
     click.secho("!!!{}!!!".format("!" * min(maxline, 80)), err=True, fg="red")
     click.secho("!! %s !!" % "".center(maxline), err=True, fg="red")

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from sentry.utils import metrics, warnings
 from sentry.utils.sdk import configure_sdk
 from sentry.utils.warnings import DeprecatedSettingWarning
-from sentry.utils.compat import map
 
 logger = logging.getLogger("sentry.runner.initializer")
 

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -431,7 +431,7 @@ def get_suggested_updates(
         rv.append(suggestion)
         new_setup_states.append(new_setup_state)
 
-    for new_setup_state, suggestion in zip(new_setup_states, rv):
+    for new_setup_state, suggestion in list(zip(new_setup_states, rv)):
         json = suggestion.to_json()
         json["enables"] = list(
             get_suggested_updates(

--- a/src/sentry/sdk_updates.py
+++ b/src/sentry/sdk_updates.py
@@ -5,7 +5,6 @@ from django.core.cache import cache
 
 from sentry.tasks.release_registry import SDK_INDEX_CACHE_KEY
 from sentry.utils.safe import get_path
-from sentry.utils.compat import zip
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -8,7 +8,6 @@ from sentry.models.group import STATUS_QUERY_CHOICES
 from sentry.models import EventUser, KEYWORD_MAP, Release, Team, User
 from sentry.search.base import ANY
 from sentry.utils.auth import find_users
-from sentry.utils.compat import map
 
 
 class InvalidQuery(Exception):

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -345,7 +345,7 @@ def tokenize_query(query):
         query_params[state].append(token)
 
     if "query" in query_params:
-        result["query"] = map(format_query, query_params["query"])
+        result["query"] = list(map(format_query, query_params["query"]))
     for tag in query_params["tags"]:
         key, value = format_tag(tag)
         result[key].append(value)

--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def text_shingle(n, value):
-    return map("".join, shingle(n, value))
+    return list(map("".join, shingle(n, value)))
 
 
 class FrameEncodingError(ValueError):

--- a/src/sentry/similarity/__init__.py
+++ b/src/sentry/similarity/__init__.py
@@ -17,7 +17,6 @@ from sentry.similarity.features import (
 from sentry.similarity.featuresv2 import GroupingBasedFeatureSet
 from sentry.similarity.signatures import MinHashSignatureBuilder
 from sentry.utils import redis
-from sentry.utils.compat import map
 from sentry.utils.datastructures import BidirectionalMapping
 from sentry.utils.iterators import shingle
 from sentry import features as feature_flags

--- a/src/sentry/similarity/backends/redis.py
+++ b/src/sentry/similarity/backends/redis.py
@@ -38,7 +38,7 @@ class RedisScriptMinHashIndexBackend(AbstractIndexBackend):
 
         arguments = []
         for bucket in band(self.bands, self.signature_builder(features)):
-            arguments.extend([1, ",".join(map("{}".format, bucket)), 1])
+            arguments.extend([1, ",".join(list(map("{}".format, bucket))), 1])
         return arguments
 
     def __index(self, scope, args):
@@ -58,7 +58,11 @@ class RedisScriptMinHashIndexBackend(AbstractIndexBackend):
             key, scores = result
             return (
                 force_text(key),
-                map(lambda score: score_replacements.get(score, score), map(float, scores)),
+                list(
+                    map(
+                        lambda score: score_replacements.get(score, score), list(map(float, scores))
+                    )
+                ),
             )
 
         def get_comparison_key(result):
@@ -72,7 +76,7 @@ class RedisScriptMinHashIndexBackend(AbstractIndexBackend):
                 key,  # lexicographical sort on key, ascending
             )
 
-        return sorted(map(decode_search_result, results), key=get_comparison_key)
+        return sorted(list(map(decode_search_result, results)), key=get_comparison_key)
 
     def classify(self, scope, items, limit=None, timestamp=None):
         if timestamp is None:
@@ -207,7 +211,7 @@ class RedisScriptMinHashIndexBackend(AbstractIndexBackend):
 
             responses = self.__index(scope, arguments + flatten(requests))
 
-            for (idx, _, _), (cursor, chunk) in zip(requests, responses):
+            for (idx, _, _), (cursor, chunk) in list(zip(requests, responses)):
                 cursor = int(cursor)
                 if cursor == 0:
                     del cursors[idx]

--- a/src/sentry/similarity/backends/redis.py
+++ b/src/sentry/similarity/backends/redis.py
@@ -6,8 +6,6 @@ from django.utils.encoding import force_text
 from sentry.similarity.backends.abstract import AbstractIndexBackend
 from sentry.utils.iterators import chunked
 from sentry.utils.redis import load_script
-from sentry.utils.compat import map
-from sentry.utils.compat import zip
 
 
 index = load_script("similarity/index.lua")

--- a/src/sentry/similarity/backends/redis.py
+++ b/src/sentry/similarity/backends/redis.py
@@ -76,7 +76,7 @@ class RedisScriptMinHashIndexBackend(AbstractIndexBackend):
                 key,  # lexicographical sort on key, ascending
             )
 
-        return sorted(list(map(decode_search_result, results)), key=get_comparison_key)
+        return sorted(map(decode_search_result, results), key=get_comparison_key)
 
     def classify(self, scope, items, limit=None, timestamp=None):
         if timestamp is None:

--- a/src/sentry/similarity/encoder.py
+++ b/src/sentry/similarity/encoder.py
@@ -1,7 +1,6 @@
 from collections import Mapping, Set, Sequence
 
 
-
 class Encoder:
     try:
         number_types = (int, long, float)  # noqa
@@ -23,12 +22,12 @@ class Encoder:
         elif isinstance(value, self.number_types):
             return str(value).encode("utf8")
         elif isinstance(value, Set):
-            return b"\x00".join(sorted(map(self.dumps, value)))
+            return b"\x00".join(sorted(list(map(self.dumps, value))))
         elif isinstance(value, Sequence):
-            return b"\x01".join(map(self.dumps, value))
+            return b"\x01".join(list(map(self.dumps, value)))
         elif isinstance(value, Mapping):
             return b"\x02".join(
-                sorted(b"\x01".join(map(self.dumps, item)) for item in value.items())
+                sorted(b"\x01".join(list(map(self.dumps, item))) for item in value.items())
             )
         else:
             raise TypeError(f"Unsupported type: {type(value)}")

--- a/src/sentry/similarity/encoder.py
+++ b/src/sentry/similarity/encoder.py
@@ -22,9 +22,9 @@ class Encoder:
         elif isinstance(value, self.number_types):
             return str(value).encode("utf8")
         elif isinstance(value, Set):
-            return b"\x00".join(sorted(list(map(self.dumps, value))))
+            return b"\x00".join(sorted(map(self.dumps, value)))
         elif isinstance(value, Sequence):
-            return b"\x01".join(list(map(self.dumps, value)))
+            return b"\x01".join(map(self.dumps, value))
         elif isinstance(value, Mapping):
             return b"\x02".join(
                 sorted(b"\x01".join(list(map(self.dumps, item))) for item in value.items())

--- a/src/sentry/similarity/encoder.py
+++ b/src/sentry/similarity/encoder.py
@@ -1,6 +1,5 @@
 from collections import Mapping, Set, Sequence
 
-from sentry.utils.compat import map
 
 
 class Encoder:

--- a/src/sentry/similarity/features.py
+++ b/src/sentry/similarity/features.py
@@ -3,8 +3,6 @@ import itertools
 import logging
 
 from sentry.utils.dates import to_timestamp
-from sentry.utils.compat import map
-from sentry.utils.compat import zip
 
 logger = logging.getLogger("sentry.similarity")
 

--- a/src/sentry/similarity/signatures.py
+++ b/src/sentry/similarity/signatures.py
@@ -7,9 +7,11 @@ class MinHashSignatureBuilder:
         self.rows = rows
 
     def __call__(self, features):
-        return map(
-            lambda column: min(
-                map(lambda feature: mmh3.hash(feature, column) % self.rows, features)
-            ),
-            range(self.columns),
+        return list(
+            map(
+                lambda column: min(
+                    list(map(lambda feature: mmh3.hash(feature, column) % self.rows, features))
+                ),
+                range(self.columns),
+            )
         )

--- a/src/sentry/similarity/signatures.py
+++ b/src/sentry/similarity/signatures.py
@@ -1,5 +1,4 @@
 import mmh3
-from sentry.utils.compat import map
 
 
 class MinHashSignatureBuilder:

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -17,7 +17,6 @@ from sentry.api.event_search import (
 
 from sentry.models import Group
 from sentry.tagstore.base import TOP_VALUES_DEFAULT_LIMIT
-from sentry.utils.compat import filter
 from sentry.utils.math import nice_int
 from sentry.utils.snuba import (
     Dataset,

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -925,12 +925,12 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
 
     if min_value is None:
         min_values = [row[get_function_alias(column)] for column in min_columns]
-        min_values = list(filter(lambda v: v is not None, min_values))
+        min_values = list(list(filter(lambda v: v is not None, min_values)))
         min_value = min(min_values) if min_values else None
 
     if max_value is None:
         max_values = [row[get_function_alias(column)] for column in max_columns]
-        max_values = list(filter(lambda v: v is not None, max_values))
+        max_values = list(list(filter(lambda v: v is not None, max_values)))
         max_value = max(max_values) if max_values else None
 
         fences = []
@@ -957,7 +957,7 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
         max_fence_value = max(fences) if fences else None
 
         candidates = [max_fence_value, max_value]
-        candidates = list(filter(lambda v: v is not None, candidates))
+        candidates = list(list(filter(lambda v: v is not None, candidates)))
         max_value = min(candidates) if candidates else None
 
     return min_value, max_value

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -925,12 +925,12 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
 
     if min_value is None:
         min_values = [row[get_function_alias(column)] for column in min_columns]
-        min_values = list(list(filter(lambda v: v is not None, min_values)))
+        min_values = list(filter(lambda v: v is not None, min_values))
         min_value = min(min_values) if min_values else None
 
     if max_value is None:
         max_values = [row[get_function_alias(column)] for column in max_columns]
-        max_values = list(list(filter(lambda v: v is not None, max_values)))
+        max_values = list(filter(lambda v: v is not None, max_values))
         max_value = max(max_values) if max_values else None
 
         fences = []
@@ -957,7 +957,7 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
         max_fence_value = max(fences) if fences else None
 
         candidates = [max_fence_value, max_value]
-        candidates = list(list(filter(lambda v: v is not None, candidates)))
+        candidates = list(filter(lambda v: v is not None, candidates))
         max_value = min(candidates) if candidates else None
 
     return min_value, max_value

--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -33,9 +33,6 @@ from sentry.utils.http import absolute_uri
 from sentry.utils.email import MessageBuilder
 from sentry.utils.iterators import chunked
 from sentry.utils.math import mean
-from sentry.utils.compat import map
-from sentry.utils.compat import zip
-from sentry.utils.compat import filter
 
 
 date_format = partial(dateformat.format, format_string="F jS, Y")

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -31,7 +31,6 @@ from sentry.shared_integrations.exceptions import (
 )
 from sentry.tasks.base import instrumented_task, retry
 from sentry.utils import metrics
-from sentry.utils.compat import filter
 from sentry.utils.http import absolute_uri
 from sentry.utils.sentryappwebhookrequests import SentryAppWebhookRequestsBuffer
 

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -179,9 +179,11 @@ def _process_resource_change(action, sender, instance_id, retryer=None, *args, *
             id=Project.objects.get_from_cache(id=instance.project_id).organization_id
         )
 
-    installations = filter(
-        lambda i: event in i.sentry_app.events,
-        SentryAppInstallation.get_installed_for_org(org.id).select_related("sentry_app"),
+    installations = list(
+        filter(
+            lambda i: event in i.sentry_app.events,
+            SentryAppInstallation.get_installed_for_org(org.id).select_related("sentry_app"),
+        )
     )
 
     for installation in installations:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1,4 +1,3 @@
-from sentry.utils.compat import zip
 
 __all__ = (
     "TestCase",

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -1,4 +1,3 @@
-
 __all__ = (
     "TestCase",
     "TransactionTestCase",
@@ -980,7 +979,7 @@ class OrganizationDashboardWidgetTestCase(APITestCase):
 
     def assert_widget_queries(self, widget_id, data):
         result_queries = DashboardWidgetQuery.objects.filter(widget_id=widget_id).order_by("order")
-        for ds, expected_ds in zip(result_queries, data):
+        for ds, expected_ds in list(zip(result_queries, data)):
             assert ds.name == expected_ds["name"]
             assert ds.fields == expected_ds["fields"]
             assert ds.conditions == expected_ds["conditions"]

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -8,7 +8,6 @@ from enum import Enum
 
 from sentry.utils.dates import to_datetime, to_timestamp
 from sentry.utils.services import Service
-from sentry.utils.compat import map
 
 ONE_MINUTE = 60
 ONE_HOUR = ONE_MINUTE * 60

--- a/src/sentry/tsdb/base.py
+++ b/src/sentry/tsdb/base.py
@@ -264,7 +264,7 @@ class BaseTSDB(Service):
                 end,
                 rollup=rollup,
             )
-            rollups[rollup] = map(to_datetime, series)
+            rollups[rollup] = list(map(to_datetime, series))
         return rollups
 
     def make_series(self, default, start, end=None, rollup=None):

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -4,7 +4,6 @@ from django.utils import timezone
 
 from sentry.tsdb.base import BaseTSDB
 from sentry.utils.dates import to_datetime, to_timestamp
-from sentry.utils.compat import map
 
 
 class InMemoryTSDB(BaseTSDB):

--- a/src/sentry/tsdb/inmemory.py
+++ b/src/sentry/tsdb/inmemory.py
@@ -66,7 +66,7 @@ class InMemoryTSDB(BaseTSDB):
         rollup, series = self.get_optimal_rollup_series(start, end, rollup)
 
         results = []
-        for timestamp in map(to_datetime, series):
+        for timestamp in list(map(to_datetime, series)):
             norm_epoch = self.normalize_to_rollup(timestamp, rollup)
 
             for key in keys:

--- a/src/sentry/tsdb/redis.py
+++ b/src/sentry/tsdb/redis.py
@@ -15,7 +15,7 @@ from sentry.tsdb.base import BaseTSDB
 from sentry.utils.dates import to_datetime, to_timestamp
 from sentry.utils.redis import check_cluster_versions, get_cluster_from_options, SentryScript
 from sentry.utils.versioning import Version
-from sentry.utils.compat import map, zip, crc32
+from sentry.utils.compat import crc32
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -7,8 +7,6 @@ from sentry.tsdb.base import BaseTSDB, TSDBModel
 from sentry.utils import snuba, outcomes
 from sentry.ingest.inbound_filters import FILTER_STAT_KEYS_TO_VALUES
 from sentry.utils.dates import to_datetime
-from sentry.utils.compat import map
-from sentry.utils.compat import zip
 
 
 SnubaModelQuerySettings = collections.namedtuple(

--- a/src/sentry/tsdb/snuba.py
+++ b/src/sentry/tsdb/snuba.py
@@ -229,7 +229,7 @@ class SnubaTSDB(BaseTSDB):
             TSDBModel.key_total_blacklisted,
             TSDBModel.key_total_rejected,
         ]:
-            keys = list(set(map(lambda x: int(x), keys)))
+            keys = list(set(list(map(lambda x: int(x), keys))))
 
         # 10s is the only rollup under an hour that we support
         if rollup and rollup == 10 and model in self.lower_rollup_query_settings:
@@ -255,7 +255,7 @@ class SnubaTSDB(BaseTSDB):
             model_aggregate = None
 
         columns = (model_query_settings.groupby, model_query_settings.aggregate)
-        keys_map = dict(zip(columns, self.flatten_keys(keys)))
+        keys_map = dict(list(zip(columns, self.flatten_keys(keys))))
         keys_map = {k: v for k, v in keys_map.items() if k is not None and v is not None}
         if environment_ids is not None:
             keys_map["environment"] = environment_ids

--- a/src/sentry/utils/avatar.py
+++ b/src/sentry/utils/avatar.py
@@ -13,7 +13,6 @@ from urllib.parse import urlencode
 
 from sentry.utils.hashlib import md5_text
 from sentry.http import safe_urlopen
-from sentry.utils.compat import map
 
 
 def get_gravatar_url(email, size=None, default="mm"):

--- a/src/sentry/utils/avatar.py
+++ b/src/sentry/utils/avatar.py
@@ -54,7 +54,7 @@ COLOR_COUNT = len(LETTER_AVATAR_COLORS)
 
 def hash_user_identifier(identifier):
     identifier = force_text(identifier, errors="replace")
-    return sum(map(ord, identifier))
+    return sum(list(map(ord, identifier)))
 
 
 def get_letter_avatar_color(identifier):

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -12,7 +12,6 @@ from django.core.cache import cache
 
 from collections import defaultdict
 from functools import reduce
-from sentry.utils.compat import zip
 
 PATH_SEPARATORS = frozenset(["/", "\\"])
 

--- a/src/sentry/utils/committers.py
+++ b/src/sentry/utils/committers.py
@@ -28,7 +28,7 @@ def tokenize_path(path):
 
 def score_path_match_length(path_a, path_b):
     score = 0
-    for a, b in zip(tokenize_path(path_a), tokenize_path(path_b)):
+    for a, b in list(zip(tokenize_path(path_a), tokenize_path(path_b))):
         if a.lower() != b.lower():
             break
         score += 1
@@ -272,7 +272,7 @@ def get_serialized_event_file_committers(project, event, frame_limit=25):
 
     serialized_commits_by_id = {}
 
-    for (commit, score), serialized_commit in zip(commits, serialized_commits):
+    for (commit, score), serialized_commit in list(zip(commits, serialized_commits)):
         serialized_commit["score"] = score
         serialized_commits_by_id[commit.id] = serialized_commit
 

--- a/src/sentry/utils/compat/__init__.py
+++ b/src/sentry/utils/compat/__init__.py
@@ -4,15 +4,18 @@ _builtin_zip = zip
 
 
 def map(a, b, *c):
-    return _builtin_map(a, b, *c)
+    # TODO(joshuarli): Remove all this.
+    return list(_builtin_map(a, b, *c))
 
 
 def filter(a, b):
-    return _builtin_filter(a, b)
+    # TODO(joshuarli): Remove all this.
+    return list(_builtin_filter(a, b))
 
 
 def zip(*a):
-    return _builtin_zip(*a)
+    # TODO(joshuarli): Remove all this.
+    return list(_builtin_zip(*a))
 
 
 from binascii import crc32 as _crc32

--- a/src/sentry/utils/compat/__init__.py
+++ b/src/sentry/utils/compat/__init__.py
@@ -1,23 +1,3 @@
-_builtin_map = map
-_builtin_filter = filter
-_builtin_zip = zip
-
-
-def map(a, b, *c):
-    # TODO(joshuarli): Remove all this.
-    return list(_builtin_map(a, b, *c))
-
-
-def filter(a, b):
-    # TODO(joshuarli): Remove all this.
-    return list(_builtin_filter(a, b))
-
-
-def zip(*a):
-    # TODO(joshuarli): Remove all this.
-    return list(_builtin_zip(*a))
-
-
 from binascii import crc32 as _crc32
 
 

--- a/src/sentry/utils/compat/__init__.py
+++ b/src/sentry/utils/compat/__init__.py
@@ -4,18 +4,15 @@ _builtin_zip = zip
 
 
 def map(a, b, *c):
-    # TODO(joshuarli): Remove all this.
-    return list(_builtin_map(a, b, *c))
+    return _builtin_map(a, b, *c)
 
 
 def filter(a, b):
-    # TODO(joshuarli): Remove all this.
-    return list(_builtin_filter(a, b))
+    return _builtin_filter(a, b)
 
 
 def zip(*a):
-    # TODO(joshuarli): Remove all this.
-    return list(_builtin_zip(*a))
+    return _builtin_zip(*a)
 
 
 from binascii import crc32 as _crc32

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -221,7 +221,7 @@ class ListResolver:
                 f"Cannot generate mailing list identifier for {instance!r}"
             )
 
-        label = ".".join(map(str, handler(instance)))
+        label = ".".join(list(map(str, handler(instance))))
         assert is_valid_dot_atom(label)
 
         return f"<{label}.{self.__namespace}>"

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -26,7 +26,6 @@ from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 from sentry.utils.strings import is_valid_dot_atom
 from sentry.web.helpers import render_to_string
-from sentry.utils.compat import map
 
 # The maximum amount of recipients to display in human format.
 MAX_RECIPIENTS = 5

--- a/src/sentry/utils/functional.py
+++ b/src/sentry/utils/functional.py
@@ -30,8 +30,8 @@ def apply_values(function, mapping):
     if not mapping:
         return {}
 
-    keys, values = zip(*mapping.items())
-    return dict(zip(keys, function(values)))
+    keys, values = list(zip(*mapping.items()))
+    return dict(list(zip(keys, function(values))))
 
 
 def compact(seq):

--- a/src/sentry/utils/functional.py
+++ b/src/sentry/utils/functional.py
@@ -1,5 +1,4 @@
 from django.utils.functional import empty
-from sentry.utils.compat import zip
 
 
 def extract_lazy_object(lo):

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -5,8 +5,6 @@ from functools import partial
 
 from sentry import options
 from sentry.utils import json
-from sentry.utils.compat import map
-from sentry.utils.compat import filter
 
 ParsedUriMatch = namedtuple("ParsedUriMatch", ["scheme", "domain", "path"])
 

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -75,7 +75,7 @@ def get_origins(project=None):
 
     # lowercase and strip the trailing slash from all origin values
     # filter out empty values
-    return frozenset(filter(bool, map(lambda x: (x or "").lower().rstrip("/"), result)))
+    return frozenset(list(filter(bool, list(map(lambda x: (x or "").lower().rstrip("/"), result)))))
 
 
 def parse_uri_match(value):

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -75,7 +75,7 @@ def get_origins(project=None):
 
     # lowercase and strip the trailing slash from all origin values
     # filter out empty values
-    return frozenset(list(filter(bool, list(map(lambda x: (x or "").lower().rstrip("/"), result)))))
+    return frozenset(filter(bool, list(map(lambda x: (x or "").lower().rstrip("/"), result))))
 
 
 def parse_uri_match(value):

--- a/src/sentry/utils/iterators.py
+++ b/src/sentry/utils/iterators.py
@@ -1,8 +1,6 @@
 import itertools
 
 
-from sentry.utils.compat import map
-from sentry.utils.compat import zip
 
 
 def advance(n, iterator):

--- a/src/sentry/utils/iterators.py
+++ b/src/sentry/utils/iterators.py
@@ -1,8 +1,6 @@
 import itertools
 
 
-
-
 def advance(n, iterator):
     """Advances an iterator n places."""
     next(itertools.islice(iterator, n, n), None)
@@ -16,10 +14,14 @@ def shingle(n, iterator):
     >>> list(shingle(2, ('foo', 'bar', 'baz')))
     [('foo', 'bar'), ('bar', 'baz')]
     """
-    return zip(
-        *map(
-            lambda i__iterator: advance(i__iterator[0], i__iterator[1]),
-            enumerate(itertools.tee(iterator, n)),
+    return list(
+        zip(
+            *list(
+                map(
+                    lambda i__iterator: advance(i__iterator[0], i__iterator[1]),
+                    enumerate(itertools.tee(iterator, n)),
+                )
+            )
         )
     )
 

--- a/src/sentry/utils/meta.py
+++ b/src/sentry/utils/meta.py
@@ -1,5 +1,4 @@
 import collections
-from sentry.utils.compat import map
 
 
 class Meta:

--- a/src/sentry/utils/meta.py
+++ b/src/sentry/utils/meta.py
@@ -24,7 +24,7 @@ class Meta:
         Enters into sub meta data at the specified path. This always returns a
         new ``Meta`` object, regardless whether the path already exists.
         """
-        return Meta(self._meta, path=self._path + map(str, path))
+        return Meta(self._meta, path=self._path + list(map(str, path)))
 
     @property
     def path(self):

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -17,7 +17,6 @@ from selenium.webdriver.common.action_chains import ActionChains
 from urllib.parse import urlparse
 
 from sentry.utils.retries import TimedRetryPolicy
-from sentry.utils.compat import map
 
 logger = logging.getLogger("sentry.testutils")
 

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -455,7 +455,7 @@ def start_chrome(**chrome_args):
 @pytest.fixture(scope="function")
 def browser(request, live_server):
     window_size = request.config.getoption("window_size")
-    window_width, window_height = map(int, window_size.split("x", 1))
+    window_width, window_height = list(map(int, window_size.split("x", 1)))
 
     driver_type = request.config.getoption("selenium_driver")
     headless = not request.config.getoption("no_headless")

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -19,7 +19,6 @@ from sentry.exceptions import InvalidConfiguration
 from sentry.utils import warnings
 from sentry.utils.warnings import DeprecatedSettingWarning
 from sentry.utils.versioning import Version, check_versions
-from sentry.utils.compat import map
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/utils/redis.py
+++ b/src/sentry/utils/redis.py
@@ -189,14 +189,15 @@ def get_cluster_from_options(setting, options, cluster_manager=clusters):
         if cluster_option_name in options:
             raise InvalidConfiguration(
                 "Cannot provide both named cluster ({!r}) and cluster configuration ({}) options.".format(
-                    cluster_option_name, ", ".join(map(repr, cluster_constructor_option_names))
+                    cluster_option_name,
+                    ", ".join(list(map(repr, cluster_constructor_option_names))),
                 )
             )
         else:
             warnings.warn(
                 DeprecatedSettingWarning(
                     "{} parameter of {}".format(
-                        ", ".join(map(repr, cluster_constructor_option_names)), setting
+                        ", ".join(list(map(repr, cluster_constructor_option_names))), setting
                     ),
                     f'{setting}["{cluster_option_name}"]',
                     removed_in_version="8.5",
@@ -246,7 +247,7 @@ def check_cluster_versions(cluster, required, recommended=None, label=None):
         # NOTE: This assumes there is no routing magic going on here, and
         # all requests to this host are being served by the same database.
         key = f"{host.host}:{host.port}"
-        versions[key] = Version(map(int, info["redis_version"].split(".", 3)))
+        versions[key] = Version(list(map(int, info["redis_version"].split(".", 3))))
 
     check_versions(
         "Redis" if label is None else f"Redis ({label})", versions, required, recommended

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -7,7 +7,6 @@ from django.utils.encoding import force_text
 
 from sentry.utils import json
 from sentry.utils.strings import truncatechars
-from sentry.utils.compat import filter
 
 
 def safe_execute(func, *args, **kwargs):

--- a/src/sentry/utils/safe.py
+++ b/src/sentry/utils/safe.py
@@ -143,7 +143,7 @@ def get_path(data, *path, **kwargs):
             return default
 
     if f and data and isinstance(data, (list, tuple)):
-        data = filter((lambda x: x is not None) if f is True else f, data)
+        data = list(filter((lambda x: x is not None) if f is True else f, data))
 
     return data if data is not None else default
 

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -406,7 +406,7 @@ def get_query_params_to_update_for_projects(query_params, with_org=False):
                 get_related_project_ids(k, query_params.filter_keys[k])
                 for k in query_params.filter_keys
             ]
-            project_ids = list(set.union(*map(set, ids)))
+            project_ids = list(set.union(*list(map(set, ids))))
     elif query_params.conditions:
         project_ids = []
         for cond in query_params.conditions:
@@ -640,7 +640,7 @@ def bulk_raw_query(snuba_param_list, referrer=None):
     if referrer:
         headers["referer"] = referrer
 
-    query_param_list = map(_prepare_query_params, snuba_param_list)
+    query_param_list = list(map(_prepare_query_params, snuba_param_list))
 
     def snuba_query(params):
         query_params, forward, reverse, thread_hub = params

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -33,7 +33,6 @@ from sentry.utils import metrics, json
 from sentry.utils.dates import to_timestamp
 from sentry.snuba.events import Columns
 from sentry.snuba.dataset import Dataset
-from sentry.utils.compat import map
 
 
 logger = logging.getLogger(__name__)

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -5,7 +5,6 @@ import string
 import zlib
 
 from django.utils.encoding import force_text, smart_text
-from sentry.utils.compat import map
 
 _word_sep_re = re.compile(r"[\s.;,_-]+", re.UNICODE)
 _camelcase_re = re.compile(r"(?:[A-Z]{2,}(?=[A-Z]))|(?:[A-Z][a-z0-9]+)|(?:[a-z0-9]+)")

--- a/src/sentry/utils/strings.py
+++ b/src/sentry/utils/strings.py
@@ -101,7 +101,7 @@ def soft_break(value, length, process=lambda chunk: chunk):
     zero-width spaces after common delimeters, as well as soft-hyphenating long
     identifiers.
     """
-    delimiters = re.compile(r"([{}]+)".format("".join(map(re.escape, ",.$:/+@!?()<>[]{}"))))
+    delimiters = re.compile(r"([{}]+)".format("".join(list(map(re.escape, ",.$:/+@!?()<>[]{}")))))
 
     def soft_break_delimiter(match):
         results = []

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -2,7 +2,6 @@ from django.utils.encoding import force_text, python_2_unicode_compatible
 
 from sentry.exceptions import InvalidConfiguration
 from sentry.utils import warnings
-from sentry.utils.compat import map
 
 
 @python_2_unicode_compatible

--- a/src/sentry/utils/versioning.py
+++ b/src/sentry/utils/versioning.py
@@ -7,7 +7,7 @@ from sentry.utils import warnings
 @python_2_unicode_compatible
 class Version(tuple):
     def __str__(self):
-        return ".".join(map(force_text, self))
+        return ".".join(list(map(force_text, self)))
 
 
 def summarize(sequence, max=3):
@@ -22,7 +22,7 @@ def summarize(sequence, max=3):
 
 def make_upgrade_message(service, modality, version, hosts):
     return "{service} {modality} be upgraded to {version} on {hosts}.".format(
-        hosts=",".join(map(force_text, summarize(list(hosts.keys()), 2))),
+        hosts=",".join(list(map(force_text, summarize(list(hosts.keys()), 2)))),
         modality=modality,
         service=service,
         version=version,

--- a/src/sentry/web/frontend/debug/debug_new_release_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_release_email.py
@@ -16,7 +16,6 @@ from sentry.models import (
 from sentry.utils.http import absolute_uri
 
 from .mail import MailPreview
-from sentry.utils.compat import zip
 
 
 class DebugNewReleaseEmailView(View):

--- a/src/sentry/web/frontend/debug/debug_new_release_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_release_email.py
@@ -103,7 +103,7 @@ class DebugNewReleaseEmailView(View):
             text_template="sentry/emails/activity/release.txt",
             context={
                 "release": release,
-                "projects": zip(projects, release_links, [6, 1, 0]),
+                "projects": list(zip(projects, release_links, [6, 1, 0])),
                 "repos": repos,
                 "reason": GroupSubscriptionReason.descriptions[GroupSubscriptionReason.committed],
                 "project_count": len(projects),

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -46,7 +46,7 @@ def clean_phone(phone):
 #      in theory only cleaned data would make it to the plugin via the form,
 #      and cleaned numbers are deduped already.
 def split_sms_to(data):
-    return set(list(filter(bool, re.split(r"\s*,\s*|\s+", data))))
+    return set(filter(bool, re.split(r"\s*,\s*|\s+", data)))
 
 
 class TwilioConfigurationForm(forms.Form):

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -11,8 +11,6 @@ from .client import TwilioApiClient
 from sentry_plugins.base import CorePluginMixin
 
 import sentry
-from sentry.utils.compat import map
-from sentry.utils.compat import filter
 
 DEFAULT_REGION = "US"
 MAX_SMS_LENGTH = 160

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -46,7 +46,7 @@ def clean_phone(phone):
 #      in theory only cleaned data would make it to the plugin via the form,
 #      and cleaned numbers are deduped already.
 def split_sms_to(data):
-    return set(filter(bool, re.split(r"\s*,\s*|\s+", data)))
+    return set(list(filter(bool, re.split(r"\s*,\s*|\s+", data))))
 
 
 class TwilioConfigurationForm(forms.Form):
@@ -85,7 +85,7 @@ class TwilioConfigurationForm(forms.Form):
         for phone in phones:
             if not validate_phone(phone):
                 raise forms.ValidationError(f"{phone} is not a valid phone number.")
-        return ",".join(sorted(set(map(clean_phone, phones))))
+        return ",".join(sorted(set(list(map(clean_phone, phones)))))
 
     def clean(self):
         # TODO: Ping Twilio and check credentials (?)

--- a/src/social_auth/__init__.py
+++ b/src/social_auth/__init__.py
@@ -1,4 +1,3 @@
-
 version = (0, 7, 28)
 
-__version__ = ".".join(map(str, version))
+__version__ = ".".join(list(map(str, version)))

--- a/src/social_auth/__init__.py
+++ b/src/social_auth/__init__.py
@@ -1,4 +1,3 @@
-from sentry.utils.compat import map
 
 version = (0, 7, 28)
 

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -272,7 +272,7 @@ class BaseAuth:
         return {
             "next": next_idx,
             "backend": self.AUTH_BACKEND.name,
-            "args": tuple(list(map(model_to_ctype, args))),
+            "args": tuple(map(model_to_ctype, args)),
             "kwargs": {key: model_to_ctype(val) for key, val in kwargs.items()},
         }
 
@@ -280,7 +280,7 @@ class BaseAuth:
         """Takes session saved data to continue pipeline and merges with any
         new extra argument needed. Returns tuple with next pipeline index
         entry, arguments and keyword arguments to continue the process."""
-        args = args[:] + tuple(list(map(ctype_to_model, session_data["args"])))
+        args = args[:] + tuple(map(ctype_to_model, session_data["args"]))
 
         kwargs = kwargs.copy()
         saved_kwargs = {key: ctype_to_model(val) for key, val in session_data["kwargs"].items()}

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -272,7 +272,7 @@ class BaseAuth:
         return {
             "next": next_idx,
             "backend": self.AUTH_BACKEND.name,
-            "args": tuple(map(model_to_ctype, args)),
+            "args": tuple(list(map(model_to_ctype, args))),
             "kwargs": {key: model_to_ctype(val) for key, val in kwargs.items()},
         }
 
@@ -280,7 +280,7 @@ class BaseAuth:
         """Takes session saved data to continue pipeline and merges with any
         new extra argument needed. Returns tuple with next pipeline index
         entry, arguments and keyword arguments to continue the process."""
-        args = args[:] + tuple(map(ctype_to_model, session_data["args"]))
+        args = args[:] + tuple(list(map(ctype_to_model, session_data["args"])))
 
         kwargs = kwargs.copy()
         saved_kwargs = {key: ctype_to_model(val) for key, val in session_data["kwargs"].items()}

--- a/src/social_auth/backends/__init__.py
+++ b/src/social_auth/backends/__init__.py
@@ -43,7 +43,6 @@ from social_auth.exceptions import (
 )
 
 from sentry.utils import json
-from sentry.utils.compat import map
 
 PIPELINE = setting(
     "SOCIAL_AUTH_PIPELINE",

--- a/tests/sentry/api/endpoints/test_organization_config_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_config_repositories.py
@@ -13,6 +13,6 @@ class OrganizationConfigRepositoriesTest(APITestCase):
         response = self.client.get(url, format="json")
 
         assert response.status_code == 200, response.content
-        provider = filter(lambda x: x["id"] == "dummy", response.data["providers"])[0]
+        provider = list(filter(lambda x: x["id"] == "dummy", response.data["providers"]))[0]
         assert provider["name"] == "Example"
         assert provider["config"]

--- a/tests/sentry/api/endpoints/test_organization_config_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_config_repositories.py
@@ -1,7 +1,6 @@
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase
-from sentry.utils.compat import filter
 
 
 class OrganizationConfigRepositoriesTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -7,7 +7,6 @@ from sentry.models import (
     DashboardWidgetDisplayTypes,
 )
 from sentry.testutils import OrganizationDashboardWidgetTestCase
-from sentry.utils.compat import zip
 
 
 class OrganizationDashboardDetailsTestCase(OrganizationDashboardWidgetTestCase):

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -168,7 +168,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         widgets = self.get_widgets(self.dashboard)
         assert len(widgets) == len(list(widget_ids))
 
-        for widget, id in zip(widgets, widget_ids):
+        for widget, id in list(zip(widgets, widget_ids)):
             assert widget.id == id
 
     def test_dashboard_does_not_exist(self):

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -109,11 +109,11 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         widgets = self.get_widgets(dashboard.id)
         assert len(widgets) == 2
 
-        for expected_widget, actual_widget in zip(data["widgets"], widgets):
+        for expected_widget, actual_widget in list(zip(data["widgets"], widgets)):
             self.assert_serialized_widget(expected_widget, actual_widget)
 
             queries = actual_widget.dashboardwidgetquery_set.all()
-            for expected_query, actual_query in zip(expected_widget["queries"], queries):
+            for expected_query, actual_query in list(zip(expected_widget["queries"], queries)):
                 self.assert_serialized_widget_query(expected_query, actual_query)
 
     def test_invalid_data(self):

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -1,6 +1,5 @@
 from django.core.urlresolvers import reverse
 
-from sentry.utils.compat import zip
 from sentry.models import Dashboard, DashboardTombstone
 from sentry.testutils import OrganizationDashboardWidgetTestCase
 

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -358,13 +358,13 @@ class UpdateOrganizationMemberTest(APITestCase):
         assert resp.status_code == 200
 
         member_teams = OrganizationMemberTeam.objects.filter(organizationmember=member_om)
-        team_ids = map(lambda x: x.team_id, member_teams)
+        team_ids = list(map(lambda x: x.team_id, member_teams))
         assert foo.id in team_ids
         assert bar.id in team_ids
 
         member_om = OrganizationMember.objects.get(id=member_om.id)
 
-        teams = map(lambda team: team.slug, member_om.teams.all())
+        teams = list(map(lambda team: team.slug, member_om.teams.all()))
         assert foo.slug in teams
         assert bar.slug in teams
 
@@ -388,7 +388,7 @@ class UpdateOrganizationMemberTest(APITestCase):
         assert resp.status_code == 400
 
         member_om = OrganizationMember.objects.get(id=member_om.id)
-        teams = map(lambda team: team.slug, member_om.teams.all())
+        teams = list(map(lambda team: team.slug, member_om.teams.all()))
         assert len(teams) == 0
 
     def test_can_update_role(self):

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -16,7 +16,6 @@ from sentry.auth.authenticators import (
     RecoveryCodeInterface,
 )
 from sentry.testutils import APITestCase
-from sentry.utils.compat import map
 
 
 class UpdateOrganizationMemberTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -59,17 +59,14 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("webhooks").enable(self.projectA)
         response = self.client.get(self.url)
         assert (
-            list(list(filter(lambda x: x["slug"] == "webhooks", response.data)))[0]["projectList"]
-            == []
+            list(filter(lambda x: x["slug"] == "webhooks", response.data))[0]["projectList"] == []
         )
 
     def test_configured_not_enabled(self):
         plugins.get("trello").disable(self.projectA)
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         response = self.client.get(self.url)
-        assert list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
-            "projectList"
-        ] == [
+        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == [
             {
                 "projectId": self.projectA.id,
                 "projectSlug": self.projectA.slug,
@@ -84,9 +81,7 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("trello").enable(self.projectA)
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         response = self.client.get(self.url)
-        assert list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
-            "projectList"
-        ] == [
+        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == [
             {
                 "projectId": self.projectA.id,
                 "projectSlug": self.projectA.slug,
@@ -103,19 +98,14 @@ class OrganizationPluginsTest(APITestCase):
         self.projectA.status = 1
         self.projectA.save()
         response = self.client.get(self.url)
-        assert (
-            list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0]["projectList"]
-            == []
-        )
+        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == []
 
     def test_configured_multiple_projects(self):
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         plugins.get("trello").set_option("key", "another_value", self.projectB)
         response = self.client.get(self.url)
-        projectList = list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
-            "projectList"
-        ]
-        assert list(list(filter(lambda x: x["projectId"] == self.projectA.id, projectList)))[0] == {
+        projectList = list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"]
+        assert list(filter(lambda x: x["projectId"] == self.projectA.id, projectList))[0] == {
             "projectId": self.projectA.id,
             "projectSlug": self.projectA.slug,
             "projectName": self.projectA.name,
@@ -123,7 +113,7 @@ class OrganizationPluginsTest(APITestCase):
             "configured": True,
             "projectPlatform": None,
         }
-        assert list(list(filter(lambda x: x["projectId"] == self.projectB.id, projectList)))[0] == {
+        assert list(filter(lambda x: x["projectId"] == self.projectB.id, projectList))[0] == {
             "projectId": self.projectB.id,
             "projectSlug": self.projectB.slug,
             "projectName": self.projectB.name,

--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -49,7 +49,7 @@ class OrganizationPluginsTest(APITestCase):
             "webhooks",
         ]
         for plugin in expected_plugins:
-            assert filter(lambda x: x["slug"] == plugin, response.data)
+            assert list(filter(lambda x: x["slug"] == plugin, response.data))
 
     def test_only_configuable_plugins(self):
         response = self.client.get(self.url)
@@ -59,14 +59,17 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("webhooks").enable(self.projectA)
         response = self.client.get(self.url)
         assert (
-            list(filter(lambda x: x["slug"] == "webhooks", response.data))[0]["projectList"] == []
+            list(list(filter(lambda x: x["slug"] == "webhooks", response.data)))[0]["projectList"]
+            == []
         )
 
     def test_configured_not_enabled(self):
         plugins.get("trello").disable(self.projectA)
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         response = self.client.get(self.url)
-        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == [
+        assert list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
+            "projectList"
+        ] == [
             {
                 "projectId": self.projectA.id,
                 "projectSlug": self.projectA.slug,
@@ -81,7 +84,9 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("trello").enable(self.projectA)
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         response = self.client.get(self.url)
-        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == [
+        assert list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
+            "projectList"
+        ] == [
             {
                 "projectId": self.projectA.id,
                 "projectSlug": self.projectA.slug,
@@ -98,14 +103,19 @@ class OrganizationPluginsTest(APITestCase):
         self.projectA.status = 1
         self.projectA.save()
         response = self.client.get(self.url)
-        assert list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"] == []
+        assert (
+            list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0]["projectList"]
+            == []
+        )
 
     def test_configured_multiple_projects(self):
         plugins.get("trello").set_option("key", "some_value", self.projectA)
         plugins.get("trello").set_option("key", "another_value", self.projectB)
         response = self.client.get(self.url)
-        projectList = list(filter(lambda x: x["slug"] == "trello", response.data))[0]["projectList"]
-        assert list(filter(lambda x: x["projectId"] == self.projectA.id, projectList))[0] == {
+        projectList = list(list(filter(lambda x: x["slug"] == "trello", response.data)))[0][
+            "projectList"
+        ]
+        assert list(list(filter(lambda x: x["projectId"] == self.projectA.id, projectList)))[0] == {
             "projectId": self.projectA.id,
             "projectSlug": self.projectA.slug,
             "projectName": self.projectA.name,
@@ -113,7 +123,7 @@ class OrganizationPluginsTest(APITestCase):
             "configured": True,
             "projectPlatform": None,
         }
-        assert list(filter(lambda x: x["projectId"] == self.projectB.id, projectList))[0] == {
+        assert list(list(filter(lambda x: x["projectId"] == self.projectB.id, projectList)))[0] == {
             "projectId": self.projectB.id,
             "projectSlug": self.projectB.slug,
             "projectName": self.projectB.name,
@@ -141,7 +151,7 @@ class OrganizationPluginsTest(APITestCase):
         plugins.get("trello").set_option("key", "some_value", another)
         url = self.url + "?plugins=trello"
         response = self.client.get(url)
-        assert map(lambda x: x["projectSlug"], response.data[0]["projectList"]) == [
+        assert list(map(lambda x: x["projectSlug"], response.data[0]["projectList"])) == [
             "another",
             "proj_a",
             "proj_b",

--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -1,7 +1,6 @@
 from django.core.urlresolvers import reverse
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase
-from sentry.utils.compat import map
 
 
 class OrganizationPluginsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -658,7 +658,7 @@ class CopyProjectSettingsTest(APITestCase):
         assert ownership.schema == self.ownership.schema
 
         rules = Rule.objects.filter(project_id=project.id).order_by("label")
-        for rule, other_rule in zip(rules, self.rules):
+        for rule, other_rule in list(zip(rules, self.rules)):
             assert rule.label == other_rule.label
 
     def assert_settings_not_copied(self, project, teams=()):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -26,7 +26,6 @@ from sentry.api.endpoints.project_details import (
     DynamicSamplingConditionSerializer,
 )
 from sentry.testutils import APITestCase
-from sentry.utils.compat import zip
 
 
 def _dyn_sampling_data():

--- a/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
+++ b/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
@@ -53,7 +53,7 @@ class ProjectIssuesResolvedInReleaseEndpointTest(APITestCase):
     def run_test(self, expected_groups):
         response = self.get_valid_response(self.org.slug, self.project.slug, self.release.version)
         assert len(response.data) == len(expected_groups)
-        expected = set(map(str, [g.id for g in expected_groups]))
+        expected = set(list(map(str, [g.id for g in expected_groups])))
         assert {item["id"] for item in response.data} == expected
 
     def test_shows_issues_from_groupresolution(self):

--- a/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
+++ b/tests/sentry/api/endpoints/test_project_issues_resolved_in_release.py
@@ -4,7 +4,6 @@ from uuid import uuid1
 from sentry.models import Commit, GroupLink, GroupResolution, ReleaseCommit, Repository
 
 from sentry.testutils import APITestCase
-from sentry.utils.compat import map
 
 
 class ProjectIssuesResolvedInReleaseEndpointTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_plugins.py
+++ b/tests/sentry/api/endpoints/test_project_plugins.py
@@ -25,13 +25,13 @@ class ProjectPluginsTest(APITestCase):
         assert response.status_code == 200, (response.status_code, response.content)
         assert len(response.data) >= 9
 
-        auto_tag = filter(lambda p: p["slug"] == "browsers", response.data)[0]
+        auto_tag = list(filter(lambda p: p["slug"] == "browsers", response.data))[0]
         assert auto_tag["name"] == "Auto Tag: Browsers"
         assert auto_tag["enabled"] is True
         assert auto_tag["isHidden"] is False
         self.assert_plugin_shape(auto_tag)
 
-        issues = filter(lambda p: p["slug"] == "issuetrackingplugin2", response.data)[0]
+        issues = list(filter(lambda p: p["slug"] == "issuetrackingplugin2", response.data))[0]
         assert issues["name"] == "IssueTrackingPlugin2"
         assert issues["enabled"] is False
         assert issues["isHidden"] is True

--- a/tests/sentry/api/endpoints/test_project_plugins.py
+++ b/tests/sentry/api/endpoints/test_project_plugins.py
@@ -3,7 +3,6 @@ from django.core.urlresolvers import reverse
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase
 from sentry.utils.compat.mock import patch
-from sentry.utils.compat import filter
 
 
 class ProjectPluginsTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -87,7 +87,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted([str(report_1.id)])
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted([str(report_1.id)])
 
     def test_cannot_access_with_dsn_auth(self):
         project = self.create_project()
@@ -119,7 +119,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted([str(report_1.id)])
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted([str(report_1.id)])
 
     def test_environments(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.models import EventUser, GroupStatus, UserReport
-from sentry.utils.compat import map
 
 
 class ProjectUserReportListTest(APITestCase, SnubaTestCase):

--- a/tests/sentry/api/endpoints/test_project_user_reports.py
+++ b/tests/sentry/api/endpoints/test_project_user_reports.py
@@ -87,7 +87,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(map(lambda x: x["id"], response.data)) == sorted([str(report_1.id)])
+        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted([str(report_1.id)])
 
     def test_cannot_access_with_dsn_auth(self):
         project = self.create_project()
@@ -119,7 +119,7 @@ class ProjectUserReportListTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(map(lambda x: x["id"], response.data)) == sorted([str(report_1.id)])
+        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted([str(report_1.id)])
 
     def test_environments(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -2,7 +2,6 @@ from django.core.urlresolvers import reverse
 
 from sentry.models import EventUser
 from sentry.testutils import APITestCase
-from sentry.utils.compat import map
 
 
 class ProjectUsersTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -40,7 +40,7 @@ class ProjectUsersTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted(
             [str(self.euser1.id), str(self.euser2.id)]
         )
 

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -40,7 +40,7 @@ class ProjectUsersTest(APITestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["id"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted(
             [str(self.euser1.id), str(self.euser2.id)]
         )
 

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -18,7 +18,7 @@ class TeamProjectIndexTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["id"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted(
             [str(project_1.id), str(project_2.id)]
         )
 

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -18,7 +18,7 @@ class TeamProjectIndexTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["id"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["id"], response.data)) == sorted(
             [str(project_1.id), str(project_2.id)]
         )
 

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -2,7 +2,6 @@ from django.core.urlresolvers import reverse
 
 from sentry.models import Project, Rule
 from sentry.testutils import APITestCase
-from sentry.utils.compat import map
 
 
 class TeamProjectIndexTest(APITestCase):

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -8,7 +8,7 @@ def psycopg2_version():
     import psycopg2
 
     version = psycopg2.__version__.split()[0].split(".")
-    return tuple(list(map(int, version)))
+    return tuple(map(int, version))
 
 
 @pytest.mark.skipif(psycopg2_version() < (2, 7), reason="Test requires psycopg 2.7+")

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -8,7 +8,7 @@ def psycopg2_version():
     import psycopg2
 
     version = psycopg2.__version__.split()[0].split(".")
-    return tuple(map(int, version))
+    return tuple(list(map(int, version)))
 
 
 @pytest.mark.skipif(psycopg2_version() < (2, 7), reason="Test requires psycopg 2.7+")

--- a/tests/sentry/db/postgres/test_base.py
+++ b/tests/sentry/db/postgres/test_base.py
@@ -2,7 +2,6 @@ import pytest
 from sentry.testutils import TestCase
 from sentry.constants import MAX_CULPRIT_LENGTH
 from django.utils.encoding import force_text, force_bytes
-from sentry.utils.compat import map
 
 
 def psycopg2_version():

--- a/tests/sentry/grouping/similarity/test_features.py
+++ b/tests/sentry/grouping/similarity/test_features.py
@@ -89,7 +89,7 @@ def test_similarity_extract_fingerprinting(fingerprint_input, insta_snapshot):
 def _get_configurations():
     # Sort configurations by ascending date
     strategies = sorted(CONFIGURATIONS.keys(), key=lambda x: x.split(":")[-1])
-    return list(zip(strategies, strategies[1:]))
+    return list(list(zip(strategies, strategies[1:])))
 
 
 @pytest.mark.parametrize("config,next_config", _get_configurations())

--- a/tests/sentry/grouping/similarity/test_features.py
+++ b/tests/sentry/grouping/similarity/test_features.py
@@ -89,7 +89,7 @@ def test_similarity_extract_fingerprinting(fingerprint_input, insta_snapshot):
 def _get_configurations():
     # Sort configurations by ascending date
     strategies = sorted(CONFIGURATIONS.keys(), key=lambda x: x.split(":")[-1])
-    return list(list(zip(strategies, strategies[1:])))
+    return list(zip(strategies, strategies[1:]))
 
 
 @pytest.mark.parametrize("config,next_config", _get_configurations())

--- a/tests/sentry/grouping/similarity/test_features.py
+++ b/tests/sentry/grouping/similarity/test_features.py
@@ -4,7 +4,6 @@ from sentry.models import Group, Project
 from sentry.event_manager import EventManager
 from sentry.grouping.api import get_default_grouping_config_dict
 from sentry.grouping.strategies.configurations import CONFIGURATIONS
-from sentry.utils.compat import zip
 from sentry.utils import json
 from sentry import eventstore
 

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -34,7 +34,6 @@ from sentry.incidents.subscription_processor import (
 from sentry.snuba.models import QuerySubscription
 from sentry.testutils import TestCase
 from sentry.utils.dates import to_timestamp
-from sentry.utils.compat import map
 
 
 EMPTY = object()

--- a/tests/sentry/incidents/test_subscription_processor.py
+++ b/tests/sentry/incidents/test_subscription_processor.py
@@ -886,17 +886,19 @@ class TestUpdateAlertRuleStats(TestCase):
         date = datetime.utcnow().replace(tzinfo=pytz.utc)
         update_alert_rule_stats(alert_rule, sub, date, {3: 20, 4: 3}, {3: 10, 4: 15})
         client = get_redis_client()
-        results = map(
-            int,
-            client.mget(
-                [
-                    "{alert_rule:1:project:2}:last_update",
-                    "{alert_rule:1:project:2}:trigger:3:alert_triggered",
-                    "{alert_rule:1:project:2}:trigger:3:resolve_triggered",
-                    "{alert_rule:1:project:2}:trigger:4:alert_triggered",
-                    "{alert_rule:1:project:2}:trigger:4:resolve_triggered",
-                ]
-            ),
+        results = list(
+            map(
+                int,
+                client.mget(
+                    [
+                        "{alert_rule:1:project:2}:last_update",
+                        "{alert_rule:1:project:2}:trigger:3:alert_triggered",
+                        "{alert_rule:1:project:2}:trigger:3:resolve_triggered",
+                        "{alert_rule:1:project:2}:trigger:4:alert_triggered",
+                        "{alert_rule:1:project:2}:trigger:4:resolve_triggered",
+                    ]
+                ),
+            )
         )
 
         assert results == [int(to_timestamp(date)), 20, 10, 3, 15]

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -37,7 +37,9 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
     def test_project_select(self, mock_react_view):
         resp = self.client.get(self.setup_path)
         assert resp.status_code == 200
-        serialized_projects = map(lambda x: serialize(x, self.user), [self.projectA, self.projectB])
+        serialized_projects = list(
+            map(lambda x: serialize(x, self.user), [self.projectA, self.projectB])
+        )
         mock_react_view.assert_called_with(
             ANY, "awsLambdaProjectSelect", {"projects": serialized_projects}
         )

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -11,7 +11,6 @@ from sentry.models import (
     ProjectKey,
 )
 from sentry.testutils import IntegrationTestCase
-from sentry.utils.compat import map
 from sentry.utils.compat.mock import patch, ANY, MagicMock
 from sentry.testutils.helpers.faux import Mock
 from sentry.pipeline import PipelineView

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -8,7 +8,6 @@ from sentry.integrations.slack.utils import build_group_attachment, build_incide
 from sentry.models import Integration, OrganizationIntegration
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
-from sentry.utils.compat import filter
 
 UNSET = object()
 

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -227,7 +227,7 @@ class LinkSharedEventTest(BaseEventTest):
 
 
 def get_block_type_text(block_type, data):
-    block = filter(lambda x: x["type"] == block_type, data["blocks"])[0]
+    block = list(filter(lambda x: x["type"] == block_type, data["blocks"]))[0]
     if block_type == "section":
         return block["text"]["text"]
 

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -41,7 +41,7 @@ def test_sources_builtin(default_project):
         sources = get_sources_for_project(default_project)
 
     # XXX: The order matters here! Project is always first, then builtin sources
-    source_ids = map(lambda s: s["id"], sources)
+    source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project", "sentry:microsoft"]
 
 
@@ -56,7 +56,7 @@ def test_sources_builtin_unknown(default_project):
     with Feature(features):
         sources = get_sources_for_project(default_project)
 
-    source_ids = map(lambda s: s["id"], sources)
+    source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project"]
 
 
@@ -71,7 +71,7 @@ def test_sources_builtin_disabled(default_project):
     with Feature(features):
         sources = get_sources_for_project(default_project)
 
-    source_ids = map(lambda s: s["id"], sources)
+    source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project"]
 
 
@@ -87,7 +87,7 @@ def test_sources_custom(default_project):
         sources = get_sources_for_project(default_project)
 
     # XXX: The order matters here! Project is always first, then custom sources
-    source_ids = map(lambda s: s["id"], sources)
+    source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project", "custom"]
 
 
@@ -103,7 +103,7 @@ def test_sources_custom_disabled(default_project):
     with Feature(features):
         sources = get_sources_for_project(default_project)
 
-    source_ids = map(lambda s: s["id"], sources)
+    source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project"]
 
 

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -7,7 +7,6 @@ from sentry.lang.native.symbolicator import (
     redact_internal_sources,
 )
 from sentry.testutils.helpers import Feature
-from sentry.utils.compat import map
 
 
 CUSTOM_SOURCE_CONFIG = """

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -28,7 +28,7 @@ class FileBlobTest(TestCase):
 
         parts = path.split("/")
         assert len(parts) == 3
-        assert map(len, parts) == [2, 4, 26]
+        assert list(map(len, parts)) == [2, 4, 26]
 
         # Check uniqueness
         path2 = FileBlob.generate_unique_path()

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -4,7 +4,6 @@ from django.core.files.base import ContentFile
 
 from sentry.models import File, FileBlob, FileBlobIndex
 from sentry.testutils import TestCase
-from sentry.utils.compat import map
 
 
 class FileBlobTest(TestCase):

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -251,7 +251,7 @@ class CopyProjectSettingsTest(TestCase):
         assert ownership.schema == self.ownership.schema
 
         rules = Rule.objects.filter(project_id=project.id).order_by("label")
-        for rule, other_rule in zip(rules, self.rules):
+        for rule, other_rule in list(zip(rules, self.rules)):
             assert rule.label == other_rule.label
 
     def assert_settings_not_copied(self, project, teams=()):

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -13,7 +13,6 @@ from sentry.models import (
     UserOption,
 )
 from sentry.testutils import TestCase
-from sentry.utils.compat import zip
 
 
 class ProjectTest(TestCase):

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -8,7 +8,6 @@ from sentry.quotas.base import QuotaConfig, QuotaScope
 from sentry.quotas.redis import is_rate_limited, RedisQuota
 from sentry.testutils import TestCase
 from sentry.utils.redis import clusters
-from sentry.utils.compat import map
 
 
 def test_is_rate_limited_script():

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -19,11 +19,13 @@ def test_is_rate_limited_script():
     # The item should not be rate limited by either key.
     assert (
         list(
-            map(
-                bool,
-                is_rate_limited(
-                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                ),
+            list(
+                map(
+                    bool,
+                    is_rate_limited(
+                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                    ),
+                )
             )
         )
         == [False, False]
@@ -32,11 +34,13 @@ def test_is_rate_limited_script():
     # The item should be rate limited by the first key (1).
     assert (
         list(
-            map(
-                bool,
-                is_rate_limited(
-                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                ),
+            list(
+                map(
+                    bool,
+                    is_rate_limited(
+                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                    ),
+                )
             )
         )
         == [True, False]
@@ -48,11 +52,13 @@ def test_is_rate_limited_script():
     # quota don't affect unrelated items that share a parent quota.
     assert (
         list(
-            map(
-                bool,
-                is_rate_limited(
-                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                ),
+            list(
+                map(
+                    bool,
+                    is_rate_limited(
+                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                    ),
+                )
             )
         )
         == [True, False]
@@ -73,9 +79,9 @@ def test_is_rate_limited_script():
     # increment
     is_rate_limited(client, ("orange", "baz"), (1, now + 60))
     # test that it's rate limited without refund
-    assert map(bool, is_rate_limited(client, ("orange", "baz"), (1, now + 60))) == [True]
+    assert list(map(bool, is_rate_limited(client, ("orange", "baz"), (1, now + 60)))) == [True]
     # test that refund key is used
-    assert map(bool, is_rate_limited(client, ("orange", "apple"), (1, now + 60))) == [False]
+    assert list(map(bool, is_rate_limited(client, ("orange", "apple"), (1, now + 60)))) == [False]
 
 
 class RedisQuotaTest(TestCase):

--- a/tests/sentry/quotas/redis/tests.py
+++ b/tests/sentry/quotas/redis/tests.py
@@ -19,13 +19,11 @@ def test_is_rate_limited_script():
     # The item should not be rate limited by either key.
     assert (
         list(
-            list(
-                map(
-                    bool,
-                    is_rate_limited(
-                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                    ),
-                )
+            map(
+                bool,
+                is_rate_limited(
+                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                ),
             )
         )
         == [False, False]
@@ -34,13 +32,11 @@ def test_is_rate_limited_script():
     # The item should be rate limited by the first key (1).
     assert (
         list(
-            list(
-                map(
-                    bool,
-                    is_rate_limited(
-                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                    ),
-                )
+            map(
+                bool,
+                is_rate_limited(
+                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                ),
             )
         )
         == [True, False]
@@ -52,13 +48,11 @@ def test_is_rate_limited_script():
     # quota don't affect unrelated items that share a parent quota.
     assert (
         list(
-            list(
-                map(
-                    bool,
-                    is_rate_limited(
-                        client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
-                    ),
-                )
+            map(
+                bool,
+                is_rate_limited(
+                    client, ("foo", "r:foo", "bar", "r:bar"), (1, now + 60, 2, now + 120)
+                ),
             )
         )
         == [True, False]

--- a/tests/sentry/similarity/test_signatures.py
+++ b/tests/sentry/similarity/test_signatures.py
@@ -2,8 +2,6 @@ from collections import Counter
 from unittest import TestCase
 
 from sentry.similarity.signatures import MinHashSignatureBuilder
-from sentry.utils.compat import map
-from sentry.utils.compat import zip
 
 
 class MinHashSignatureBuilderTestCase(TestCase):

--- a/tests/sentry/similarity/test_signatures.py
+++ b/tests/sentry/similarity/test_signatures.py
@@ -19,7 +19,9 @@ class MinHashSignatureBuilderTestCase(TestCase):
         b = set("the quick brown fox jumps over the lazy dog".split())
 
         results = Counter(
-            map(lambda l__r: l__r[0] == l__r[1], zip(get_signature(a), get_signature(b)))
+            list(
+                map(lambda l__r: l__r[0] == l__r[1], list(zip(get_signature(a), get_signature(b))))
+            )
         )
 
         similarity = len(a & b) / float(len(a | b))

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -38,7 +38,6 @@ from sentry.utils.dates import to_datetime, to_timestamp, floor_to_utc_day
 from sentry.testutils.helpers.datetime import iso_format
 
 
-
 @pytest.yield_fixture(scope="module")
 def interval():
     stop = datetime(2016, 9, 12, tzinfo=pytz.utc)
@@ -354,5 +353,5 @@ class ReportTestCase(TestCase, SnubaTestCase):
         )
 
         assert any(
-            map(lambda x: x[1] == (2, 0), response)
+            list(map(lambda x: x[1] == (2, 0), response))
         ), "must show two issues resolved in one rollup window"

--- a/tests/sentry/tasks/test_reports.py
+++ b/tests/sentry/tasks/test_reports.py
@@ -37,7 +37,6 @@ from sentry.testutils.factories import DEFAULT_EVENT_DATA
 from sentry.utils.dates import to_datetime, to_timestamp, floor_to_utc_day
 from sentry.testutils.helpers.datetime import iso_format
 
-from sentry.utils.compat import map
 
 
 @pytest.yield_fixture(scope="module")

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -139,7 +139,7 @@ class AuthSAML2Test(AuthProviderTestCase):
 
         auth = self.accept_auth(follow=True)
 
-        messages = map(lambda m: str(m), auth.context["messages"])
+        messages = list(map(lambda m: str(m), auth.context["messages"]))
 
         assert len(messages) == 2
         assert messages[0] == "You have successfully linked your account to your SSO provider."
@@ -163,7 +163,7 @@ class AuthSAML2Test(AuthProviderTestCase):
 
         assert auth.status_code == 200
 
-        messages = map(lambda m: str(m), auth.context["messages"])
+        messages = list(map(lambda m: str(m), auth.context["messages"]))
         assert len(messages) == 1
         assert messages[0] == "The organization does not exist or does not have SAML SSO enabled."
 

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -18,7 +18,6 @@ from sentry.models import (
 )
 from sentry.testutils import AuthProviderTestCase
 from sentry.testutils.helpers import Feature
-from sentry.utils.compat import map
 
 
 dummy_provider_config = {

--- a/tests/sentry_plugins/twilio/test_plugin.py
+++ b/tests/sentry_plugins/twilio/test_plugin.py
@@ -6,7 +6,6 @@ from sentry.plugins.base import Notification
 from sentry.testutils import TestCase, PluginTestCase
 from sentry_plugins.twilio.plugin import TwilioConfigurationForm, TwilioPlugin
 from urllib.parse import parse_qs
-from sentry.utils.compat import map
 
 
 class TwilioConfigurationFormTest(TestCase):

--- a/tests/sentry_plugins/twilio/test_plugin.py
+++ b/tests/sentry_plugins/twilio/test_plugin.py
@@ -38,7 +38,7 @@ class TwilioConfigurationFormTest(TestCase):
         # extracting the message from django.forms.ValidationError
         # is the easiest and simplest way I've found to assert as_data
         for e in errors:
-            errors[e] = map(lambda x: x.message, errors[e])
+            errors[e] = list(map(lambda x: x.message, errors[e]))
 
         self.assertDictEqual(
             errors,

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -36,7 +36,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -172,7 +172,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -216,7 +216,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url + "?environment=production", format="json")
 
         assert response.status_code == 200, response.content
-        assert set(map(lambda x: x["eventID"], response.data)) == {
+        assert set(list(map(lambda x: x["eventID"], response.data))) == {
             str(events["production"].event_id)
         }
 
@@ -224,7 +224,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             url, data={"environment": ["production", "development"]}, format="json"
         )
         assert response.status_code == 200, response.content
-        assert set(map(lambda x: x["eventID"], response.data)) == {
+        assert set(list(map(lambda x: x["eventID"], response.data))) == {
             str(event.event_id) for event in events.values()
         }
 
@@ -257,7 +257,9 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted([str(event_2.event_id)])
+        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+            [str(event_2.event_id)]
+        )
 
     def test_search_event_has_tags(self):
         self.login_as(user=self.user)
@@ -294,7 +296,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -348,4 +350,4 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
             response = self.client.get(url, format="json")
             assert response.status_code == 200, response.content
             assert len(response.data) == 1, response.data
-            assert map(lambda x: x["eventID"], response.data) == [str(event.event_id)]
+            assert list(map(lambda x: x["eventID"], response.data)) == [str(event.event_id)]

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -36,7 +36,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -172,7 +172,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 
@@ -257,9 +257,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
-            [str(event_2.event_id)]
-        )
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted([str(event_2.event_id)])
 
     def test_search_event_has_tags(self):
         self.login_as(user=self.user)
@@ -296,7 +294,7 @@ class GroupEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [str(event_1.event_id), str(event_2.event_id)]
         )
 

--- a/tests/snuba/api/endpoints/test_group_events.py
+++ b/tests/snuba/api/endpoints/test_group_events.py
@@ -4,7 +4,6 @@ from freezegun import freeze_time
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
-from sentry.utils.compat import map
 
 
 class GroupEventsTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -5,7 +5,6 @@ from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import map
 
 
 class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -14,7 +14,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         self.day_ago = iso_format(before_now(days=1))
 
     def assert_events_in_response(self, response, event_ids):
-        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(event_ids)
+        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(event_ids)
 
     def test_simple(self):
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -14,7 +14,7 @@ class OrganizationEventsEndpointTest(APITestCase, SnubaTestCase):
         self.day_ago = iso_format(before_now(days=1))
 
     def assert_events_in_response(self, response, event_ids):
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(event_ids)
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(event_ids)
 
     def test_simple(self):
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -266,7 +266,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             assert len(data) == 6
 
             rows = data[0:6]
-            for test in zip(event_counts, rows):
+            for test in list(zip(event_counts, rows)):
                 assert test[1][1][0]["count"] == test[0] / (3600.0 / 60.0)
 
     def test_throughput_epm_day_rollup(self):
@@ -344,7 +344,7 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase):
             assert len(data) == 6
 
             rows = data[0:6]
-            for test in zip(event_counts, rows):
+            for test in list(zip(event_counts, rows)):
                 assert test[1][1][0]["count"] == test[0] / 60.0
 
     def test_throughput_eps_no_rollup(self):

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -8,7 +8,7 @@ from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
-from sentry.utils.compat import zip, mock
+from sentry.utils.compat import mock
 from sentry.utils.samples import load_data
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2451,7 +2451,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             results = response.data["data"]
             assert results[0]["count"] == 1, datum
 
-            for (field, exp) in zip(fields, expected):
+            for (field, exp) in list(zip(fields, expected)):
                 assert results[0][field] == exp, field + str(datum)
 
     def test_failure_count_alias_field(self):

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -10,7 +10,7 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 
 from sentry.utils import json
 from sentry.utils.samples import load_data
-from sentry.utils.compat import zip, mock
+from sentry.utils.compat import mock
 from sentry.utils.snuba import RateLimitExceeded, QueryIllegalTypeOfArgument, QueryExecutionError
 
 

--- a/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
+++ b/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
@@ -65,7 +65,7 @@ class OrganizationIssuesResolvedInReleaseEndpointTest(APITestCase, SnubaTestCase
 
         response = self.get_valid_response(self.org.slug, self.release.version, **params)
         assert len(response.data) == len(expected_groups)
-        expected = set(map(str, [g.id for g in expected_groups]))
+        expected = set(list(map(str, [g.id for g in expected_groups])))
         assert {item["id"] for item in response.data} == expected
 
     def test_shows_issues_from_groupresolution(self):

--- a/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
+++ b/tests/snuba/api/endpoints/test_organization_issues_resolved_in_release.py
@@ -4,7 +4,6 @@ from uuid import uuid1
 from sentry.models import Commit, GroupLink, GroupResolution, ReleaseCommit, Repository
 
 from sentry.testutils import APITestCase, SnubaTestCase
-from sentry.utils.compat import map
 
 
 class OrganizationIssuesResolvedInReleaseEndpointTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -24,7 +24,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
+        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
             [event_1.event_id, event_2.event_id]
         )
 

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -2,7 +2,6 @@ from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
-from sentry.utils.compat import map
 
 
 class ProjectEventsTest(APITestCase, SnubaTestCase):

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -24,7 +24,7 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 200, response.content
         assert len(response.data) == 2
-        assert sorted(map(lambda x: x["eventID"], response.data)) == sorted(
+        assert sorted(list(map(lambda x: x["eventID"], response.data))) == sorted(
             [event_1.event_id, event_2.event_id]
         )
 

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -29,7 +29,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.testutils.helpers.features import with_feature
 from sentry.tasks.merge import merge_groups
 
-from sentry.utils.compat import map
 
 # Use the default redis client as a cluster client in the similarity index
 index = _make_index_backend(redis.clusters.get("default").get_local_client(0))

--- a/tests/snuba/tasks/test_unmerge.py
+++ b/tests/snuba/tasks/test_unmerge.py
@@ -252,7 +252,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         merge_source, source, destination = list(Group.objects.all())
 
         assert len(events) == 3
-        assert sum(map(len, events.values())) == 17
+        assert sum(list(map(len, events.values()))) == 17
 
         production_environment = Environment.objects.get(
             organization_id=project.organization_id, name="production"
@@ -308,7 +308,7 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
         assert source.id != destination.id
         assert source.project == destination.project
 
-        destination_event_ids = map(lambda event: event.event_id, list(events.values())[1])
+        destination_event_ids = list(map(lambda event: event.event_id, list(events.values())[1]))
 
         assert set(
             UserReport.objects.filter(group_id=source.id).values_list("event_id", flat=True)
@@ -331,8 +331,8 @@ class UnmergeTestCase(TestCase, SnubaTestCase):
             )
         } == {("red", 4), ("green", 3), ("blue", 3)}
 
-        destination_event_ids = map(
-            lambda event: event.event_id, list(events.values())[0] + list(events.values())[2]
+        destination_event_ids = list(
+            map(lambda event: event.event_id, list(events.values())[0] + list(events.values())[2])
         )
 
         assert set(


### PR DESCRIPTION
This inlines list wrappings (on exactly the files with the compat since it's removed from sentry-flake8 a while ago), so I can remove all the compat imports and all this function overhead that's vestigial from the 2 -> 3 transition. People who do typing afterwards can identify whether or not the list wrapping can be removed.

This was done by staging the changes from a series of fastmods and manual changes to remove the imports first, then running `joshware.py ./**/*.py` and checking out any files with only ` M`, then staging the rest.

```
git status -sb -uall | grep '^\ M'
 M src/sentry/api/endpoints/organization_events_trace.py
 M src/sentry/api/endpoints/organization_has_mobile_app_events.py
 M src/sentry/snuba/tasks.py
 M tests/sentry/api/endpoints/test_organization_member_index.py
 M tests/snuba/api/endpoints/test_organization_events_trace.py
```

Then I looked for obvious regressions in the diff like `set(list(map` and manually fixed them. There are quite a few. I might uhh, redo this but make my script interactive and print diffs to confirm.

I started out with `ast` but then realized it's lossy (comments, some whitespaces), so switched to using `libcst`:

```py
from pathlib import Path
import sys

import libcst as cst

looking_for_you = ("map", "filter", "zip")

class GoodTransformer(cst.CSTTransformer):
    def leave_Call(self, _, node):
        if isinstance(node.func, cst.Name):
            if node.func.value in looking_for_you:
                return cst.Call(func=cst.Name("list"), args=[cst.Arg(value=node)])
        return node

for fp in sys.argv[1:]:
    print(fp)
    m = cst.parse_module(Path(fp).read_text())
    Path(fp).write_text(m.visit(GoodTransformer()).code)
```
