### PR TITLE
ref: add Readonly to getDerivedStateFromProps props

### DIFF
--- a/src/sentry/static/sentry/app/components/bulkController/index.tsx
+++ b/src/sentry/static/sentry/app/components/bulkController/index.tsx
@@ -74,7 +74,7 @@ class BulkController extends React.Component<Props, State> {
     isAllSelected: false,
   };
 
-  static getDerivedStateFromProps(props: Props, state: State) {
+  static getDerivedStateFromProps(props: Readonly<Props>, state: State) {
     return {
       ...state,
       selectedIds: intersection(state.selectedIds, props.pageIds),

--- a/src/sentry/static/sentry/app/components/charts/transitionChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/transitionChart.tsx
@@ -26,7 +26,7 @@ class TransitionChart extends React.Component<Props, State> {
     key: 1,
   };
 
-  static getDerivedStateFromProps(props: Props, state: State) {
+  static getDerivedStateFromProps(props: Readonly<Props>, state: State) {
     // Transitions are controlled using variables called:
     // - loading and,
     // - reloading (also called pending in other apps)

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -44,7 +44,7 @@ class SpansInterface extends React.Component<Props, State> {
     operationNameFilters: noFilter,
   };
 
-  static getDerivedStateFromProps(props: Props, state: State): State {
+  static getDerivedStateFromProps(props: Readonly<Props>, state: State): State {
     return {
       ...state,
       parsedTrace: parseTrace(props.event),

--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -94,7 +94,7 @@ class GridEditable<
   // Static methods do not allow the use of generics bounded to the parent class
   // For more info: https://github.com/microsoft/TypeScript/issues/14600
   static getDerivedStateFromProps(
-    props: GridEditableProps<Object, keyof Object>,
+    props: Readonly<GridEditableProps<Object, keyof Object>>,
     prevState: GridEditableState
   ): GridEditableState {
     return {

--- a/src/sentry/static/sentry/app/views/discover/index.tsx
+++ b/src/sentry/static/sentry/app/views/discover/index.tsx
@@ -72,7 +72,7 @@ class DiscoverContainer extends React.Component<Props, State> {
     this.queryBuilder = createQueryBuilder(query, organization);
   }
 
-  static getDerivedStateFromProps(nextProps: Props, currState): State {
+  static getDerivedStateFromProps(nextProps: Readonly<Props>, currState): State {
     const nextState = {...currState};
     nextState.view = getView(nextProps.params, nextProps.location.query.view);
 

--- a/src/sentry/static/sentry/app/views/discover/sidebar/savedQueryList.tsx
+++ b/src/sentry/static/sentry/app/views/discover/sidebar/savedQueryList.tsx
@@ -39,7 +39,7 @@ export default class SavedQueries extends React.Component<
   };
 
   static getDerivedStateFromProps(
-    nextProps: SavedQueriesProps,
+    nextProps: Readonly<SavedQueriesProps>,
     prevState: SavedQueriesState
   ): Partial<SavedQueriesState> {
     const nextState: Partial<SavedQueriesState> = {};

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -69,7 +69,7 @@ function readShowTagsState() {
 }
 
 class Results extends React.Component<Props, State> {
-  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
+  static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     const eventView = EventView.fromLocation(nextProps.location);
     return {...prevState, eventView};
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -59,7 +59,7 @@ type State = {
 };
 
 class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
-  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
+  static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     const {eventView: nextEventView, savedQuery, savedQueryLoading} = nextProps;
 
     // For a new unsaved query

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -58,7 +58,7 @@ type State = {
 };
 
 class OrganizationContext extends React.Component<Props, State> {
-  static getDerivedStateFromProps(props: Props, prevState: State): State {
+  static getDerivedStateFromProps(props: Readonly<Props>, prevState: State): State {
     const {prevProps} = prevState;
 
     if (OrganizationContext.shouldRemount(prevProps, props)) {

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -72,7 +72,7 @@ function isStatsPeriodDefault(
 }
 
 class PerformanceLanding extends React.Component<Props, State> {
-  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
+  static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     return {
       ...prevState,
       eventView: generatePerformanceEventView(

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -63,7 +63,7 @@ class TransactionSummary extends React.Component<Props, State> {
     ),
   };
 
-  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
+  static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     return {
       ...prevState,
       eventView: generateSummaryEventView(

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/index.tsx
@@ -44,7 +44,7 @@ class TransactionVitals extends React.Component<Props> {
     ),
   };
 
-  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
+  static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     return {
       ...prevState,
       eventView: generateRumEventView(

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/index.tsx
@@ -49,7 +49,7 @@ class VitalDetail extends React.Component<Props, State> {
     ),
   };
 
-  static getDerivedStateFromProps(nextProps: Props, prevState: State): State {
+  static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
     return {
       ...prevState,
       eventView: generatePerformanceVitalDetailView(


### PR DESCRIPTION
This was an issue in #23893 and fixed only for that one function. Using it
tree-wide improves our type safety and prevents future issues.