### PR TITLE
feat: Add killswitch for race free group creation

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -280,3 +280,5 @@ register("store.nodestore-stats-sample-rate", default=0.0)  # unused
 
 # Killswitch to stop storing any reprocessing payloads.
 register("store.reprocessing-force-disable", default=False)
+
+register("store.race-free-group-creation-force-disable", default=False)


### PR DESCRIPTION
addition to #23577 before we turn it on for high-volume projects. we'll test with test projects first anyway

first we need to register the option, in the next deploy we can actually use the option