### PR TITLE
fix(dashboards): Fix widget keys

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -169,5 +169,5 @@ const WidgetContainer = styled('div')`
 `;
 
 function generateWidgetId(widget: Widget, index: number) {
-  return widget.id ?? `index-${index}`;
+  return widget.id ? `${widget.id}-index-${index}` : `index-${index}`;
 }

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -265,7 +265,7 @@ class DashboardDetail extends React.Component<Props, State> {
       return {
         ...prevState,
         modifiedDashboard: {
-          ...modifiedDashboard,
+          ...prevState.modifiedDashboard,
           widgets,
         },
       };

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -265,7 +265,7 @@ class DashboardDetail extends React.Component<Props, State> {
       return {
         ...prevState,
         modifiedDashboard: {
-          ...prevState.modifiedDashboard,
+          ...prevState.modifiedDashboard!,
           widgets,
         },
       };

--- a/tests/js/sentry-test/fixtures/widget.js
+++ b/tests/js/sentry-test/fixtures/widget.js
@@ -27,7 +27,7 @@ const DEFAULT_QUERIES = {
 
 export function Widget(queries = {...DEFAULT_QUERIES}, options) {
   return {
-    displayType: 'line',
+    type: 'line',
     queries,
     title: 'Widget',
     ...options,

--- a/tests/js/sentry-test/fixtures/widget.js
+++ b/tests/js/sentry-test/fixtures/widget.js
@@ -27,7 +27,7 @@ const DEFAULT_QUERIES = {
 
 export function Widget(queries = {...DEFAULT_QUERIES}, options) {
   return {
-    type: 'line',
+    displayType: 'line',
     queries,
     title: 'Widget',
     ...options,

--- a/tests/js/spec/views/dashboardsV2/detail.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/detail.spec.jsx
@@ -167,6 +167,7 @@ describe('Dashboards > Detail', function () {
           {
             title: 'Errors',
             interval: '1d',
+            id: '1',
           }
         ),
         TestStubs.Widget(
@@ -174,6 +175,21 @@ describe('Dashboards > Detail', function () {
           {
             title: 'Transactions',
             interval: '1d',
+            id: '2',
+          }
+        ),
+        TestStubs.Widget(
+          [
+            {
+              name: '',
+              conditions: 'event.type:transaction transaction:/api/cats',
+              fields: ['p50()'],
+            },
+          ],
+          {
+            title: 'p50 of /api/cats',
+            interval: '1d',
+            id: '3',
           }
         ),
       ];
@@ -231,10 +247,16 @@ describe('Dashboards > Detail', function () {
       const card = wrapper.find('WidgetCard').first();
       card.find('StyledPanel').simulate('mouseOver');
 
-      // Remove the first widget
+      // Remove the second and third widgets
       wrapper
         .find('WidgetCard')
-        .first()
+        .at(1)
+        .find('IconClick[data-test-id="widget-delete"]')
+        .simulate('click');
+
+      wrapper
+        .find('WidgetCard')
+        .at(1)
         .find('IconClick[data-test-id="widget-delete"]')
         .simulate('click');
 
@@ -247,7 +269,7 @@ describe('Dashboards > Detail', function () {
         expect.objectContaining({
           data: expect.objectContaining({
             title: 'Custom Errors',
-            widgets: [widgets[1]],
+            widgets: [widgets[0]],
           }),
         })
       );


### PR DESCRIPTION
Deleting widgets with an id will delete the wrong widget. This becomes obvious when deleting the first widget every time until the last widget with an id cannot be deleted.

A corresponding React test was updated to support this edge case. 

