### PR TITLE
fix(header-overflow): detail long title

### DIFF
--- a/src/sentry/static/sentry/app/components/layouts/thirds.tsx
+++ b/src/sentry/static/sentry/app/components/layouts/thirds.tsx
@@ -90,23 +90,14 @@ export const Title = styled('h2')`
  * are stacked vertically.
  */
 export const Header = styled('div')`
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  flex-grow: 0;
-  justify-content: space-between;
-  padding: ${space(2)} ${space(4)} 0 ${space(4)};
-  margin: 0;
-
+  display: grid;
+  padding: ${space(2)} ${space(2)} 0 ${space(2)};
   background-color: transparent;
   border-bottom: 1px solid ${p => p.theme.border};
 
-  @media (max-width: ${p => p.theme.breakpoints[0]}) {
-    padding: ${space(2)} ${space(2)} 0 ${space(2)};
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints[1]}) {
-    flex-direction: column;
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    grid-template-columns: 1fr auto;
+    padding: ${space(2)} ${space(4)} 0 ${space(4)};
   }
 `;
 


### PR DESCRIPTION
- Limited title width according to container and action btns (does not affect other pages)

**Before:**
![Screen Shot 2021-02-26 at 1 12 58 PM](https://user-images.githubusercontent.com/4830259/109356018-fb056780-7834-11eb-823f-3f3628cd9dce.png)

**After:**
![Screen Shot 2021-02-26 at 1 17 47 PM](https://user-images.githubusercontent.com/4830259/109356056-08baed00-7835-11eb-989a-108ed4956b43.png)