### PR TITLE
build(ci): Skip frontend test job instead of each step

### DIFF
--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -9,9 +9,34 @@ on:
   pull_request:
 
 jobs:
+  files-changed:
+    name: check frontend files changed
+    runs-on: ubuntu-20.04
+    timeout-minutes: 5
+
+    outputs:
+      frontend: ${{ steps.changes.outputs.frontend }}
+      frontend_components_modified_lintable_files: ${{ steps.changes.outputs.frontend_components_modified_lintable_files }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check for frontend file changes
+        uses: getsentry/paths-filter@master
+        id: changes
+        with:
+          list-files: shell
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+
   typescript-and-lint:
     name: typescript and lint
+    needs: files-changed
     runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    if: needs.files-changed.outputs.frontend == 'true'
+
     steps:
       - uses: actions/checkout@v2
 
@@ -32,17 +57,14 @@ jobs:
           filters: .github/file-filters.yml
 
       - uses: volta-cli/action@v1
-        if: steps.changes.outputs.frontend == 'true'
 
       # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        if: steps.changes.outputs.frontend == 'true'
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        if: steps.changes.outputs.frontend == 'true'
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
@@ -50,13 +72,11 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install dependencies
-        if: steps.changes.outputs.frontend == 'true'
         run: yarn install --frozen-lockfile
 
       # Setup custom tsc matcher, see https://github.com/actions/setup-node/issues/97
       - name: setup matchers
         id: matchers
-        if: steps.changes.outputs.frontend == 'true'
         run: |
           echo "::remove-matcher owner=masters::"
           echo "::add-matcher::.github/tsc.json"
@@ -64,7 +84,7 @@ jobs:
 
       # Lint entire frontend if this is on main branch
       - name: eslint
-        if: github.ref == 'refs/heads/master' && steps.changes.outputs.frontend == 'true'
+        if: github.ref == 'refs/heads/master'
         run: |
           # Run relax config on main branch (and stricter config for changed files)
           yarn lint -c .eslintrc.relax.js
@@ -73,37 +93,37 @@ jobs:
       # Otherwise if it's not main branch, only lint modified files
       # Note `eslint --fix` will not fail when it auto fixes files
       - name: eslint (changed files only)
-        if: github.ref != 'refs/heads/master' && steps.changes.outputs.frontend == 'true'
+        if: github.ref != 'refs/heads/master'
         run: |
-          yarn eslint --fix ${{ steps.changes.outputs.frontend_modified_lintable_files }}
+          yarn eslint --fix ${{ needs.files-changed.outputs.frontend_modified_lintable_files }}
 
       - name: stylelint (changed files only)
-        if: github.ref != 'refs/heads/master' && steps.changes.outputs.frontend_components_modified_lintable == 'true'
+        if: github.ref != 'refs/heads/master' && needs.files-changed.outputs.frontend_components_modified_lintable == 'true'
         run: |
-          yarn stylelint ${{ steps.changes.outputs.frontend_components_modified_lintable_files }}
+          yarn stylelint ${{ needs.files-changed.outputs.frontend_components_modified_lintable_files }}
 
       # Check (and error) for dirty working tree for forks
       # Reason being we need a different token to auto commit changes and
       # forks do not have access to said token
       - name: Check for dirty git working tree (forks)
-        if: steps.token.outcome != 'success' && github.ref != 'refs/heads/master' && steps.changes.outputs.frontend == 'true'
+        if: steps.token.outcome != 'success' && github.ref != 'refs/heads/master'
         run: |
           git diff --quiet || (echo '::error ::lint produced file changes, run linter locally and try again' && exit 1)
 
       # If working tree is dirty, commit and update if we have a token
       - name: Commit any eslint fixed files
-        if: steps.token.outcome == 'success' && github.ref != 'refs/heads/master' && steps.changes.outputs.frontend == 'true'
+        if: steps.token.outcome == 'success' && github.ref != 'refs/heads/master'
         uses: getsentry/action-github-commit@main
         with:
           github-token: ${{ steps.token.outputs.token }}
 
       - name: tsc
-        if: always() && steps.changes.outputs.frontend == 'true'
+        if: always()
         run: |
           yarn tsc -p config/tsconfig.build.json
 
       - name: storybook
-        if: github.ref != 'refs/heads/master' && steps.changes.outputs.frontend == 'true'
+        if: github.ref != 'refs/heads/master'
         env:
           STORYBOOK_BUILD: 1
         run: |
@@ -111,28 +131,22 @@ jobs:
 
   webpack:
     runs-on: ubuntu-20.04
+    needs: files-changed
+    timeout-minutes: 10
+    if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: Check for frontend file changes
-        uses: getsentry/paths-filter@v2
-        id: changes
-        with:
-          token: ${{ github.token }}
-          filters: .github/file-filters.yml
-
       - uses: volta-cli/action@v1
-        if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
 
       # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock', 'api-docs/yarn.lock') }}
@@ -140,11 +154,9 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Install dependencies
-        if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
         run: yarn install --frozen-lockfile
 
       - uses: getsentry/size-limit-action@v3
-        if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
         env:
           SENTRY_INSTRUMENTATION: 1
           SENTRY_WEBPACK_WEBHOOK_SECRET: ${{ secrets.SENTRY_WEBPACK_WEBHOOK_SECRET }}

--- a/.github/workflows/js-build-and-lint.yml
+++ b/.github/workflows/js-build-and-lint.yml
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: files-changed
     timeout-minutes: 10
-    if: github.ref == 'refs/heads/master' || steps.changes.outputs.frontend == 'true'
+    if: github.ref == 'refs/heads/master' || needs.files-changed.outputs.frontend == 'true'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Changes js build and lint workflow to skip at the job level instead of each job
step.

This simplifies the workflow and more accurately reflects the status of
tests when frontend files change. See
https://github.com/getsentry/getsentry/issues/5196 for more details.

Related to https://github.com/getsentry/sentry/pull/24198