### PR TITLE
feat(demo): delete demo orgs after 24 hours

### DIFF
--- a/src/sentry/demo/tasks.py
+++ b/src/sentry/demo/tasks.py
@@ -1,0 +1,25 @@
+from sentry.models import Organization, OrganizationStatus, User
+from sentry.tasks.base import instrumented_task
+from sentry.tasks.deletion import delete_organization, retry
+from sentry.exceptions import DeleteAborted
+
+MAX_RETRIES = 5
+
+
+@instrumented_task(
+    name="sentry.demo.tasks.delete_organization_and_user",
+    queue="cleanup",
+    default_retry_delay=60 * 5,
+    max_retries=MAX_RETRIES,
+)
+@retry(exclude=(DeleteAborted,))
+def delete_organization_and_user(organization_id, user_id):
+    Organization.objects.filter(id=organization_id).update(
+        status=OrganizationStatus.PENDING_DELETION
+    )
+    User.objects.filter(id=user_id).delete()
+
+    delete_organization(
+        object_id=organization_id,
+        actor_id=user_id,
+    )

--- a/tests/sentry/demo/test_tasks.py
+++ b/tests/sentry/demo/test_tasks.py
@@ -1,0 +1,14 @@
+from sentry.models import Organization, User
+from sentry.demo.tasks import delete_organization_and_user
+from sentry.testutils import TestCase
+
+
+class DeleteOrganizationAndUser(TestCase):
+    def test_simple(self):
+        org = self.create_organization()
+        user = self.create_user()
+        with self.tasks():
+            delete_organization_and_user(org.id, user.id)
+
+        assert not Organization.objects.filter(id=org.id).exists()
+        assert not User.objects.filter(id=user.id).exists()


### PR DESCRIPTION
This PR adds the functionality to delete the demo user and organization 24 hours after they are created (follow up to https://github.com/getsentry/sentry/pull/24083). This way, we can continuously clean up old orgs/users from previous demo visitors.