### PR TITLE
fix(discover): id should be default column when drilldown results in no columns

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -171,6 +171,7 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
 const ALIASED_AGGREGATES_COLUMN = {
   last_seen: 'timestamp',
   failure_count: 'transaction.status',
+  count: 'id',
 };
 
 /**
@@ -228,8 +229,6 @@ export function getExpandedResults(
     if (
       // if expanding the function failed
       column === null ||
-      // id is implicitly a part of all non-aggregate results
-      column.field === 'id' ||
       // the new column is already present
       fieldSet.has(column.field)
     ) {

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -172,7 +172,6 @@ export function downloadAsCsv(tableData, columnOrder, filename) {
 const ALIASED_AGGREGATES_COLUMN = {
   last_seen: 'timestamp',
   failure_count: 'transaction.status',
-  count: 'id',
 };
 
 /**
@@ -240,6 +239,10 @@ export function getExpandedResults(
 
     return column;
   });
+
+  if (expandedColumns.length && expandedColumns.every(col => col === null)) {
+    expandedColumns[0] = {kind: 'field', field: 'id'};
+  }
 
   // update the columns according the the expansion above
   const nextView = expandedColumns.reduceRight(

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -1,4 +1,5 @@
 import {browserHistory} from 'react-router';
+import * as Sentry from '@sentry/react';
 import {Location, Query} from 'history';
 import Papa from 'papaparse';
 
@@ -248,6 +249,11 @@ export function getExpandedResults(
         : newView.withUpdatedColumn(index, column, undefined),
     eventView.clone()
   );
+
+  if (nextView.isEqualTo(eventView)) {
+    Sentry.captureException(new Error('Failed to drilldown'));
+  }
+
   nextView.query = generateExpandedConditions(nextView, additionalConditions, dataRow);
   return nextView;
 }

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -240,7 +240,7 @@ export function getExpandedResults(
     return column;
   });
 
-  if (expandedColumns.length && expandedColumns.every(col => col === null)) {
+  if (fieldSet.size === 0) {
     expandedColumns[0] = {kind: 'field', field: 'id'};
   }
 

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -245,13 +245,23 @@ describe('getExpandedResults()', function () {
     environment: ['staging'],
   };
 
+  it('id should be default column when drilldown results in no columns', () => {
+    const view = new EventView({
+      ...state,
+      fields: [{field: 'count()'}, {field: 'epm()'}, {field: 'eps()'}],
+    });
+
+    const result = getExpandedResults(view, {}, {});
+
+    expect(result.fields).toEqual([{field: 'id', width: -1}]);
+  });
+
   it('preserves aggregated fields', () => {
     let view = new EventView(state);
 
     let result = getExpandedResults(view, {}, {});
     // id should be omitted as it is an implicit property on unaggregated results.
     expect(result.fields).toEqual([
-      {field: 'id', width: -1},
       {field: 'timestamp', width: -1},
       {field: 'title'},
       {field: 'custom_tag'},
@@ -273,7 +283,6 @@ describe('getExpandedResults()', function () {
     result = getExpandedResults(view, {}, {});
     // id should be omitted as it is an implicit property on unaggregated results.
     expect(result.fields).toEqual([
-      {field: 'id', width: -1},
       {field: 'timestamp', width: -1},
       {field: 'title'},
       {field: 'custom_tag'},

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -251,6 +251,7 @@ describe('getExpandedResults()', function () {
     let result = getExpandedResults(view, {}, {});
     // id should be omitted as it is an implicit property on unaggregated results.
     expect(result.fields).toEqual([
+      {field: 'id', width: -1},
       {field: 'timestamp', width: -1},
       {field: 'title'},
       {field: 'custom_tag'},
@@ -272,6 +273,7 @@ describe('getExpandedResults()', function () {
     result = getExpandedResults(view, {}, {});
     // id should be omitted as it is an implicit property on unaggregated results.
     expect(result.fields).toEqual([
+      {field: 'id', width: -1},
       {field: 'timestamp', width: -1},
       {field: 'title'},
       {field: 'custom_tag'},


### PR DESCRIPTION
Attempting to drilldown on a Discover query when `count()` is the only column will lead to the same query:

<img width="1679" alt="Screen Shot 2021-02-25 at 2 55 52 PM" src="https://user-images.githubusercontent.com/139499/109209468-933e1680-7779-11eb-9bad-a643504b51e1.png">

Today in Discover, we show the ID column as the first column whenever an `id` column is not present. Otherwise it is hidden. Thus, when a drilldown results in no columns, then we should add the `id` column as a default.


If a drilldown results to the same set of columns, then we send a Sentry error. This should let the Visibility team know which set of columns are the cause.