### PR TITLE
Update slack integration to use Authorization header for GET requests

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -108,11 +108,11 @@ class SlackIntegrationProvider(IntegrationProvider):
         return [identity_pipeline_view]
 
     def get_team_info(self, access_token):
-        payload = {"token": access_token}
+        headers = {"Authorization": "Bearer %s" % access_token}
 
         client = SlackClient()
         try:
-            resp = client.get("/team.info", params=payload)
+            resp = client.get("/team.info", headers=headers)
         except ApiError as e:
             logger.error("slack.team-info.response-error", extra={"error": str(e)})
             raise IntegrationError("Could not retrieve Slack team information.")

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -390,16 +390,13 @@ def get_channel_id_with_timeout(integration, name, timeout):
         3. timed_out: boolean (whether we hit our self-imposed time limit)
     """
 
-    token_payload = {"token": integration.metadata["access_token"]}
+    headers = {"Authorization": "Bearer %s" % integration.metadata["access_token"]}
 
-    payload = dict(
-        token_payload,
-        **{
-            "exclude_archived": False,
-            "exclude_members": True,
-            "types": "public_channel,private_channel",
-        },
-    )
+    payload = {
+        "exclude_archived": False,
+        "exclude_members": True,
+        "types": "public_channel,private_channel",
+    }
 
     list_types = LIST_TYPES
 
@@ -414,7 +411,7 @@ def get_channel_id_with_timeout(integration, name, timeout):
             endpoint = "/%s.list" % list_type
             try:
                 # Slack limits the response of `<list_type>.list` to 1000 channels
-                items = client.get(endpoint, params=dict(payload, cursor=cursor, limit=1000))
+                items = client.get(endpoint, headers=headers, params=dict(payload, cursor=cursor, limit=1000))
             except ApiError as e:
                 logger.info("rule.slack.%s_list_failed" % list_type, extra={"error": str(e)})
                 return (prefix, None, False)

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -411,7 +411,9 @@ def get_channel_id_with_timeout(integration, name, timeout):
             endpoint = "/%s.list" % list_type
             try:
                 # Slack limits the response of `<list_type>.list` to 1000 channels
-                items = client.get(endpoint, headers=headers, params=dict(payload, cursor=cursor, limit=1000))
+                items = client.get(
+                    endpoint, headers=headers, params=dict(payload, cursor=cursor, limit=1000)
+                )
             except ApiError as e:
                 logger.info("rule.slack.%s_list_failed" % list_type, extra={"error": str(e)})
                 return (prefix, None, False)


### PR DESCRIPTION
Related: https://forum.sentry.io/t/unable-to-setup-slack-integration/13042/8

Passing in the token as a query parameter appears to no longer be valid. With these changes I have been able to complete the Slack Integration setup and interact with the message boxes.

I assume some tests will fail that I will need to come back and clean up.