### PR TITLE
feat(codeowners): Set CodeOwners APIs behind feature flags

### DIFF
--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -4,7 +4,9 @@ from django.utils import timezone
 
 from rest_framework import serializers, status
 from rest_framework.response import Response
+from rest_framework.exceptions import PermissionDenied
 
+from sentry import features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import (
@@ -149,7 +151,12 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
         return self.instance
 
 
-class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
+class ProjectCodeOwnersMixin:
+    def has_feature(self, request, project):
+        return features.has("projects:import-codeowners", project, actor=request.user)
+
+
+class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin, ProjectCodeOwnersMixin):
     def get(self, request, project):
         """
         Retrieve List of CODEOWNERS configurations for a project
@@ -159,6 +166,10 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
 
         :auth: required
         """
+
+        if not self.has_feature(request, project):
+            raise PermissionDenied
+
         codeowners = list(ProjectCodeOwners.objects.filter(project=project))
 
         return Response(serialize(codeowners, request.user), status.HTTP_200_OK)
@@ -174,6 +185,9 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin):
         :param string codeMappingId: id of the RepositoryProjectPathConfig object
         :auth: required
         """
+        if not self.has_feature(request, project):
+            raise PermissionDenied
+
         serializer = ProjectCodeOwnerSerializer(
             context={"ownership": self.get_ownership(project), "project": project},
             data={**request.data},

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -905,6 +905,10 @@ SENTRY_FEATURES = {
     "organizations:dashboards-edit": False,
     # Enable experimental performance improvements.
     "organizations:enterprise-perf": False,
+    # Enable the API to create/update/delete external team associations
+    "organizations:external-team-associations": False,
+    # Enable the API to create/update/delete external user associations
+    "organizations:external-user-associations": False,
     # Special feature flag primarily used on the sentry.io SAAS product for
     # easily enabling features while in early development.
     "organizations:internal-catchall": False,
@@ -972,10 +976,6 @@ SENTRY_FEATURES = {
     "organizations:images-loaded-v2": False,
     # Enable teams to have ownership of alert rules
     "organizations:team-alerts-ownership": False,
-    # Enable the API to create/update/delete external user associations
-    "organizations:external-user-associations": False,
-    # Enable the API to create/update/delete external team associations
-    "organizations:external-team-associations": False,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.
@@ -986,6 +986,8 @@ SENTRY_FEATURES = {
     "projects:discard-groups": False,
     # DEPRECATED: pending removal
     "projects:dsym": False,
+    # Enable the API to importing CODEOWNERS for a project
+    "projects:import-codeowners": False,
     # Enable selection of members, teams or code owners as email targets for issue alerts.
     "projects:issue-alerts-targeting": True,
     # Enable functionality for attaching  minidumps to events and displaying
@@ -1001,8 +1003,6 @@ SENTRY_FEATURES = {
     "projects:servicehooks": False,
     # Use Kafka (instead of Celery) for ingestion pipeline.
     "projects:kafka-ingest": False,
-    # Enable the API to importing CODEOWNERS for a project
-    "projects:import-codeowners": False,
     # Don't add feature defaults down here! Please add them in their associated
     # group sorted alphabetically.
 }

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -972,6 +972,10 @@ SENTRY_FEATURES = {
     "organizations:images-loaded-v2": False,
     # Enable teams to have ownership of alert rules
     "organizations:team-alerts-ownership": False,
+    # Enable the API to create/update/delete external user associations
+    "organizations:external-user-associations": False,
+    # Enable the API to create/update/delete external team associations
+    "organizations:external-team-associations": False,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.
@@ -997,6 +1001,8 @@ SENTRY_FEATURES = {
     "projects:servicehooks": False,
     # Use Kafka (instead of Celery) for ingestion pipeline.
     "projects:kafka-ingest": False,
+    # Enable the API to importing CODEOWNERS for a project
+    "projects:import-codeowners": False,
     # Don't add feature defaults down here! Please add them in their associated
     # group sorted alphabetically.
 }

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -68,6 +68,8 @@ default_manager.add("organizations:enterprise-perf", OrganizationFeature)  # NOQ
 default_manager.add("organizations:event-attachments", OrganizationFeature)  # NOQA
 default_manager.add("organizations:event-attachments-viewer", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events", OrganizationFeature)  # NOQA
+default_manager.add("organizations:external-team-associations", OrganizationFeature)  # NOQA
+default_manager.add("organizations:external-user-associations", OrganizationFeature)  # NOQA
 default_manager.add("organizations:filters-and-sampling", OrganizationFeature)  # NOQA
 default_manager.add("organizations:global-views", OrganizationFeature)  # NOQA
 default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
@@ -123,8 +125,6 @@ default_manager.add("organizations:performance-vitals-overview", OrganizationFea
 default_manager.add("organizations:performance-ops-breakdown", OrganizationFeature)  # NOQA
 default_manager.add("organizations:performance-tag-explorer", OrganizationFeature)  # NOQA
 default_manager.add("organizations:team-alerts-ownership", OrganizationFeature)  # NOQA
-default_manager.add("organizations:external-user-associations", OrganizationFeature)  # NOQA
-default_manager.add("organizations:external-team-associations", OrganizationFeature)  # NOQA
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.
 
@@ -133,6 +133,7 @@ default_manager.add("projects:alert-filters", ProjectFeature)  # NOQA
 default_manager.add("projects:custom-inbound-filters", ProjectFeature)  # NOQA
 default_manager.add("projects:data-forwarding", ProjectFeature)  # NOQA
 default_manager.add("projects:discard-groups", ProjectFeature)  # NOQA
+default_manager.add("projects:import-codeowners", ProjectFeature)  # NOQA
 default_manager.add("projects:issue-alerts-targeting", ProjectFeature)  # NOQA
 default_manager.add("projects:minidump", ProjectFeature)  # NOQA
 default_manager.add("projects:rate-limits", ProjectFeature)  # NOQA
@@ -142,7 +143,6 @@ default_manager.add("projects:similarity-view", ProjectFeature)  # NOQA
 default_manager.add("projects:similarity-indexing", ProjectFeature)  # NOQA
 default_manager.add("projects:similarity-view-v2", ProjectFeature)  # NOQA
 default_manager.add("projects:similarity-indexing-v2", ProjectFeature)  # NOQA
-default_manager.add("projects:import-codeowners", ProjectFeature)  # NOQA
 
 # Project plugin features
 default_manager.add("projects:plugins", ProjectPluginFeature)  # NOQA

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -123,7 +123,8 @@ default_manager.add("organizations:performance-vitals-overview", OrganizationFea
 default_manager.add("organizations:performance-ops-breakdown", OrganizationFeature)  # NOQA
 default_manager.add("organizations:performance-tag-explorer", OrganizationFeature)  # NOQA
 default_manager.add("organizations:team-alerts-ownership", OrganizationFeature)  # NOQA
-
+default_manager.add("organizations:external-user-associations", OrganizationFeature)  # NOQA
+default_manager.add("organizations:external-team-associations", OrganizationFeature)  # NOQA
 # NOTE: Don't add features down here! Add them to their specific group and sort
 #       them alphabetically! The order features are registered is not important.
 
@@ -141,6 +142,7 @@ default_manager.add("projects:similarity-view", ProjectFeature)  # NOQA
 default_manager.add("projects:similarity-indexing", ProjectFeature)  # NOQA
 default_manager.add("projects:similarity-view-v2", ProjectFeature)  # NOQA
 default_manager.add("projects:similarity-indexing-v2", ProjectFeature)  # NOQA
+default_manager.add("projects:import-codeowners", ProjectFeature)  # NOQA
 
 # Project plugin features
 default_manager.add("projects:plugins", ProjectPluginFeature)  # NOQA

--- a/tests/sentry/api/endpoints/test_external_team.py
+++ b/tests/sentry/api/endpoints/test_external_team.py
@@ -18,7 +18,8 @@ class ExternalTeamTest(APITestCase):
 
     def test_basic_post(self):
         data = {"externalName": "@getsentry/ecosystem", "provider": "github"}
-        response = self.client.post(self.url, data)
+        with self.feature({"organizations:external-team-associations": True}):
+            response = self.client.post(self.url, data)
         assert response.status_code == 201, response.content
         assert response.data == {
             "id": str(response.data["id"]),
@@ -26,19 +27,28 @@ class ExternalTeamTest(APITestCase):
             **data,
         }
 
+    def test_without_feature_flag(self):
+        data = {"externalName": "@getsentry/ecosystem", "provider": "github"}
+        response = self.client.post(self.url, data)
+        assert response.status_code == 403
+        assert response.data == {"detail": "You do not have permission to perform this action."}
+
     def test_missing_provider(self):
-        response = self.client.post(self.url, {"externalName": "@getsentry/ecosystem"})
+        with self.feature({"organizations:external-team-associations": True}):
+            response = self.client.post(self.url, {"externalName": "@getsentry/ecosystem"})
         assert response.status_code == 400
         assert response.data == {"provider": ["This field is required."]}
 
     def test_missing_externalName(self):
-        response = self.client.post(self.url, {"provider": "gitlab"})
+        with self.feature({"organizations:external-team-associations": True}):
+            response = self.client.post(self.url, {"provider": "gitlab"})
         assert response.status_code == 400
         assert response.data == {"externalName": ["This field is required."]}
 
     def test_invalid_provider(self):
         data = {"externalName": "@getsentry/ecosystem", "provider": "git"}
-        response = self.client.post(self.url, data)
+        with self.feature({"organizations:external-team-associations": True}):
+            response = self.client.post(self.url, data)
         assert response.status_code == 400
         assert response.data == {"provider": ['"git" is not a valid choice.']}
 
@@ -52,7 +62,8 @@ class ExternalTeamTest(APITestCase):
             "externalName": self.external_team.external_name,
             "provider": ExternalTeam.get_provider_string(self.external_team.provider),
         }
-        response = self.client.post(self.url, data)
+        with self.feature({"organizations:external-team-associations": True}):
+            response = self.client.post(self.url, data)
         assert response.status_code == 200
         assert response.data == {
             "id": str(self.external_team.id),

--- a/tests/sentry/api/endpoints/test_external_team_details.py
+++ b/tests/sentry/api/endpoints/test_external_team_details.py
@@ -20,17 +20,20 @@ class ExternalTeamDetailsTest(APITestCase):
         )
 
     def test_basic_delete(self):
-        resp = self.client.delete(self.url)
+        with self.feature({"organizations:external-team-associations": True}):
+            resp = self.client.delete(self.url)
         assert resp.status_code == 204
         assert not ExternalTeam.objects.filter(id=str(self.external_team.id)).exists()
 
     def test_basic_update(self):
-        resp = self.client.put(self.url, {"externalName": "@getsentry/growth"})
+        with self.feature({"organizations:external-team-associations": True}):
+            resp = self.client.put(self.url, {"externalName": "@getsentry/growth"})
         assert resp.status_code == 200
         assert resp.data["id"] == str(self.external_team.id)
         assert resp.data["externalName"] == "@getsentry/growth"
 
     def test_invalid_provider_update(self):
-        resp = self.client.put(self.url, {"provider": "git"})
+        with self.feature({"organizations:external-team-associations": True}):
+            resp = self.client.put(self.url, {"provider": "git"})
         assert resp.status_code == 400
         assert resp.data == {"provider": ['"git" is not a valid choice.']}

--- a/tests/sentry/api/endpoints/test_external_user.py
+++ b/tests/sentry/api/endpoints/test_external_user.py
@@ -20,7 +20,8 @@ class ExternalUserTest(APITestCase):
         }
 
     def test_basic_post(self):
-        response = self.client.post(self.url, self.data)
+        with self.feature({"organizations:external-user-associations": True}):
+            response = self.client.post(self.url, self.data)
         assert response.status_code == 201, response.content
         assert response.data == {
             **self.data,
@@ -28,27 +29,36 @@ class ExternalUserTest(APITestCase):
             "memberId": str(self.organization_member.id),
         }
 
+    def test_without_feature_flag(self):
+        response = self.client.post(self.url, self.data)
+        assert response.status_code == 403
+        assert response.data == {"detail": "You do not have permission to perform this action."}
+
     def test_missing_provider(self):
         self.data.pop("provider")
-        response = self.client.post(self.url, self.data)
+        with self.feature({"organizations:external-user-associations": True}):
+            response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"provider": ["This field is required."]}
 
     def test_missing_externalName(self):
         self.data.pop("externalName")
-        response = self.client.post(self.url, self.data)
+        with self.feature({"organizations:external-user-associations": True}):
+            response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"externalName": ["This field is required."]}
 
     def test_missing_memberId(self):
         self.data.pop("memberId")
-        response = self.client.post(self.url, self.data)
+        with self.feature({"organizations:external-user-associations": True}):
+            response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"memberId": ["This field is required."]}
 
     def test_invalid_provider(self):
         self.data.update(provider="unknown")
-        response = self.client.post(self.url, self.data)
+        with self.feature({"organizations:external-user-associations": True}):
+            response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"provider": ['"unknown" is not a valid choice.']}
 
@@ -57,7 +67,8 @@ class ExternalUserTest(APITestCase):
             self.user, self.organization, external_name=self.data["externalName"]
         )
 
-        response = self.client.post(self.url, self.data)
+        with self.feature({"organizations:external-user-associations": True}):
+            response = self.client.post(self.url, self.data)
         assert response.status_code == 200
         assert response.data == {
             **self.data,

--- a/tests/sentry/api/endpoints/test_external_user_details.py
+++ b/tests/sentry/api/endpoints/test_external_user_details.py
@@ -16,17 +16,20 @@ class ExternalUserDetailsTest(APITestCase):
         )
 
     def test_basic_delete(self):
-        resp = self.client.delete(self.url)
+        with self.feature({"organizations:external-user-associations": True}):
+            resp = self.client.delete(self.url)
         assert resp.status_code == 204
         assert not ExternalUser.objects.filter(id=str(self.external_user.id)).exists()
 
     def test_basic_update(self):
-        resp = self.client.put(self.url, {"externalName": "@new_username"})
+        with self.feature({"organizations:external-user-associations": True}):
+            resp = self.client.put(self.url, {"externalName": "@new_username"})
         assert resp.status_code == 200
         assert resp.data["id"] == str(self.external_user.id)
         assert resp.data["externalName"] == "@new_username"
 
     def test_invalid_provider_update(self):
-        resp = self.client.put(self.url, {"provider": "unknown"})
+        with self.feature({"organizations:external-user-associations": True}):
+            resp = self.client.put(self.url, {"provider": "unknown"})
         assert resp.status_code == 400
         assert resp.data == {"provider": ['"unknown" is not a valid choice.']}

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -36,7 +36,8 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         )
 
     def test_basic_delete(self):
-        response = self.client.delete(self.url)
+        with self.feature({"projects:import-codeowners": True}):
+            response = self.client.delete(self.url)
         assert response.status_code == 204
         assert not ProjectCodeOwners.objects.filter(id=str(self.codeowners.id)).exists()
 
@@ -46,7 +47,8 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         data = {
             "raw": "\n# cool stuff comment\n*.js                    @getsentry/frontend @NisanthanNanthakumar\n# good comment\n\n\n  docs/*  @getsentry/docs @getsentry/ecosystem\n\n"
         }
-        response = self.client.put(self.url, data)
+        with self.feature({"projects:import-codeowners": True}):
+            response = self.client.put(self.url, data)
         assert response.status_code == 200
         assert response.data["id"] == str(self.codeowners.id)
         assert response.data["raw"] == data["raw"].strip()
@@ -60,8 +62,8 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
                 "codeowners_id": 1000,
             },
         )
-
-        response = self.client.put(self.url, self.data)
+        with self.feature({"projects:import-codeowners": True}):
+            response = self.client.put(self.url, self.data)
         assert response.status_code == 404
         assert response.data == {"detail": "The requested resource does not exist"}
 
@@ -69,7 +71,8 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         data = {
             "raw": "\n# cool stuff comment\n*.js                    @getsentry/frontend @NisanthanNanthakumar\n# good comment\n\n\n  docs/*  @getsentry/docs @getsentry/ecosystem\nsrc/sentry/*       @AnotherUser\n\n"
         }
-        response = self.client.put(self.url, data)
+        with self.feature({"projects:import-codeowners": True}):
+            response = self.client.put(self.url, data)
         assert response.status_code == 400
         assert response.data == {
             "raw": [
@@ -78,12 +81,14 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         }
 
     def test_invalid_code_mapping_id_update(self):
-        response = self.client.put(self.url, {"codeMappingId": 500})
+        with self.feature({"projects:import-codeowners": True}):
+            response = self.client.put(self.url, {"codeMappingId": 500})
         assert response.status_code == 400
         assert response.data == {"codeMappingId": ["This code mapping does not exist."]}
 
     def test_codeowners_email_update(self):
         data = {"raw": f"\n# cool stuff comment\n*.js {self.user.email}\n# good comment\n\n\n"}
-        response = self.client.put(self.url, data)
+        with self.feature({"projects:import-codeowners": True}):
+            response = self.client.put(self.url, data)
         assert response.status_code == 200
         assert response.data["raw"] == "# cool stuff comment\n*.js admin@sentry.io\n# good comment"


### PR DESCRIPTION
## Objective:
We now have APIs for CodeOwners, External Teams and External Users. We want to put these APIs behind feature flags and release to early adopters.