### PR TITLE
feat(inbox): Log exposure to inbox experiment

### DIFF
--- a/src/sentry/static/sentry/app/data/experimentConfig.tsx
+++ b/src/sentry/static/sentry/app/data/experimentConfig.tsx
@@ -25,6 +25,12 @@ export const experimentList = [
     parameter: 'exposed',
     assignments: [0, 1],
   },
+  {
+    key: 'InboxExperiment',
+    type: ExperimentType.Organization,
+    parameter: 'exposed',
+    assignments: [0, 1],
+  },
 ] as const;
 
 export const experimentConfig = experimentList.reduce(

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -44,7 +44,7 @@ import {
   TagCollection,
 } from 'app/types';
 import {defined} from 'app/utils';
-import {analytics, metric, trackAnalyticsEvent} from 'app/utils/analytics';
+import {analytics, logExperiment, metric, trackAnalyticsEvent} from 'app/utils/analytics';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import CursorPoller from 'app/utils/cursorPoller';
 import {getUtcDateString} from 'app/utils/dates';
@@ -178,6 +178,7 @@ class IssueListOverview extends React.Component<Props, State> {
     this.fetchSavedSearches();
     this.fetchTags();
     this.fetchMemberList();
+    this.logInboxExperiment();
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {
@@ -655,6 +656,14 @@ class IssueListOverview extends React.Component<Props, State> {
     const {orgId} = this.props.params;
 
     return `/organizations/${orgId}/issues-stats/`;
+  }
+
+  logInboxExperiment() {
+    const {organization} = this.props;
+    // Only log users in experiment
+    if ([0, 1].includes(organization.experiments?.InboxExperiment!)) {
+      logExperiment({organization, key: 'InboxExperiment'});
+    }
   }
 
   onRealtimeChange = (realtime: boolean) => {

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -10,6 +10,7 @@ import ErrorRobot from 'app/components/errorRobot';
 import StreamGroup from 'app/components/stream/group';
 import GroupStore from 'app/stores/groupStore';
 import TagStore from 'app/stores/tagStore';
+import {logExperiment} from 'app/utils/analytics';
 import * as parseLinkHeader from 'app/utils/parseLinkHeader';
 import IssueListWithStores, {IssueListOverview} from 'app/views/issueList/overview';
 
@@ -20,6 +21,7 @@ jest.mock('app/components/stream/group', () => jest.fn(() => null));
 jest.mock('app/views/issueList/noGroupsHandler/congratsRobots', () =>
   jest.fn(() => null)
 );
+jest.mock('app/utils/analytics');
 
 const DEFAULT_LINKS_HEADER =
   '<http://127.0.0.1:8000/api/0/organizations/org-slug/issues/?cursor=1443575731:0:1>; rel="previous"; results="false"; cursor="1443575731:0:1", ' +
@@ -1672,8 +1674,10 @@ describe('IssueList', function () {
     const parseLinkHeaderSpy = jest.spyOn(parseLinkHeader, 'default');
     it('renders inbox layout', function () {
       organization.features = ['inbox'];
+      organization.experiments = {InboxExperiment: 1};
       wrapper = mountWithTheme(<IssueListOverview {...props} />);
       expect(wrapper.find('IssueListHeader').exists()).toBeTruthy();
+      expect(logExperiment).toHaveBeenCalledTimes(1);
     });
 
     it('displays a count that represents the current page', function () {


### PR DESCRIPTION
On the issue stream, log inbox experiment for users that are exposed (to the experiment). Those users will have a 0 or 1. Others will have a -1.