### PR TITLE
feat(snuba): Add ability to cache snuba responses for a period of time.

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1211,7 +1211,7 @@ SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE = "90%"
 # Snuba configuration
 SENTRY_SNUBA = os.environ.get("SNUBA", "http://127.0.0.1:1218")
 SENTRY_SNUBA_TIMEOUT = 30
-SENTRY_SNUBA_CACHE_TTL_SECONDS = 10
+SENTRY_SNUBA_CACHE_TTL_SECONDS = 60
 
 # Node storage backend
 SENTRY_NODESTORE = "sentry.nodestore.django.DjangoNodeStorage"

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1211,6 +1211,7 @@ SENTRY_DEFAULT_MAX_EVENTS_PER_MINUTE = "90%"
 # Snuba configuration
 SENTRY_SNUBA = os.environ.get("SNUBA", "http://127.0.0.1:1218")
 SENTRY_SNUBA_TIMEOUT = 30
+SENTRY_SNUBA_CACHE_TTL_SECONDS = 10
 
 # Node storage backend
 SENTRY_NODESTORE = "sentry.nodestore.django.DjangoNodeStorage"

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -2,6 +2,9 @@ from collections import namedtuple, OrderedDict
 from copy import deepcopy
 from contextlib import contextmanager
 from datetime import datetime, timedelta
+from hashlib import sha1
+from operator import itemgetter
+
 from dateutil.parser import parse as parse_datetime
 import logging
 import functools
@@ -15,6 +18,7 @@ from sentry_sdk import Hub
 
 from concurrent.futures import ThreadPoolExecutor
 from django.conf import settings
+from django.core.cache import cache
 from urllib.parse import urlparse
 
 from sentry.models import (
@@ -612,6 +616,7 @@ def raw_query(
     rollup=None,
     referrer=None,
     is_grouprelease=False,
+    use_cache=False,
     **kwargs,
 ):
     """
@@ -630,38 +635,50 @@ def raw_query(
         is_grouprelease=is_grouprelease,
         **kwargs,
     )
-    return bulk_raw_query([snuba_params], referrer=referrer)[0]
+    return bulk_raw_query([snuba_params], referrer=referrer, use_cache=use_cache)[0]
 
 
-def bulk_raw_query(snuba_param_list, referrer=None):
+def bulk_raw_query(snuba_param_list, referrer=None, use_cache=False):
     headers = {}
     if referrer:
         headers["referer"] = referrer
 
-    query_param_list = map(_prepare_query_params, snuba_param_list)
+    # Store the original position of the query so that we can maintain the order
+    query_param_list = list(enumerate(map(_prepare_query_params, snuba_param_list)))
 
-    def snuba_query(params):
-        query_params, forward, reverse, thread_hub = params
-        try:
-            with timer("snuba_query"):
-                referrer = headers.get("referer", "<unknown>")
-                if SNUBA_INFO:
-                    # We want debug in the body, but not in the logger, so dump the json twice
-                    logger.info(f"{referrer}.body: {json.dumps(query_params)}")
-                    query_params["debug"] = True
-                body = json.dumps(query_params)
-                with thread_hub.start_span(op="snuba", description=f"query {referrer}") as span:
-                    span.set_tag("referrer", referrer)
-                    for param_key, param_data in query_params.items():
-                        span.set_data(param_key, param_data)
-                    return (
-                        _snuba_pool.urlopen("POST", "/query", body=body, headers=headers),
-                        forward,
-                        reverse,
-                    )
-        except urllib3.exceptions.HTTPError as err:
-            raise SnubaError(err)
+    results = []
 
+    if use_cache:
+        # sqc - Snuba Query Cache
+        cache_keys = [
+            f"sqc:{sha1(json.dumps(query_params[0], sort_keys=True).encode('utf-8')).hexdigest()}"
+            for _, query_params in query_param_list
+        ]
+        cache_data = cache.get_many(cache_keys)
+        to_query = []
+        for (query_pos, query_params), cache_key in zip(query_param_list, cache_keys):
+            cached_result = cache_data.get(cache_key)
+            if cached_result is None:
+                to_query.append((query_pos, query_params, cache_key))
+            else:
+                results.append((query_pos, json.loads(cached_result)))
+    else:
+        to_query = [(query_pos, query_params, None) for query_pos, query_params in query_param_list]
+
+    if to_query:
+        query_results = _bulk_snuba_query(map(itemgetter(1), to_query), headers)
+        for result, (query_pos, _, cache_key) in zip(query_results, to_query):
+            if cache_key:
+                cache.set(cache_key, json.dumps(result), settings.SENTRY_SNUBA_CACHE_TTL_SECONDS)
+            results.append((query_pos, result))
+
+    # Sort so that we get the results back in the original param list order
+    results.sort()
+    # Drop the sort order val
+    return map(itemgetter(1), results)
+
+
+def _bulk_snuba_query(snuba_param_list, headers):
     with sentry_sdk.start_span(
         op="start_snuba_query",
         description=f"running {len(snuba_param_list)} snuba queries",
@@ -670,13 +687,14 @@ def bulk_raw_query(snuba_param_list, referrer=None):
         if len(snuba_param_list) > 1:
             query_results = list(
                 _query_thread_pool.map(
-                    snuba_query, [params + (Hub(Hub.current),) for params in query_param_list]
+                    _snuba_query,
+                    [params + (Hub(Hub.current), headers) for params in snuba_param_list],
                 )
             )
         else:
             # No need to submit to the thread pool if we're just performing a
             # single query
-            query_results = [snuba_query(query_param_list[0] + (Hub(Hub.current),))]
+            query_results = [_snuba_query(snuba_param_list[0] + (Hub(Hub.current), headers))]
 
     results = []
     for response, _, reverse in query_results:
@@ -720,6 +738,29 @@ def bulk_raw_query(snuba_param_list, referrer=None):
     return results
 
 
+def _snuba_query(params):
+    query_params, forward, reverse, thread_hub, headers = params
+    try:
+        with timer("snuba_query"):
+            referrer = headers.get("referer", "<unknown>")
+            if SNUBA_INFO:
+                # We want debug in the body, but not in the logger, so dump the json twice
+                logger.info(f"{referrer}.body: {json.dumps(query_params)}")
+                query_params["debug"] = True
+            body = json.dumps(query_params)
+            with thread_hub.start_span(op="snuba", description=f"query {referrer}") as span:
+                span.set_tag("referrer", referrer)
+                for param_key, param_data in query_params.items():
+                    span.set_data(param_key, param_data)
+                return (
+                    _snuba_pool.urlopen("POST", "/query", body=body, headers=headers),
+                    forward,
+                    reverse,
+                )
+    except urllib3.exceptions.HTTPError as err:
+        raise SnubaError(err)
+
+
 def query(
     dataset=None,
     start=None,
@@ -730,6 +771,7 @@ def query(
     aggregations=None,
     selected_columns=None,
     totals=None,
+    use_cache=False,
     **kwargs,
 ):
 
@@ -749,6 +791,7 @@ def query(
             aggregations=aggregations,
             selected_columns=selected_columns,
             totals=totals,
+            use_cache=use_cache,
             **kwargs,
         )
     except (QueryOutsideRetentionError, QueryOutsideGroupActivityError):

--- a/tests/snuba/test_snuba.py
+++ b/tests/snuba/test_snuba.py
@@ -1,3 +1,5 @@
+import copy
+from unittest import mock
 from datetime import datetime, timedelta
 
 import pytest
@@ -142,3 +144,56 @@ class BulkRawQueryTest(TestCase, SnubaTestCase):
             {"issue": event_1.group.id, "event_id": event_1.event_id},
             {"issue": event_2.group.id, "event_id": event_2.event_id},
         ]
+
+    @mock.patch("sentry.utils.snuba._bulk_snuba_query", side_effect=snuba._bulk_snuba_query)
+    def test_cache(self, _bulk_snuba_query):
+        one_min_ago = iso_format(before_now(minutes=1))
+        event_1 = self.store_event(
+            data={"fingerprint": ["group-1"], "message": "hello", "timestamp": one_min_ago},
+            project_id=self.project.id,
+        )
+        event_2 = self.store_event(
+            data={"fingerprint": ["group-2"], "message": "hello", "timestamp": one_min_ago},
+            project_id=self.project.id,
+        )
+        params = [
+            snuba.SnubaQueryParams(
+                start=timezone.now() - timedelta(days=1),
+                end=timezone.now(),
+                selected_columns=["event_id", "group_id", "timestamp"],
+                filter_keys={"project_id": [self.project.id], "group_id": [event_1.group.id]},
+            ),
+            snuba.SnubaQueryParams(
+                start=timezone.now() - timedelta(days=1),
+                end=timezone.now(),
+                selected_columns=["event_id", "group_id", "timestamp"],
+                filter_keys={"project_id": [self.project.id], "group_id": [event_2.group.id]},
+            ),
+        ]
+
+        results = snuba.bulk_raw_query(
+            copy.deepcopy(params),
+            use_cache=True,
+        )
+        assert [
+            {"issue": r["data"][0]["group_id"], "event_id": r["data"][0]["event_id"]}
+            for r in results
+        ] == [
+            {"issue": event_1.group.id, "event_id": event_1.event_id},
+            {"issue": event_2.group.id, "event_id": event_2.event_id},
+        ]
+        assert _bulk_snuba_query.call_count == 1
+        _bulk_snuba_query.reset_mock()
+
+        results = snuba.bulk_raw_query(
+            copy.deepcopy(params),
+            use_cache=True,
+        )
+        assert [
+            {"issue": r["data"][0]["group_id"], "event_id": r["data"][0]["event_id"]}
+            for r in results
+        ] == [
+            {"issue": event_1.group.id, "event_id": event_1.event_id},
+            {"issue": event_2.group.id, "event_id": event_2.event_id},
+        ]
+        assert _bulk_snuba_query.call_count == 0


### PR DESCRIPTION
To prevent us hammering Snuba with a lot of duplicate queries we want to have an option to cache
responses for a short period of time. This is primarily intended for use with issue alert conditions
`EventFrequencyCondition` and `EventUniqueUserFrequencyCondition`, but I could see us potentially
turning this on system wide.

This should have no real impact on customers, since there is already a read-through cache in Snuba
for preventing duplicate queries to Clickhouse. The main reason for this cache is to prevent causing
excess CPU usage on Snuba.