### PR TITLE
Revert "build(ci): Skip backend test job instead of each step (#24198)"

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -7,38 +7,10 @@ on:
   pull_request:
 
 jobs:
-  # If we make these jobs "required" to merge on GH, then on every PR, GitHub automatically
-  # creates a status check in the "pending" state. This means that the workflow needs to run
-  # for every PR in order to update the status checks.
-  #
-  # In order to optimize CI usage, we want the tests to only run when python files change,
-  # since frontend changes should have no effect on these test suites. We cannot use GH workflow
-  # path filters because entire workflow would be skipped vs skipping individual jobs which
-  # would still allow this status check to pass.
-  files-changed:
-    name: check backend files changed
-    runs-on: ubuntu-20.04
-    timeout-minutes: 5
-
-    outputs:
-      backend: ${{ steps.changes.outputs.backend }}
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Check for python file changes
-        uses: getsentry/paths-filter@v2
-        id: changes
-        with:
-          token: ${{ github.token }}
-          filters: .github/file-filters.yml
-
   test:
     name: backend test
-    needs: files-changed
     runs-on: ubuntu-20.04
-    timeout-minutes: 20
-    if: needs.files-changed.outputs.backend == 'true'
-
+    timeout-minutes: 30
     strategy:
       matrix:
         instance: [0, 1]
@@ -71,20 +43,24 @@ jobs:
 
       - name: Set python version output
         id: python-version
+        if: steps.changes.outputs.backend == 'true'
         run: |
           echo "::set-output name=python-version::$(cat .python-version)"
 
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
+        if: steps.changes.outputs.backend == 'true'
         with:
           python-version: ${{ steps.python-version.outputs.python-version }}
 
       - name: Setup pip
         uses: ./.github/actions/setup-pip
+        if: steps.changes.outputs.backend == 'true'
         id: pip
 
       - name: pip cache
         uses: actions/cache@v2
+        if: steps.changes.outputs.backend == 'true'
         with:
           path: ${{ steps.pip.outputs.pip-cache-dir }}
           key: ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ hashFiles('**/requirements-*.txt') }}
@@ -93,11 +69,13 @@ jobs:
 
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
+        if: steps.changes.outputs.backend == 'true'
         id: setup
         with:
           snuba: true
 
       - name: Run backend test (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
+        if: steps.changes.outputs.backend == 'true'
         run: |
           # Note: `USE_SNUBA` is not used for backend tests because there are a few failing tests with Snuba enabled.
           unset USE_SNUBA


### PR DESCRIPTION
This reverts commit d8c003f823330e46335fb66856bfa6cdb65a7bab.

This doesn't work because of a bug in GH runners: https://github.com/actions/runner/issues/952

Because the backend test has 2 matrix instances, when the job is
skipped, it does not create the needed Checks to satisfy our branch
protection requirements