### PR TITLE
ref(notification platform): Add comments about UserOption keys

### DIFF
--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -11,9 +11,15 @@ from sentry.models.integration import ExternalProviders
 
 class NotificationSettingTypes(Enum):
     DEFAULT = 0
+    # top level config of on/off
+    # for workflow also includes SUBSCRIBE_ONLY
+    # for deploy also includes COMMITTED_ONLY
     DEPLOY = 10
+    # send deploy notifications
     ISSUE_ALERTS = 20
+    # notifications for issues
     WORKFLOW = 30
+    # notifications for changes in assignment, resolution, comments
 
 
 NOTIFICATION_SETTING_TYPES = {

--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -10,16 +10,16 @@ from sentry.models.integration import ExternalProviders
 
 
 class NotificationSettingTypes(Enum):
-    DEFAULT = 0
     # top level config of on/off
     # for workflow also includes SUBSCRIBE_ONLY
     # for deploy also includes COMMITTED_ONLY
-    DEPLOY = 10
+    DEFAULT = 0
     # send deploy notifications
-    ISSUE_ALERTS = 20
+    DEPLOY = 10
     # notifications for issues
-    WORKFLOW = 30
+    ISSUE_ALERTS = 20
     # notifications for changes in assignment, resolution, comments
+    WORKFLOW = 30
 
 
 NOTIFICATION_SETTING_TYPES = {

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -116,6 +116,42 @@ class UserOption(Model):
     Keeping user feature state
     key: "feature:assignment"
     value: { updated: datetime, state: bool }
+
+    where key is one of:
+     - clock_24_hours
+        - 12hr vs 24hr
+     - issue:defaults
+        - only used in Jira, set default reporter field
+     - issues:defaults:jira
+        - unused
+     - issues:defaults:jira_server
+        - unused
+     - language
+        - which language to display the app in
+     - mail:email
+        - which email address to send an email to
+     - reports:disabled-organizations
+        - which orgs to not send weekly reports to
+     - seen_release_broadcast
+        - unused
+     - self_assign_issue
+        - "Claim Unassigned Issues I've Resolved"
+     - self_notifications
+        - "Notify Me About My Own Activity"
+     - stacktrace_order
+        - default, most recent first, most recent last
+     - subscribe_by_default
+        - "Only On Issues I Subscribe To", "Only On Deploys With My Commits"
+     - subscribe_notes
+        - unused
+     - timezone
+        - user's timezone to display timestamps
+     - theme
+        - dark, light, or default
+     - twilio:alert
+        - unused
+     - workflow_notifications
+        - unused
     """
 
     __core__ = True

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -118,6 +118,7 @@ class UserOption(Model):
     value: { updated: datetime, state: bool }
 
     where key is one of:
+     (please add to this list if adding new keys)
      - clock_24_hours
         - 12hr vs 24hr
      - issue:defaults

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -120,7 +120,7 @@ class UserOption(Model):
     where key is one of:
      (please add to this list if adding new keys)
      - clock_24_hours
-        - 12hr vs 24hr
+        - 12hr vs. 24hr
      - issue:defaults
         - only used in Jira, set default reporter field
      - issues:defaults:jira


### PR DESCRIPTION
Make life a little easier for the next person by adding comments in the `UserOption` docstring about what each of the keys represent. I took out the ones that are soon to be migrated to the `NotificationSetting` table and commented in `NotificationSettingTypes` instead.