### PR TITLE
feat(alerts): Restrict alerts popover to only show on alerts page

### DIFF
--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -320,6 +320,7 @@ type Props = {
   referrer?: string;
   hideIcon?: boolean;
   api: Client;
+  showPermissionGuide?: boolean;
 } & WithRouterProps &
   React.ComponentProps<typeof Button>;
 
@@ -333,6 +334,7 @@ const CreateAlertButton = withApi(
       router,
       hideIcon,
       api,
+      showPermissionGuide,
       ...buttonProps
     }: Props) => {
       function handleClickWithoutProject(event: React.MouseEvent) {
@@ -391,7 +393,7 @@ const CreateAlertButton = withApi(
         </Button>
       );
 
-      const showGuide = !organization.alertsMemberWrite;
+      const showGuide = !organization.alertsMemberWrite && !!showPermissionGuide;
 
       return (
         <Access organization={organization} access={['alerts:write']}>

--- a/src/sentry/static/sentry/app/views/alerts/list/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/header.tsx
@@ -53,6 +53,7 @@ const AlertHeader = ({router, organization, activeTab}: Props) => {
               size="small"
               priority="primary"
               referrer="alert_stream"
+              showPermissionGuide
             >
               {t('Create Alert Rule')}
             </CreateAlertButton>

--- a/tests/js/spec/components/createAlertButton.spec.jsx
+++ b/tests/js/spec/components/createAlertButton.spec.jsx
@@ -2,7 +2,9 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 
-import {CreateAlertFromViewButton} from 'app/components/createAlertButton';
+import CreateAlertButton, {
+  CreateAlertFromViewButton,
+} from 'app/components/createAlertButton';
 import EventView from 'app/utils/discover/eventView';
 import {ALL_VIEWS, DEFAULT_EVENT_VIEW} from 'app/views/eventsV2/data';
 
@@ -21,6 +23,15 @@ function generateWrappedComponent(organization, eventView) {
       onSuccess={onSuccessMock}
     />,
     TestStubs.routerContext()
+  );
+}
+
+function generateWrappedComponentButton(organization, showPermissionGuide) {
+  return mountWithTheme(
+    <CreateAlertButton
+      organization={organization}
+      showPermissionGuide={showPermissionGuide}
+    />
   );
 }
 
@@ -190,30 +201,24 @@ describe('CreateAlertFromViewButton', () => {
   });
 
   it('shows a guide for members', async () => {
-    const eventView = EventView.fromSavedQuery({
-      ...DEFAULT_EVENT_VIEW,
-    });
     const noAccessOrg = {
       ...organization,
       access: [],
     };
 
-    const wrapper = generateWrappedComponent(noAccessOrg, eventView);
+    const wrapper = generateWrappedComponentButton(noAccessOrg, true);
 
     const guide = wrapper.find('GuideAnchor');
     expect(guide.props().target).toBe('alerts_write_member');
   });
 
   it('shows a guide for owners/admins', async () => {
-    const eventView = EventView.fromSavedQuery({
-      ...DEFAULT_EVENT_VIEW,
-    });
     const adminAccessOrg = {
       ...organization,
       access: ['org:write'],
     };
 
-    const wrapper = generateWrappedComponent(adminAccessOrg, eventView);
+    const wrapper = generateWrappedComponentButton(adminAccessOrg, true);
 
     const guide = wrapper.find('GuideAnchor');
     expect(guide.props().target).toBe('alerts_write_owner');


### PR DESCRIPTION
Adds a prop to the `CreateAlertButton` which will allow us to conditionally turn on the assistant guide for whichever pages we want. Currently this prop is only enabled for the alerts page.

**The guide in question:**
<img width="340" alt="Screen Shot 2021-03-02 at 3 01 52 PM" src="https://user-images.githubusercontent.com/9372512/109708357-4e472500-7b69-11eb-8d01-f1f530bb2488.png">
