### PR TITLE
feat(serverless): Added node14 support for Lambda Integration

### DIFF
--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -14,6 +14,7 @@ from sentry.tasks.release_registry import LAYER_INDEX_CACHE_KEY
 from sentry.utils.compat import filter, map
 
 SUPPORTED_RUNTIMES = [
+    "nodejs14.x",
     "nodejs12.x",
     "nodejs10.x",
     "python2.7",

--- a/tests/sentry/integrations/aws_lambda/test_utils.py
+++ b/tests/sentry/integrations/aws_lambda/test_utils.py
@@ -104,6 +104,7 @@ class GetSupportedFunctionsTest(TestCase):
                 "Functions": [
                     {"FunctionName": "lambdaC", "Runtime": "nodejs12.x"},
                     {"FunctionName": "lambdaD", "Runtime": "python3.6"},
+                    {"FunctionName": "lambdaE", "Runtime": "nodejs14.x"},
                 ]
             },
         ]
@@ -116,6 +117,7 @@ class GetSupportedFunctionsTest(TestCase):
         {"FunctionName": "lambdaB", "Runtime": "nodejs10.x"},
         {"FunctionName": "lambdaC", "Runtime": "nodejs12.x"},
         {"FunctionName": "lambdaD", "Runtime": "python3.6"},
+        {"FunctionName": "lambdaE", "Runtime": "nodejs14.x"},
     ]
 
     mock_client.get_paginator.assert_called_once_with("list_functions")


### PR DESCRIPTION
This PR adds support for `node14js.x` runtime support for AWS Lambda Integration 