### PR TITLE
fix(migrations): Fix backfill_file_type_on_event_attachement

### DIFF
--- a/src/sentry/migrations/0101_backfill_file_type_on_event_attachment.py
+++ b/src/sentry/migrations/0101_backfill_file_type_on_event_attachment.py
@@ -18,7 +18,7 @@ def backfill_file_type(apps, schema_editor):
     all_event_attachments = EventAttachment.objects.all()
     for event_attachment in RangeQuerySetWrapper(all_event_attachments, step=1000):
         if event_attachment.type is None:
-            file = File.objects.get(event_attachment.file_id)
+            file = File.objects.get(id=event_attachment.file_id)
             event_attachment.type = file.type
             event_attachment.save(update_fields=["type"])
 


### PR DESCRIPTION
[Django `Model.get()` always expects `kwargs`](https://docs.djangoproject.com/en/1.11/ref/models/querysets/#django.db.models.query.QuerySet.get) and in this migration, we simply passed the `id` as a bare argument. This PR fixes the issue my explicitly naming the argument as `id`.
