### PR TITLE
(contexts): Add duration between timestamp and event time to known context data

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contexts/app/app.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/app/app.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import ContextBlock from 'app/components/events/contexts/contextBlock';
+import {Event} from 'app/types/event';
 
 import getUnknownData from '../getUnknownData';
 
@@ -9,6 +10,7 @@ import {AppData, AppKnownDataType} from './types';
 
 type Props = {
   data: AppData;
+  event: Event;
 };
 
 const appKnownDataValues = [
@@ -23,9 +25,9 @@ const appKnownDataValues = [
 
 const appIgnoredDataValues = [];
 
-const App = ({data}: Props) => (
+const App = ({data, event}: Props) => (
   <React.Fragment>
-    <ContextBlock data={getAppKnownData(data, appKnownDataValues)} />
+    <ContextBlock data={getAppKnownData(event, data, appKnownDataValues)} />
     <ContextBlock
       data={getUnknownData(data, [...appKnownDataValues, ...appIgnoredDataValues])}
     />

--- a/src/sentry/static/sentry/app/components/events/contexts/app/getAppKnownData.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/app/getAppKnownData.tsx
@@ -1,11 +1,13 @@
 import {KeyValueListData} from 'app/components/events/interfaces/keyValueList/types';
 import {getMeta} from 'app/components/events/meta/metaProxy';
+import {Event} from 'app/types/event';
 import {defined} from 'app/utils';
 
 import getAppKnownDataDetails from './getAppKnownDataDetails';
 import {AppData, AppKnownDataType} from './types';
 
 function getAppKnownData(
+  event: Event,
   data: AppData,
   appKnownDataValues: Array<AppKnownDataType>
 ): Array<KeyValueListData> {
@@ -16,7 +18,7 @@ function getAppKnownData(
   );
 
   for (const key of dataKeys) {
-    const knownDataDetails = getAppKnownDataDetails(data, key as AppKnownDataType);
+    const knownDataDetails = getAppKnownDataDetails(event, data, key as AppKnownDataType);
 
     knownData.push({
       key,

--- a/src/sentry/static/sentry/app/components/events/contexts/app/getAppKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/app/getAppKnownDataDetails.tsx
@@ -1,4 +1,9 @@
+import React from 'react';
+
 import {t} from 'app/locale';
+import {Event} from 'app/types/event';
+
+import {getRelativeTimeFromEventDateCreated} from '../utils';
 
 import {AppData, AppKnownDataType} from './types';
 
@@ -7,7 +12,11 @@ type Output = {
   value?: React.ReactNode;
 };
 
-function getAppKnownDataDetails(data: AppData, type: AppKnownDataType): Output {
+function getAppKnownDataDetails(
+  event: Event,
+  data: AppData,
+  type: AppKnownDataType
+): Output {
   switch (type) {
     case AppKnownDataType.ID:
       return {
@@ -17,7 +26,10 @@ function getAppKnownDataDetails(data: AppData, type: AppKnownDataType): Output {
     case AppKnownDataType.START_TIME:
       return {
         subject: t('Start Time'),
-        value: data.app_start_time,
+        value: getRelativeTimeFromEventDateCreated(
+          event.dateCreated,
+          data.app_start_time
+        ),
       };
     case AppKnownDataType.DEVICE_HASH:
       return {

--- a/src/sentry/static/sentry/app/components/events/contexts/device/device.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device/device.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import ContextBlock from 'app/components/events/contexts/contextBlock';
+import {Event} from 'app/types/event';
 
 import getUnknownData from '../getUnknownData';
 
@@ -9,6 +10,7 @@ import {DeviceData, DeviceKnownDataType} from './types';
 
 type Props = {
   data: DeviceData;
+  event: Event;
 };
 
 const deviceKnownDataValues = [
@@ -53,9 +55,9 @@ const deviceKnownDataValues = [
 
 const deviceIgnoredDataValues = [];
 
-const Device = ({data}: Props) => (
+const Device = ({data, event}: Props) => (
   <React.Fragment>
-    <ContextBlock data={getDeviceKnownData(data, deviceKnownDataValues)} />
+    <ContextBlock data={getDeviceKnownData(event, data, deviceKnownDataValues)} />
     <ContextBlock
       data={getUnknownData(data, [...deviceKnownDataValues, ...deviceIgnoredDataValues])}
     />

--- a/src/sentry/static/sentry/app/components/events/contexts/device/getDeviceKnownData.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device/getDeviceKnownData.tsx
@@ -1,11 +1,13 @@
 import {KeyValueListData} from 'app/components/events/interfaces/keyValueList/types';
 import {getMeta} from 'app/components/events/meta/metaProxy';
+import {Event} from 'app/types/event';
 import {defined} from 'app/utils';
 
 import getDeviceKnownDataDetails from './getDeviceKnownDataDetails';
 import {DeviceData, DeviceKnownDataType} from './types';
 
 function getOperatingSystemKnownData(
+  event: Event,
   data: DeviceData,
   deviceKnownDataValues: Array<DeviceKnownDataType>
 ): Array<KeyValueListData> {
@@ -16,7 +18,11 @@ function getOperatingSystemKnownData(
   );
 
   for (const key of dataKeys) {
-    const knownDataDetails = getDeviceKnownDataDetails(data, key as DeviceKnownDataType);
+    const knownDataDetails = getDeviceKnownDataDetails(
+      event,
+      data,
+      key as DeviceKnownDataType
+    );
 
     knownData.push({
       key,

--- a/src/sentry/static/sentry/app/components/events/contexts/device/getDeviceKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device/getDeviceKnownDataDetails.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 import DeviceName from 'app/components/deviceName';
 import FileSize from 'app/components/fileSize';
 import {t} from 'app/locale';
+import {Event} from 'app/types/event';
 import {defined} from 'app/utils';
+
+import {getRelativeTimeFromEventDateCreated} from '../utils';
 
 import formatMemory from './formatMemory';
 import formatStorage from './formatStorage';
@@ -14,7 +17,11 @@ type Output = {
   value?: React.ReactNode;
 };
 
-function getDeviceKnownDataDetails(data: DeviceData, type: DeviceKnownDataType): Output {
+function getDeviceKnownDataDetails(
+  event: Event,
+  data: DeviceData,
+  type: DeviceKnownDataType
+): Output {
   switch (type) {
     case DeviceKnownDataType.NAME:
       return {
@@ -135,7 +142,7 @@ function getDeviceKnownDataDetails(data: DeviceData, type: DeviceKnownDataType):
     case DeviceKnownDataType.BOOT_TIME:
       return {
         subject: t('Boot Time'),
-        value: data.boot_time,
+        value: getRelativeTimeFromEventDateCreated(event.dateCreated, data.boot_time),
       };
     case DeviceKnownDataType.TIMEZONE:
       return {

--- a/src/sentry/static/sentry/app/components/events/contexts/operatingSystem/getOperatingSystemKnownDataDetails.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/operatingSystem/getOperatingSystemKnownDataDetails.tsx
@@ -31,7 +31,7 @@ function getOperatingSystemKnownDataDetails(
     case OperatingSystemKnownDataType.ROOTED:
       return {
         subject: t('Rooted'),
-        value: defined(data.rooted) ? (data.rooted ? 'yes' : 'no') : null,
+        value: defined(data.rooted) ? (data.rooted ? t('yes') : t('no')) : null,
       };
     default:
       return {

--- a/src/sentry/static/sentry/app/components/events/contexts/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/utils.tsx
@@ -65,5 +65,5 @@ export function getRelativeTimeFromEventDateCreated(
 
 const RelativeTime = styled('span')`
   color: ${p => p.theme.subText};
-  margin-left: ${space(0.25)};
+  margin-left: ${space(0.5)};
 `;

--- a/src/sentry/static/sentry/app/components/events/contexts/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/utils.tsx
@@ -1,4 +1,11 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import moment from 'moment-timezone';
+
+import {t} from 'app/locale';
 import plugins from 'app/plugins';
+import space from 'app/styles/space';
+import {defined} from 'app/utils';
 
 const CONTEXT_TYPES = {
   default: require('app/components/events/contexts/default').default,
@@ -29,3 +36,34 @@ export function getSourcePlugin(pluginContexts: Array<any>, contextType: string)
   }
   return null;
 }
+
+export function getRelativeTimeFromEventDateCreated(
+  eventDateCreated: string,
+  timestamp?: string
+) {
+  if (!defined(timestamp)) {
+    return timestamp;
+  }
+
+  const dateTime = moment(timestamp);
+
+  if (!dateTime.isValid()) {
+    return timestamp;
+  }
+
+  const relativeTime = `(${dateTime.from(eventDateCreated, true)} ${t(
+    'before this event'
+  )})`;
+
+  return (
+    <React.Fragment>
+      {timestamp}
+      <RelativeTime>{relativeTime}</RelativeTime>
+    </React.Fragment>
+  );
+}
+
+const RelativeTime = styled('span')`
+  color: ${p => p.theme.subText};
+  margin-left: ${space(0.25)};
+`;


### PR DESCRIPTION
Add duration between timestamp and event time to the following context data:

 - App - Start Time
 - Device - Boot-Time
 
closes: https://github.com/getsentry/sentry/issues/24209


Preview: 

![image](https://user-images.githubusercontent.com/29228205/109979938-b7f93780-7cff-11eb-8cc3-d898b7025adc.png)
