### PR TITLE
fix(ci): Clone repo with higher depth to fix codecov problems

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -25,6 +25,11 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout sentry
 
+        with:
+          # Avoid codecov error message related to SHA resolution:
+          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
+          fetch-depth: '2'
+
       - uses: volta-cli/action@v1
 
       # See https://github.com/actions/cache/blob/master/examples.md#node---yarn for example

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+        with:
+          # Avoid codecov error message related to SHA resolution:
+          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
+          fetch-depth: '2'
+
       # If we make these jobs "required" to merge on GH, then on every PR, GitHub automatically
       # creates a status check in the "pending" state. This means that the workflow needs to run
       # for every PR in order to update the status checks.

--- a/.github/workflows/relay-integration-test.yml
+++ b/.github/workflows/relay-integration-test.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+        with:
+          # Avoid codecov error message related to SHA resolution:
+          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
+          fetch-depth: '2'
+
       - name: Check for python file changes
         uses: getsentry/paths-filter@v2
         id: changes

--- a/.github/workflows/snuba-integration-test.yml
+++ b/.github/workflows/snuba-integration-test.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+        with:
+          # Avoid codecov error message related to SHA resolution:
+          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
+          fetch-depth: '2'
+
       # If we make these jobs "required" to merge on GH, then on every PR, GitHub automatically
       # creates a status check in the "pending" state. This means that the workflow needs to run
       # for every PR in order to update the status checks.

--- a/.github/workflows/symbolicator-integration-test.yml
+++ b/.github/workflows/symbolicator-integration-test.yml
@@ -14,6 +14,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+        with:
+          # Avoid codecov error message related to SHA resolution:
+          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
+          fetch-depth: '2'
+
       - name: Check for python file changes
         uses: getsentry/paths-filter@v2
         id: changes


### PR DESCRIPTION
I have had a problem where Codecov either shows too much difference
between my PR and master, or no diff at all. Both states have happened
within the same PR as Codecov processed new webhooks from GitHub, and in
both cases merge commits were involved. With Codecov support I have
found that their uploader throws this particular error message, and
so let's try giving the uploader more commits so maybe next time it
determines the parent commits correctly (?).

In case the actual code diff is wrong, this also has dramatic impact on code coverage, of course. Because you suddenly have uncovered lines in your PR that you didn't touch in the first place.