### PR TITLE
fix(charts): Area chart not passing colors properly

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/areaChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/areaChart.tsx
@@ -25,6 +25,7 @@ class AreaChart extends React.Component<Props> {
     return (
       <BaseChart
         {...props}
+        colors={colors}
         series={series.map(({seriesName, data, ...otherSeriesProps}, i) =>
           AreaSeries({
             stack: stacked ? 'area' : undefined,

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
@@ -51,14 +51,20 @@ type Props = {
 };
 
 class ReleaseChartContainer extends React.Component<Props> {
-  getTransactionsChartColors(): [string, string] {
+  /**
+   * This returns an array with 3 colors, one for each of
+   * 1. This Release
+   * 2. Other Releases
+   * 3. Releases (the markers)
+   */
+  getTransactionsChartColors(): [string, string, string] {
     const {yAxis, theme} = this.props;
 
     switch (yAxis) {
       case YAxis.FAILED_TRANSACTIONS:
-        return [theme.red300, theme.red100];
+        return [theme.red300, theme.red100, theme.purple300];
       default:
-        return [theme.purple300, theme.purple100];
+        return [theme.purple300, theme.purple100, theme.purple300];
     }
   }
 


### PR DESCRIPTION
AreaChart is not passing the colors prop to BaseChart causing the tooltips to
have mismatched colors.