### PR TITLE
ref: Reverting back to get_event_by_id

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -161,26 +161,20 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
         """ For the full event trace, we return the results as a graph instead of a flattened list """
         parent_events = {}
         result = parent_events[root["id"]] = self.serialize_event(root, None, 0, True)
-        with sentry_sdk.start_span(
-            op="nodestore", description=f"retrieving {len(parent_map)} nodes"
-        ) as span:
-            span.set_data("total nodes", len(parent_map))
-            node_data = {
-                event.event_id: event
-                for event in eventstore.get_events(
-                    eventstore.Filter(
-                        project_ids=params["project_id"],
-                        event_ids=[event["id"] for event in parent_map.values()],
-                    )
-                )
-            }
 
         with sentry_sdk.start_span(op="building.trace", description="full trace"):
             to_check = deque([root])
             iteration = 0
             while to_check:
                 current_event = to_check.popleft()
-                event = node_data.get(current_event["id"])
+
+                # This is faster than doing a call to get_events, since get_event_by_id only makes a call to snuba
+                # when non transaction events are included.
+                with sentry_sdk.start_span(op="nodestore", description="get_event_by_id"):
+                    event = eventstore.get_event_by_id(
+                        current_event["project.id"], current_event["id"]
+                    )
+
                 previous_event = parent_events[current_event["id"]]
 
                 previous_event.update(


### PR DESCRIPTION
- get_events will always make a snuba call to bind group ids which is
  more work than required for our purposes.
- As well there isn't any additional benefit to calling get_events here
  since there isn't any batching done through `get_multi`
- This replaces #24081, after discussing this with @lynnagara more, we're not getting any additional benefit from calling `get_events` so in this specific case where we have all the event_ids already calling `get_event_by_id` n(up to 100) times is actually faster.