### PR TITLE
feat(alerts): Issue alerts now support a team field

### DIFF
--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -70,6 +70,8 @@ export type UnsavedIssueAlertRule = {
   environment?: null | string;
   frequency: number;
   name: string;
+  // the id of the team which owns the alert
+  team?: string;
 };
 
 // Issue-based alert rule

--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -70,7 +70,6 @@ export type UnsavedIssueAlertRule = {
   environment?: null | string;
   frequency: number;
   name: string;
-  // the id of the team which owns the alert
   team?: string;
 };
 

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
@@ -19,6 +19,7 @@ import Button from 'app/components/button';
 import Confirm from 'app/components/confirm';
 import LoadingMask from 'app/components/loadingMask';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import SelectMembers from 'app/components/selectMembers';
 import {ALL_ENVIRONMENTS_KEY} from 'app/constants';
 import {IconChevron, IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
@@ -427,6 +428,17 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     }));
   };
 
+  getTeamId = () => {
+    const {rule} = this.state;
+    const team = rule?.team ?? '';
+    // ownership follows the format team:<id>, just grab the id
+    return team.split(':')[1];
+  };
+
+  handleTeamChange = (optionRecord: {value: string; label: string}) => {
+    this.handleChange('team', `team:${optionRecord.value}`);
+  };
+
   renderLoading() {
     return this.renderBody();
   }
@@ -506,6 +518,22 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                   onChange={val => this.handleEnvironmentChange(val)}
                   disabled={!hasAccess}
                 />
+
+                <Feature features={['organizations:team-alerts-ownership']}>
+                  <StyledField
+                    label={t('Team')}
+                    help={t('The team that owns this alert.')}
+                    disabled={!hasAccess}
+                  >
+                    <SelectMembers
+                      showTeam
+                      project={project}
+                      organization={organization}
+                      value={this.getTeamId()}
+                      onChange={this.handleTeamChange}
+                    />
+                  </StyledField>
+                </Feature>
 
                 <StyledField
                   label={t('Alert name')}


### PR DESCRIPTION
Workflow team is adding "team owner" support for issue alert rules. This will allow you to filter through only the alerts your team cares about rather than being presented with a huge list of all alerts in a project. The start is to place this team selector within the issue alert creation flow:

<img width="1198" alt="Screen Shot 2021-03-01 at 5 04 48 PM" src="https://user-images.githubusercontent.com/9372512/109566530-00bbb100-7ab2-11eb-84a1-6822a939cf9d.png">

Not a required field and users can choose to leave an alert unassigned.

related to: https://github.com/getsentry/sentry/pull/24100