### PR TITLE
fix(ui): Update alert welcome task url

### DIFF
--- a/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/taskConfig.tsx
@@ -201,7 +201,7 @@ export function getOnboardingTasks(
       skippable: true,
       requisites: [OnboardingTaskKey.FIRST_PROJECT],
       actionType: 'app',
-      location: `/settings/${organization.slug}/projects/:projectId/alerts/`,
+      location: `/organizations/${organization.slug}/alerts/rules/`,
       display: true,
     },
   ];


### PR DESCRIPTION
This is the welcome tasks for new users. Old url still points to project settings, alert creation has moved.