### PR TITLE
fix(discover): getExpandedResults should generate an EventView from an empty EventView

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -239,7 +239,10 @@ export function getExpandedResults(
     return column;
   });
 
-  if (fieldSet.size === 0) {
+  // id should be default column when expanded results in no columns; but only if
+  // the Discover query's columns is non-empty.
+  // This typically occurs in Discover drilldowns.
+  if (fieldSet.size === 0 && expandedColumns.length) {
     expandedColumns[0] = {kind: 'field', field: 'id'};
   }
 

--- a/tests/js/spec/views/eventsV2/utils.spec.jsx
+++ b/tests/js/spec/views/eventsV2/utils.spec.jsx
@@ -411,6 +411,13 @@ describe('getExpandedResults()', function () {
     expect(result.query).toEqual('event.type:error custom_tag:tag_value');
   });
 
+  it('generate eventview from an empty eventview', () => {
+    const view = EventView.fromLocation({query: {}});
+    const result = getExpandedResults(view, {some_tag: 'value'}, {});
+    expect(result.fields).toEqual([]);
+    expect(result.query).toEqual('some_tag:value');
+  });
+
   it('applies array value conditions from event data', () => {
     const view = new EventView({
       ...state,


### PR DESCRIPTION
When viewing a Discover event details page with no query string, `getExpandedResults()` will be unable to generate an EventView instance from an empty EventView instance. This occurs for the generated tag URLs.

Fixes JAVASCRIPT-23XH
Fixes JAVASCRIPT-23YS