### PR TITLE
ref(perf): Add experimental endpoint for performance facets

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -24,6 +24,7 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsV2EndpointBa
             return Response([])
 
         aggregate_column = request.GET.get("aggregateColumn", "duration")
+        orderby = request.GET.getlist("order", None)
 
         with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
             with self.handle_query_errors():
@@ -32,6 +33,7 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsV2EndpointBa
                     params=params,
                     referrer="api.organization-events-facets-performance.top-tags",
                     aggregate_column=aggregate_column,
+                    orderby=orderby,
                 )
 
         with sentry_sdk.start_span(op="discover.endpoint", description="populate_results") as span:

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -1,0 +1,50 @@
+import sentry_sdk
+
+from collections import defaultdict
+from rest_framework.response import Response
+
+from sentry.api.bases import OrganizationEventsV2EndpointBase, NoProjects
+from sentry.snuba import discover
+from sentry import features, tagstore
+
+
+class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsV2EndpointBase):
+    def has_feature(self, organization, request):
+        return features.has(
+            "organizations:performance-tag-explorer", organization, actor=request.user
+        )
+
+    def get(self, request, organization):
+        if not self.has_feature(organization, request):
+            return Response(status=404)
+
+        try:
+            params = self.get_snuba_params(request, organization)
+        except NoProjects:
+            return Response([])
+
+        aggregate_column = request.GET.get("aggregateColumn", "duration")
+
+        with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
+            with self.handle_query_errors():
+                facets = discover.get_performance_facets(
+                    query=request.GET.get("query"),
+                    params=params,
+                    referrer="api.organization-events-facets-performance.top-tags",
+                    aggregate_column=aggregate_column,
+                )
+
+        with sentry_sdk.start_span(op="discover.endpoint", description="populate_results") as span:
+            span.set_data("facet_count", len(facets or []))
+            resp = defaultdict(lambda: {"key": "", "topValues": []})
+            for row in facets:
+                values = resp[row.key]
+                values["key"] = tagstore.get_standardized_key(row.key)
+                values["topValues"].append(
+                    {
+                        "name": tagstore.get_tag_value_label(row.key, row.value),
+                        "value": row.value,
+                        f"avg_{aggregate_column}": row.count,
+                    }
+                )
+        return Response(list(resp.values()))

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -101,6 +101,9 @@ from .endpoints.organization_events import (
 )
 from .endpoints.organization_events_histogram import OrganizationEventsHistogramEndpoint
 from .endpoints.organization_events_facets import OrganizationEventsFacetsEndpoint
+from .endpoints.organization_events_facets_performance import (
+    OrganizationEventsFacetsPerformanceEndpoint,
+)
 from .endpoints.organization_events_meta import (
     OrganizationEventsMetaEndpoint,
     OrganizationEventBaseline,
@@ -895,6 +898,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/events-facets/$",
                     OrganizationEventsFacetsEndpoint.as_view(),
                     name="sentry-api-0-organization-events-facets",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/events-facets-performance/$",
+                    OrganizationEventsFacetsPerformanceEndpoint.as_view(),
+                    name="sentry-api-0-organization-events-facets-performance",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/events-meta/$",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -261,6 +261,9 @@ register("discover2.max_tags_to_combine", default=3, flags=FLAG_PRIORITIZE_DISK)
 # Enables setting a sampling rate when producing the tag facet.
 register("discover2.tags_facet_enable_sampling", default=True, flags=FLAG_PRIORITIZE_DISK)
 
+# Enables setting a sampling rate when producing the tag facet.
+register("discover2.tags_performance_facet_sample_rate", default=0.1)
+
 # Killswitch for datascrubbing after stacktrace processing. Set to False to
 # disable datascrubbers.
 register("processing.can-use-scrubbers", default=True)

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -736,7 +736,13 @@ def get_facets(query, params, limit=10, referrer=None):
 
 
 def get_performance_facets(
-    query, params, aggregate_column="duration", aggregate_function="avg", limit=20, referrer=None
+    query,
+    params,
+    orderby=None,
+    aggregate_column="duration",
+    aggregate_function="avg",
+    limit=20,
+    referrer=None,
 ):
     """
     High-level API for getting 'facet map' results for performance data
@@ -802,6 +808,9 @@ def get_performance_facets(
         if i >= len(top_tags) - max_aggregate_tags:
             aggregate_tags.append(tag)
 
+    if orderby is None:
+        orderby = []
+
     if aggregate_tags:
         with sentry_sdk.start_span(op="discover.discover", description="facets.aggregate_tags"):
             conditions = snuba_filter.conditions
@@ -812,7 +821,7 @@ def get_performance_facets(
                 start=snuba_filter.start,
                 end=snuba_filter.end,
                 filter_keys=snuba_filter.filter_keys,
-                orderby=["tags_key"],
+                orderby=orderby + ["tags_key"],
                 groupby=["tags_key", "tags_value"],
                 dataset=Dataset.Discover,
                 referrer=referrer,

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -769,7 +769,7 @@ def get_performance_facets(
     sample = len(snuba_filter.filter_keys["project_id"]) > 2
 
     with sentry_sdk.start_span(op="discover.discover", description="facets.frequent_tags"):
-        # Get the most frequent tag keys
+        # Get the tag keys with the highest deviation
         key_names = raw_query(
             aggregations=[["stddevSamp", aggregate_column, "stddev"]],
             start=snuba_filter.start,
@@ -778,6 +778,7 @@ def get_performance_facets(
             filter_keys=snuba_filter.filter_keys,
             orderby=["-stddev", "tags_key"],
             groupby="tags_key",
+            # TODO(Kevan): Check using having vs where before mainlining
             having=[excluded_tags],
             dataset=Dataset.Discover,
             limit=limit,

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -693,14 +693,19 @@ class SnubaTestCase(BaseTestCase):
         # While snuba is synchronous, clickhouse isn't entirely synchronous.
         attempt = 0
         snuba_filter = eventstore.Filter(project_ids=[project_id])
+        last_events_seen = 0
+
         while attempt < attempts:
             events = eventstore.get_events(snuba_filter)
+            last_events_seen = len(events)
             if len(events) >= total:
                 break
             attempt += 1
             time.sleep(0.05)
         if attempt == attempts:
-            assert False, f"Could not ensure event was persisted within {attempt} attempt(s)"
+            assert (
+                False
+            ), f"Could not ensure that {total} event(s) were persisted within {attempt} attempt(s). Event count is instead currently {last_events_seen}."
 
     def store_session(self, session):
         assert (

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -2551,7 +2551,9 @@ class GetPerformanceFacetsTest(SnubaTestCase, TestCase):
         self.two_mins_ago = before_now(minutes=2)
         self._transaction_count = 0
 
-    def store_transaction(self, name="exampleTransaction", duration=100, tags={}):
+    def store_transaction(self, name="exampleTransaction", duration=100, tags=None):
+        if tags is None:
+            tags = {}
         event = load_data("transaction")
         event.update(
             {


### PR DESCRIPTION
### Summary
This is an experimental endpoint to test performance and usability of finding tag values that have an impact on performance. Trying out a sampled stddev instead of count to find tags that have high variability within them in the first place (although might need a count constraint too, but we can try this for now). Added a few simple tests just to make sure happy path won't error in prod.

#### Other
- Have a pattern semi in-place for potentially allowing other functions and columns for facets, just doing it with avg for now because it's simple
- Just set a static 0.1 sample rate to make sure calls don't take too long, we can adjust this with count for a more dynamic sample rate based off of population size later for better accuracy / performance tradeoff.
- We can fix up how it's serialized later once we find out what kind of performance we are getting with a large dataset.