### PR TITLE
feat(dashboards): Show configuration / upsell popovers for Create/Edit Dashboards buttons.

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/index.tsx
@@ -352,7 +352,7 @@ class Sidebar extends React.Component<Props, State> {
 
     const dashboards = hasOrganization && (
       <Feature
-        features={['discover', 'discover-query']}
+        features={['discover', 'discover-query', 'dashboards-basic', 'dashboards-edit']}
         organization={organization}
         requireAll={false}
       >

--- a/src/sentry/static/sentry/app/stores/hookStore.tsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.tsx
@@ -30,6 +30,7 @@ const validHookNames = new Set<HookName>([
   'feature-disabled:events-sidebar-item',
   'feature-disabled:grid-editable-actions',
   'feature-disabled:open-discover',
+  'feature-disabled:dashboards-edit',
   'feature-disabled:incidents-sidebar-item',
   'feature-disabled:performance-new-project',
   'feature-disabled:performance-page',

--- a/src/sentry/static/sentry/app/types/hooks.tsx
+++ b/src/sentry/static/sentry/app/types/hooks.tsx
@@ -102,6 +102,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:events-sidebar-item': FeatureDisabledHook;
   'feature-disabled:grid-editable-actions': FeatureDisabledHook;
   'feature-disabled:open-discover': FeatureDisabledHook;
+  'feature-disabled:dashboards-edit': FeatureDisabledHook;
   'feature-disabled:incidents-sidebar-item': FeatureDisabledHook;
   'feature-disabled:performance-new-project': FeatureDisabledHook;
   'feature-disabled:performance-page': FeatureDisabledHook;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -283,7 +283,6 @@ class DashboardDetail extends React.Component<Props, State> {
     const {modifiedDashboard, dashboardState} = this.state;
 
     const isEditing = ['edit', 'create', 'pending_delete'].includes(dashboardState);
-    const canEdit = organization.features.includes('dashboards-edit');
 
     return (
       <GlobalSelectionHeader
@@ -322,7 +321,6 @@ class DashboardDetail extends React.Component<Props, State> {
                     onCommit={this.onCommit({dashboard, reloadData})}
                     onDelete={this.onDelete(dashboard)}
                     dashboardState={dashboardState}
-                    canEdit={canEdit}
                   />
                 </StyledPageHeader>
                 {error ? (

--- a/tests/js/spec/views/dashboardsV2/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/detail.spec.jsx
@@ -124,12 +124,16 @@ describe('Dashboards > Detail', function () {
     });
 
     it('disables buttons based on features', async function () {
+      initialData = initializeOrg({
+        organization: TestStubs.Organization({
+          features: ['global-views', 'dashboards-basic', 'discover-query'],
+          projects: [TestStubs.Project()],
+        }),
+      });
+
       wrapper = mountWithTheme(
         <DashboardDetail
-          organization={{
-            ...initialData.organization,
-            features: ['dashboards-basic', 'discover-basic'],
-          }}
+          organization={initialData.organization}
           params={{orgId: 'org-slug', dashboardId: 'default-overview'}}
           router={initialData.router}
           location={initialData.router.location}


### PR DESCRIPTION
Show upsell/upgrade popovers for Create/Edit Dashboards buttons.

## On-premise

![Screen Shot 2021-03-02 at 2 54 54 PM](https://user-images.githubusercontent.com/139499/109708803-df1e0080-7b69-11eb-8805-d6ec7e2b93ab.png)

## Sentry SaaS


![Screen Shot 2021-03-02 at 3 07 37 PM](https://user-images.githubusercontent.com/139499/109708813-e1805a80-7b69-11eb-82ce-8a42155cde0d.png)

## TODO

- [x] update the sidebar nav to require `dashboards-basic`.
