### PR TITLE
fix(ui): Display loading indicator longer for sample event

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/createSampleEventButton.tsx
+++ b/src/sentry/static/sentry/app/views/onboarding/createSampleEventButton.tsx
@@ -102,7 +102,9 @@ class CreateSampleEventButton extends React.Component<Props, State> {
       return;
     }
 
-    addLoadingMessage(t('Processing sample event...'));
+    addLoadingMessage(t('Processing sample event...'), {
+      duration: EVENT_POLL_RETRIES * EVENT_POLL_INTERVAL,
+    });
     this.setState({creating: true});
 
     try {
@@ -114,6 +116,7 @@ class CreateSampleEventButton extends React.Component<Props, State> {
         Sentry.captureException(new Error('Failed to create sample event'));
       });
       this.setState({creating: false});
+      clearIndicators();
       addErrorMessage(t('Failed to create a new sample event'));
       return;
     }


### PR DESCRIPTION
Loading indicator sometimes disappears before event has finished loading.