### PR TITLE
fix(discover): Support add and exclude cell actions for array values.

### DIFF
--- a/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
+++ b/src/sentry/static/sentry/app/utils/tokenizeSearch.tsx
@@ -138,7 +138,7 @@ export class QueryResults {
   }
 
   getTagValues(tag: string) {
-    return this.tagValues[tag];
+    return this.tagValues[tag] ?? [];
   }
 
   getTagKeys() {

--- a/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/cellAction.tsx
@@ -28,8 +28,16 @@ export function updateQuery(
   results: QueryResults,
   action: Actions,
   key: string,
-  value: React.ReactText
+  value: React.ReactText | string[]
 ) {
+  // De-duplicate array values
+  if (Array.isArray(value)) {
+    value = [...new Set(value)];
+    if (value.length === 1) {
+      value = value[0];
+    }
+  }
+
   switch (action) {
     case Actions.ADD:
       // If the value is null/undefined create a has !has condition.
@@ -40,7 +48,17 @@ export function updateQuery(
         results.addTagValues('!has', [key]);
       } else {
         // Remove exclusion if it exists.
-        results.removeTag(`!${key}`).setTagValues(key, [`${value}`]);
+        results.removeTag(`!${key}`);
+
+        if (Array.isArray(value)) {
+          // For array values, add to existing filters
+          const currentFilters = results.getTagValues(key);
+          value = [...new Set([...currentFilters, ...value])];
+        } else {
+          value = [String(value)];
+        }
+
+        results.setTagValues(key, value);
       }
       break;
     case Actions.EXCLUDE:
@@ -54,7 +72,10 @@ export function updateQuery(
         results.removeTag(key);
         // Negations should stack up.
         const negation = `!${key}`;
-        results.addTagValues(negation, [`${value}`]);
+        value = Array.isArray(value) ? value : [String(value)];
+        const currentNegations = results.getTagValues(negation);
+        value = [...new Set([...currentNegations, ...value])];
+        results.setTagValues(negation, value);
       }
       break;
     case Actions.SHOW_GREATER_THAN: {
@@ -163,17 +184,12 @@ class CellAction extends React.Component<Props, State> {
     const {dataRow, column, handleCellAction, allowActions} = this.props;
     const fieldAlias = getAggregateAlias(column.name);
 
-    // Slice out the last element from array values as that is the value
-    // we show. See utils/discover/fieldRenderers.tsx and how
-    // strings and error.handled are rendered.
     let value = dataRow[fieldAlias];
-    if (Array.isArray(value)) {
-      value = value.slice(-1)[0];
-    }
 
     // error.handled is a strange field where null = true.
     if (
-      value === null &&
+      Array.isArray(value) &&
+      value[0] === null &&
       column.column.kind === 'field' &&
       column.column.field === 'error.handled'
     ) {

--- a/src/sentry/static/sentry/app/views/settings/organizationMembers/components/membersFilter.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationMembers/components/membersFilter.tsx
@@ -29,7 +29,9 @@ type Filters = {
 };
 
 const getBoolean = (list: string[]) =>
-  Array.isArray(list) ? list && list.map(v => v.toLowerCase()).includes('true') : null;
+  Array.isArray(list) && list.length
+    ? list && list.map(v => v.toLowerCase()).includes('true')
+    : null;
 
 const MembersFilter = ({className, roles, query, onChange}: Props) => {
   const search = tokenizeSearch(query);

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -335,6 +335,18 @@ describe('utils/tokenizeSearch', function () {
 
       expect(results.getTagKeys()).toEqual(['tag', 'other']);
     });
+
+    it('getTagValues', () => {
+      const results = new QueryResults([
+        'tag:value',
+        'other:value',
+        'tag:value2',
+        'additional text',
+      ]);
+      expect(results.getTagValues('tag')).toEqual(['value', 'value2']);
+
+      expect(results.getTagValues('nonexistent')).toEqual([]);
+    });
   });
 
   describe('stringifyQueryObject()', function () {

--- a/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
+++ b/tests/js/spec/views/eventsV2/table/cellAction.spec.jsx
@@ -15,6 +15,12 @@ const defaultData = {
   'measurements.fcp': 1234,
   percentile_measurements_fcp_0_5: 1234,
   'error.handled': [null],
+  'error.type': [
+    'ServerException',
+    'ClickhouseError',
+    'QueryException',
+    'QueryException',
+  ],
 };
 
 function makeWrapper(eventView, handleCellAction, columnIndex = 0, data = defaultData) {
@@ -44,6 +50,7 @@ describe('Discover -> CellAction', function () {
         'measurements.fcp',
         'percentile(measurements.fcp, 0.5)',
         'error.handled',
+        'error.type',
       ],
       widths: ['437', '647', '416', '905'],
       sort: ['title'],
@@ -184,6 +191,23 @@ describe('Discover -> CellAction', function () {
       expect(handleCellAction).toHaveBeenCalledWith('add', 1);
     });
 
+    it('error.type with array values adds condition', function () {
+      wrapper = makeWrapper(view, handleCellAction, 8, defaultData);
+
+      // Show button and menu.
+      wrapper.find('Container').simulate('mouseEnter');
+      wrapper.find('MenuButton').simulate('click');
+
+      wrapper.find('button[data-test-id="add-to-filter"]').simulate('click');
+
+      expect(handleCellAction).toHaveBeenCalledWith('add', [
+        'ServerException',
+        'ClickhouseError',
+        'QueryException',
+        'QueryException',
+      ]);
+    });
+
     it('error.handled with 0 adds condition', function () {
       wrapper = makeWrapper(view, handleCellAction, 7, {
         ...defaultData,
@@ -196,7 +220,7 @@ describe('Discover -> CellAction', function () {
 
       wrapper.find('button[data-test-id="add-to-filter"]').simulate('click');
 
-      expect(handleCellAction).toHaveBeenCalledWith('add', 0);
+      expect(handleCellAction).toHaveBeenCalledWith('add', [0]);
     });
 
     it('show appropriate actions for string cells', function () {
@@ -328,12 +352,16 @@ describe('Discover -> CellAction', function () {
 
 describe('updateQuery()', function () {
   it('modifies the query with has/!has', function () {
-    const results = new QueryResults([]);
+    let results = new QueryResults([]);
     updateQuery(results, Actions.ADD, 'a', null);
     expect(results.formatString()).toEqual('!has:a');
     updateQuery(results, Actions.EXCLUDE, 'a', null);
     expect(results.formatString()).toEqual('has:a');
     updateQuery(results, Actions.ADD, 'a', null);
+    expect(results.formatString()).toEqual('!has:a');
+
+    results = new QueryResults([]);
+    updateQuery(results, Actions.ADD, 'a', [null]);
     expect(results.formatString()).toEqual('!has:a');
   });
 
@@ -345,6 +373,8 @@ describe('updateQuery()', function () {
     expect(results.formatString()).toEqual('a:1 b:1');
     updateQuery(results, Actions.ADD, 'a', '2');
     expect(results.formatString()).toEqual('b:1 a:2');
+    updateQuery(results, Actions.ADD, 'a', ['1', '2', '3']);
+    expect(results.formatString()).toEqual('b:1 a:2 a:1 a:3');
   });
 
   it('modifies the query with exclusions', function () {
@@ -354,7 +384,9 @@ describe('updateQuery()', function () {
     updateQuery(results, Actions.EXCLUDE, 'b', '1');
     expect(results.formatString()).toEqual('!a:1 !b:1');
     updateQuery(results, Actions.EXCLUDE, 'a', '2');
-    expect(results.formatString()).toEqual('!a:1 !b:1 !a:2');
+    expect(results.formatString()).toEqual('!b:1 !a:1 !a:2');
+    updateQuery(results, Actions.EXCLUDE, 'a', ['1', '2', '3']);
+    expect(results.formatString()).toEqual('!b:1 !a:1 !a:2 !a:3');
   });
 
   it('modifies the query with a mix of additions and exclusions', function () {


### PR DESCRIPTION
- For "Add to filter" cell action, array values are added to existing filters instead of replacing them. Values are deduplicated.
- For "Exclude from filter" cell action, values are deduplicated before added to negating search filters.

### Adding array values

https://user-images.githubusercontent.com/139499/109231949-6566cb00-7795-11eb-82b2-408a516c8276.mp4


### Excluding array values

https://user-images.githubusercontent.com/139499/109231944-626bda80-7795-11eb-8975-3ffb565a74e1.mp4

