### PR TITLE
fix(dashboard): Fix fields being mutated in widget serializer

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -67,7 +67,7 @@ class DashboardWidgetQuerySerializer(CamelSnakeSerializer):
 
         # Validate the query that would be created when run.
         conditions = self._get_attr(data, "conditions", "")
-        fields = self._get_attr(data, "fields", [])
+        fields = self._get_attr(data, "fields", []).copy()
         orderby = self._get_attr(data, "orderby", "")
         try:
             # When using the eps/epm functions, they require an interval argument

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -213,11 +213,11 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     ],
                 },
                 {
-                    "title": "Errors over time",
-                    "displayType": "line",
+                    "title": "Errors per project",
+                    "displayType": "table",
                     "interval": "5m",
                     "queries": [
-                        {"name": "Errors", "fields": ["count()"], "conditions": "event.type:error"}
+                        {"name": "Errors", "fields": ["count()", "project"], "conditions": "event.type:error"}
                     ],
                 },
             ],

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -217,7 +217,11 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
                     "displayType": "table",
                     "interval": "5m",
                     "queries": [
-                        {"name": "Errors", "fields": ["count()", "project"], "conditions": "event.type:error"}
+                        {
+                            "name": "Errors",
+                            "fields": ["count()", "project"],
+                            "conditions": "event.type:error",
+                        }
                     ],
                 },
             ],


### PR DESCRIPTION
Widget query fields may be mutated during serialization for validation purposes. For example, `project` field may be mutated to `project.id`.

We prevent this by doing a shallow copy on `fields` list.

A corresponding test has been updated for this specific case.