### PR TITLE
fix(alerts): Change team to owner in UnsavedIssueAlertRule type

### DIFF
--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -70,7 +70,7 @@ export type UnsavedIssueAlertRule = {
   environment?: null | string;
   frequency: number;
   name: string;
-  team?: string;
+  owner?: string;
 };
 
 // Issue-based alert rule

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
@@ -430,13 +430,14 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
   getTeamId = () => {
     const {rule} = this.state;
-    const team = rule?.team ?? '';
+    const owner = rule?.owner ?? '';
     // ownership follows the format team:<id>, just grab the id
-    return team.split(':')[1];
+    return owner.split(':')[1];
   };
 
-  handleTeamChange = (optionRecord: {value: string; label: string}) => {
-    this.handleChange('team', `team:${optionRecord.value}`);
+  handleOwnerChange = (optionRecord: {value: string; label: string}) => {
+    // currently only supporting teams as owners
+    this.handleChange('owner', `team:${optionRecord.value}`);
   };
 
   renderLoading() {
@@ -530,7 +531,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                       project={project}
                       organization={organization}
                       value={this.getTeamId()}
-                      onChange={this.handleTeamChange}
+                      onChange={this.handleOwnerChange}
                     />
                   </StyledField>
                 </Feature>


### PR DESCRIPTION
Just a quick refactor to match https://github.com/getsentry/sentry/pull/24100 

which uses `owner` as the name instead of `team`.