### PR TITLE
ref(slack): Organize unfurlers into modules

### DIFF
--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -1,151 +1,20 @@
-import enum
-import re
 from collections import defaultdict
 from typing import (
     Any,
-    Callable,
     DefaultDict,
     Dict,
     List,
-    Mapping,
-    Match,
-    NamedTuple,
-    Pattern,
-    Tuple,
-    Union,
 )
 
-from django.db.models import Q
-
-from sentry import eventstore
 from sentry.api.base import Endpoint
-from sentry.incidents.models import Incident
-from sentry.models import Group, Project
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.web.decorators import transaction_start
 from sentry.utils import json
 
 from .client import SlackClient
 from .requests import SlackEventRequest, SlackRequestError
-from .utils import build_group_attachment, build_incident_attachment, parse_link, logger
-
-UnfurledUrl = Any
-
-
-class LinkType(enum.Enum):
-    ISSUES = "issues"
-    INCIDENTS = "incidents"
-    DISCOVER = "discover"
-
-
-class UnfurlableUrl(NamedTuple):
-    url: str
-    args: Mapping[str, Any]
-
-
-class Handler(NamedTuple):
-    matcher: Pattern
-    arg_types: Mapping[str, type]
-    fn: Callable[[Any, List[UnfurlableUrl]], UnfurledUrl]
-
-
-def unfurl_issues(integration, links: List[UnfurlableUrl]) -> UnfurledUrl:
-    """
-    Returns a map of the attachments used in the response we send to Slack
-    for a particular issue by the URL of the yet-unfurled links a user included
-    in their Slack message.
-
-    url_by_issue_id: a map with URL as the value and the issue ID as the key
-    event_id_by_url: a map with the event ID in a URL as the value and the URL as the key
-    """
-    group_by_id = {
-        g.id: g
-        for g in Group.objects.filter(
-            id__in={link.args["issue_id"] for link in links},
-            project__in=Project.objects.filter(organization__in=integration.organizations.all()),
-        )
-    }
-    if not group_by_id:
-        return {}
-
-    out = {}
-    for link in links:
-        issue_id = link.args["issue_id"]
-
-        if issue_id in group_by_id:
-            group = group_by_id[issue_id]
-            # lookup the event by the id
-            event_id = link.args["event_id"]
-            event = eventstore.get_event_by_id(group.project_id, event_id) if event_id else None
-            out[link.url] = build_group_attachment(
-                group_by_id[issue_id], event=event, link_to_event=True
-            )
-    return out
-
-
-def unfurl_incidents(integration, links: List[UnfurlableUrl]) -> UnfurledUrl:
-    filter_query = Q()
-    # Since we don't have real ids here, we use the org slug so that we can
-    # make sure the identifiers correspond to the correct organization.
-    for link in links:
-        identifier = link.args["incident_id"]
-        org_slug = link.args["org_slug"]
-        filter_query |= Q(identifier=identifier, organization__slug=org_slug)
-
-    results = {
-        i.identifier: i
-        for i in Incident.objects.filter(
-            filter_query,
-            # Filter by integration organization here as well to make sure that
-            # we have permission to access these incidents.
-            organization__in=integration.organizations.all(),
-        )
-    }
-    if not results:
-        return {}
-
-    return {
-        link.url: build_incident_attachment(
-            action=None,
-            incident=results[link.args["incident_id"]],
-        )
-        for link in links
-        if link.args["incident_id"] in results
-    }
-
-
-# XXX: The regex matchers could be more tightly bound to our configured domain,
-# but slack limits what we can unfurl anyways so its probably safe
-_link_handlers = {
-    LinkType.ISSUES: Handler(
-        fn=unfurl_issues,
-        matcher=re.compile(
-            r"^https?\://[^/]+/[^/]+/[^/]+/issues/(?P<issue_id>\d+)(?:/events/(?P<event_id>\w+))?"
-        ),
-        arg_types={
-            "issue_id": int,
-            "event_id": str,
-        },
-    ),
-    LinkType.INCIDENTS: Handler(
-        fn=unfurl_incidents,
-        matcher=re.compile(
-            r"^https?\://[^/]+/organizations/(?P<org_slug>[^/]+)/incidents/(?P<incident_id>\d+)"
-        ),
-        arg_types={
-            "org_slug": str,
-            "incident_id": int,
-        },
-    ),
-}
-
-
-def match_link(link: str) -> Union[Tuple[LinkType, Match], Tuple[None, None]]:
-    for link_type, handler in _link_handlers.items():
-        match = handler.matcher.match(link)
-        if match:
-            return link_type, match
-    return None, None
+from .unfurl import LinkType, UnfurlableUrl, match_link, link_handlers
+from .utils import parse_link, logger
 
 
 # XXX(dcramer): a lot of this is copied from sentry-plugins right now, and will
@@ -205,19 +74,6 @@ class SlackEventEndpoint(Endpoint):
 
         return self.respond()
 
-    def _parse_url(self, link) -> Union[Tuple[LinkType, Mapping[str, Any]], Tuple[None, None]]:
-        """
-        Determines if the URL is something we are able to unfurl, if it is we
-        will return the named groups from the regex match, along with the link
-        type.
-        """
-        link_type, match = match_link(link)
-
-        if link_type is None or match is None:
-            return None, None
-
-        return link_type, match.groupdict()
-
     def on_link_shared(self, request, integration, token, data):
         matches: DefaultDict[LinkType, List[UnfurlableUrl]] = defaultdict(list)
         links_seen = set()
@@ -234,23 +90,19 @@ class SlackEventEndpoint(Endpoint):
             except Exception as e:
                 logger.error("slack.parse-link-error", extra={"error": str(e)})
 
-            link_type, args = self._parse_url(item["url"])
+            link_type, args = match_link(item["url"])
 
-            if not link_type or args is None:
+            # Link can't be unfurled
+            if link_type is None or args is None:
                 continue
-
-            # Coerce link argument types
-            arg_types = _link_handlers[link_type].arg_types
-            clean_args = {k: arg_types[k](v) if v is not None else None for k, v in args.items()}
 
             # Don't unfurl the same thing multiple times
-            seen_marker = (link_type, frozenset(args.items()))
-            if seen_marker not in links_seen:
-                links_seen.add(seen_marker)
-            else:
+            seen_marker = hash(json.dumps((link_type, args), sort_keys=True))
+            if seen_marker in links_seen:
                 continue
 
-            matches[link_type].append(UnfurlableUrl(url=item["url"], args=clean_args))
+            links_seen.add(seen_marker)
+            matches[link_type].append(UnfurlableUrl(url=item["url"], args=args))
 
         if not matches:
             return
@@ -258,7 +110,7 @@ class SlackEventEndpoint(Endpoint):
         # Unfurl each link type
         results: Dict[str, Any] = {}
         for link_type, unfurl_data in matches.items():
-            results.update(_link_handlers[link_type].fn(integration, unfurl_data))
+            results.update(link_handlers[link_type].fn(request, integration, unfurl_data))
 
         if not results:
             return

--- a/src/sentry/integrations/slack/unfurl/__init__.py
+++ b/src/sentry/integrations/slack/unfurl/__init__.py
@@ -1,0 +1,62 @@
+import enum
+from typing import (
+    Any,
+    Callable,
+    List,
+    Mapping,
+    NamedTuple,
+    Pattern,
+)
+
+
+UnfurledUrl = Any
+ArgsMapper = Callable[[str, Mapping[str, str]], Mapping[str, Any]]
+
+
+class LinkType(enum.Enum):
+    ISSUES = "issues"
+    INCIDENTS = "incidents"
+
+
+class UnfurlableUrl(NamedTuple):
+    url: str
+    args: Mapping[str, Any]
+
+
+class Handler(NamedTuple):
+    matcher: Pattern
+    arg_mapper: ArgsMapper
+    fn: Callable[[Any, Any, List[UnfurlableUrl]], UnfurledUrl]
+
+
+def make_type_coercer(type_map: Mapping[str, type]) -> ArgsMapper:
+    """
+    Given a mapping of argument names to types, cosntruct a function that will
+    coerce given arguments into those types.
+    """
+
+    def type_coercer(url: str, args: Mapping[str, str]) -> Mapping[str, Any]:
+        return {k: type_map[k](v) if v is not None else None for k, v in args.items()}
+
+    return type_coercer
+
+
+from .issues import handler as issues_handler
+from .incidents import handler as incidents_handler
+
+link_handlers = {
+    LinkType.ISSUES: issues_handler,
+    LinkType.INCIDENTS: incidents_handler,
+}
+
+
+def match_link(link: str):
+    for link_type, handler in link_handlers.items():
+        match = handler.matcher.match(link)
+        if not match:
+            continue
+
+        args = handler.arg_mapper(link, match.groupdict())
+        return link_type, args
+
+    return None, None

--- a/src/sentry/integrations/slack/unfurl/incidents.py
+++ b/src/sentry/integrations/slack/unfurl/incidents.py
@@ -1,0 +1,56 @@
+import re
+from typing import List
+from django.db.models import Q
+
+from sentry.incidents.models import Incident
+from sentry.integrations.slack.utils import build_incident_attachment
+
+from . import Handler, UnfurlableUrl, UnfurledUrl, make_type_coercer
+
+
+map_incident_args = make_type_coercer(
+    {
+        "org_slug": str,
+        "incident_id": int,
+    }
+)
+
+
+def unfurl_incidents(request, integration, links: List[UnfurlableUrl]) -> UnfurledUrl:
+    filter_query = Q()
+    # Since we don't have real ids here, we use the org slug so that we can
+    # make sure the identifiers correspond to the correct organization.
+    for link in links:
+        identifier = link.args["incident_id"]
+        org_slug = link.args["org_slug"]
+        filter_query |= Q(identifier=identifier, organization__slug=org_slug)
+
+    results = {
+        i.identifier: i
+        for i in Incident.objects.filter(
+            filter_query,
+            # Filter by integration organization here as well to make sure that
+            # we have permission to access these incidents.
+            organization__in=integration.organizations.all(),
+        )
+    }
+    if not results:
+        return {}
+
+    return {
+        link.url: build_incident_attachment(
+            action=None,
+            incident=results[link.args["incident_id"]],
+        )
+        for link in links
+        if link.args["incident_id"] in results
+    }
+
+
+handler = Handler(
+    fn=unfurl_incidents,
+    matcher=re.compile(
+        r"^https?\://[^/]+/organizations/(?P<org_slug>[^/]+)/alerts/rules/details/(?P<incident_id>\d+)"
+    ),
+    arg_mapper=map_incident_args,
+)

--- a/src/sentry/integrations/slack/unfurl/issues.py
+++ b/src/sentry/integrations/slack/unfurl/issues.py
@@ -1,0 +1,61 @@
+import re
+from typing import List
+
+from sentry import eventstore
+from sentry.models import Group, Project
+from sentry.integrations.slack.utils import build_group_attachment
+
+from . import (
+    Handler,
+    UnfurlableUrl,
+    UnfurledUrl,
+    make_type_coercer,
+)
+
+
+map_issue_args = make_type_coercer(
+    {
+        "issue_id": int,
+        "event_id": str,
+    }
+)
+
+
+def unfurl_issues(request, integration, links: List[UnfurlableUrl]) -> UnfurledUrl:
+    """
+    Returns a map of the attachments used in the response we send to Slack
+    for a particular issue by the URL of the yet-unfurled links a user included
+    in their Slack message.
+    """
+    group_by_id = {
+        g.id: g
+        for g in Group.objects.filter(
+            id__in={link.args["issue_id"] for link in links},
+            project__in=Project.objects.filter(organization__in=integration.organizations.all()),
+        )
+    }
+    if not group_by_id:
+        return {}
+
+    out = {}
+    for link in links:
+        issue_id = link.args["issue_id"]
+
+        if issue_id in group_by_id:
+            group = group_by_id[issue_id]
+            # lookup the event by the id
+            event_id = link.args["event_id"]
+            event = eventstore.get_event_by_id(group.project_id, event_id) if event_id else None
+            out[link.url] = build_group_attachment(
+                group_by_id[issue_id], event=event, link_to_event=True
+            )
+    return out
+
+
+handler = Handler(
+    fn=unfurl_issues,
+    matcher=re.compile(
+        r"^https?\://[^/]+/[^/]+/[^/]+/issues/(?P<issue_id>\d+)(?:/events/(?P<event_id>\w+))?"
+    ),
+    arg_mapper=map_issue_args,
+)

--- a/tests/sentry/integrations/slack/test_event_endpoint.py
+++ b/tests/sentry/integrations/slack/test_event_endpoint.py
@@ -41,7 +41,7 @@ LINK_SHARED_EVENT = """{
         },
         {
             "domain": "example.com",
-            "url": "http://testserver/organizations/%(org1)s/incidents/%(incident)s/"
+            "url": "http://testserver/organizations/%(org1)s/alerts/rules/details/%(incident)s/"
         },
         {
             "domain": "another-example.com",
@@ -169,9 +169,7 @@ class LinkSharedEventTest(BaseEventTest):
         data = dict(parse_qsl(responses.calls[0].request.body))
         unfurls = json.loads(data["unfurls"])
         issue_url = f"http://testserver/organizations/{self.org.slug}/issues/{group1.id}/"
-        incident_url = (
-            f"http://testserver/organizations/{self.org.slug}/incidents/{incident.identifier}/"
-        )
+        incident_url = f"http://testserver/organizations/{self.org.slug}/alerts/rules/details/{incident.identifier}/"
         event_url = f"http://testserver/organizations/{self.org.slug}/issues/{group3.id}/events/{event.event_id}/"
 
         assert unfurls == {


### PR DESCRIPTION
The endpoint was getting pretty hairy.

I'm not happy with having to order the imports of the module, so maybe I could pull some of the stuff in `__init__` into a diff module to avoid the circular dep