### PR TITLE
cleanup: Remove global selection logic for discover 1

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/globalSelection.tsx
@@ -58,13 +58,13 @@ type DateTimeObject = {
 /**
  * Cast project ids to strings, as everything is assumed to be a string in URL params
  *
- * Discover v1 uses a different interface, and passes slightly different datatypes e.g. Date for dates
+ * We also handle internal types so Dates and booleans can show up in the start/end/utc
+ * keys. Long term it would be good to narrow down these types.
  */
 type UrlParams = {
   project?: ProjectId[] | null;
   environment?: EnvironmentId[] | null;
 } & DateTimeObject & {
-    // TODO(discoverv1): This can be back to `ParamValue` when we remove Discover
     [others: string]: any;
   };
 

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/globalSelectionHeader.tsx
@@ -22,13 +22,7 @@ import {IconArrow} from 'app/icons';
 import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
 import space from 'app/styles/space';
-import {
-  Environment,
-  GlobalSelection,
-  MinimalProject,
-  Organization,
-  Project,
-} from 'app/types';
+import {GlobalSelection, MinimalProject, Organization, Project} from 'app/types';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import Projects from 'app/utils/projects';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
@@ -38,11 +32,6 @@ import Header from './header';
 const PROJECTS_PER_PAGE = 50;
 
 const defaultProps = {
-  /**
-   * Disable automatic routing
-   */
-  hasCustomRouting: false,
-
   /**
    * Display Environment selector?
    */
@@ -66,7 +55,7 @@ const defaultProps = {
 };
 
 type Props = {
-  children?: React.ReactNode; // TODO(discoverv1): This should be required when discoverv1 is removed
+  children: React.ReactNode;
   organization: Organization;
 
   memberProjects: Project[];
@@ -136,8 +125,8 @@ type Props = {
   // Callbacks //
   onChangeProjects?: (val: number[]) => void;
   onUpdateProjects?: (selectedProjects: number[]) => void;
-  onChangeEnvironments?: (environments: Environment[]) => void;
-  onUpdateEnvironments?: (environments: Environment[]) => void;
+  onChangeEnvironments?: (environments: string[]) => void;
+  onUpdateEnvironments?: (environments: string[]) => void;
   onChangeTime?: (datetime: any) => void;
   onUpdateTime?: (datetime: any) => void;
 
@@ -169,14 +158,14 @@ type Props = {
 
 type State = {
   projects: number[] | null;
-  environments: Environment[] | null;
+  environments: string[] | null;
   searchQuery: string;
 };
 
 class GlobalSelectionHeader extends React.Component<Props, State> {
   static defaultProps = defaultProps;
 
-  state = {
+  state: State = {
     projects: null,
     environments: null,
     searchQuery: '',
@@ -185,26 +174,20 @@ class GlobalSelectionHeader extends React.Component<Props, State> {
   hasMultipleProjectSelection = () =>
     new Set(this.props.organization.features).has('global-views');
 
-  // Returns `router` from props if `hasCustomRouting` property is false
-  getRouter = () => (!this.props.hasCustomRouting ? this.props.router : null);
-
   // Returns an options object for `update*` actions
-  getUpdateOptions = () =>
-    !this.props.hasCustomRouting
-      ? {
-          save: true,
-          resetParams: this.props.resetParamsOnChange,
-        }
-      : {};
+  getUpdateOptions = () => ({
+    save: true,
+    resetParams: this.props.resetParamsOnChange,
+  });
 
-  handleChangeProjects = projects => {
+  handleChangeProjects = (projects: State['projects']) => {
     this.setState({
       projects,
     });
     callIfFunction(this.props.onChangeProjects, projects);
   };
 
-  handleChangeEnvironments = environments => {
+  handleChangeEnvironments = (environments: State['environments']) => {
     this.setState({
       environments,
     });
@@ -228,13 +211,13 @@ class GlobalSelectionHeader extends React.Component<Props, State> {
       utc,
     };
 
-    updateDateTime(newValueObj, this.getRouter(), this.getUpdateOptions());
+    updateDateTime(newValueObj, this.props.router, this.getUpdateOptions());
     callIfFunction(this.props.onUpdateTime, newValueObj);
   };
 
   handleUpdateEnvironmments = () => {
     const {environments} = this.state;
-    updateEnvironments(environments, this.getRouter(), this.getUpdateOptions());
+    updateEnvironments(environments, this.props.router, this.getUpdateOptions());
     this.setState({environments: null});
     callIfFunction(this.props.onUpdateEnvironments, environments);
   };
@@ -243,7 +226,7 @@ class GlobalSelectionHeader extends React.Component<Props, State> {
     const {projects} = this.state;
 
     // Clear environments when switching projects
-    updateProjects(projects || [], this.getRouter(), {
+    updateProjects(projects || [], this.props.router, {
       ...this.getUpdateOptions(),
       environments: [],
     });

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/index.tsx
@@ -18,13 +18,6 @@ type GlobalSelectionHeaderProps = Omit<
 type Props = {
   organization: Organization;
   projects: Project[];
-
-  /**
-   * If this is true, do not attempt to control routing. This is only used in discover v1
-   *
-   * TODO(discoverv1): Removeme
-   */
-  hasCustomRouting?: boolean;
 } & ReactRouter.WithRouterProps &
   GlobalSelectionHeaderProps &
   Partial<
@@ -60,7 +53,6 @@ class GlobalSelectionHeaderContainer extends React.Component<Props> {
       defaultSelection,
       forceProject,
       shouldForceProject,
-      hasCustomRouting,
       skipLoadLastUsed,
       showAbsolute,
       ...props
@@ -79,9 +71,8 @@ class GlobalSelectionHeaderContainer extends React.Component<Props> {
             organization={organization}
             defaultSelection={defaultSelection}
             forceProject={forceProject}
-            isDisabled={!!hasCustomRouting}
             shouldForceProject={!!shouldForceProject}
-            shouldEnforceSingleProject={!hasCustomRouting && enforceSingleProject}
+            shouldEnforceSingleProject={enforceSingleProject}
             memberProjects={memberProjects}
             showAbsolute={showAbsolute}
           />
@@ -91,7 +82,7 @@ class GlobalSelectionHeaderContainer extends React.Component<Props> {
           loadingProjects={loadingProjects}
           location={location}
           organization={organization}
-          router={!hasCustomRouting ? router : null}
+          router={router}
           routes={routes}
           shouldForceProject={!!shouldForceProject}
           defaultSelection={defaultSelection}

--- a/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/initializeGlobalSelectionHeader.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/globalSelectionHeader/initializeGlobalSelectionHeader.tsx
@@ -19,7 +19,6 @@ const getDateObjectFromQuery = query =>
   );
 
 type Props = {
-  isDisabled: boolean;
   shouldEnforceSingleProject: boolean;
   /**
    * Skip loading from local storage


### PR DESCRIPTION
Discover 1 helped introduce the global selection header but it also had some quirky behavior and required custom affordances that we don't use anywhere else. With discover 1 gone we don't need this code anymore either.