### PR TITLE
fix(key-transaction): btn color and icon size

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
@@ -128,12 +128,7 @@ class KeyTransactionButton extends React.Component<Props, State> {
 
     return (
       <Button
-        icon={
-          <IconStar
-            color={isKeyTransaction ? 'yellow300' : 'textColor'}
-            isSolid={!!isKeyTransaction}
-          />
-        }
+        icon={isKeyTransaction ? <IconStar color="yellow300" isSolid /> : <IconStar />}
         onClick={this.toggleKeyTransactionHandler}
       >
         {t('Key Transaction')}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/keyTransactionButton.tsx
@@ -130,8 +130,7 @@ class KeyTransactionButton extends React.Component<Props, State> {
       <Button
         icon={
           <IconStar
-            size="xs"
-            color={isKeyTransaction ? 'yellow300' : 'gray500'}
+            color={isKeyTransaction ? 'yellow300' : 'textColor'}
             isSolid={!!isKeyTransaction}
           />
         }


### PR DESCRIPTION
**Before:**
![Screen Shot 2021-03-02 at 2 41 48 PM](https://user-images.githubusercontent.com/4830259/109725132-8ba9b380-7b65-11eb-99e0-a8b07ff51ce0.png)
![Screen Shot 2021-03-02 at 2 41 41 PM](https://user-images.githubusercontent.com/4830259/109725147-8fd5d100-7b65-11eb-8cfc-dfbe8c1c1022.png)
![Screen Shot 2021-03-02 at 2 44 13 PM](https://user-images.githubusercontent.com/4830259/109725298-c875aa80-7b65-11eb-9123-6bfdfcc35d6c.png)
![Screen Shot 2021-03-02 at 2 44 08 PM](https://user-images.githubusercontent.com/4830259/109725305-cad80480-7b65-11eb-85a4-198bcfcbd7e5.png)

**After:**
![Screen Shot 2021-03-02 at 2 41 15 PM](https://user-images.githubusercontent.com/4830259/109725162-95cbb200-7b65-11eb-838c-fd9309c8cb0e.png)
![Screen Shot 2021-03-02 at 2 41 26 PM](https://user-images.githubusercontent.com/4830259/109725166-97957580-7b65-11eb-98f1-530c8bbe38a7.png)
![Screen Shot 2021-03-02 at 2 43 35 PM](https://user-images.githubusercontent.com/4830259/109725235-b1cf5380-7b65-11eb-87da-aee1fa9804df.png)
![Screen Shot 2021-03-02 at 2 43 30 PM](https://user-images.githubusercontent.com/4830259/109725244-b3008080-7b65-11eb-9d93-7cd5939be98e.png)