### PR TITLE
feat(demo): adds Modal to SentryApp globals

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -201,6 +201,7 @@ globals.SentryApp = {
   Indicators: require('app/components/indicators').default,
   SetupWizard: require('app/components/setupWizard').default,
   HookStore: require('app/stores/hookStore').default,
+  Modal: require('app/actionCreators/modal'),
 };
 
 // Make globals available on the window object


### PR DESCRIPTION
This adds the exports of `app/actionCreators/modal` as `window.SentryApp.Modal` so we can open a modal in the demo using the external assets we inject. 