### PR TITLE
ref(images-loaded): Check 'Not Found' filter option by default if Image status equals 'Missing'

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownControl.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownControl.tsx
@@ -34,7 +34,7 @@ type Props = DefaultProps & {
   children:
     | ((args: ChildrenArgs) => React.ReactElement)
     | React.ReactElement
-    | Array<React.ReactNode>;
+    | Array<React.ReactElement>;
   /**
    * String or element for the button contents.
    */

--- a/src/sentry/static/sentry/app/components/dropdownControl.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownControl.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import DropdownBubble from 'app/components/dropdownBubble';
 import DropdownButton from 'app/components/dropdownButton';
-import DropdownMenu, {GetActorPropsFn} from 'app/components/dropdownMenu';
+import DropdownMenu, {GetActorPropsFn, GetMenuPropsFn} from 'app/components/dropdownMenu';
 import MenuItem from 'app/components/menuItem';
 
 type ButtonPriority = React.ComponentProps<typeof DropdownButton>['priority'];
@@ -20,7 +20,21 @@ type DefaultProps = {
   menuWidth: string;
 };
 
+type ChildrenArgs = {
+  isOpen: boolean;
+  getMenuProps: GetMenuPropsFn;
+};
+
+type ButtonArgs = {
+  isOpen: boolean;
+  getActorProps: GetActorPropsFn;
+};
+
 type Props = DefaultProps & {
+  children:
+    | ((args: ChildrenArgs) => React.ReactElement)
+    | React.ReactElement
+    | Array<React.ReactNode>;
   /**
    * String or element for the button contents.
    */
@@ -29,7 +43,7 @@ type Props = DefaultProps & {
    * A closure that returns a styled button. Function will get {isOpen, getActorProps}
    * as arguments. Use this if you need to style/replace the dropdown button.
    */
-  button?: (props: {isOpen: boolean; getActorProps: GetActorPropsFn}) => React.ReactNode;
+  button?: (args: ButtonArgs) => React.ReactNode;
   /**
    * Align the dropdown menu to the right. (Default aligns to left)
    */
@@ -62,6 +76,7 @@ class DropdownControl extends React.Component<Props> {
 
   renderButton(isOpen: boolean, getActorProps: GetActorPropsFn) {
     const {label, button, buttonProps, priority} = this.props;
+
     if (button) {
       return button({isOpen, getActorProps});
     }
@@ -77,17 +92,32 @@ class DropdownControl extends React.Component<Props> {
     );
   }
 
-  render() {
-    const {
-      children,
-      alwaysRenderMenu,
-      alignRight,
-      menuWidth,
-      blendWithActor,
-      priority,
-      className,
-    } = this.props;
+  renderChildren(isOpen: boolean, getMenuProps: GetMenuPropsFn) {
+    const {children, alignRight, menuWidth, blendWithActor, priority} = this.props;
+
+    if (typeof children === 'function') {
+      return children({isOpen, getMenuProps});
+    }
+
     const alignMenu = alignRight ? 'right' : 'left';
+
+    return (
+      <Content
+        {...getMenuProps()}
+        priority={priority}
+        alignMenu={alignMenu}
+        width={menuWidth}
+        isOpen={isOpen}
+        blendWithActor={blendWithActor}
+        blendCorner
+      >
+        {children}
+      </Content>
+    );
+  }
+
+  render() {
+    const {alwaysRenderMenu, className} = this.props;
 
     return (
       <Container className={className}>
@@ -95,17 +125,7 @@ class DropdownControl extends React.Component<Props> {
           {({isOpen, getMenuProps, getActorProps}) => (
             <React.Fragment>
               {this.renderButton(isOpen, getActorProps)}
-              <Content
-                {...getMenuProps()}
-                priority={priority}
-                alignMenu={alignMenu}
-                width={menuWidth}
-                isOpen={isOpen}
-                blendWithActor={blendWithActor}
-                blendCorner
-              >
-                {children}
-              </Content>
+              {this.renderChildren(isOpen, getMenuProps)}
             </React.Fragment>
           )}
         </DropdownMenu>
@@ -124,7 +144,7 @@ const StyledDropdownButton = styled(DropdownButton)`
   white-space: nowrap;
 `;
 
-const Content = styled(DropdownBubble)<{priority: ButtonPriority; isOpen: boolean}>`
+const Content = styled(DropdownBubble)<{isOpen: boolean; priority?: ButtonPriority}>`
   display: ${p => (p.isOpen ? 'block' : 'none')};
   border-color: ${p => p.theme.button[p.priority || 'form'].border};
 `;
@@ -134,4 +154,4 @@ const DropdownItem = styled(MenuItem)`
 `;
 
 export default DropdownControl;
-export {DropdownItem};
+export {DropdownItem, Content};

--- a/src/sentry/static/sentry/app/components/dropdownMenu.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownMenu.tsx
@@ -41,7 +41,7 @@ type MenuProps = {
 };
 
 export type GetActorPropsFn = (opts?: GetActorArgs) => ActorProps;
-type GetMenuPropsFn = (opts?: GetMenuArgs) => MenuProps;
+export type GetMenuPropsFn = (opts?: GetMenuArgs) => MenuProps;
 
 type RenderProps = {
   isOpen: boolean;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -229,6 +229,7 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
       arch: architecture,
       unwind_status,
       debug_status,
+      status,
     } = image ?? {};
 
     const candidates = this.getCandidates();
@@ -291,6 +292,7 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
               </SearchInSettingsAction>
             )}
             <Candidates
+              imageStatus={status}
               candidates={candidates}
               organization={organization}
               projectId={projectId}

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/filter/dropDownButton.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/filter/dropDownButton.tsx
@@ -46,6 +46,13 @@ const StyledDropdownButton = styled(DropdownButton)`
   max-width: 200px;
   white-space: nowrap;
 
+  ${p =>
+    p.isOpen &&
+    `
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    `}
+
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     border-right: 0;
     border-top-right-radius: 0;

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/filter/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/filter/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import CheckboxFancy from 'app/components/checkboxFancy/checkboxFancy';
-import DropdownControl from 'app/components/dropdownControl';
+import DropdownControl, {Content} from 'app/components/dropdownControl';
 import List from 'app/components/list';
 import ListItem from 'app/components/list/listItem';
 import space from 'app/styles/space';
@@ -50,8 +50,6 @@ function Filter({options, onFilter, className}: Props) {
   return (
     <Wrapper className={className}>
       <DropdownControl
-        menuWidth="240px"
-        blendWithActor
         button={({isOpen, getActorProps}) => (
           <DropDownButton
             isOpen={isOpen}
@@ -60,28 +58,38 @@ function Filter({options, onFilter, className}: Props) {
           />
         )}
       >
-        <Content>
-          {Object.keys(options).map(category => (
-            <React.Fragment key={category}>
-              <Header>{category}</Header>
-              <List>
-                {options[category].map(groupedOption => {
-                  const {symbol, isChecked, id} = groupedOption;
-                  return (
-                    <StyledListItem
-                      key={id}
-                      onClick={handleClick(category, groupedOption)}
-                      isChecked={isChecked}
-                    >
-                      {symbol}
-                      <CheckboxFancy isChecked={isChecked} />
-                    </StyledListItem>
-                  );
-                })}
-              </List>
-            </React.Fragment>
-          ))}
-        </Content>
+        {({getMenuProps, isOpen}) => (
+          <StyledContent
+            {...getMenuProps()}
+            alignMenu="left"
+            width="240px"
+            isOpen={isOpen}
+            className="drop-down-filter-menu"
+            blendWithActor
+            blendCorner
+          >
+            {Object.keys(options).map(category => (
+              <React.Fragment key={category}>
+                <Header>{category}</Header>
+                <List>
+                  {options[category].map(groupedOption => {
+                    const {symbol, isChecked, id} = groupedOption;
+                    return (
+                      <StyledListItem
+                        key={id}
+                        onClick={handleClick(category, groupedOption)}
+                        isChecked={isChecked}
+                      >
+                        {symbol}
+                        <CheckboxFancy isChecked={isChecked} />
+                      </StyledListItem>
+                    );
+                  })}
+                </List>
+              </React.Fragment>
+            ))}
+          </StyledContent>
+        )}
       </DropdownControl>
     </Wrapper>
   );
@@ -94,7 +102,7 @@ const Wrapper = styled('div')`
   display: flex;
 `;
 
-const Content = styled('div')`
+const StyledContent = styled(Content)`
   > * :last-child {
     margin-bottom: -1px;
   }

--- a/src/sentry/static/sentry/app/views/issueList/sortOptions.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/sortOptions.tsx
@@ -26,17 +26,19 @@ const IssueListSortOptions = ({onSelect, sort, query}: Props) => {
 
   return (
     <DropdownControl buttonProps={{prefix: t('Sort by')}} label={getSortLabel(sortKey)}>
-      {getMenuItem(IssueSortOptions.PRIORITY)}
-      {getMenuItem(IssueSortOptions.DATE)}
-      {getMenuItem(IssueSortOptions.NEW)}
-      {getMenuItem(IssueSortOptions.FREQ)}
-      {getMenuItem(IssueSortOptions.USER)}
-      <Feature features={['issue-list-trend-sort']}>
-        {getMenuItem(IssueSortOptions.TREND)}
-      </Feature>
-      <Feature features={['inbox']}>
-        {isForReviewQuery(query) && getMenuItem(IssueSortOptions.INBOX)}
-      </Feature>
+      <React.Fragment>
+        {getMenuItem(IssueSortOptions.PRIORITY)}
+        {getMenuItem(IssueSortOptions.DATE)}
+        {getMenuItem(IssueSortOptions.NEW)}
+        {getMenuItem(IssueSortOptions.FREQ)}
+        {getMenuItem(IssueSortOptions.USER)}
+        <Feature features={['issue-list-trend-sort']}>
+          {getMenuItem(IssueSortOptions.TREND)}
+        </Feature>
+        <Feature features={['inbox']}>
+          {isForReviewQuery(query) && getMenuItem(IssueSortOptions.INBOX)}
+        </Feature>
+      </React.Fragment>
     </DropdownControl>
   );
 };


### PR DESCRIPTION
. Add new filter logic: 
   - If the Image Status equals Missing, then check also 'Not Found' by default
   - If one of the filter's category has one option, then the filter won't display this category
 
. Fix a minor issue with DropDownMenu
   - Change the prop children to a function or an element was necessary, so then the dropdown menu can be customized
   
**Before:**
![image](https://user-images.githubusercontent.com/29228205/109321437-707f3100-7851-11eb-9bfc-09c24badcbed.png)


**After:**
![image](https://user-images.githubusercontent.com/29228205/109321473-770da880-7851-11eb-96cf-c2352c26fecb.png)

