### PR TITLE
feat(demo): convert to post

### DIFF
--- a/src/sentry/web/frontend/demo_start.py
+++ b/src/sentry/web/frontend/demo_start.py
@@ -3,7 +3,6 @@ import petname
 from django.http import Http404
 from django.conf import settings
 from django.db import transaction
-from django.views.decorators.csrf import csrf_exempt
 from django.template.defaultfilters import slugify
 
 from sentry import roles
@@ -26,9 +25,11 @@ def generate_random_name():
 
 
 class DemoStartView(BaseView):
+    csrf_protect = False
+    auth_required = False
+
     @transaction.atomic
-    @csrf_exempt
-    def dispatch(self, request):
+    def post(self, request):
         # need this check for tests since the route will exist even if DEMO_MODE=False
         if not settings.DEMO_MODE:
             raise Http404

--- a/tests/sentry/web/frontend/test_demo_start.py
+++ b/tests/sentry/web/frontend/test_demo_start.py
@@ -28,7 +28,7 @@ class AuthLoginTest(TestCase):
     @mock.patch("sentry.web.frontend.demo_start.generate_random_name", return_value=org_name)
     def test_basic(self, mock_generate_name):
         owner = User.objects.create(email=org_owner_email)
-        resp = self.client.get(self.path)
+        resp = self.client.post(self.path)
         assert resp.status_code == 302
 
         org = Organization.objects.get(name=org_name)
@@ -52,12 +52,12 @@ class AuthLoginTest(TestCase):
     @mock.patch("sentry.web.frontend.demo_start.generate_random_name", return_value=org_name)
     def test_no_owner(self, mock_generate_name):
         with pytest.raises(Exception):
-            self.client.get(self.path)
+            self.client.post(self.path)
 
         # verify we are using atomic transactions
         assert not Organization.objects.filter(name=org_name).exists()
 
     @override_settings(DEMO_MODE=False)
     def test_disabled(self):
-        resp = self.client.get(self.path)
+        resp = self.client.post(self.path)
         assert resp.status_code == 404


### PR DESCRIPTION
Start demo on a form POST redirect instead of a GET request. This is better because GET requests shouldn't cause state changes.