### PR TITLE
ref(dynamic-sampling): Enforce unique category within a rule

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/conditionFields.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/conditionFields.tsx
@@ -36,10 +36,24 @@ function ConditionFields({
   onDelete,
   onChange,
 }: Props) {
+  const availableCategoryOptions = categoryOptions.filter(
+    categoryOption =>
+      !conditions.find(condition => condition.category === categoryOption[0])
+  );
   return (
     <Wrapper>
       {conditions.map(({match, category}, index) => {
+        const selectedCategoryOption = categoryOptions.find(
+          categoryOption => categoryOption[0] === category
+        );
+
+        // selectedCategoryOption should be always defined
+        const choices = selectedCategoryOption
+          ? [selectedCategoryOption, ...availableCategoryOptions]
+          : availableCategoryOptions;
+
         const showLegacyBrowsers = category === DynamicSamplingInnerName.LEGACY_BROWSERS;
+
         return (
           <FieldsWrapper key={index}>
             <Fields>
@@ -49,7 +63,7 @@ function ConditionFields({
                 name={`category-${index}`}
                 value={category}
                 onChange={value => onChange(index, 'category', value)}
-                choices={categoryOptions}
+                choices={choices}
                 inline={false}
                 hideControlState
                 showHelpInTooltip
@@ -95,9 +109,11 @@ function ConditionFields({
           </FieldsWrapper>
         );
       })}
-      <StyledButton icon={<IconAdd isCircled />} onClick={onAdd} size="small">
-        {t('Add Condition')}
-      </StyledButton>
+      {!!availableCategoryOptions.length && (
+        <StyledButton icon={<IconAdd isCircled />} onClick={onAdd} size="small">
+          {t('Add Condition')}
+        </StyledButton>
+      )}
     </Wrapper>
   );
 }

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/errorRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/errorRuleModal.tsx
@@ -47,18 +47,6 @@ class ErrorRuleModal extends Form<Props, State> {
     ];
   }
 
-  handleAddCondition = () => {
-    this.setState(state => ({
-      conditions: [
-        ...state.conditions,
-        {
-          category: DynamicSamplingInnerName.EVENT_RELEASE,
-          match: '',
-        },
-      ],
-    }));
-  };
-
   handleSubmit = () => {
     const {sampleRate, conditions, transaction} = this.state;
 

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/form.tsx
@@ -172,9 +172,40 @@ class Form<P extends Props = Props, S extends State = State> extends React.Compo
     throw new Error('Not implemented');
   };
 
-  handleAddCondition = (): never | void => {
-    // Children have to implement this
-    throw new Error('Not implemented');
+  handleAddCondition = () => {
+    const {conditions} = this.state;
+    const categoryOptions = this.getCategoryOptions();
+
+    if (!conditions.length) {
+      this.setState({
+        conditions: [
+          {
+            category: categoryOptions[0][0],
+            match: '',
+          },
+        ],
+      });
+      return;
+    }
+
+    const nextCategory = categoryOptions.find(
+      categoryOption =>
+        !conditions.find(condition => condition.category === categoryOption[0])
+    );
+
+    if (!nextCategory) {
+      return;
+    }
+
+    this.setState({
+      conditions: [
+        ...conditions,
+        {
+          category: nextCategory[0],
+          match: '',
+        },
+      ],
+    });
   };
 
   handleChangeCondition = <T extends keyof Conditions[0]>(

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/transactionRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/transactionRuleModal.tsx
@@ -130,6 +130,7 @@ class TransactionRuleModal extends Form<Props, State> {
         [DynamicSamplingInnerName.TRACE_USER, t('Users')],
       ];
     }
+
     return [
       [DynamicSamplingInnerName.EVENT_RELEASE, t('Releases')],
       [DynamicSamplingInnerName.EVENT_ENVIRONMENT, t('Environments')],
@@ -161,20 +162,6 @@ class TransactionRuleModal extends Form<Props, State> {
       </Field>
     );
   }
-
-  handleAddCondition = () => {
-    this.setState(state => ({
-      conditions: [
-        ...state.conditions,
-        {
-          category: state.tracing
-            ? DynamicSamplingInnerName.TRACE_RELEASE
-            : DynamicSamplingInnerName.EVENT_RELEASE,
-          match: '',
-        },
-      ],
-    }));
-  };
 
   handleSubmit = () => {
     const {tracing, sampleRate, conditions, transaction} = this.state;


### PR DESCRIPTION
closes: https://app.asana.com/0/1182975495223897/1199938177685000

**Problem:**

Currently, when creating a rule the user is able to specify the same condition multiple times.
This makes little sense ( no reason why a user would need to create a condition where the environment is "prod" and the environment is "dev"). Since a condition supports arrays of parameters a user can create a rule where the environment is "prod" or "dev" without needing to specify the condition twice.


**Solution:**
Enforce unique conditions within a rule (once a condition was used in a rule it can be removed from the selection box).