### PR TITLE
feat(alerts): Team alerts feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -968,6 +968,8 @@ SENTRY_FEATURES = {
     "organizations:alert-details-redesign": False,
     # Enable the new images loaded design and features
     "organizations:images-loaded-v2": False,
+    # Enable teams to have ownership of alert rules
+    "organizations:team-alerts-ownership": False,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -121,6 +121,7 @@ default_manager.add("organizations:performance-landing-v2", OrganizationFeature)
 default_manager.add("organizations:performance-vitals-overview", OrganizationFeature)  # NOQA
 default_manager.add("organizations:performance-ops-breakdown", OrganizationFeature)  # NOQA
 default_manager.add("organizations:performance-tag-explorer", OrganizationFeature)  # NOQA
+default_manager.add("organizations:team-alerts-ownership", OrganizationFeature)  # NOQA
 
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.


### PR DESCRIPTION
A feature flag to support allowing teams to have ownership of alerts, rather than them just belonging to a single project.