### PR TITLE
feat(ui): Show release adoption based on sessions

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -936,6 +936,8 @@ SENTRY_FEATURES = {
     "organizations:releases-top-charts": False,
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
+    # Enable calculating release adoption based on sessions
+    "organizations:session-adoption": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -98,6 +98,7 @@ default_manager.add("organizations:relay", OrganizationFeature)  # NOQA
 default_manager.add("organizations:releases-top-charts", OrganizationFeature)  # NOQA
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:rule-page", OrganizationFeature)  # NOQA
+default_manager.add("organizations:session-adoption", OrganizationFeature)  # NOQA
 default_manager.add("organizations:set-grouping-config", OrganizationFeature)  # NOQA
 default_manager.add("organizations:custom-event-title", OrganizationFeature)  # NOQA
 default_manager.add("organizations:slack-migration", OrganizationFeature)  # NOQA

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -288,6 +288,7 @@ export type Health = {
   sessionsCrashed: number;
   sessionsErrored: number;
   adoption: number | null;
+  sessions_adoption: number | null;
   hasHealthData: boolean;
   durationP50: number | null;
   durationP90: number | null;

--- a/src/sentry/static/sentry/app/views/releases/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/index.tsx
@@ -296,7 +296,7 @@ class ReleasesList extends AsyncView<Props, State> {
             key={`${release.version}-${release.projects[0].slug}`}
             activeDisplay={activeDisplay}
             release={release}
-            orgSlug={organization.slug}
+            organization={organization}
             location={location}
             selection={selection}
             reloading={reloading}

--- a/src/sentry/static/sentry/app/views/releases/list/releaseCard.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseCard.tsx
@@ -10,7 +10,7 @@ import TimeSince from 'app/components/timeSince';
 import Version from 'app/components/version';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
-import {GlobalSelection, Release} from 'app/types';
+import {GlobalSelection, Organization, Release} from 'app/types';
 
 import ReleaseHealth from './releaseHealth';
 import {DisplayOption} from './utils';
@@ -35,7 +35,7 @@ function getReleaseProjectId(release: Release, selection: GlobalSelection) {
 
 type Props = {
   release: Release;
-  orgSlug: string;
+  organization: Organization;
   activeDisplay: DisplayOption;
   location: Location;
   selection: GlobalSelection;
@@ -45,7 +45,7 @@ type Props = {
 
 const ReleaseCard = ({
   release,
-  orgSlug,
+  organization,
   activeDisplay,
   location,
   reloading,
@@ -60,9 +60,9 @@ const ReleaseCard = ({
         <ReleaseInfoHeader>
           <GlobalSelectionLink
             to={{
-              pathname: `/organizations/${orgSlug}/releases/${encodeURIComponent(
-                version
-              )}/`,
+              pathname: `/organizations/${
+                organization.slug
+              }/releases/${encodeURIComponent(version)}/`,
               query: {project: getReleaseProjectId(release, selection)},
             }}
           >
@@ -84,7 +84,7 @@ const ReleaseCard = ({
       <ReleaseProjects>
         <ReleaseHealth
           release={release}
-          orgSlug={orgSlug}
+          organization={organization}
           activeDisplay={activeDisplay}
           location={location}
           showPlaceholders={showHealthPlaceholders}

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/content.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/content.tsx
@@ -116,6 +116,16 @@ const Content = ({
               totalSessions,
               totalSessions24h,
             } = healthData || {};
+            const selectedAdoption =
+              activeDisplay === DisplayOption.CRASH_FREE_SESSIONS &&
+              supportsSessionAdoption
+                ? sessions_adoption
+                : adoption;
+            const selected24hCount =
+              activeDisplay === DisplayOption.CRASH_FREE_SESSIONS &&
+              supportsSessionAdoption
+                ? totalSessions24h
+                : totalUsers24h;
 
             return (
               <ProjectRow key={`${releaseVersion}-${slug}-health`}>
@@ -124,62 +134,32 @@ const Content = ({
                     <ProjectBadge project={project} avatarSize={16} />
                   </Column>
 
-                  {activeDisplay === DisplayOption.CRASH_FREE_SESSIONS &&
-                  supportsSessionAdoption ? (
-                    <AdoptionColumn>
-                      {showPlaceholders ? (
-                        <StyledPlaceholder width="150px" />
-                      ) : defined(sessions_adoption) ? (
-                        <AdoptionWrapper>
-                          <ProgressBarWrapper>
-                            <Tooltip
-                              containerDisplayMode="block"
-                              title={
-                                <AdoptionTooltip
-                                  totalUsers={totalUsers}
-                                  totalSessions={totalSessions}
-                                  totalUsers24h={totalUsers24h}
-                                  totalSessions24h={totalSessions24h}
-                                />
-                              }
-                            >
-                              <ProgressBar value={Math.ceil(sessions_adoption)} />
-                            </Tooltip>
-                          </ProgressBarWrapper>
-                          <Count value={totalSessions24h ?? 0} />
-                        </AdoptionWrapper>
-                      ) : (
-                        <NotAvailable />
-                      )}
-                    </AdoptionColumn>
-                  ) : (
-                    <AdoptionColumn>
-                      {showPlaceholders ? (
-                        <StyledPlaceholder width="150px" />
-                      ) : defined(adoption) ? (
-                        <AdoptionWrapper>
-                          <ProgressBarWrapper>
-                            <Tooltip
-                              containerDisplayMode="block"
-                              title={
-                                <AdoptionTooltip
-                                  totalUsers={totalUsers}
-                                  totalSessions={totalSessions}
-                                  totalUsers24h={totalUsers24h}
-                                  totalSessions24h={totalSessions24h}
-                                />
-                              }
-                            >
-                              <ProgressBar value={Math.ceil(adoption)} />
-                            </Tooltip>
-                          </ProgressBarWrapper>
-                          <Count value={totalUsers24h ?? 0} />
-                        </AdoptionWrapper>
-                      ) : (
-                        <NotAvailable />
-                      )}
-                    </AdoptionColumn>
-                  )}
+                  <AdoptionColumn>
+                    {showPlaceholders ? (
+                      <StyledPlaceholder width="150px" />
+                    ) : defined(selectedAdoption) ? (
+                      <AdoptionWrapper>
+                        <ProgressBarWrapper>
+                          <Tooltip
+                            containerDisplayMode="block"
+                            title={
+                              <AdoptionTooltip
+                                totalUsers={totalUsers}
+                                totalSessions={totalSessions}
+                                totalUsers24h={totalUsers24h}
+                                totalSessions24h={totalSessions24h}
+                              />
+                            }
+                          >
+                            <ProgressBar value={Math.ceil(selectedAdoption)} />
+                          </Tooltip>
+                        </ProgressBarWrapper>
+                        <Count value={selected24hCount ?? 0} />
+                      </AdoptionWrapper>
+                    ) : (
+                      <NotAvailable />
+                    )}
+                  </AdoptionColumn>
 
                   {activeDisplay === DisplayOption.CRASH_FREE_USERS ? (
                     <SessionsColumn>

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/index.tsx
@@ -7,7 +7,7 @@ import TextOverflow from 'app/components/textOverflow';
 import Tooltip from 'app/components/tooltip';
 import {tct, tn} from 'app/locale';
 import space from 'app/styles/space';
-import {GlobalSelection, Release} from 'app/types';
+import {GlobalSelection, Organization, Release} from 'app/types';
 
 import {DisplayOption} from '../utils';
 
@@ -15,7 +15,7 @@ import Content from './content';
 
 type Props = {
   release: Release;
-  orgSlug: string;
+  organization: Organization;
   activeDisplay: DisplayOption;
   location: Location;
   showPlaceholders: boolean;
@@ -36,7 +36,7 @@ class ReleaseHealth extends React.Component<Props> {
   render() {
     const {
       release,
-      orgSlug,
+      organization,
       activeDisplay,
       location,
       showPlaceholders,
@@ -68,8 +68,8 @@ class ReleaseHealth extends React.Component<Props> {
     return (
       <React.Fragment>
         <Content
+          organization={organization}
           activeDisplay={activeDisplay}
-          orgSlug={orgSlug}
           releaseVersion={release.version}
           projects={projectsToShow}
           location={location}


### PR DESCRIPTION
This will allow us to show adoption based on selected display options - either sessions or users.

Backend part: https://github.com/getsentry/sentry/pull/24091
Getsentry flag: https://github.com/getsentry/getsentry/pull/5170