### PR TITLE
feat(alerts): Add new `team` column to alert rules page

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -244,8 +244,7 @@ const StyledPanelTable = styled(PanelTable)<{showTeamCol: boolean}>`
     line-height: normal;
   }
   font-size: ${p => p.theme.fontSizeMedium};
-  grid-template-columns: ${p =>
-    p.showTeamCol ? 'auto 1.5fr 1fr 1fr 1fr 1fr auto' : 'auto 1.5fr 1fr 1fr 1fr auto'};
+  grid-template-columns: auto 1.5fr 1fr 1fr 1fr ${p => (p.showTeamCol ? '1fr' : '')} auto;
   margin-bottom: 0;
   white-space: nowrap;
   ${p =>

--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -5,13 +5,15 @@ import memoize from 'lodash/memoize';
 import moment from 'moment';
 
 import Access from 'app/components/acl/access';
+import Feature from 'app/components/acl/feature';
+import ActorAvatar from 'app/components/avatar/actorAvatar';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import Confirm from 'app/components/confirm';
 import ErrorBoundary from 'app/components/errorBoundary';
 import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
-import {IconDelete, IconSettings} from 'app/icons';
+import {IconDelete, IconSettings, IconUser} from 'app/icons';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -51,6 +53,9 @@ class RuleListRow extends React.Component<Props, State> {
       !isIssueAlert(rule) && organization.features.includes('alert-details-redesign');
     const detailsLink = `/organizations/${orgId}/alerts/rules/details/${rule.id}/`;
 
+    const ownerId = rule.owner?.split(':')[1];
+    const teamActor = ownerId ? {type: 'team' as 'team', id: ownerId, name: ''} : null;
+
     return (
       <ErrorBoundary>
         <RuleType>{isIssueAlert(rule) ? t('Issue') : t('Metric')}</RuleType>
@@ -61,6 +66,15 @@ class RuleListRow extends React.Component<Props, State> {
           avatarSize={18}
           project={!projectsLoaded ? {slug} : this.getProject(slug, projects)}
         />
+        <Feature features={['organizations:team-alerts-ownership']}>
+          <TeamIcon>
+            {teamActor ? (
+              <ActorAvatar actor={teamActor} size={24} />
+            ) : (
+              <IconUser size="20px" color="gray400" />
+            )}
+          </TeamIcon>
+        </Feature>
         <CreatedBy>{rule?.createdBy?.name ?? '-'}</CreatedBy>
         <div>{dateCreated}</div>
         <RightColumn>
@@ -136,6 +150,11 @@ const CreatedBy = styled('div')`
 
 const ProjectBadge = styled(IdBadge)`
   flex-shrink: 0;
+`;
+
+const TeamIcon = styled('div')`
+  display: flex;
+  align-items: center;
 `;
 
 export default RuleListRow;

--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -17,7 +17,7 @@ import {IconDelete, IconSettings, IconUser} from 'app/icons';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
-import {Organization, Project} from 'app/types';
+import {Actor, Organization, Project} from 'app/types';
 import {IssueAlertRule} from 'app/types/alerts';
 
 import {isIssueAlert} from '../utils';
@@ -54,7 +54,9 @@ class RuleListRow extends React.Component<Props, State> {
     const detailsLink = `/organizations/${orgId}/alerts/rules/details/${rule.id}/`;
 
     const ownerId = rule.owner?.split(':')[1];
-    const teamActor = ownerId ? {type: 'team' as 'team', id: ownerId, name: ''} : null;
+    const teamActor = ownerId
+      ? {type: 'team' as Actor['type'], id: ownerId, name: ''}
+      : null;
 
     return (
       <ErrorBoundary>


### PR DESCRIPTION
**Welcome to the future of alerts where your team can now own alerts!!**
Building off of https://github.com/getsentry/sentry/pull/24100 we will now display owner information on the alert rules page.

**It looks like this:**
<img width="1184" alt="Screen Shot 2021-03-02 at 4 51 48 PM" src="https://user-images.githubusercontent.com/9372512/109720082-9d945200-7b77-11eb-9d6a-5ddca7ce11a8.png">


Currently, visibility of this is controlled by `organizations:team-alerts-ownership`

**The original experience is maintained:**
<img width="1183" alt="Screen Shot 2021-03-02 at 4 50 48 PM" src="https://user-images.githubusercontent.com/9372512/109719996-7b023900-7b77-11eb-87f8-55e25078d7c9.png">
