### PR TITLE
fix(discover): Drilldown only fails if they actually occur

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 import {Location, LocationDescriptorObject} from 'history';
 
 import {openModal} from 'app/actionCreators/modal';
@@ -128,7 +129,15 @@ class TableView extends React.Component<TableViewProps> {
 
       return [
         <Tooltip key={`eventlink${rowIndex}`} title={t('Open Group')}>
-          <Link to={target} data-test-id="open-group">
+          <Link
+            to={target}
+            data-test-id="open-group"
+            onClick={() => {
+              if (nextView.isEqualTo(eventView)) {
+                Sentry.captureException(new Error('Failed to drilldown'));
+              }
+            }}
+          >
             <StyledIcon size="sm" />
           </Link>
         </Tooltip>,

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -1,5 +1,4 @@
 import {browserHistory} from 'react-router';
-import * as Sentry from '@sentry/react';
 import {Location, Query} from 'history';
 import Papa from 'papaparse';
 
@@ -252,10 +251,6 @@ export function getExpandedResults(
         : newView.withUpdatedColumn(index, column, undefined),
     eventView.clone()
   );
-
-  if (nextView.isEqualTo(eventView)) {
-    Sentry.captureException(new Error('Failed to drilldown'));
-  }
 
   nextView.query = generateExpandedConditions(nextView, additionalConditions, dataRow);
   return nextView;


### PR DESCRIPTION
Drilldown failures are logged to Sentry in https://github.com/getsentry/sentry/pull/24106

False positives were reported for generated tag URLs in the Discover event details view: https://github.com/getsentry/sentry/blob/834ab6ff2132a49a8decbdf06ce2d21326b070f6/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx#L108-L121

We instead generate a Sentry error for Drilldown failures for when the actual drilldown occurs; i.e. when the user clicks on "Open Group" icon in the Discover table results.

Fixes JAVASCRIPT-23XG