### PR TITLE
fix(workflow): Allow logging via experiment manager

### DIFF
--- a/src/sentry/experiments/manager.py
+++ b/src/sentry/experiments/manager.py
@@ -13,7 +13,7 @@ class ExperimentManager:
         """
         self._experiments[experiment.__name__] = {"experiment": experiment, "param": param}
 
-    def all(self, org=None, actor=None, user=None):
+    def all(self, org=None, actor=None, user=None, log_exposure=False):
         """
         Returns an object with all the experiment assignments for an organization or user.
 
@@ -36,10 +36,10 @@ class ExperimentManager:
         for k, v in self._experiments.items():
             cls = v["experiment"]
             if hasattr(cls, "unit") and cls.unit == unit:
-                assignments[k] = cls(**kwargs).get_variant(v["param"], log_exposure=False)
+                assignments[k] = cls(**kwargs).get_variant(v["param"], log_exposure=log_exposure)
         return assignments
 
-    def get(self, experiment_name, org=None, actor=None, user=None):
+    def get(self, experiment_name, org=None, actor=None, user=None, log_exposure=False):
         """
         Returns the assignment for an experiment.
 
@@ -61,4 +61,4 @@ class ExperimentManager:
             kwargs = {"user": user}
 
         cls = value["experiment"]
-        return cls(**kwargs).get_variant(value["param"], log_exposure=False)
+        return cls(**kwargs).get_variant(value["param"], log_exposure=log_exposure)


### PR DESCRIPTION
When getting an experiment from the experiment manager, allow enabling log_exposure. This will be used in getsentry w/ inbox experiment, would like to log the inbox experiment to amplitude etc. 