### PR TITLE
fix(discover): Mark saved queries that are out of retention

### DIFF
--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -2,6 +2,7 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.user import UserSerializer
 from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.discover.models import DiscoverSavedQuery
+from sentry.utils.dates import parse_timestamp, outside_retention_with_modified_start
 
 
 @register(DiscoverSavedQuery)
@@ -27,6 +28,7 @@ class DiscoverSavedQuerySerializer(Serializer):
             "name": obj.name,
             "projects": [project.id for project in obj.projects.all()],
             "version": obj.version or obj.query.get("version", 1),
+            "expired": False,
             "dateCreated": obj.date_created,
             "dateUpdated": obj.date_updated,
             "createdBy": serialize(obj.created_by, serializer=UserSerializer())
@@ -37,6 +39,13 @@ class DiscoverSavedQuerySerializer(Serializer):
         for key in query_keys:
             if obj.query.get(key) is not None:
                 data[key] = obj.query[key]
+
+        # expire queries that are beyond the retention period
+        if "start" in obj.query:
+            start, end = parse_timestamp(obj.query["start"]), parse_timestamp(obj.query["end"])
+            data["expired"], data["start"] = outside_retention_with_modified_start(
+                start, end, obj.organization
+            )
 
         if obj.query.get("all_projects"):
             data["projects"] = list(ALL_ACCESS_PROJECTS)

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1501,6 +1501,7 @@ export type NewQuery = {
   fields: Readonly<string[]>;
   widths?: Readonly<string[]>;
   orderby?: string;
+  expired?: boolean;
 
   // GlobalSelectionHeader
   projects: Readonly<number[]>;

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -242,6 +242,7 @@ class EventView {
   yAxis: string | undefined;
   display: string | undefined;
   interval: string | undefined;
+  expired?: boolean;
   createdBy: User | undefined;
   additionalConditions: QueryResults; // This allows views to always add additional conditins to the query to get specific data. It should not show up in the UI unless explicitly called.
 
@@ -259,6 +260,7 @@ class EventView {
     yAxis: string | undefined;
     display: string | undefined;
     interval?: string;
+    expired?: boolean;
     createdBy: User | undefined;
     additionalConditions: QueryResults;
   }) {
@@ -291,6 +293,7 @@ class EventView {
     this.display = props.display;
     this.interval = props.interval;
     this.createdBy = props.createdBy;
+    this.expired = props.expired;
     this.additionalConditions = props.additionalConditions ?? new QueryResults([]);
   }
 
@@ -378,6 +381,7 @@ class EventView {
       yAxis: saved.yAxis,
       display: saved.display,
       createdBy: saved.createdBy,
+      expired: saved.expired,
       additionalConditions: new QueryResults([]),
     });
   }
@@ -594,6 +598,7 @@ class EventView {
       yAxis: this.yAxis,
       display: this.display,
       interval: this.interval,
+      expired: this.expired,
       createdBy: this.createdBy,
       additionalConditions: this.additionalConditions,
     });

--- a/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/miniGraph.tsx
@@ -76,6 +76,8 @@ class MiniGraph extends React.Component<Props> {
       topEvents,
       orderby,
       showDaily: isDaily,
+      expired: eventView.expired,
+      name: eventView.name,
     };
   }
 
@@ -135,6 +137,8 @@ class MiniGraph extends React.Component<Props> {
       topEvents,
       orderby,
       showDaily,
+      expired,
+      name,
     } = this.getRefreshProps(this.props);
 
     return (
@@ -153,6 +157,8 @@ class MiniGraph extends React.Component<Props> {
         field={field}
         topEvents={topEvents}
         orderby={orderby}
+        expired={expired}
+        name={name}
       >
         {({loading, timeseriesData, results, errored}) => {
           if (errored) {

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -17,7 +17,6 @@ from concurrent.futures import ThreadPoolExecutor
 from django.conf import settings
 from urllib.parse import urlparse
 
-from sentry import quotas
 from sentry.models import (
     Environment,
     Group,
@@ -30,7 +29,7 @@ from sentry.models import (
 )
 from sentry.net.http import connection_from_url
 from sentry.utils import metrics, json
-from sentry.utils.dates import to_timestamp
+from sentry.utils.dates import to_timestamp, outside_retention_with_modified_start
 from sentry.snuba.events import Columns
 from sentry.snuba.dataset import Dataset
 from sentry.utils.compat import map
@@ -504,13 +503,11 @@ def _prepare_query_params(query_params):
             else:
                 query_params.conditions.append((col, "IN", keys))
 
-    retention = quotas.get_event_retention(organization=Organization(organization_id))
-    if retention:
-        start = max(start, datetime.utcnow() - timedelta(days=retention))
-        if start > end:
-            raise QueryOutsideRetentionError(
-                "Invalid date range. Please try a more recent date range."
-            )
+    expired, start = outside_retention_with_modified_start(
+        start, end, Organization(organization_id)
+    )
+    if expired:
+        raise QueryOutsideRetentionError("Invalid date range. Please try a more recent date range.")
 
     # if `shrink_time_window` pushed `start` after `end` it means the user queried
     # a Group for T1 to T2 when the group was only active for T3 to T4, so the query

--- a/tests/js/spec/components/charts/eventsRequest.spec.jsx
+++ b/tests/js/spec/components/charts/eventsRequest.spec.jsx
@@ -490,4 +490,33 @@ describe('EventsRequest', function () {
       );
     });
   });
+
+  describe('out of retention', function () {
+    beforeEach(function () {
+      doEventsRequest.mockClear();
+    });
+
+    it('does not make request', async function () {
+      wrapper = mount(
+        <EventsRequest {...DEFAULTS} expired>
+          {mock}
+        </EventsRequest>
+      );
+      expect(doEventsRequest).not.toHaveBeenCalled();
+    });
+
+    it('errors', async function () {
+      wrapper = mount(
+        <EventsRequest {...DEFAULTS} expired>
+          {mock}
+        </EventsRequest>
+      );
+      expect(mock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          expired: true,
+          errored: true,
+        })
+      );
+    });
+  });
 });


### PR DESCRIPTION
Discover saved queries can be saved with an absolute date range.
When these dates exceed the retention, we want to flag the issue
so the user may delete or update the query.