### PR TITLE
feat(ui): Allow relative dates to be formatted even shorter

### DIFF
--- a/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
+++ b/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
@@ -165,7 +165,13 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
       {showDateAdded && dateAdded && (
         <React.Fragment>
           <Separator type={tagType ?? 'default'}>{' | '}</Separator>
-          <TimeSince date={dateAdded} suffix="" shorten disabledAbsoluteTooltip />
+          <TimeSince
+            date={dateAdded}
+            suffix=""
+            shorten
+            extraShort
+            disabledAbsoluteTooltip
+          />
         </React.Fragment>
       )}
     </StyledTag>

--- a/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
+++ b/src/sentry/static/sentry/app/components/group/inboxBadges/inboxReason.tsx
@@ -165,13 +165,7 @@ function InboxReason({inbox, fontSize = 'sm', showDateAdded}: Props) {
       {showDateAdded && dateAdded && (
         <React.Fragment>
           <Separator type={tagType ?? 'default'}>{' | '}</Separator>
-          <TimeSince
-            date={dateAdded}
-            suffix=""
-            shorten
-            extraShort
-            disabledAbsoluteTooltip
-          />
+          <TimeSince date={dateAdded} suffix="" extraShort disabledAbsoluteTooltip />
         </React.Fragment>
       )}
     </StyledTag>

--- a/src/sentry/static/sentry/app/components/timeSince.tsx
+++ b/src/sentry/static/sentry/app/components/timeSince.tsx
@@ -39,6 +39,11 @@ type Props = DefaultProps & {
    * For relative time shortens minutes to min, day to d etc.
    */
   shorten?: boolean;
+  /**
+   * Shorter date abbreviations than shorten
+   * min to m, hr to h
+   */
+  extraShort?: boolean;
 
   tooltipTitle?: string;
 
@@ -62,7 +67,12 @@ class TimeSince extends React.PureComponent<Props, State> {
   // See: https://github.com/emotion-js/emotion/pull/1514
   static getDerivedStateFromProps(props) {
     return {
-      relative: getRelativeDate(props.date, props.suffix, props.shorten),
+      relative: getRelativeDate(
+        props.date,
+        props.suffix,
+        props.shorten,
+        props.extraShort
+      ),
     };
   }
 
@@ -82,7 +92,12 @@ class TimeSince extends React.PureComponent<Props, State> {
   setRelativeDateTicker = () => {
     this.ticker = window.setTimeout(() => {
       this.setState({
-        relative: getRelativeDate(this.props.date, this.props.suffix, this.props.shorten),
+        relative: getRelativeDate(
+          this.props.date,
+          this.props.suffix,
+          this.props.shorten,
+          this.props.extraShort
+        ),
       });
       this.setRelativeDateTicker();
     }, ONE_MINUTE_IN_MS);
@@ -96,6 +111,7 @@ class TimeSince extends React.PureComponent<Props, State> {
       className,
       tooltipTitle,
       shorten: _shorten,
+      extraShort: _extraShort,
       ...props
     } = this.props;
     const dateObj = getDateObj(date);
@@ -139,7 +155,8 @@ function getDateObj(date: RelaxedDateType): Date {
 export function getRelativeDate(
   currentDateTime: RelaxedDateType,
   suffix?: string,
-  shorten?: boolean
+  shorten?: boolean,
+  extraShort?: boolean
 ): string {
   const date = getDateObj(currentDateTime);
 
@@ -149,7 +166,7 @@ export function getRelativeDate(
       suffix,
     });
   } else if (shorten && !suffix) {
-    return getDuration(moment().diff(moment(date), 'seconds'), 0, true);
+    return getDuration(moment().diff(moment(date), 'seconds'), 0, true, extraShort);
   } else if (!suffix) {
     return moment(date).fromNow(true);
   } else if (suffix === 'ago') {

--- a/src/sentry/static/sentry/app/components/timeSince.tsx
+++ b/src/sentry/static/sentry/app/components/timeSince.tsx
@@ -160,13 +160,13 @@ export function getRelativeDate(
 ): string {
   const date = getDateObj(currentDateTime);
 
-  if (shorten && suffix) {
+  if ((shorten || extraShort) && suffix) {
     return t('%(time)s %(suffix)s', {
-      time: getDuration(moment().diff(moment(date), 'seconds'), 0, true),
+      time: getDuration(moment().diff(moment(date), 'seconds'), 0, shorten, extraShort),
       suffix,
     });
   } else if ((shorten || extraShort) && !suffix) {
-    return getDuration(moment().diff(moment(date), 'seconds'), 0, true, extraShort);
+    return getDuration(moment().diff(moment(date), 'seconds'), 0, shorten, extraShort);
   } else if (!suffix) {
     return moment(date).fromNow(true);
   } else if (suffix === 'ago') {

--- a/src/sentry/static/sentry/app/components/timeSince.tsx
+++ b/src/sentry/static/sentry/app/components/timeSince.tsx
@@ -36,11 +36,11 @@ type Props = DefaultProps & {
   disabledAbsoluteTooltip?: boolean;
 
   /**
-   * For relative time shortens minutes to min, day to d etc.
+   * For relative time shortens minutes to min, hour to hr etc.
    */
   shorten?: boolean;
   /**
-   * Shorter date abbreviations than shorten
+   * Shortens the shortened relative time. Pass both shorten and extraShort.
    * min to m, hr to h
    */
   extraShort?: boolean;

--- a/src/sentry/static/sentry/app/components/timeSince.tsx
+++ b/src/sentry/static/sentry/app/components/timeSince.tsx
@@ -40,7 +40,7 @@ type Props = DefaultProps & {
    */
   shorten?: boolean;
   /**
-   * Shortens the shortened relative time. Pass both shorten and extraShort.
+   * Shortens the shortened relative time
    * min to m, hr to h
    */
   extraShort?: boolean;
@@ -165,7 +165,7 @@ export function getRelativeDate(
       time: getDuration(moment().diff(moment(date), 'seconds'), 0, true),
       suffix,
     });
-  } else if (shorten && !suffix) {
+  } else if ((shorten || extraShort) && !suffix) {
     return getDuration(moment().diff(moment(date), 'seconds'), 0, true, extraShort);
   } else if (!suffix) {
     return moment(date).fromNow(true);

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -62,7 +62,7 @@ export function getDuration(
 ): string {
   const value = Math.abs(seconds * 1000);
 
-  if (value >= MONTH) {
+  if (value >= MONTH && !extraShort) {
     const {label, result} = roundWithFixed(value / MONTH, fixedDigits);
     return `${label}${
       abbreviation ? tn('mo', 'mos', result) : ` ${tn('month', 'months', result)}`
@@ -70,35 +70,42 @@ export function getDuration(
   }
   if (value >= WEEK) {
     const {label, result} = roundWithFixed(value / WEEK, fixedDigits);
-    return `${label}${
-      abbreviation ? (extraShort ? t('w') : t('wk')) : ` ${tn('week', 'weeks', result)}`
-    }`;
+    const units = extraShort
+      ? t('w')
+      : abbreviation
+      ? t('wk')
+      : ` ${tn('week', 'weeks', result)}`;
+    return `${label}${units}`;
   }
   if (value >= 172800000) {
     const {label, result} = roundWithFixed(value / DAY, fixedDigits);
     return `${label}${
-      abbreviation ? (extraShort ? t('d') : t('d')) : ` ${tn('day', 'days', result)}`
+      abbreviation || extraShort ? t('d') : ` ${tn('day', 'days', result)}`
     }`;
   }
   if (value >= 7200000) {
     const {label, result} = roundWithFixed(value / HOUR, fixedDigits);
-    return `${label}${
-      abbreviation ? (extraShort ? t('h') : t('hr')) : ` ${tn('hour', 'hours', result)}`
-    }`;
+    const units = extraShort
+      ? t('h')
+      : abbreviation
+      ? t('hr')
+      : ` ${tn('hour', 'hours', result)}`;
+    return `${label}${units}`;
   }
   if (value >= 120000) {
     const {label, result} = roundWithFixed(value / MINUTE, fixedDigits);
-    return `${label}${
-      abbreviation
-        ? extraShort
-          ? t('m')
-          : t('min')
-        : ` ${tn('minute', 'minutes', result)}`
-    }`;
+    const units = extraShort
+      ? t('m')
+      : abbreviation
+      ? t('min')
+      : ` ${tn('minute', 'minutes', result)}`;
+    return `${label}${units}`;
   }
   if (value >= SECOND) {
     const {label, result} = roundWithFixed(value / SECOND, fixedDigits);
-    return `${label}${abbreviation ? t('s') : ` ${tn('second', 'seconds', result)}`}`;
+    return `${label}${
+      abbreviation || extraShort ? t('s') : ` ${tn('second', 'seconds', result)}`
+    }`;
   }
 
   const {label} = roundWithFixed(value, fixedDigits);

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -70,12 +70,13 @@ export function getDuration(
   }
   if (value >= WEEK) {
     const {label, result} = roundWithFixed(value / WEEK, fixedDigits);
-    const units = extraShort
-      ? t('w')
-      : abbreviation
-      ? t('wk')
-      : ` ${tn('week', 'weeks', result)}`;
-    return `${label}${units}`;
+    if (extraShort) {
+      return `${label}${t('w')}`;
+    }
+    if (abbreviation) {
+      return `${label}${t('wk')}`;
+    }
+    return `${label} ${tn('week', 'weeks', result)}`;
   }
   if (value >= 172800000) {
     const {label, result} = roundWithFixed(value / DAY, fixedDigits);
@@ -85,27 +86,30 @@ export function getDuration(
   }
   if (value >= 7200000) {
     const {label, result} = roundWithFixed(value / HOUR, fixedDigits);
-    const units = extraShort
-      ? t('h')
-      : abbreviation
-      ? t('hr')
-      : ` ${tn('hour', 'hours', result)}`;
-    return `${label}${units}`;
+    if (extraShort) {
+      return `${label}${t('h')}`;
+    }
+    if (abbreviation) {
+      return `${label}${t('hr')}`;
+    }
+    return `${label} ${tn('hour', 'hours', result)}`;
   }
   if (value >= 120000) {
     const {label, result} = roundWithFixed(value / MINUTE, fixedDigits);
-    const units = extraShort
-      ? t('m')
-      : abbreviation
-      ? t('min')
-      : ` ${tn('minute', 'minutes', result)}`;
-    return `${label}${units}`;
+    if (extraShort) {
+      return `${label}${t('m')}`;
+    }
+    if (abbreviation) {
+      return `${label}${t('min')}`;
+    }
+    return `${label} ${tn('minute', 'minutes', result)}`;
   }
   if (value >= SECOND) {
     const {label, result} = roundWithFixed(value / SECOND, fixedDigits);
-    return `${label}${
-      abbreviation || extraShort ? t('s') : ` ${tn('second', 'seconds', result)}`
-    }`;
+    if (extraShort || abbreviation) {
+      return `${label}${t('s')}`;
+    }
+    return `${label} ${tn('second', 'seconds', result)}`;
   }
 
   const {label} = roundWithFixed(value, fixedDigits);

--- a/src/sentry/static/sentry/app/utils/formatters.tsx
+++ b/src/sentry/static/sentry/app/utils/formatters.tsx
@@ -57,7 +57,8 @@ export const SECOND = 1000;
 export function getDuration(
   seconds: number,
   fixedDigits: number = 0,
-  abbreviation: boolean = false
+  abbreviation: boolean = false,
+  extraShort: boolean = false
 ): string {
   const value = Math.abs(seconds * 1000);
 
@@ -69,19 +70,31 @@ export function getDuration(
   }
   if (value >= WEEK) {
     const {label, result} = roundWithFixed(value / WEEK, fixedDigits);
-    return `${label}${abbreviation ? t('wk') : ` ${tn('week', 'weeks', result)}`}`;
+    return `${label}${
+      abbreviation ? (extraShort ? t('w') : t('wk')) : ` ${tn('week', 'weeks', result)}`
+    }`;
   }
   if (value >= 172800000) {
     const {label, result} = roundWithFixed(value / DAY, fixedDigits);
-    return `${label}${abbreviation ? t('d') : ` ${tn('day', 'days', result)}`}`;
+    return `${label}${
+      abbreviation ? (extraShort ? t('d') : t('d')) : ` ${tn('day', 'days', result)}`
+    }`;
   }
   if (value >= 7200000) {
     const {label, result} = roundWithFixed(value / HOUR, fixedDigits);
-    return `${label}${abbreviation ? t('hr') : ` ${tn('hour', 'hours', result)}`}`;
+    return `${label}${
+      abbreviation ? (extraShort ? t('h') : t('hr')) : ` ${tn('hour', 'hours', result)}`
+    }`;
   }
   if (value >= 120000) {
     const {label, result} = roundWithFixed(value / MINUTE, fixedDigits);
-    return `${label}${abbreviation ? t('min') : ` ${tn('minute', 'minutes', result)}`}`;
+    return `${label}${
+      abbreviation
+        ? extraShort
+          ? t('m')
+          : t('min')
+        : ` ${tn('minute', 'minutes', result)}`
+    }`;
   }
   if (value >= SECOND) {
     const {label, result} = roundWithFixed(value / SECOND, fixedDigits);

--- a/tests/js/spec/utils/formatters.spec.jsx
+++ b/tests/js/spec/utils/formatters.spec.jsx
@@ -41,19 +41,19 @@ describe('getDuration()', function () {
   });
 
   it('should format numbers and abbreviate units with one letter', function () {
-    expect(getDuration(0, 2, true, true)).toBe('0.00ms');
-    expect(getDuration(0, 0, true, true)).toBe('0ms');
-    expect(getDuration(0.1, 0, true, true)).toBe('100ms');
-    expect(getDuration(0.1, 2, true, true)).toBe('100.00ms');
-    expect(getDuration(1, 2, true, true)).toBe('1.00s');
-    expect(getDuration(122, 0, true, true)).toBe('2m');
-    expect(getDuration(3600, 0, true, true)).toBe('60m');
-    expect(getDuration(86400, 0, true, true)).toBe('24h');
-    expect(getDuration(86400 * 2, 0, true, true)).toBe('2d');
-    expect(getDuration(604800, 0, true, true)).toBe('1w');
-    expect(getDuration(604800 * 2, 0, true, true)).toBe('2w');
-    expect(getDuration(2629800, 0, true, true)).toBe('1mo');
-    expect(getDuration(604800 * 12, 0, true, true)).toBe('3mos');
+    expect(getDuration(0, 2, false, true)).toBe('0.00ms');
+    expect(getDuration(0, 0, false, true)).toBe('0ms');
+    expect(getDuration(0.1, 0, false, true)).toBe('100ms');
+    expect(getDuration(0.1, 2, false, true)).toBe('100.00ms');
+    expect(getDuration(1, 2, false, true)).toBe('1.00s');
+    expect(getDuration(122, 0, false, true)).toBe('2m');
+    expect(getDuration(3600, 0, false, true)).toBe('60m');
+    expect(getDuration(86400, 0, false, true)).toBe('24h');
+    expect(getDuration(86400 * 2, 0, false, true)).toBe('2d');
+    expect(getDuration(604800, 0, false, true)).toBe('1w');
+    expect(getDuration(604800 * 2, 0, false, true)).toBe('2w');
+    expect(getDuration(2629800, 0, false, true)).toBe('4w');
+    expect(getDuration(604800 * 12, 0, false, true)).toBe('12w');
   });
 });
 

--- a/tests/js/spec/utils/formatters.spec.jsx
+++ b/tests/js/spec/utils/formatters.spec.jsx
@@ -39,6 +39,22 @@ describe('getDuration()', function () {
     expect(getDuration(2629800, 0, true)).toBe('1mo');
     expect(getDuration(604800 * 12, 0, true)).toBe('3mos');
   });
+
+  it('should format numbers and abbreviate units with one letter', function () {
+    expect(getDuration(0, 2, true, true)).toBe('0.00ms');
+    expect(getDuration(0, 0, true, true)).toBe('0ms');
+    expect(getDuration(0.1, 0, true, true)).toBe('100ms');
+    expect(getDuration(0.1, 2, true, true)).toBe('100.00ms');
+    expect(getDuration(1, 2, true, true)).toBe('1.00s');
+    expect(getDuration(122, 0, true, true)).toBe('2m');
+    expect(getDuration(3600, 0, true, true)).toBe('60m');
+    expect(getDuration(86400, 0, true, true)).toBe('24h');
+    expect(getDuration(86400 * 2, 0, true, true)).toBe('2d');
+    expect(getDuration(604800, 0, true, true)).toBe('1w');
+    expect(getDuration(604800 * 2, 0, true, true)).toBe('2w');
+    expect(getDuration(2629800, 0, true, true)).toBe('1mo');
+    expect(getDuration(604800 * 12, 0, true, true)).toBe('3mos');
+  });
 });
 
 describe('formatAbbreviatedNumber()', function () {


### PR DESCRIPTION
We need **even shorter** dates. For the inbox this makes some sense as dates can only be minutes, hours, days.