### PR TITLE
fix(copy): changed name of "Emails" in settings to "Email Addresses"

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/accountEmails.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountEmails.tsx
@@ -84,10 +84,10 @@ class AccountEmails extends AsyncView<Props, State> {
 
     return (
       <div>
-        <SettingsPageHeader title={t('Emails')} />
+        <SettingsPageHeader title={t('Email Addresses')} />
 
         <Panel>
-          <PanelHeader>{t('Emails')}</PanelHeader>
+          <PanelHeader>{t('Email Addresses')}</PanelHeader>
           <PanelBody>
             {primary && (
               <EmailRow

--- a/src/sentry/static/sentry/app/views/settings/account/navigationConfiguration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/navigationConfiguration.tsx
@@ -32,7 +32,7 @@ function getConfiguration({organization}: ConfigParams): NavigationSection[] {
         },
         {
           path: `${pathPrefix}/emails/`,
-          title: t('Emails'),
+          title: t('Email Addresses'),
           description: t(
             'Add or remove secondary emails, change your primary email, verify your emails'
           ),


### PR DESCRIPTION
Changing "Emails" in settings to "Email Addresses" to prevent confusion with the Notifications tab.