### PR TITLE
ref(external issues): Add logging to get endpoint for external issues

### DIFF
--- a/src/sentry/api/endpoints/group_external_issues.py
+++ b/src/sentry/api/endpoints/group_external_issues.py
@@ -4,7 +4,7 @@ from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import PlatformExternalIssue
 
-logger = logging.getLogger("sentry.group_external_issues.api")
+logger = logging.getLogger("sentry.api")
 
 
 class GroupExternalIssuesEndpoint(GroupEndpoint):

--- a/src/sentry/api/endpoints/group_external_issues.py
+++ b/src/sentry/api/endpoints/group_external_issues.py
@@ -1,6 +1,10 @@
+import logging
+
 from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import PlatformExternalIssue
+
+logger = logging.getLogger("sentry.group_external_issues.api")
 
 
 class GroupExternalIssuesEndpoint(GroupEndpoint):
@@ -8,6 +12,12 @@ class GroupExternalIssuesEndpoint(GroupEndpoint):
 
         external_issues = PlatformExternalIssue.objects.filter(group_id=group.id)
 
+        logger.info(
+            "group_external_issue.get",
+            extra={
+                "user": request.user,
+            },
+        )
         return self.paginate(
             request=request,
             queryset=external_issues,

--- a/src/sentry/api/endpoints/group_external_issues.py
+++ b/src/sentry/api/endpoints/group_external_issues.py
@@ -15,7 +15,8 @@ class GroupExternalIssuesEndpoint(GroupEndpoint):
         logger.info(
             "group_external_issue.get",
             extra={
-                "user": request.user,
+                "user": request.user.username,
+                "is_sentry_app_user": request.user.is_sentry_app,
             },
         )
         return self.paginate(


### PR DESCRIPTION
Building off of https://github.com/getsentry/sentry/pull/24022 add a temporary log line to see if anyone besides us is using this endpoint, since we're having some inconsistencies with the data received from transactions.


cc @MeredithAnya @manuzope 