### PR TITLE
ui(quicktrace): Clean up some quick trace UI

### DIFF
--- a/src/sentry/static/sentry/app/components/truncate.tsx
+++ b/src/sentry/static/sentry/app/components/truncate.tsx
@@ -52,7 +52,7 @@ class Truncate extends React.Component<Props, State> {
         : value.slice(0, maxLength - 4);
 
       // Try to trim to values from the regex
-      if (trimRegex && trimRegex.test(slicedValue)) {
+      if (trimRegex && slicedValue.search(trimRegex) >= 0) {
         if (leftTrim) {
           shortValue = (
             <span>

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
@@ -4,6 +4,7 @@ import {Location, LocationDescriptor} from 'history';
 
 import DropdownLink from 'app/components/dropdownLink';
 import ErrorBoundary from 'app/components/errorBoundary';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
 import Link from 'app/components/links/link';
 import Placeholder from 'app/components/placeholder';
 import Tooltip from 'app/components/tooltip';
@@ -19,14 +20,17 @@ import {
   QuickTraceQueryChildrenProps,
 } from 'app/utils/performance/quickTrace/types';
 import {isTransaction, parseQuickTrace} from 'app/utils/performance/quickTrace/utils';
+import Projects from 'app/utils/projects';
 import {Theme} from 'app/utils/theme';
 
 import {
   DropdownItem,
+  DropdownItemSubContainer,
   EventNode,
   MetaData,
   QuickTraceContainer,
   SectionSubtext,
+  StyledTruncate,
   TraceConnector,
 } from './styles';
 import {
@@ -57,7 +61,7 @@ export default function QuickTrace({
   const traceTarget = generateTraceTarget(event, organization);
 
   const body = isLoading ? (
-    <Placeholder height="33px" />
+    <Placeholder height="27px" />
   ) : error || trace === null ? (
     '\u2014'
   ) : (
@@ -299,13 +303,26 @@ function EventNodeSelector({
           const target = generateSingleEventTarget(event, organization, location);
           return (
             <DropdownItem key={event.event_id} to={target} first={i === 0}>
-              <Truncate
-                value={event.transaction}
-                maxLength={35}
-                leftTrim
-                trimRegex={/\.|\//g}
-                expandable={false}
-              />
+              <DropdownItemSubContainer>
+                <Projects orgId={organization.slug} slugs={[event.project_slug]}>
+                  {({projects}) => {
+                    const project = projects.find(p => p.slug === event.project_slug);
+                    return (
+                      <ProjectBadge
+                        hideName
+                        project={project ? project : {slug: event.project_slug}}
+                        avatarSize={16}
+                      />
+                    );
+                  }}
+                </Projects>
+                <StyledTruncate
+                  value={event.transaction}
+                  maxLength={35}
+                  leftTrim
+                  trimRegex={/\.|\//g}
+                />
+              </DropdownItemSubContainer>
               <SectionSubtext>
                 {getDuration(
                   event['transaction.duration'] / 1000,

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
@@ -6,6 +6,7 @@ import {SectionHeading} from 'app/components/charts/styles';
 import MenuItem from 'app/components/menuItem';
 import QuestionTooltip from 'app/components/questionTooltip';
 import Tag, {Background} from 'app/components/tag';
+import Truncate from 'app/components/truncate';
 import space from 'app/styles/space';
 
 type MetaDataProps = {
@@ -103,3 +104,20 @@ export function DropdownItem({children, first, to}: DropdownItemProps) {
     </StyledMenuItem>
   );
 }
+
+export const DropdownItemSubContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+`;
+
+export const StyledTruncate = styled(Truncate)`
+  margin-left: ${space(1)};
+
+  /**
+   * This is the class added to the element that is shown on hover.
+   */
+  .full-value {
+    left: auto;
+    right: -5px;
+  }
+`;


### PR DESCRIPTION
This cleans up some of the quick trace UI
1. Adds a project icon to the hover card
2. Adds hover to expand effect in the hover card
3. Update placeholder size


https://user-images.githubusercontent.com/10239353/109988920-fe39a100-7cd5-11eb-9fba-d0b6d1191583.mp4

