### PR TITLE
ref(stacktrace-link): Add hovercards for error states

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -16,7 +16,12 @@ def get_link(config, filepath, default, version=None):
 
     formatted_path = filepath.replace(config.stack_root, config.source_root, 1)
 
-    return install.get_stacktrace_link(config.repository, formatted_path, default, version)
+    attempted_url = None
+    link = install.get_stacktrace_link(config.repository, formatted_path, default, version)
+
+    if not link:
+        attempted_url = install.format_source_url(config.repository, formatted_path, default)
+    return (link, attempted_url)
 
 
 class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
@@ -71,7 +76,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                     result["error"] = "stack_root_mismatch"
                     continue
 
-                link = get_link(config, filepath, config.default_branch, commitId)
+                link, attempted_url = get_link(config, filepath, config.default_branch, commitId)
 
                 # it's possible for the link to be None, and in that
                 # case it means we could not find a match for the
@@ -81,6 +86,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                     scope.set_tag("stacktrace_link.found", False)
                     scope.set_tag("stacktrace_link.error", "file_not_found")
                     result["error"] = "file_not_found"
+                    result["attemptedUrl"] = attempted_url
                 else:
                     scope.set_tag("stacktrace_link.found", True)
                     # if we found a match, we can break

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -144,6 +144,9 @@ class ExampleIntegration(IntegrationInstallation, IssueSyncMixin):
     def get_stacktrace_link(self, repo, path, default, version):
         pass
 
+    def format_source_url(self, repo, filepath, branch):
+        return f"https://example.com/{repo.name}/blob/{branch}/{filepath}"
+
 
 class ExampleIntegrationProvider(IntegrationProvider):
     """

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -272,15 +272,15 @@ class StacktraceLink extends AsyncComponent<Props, State> {
             error === 'stack_root_mismatch' ? (
               <HeaderContainer>
                 <HovercardLine>
-                  {`filename: `} <code>{`${frame.filename}`}</code>
+                  filename: <code>{`${frame.filename}`}</code>
                 </HovercardLine>
                 <HovercardLine>
-                  {`stack root: `} <code>{`${config?.stackRoot}`}</code>
+                  stack root: <code>{`${config?.stackRoot}`}</code>
                 </HovercardLine>
               </HeaderContainer>
             ) : (
               <HeaderContainer>
-                <div>{`${url}`}</div>
+                <HovercardLine>{url}</HovercardLine>
               </HeaderContainer>
             )
           }

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -263,7 +263,7 @@ class StacktraceLink extends AsyncComponent<Props, State> {
         <StyledHovercard
           header={
             error === 'stack_root_mismatch' ? (
-              <span>{t('Mistmatch between filename and stack root')}</span>
+              <span>{t('Mismatch between filename and stack root')}</span>
             ) : (
               <span>{t('Unable to find source code url')}</span>
             )
@@ -360,7 +360,8 @@ const StyledIconClose = styled(IconClose)`
 `;
 
 const StyledIconInfo = styled(IconInfo)`
-  margin-right: ${space(1)};
+  margin-right: ${space(0.5)};
+  margin-bottom: -2px;
   cursor: pointer;
   line-height: 0;
 `;
@@ -387,6 +388,7 @@ const HeaderContainer = styled('div')`
 const HovercardLine = styled('div')`
   padding-bottom: 3px;
 `;
+
 const ErrorInformation = styled('div')`
   padding-right: 5px;
   margin-right: ${space(1)};

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLink.tsx
@@ -6,9 +6,11 @@ import {openModal} from 'app/actionCreators/modal';
 import {promptsCheck, promptsUpdate} from 'app/actionCreators/prompts';
 import Access from 'app/components/acl/access';
 import AsyncComponent from 'app/components/asyncComponent';
-import Button from 'app/components/button';
+import {Body, Header, Hovercard} from 'app/components/hovercard';
+import {IconInfo} from 'app/icons';
 import {IconClose} from 'app/icons/iconClose';
 import {t, tct} from 'app/locale';
+import space from 'app/styles/space';
 import {
   Frame,
   Integration,
@@ -39,6 +41,7 @@ type StacktraceResultItem = {
   config?: RepositoryProjectPathConfigWithIntegration;
   sourceUrl?: string;
   error?: 'file_not_found' | 'stack_root_mismatch';
+  attemptedUrl?: string;
 };
 
 type State = AsyncComponent['state'] & {
@@ -71,11 +74,9 @@ class StacktraceLink extends AsyncComponent<Props, State> {
 
     switch (error) {
       case 'stack_root_mismatch':
-        return t('Error matching your configuration, check your stack trace root.');
+        return t('Error matching your configuration.');
       case 'file_not_found':
-        return t(
-          'Could not find source file, check your repository and source code root.'
-        );
+        return t('Source file not found.');
       default:
         return t('There was an error encountered with the code mapping for this project');
     }
@@ -252,20 +253,68 @@ class StacktraceLink extends AsyncComponent<Props, State> {
     return null;
   }
 
-  renderMatchNoUrl() {
+  renderHovercard() {
+    const error = this.match.error;
+    const url = this.match.attemptedUrl;
+    const {frame} = this.props;
     const {config} = this.match;
+    return (
+      <React.Fragment>
+        <StyledHovercard
+          header={
+            error === 'stack_root_mismatch' ? (
+              <span>{t('Mistmatch between filename and stack root')}</span>
+            ) : (
+              <span>{t('Unable to find source code url')}</span>
+            )
+          }
+          body={
+            error === 'stack_root_mismatch' ? (
+              <HeaderContainer>
+                <HovercardLine>
+                  {`filename: `} <code>{`${frame.filename}`}</code>
+                </HovercardLine>
+                <HovercardLine>
+                  {`stack root: `} <code>{`${config?.stackRoot}`}</code>
+                </HovercardLine>
+              </HeaderContainer>
+            ) : (
+              <HeaderContainer>
+                <div>{`${url}`}</div>
+              </HeaderContainer>
+            )
+          }
+        >
+          <StyledIconInfo size="xs" />
+        </StyledHovercard>
+      </React.Fragment>
+    );
+  }
+
+  renderMatchNoUrl() {
+    const {config, error} = this.match;
     const {organization} = this.props;
-    const text = this.errorText;
     const url = `/settings/${organization.slug}/integrations/${config?.provider.key}/${config?.integrationId}/?tab=codeMappings`;
     return (
       <CodeMappingButtonContainer columnQuantity={2}>
-        {text}
-        <Button onClick={() => this.onReconfigureMapping()} to={url} size="xsmall">
-          {t('Configure Stack Trace Linking')}
-        </Button>
+        <ErrorInformation>
+          {error && this.renderHovercard()}
+          <ErrorText>{this.errorText}</ErrorText>
+          {tct('[link:Configure Stack Trace Linking] to fix this problem.', {
+            link: (
+              <a
+                onClick={() => {
+                  this.onReconfigureMapping();
+                }}
+                href={url}
+              />
+            ),
+          })}
+        </ErrorInformation>
       </CodeMappingButtonContainer>
     );
   }
+
   renderMatchWithUrl(config: RepositoryProjectPathConfigWithIntegration, url: string) {
     url = `${url}#L${this.props.frame.lineNo}`;
     return (
@@ -308,4 +357,40 @@ export const CodeMappingButtonContainer = styled(OpenInContainer)`
 const StyledIconClose = styled(IconClose)`
   margin: auto;
   cursor: pointer;
+`;
+
+const StyledIconInfo = styled(IconInfo)`
+  margin-right: ${space(1)};
+  cursor: pointer;
+  line-height: 0;
+`;
+
+const StyledHovercard = styled(Hovercard)`
+  font-weight: normal;
+  width: inherit;
+  line-height: 0;
+  ${Header} {
+    font-weight: strong;
+    font-size: ${p => p.theme.fontSizeSmall};
+    color: ${p => p.theme.subText};
+  }
+  ${Body} {
+    font-weight: normal;
+    font-size: ${p => p.theme.fontSizeSmall};
+  }
+`;
+const HeaderContainer = styled('div')`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+`;
+const HovercardLine = styled('div')`
+  padding-bottom: 3px;
+`;
+const ErrorInformation = styled('div')`
+  padding-right: 5px;
+  margin-right: ${space(1)};
+`;
+const ErrorText = styled('span')`
+  margin-right: ${space(0.5)};
 `;

--- a/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/stacktraceLink.spec.jsx
@@ -106,6 +106,7 @@ describe('StacktraceLink', function () {
         sourceUrl: null,
         error: 'file_not_found',
         integrations: [integration],
+        attemptedUrl: 'https://something.io/blah',
       },
     });
     const wrapper = mountWithTheme(
@@ -120,8 +121,9 @@ describe('StacktraceLink', function () {
     );
     expect(wrapper.state('match').sourceUrl).toBeFalsy();
     expect(wrapper.find('CodeMappingButtonContainer').text()).toContain(
-      'Could not find source file, check your repository and source code root.'
+      'Source file not found.'
     );
+    expect(wrapper.state('match').attemptedUrl).toEqual('https://something.io/blah');
   });
 
   it('renders stack_root_mismatch message', async function () {
@@ -147,7 +149,33 @@ describe('StacktraceLink', function () {
     );
     expect(wrapper.state('match').sourceUrl).toBeFalsy();
     expect(wrapper.find('CodeMappingButtonContainer').text()).toContain(
-      'Error matching your configuration, check your stack trace root.'
+      'Error matching your configuration.'
+    );
+  });
+
+  it('renders default error message', async function () {
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      query: {file: frame.filename, commitId: 'master', platform},
+      body: {
+        config,
+        sourceUrl: null,
+        integrations: [integration],
+      },
+    });
+    const wrapper = mountWithTheme(
+      <StacktraceLink
+        frame={frame}
+        event={event}
+        projects={[project]}
+        organization={org}
+        lineNo={frame.lineNo}
+      />,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.state('match').sourceUrl).toBeFalsy();
+    expect(wrapper.find('CodeMappingButtonContainer').text()).toContain(
+      'There was an error encountered with the code mapping for this project'
     );
   });
 });

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -101,7 +101,10 @@ class ProjectStacktraceLinkTest(APITestCase):
         assert not response.data["sourceUrl"]
         assert response.data["error"] == "file_not_found"
         assert response.data["integrations"] == [self._serialized_integration()]
-        assert response.data["attemptedUrl"] == f"https://example.com/{self.repo.name}/blob/master/src/sentry/src/sentry/utils/safe.py"
+        assert (
+            response.data["attemptedUrl"]
+            == f"https://example.com/{self.repo.name}/blob/master/src/sentry/src/sentry/utils/safe.py"
+        )
 
     def test_stack_root_mismatch_error(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
**Context:**
For stacktrace linking, we wanted to make sure that you can accurately link to your source code. This means if for some reason we can't do that, we won't render a link. See https://github.com/getsentry/sentry/pull/22076 for our first iteration of giving more context when we can't render a link. 

**UI improvements**
While the previous iteration did give users an action (they can go back to configure their code mapping), it still wasn't super clear on the _why_ for when the link wasn't shown. These hovercards are to give more context for the two main cases we've seen:

* `source_root_mismatch`
The source root in their configuration doesn't match the filename in the stack trace. We give them both the filename and the stack root in the hovercard so they can easily see why they don't match. 
![Screen Shot 2021-03-01 at 9 28 38 AM](https://user-images.githubusercontent.com/15368179/109539807-95082280-7a76-11eb-9689-fca4ab7e9e99.png)

* `file_not_found`
We got a `404` from GH or GitLab. Sometimes people put the full url as the source root (`https://blah.com`) and so showing what the "attempted url" is can help them fix their configuration.
![Screen Shot 2021-03-01 at 9 25 07 AM](https://user-images.githubusercontent.com/15368179/109539814-96394f80-7a76-11eb-999c-7d817f4c0cef.png)

**New Attribute `attemptedUrl`**
Added the `attemptedUrl` to the payload so that we have it to render in the frontend. We don't need to use the `version` (aka the commit) because when we actually call the API to check the file, if we fail with the commit, we fall back to the default already. 

We can probably add information in the docs about that.
