### PR TITLE
feat(mobile-prompt): adds logging back for discover result

### DIFF
--- a/src/sentry/api/endpoints/organization_has_mobile_app_events.py
+++ b/src/sentry/api/endpoints/organization_has_mobile_app_events.py
@@ -73,4 +73,6 @@ class OrganizationHasMobileAppEvents(OrganizationEventsEndpointBase):
             return {
                 "browserName": one_result["browser.name"],
                 "clientOsName": one_result["client_os.name"],
+                "projectSlug": one_result["project"],
+                "eventId": one_result["id"],
             }

--- a/src/sentry/api/endpoints/organization_has_mobile_app_events.py
+++ b/src/sentry/api/endpoints/organization_has_mobile_app_events.py
@@ -44,7 +44,7 @@ class OrganizationHasMobileAppEvents(OrganizationEventsEndpointBase):
             result = discover.query(
                 query=query,
                 orderby="-timestamp",
-                selected_columns=["browser.name", "client_os.name", "timestamp"],
+                selected_columns=["browser.name", "client_os.name", "timestamp", "project", "id"],
                 limit=1,
                 params={
                     "start": timezone.now() - timedelta(days=1),
@@ -59,6 +59,16 @@ class OrganizationHasMobileAppEvents(OrganizationEventsEndpointBase):
                 return None
 
             one_result = data[0]
+            # log the info so we can debug this later
+            logger.info(
+                "result_found",
+                extra={
+                    "organization_id": organization.id,
+                    "organization_slug": organization.slug,
+                    "project_slug": one_result["project"],
+                    "event_id": one_result["id"],
+                },
+            )
             # only send back browserName and clientOsName for now
             return {
                 "browserName": one_result["browser.name"],

--- a/tests/sentry/api/endpoints/test_organization_has_mobile_app_events.py
+++ b/tests/sentry/api/endpoints/test_organization_has_mobile_app_events.py
@@ -32,14 +32,21 @@ class OrganizationIntegrationRequestTest(APITestCase):
                 }
             ]
         }
+        expected = {
+            "browserName": "okhttp",
+            "clientOsName": "",
+            "projectSlug": self.project.slug,
+            "eventId": "1234",
+        }
+
         response = self.get_response(self.organization.slug, userAgents=["okhttp"])
         assert response.status_code == 200
-        assert response.data == {"browserName": "okhttp", "clientOsName": ""}
+        assert response.data == expected
         assert mock_query.call_count == 1
 
         response = self.get_response(self.organization.slug, userAgents=["okhttp"])
         assert response.status_code == 200
-        assert response.data == {"browserName": "okhttp", "clientOsName": ""}
+        assert response.data == expected
         assert mock_query.call_count == 1
 
     def test_no_match(self):

--- a/tests/sentry/api/endpoints/test_organization_has_mobile_app_events.py
+++ b/tests/sentry/api/endpoints/test_organization_has_mobile_app_events.py
@@ -22,7 +22,16 @@ class OrganizationIntegrationRequestTest(APITestCase):
 
     @mock.patch("sentry.api.endpoints.organization_has_mobile_app_events.discover.query")
     def test_hit_cache_on_success(self, mock_query):
-        mock_query.return_value = {"data": [{"browser.name": "okhttp", "client_os.name": ""}]}
+        mock_query.return_value = {
+            "data": [
+                {
+                    "browser.name": "okhttp",
+                    "client_os.name": "",
+                    "project": self.project.slug,
+                    "id": "1234",
+                }
+            ]
+        }
         response = self.get_response(self.organization.slug, userAgents=["okhttp"])
         assert response.status_code == 200
         assert response.data == {"browserName": "okhttp", "clientOsName": ""}


### PR DESCRIPTION
We are getting reports of many false positives saying we found a mobile event from users when they claim they don't have any. This PR adds the `project` and `id` of the event into the Discover query so we can log it and be able to debug our results more easily. Also adding it back to the response so we can debug at the network level as well.