### PR TITLE
feat(event-error-list): Add Proguard error message

### DIFF
--- a/src/sentry/static/sentry/app/components/events/errors.tsx
+++ b/src/sentry/static/sentry/app/components/events/errors.tsx
@@ -88,7 +88,7 @@ class Errors extends React.Component<Props, State> {
     const {event} = this.props;
     const {errors} = event;
 
-    const sourceCodeErrors = errors.filter(
+    const sourceCodeErrors = (errors ?? []).filter(
       error => error.type === 'js_no_source' && error.data.url
     );
 
@@ -127,13 +127,13 @@ class Errors extends React.Component<Props, State> {
   render() {
     const {event, proGuardErrors} = this.props;
     const {isOpen, releaseArtifacts} = this.state;
-    const {dist} = event;
+    const {dist, errors: eventErrors = []} = event;
 
     // XXX: uniqWith returns unique errors and is not performant with large datasets
-    const eventErrors: Array<Error> =
-      event.errors.length > MAX_ERRORS ? event.errors : uniqWith(event.errors, isEqual);
+    const otherErrors: Array<Error> =
+      eventErrors.length > MAX_ERRORS ? eventErrors : uniqWith(eventErrors, isEqual);
 
-    const errors = [...eventErrors, ...proGuardErrors];
+    const errors = [...otherErrors, ...proGuardErrors];
 
     return (
       <StyledBanner priority="danger">

--- a/src/sentry/static/sentry/app/components/events/errors.tsx
+++ b/src/sentry/static/sentry/app/components/events/errors.tsx
@@ -21,12 +21,13 @@ import {BannerContainer, BannerSummary} from './styles';
 
 const MAX_ERRORS = 100;
 
-type Error = ErrorItem['props']['error'];
+export type Error = ErrorItem['props']['error'];
 
 type Props = {
   api: Client;
   orgSlug: Organization['slug'];
   projectSlug: Project['slug'];
+  proGuardErrors: Array<Error>;
   event: Event;
 };
 
@@ -124,19 +125,21 @@ class Errors extends React.Component<Props, State> {
   };
 
   render() {
-    const {event} = this.props;
+    const {event, proGuardErrors} = this.props;
     const {isOpen, releaseArtifacts} = this.state;
     const {dist} = event;
 
     // XXX: uniqWith returns unique errors and is not performant with large datasets
-    const errors: Array<Error> =
+    const eventErrors: Array<Error> =
       event.errors.length > MAX_ERRORS ? event.errors : uniqWith(event.errors, isEqual);
+
+    const errors = [...eventErrors, ...proGuardErrors];
 
     return (
       <StyledBanner priority="danger">
         <BannerSummary>
           <StyledIconWarning />
-          <span>
+          <span data-test-id="errors-banner-summary-info">
             {tn(
               'There was %s error encountered while processing this event',
               'There were %s errors encountered while processing this event',

--- a/src/sentry/static/sentry/app/components/events/eventEntries.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.tsx
@@ -208,7 +208,6 @@ class EventEntries extends React.Component<Props, State> {
           }
           Sentry.captureMessage('Event contains proguard image but not uuid');
         });
-        return;
       }
     }
 
@@ -237,11 +236,18 @@ class EventEntries extends React.Component<Props, State> {
       });
 
       // This capture will be removed once we're confident with the level of effectiveness
-      Sentry.captureMessage(
-        !proGuardImage
-          ? 'No Proguard is used at all, but a frame did match the regex'
-          : "Displaying ProGuard warning 'proguard_potentially_misconfigured_plugin' for suspected event"
-      );
+      Sentry.withScope(function (s) {
+        s.setLevel(Sentry.Severity.Warning);
+        if (event.sdk) {
+          s.setTag('offending.event.sdk.name', event.sdk.name);
+          s.setTag('offending.event.sdk.version', event.sdk.version);
+        }
+        Sentry.captureMessage(
+          !proGuardImage
+            ? 'No Proguard is used at all, but a frame did match the regex'
+            : "Displaying ProGuard warning 'proguard_potentially_misconfigured_plugin' for suspected event"
+        );
+      });
     }
 
     this.setState({proGuardErrors, isLoading: false});

--- a/src/sentry/static/sentry/app/components/events/eventEntries.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.tsx
@@ -47,7 +47,7 @@ import findBestThread from './interfaces/threads/threadSelector/findBestThread';
 import getThreadException from './interfaces/threads/threadSelector/getThreadException';
 import EventEntry from './eventEntry';
 
-const MATCH_MINIFIED_DATA_REGEX = /^(\w|\w{2}\.\w{1,2}|\w{3}((\.\w)|(\.\w{2}){2}))(\.|$)/g;
+const MINIFIED_DATA_JAVA_EVENT_REGEX_MATCH = /^(\w|\w{2}\.\w{1,2}|\w{3}((\.\w)|(\.\w{2}){2}))(\.|$)/g;
 
 const defaultProps = {
   isShare: false,
@@ -124,7 +124,7 @@ class EventEntries extends React.Component<Props, State> {
       return false;
     }
 
-    return !![...str.matchAll(MATCH_MINIFIED_DATA_REGEX)].length;
+    return !![...str.matchAll(MINIFIED_DATA_JAVA_EVENT_REGEX_MATCH)].length;
   }
 
   hasThreadOrExceptionMinifiedFrameData(event: Event, bestThread?: Thread) {

--- a/src/sentry/static/sentry/app/components/events/eventEntries.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import {Location} from 'history';
 
+import {Client} from 'app/api';
 import ErrorBoundary from 'app/components/errorBoundary';
 import EventContexts from 'app/components/events/contexts';
 import EventContextSummary from 'app/components/events/contextSummary/contextSummary';
 import EventDevice from 'app/components/events/device';
-import EventErrors from 'app/components/events/errors';
+import EventErrors, {Error} from 'app/components/events/errors';
 import EventAttachments from 'app/components/events/eventAttachments';
 import EventCause from 'app/components/events/eventCause';
 import EventCauseEmpty from 'app/components/events/eventCauseEmpty';
@@ -20,22 +22,40 @@ import RRWebIntegration from 'app/components/events/rrwebIntegration';
 import EventSdkUpdates from 'app/components/events/sdkUpdates';
 import {DataSection} from 'app/components/events/styles';
 import EventUserFeedback from 'app/components/events/userFeedback';
-import {t} from 'app/locale';
+import ExternalLink from 'app/components/links/externalLink';
+import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
-import {Group, Organization, Project, SharedViewOrganization} from 'app/types';
-import {Entry, Event} from 'app/types/event';
+import {
+  ExceptionValue,
+  Group,
+  Organization,
+  Project,
+  SharedViewOrganization,
+} from 'app/types';
+import {DebugFile} from 'app/types/debugFiles';
+import {Image} from 'app/types/debugImage';
+import {Entry, EntryType, Event} from 'app/types/event';
+import {Thread} from 'app/types/events';
 import {isNotSharedOrganization} from 'app/types/utils';
-import {objectIsEmpty} from 'app/utils';
+import {defined, objectIsEmpty} from 'app/utils';
 import {analytics} from 'app/utils/analytics';
+import withApi from 'app/utils/withApi';
 import withOrganization from 'app/utils/withOrganization';
+import {projectProcessingIssuesMessages} from 'app/views/settings/project/projectProcessingIssues';
 
+import findBestThread from './interfaces/threads/threadSelector/findBestThread';
+import getThreadException from './interfaces/threads/threadSelector/getThreadException';
 import EventEntry from './eventEntry';
+
+const MATCH_MINIFIED_DATA_REGEX = /^(\w|\w{2}\.\w{1,2}|\w{3}((\.\w)|(\.\w{2}){2}))(\.|$)/g;
 
 const defaultProps = {
   isShare: false,
   showExampleCommit: false,
   showTagSummary: true,
 };
+
+type ProGuardErrors = Array<Error>;
 
 type Props = {
   /**
@@ -45,38 +65,193 @@ type Props = {
   event: Event;
   project: Project;
   location: Location;
-
+  api: Client;
   group?: Group;
   className?: string;
 } & typeof defaultProps;
 
-class EventEntries extends React.Component<Props> {
+type State = {
+  isLoading: boolean;
+  proGuardErrors: ProGuardErrors;
+};
+
+class EventEntries extends React.Component<Props, State> {
   static defaultProps = defaultProps;
 
+  state: State = {
+    isLoading: true,
+    proGuardErrors: [],
+  };
+
   componentDidMount() {
-    const {event} = this.props;
-
-    if (!event || !event.errors || !(event.errors.length > 0)) {
-      return;
-    }
-    const errors = event.errors;
-    const errorTypes = errors.map(errorEntries => errorEntries.type);
-    const errorMessages = errors.map(errorEntries => errorEntries.message);
-
-    this.recordIssueError(errorTypes, errorMessages);
+    this.checkProGuardError();
+    this.recordIssueError();
   }
 
-  shouldComponentUpdate(nextProps: Props) {
+  shouldComponentUpdate(nextProps: Props, nextState: State) {
     const {event, showExampleCommit} = this.props;
 
     return (
       (event && nextProps.event && event.id !== nextProps.event.id) ||
-      showExampleCommit !== nextProps.showExampleCommit
+      showExampleCommit !== nextProps.showExampleCommit ||
+      nextState.isLoading !== this.state.isLoading
     );
   }
 
-  recordIssueError(errorTypes: any[], errorMessages: string[]) {
+  async fetchDebugFile(query: string): Promise<Array<DebugFile>> {
+    const {api, organization, project} = this.props;
+    try {
+      const debugFiles = await api.requestPromise(
+        `/projects/${organization.slug}/${project.slug}/files/dsyms/`,
+        {
+          method: 'GET',
+          query: {
+            query,
+            file_formats: 'proguard',
+          },
+        }
+      );
+      return debugFiles;
+    } catch (error) {
+      Sentry.captureException(error);
+      // do nothing, the UI will not display extra error details
+      return [];
+    }
+  }
+
+  isDataMinified(str: string | null) {
+    if (!str) {
+      return false;
+    }
+
+    return !![...str.matchAll(MATCH_MINIFIED_DATA_REGEX)].length;
+  }
+
+  hasThreadOrExceptionMinifiedFrameData(event: Event, bestThread?: Thread) {
+    if (!bestThread) {
+      const exceptionValues: Array<ExceptionValue> =
+        event.entries?.find(e => e.type === EntryType.EXCEPTION)?.data?.values ?? [];
+
+      return !!exceptionValues.find(exceptionValue =>
+        exceptionValue.stacktrace?.frames?.find(frame =>
+          this.isDataMinified(frame.module)
+        )
+      );
+    }
+
+    const threadExceptionValues = getThreadException(event, bestThread)?.values;
+
+    return !!(threadExceptionValues
+      ? threadExceptionValues.find(threadExceptionValue =>
+          threadExceptionValue.stacktrace?.frames?.find(frame =>
+            this.isDataMinified(frame.module)
+          )
+        )
+      : bestThread?.stacktrace?.frames?.find(frame => this.isDataMinified(frame.module)));
+  }
+
+  async checkProGuardError() {
+    const {event} = this.props;
+
+    if (!event || event.platform !== 'java') {
+      this.setState({isLoading: false});
+      return;
+    }
+
+    const hasEventErrorsProGuardMissingMapping = event.errors?.find(
+      error => error.type === 'proguard_missing_mapping'
+    );
+
+    if (hasEventErrorsProGuardMissingMapping) {
+      this.setState({isLoading: false});
+      return;
+    }
+
+    const proGuardErrors: ProGuardErrors = [];
+
+    const debugImages = event.entries?.find(e => e.type === EntryType.DEBUGMETA)?.data
+      .images as undefined | Array<Image>;
+
+    // When debugImages contains a 'proguard' entry, it must always be only one entry
+    const proGuardImage = debugImages?.find(
+      debugImage => debugImage?.type === 'proguard'
+    );
+
+    const proGuardImageUuid = proGuardImage?.uuid;
+
+    // If an entry is of type 'proguard' and has 'uuid',
+    // it means that the Sentry Gradle plugin has been executed,
+    // otherwise the proguard id wouldn't be in the event.
+    // But maybe it failed to upload the mappings file
+    if (defined(proGuardImageUuid)) {
+      const debugFile = await this.fetchDebugFile(proGuardImageUuid);
+
+      if (!debugFile.length) {
+        proGuardErrors.push({
+          type: 'proguard_missing_mapping',
+          message: projectProcessingIssuesMessages.proguard_missing_mapping,
+          data: {mapping_uuid: proGuardImageUuid},
+        });
+      }
+
+      this.setState({proGuardErrors, isLoading: false});
+      return;
+    } else {
+      if (proGuardImage) {
+        Sentry.withScope(function (s) {
+          s.setLevel(Sentry.Severity.Warning);
+          if (event.sdk) {
+            s.setTag('offending.event.sdk.name', event.sdk.name);
+            s.setTag('offending.event.sdk.version', event.sdk.version);
+          }
+          Sentry.captureMessage('Event contains proguard image but not uuid');
+        });
+      }
+    }
+
+    const threads: Array<Thread> =
+      event.entries?.find(e => e.type === EntryType.THREADS)?.data?.values ?? [];
+
+    const bestThread = findBestThread(threads);
+    const hasThreadOrExceptionMinifiedData = this.hasThreadOrExceptionMinifiedFrameData(
+      event,
+      bestThread
+    );
+
+    if (hasThreadOrExceptionMinifiedData) {
+      proGuardErrors.push({
+        type: 'proguard_potentially_misconfigured_plugin',
+        message: tct(
+          'Some frames appear to be minified. Did you configure the [plugin]?',
+          {
+            plugin: (
+              <ExternalLink href="https://docs.sentry.io/platforms/android/proguard/#gradle">
+                Sentry Gradle Plugin
+              </ExternalLink>
+            ),
+          }
+        ),
+      });
+
+      // This capture will be removed once we're confident with the level of effectiveness
+      Sentry.captureMessage(
+        "Displaying ProGuard warning 'proguard_potentially_misconfigured_plugin' for suspected event"
+      );
+    }
+
+    this.setState({proGuardErrors, isLoading: false});
+  }
+
+  recordIssueError() {
     const {organization, project, event} = this.props;
+
+    if (!event || !event.errors || !(event.errors.length > 0)) {
+      return;
+    }
+
+    const errors = event.errors;
+    const errorTypes = errors.map(errorEntries => errorEntries.type);
+    const errorMessages = errors.map(errorEntries => errorEntries.message);
 
     const orgId = organization.id;
     const platform = project.platform;
@@ -131,9 +306,9 @@ class EventEntries extends React.Component<Props> {
       showTagSummary,
       location,
     } = this.props;
+    const {proGuardErrors, isLoading} = this.state;
 
-    const features =
-      organization && organization.features ? new Set(organization.features) : new Set();
+    const features = new Set(organization?.features);
     const hasQueryFeature = features.has('discover-query');
 
     if (!event) {
@@ -143,19 +318,19 @@ class EventEntries extends React.Component<Props> {
         </div>
       );
     }
+
     const hasContext = !objectIsEmpty(event.user) || !objectIsEmpty(event.contexts);
-    const hasErrors = !objectIsEmpty(event.errors);
+    const hasErrors = !objectIsEmpty(event.errors) || !!proGuardErrors.length;
 
     return (
-      <div className={className} data-test-id="event-entries">
-        {hasErrors && (
-          <ErrorContainer>
-            <EventErrors
-              event={event}
-              orgSlug={organization.slug}
-              projectSlug={project.slug}
-            />
-          </ErrorContainer>
+      <div className={className} data-test-id={`event-entries-loading-${isLoading}`}>
+        {hasErrors && !isLoading && (
+          <EventErrors
+            event={event}
+            orgSlug={organization.slug}
+            projectSlug={project.slug}
+            proGuardErrors={proGuardErrors}
+          />
         )}
         {!isShare &&
           isNotSharedOrganization(organization) &&
@@ -260,5 +435,5 @@ const StyledEventUserFeedback = styled(EventUserFeedback)<StyledEventUserFeedbac
 `;
 
 // TODO(ts): any required due to our use of SharedViewOrganization
-export default withOrganization<any>(EventEntries);
+export default withOrganization<any>(withApi(EventEntries));
 export {BorderlessEventEntries};

--- a/src/sentry/static/sentry/app/components/events/eventEntries.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.tsx
@@ -151,7 +151,7 @@ class EventEntries extends React.Component<Props, State> {
   }
 
   async checkProGuardError() {
-    const {event} = this.props;
+    const {event, isShare} = this.props;
 
     if (!event || event.platform !== 'java') {
       this.setState({isLoading: false});
@@ -184,6 +184,11 @@ class EventEntries extends React.Component<Props, State> {
     // otherwise the proguard id wouldn't be in the event.
     // But maybe it failed to upload the mappings file
     if (defined(proGuardImageUuid)) {
+      if (isShare) {
+        this.setState({isLoading: false});
+        return;
+      }
+
       const proguardMappingFiles = await this.fetchProguardMappingFiles(
         proGuardImageUuid
       );

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -231,6 +231,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                         location={location}
                         showExampleCommit={false}
                         showTagSummary={false}
+                        api={this.api}
                       />
                     </QuickTraceContext.Provider>
                   </SpanEntryContext.Provider>

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/groupEventDetails.tsx
@@ -200,6 +200,7 @@ class GroupEventDetails extends React.Component<Props, State> {
       />
     );
   }
+
   render() {
     const {
       className,

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
@@ -182,6 +182,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                       showExampleCommit={false}
                       showTagSummary={false}
                       location={location}
+                      api={this.api}
                     />
                   </QuickTraceContext.Provider>
                 </SpanEntryContext.Provider>

--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.tsx
@@ -33,7 +33,7 @@ import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 
-const MESSAGES = {
+export const projectProcessingIssuesMessages = {
   native_no_crashed_thread: t('No crashed thread found in crash report'),
   native_internal_failure: t('Internal failure when attempting to symbolicate: {error}'),
   native_bad_dsym: t('The debug information file used was broken.'),
@@ -264,7 +264,7 @@ class ProjectProcessingIssues extends React.Component<Props, State> {
   }
 
   getProblemDescription(item: ProcessingIssueItem) {
-    const msg = MESSAGES[item.type];
+    const msg = projectProcessingIssuesMessages[item.type];
     return msg || t('Unknown Error');
   }
 

--- a/src/sentry/static/sentry/app/views/sharedGroupDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/sharedGroupDetails/index.tsx
@@ -102,7 +102,7 @@ class SharedGroupDetails extends React.Component<Props, State> {
       return <LoadingError onRetry={this.handleRetry} />;
     }
 
-    const {location} = this.props;
+    const {location, api} = this.props;
     const {permalink, latestEvent, project} = group;
     const title = this.getTitle();
 
@@ -131,6 +131,7 @@ class SharedGroupDetails extends React.Component<Props, State> {
                     group={group}
                     event={latestEvent}
                     project={project}
+                    api={api}
                     isShare
                   />
                 </Container>

--- a/tests/acceptance/page_objects/issue_details.py
+++ b/tests/acceptance/page_objects/issue_details.py
@@ -78,7 +78,7 @@ class IssueDetailsPage(BasePage):
 
     def wait_until_loaded(self):
         self.browser.wait_until_not(".loading-indicator")
-        self.browser.wait_until_test_id("event-entries")
+        self.browser.wait_until_test_id("event-entries-loading-false")
         self.browser.wait_until_test_id("linked-issues")
         self.browser.wait_until_test_id("loaded-device-name")
         if self.browser.element_exists("#grouping-info"):

--- a/tests/acceptance/test_shared_issue.py
+++ b/tests/acceptance/test_shared_issue.py
@@ -22,5 +22,5 @@ class SharedIssueTest(AcceptanceTestCase):
 
         self.browser.get(f"/share/issue/{event.group.get_share_id()}/")
         self.browser.wait_until_not(".loading-indicator")
-        self.browser.wait_until_test_id("event-entries")
+        self.browser.wait_until_test_id("event-entries-loading-false")
         self.browser.snapshot("shared issue python")

--- a/tests/js/sentry-test/fixtures/event.js
+++ b/tests/js/sentry-test/fixtures/event.js
@@ -7,6 +7,7 @@ export function Event(params) {
     eventID: '12345678901234567890123456789012',
     dateCreated: '2019-05-21T18:01:48.762Z',
     tags: [],
+    errors: [],
     ...params,
   };
 }

--- a/tests/js/spec/views/organizationGroupDetails/groupEventEntries.spec.tsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventEntries.spec.tsx
@@ -1,0 +1,291 @@
+import React from 'react';
+
+import {mountWithTheme} from 'sentry-test/enzyme';
+import {initializeOrg} from 'sentry-test/initializeOrg';
+
+import {Error} from 'app/components/events/errors';
+import EventEntries from 'app/components/events/eventEntries';
+import {EntryType, Event} from 'app/types/event';
+
+const {organization, project} = initializeOrg();
+
+// @ts-expect-error
+const api = new MockApiClient();
+
+async function renderComponent(event: Event, errors?: Array<Error>) {
+  const wrapper = mountWithTheme(
+    <EventEntries
+      organization={organization}
+      event={{...event, errors: errors ?? event.errors}}
+      project={project}
+      location={location}
+      api={api}
+    />
+  );
+
+  // @ts-expect-error
+  await tick();
+  wrapper.update();
+
+  const eventErrors = wrapper.find('Errors');
+
+  const bannerSummary = eventErrors.find('BannerSummary');
+  const bannerSummaryInfo = bannerSummary.find(
+    'span[data-test-id="errors-banner-summary-info"]'
+  );
+
+  const toggleButton = bannerSummary
+    .find('[data-test-id="event-error-toggle"]')
+    .hostNodes();
+  toggleButton.simulate('click');
+
+  // @ts-expect-error
+  await tick();
+  wrapper.update();
+
+  const errorItem = wrapper.find('ErrorItem');
+
+  return {bannerSummaryInfoText: bannerSummaryInfo.text(), errorItem};
+}
+
+describe('GroupEventEntries', function () {
+  // @ts-expect-error
+  const event = TestStubs.Event();
+
+  beforeEach(() => {
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/events/${event.id}/grouping-info/`,
+      body: {},
+    });
+    // @ts-expect-error
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/files/dsyms/`,
+      body: [],
+    });
+  });
+
+  describe('EventError', function () {
+    it('renders', async function () {
+      const errors: Array<Error> = [
+        {
+          type: 'invalid_data',
+          data: {
+            name: 'logentry',
+          },
+          message: 'no message present',
+        },
+        {
+          type: 'invalid_data',
+          data: {
+            name: 'breadcrumbs.values.2.data',
+          },
+          message: 'expected an object',
+        },
+      ];
+
+      const {bannerSummaryInfoText, errorItem} = await renderComponent(event, errors);
+
+      expect(bannerSummaryInfoText).toEqual(
+        `There were ${errors.length} errors encountered while processing this event`
+      );
+      expect(errorItem.length).toBe(2);
+      expect(errorItem.at(0).props().error).toEqual(errors[0]);
+      expect(errorItem.at(1).props().error).toEqual(errors[1]);
+    });
+
+    describe('Proguard erros', function () {
+      const proGuardUuid = 'a59c8fcc-2f27-49f8-af9e-02661fc3e8d7';
+
+      it('Missing mapping file', async function () {
+        const newEvent = {
+          ...event,
+          platform: 'java',
+          entries: [
+            {
+              type: EntryType.DEBUGMETA,
+              data: {
+                images: [{type: 'proguard', uuid: proGuardUuid}],
+              },
+            },
+          ],
+        };
+
+        const {errorItem, bannerSummaryInfoText} = await renderComponent(newEvent);
+
+        expect(bannerSummaryInfoText).toEqual(
+          'There was 1 error encountered while processing this event'
+        );
+
+        expect(errorItem.length).toBe(1);
+        expect(errorItem.at(0).props().error).toEqual({
+          type: 'proguard_missing_mapping',
+          message: 'A proguard mapping file was missing.',
+          data: {mapping_uuid: proGuardUuid},
+        });
+      });
+
+      it("Don't display extra proguard errors, if the entry error of an event has an error of type 'proguard_missing_mapping'", async function () {
+        const newEvent = {
+          ...event,
+          platform: 'java',
+          entries: [
+            {
+              type: EntryType.DEBUGMETA,
+              data: {
+                images: [{type: 'proguard', uuid: proGuardUuid}],
+              },
+            },
+          ],
+          errors: [
+            {
+              type: 'proguard_missing_mapping',
+              message: 'A proguard mapping file was missing.',
+              data: {mapping_uuid: proGuardUuid},
+            },
+          ],
+        };
+
+        const {bannerSummaryInfoText, errorItem} = await renderComponent(newEvent);
+
+        expect(bannerSummaryInfoText).toEqual(
+          'There was 1 error encountered while processing this event'
+        );
+
+        expect(errorItem.length).toBe(1);
+        expect(errorItem.at(0).props().error).toEqual({
+          type: 'proguard_missing_mapping',
+          message: 'A proguard mapping file was missing.',
+          data: {mapping_uuid: proGuardUuid},
+        });
+      });
+
+      describe('ProGuard Plugin seems to not be correctly configured', function () {
+        it('find minified data in the exception entry', async function () {
+          const newEvent = {
+            ...event,
+            platform: 'java',
+            entries: [
+              {
+                type: 'exception',
+                data: {
+                  values: [
+                    {
+                      stacktrace: {
+                        frames: [
+                          {
+                            function: null,
+                            colNo: null,
+                            vars: {},
+                            symbol: null,
+                            module: 'aB.a.Class',
+                          },
+                        ],
+                        framesOmitted: null,
+                        registers: null,
+                        hasSystemFrames: false,
+                      },
+                      module: null,
+                      rawStacktrace: null,
+                      mechanism: null,
+                      threadId: null,
+                      value: 'Unexpected token else',
+                      type: 'SyntaxError',
+                    },
+                  ],
+                  excOmitted: null,
+                  hasSystemFrames: false,
+                },
+              },
+            ],
+          };
+
+          const {bannerSummaryInfoText, errorItem} = await renderComponent(newEvent);
+
+          expect(bannerSummaryInfoText).toEqual(
+            'There was 1 error encountered while processing this event'
+          );
+
+          expect(errorItem.length).toBe(1);
+          const {type, message} = errorItem.at(0).props().error;
+          expect(type).toEqual('proguard_potentially_misconfigured_plugin');
+          expect(message).toBeTruthy();
+        });
+
+        it('find minified data in the threads entry', async function () {
+          const newEvent = {
+            ...event,
+            platform: 'java',
+            entries: [
+              {
+                type: 'exception',
+                data: {
+                  values: [
+                    {
+                      stacktrace: {
+                        frames: [
+                          {
+                            function: null,
+                            colNo: null,
+                            vars: {},
+                            symbol: null,
+                            module: 'aB.a.Class',
+                          },
+                        ],
+                        framesOmitted: null,
+                        registers: null,
+                        hasSystemFrames: false,
+                      },
+                      module: null,
+                      rawStacktrace: null,
+                      mechanism: null,
+                      threadId: null,
+                      value: 'Unexpected token else',
+                      type: 'SyntaxError',
+                    },
+                  ],
+                  excOmitted: null,
+                  hasSystemFrames: false,
+                },
+              },
+              {
+                type: 'threads',
+                data: {
+                  values: [
+                    {
+                      stacktrace: {
+                        frames: [
+                          {
+                            function: 'start',
+                            package: 'libdyld.dylib',
+                            module: 'aB.a.Class',
+                          },
+                          {
+                            function: 'main',
+                            package: 'iOS-Swift',
+                            module: '',
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          };
+
+          const {bannerSummaryInfoText, errorItem} = await renderComponent(newEvent);
+
+          expect(bannerSummaryInfoText).toEqual(
+            'There was 1 error encountered while processing this event'
+          );
+
+          expect(errorItem.length).toBe(1);
+          const {type, message} = errorItem.at(0).props().error;
+          expect(type).toEqual('proguard_potentially_misconfigured_plugin');
+          expect(message).toBeTruthy();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Goal:** When ProGuard minified stack traces exist in the event, display on the top of the event page, in the Errors list, what exactly went wrong. The two cases covered in this PR are:

1 - When the event has the `debug_meta` property with an image that has a type  `proguard` and a valid `uuid`  but the `proguard` file wasn't found.
2- Stack trace is minified but the event doesn't have a `proguard` image in the `debug_meta` property.


closes:
https://app.asana.com/0/1182975495223914/1199681848766378

**Preview:**

![image](https://user-images.githubusercontent.com/29228205/109793001-658f1c80-7c14-11eb-81ed-14ee21a237cc.png)
