### PR TITLE
fix(quicktrace): Fall back to light trace when needed

### DIFF
--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/utils.ts
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/utils.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import omit from 'lodash/omit';
 
 import {Client} from 'app/api';
@@ -62,6 +61,10 @@ export function flattenRelevantPaths(
     }
   }
 
+  if (!events.length) {
+    throw new Error('No relevant path exists!');
+  }
+
   /**
    * Traverse all transactions from current transaction onwards and add
    * them all to the relevant path.
@@ -115,19 +118,14 @@ export function parseQuickTrace(
   const {type, trace} = quickTrace;
 
   if (type === 'empty' || trace === null) {
-    return null;
+    throw new Error('Current event not in quick trace!');
   }
 
   const isFullTrace = type === 'full';
 
   const current = trace.find(e => e.event_id === event.id) ?? null;
   if (current === null) {
-    /**
-     * The current event should always be present in the trace, if not
-     * there is no reason to look at the rest for the quick trace.
-     */
-    Sentry.captureException(new Error('Current event not in quick trace'));
-    return null;
+    throw new Error('Current event not in quick trace!');
   }
 
   /**

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import * as Sentry from '@sentry/react';
 import {Location, LocationDescriptor} from 'history';
 
 import DropdownLink from 'app/components/dropdownLink';
@@ -103,8 +104,12 @@ function QuickTracePills({
     return null;
   }
 
-  const parsedQuickTrace = parseQuickTrace(quickTrace, event);
-  if (parsedQuickTrace === null) {
+  let parsedQuickTrace;
+  try {
+    parsedQuickTrace = parseQuickTrace(quickTrace, event);
+  } catch (error) {
+    Sentry.setTag('currentEventID', event.id);
+    Sentry.captureException(new Error('Current event not in quick trace'));
     return <React.Fragment>{'\u2014'}</React.Fragment>;
   }
 

--- a/tests/js/spec/utils/performance/quickTrace/utils.spec.ts
+++ b/tests/js/spec/utils/performance/quickTrace/utils.spec.ts
@@ -110,8 +110,9 @@ describe('Quick Trace Utils', function () {
     it('flattens trace without the expected event', function () {
       const trace = generateTrace(1);
       const current = {id: 'you cant find me'} as Event;
-      const relevantPath = flattenRelevantPaths(current, trace);
-      expect(relevantPath).toEqual([]);
+      expect(() => flattenRelevantPaths(current, trace)).toThrow(
+        'No relevant path exists!'
+      );
     });
 
     it('flattens a single transaction trace', function () {
@@ -163,19 +164,18 @@ describe('Quick Trace Utils', function () {
   describe('parseQuickTrace', function () {
     it('parses empty trace', function () {
       const current = generateEventSelector({generation: 0, offset: 0});
-      const parsedQuickTrace = parseQuickTrace({type: 'empty', trace: []}, current);
-      expect(parsedQuickTrace).toEqual(null);
+      expect(() => parseQuickTrace({type: 'empty', trace: []}, current)).toThrow(
+        'Current event not in quick trace'
+      );
     });
 
     describe('partial trace', function () {
       it('parses correctly without the expected event', function () {
         const relevantPath = [generateTransactionLite({generation: 0, offset: 0})];
         const current = generateEventSelector({generation: 1, offset: 0});
-        const parsedQuickTrace = parseQuickTrace(
-          {type: 'partial', trace: relevantPath},
-          current
-        );
-        expect(parsedQuickTrace).toEqual(null);
+        expect(() =>
+          parseQuickTrace({type: 'partial', trace: relevantPath}, current)
+        ).toThrow('Current event not in quick trace');
       });
 
       it('parses only the current event', function () {


### PR DESCRIPTION
The full trace sometimes is missing the current event. This is due to certain
transactions being missing, in particular, ones on the path between the root and
the current event. When this happens, the current event will not be in the
constructed trace. Instead of showing an emdash, this change opts to show the
results of the light trace if possible.