### PR TITLE
ref(integrations): Dual Write Usages

### DIFF
--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -35,10 +35,8 @@ from sentry.models import (
 from sentry.grouping.enhancer import Enhancements, InvalidEnhancerConfig
 from sentry.grouping.fingerprinting import FingerprintingRules, InvalidFingerprintingConfig
 from sentry.models.integration import ExternalProviders
-from sentry.notifications.types import (
-    NotificationSettingTypes,
-    NotificationSettingOptionValues,
-)
+from sentry.notifications.legacy_mappings import get_option_value_from_boolean
+from sentry.notifications.types import NotificationSettingTypes
 from sentry.tasks.deletion import delete_project
 from sentry.utils import json
 from sentry.utils.compat import filter
@@ -538,15 +536,10 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 changed_proj_settings["sentry:origins"] = result["allowedDomains"]
 
         if "isSubscribed" in result:
-            value = (
-                NotificationSettingOptionValues.ALWAYS
-                if result.get("isSubscribed")
-                else NotificationSettingOptionValues.NEVER
-            )
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.ISSUE_ALERTS,
-                value,
+                get_option_value_from_boolean(result.get("isSubscribed")),
                 user=request.user,
                 project=project,
             )

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -25,15 +25,20 @@ from sentry.models import (
     AuditLogEntryEvent,
     Group,
     GroupStatus,
+    NotificationSetting,
     Project,
     ProjectBookmark,
     ProjectRedirect,
     ProjectStatus,
     ProjectTeam,
-    UserOption,
 )
 from sentry.grouping.enhancer import Enhancements, InvalidEnhancerConfig
 from sentry.grouping.fingerprinting import FingerprintingRules, InvalidFingerprintingConfig
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import (
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
+)
 from sentry.tasks.deletion import delete_project
 from sentry.utils import json
 from sentry.utils.compat import filter
@@ -532,13 +537,18 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             if project.update_option("sentry:origins", result["allowedDomains"]):
                 changed_proj_settings["sentry:origins"] = result["allowedDomains"]
 
-        if result.get("isSubscribed"):
-            UserOption.objects.set_value(
-                user=request.user, key="mail:alert", value=1, project=project
+        if "isSubscribed" in result:
+            value = (
+                NotificationSettingOptionValues.ALWAYS
+                if result.get("isSubscribed")
+                else NotificationSettingOptionValues.NEVER
             )
-        elif result.get("isSubscribed") is False:
-            UserOption.objects.set_value(
-                user=request.user, key="mail:alert", value=0, project=project
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                value,
+                user=request.user,
+                project=project,
             )
 
         if "dynamicSampling" in result:

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -1,12 +1,18 @@
 from collections import defaultdict
-from rest_framework import serializers
+from rest_framework import serializers, status
 from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers import serialize, Serializer
 from sentry.models import UserOption
-from sentry.notifications.legacy_mappings import USER_OPTION_SETTINGS
+from sentry.models.integration import ExternalProviders
+from sentry.models.notificationsetting import NotificationSetting
+from sentry.notifications.legacy_mappings import (
+    get_option_value_from_int,
+    get_type_from_user_option_settings_key,
+    USER_OPTION_SETTINGS,
+)
 from sentry.notifications.types import UserOptionsSettingsKey
 
 
@@ -61,15 +67,33 @@ class UserNotificationDetailsEndpoint(UserEndpoint):
     def put(self, request, user):
         serializer = UserNotificationDetailsSerializer(data=request.data)
 
-        if serializer.is_valid():
-            for key, value in serializer.validated_data.items():
-                db_key = USER_OPTION_SETTINGS[UserOptionsSettingsKey(key)]["key"]
-                (uo, created) = UserOption.objects.get_or_create(
-                    user=user, key=db_key, project=None, organization=None
-                )
-                # Convert integers and booleans to string representations of ints.
-                uo.update(value=str(int(value)))
-
-            return self.get(request, user)
-        else:
+        if not serializer.is_valid():
             return Response(serializer.errors, status=400)
+
+        for key, value in serializer.validated_data.items():
+            try:
+                key = UserOptionsSettingsKey(key)
+            except ValueError:
+                return Response(
+                    {"detail": "Unknown key: %s." % key},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            if key in [UserOptionsSettingsKey.DEPLOY, UserOptionsSettingsKey.WORKFLOW]:
+                type = get_type_from_user_option_settings_key(key)
+                NotificationSetting.objects.update_settings(
+                    ExternalProviders.EMAIL,
+                    type,
+                    get_option_value_from_int(type, int(value)),
+                    user=user,
+                )
+            else:
+                user_option, _ = UserOption.objects.get_or_create(
+                    key=USER_OPTION_SETTINGS[key]["key"],
+                    user=user,
+                    project=None,
+                    organization=None,
+                )
+                user_option.update(value=str(int(value)))
+
+        return self.get(request, user)

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -6,14 +6,16 @@ from sentry.api.bases.user import UserEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import UserNotificationsSerializer
 from sentry.models import (
-    OrganizationMember,
-    OrganizationMemberTeam,
-    OrganizationStatus,
-    ProjectTeam,
+    NotificationSetting,
     UserOption,
     UserEmail,
 )
-from sentry.notifications.legacy_mappings import get_legacy_key_from_fine_tuning_key
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.legacy_mappings import (
+    get_legacy_key_from_fine_tuning_key,
+    get_option_value_from_int,
+    get_type_from_fine_tuning_key, 
+)
 from sentry.notifications.types import FineTuningAPIKey
 
 
@@ -28,7 +30,6 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
             )
 
         notifications = UserNotificationsSerializer()
-
         serialized = serialize(
             user,
             request.user,
@@ -68,54 +69,10 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        key = get_legacy_key_from_fine_tuning_key(notification_type)
-        filter_args = {"user": user, "key": key}
-
         if notification_type == FineTuningAPIKey.REPORTS:
-            (user_option, created) = UserOption.objects.get_or_create(**filter_args)
+            return self._handle_put_reports(user, request.data)
 
-            value = set(user_option.value or [])
-
-            # set of org ids that user is a member of
-            org_ids = self.get_org_ids(user)
-            for org_id, enabled in request.data.items():
-                org_id = int(org_id)
-                # We want "0" to be falsey
-                enabled = int(enabled)
-
-                # make sure user is in org
-                if org_id not in org_ids:
-                    return Response(
-                        {
-                            "detail": "User does not belong to at least one of the \
-                            requested orgs (org_id: %s)."
-                            % org_id
-                        },
-                        status=status.HTTP_403_FORBIDDEN,
-                    )
-
-                # list contains org ids that should have reports DISABLED
-                # so if enabled need to check if org_id exists in list (because by default
-                # they will have reports enabled)
-                if enabled and org_id in value:
-                    value.remove(org_id)
-                elif not enabled:
-                    value.add(org_id)
-
-            user_option.update(value=list(value))
-            return Response(status=status.HTTP_204_NO_CONTENT)
-
-        if notification_type in [
-            FineTuningAPIKey.ALERTS,
-            FineTuningAPIKey.WORKFLOW,
-            FineTuningAPIKey.EMAIL,
-        ]:
-            update_key = "project"
-            parent_ids = set(self.get_project_ids(user))
-        else:
-            update_key = "organization"
-            parent_ids = set(self.get_org_ids(user))
-
+        # Validate that all of the IDs are integers.
         try:
             ids_to_update = {int(i) for i in request.data.keys()}
         except ValueError:
@@ -124,8 +81,12 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        # make sure that the ids we are going to update are a subset of the user's
-        # list of orgs or projects
+        # Make sure that the IDs we are going to update are a subset of the
+        # user's list of organizations or projects.
+        parents = (
+            user.get_orgs() if notification_type == FineTuningAPIKey.DEPLOY else user.get_projects()
+        )
+        parent_ids = {parent.id for parent in parents}
         if not ids_to_update.issubset(parent_ids):
             bad_ids = ids_to_update - parent_ids
             return Response(
@@ -139,58 +100,96 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
             )
 
         if notification_type == FineTuningAPIKey.EMAIL:
-            # make sure target emails exist and are verified
-            emails_to_check = set(request.data.values())
-            emails = UserEmail.objects.filter(
-                user=user, email__in=emails_to_check, is_verified=True
-            )
+            return self._handle_put_emails(user, request.data)
 
-            # Is there a better way to check this?
-            if len(emails) != len(emails_to_check):
+        return self._handle_put_notification_settings(
+            user, notification_type, parents, request.data
+        )
+
+    @staticmethod
+    def _handle_put_reports(user, data):
+        user_option, _ = UserOption.objects.get_or_create(
+            user=user,
+            key="reports:disabled-organizations",
+        )
+
+        value = set(user_option.value or [])
+
+        # The set of IDs of the organizations of which the user is a member.
+        org_ids = {organization.id for organization in user.get_orgs()}
+        for org_id, enabled in data.items():
+            org_id = int(org_id)
+            # We want "0" to be falsey
+            enabled = int(enabled)
+
+            # make sure user is in org
+            if org_id not in org_ids:
                 return Response(
                     {
-                        "detail": "Invalid email value(s) provided. Email values \
-                        must be verified emails for the given user."
+                        "detail": "User does not belong to at least one of the requested orgs (org_id: %s)."
+                        % org_id
                     },
-                    status=status.HTTP_400_BAD_REQUEST,
+                    status=status.HTTP_403_FORBIDDEN,
                 )
 
+            # The list contains organization IDs that should have reports
+            # DISABLED. If enabled, we need to check if org_id exists in list
+            # (because by default they will have reports enabled.)
+            if enabled and org_id in value:
+                value.remove(org_id)
+            elif not enabled:
+                value.add(org_id)
+
+        user_option.update(value=list(value))
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @staticmethod
+    def _handle_put_emails(user, data):
+        # Make sure target emails exist and are verified
+        emails_to_check = set(data.values())
+        emails = UserEmail.objects.filter(user=user, email__in=emails_to_check, is_verified=True)
+
+        # Is there a better way to check this?
+        if len(emails) != len(emails_to_check):
+            return Response(
+                {
+                    "detail": "Invalid email value(s) provided. Email values must be verified emails for the given user."
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         with transaction.atomic():
-            for id in request.data:
-                val = request.data[id]
-                int_val = int(val) if notification_type != FineTuningAPIKey.EMAIL else None
+            for id, value in data.items():
+                user_option, _ = UserOption.objects.get_or_create(
+                    {
+                        "user": user,
+                        "key": "mail:email",
+                        "project_id": id,
+                    }
+                )
+                user_option.update(value=str(value))
 
-                filter_args["%s_id" % update_key] = id
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
-                # 'email' doesn't have a default to delete, and it's a string
-                # -1 is a magic value to use "default" value, so just delete option
-                if int_val == -1:
-                    UserOption.objects.filter(**filter_args).delete()
-                else:
-                    user_option, _ = UserOption.objects.get_or_create(**filter_args)
+    @staticmethod
+    def _handle_put_notification_settings(user, notification_type: FineTuningAPIKey, parents, data):
+        with transaction.atomic():
+            for parent in parents:
+                # This partitioning always does the same thing because notification_type stays constant.
+                project_option, organization_option = (
+                    (None, parent)
+                    if notification_type == FineTuningAPIKey.DEPLOY
+                    else (parent, None)
+                )
 
-                    # Values have been saved as strings for `mail:alerts` *shrug*
-                    # `reports:disabled-organizations` requires an array of ids
-                    user_option.update(
-                        value=int_val if notification_type == FineTuningAPIKey.ALERTS else str(val)
-                    )
+                type = get_type_from_fine_tuning_key(notification_type)
+                NotificationSetting.objects.update_settings(
+                    ExternalProviders.EMAIL,
+                    type,
+                    get_option_value_from_int(type, int(data[parent.id])),
+                    user=user,
+                    project=project_option,
+                    organization=organization_option,
+                )
 
-            return Response(status=status.HTTP_204_NO_CONTENT)
-
-    def get_org_ids(self, user):
-        """ Get org ids for user """
-        return set(
-            OrganizationMember.objects.filter(
-                user=user, organization__status=OrganizationStatus.ACTIVE
-            ).values_list("organization_id", flat=True)
-        )
-
-    def get_project_ids(self, user):
-        """ Get project ids that user has access to """
-        return set(
-            ProjectTeam.objects.filter(
-                team_id__in=OrganizationMemberTeam.objects.filter(
-                    organizationmember__user=user
-                ).values_list("team_id", flat=True)
-            ).values_list("project_id", flat=True)
-        )
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -33,7 +33,7 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
             user,
             request.user,
             notifications,
-            notification_option_key=get_legacy_key_from_fine_tuning_key(notification_type),
+            notification_type=notification_type,
         )
         return Response(serialized)
 

--- a/src/sentry/api/serializers/models/user_notifications.py
+++ b/src/sentry/api/serializers/models/user_notifications.py
@@ -2,27 +2,29 @@ from collections import defaultdict
 
 from sentry.api.serializers import Serializer
 from sentry.models import UserOption
+from sentry.notifications.legacy_mappings import get_legacy_key_from_fine_tuning_key
+from sentry.notifications.types import FineTuningAPIKey
 
 
-# notification_option_key is one of:
-# - mail:alert
-# - workflow:notifications
-# - deploy-emails
-# - reports:disabled-organizations
-# - mail:email
 class UserNotificationsSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
-        notification_option_key = kwargs["notification_option_key"]
-        filter_args = {}
+        notification_type = kwargs["notification_type"]
 
-        if notification_option_key in ["mail:alert", "workflow:notifications", "mail:email"]:
+        filter_args = {}
+        if notification_type in [
+            FineTuningAPIKey.ALERTS,
+            FineTuningAPIKey.EMAIL,
+            FineTuningAPIKey.WORKFLOW,
+        ]:
             filter_args["project__isnull"] = False
-        elif notification_option_key == "deploy":
+        elif notification_type == FineTuningAPIKey.DEPLOY:
             filter_args["organization__isnull"] = False
 
         data = list(
             UserOption.objects.filter(
-                key=notification_option_key, user__in=item_list, **filter_args
+                key=get_legacy_key_from_fine_tuning_key(notification_type),
+                user__in=item_list,
+                **filter_args,
             ).select_related("user", "project", "organization")
         )
 
@@ -34,11 +36,11 @@ class UserNotificationsSerializer(Serializer):
         return results
 
     def serialize(self, obj, attrs, user, **kwargs):
-        notification_option_key = kwargs["notification_option_key"]
+        notification_type = kwargs["notification_type"]
         data = {}
 
         for uo in attrs:
-            if notification_option_key == "reports:disabled-organizations":
+            if notification_type == FineTuningAPIKey.REPORTS:
                 # UserOption for key=reports:disabled-organizations saves a list of orgIds
                 # that should not receive reports
                 # This UserOption should have both project + organization = None

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -49,7 +49,7 @@ def get_user_options(key, user_ids, project, default):
         for option in UserOption.objects.filter(
             Q(project__isnull=True) | Q(project=project),
             user_id__in=user_ids,
-            key="workflow:notifications",
+            key=key,
         )
     }
 

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -269,7 +269,7 @@ class Project(Model, PendingDeletionMixin):
                 for uo in UserOption.objects.filter(
                     key="subscribe_by_default", user__in=members_to_check
                 )
-                if uo.value == "0"
+                if str(uo.value) == "0"
             }
             member_set = [x for x in member_set if x not in disabled]
 

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -320,14 +320,14 @@ class User(BaseModel, AbstractBaseUser):
             id__in=OrganizationMember.objects.filter(user=self).values("organization"),
         )
 
-    def get_projects(self, user):
+    def get_projects(self):
         from sentry.models import Project, ProjectStatus, ProjectTeam, OrganizationMemberTeam
 
         return Project.objects.filter(
             status=ProjectStatus.VISIBLE,
             id__in=ProjectTeam.objects.filter(
                 team_id__in=OrganizationMemberTeam.objects.filter(
-                    organizationmember__user=user
+                    organizationmember__user=self
                 ).values_list("team_id", flat=True)
             ).values_list("project_id", flat=True),
         )

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -320,6 +320,18 @@ class User(BaseModel, AbstractBaseUser):
             id__in=OrganizationMember.objects.filter(user=self).values("organization"),
         )
 
+    def get_projects(self, user):
+        from sentry.models import Project, ProjectStatus, ProjectTeam, OrganizationMemberTeam
+
+        return Project.objects.filter(
+            status=ProjectStatus.VISIBLE,
+            id__in=ProjectTeam.objects.filter(
+                team_id__in=OrganizationMemberTeam.objects.filter(
+                    organizationmember__user=user
+                ).values_list("team_id", flat=True)
+            ).values_list("project_id", flat=True),
+        )
+
     def get_orgs_require_2fa(self):
         from sentry.models import Organization, OrganizationStatus
 

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -12,7 +12,18 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_http_methods
 
-from sentry.models import UserEmail, LostPasswordHash, Project, UserOption, Authenticator
+from sentry.models import (
+    Authenticator,
+    LostPasswordHash,
+    NotificationSetting,
+    Project,
+    UserEmail,
+)
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import (
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
+)
 from sentry.security import capture_security_activity
 from sentry.signals import email_verified
 from sentry.web.decorators import login_required, signed_auth_required, set_referrer_policy
@@ -235,8 +246,12 @@ def email_unsubscribe_project(request, project_id):
 
     if request.method == "POST":
         if "cancel" not in request.POST:
-            UserOption.objects.set_value(
-                user=request.user, key="mail:alert", value=0, project=project
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                NotificationSettingOptionValues.NEVER,
+                user=request.user,
+                project=project,
             )
         return HttpResponseRedirect(auth.get_login_url())
 

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -785,16 +785,13 @@ class CopyProjectSettingsTest(APITestCase):
     def test_additional_params_in_payload(self):
         # Right now these are overwritten with the copied project's settings
         project = self.create_project()
-        self.get_valid_response(
-            project.organization.slug,
-            project.slug,
-            **{
-                "copy_from_project": self.other_project.id,
-                "sentry:resolve_age": 2,
-                "sentry:scrub_data": True,
-                "sentry:scrub_defaults": True,
-            },
-        )
+        data = {
+            "copy_from_project": self.other_project.id,
+            "sentry:resolve_age": 2,
+            "sentry:scrub_data": True,
+            "sentry:scrub_defaults": True,
+        }
+        self.get_valid_response(project.organization.slug, project.slug, **data)
         self.assert_settings_copied(project)
         self.assert_other_project_settings_not_changed()
 

--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -74,15 +74,12 @@ class UserNotificationDetailsTest(APITestCase):
         user = self.create_user(email="a@example.com")
         self.login_as(user=user)
 
-        response = self.get_valid_response(
-            "me",
-            method="put",
-            **{
-                "deployNotifications": 2,
-                "personalActivityNotifications": True,
-                "selfAssignOnResolve": True,
-            },
-        )
+        data = {
+            "deployNotifications": 2,
+            "personalActivityNotifications": True,
+            "selfAssignOnResolve": True,
+        }
+        response = self.get_valid_response("me", method="put", **data)
 
         assert response.data.get("deployNotifications") == 2
         assert response.data.get("personalActivityNotifications") is True
@@ -116,7 +113,7 @@ class UserNotificationDetailsTest(APITestCase):
             UserOption.objects.get(
                 user=user, project=None, organization=org, key="deploy-emails"
             ).value
-            == 1
+            == "4"
         )
         assert (
             UserOption.objects.get(

--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -1,5 +1,10 @@
-from sentry.models import UserOption
 from sentry.notifications.legacy_mappings import UserOptionValue
+from sentry.models import NotificationSetting, UserOption
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import (
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
+)
 from sentry.testutils import APITestCase
 
 
@@ -30,22 +35,29 @@ class UserNotificationDetailsTest(APITestCase):
         self.get_valid_response(user.id)
 
     def test_returns_correct_defaults(self):
+        """
+        In this test we add existing per-project and per-organization
+        Notification settings in order to test that defaults are correct.
+        """
         user = self.create_user(email="a@example.com")
         org = self.create_organization(name="Org Name", owner=user)
 
-        # Adding existing UserOptions for a project or org to test that defaults are correct
         # default is 3
-        UserOption.objects.create(
-            user=user, project=None, organization=org, key="deploy-emails", value=1
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.DEPLOY,
+            NotificationSettingOptionValues.NEVER,
+            user=user,
+            organization=org,
         )
 
         # default is UserOptionValue.participating_only
-        UserOption.objects.create(
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
             user=user,
-            project=None,
             organization=org,
-            key="workflow:notifications",
-            value=UserOptionValue.all_conversations,
         )
 
         self.login_as(user=user)
@@ -89,8 +101,12 @@ class UserNotificationDetailsTest(APITestCase):
         user = self.create_user(email="a@example.com")
         org = self.create_organization(name="Org Name", owner=user)
         self.login_as(user=user)
-        UserOption.objects.create(
-            user=user, project=None, organization=org, key="deploy-emails", value=1
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.DEPLOY,
+            NotificationSettingOptionValues.NEVER,
+            user=user,
+            organization=org,
         )
 
         response = self.get_valid_response("me", method="put", **{"deployNotifications": 2})

--- a/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
+++ b/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
@@ -44,7 +44,7 @@ class UserNotificationFineTuningTest(APITestCase):
             organization=self.org,
         )
         response = self.get_valid_response("me", "deploy")
-        assert response.data.get(self.org.id) == 1
+        assert response.data.get(self.org.id) == "2"
 
         UserOption.objects.create(
             user=self.user,
@@ -71,7 +71,7 @@ class UserNotificationFineTuningTest(APITestCase):
             "alerts",
             method="put",
             status_code=204,
-            **{str(self.project.id): 1, str(self.project2.id): 2},
+            **{str(self.project.id): 1, str(self.project2.id): 0},
         )
 
         assert (
@@ -81,7 +81,7 @@ class UserNotificationFineTuningTest(APITestCase):
 
         assert (
             UserOption.objects.get(user=self.user, project=self.project2, key="mail:alert").value
-            == 2
+            == 0
         )
 
         # Can return to default
@@ -95,7 +95,7 @@ class UserNotificationFineTuningTest(APITestCase):
 
         assert (
             UserOption.objects.get(user=self.user, project=self.project2, key="mail:alert").value
-            == 2
+            == 0
         )
 
     def test_saves_and_returns_workflow(self):
@@ -140,13 +140,8 @@ class UserNotificationFineTuningTest(APITestCase):
     def test_saves_and_returns_email_routing(self):
         UserEmail.objects.create(user=self.user, email="alias@example.com", is_verified=True).save()
 
-        self.get_valid_response(
-            "me",
-            "email",
-            method="put",
-            status_code=204,
-            **{str(self.project.id): "a@example.com", str(self.project2.id): "alias@example.com"},
-        )
+        data = {str(self.project.id): "a@example.com", str(self.project2.id): "alias@example.com"}
+        self.get_valid_response("me", "email", method="put", status_code=204, **data)
 
         assert (
             UserOption.objects.get(user=self.user, project=self.project, key="mail:email").value
@@ -185,22 +180,20 @@ class UserNotificationFineTuningTest(APITestCase):
 
     def test_saves_and_returns_deploy(self):
         self.get_valid_response(
-            "me", "deploy", method="put", status_code=204, **{str(self.org.id): 0}
+            "me", "deploy", method="put", status_code=204, **{str(self.org.id): 4}
         )
 
         assert (
-            UserOption.objects.get(
-                user=self.user, organization=self.org.id, key="deploy-emails"
-            ).value
-            == "0"
+            UserOption.objects.get(user=self.user, organization=self.org, key="deploy-emails").value
+            == "4"
         )
 
         self.get_valid_response(
-            "me", "deploy", method="put", status_code=204, **{str(self.org.id): 1}
+            "me", "deploy", method="put", status_code=204, **{str(self.org.id): 2}
         )
         assert (
             UserOption.objects.get(user=self.user, organization=self.org, key="deploy-emails").value
-            == "1"
+            == "2"
         )
 
         self.get_valid_response(

--- a/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
+++ b/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
@@ -1,4 +1,9 @@
-from sentry.models import UserEmail, UserOption
+from sentry.models import NotificationSetting, UserEmail, UserOption
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import (
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
+)
 from sentry.testutils import APITestCase
 
 
@@ -21,12 +26,22 @@ class UserNotificationFineTuningTest(APITestCase):
         self.login_as(user=self.user)
 
     def test_returns_correct_defaults(self):
-        UserOption.objects.create(user=self.user, project=self.project, key="mail:alert", value=1)
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.ALWAYS,
+            user=self.user,
+            project=self.project,
+        )
         response = self.get_valid_response("me", "alerts")
         assert response.data.get(self.project.id) == 1
 
-        UserOption.objects.create(
-            user=self.user, organization=self.org, key="deploy-emails", value=1
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.DEPLOY,
+            NotificationSettingOptionValues.ALWAYS,
+            user=self.user,
+            organization=self.org,
         )
         response = self.get_valid_response("me", "deploy")
         assert response.data.get(self.org.id) == 1

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -11,9 +11,14 @@ from sentry.models import (
     GroupSnooze,
     GroupStatus,
     GroupSubscription,
+    NotificationSetting,
     UserOption,
 )
-from sentry.notifications.legacy_mappings import UserOptionValue
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import (
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
+)
 from sentry.testutils import TestCase
 from sentry.utils.compat import mock
 from sentry.utils.compat.mock import patch
@@ -162,55 +167,113 @@ class GroupSerializerTest(TestCase):
         group = self.create_group()
 
         combinations = (
-            # ((default, project), (subscribed, details))
-            ((UserOptionValue.all_conversations, None), (True, None)),
-            ((UserOptionValue.all_conversations, UserOptionValue.all_conversations), (True, None)),
+            # (default, project, subscribed, has_details)
             (
-                (UserOptionValue.all_conversations, UserOptionValue.participating_only),
-                (False, None),
+                NotificationSettingOptionValues.ALWAYS,
+                NotificationSettingOptionValues.DEFAULT,
+                True,
+                False,
             ),
             (
-                (UserOptionValue.all_conversations, UserOptionValue.no_conversations),
-                (False, {"disabled": True}),
-            ),
-            ((None, None), (False, None)),
-            ((UserOptionValue.participating_only, None), (False, None)),
-            ((UserOptionValue.participating_only, UserOptionValue.all_conversations), (True, None)),
-            (
-                (UserOptionValue.participating_only, UserOptionValue.participating_only),
-                (False, None),
+                NotificationSettingOptionValues.ALWAYS,
+                NotificationSettingOptionValues.ALWAYS,
+                True,
+                False,
             ),
             (
-                (UserOptionValue.participating_only, UserOptionValue.no_conversations),
-                (False, {"disabled": True}),
+                NotificationSettingOptionValues.ALWAYS,
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                False,
+                False,
             ),
-            ((UserOptionValue.no_conversations, None), (False, {"disabled": True})),
-            ((UserOptionValue.no_conversations, UserOptionValue.all_conversations), (True, None)),
-            ((UserOptionValue.no_conversations, UserOptionValue.participating_only), (False, None)),
             (
-                (UserOptionValue.no_conversations, UserOptionValue.no_conversations),
-                (False, {"disabled": True}),
+                NotificationSettingOptionValues.ALWAYS,
+                NotificationSettingOptionValues.NEVER,
+                False,
+                True,
+            ),
+            (
+                NotificationSettingOptionValues.DEFAULT,
+                NotificationSettingOptionValues.DEFAULT,
+                False,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                NotificationSettingOptionValues.DEFAULT,
+                False,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                NotificationSettingOptionValues.ALWAYS,
+                True,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                False,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                NotificationSettingOptionValues.NEVER,
+                False,
+                True,
+            ),
+            (
+                NotificationSettingOptionValues.NEVER,
+                NotificationSettingOptionValues.DEFAULT,
+                False,
+                True,
+            ),
+            (
+                NotificationSettingOptionValues.NEVER,
+                NotificationSettingOptionValues.ALWAYS,
+                True,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.NEVER,
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                False,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.NEVER,
+                NotificationSettingOptionValues.NEVER,
+                False,
+                True,
             ),
         )
 
-        def maybe_set_value(project, value):
-            if value is not None:
-                UserOption.objects.set_value(
-                    user=user, project=project, key="workflow:notifications", value=value
-                )
-            else:
-                UserOption.objects.unset_value(
-                    user=user, project=project, key="workflow:notifications"
-                )
-
-        for options, (is_subscribed, subscription_details) in combinations:
-            default_value, project_value = options
+        for default_value, project_value, is_subscribed, has_details in combinations:
             UserOption.objects.clear_local_cache()
-            maybe_set_value(None, default_value)
-            maybe_set_value(group.project, project_value)
+
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.WORKFLOW,
+                default_value,
+                user=user,
+            )
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.WORKFLOW,
+                project_value,
+                user=user,
+                project=group.project,
+            )
+
             result = serialize(group, user)
+            subscription_details = result.get("subscriptionDetails")
+
             assert result["isSubscribed"] is is_subscribed
-            assert result.get("subscriptionDetails") == subscription_details
+            assert (
+                subscription_details == {"disabled": True}
+                if has_details
+                else subscription_details is None
+            )
 
     def test_global_no_conversations_overrides_group_subscription(self):
         user = self.create_user()
@@ -220,11 +283,11 @@ class GroupSerializerTest(TestCase):
             user=user, group=group, project=group.project, is_active=True
         )
 
-        UserOption.objects.set_value(
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.NEVER,
             user=user,
-            project=None,
-            key="workflow:notifications",
-            value=UserOptionValue.no_conversations,
         )
 
         result = serialize(group, user)
@@ -239,11 +302,12 @@ class GroupSerializerTest(TestCase):
             user=user, group=group, project=group.project, is_active=True
         )
 
-        UserOption.objects.set_value(
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.NEVER,
             user=user,
             project=group.project,
-            key="workflow:notifications",
-            value=UserOptionValue.no_conversations,
         )
 
         result = serialize(group, user)

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -24,7 +24,11 @@ from sentry.incidents.models import (
     TriggerStatus,
     INCIDENT_STATUS,
 )
-from sentry.models import Integration, NotificationSetting, PagerDutyService, UserOption
+from sentry.models import (
+    Integration,
+    NotificationSetting,
+    PagerDutyService,
+)
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
     NotificationSettingTypes,
@@ -85,7 +89,12 @@ class EmailActionHandlerGetTargetsTest(TestCase):
             project=self.project,
         )
         disabled_user = self.create_user()
-        UserOption.objects.set_value(user=disabled_user, key="subscribe_by_default", value="0")
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=disabled_user,
+        )
 
         new_user = self.create_user()
         self.create_team_membership(team=self.team, user=new_user)

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -24,7 +24,12 @@ from sentry.incidents.models import (
     TriggerStatus,
     INCIDENT_STATUS,
 )
-from sentry.models import Integration, PagerDutyService, UserOption
+from sentry.models import Integration, NotificationSetting, PagerDutyService, UserOption
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import (
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
+)
 from sentry.testutils import TestCase
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
@@ -44,8 +49,12 @@ class EmailActionHandlerGetTargetsTest(TestCase):
         assert handler.get_targets() == [(self.user.id, self.user.email)]
 
     def test_user_alerts_disabled(self):
-        UserOption.objects.set_value(
-            user=self.user, key="mail:alert", value=0, project=self.project
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+            project=self.project,
         )
         action = self.create_alert_rule_trigger_action(
             target_type=AlertRuleTriggerAction.TargetType.USER,
@@ -68,8 +77,12 @@ class EmailActionHandlerGetTargetsTest(TestCase):
         }
 
     def test_team_alert_disabled(self):
-        UserOption.objects.set_value(
-            user=self.user, key="mail:alert", value=0, project=self.project
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+            project=self.project,
         )
         disabled_user = self.create_user()
         UserOption.objects.set_value(user=disabled_user, key="subscribe_by_default", value="0")

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -8,14 +8,18 @@ from sentry.models import (
     Deploy,
     Environment,
     GroupSubscriptionReason,
+    NotificationSetting,
     Release,
     ReleaseCommit,
     Repository,
     UserEmail,
-    UserOption,
 )
 from sentry.mail.activity.release import ReleaseActivityEmail
-from sentry.notifications.legacy_mappings import UserOptionValue
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import (
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
+)
 from sentry.testutils import TestCase
 
 
@@ -103,26 +107,28 @@ class ReleaseTestCase(TestCase):
         self.commit3 = self.another_commit(2, "c", self.user4, repository)
         self.commit4 = self.another_commit(3, "e", self.user5, repository, user5_alt_email)
 
-        UserOption.objects.set_value(
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.DEPLOY,
+            NotificationSettingOptionValues.ALWAYS,
             user=self.user3,
             organization=self.org,
-            key="deploy-emails",
-            value=UserOptionValue.all_deploys,
         )
 
-        UserOption.objects.set_value(
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.DEPLOY,
+            NotificationSettingOptionValues.NEVER,
             user=self.user4,
             organization=self.org,
-            key="deploy-emails",
-            value=UserOptionValue.no_deploys,
         )
 
         # added to make sure org default above takes precedent
-        UserOption.objects.set_value(
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.DEPLOY,
+            NotificationSettingOptionValues.ALWAYS,
             user=self.user4,
-            organization=None,
-            key="deploy-emails",
-            value=UserOptionValue.all_deploys,
         )
 
     def test_simple(self):
@@ -224,8 +230,11 @@ class ReleaseTestCase(TestCase):
         user6 = self.create_user()
         self.create_member(user=user6, organization=self.org, teams=[self.team])
 
-        UserOption.objects.set_value(
-            user=user6, organization=None, key="deploy-emails", value=UserOptionValue.all_deploys
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.DEPLOY,
+            NotificationSettingOptionValues.ALWAYS,
+            user=user6,
         )
         release, deploy = self.another_release("b")
 

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -14,6 +14,7 @@ from sentry.mail import mail_adapter
 from sentry.mail.adapter import ActionTargetType
 from sentry.models import (
     Activity,
+    NotificationSetting,
     Organization,
     OrganizationMember,
     OrganizationMemberTeam,
@@ -25,7 +26,11 @@ from sentry.models import (
     UserOption,
     UserReport,
 )
-from sentry.notifications.legacy_mappings import UserOptionValue
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import (
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
+)
 from sentry.ownership import grammar
 from sentry.ownership.grammar import dump_schema, Matcher, Owner
 from sentry.plugins.base import Notification
@@ -94,8 +99,12 @@ class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
         )
 
         # Make sure that disabling mail alerts works as expected
-        UserOption.objects.set_value(
-            user=self.user2, key="mail:alert", value=0, project=self.project
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user2,
+            project=self.project,
         )
         assert {self.user.pk} == self.adapter.get_send_to(
             self.project, ActionTargetType.ISSUE_OWNERS, event=event.data
@@ -108,8 +117,12 @@ class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
         )
 
         # Make sure that disabling mail alerts works as expected
-        UserOption.objects.set_value(
-            user=self.user2, key="mail:alert", value=0, project=self.project
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user2,
+            project=self.project,
         )
         assert {self.user.pk} == self.adapter.get_send_to(
             self.project, ActionTargetType.ISSUE_OWNERS, event=event.data
@@ -160,7 +173,13 @@ class MailAdapterGetSendableUsersTest(BaseMailAdapterTest, TestCase):
         assert sorted({user.pk, user2.pk}) == sorted(self.adapter.get_sendable_users(project))
 
         # disabled user2
-        UserOption.objects.create(key="mail:alert", value=0, project=project, user=user2)
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user2,
+            project=self.project,
+        )
 
         assert user2.pk not in self.adapter.get_sendable_users(project)
 
@@ -431,7 +450,13 @@ class MailAdapterNotifyTest(BaseMailAdapterTest, TestCase):
         self.assert_notify(event_single_user, [user2.email])
 
         # Make sure that disabling mail alerts works as expected
-        UserOption.objects.set_value(user=user2, key="mail:alert", value=0, project=project)
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=user2,
+            project=project,
+        )
         event_all_users = self.store_event(
             data=self.make_event_data("foo.cbl"), project_id=project.id
         )
@@ -557,14 +582,22 @@ class MailAdapterShouldNotifyTest(BaseMailAdapterTest, TestCase):
         assert self.adapter.should_notify(ActionTargetType.MEMBER, self.group)
 
     def test_should_not_notify_no_users(self):
-        UserOption.objects.set_value(
-            user=self.user, key="mail:alert", value=0, project=self.project
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+            project=self.project,
         )
         assert not self.adapter.should_notify(ActionTargetType.ISSUE_OWNERS, self.group)
 
     def test_should_always_notify_target_member(self):
-        UserOption.objects.set_value(
-            user=self.user, key="mail:alert", value=0, project=self.project
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+            project=self.project,
         )
         assert self.adapter.should_notify(ActionTargetType.MEMBER, self.group)
 
@@ -634,8 +667,12 @@ class MailAdapterGetSendToOwnersTest(BaseMailAdapterTest, TestCase):
 
     def test_disable_alerts(self):
         # Make sure that disabling mail alerts works as expected
-        UserOption.objects.set_value(
-            user=self.user2, key="mail:alert", value=0, project=self.project
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user2,
+            project=self.project,
         )
         event_all_users = self.store_event(
             data=self.make_event_data("foo.cbl"), project_id=self.project.id
@@ -651,7 +688,13 @@ class MailAdapterGetSendToTeamTest(BaseMailAdapterTest, TestCase):
         assert {self.user.id} == self.adapter.get_send_to_team(self.project, str(self.team.id))
 
     def test_send_disabled(self):
-        UserOption.objects.create(key="mail:alert", value=0, project=self.project, user=self.user)
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+            project=self.project,
+        )
         assert set() == self.adapter.get_send_to_team(self.project, str(self.team.id))
 
     def test_invalid_team(self):
@@ -678,7 +721,13 @@ class MailAdapterGetSendToMemberTest(BaseMailAdapterTest, TestCase):
         assert {self.user.id} == self.adapter.get_send_to_member(self.project, str(self.user.id))
 
     def test_send_disabled_still_sends(self):
-        UserOption.objects.create(key="mail:alert", value=0, project=self.project, user=self.user)
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+            project=self.project,
+        )
         assert {self.user.id} == self.adapter.get_send_to_member(self.project, str(self.user.id))
 
     def test_invalid_user(self):
@@ -706,8 +755,11 @@ class MailAdapterGetSendToMemberTest(BaseMailAdapterTest, TestCase):
 
 class MailAdapterNotifyAboutActivityTest(BaseMailAdapterTest, TestCase):
     def test_assignment(self):
-        UserOption.objects.set_value(
-            user=self.user, key="workflow:notifications", value=UserOptionValue.all_conversations
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
+            user=self.user,
         )
         activity = Activity.objects.create(
             project=self.project,
@@ -728,8 +780,11 @@ class MailAdapterNotifyAboutActivityTest(BaseMailAdapterTest, TestCase):
         assert msg.to == [self.user.email]
 
     def test_assignment_team(self):
-        UserOption.objects.set_value(
-            user=self.user, key="workflow:notifications", value=UserOptionValue.all_conversations
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
+            user=self.user,
         )
 
         activity = Activity.objects.create(
@@ -752,8 +807,11 @@ class MailAdapterNotifyAboutActivityTest(BaseMailAdapterTest, TestCase):
 
     def test_note(self):
         user_foo = self.create_user("foo@example.com")
-        UserOption.objects.set_value(
-            user=self.user, key="workflow:notifications", value=UserOptionValue.all_conversations
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
+            user=self.user,
         )
 
         activity = Activity.objects.create(
@@ -791,8 +849,11 @@ class MailAdapterHandleSignalTest(BaseMailAdapterTest, TestCase):
 
     def test_user_feedback(self):
         report = self.create_report()
-        UserOption.objects.set_value(
-            user=self.user, key="workflow:notifications", value=UserOptionValue.all_conversations
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
+            user=self.user,
         )
 
         with self.tasks():
@@ -820,8 +881,11 @@ class MailAdapterHandleSignalTest(BaseMailAdapterTest, TestCase):
     def test_user_feedback__enhanced_privacy(self):
         self.organization.update(flags=F("flags").bitor(Organization.flags.enhanced_privacy))
         assert self.organization.flags.enhanced_privacy.is_set is True
-        UserOption.objects.set_value(
-            user=self.user, key="workflow:notifications", value=UserOptionValue.all_conversations
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
+            user=self.user,
         )
 
         report = self.create_report()

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -23,7 +23,6 @@ from sentry.models import (
     Repository,
     Rule,
     User,
-    UserOption,
     UserReport,
 )
 from sentry.models.integration import ExternalProviders
@@ -188,16 +187,26 @@ class MailAdapterGetSendableUsersTest(BaseMailAdapterTest, TestCase):
         assert user4.pk in self.adapter.get_sendable_users(project)
 
         # disabled by default user4
-        uo1 = UserOption.objects.create(
-            key="subscribe_by_default", value="0", project=project, user=user4
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=user4,
         )
 
         assert user4.pk not in self.adapter.get_sendable_users(project)
 
-        uo1.delete()
+        NotificationSetting.objects.remove_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            user=user4,
+        )
 
-        UserOption.objects.create(
-            key="subscribe_by_default", value="0", project=project, user=user4
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=user4,
         )
 
         assert user4.pk not in self.adapter.get_sendable_users(project)

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -176,8 +176,8 @@ class MailAdapterGetSendableUsersTest(BaseMailAdapterTest, TestCase):
             ExternalProviders.EMAIL,
             NotificationSettingTypes.ISSUE_ALERTS,
             NotificationSettingOptionValues.NEVER,
-            user=self.user2,
-            project=self.project,
+            user=user2,
+            project=project,
         )
 
         assert user2.pk not in self.adapter.get_sendable_users(project)

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -1,9 +1,20 @@
 import functools
-import itertools
 
-from sentry.models import GroupSubscription, GroupSubscriptionReason, UserOption
-from sentry.notifications.legacy_mappings import UserOptionValue
+from sentry.models import (
+    GroupSubscription,
+    GroupSubscriptionReason,
+    NotificationSetting,
+)
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import (
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
+)
 from sentry.testutils import TestCase
+
+
+def clear_workflow_options(user):
+    NotificationSetting.objects.remove_settings_for_user(user, NotificationSettingTypes.WORKFLOW)
 
 
 class SubscribeTest(TestCase):
@@ -92,8 +103,11 @@ class GetParticipantsTest(TestCase):
         self.create_member(user=user, organization=org, teams=[team])
         self.create_member(user=user2, organization=org)
 
-        UserOption.objects.set_value(
-            user=user, key="workflow:notifications", value=UserOptionValue.all_conversations
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
+            user=user,
         )
 
         # implicit membership
@@ -111,8 +125,11 @@ class GetParticipantsTest(TestCase):
         # not participating by default
         GroupSubscription.objects.filter(user=user, group=group).delete()
 
-        UserOption.objects.set_value(
-            user=user, key="workflow:notifications", value=UserOptionValue.participating_only
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+            user=user,
         )
 
         users = GroupSubscription.objects.get_participants(group=group)
@@ -140,13 +157,12 @@ class GetParticipantsTest(TestCase):
         user = self.create_user()
         self.create_member(user=user, organization=org, teams=[team])
 
-        user_option_sequence = itertools.count(300)  # prevent accidental overlap with user id
-        UserOption.objects.set_value(
-            user=user, key="workflow:notifications", value=UserOptionValue.all_conversations
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
+            user=user,
         )
-
-        def clear_workflow_options():
-            UserOption.objects.filter(user=user, key="workflow:notifications").delete()
 
         get_participants = functools.partial(GroupSubscription.objects.get_participants, group)
 
@@ -156,39 +172,38 @@ class GetParticipantsTest(TestCase):
         with self.assertChanges(
             get_participants, before={user: GroupSubscriptionReason.implicit}, after={}
         ):
-            UserOption.objects.create(
-                id=next(user_option_sequence),
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.WORKFLOW,
+                NotificationSettingOptionValues.NEVER,
                 user=user,
                 project=project,
-                key="workflow:notifications",
-                value=UserOptionValue.no_conversations,
             )
 
-        clear_workflow_options()
+        clear_workflow_options(user)
 
         # Implicit subscription, ensure the project setting overrides the
         # explicit global option.
 
-        UserOption.objects.create(
-            id=next(user_option_sequence),
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
             user=user,
-            project=None,
-            key="workflow:notifications",
-            value=UserOptionValue.all_conversations,
         )
 
         with self.assertChanges(
             get_participants, before={user: GroupSubscriptionReason.implicit}, after={}
         ):
-            UserOption.objects.create(
-                id=next(user_option_sequence),
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.WORKFLOW,
+                NotificationSettingOptionValues.NEVER,
                 user=user,
                 project=project,
-                key="workflow:notifications",
-                value=UserOptionValue.no_conversations,
             )
 
-        clear_workflow_options()
+        clear_workflow_options(user)
 
         # Explicit subscription, overridden by the global option.
 
@@ -203,38 +218,36 @@ class GetParticipantsTest(TestCase):
         with self.assertChanges(
             get_participants, before={user: GroupSubscriptionReason.comment}, after={}
         ):
-            UserOption.objects.create(
-                id=next(user_option_sequence),
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.WORKFLOW,
+                NotificationSettingOptionValues.NEVER,
                 user=user,
-                project=None,
-                key="workflow:notifications",
-                value=UserOptionValue.no_conversations,
             )
 
-        clear_workflow_options()
+        clear_workflow_options(user)
 
         # Explicit subscription, overridden by the project option.
 
-        UserOption.objects.create(
-            id=next(user_option_sequence),
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
             user=user,
-            project=None,
-            key="workflow:notifications",
-            value=UserOptionValue.participating_only,
         )
 
         with self.assertChanges(
             get_participants, before={user: GroupSubscriptionReason.comment}, after={}
         ):
-            UserOption.objects.create(
-                id=next(user_option_sequence),
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.WORKFLOW,
+                NotificationSettingOptionValues.NEVER,
                 user=user,
                 project=project,
-                key="workflow:notifications",
-                value=UserOptionValue.no_conversations,
             )
 
-        clear_workflow_options()
+        clear_workflow_options(user)
 
         # Explicit subscription, overridden by the project option which also
         # overrides the default option.
@@ -242,12 +255,12 @@ class GetParticipantsTest(TestCase):
         with self.assertChanges(
             get_participants, before={user: GroupSubscriptionReason.comment}, after={}
         ):
-            UserOption.objects.create(
-                id=next(user_option_sequence),
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.WORKFLOW,
+                NotificationSettingOptionValues.NEVER,
                 user=user,
                 project=project,
-                key="workflow:notifications",
-                value=UserOptionValue.no_conversations,
             )
 
     def test_participating_only(self):
@@ -257,14 +270,12 @@ class GetParticipantsTest(TestCase):
         group = self.create_group(project=project)
         user = self.create_user()
         self.create_member(user=user, organization=org, teams=[team])
-        UserOption.objects.set_value(
-            user=user, key="workflow:notifications", value=UserOptionValue.all_conversations
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
+            user=user,
         )
-
-        user_option_sequence = itertools.count(300)  # prevent accidental overlap with user id
-
-        def clear_workflow_options():
-            UserOption.objects.filter(user=user, key="workflow:notifications").delete()
 
         get_participants = functools.partial(GroupSubscription.objects.get_participants, group)
 
@@ -274,48 +285,46 @@ class GetParticipantsTest(TestCase):
         with self.assertChanges(
             get_participants, before={user: GroupSubscriptionReason.implicit}, after={}
         ):
-            UserOption.objects.create(
-                id=next(user_option_sequence),
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.WORKFLOW,
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
                 user=user,
                 project=project,
-                key="workflow:notifications",
-                value=UserOptionValue.participating_only,
             )
 
-        clear_workflow_options()
+        clear_workflow_options(user)
 
         # Implicit subscription, ensure the project setting overrides the
         # explicit global option.
 
-        UserOption.objects.create(
-            id=next(user_option_sequence),
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
             user=user,
-            project=None,
-            key="workflow:notifications",
-            value=UserOptionValue.all_conversations,
         )
 
         with self.assertChanges(
             get_participants, before={user: GroupSubscriptionReason.implicit}, after={}
         ):
-            UserOption.objects.create(
-                id=next(user_option_sequence),
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.WORKFLOW,
+                NotificationSettingOptionValues.NEVER,
                 user=user,
                 project=project,
-                key="workflow:notifications",
-                value=UserOptionValue.no_conversations,
             )
 
-        clear_workflow_options()
+        clear_workflow_options(user)
 
         # Ensure the global default is applied.
 
-        UserOption.objects.create(
-            id=next(user_option_sequence),
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
             user=user,
-            project=None,
-            key="workflow:notifications",
-            value=UserOptionValue.participating_only,
         )
 
         with self.assertChanges(
@@ -330,16 +339,16 @@ class GetParticipantsTest(TestCase):
             )
 
         subscription.delete()
-        clear_workflow_options()
+        clear_workflow_options(user)
 
         # Ensure the project setting overrides the global default.
 
-        UserOption.objects.create(
-            id=next(user_option_sequence),
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
             user=user,
             project=group.project,
-            key="workflow:notifications",
-            value=UserOptionValue.participating_only,
         )
 
         with self.assertChanges(
@@ -354,24 +363,23 @@ class GetParticipantsTest(TestCase):
             )
 
         subscription.delete()
-        clear_workflow_options()
+        clear_workflow_options(user)
 
         # Ensure the project setting overrides the global setting.
 
-        UserOption.objects.create(
-            id=next(user_option_sequence),
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
             user=user,
-            project=None,
-            key="workflow:notifications",
-            value=UserOptionValue.all_conversations,
         )
 
-        UserOption.objects.create(
-            id=next(user_option_sequence),
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
             user=user,
             project=group.project,
-            key="workflow:notifications",
-            value=UserOptionValue.participating_only,
         )
 
         with self.assertChanges(
@@ -386,22 +394,21 @@ class GetParticipantsTest(TestCase):
             )
 
         subscription.delete()
-        clear_workflow_options()
+        clear_workflow_options(user)
 
-        UserOption.objects.create(
-            id=next(user_option_sequence),
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
             user=user,
-            project=None,
-            key="workflow:notifications",
-            value=UserOptionValue.participating_only,
         )
 
-        UserOption.objects.create(
-            id=next(user_option_sequence),
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
             user=user,
             project=group.project,
-            key="workflow:notifications",
-            value=UserOptionValue.all_conversations,
         )
 
         with self.assertChanges(
@@ -442,11 +449,12 @@ class GetParticipantsTest(TestCase):
 
         assert users == {}
 
-        UserOption.objects.set_value(
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
             user=user,
             project=project,
-            key="workflow:notifications",
-            value=UserOptionValue.participating_only,
         )
 
         # explicit participation, participating only
@@ -461,11 +469,12 @@ class GetParticipantsTest(TestCase):
 
         assert users == {}
 
-        UserOption.objects.set_value(
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
             user=user,
             project=project,
-            key="workflow:notifications",
-            value=UserOptionValue.all_conversations,
         )
 
         # explicit participation, explicit participating only

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -11,7 +11,6 @@ from sentry.models import (
     ReleaseProject,
     ReleaseProjectEnvironment,
     Rule,
-    UserOption,
 )
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
@@ -306,17 +305,32 @@ class FilterToSubscribedUsersTest(TestCase):
 
     def test_global_enabled(self):
         user = self.create_user()
-        UserOption.objects.set_value(user, "subscribe_by_default", "1")
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.ALWAYS,
+            user=user,
+        )
         self.run_test([user], [user])
 
     def test_global_disabled(self):
         user = self.create_user()
-        UserOption.objects.set_value(user, "subscribe_by_default", "0")
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=user,
+        )
         self.run_test([user], [])
 
     def test_project_enabled(self):
         user = self.create_user()
-        UserOption.objects.set_value(user, "subscribe_by_default", "0")
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=user,
+        )
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
             NotificationSettingTypes.ISSUE_ALERTS,
@@ -328,7 +342,12 @@ class FilterToSubscribedUsersTest(TestCase):
 
     def test_project_disabled(self):
         user = self.create_user()
-        UserOption.objects.set_value(user, "subscribe_by_default", "1")
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.ALWAYS,
+            user=user,
+        )
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
             NotificationSettingTypes.ISSUE_ALERTS,
@@ -340,11 +359,28 @@ class FilterToSubscribedUsersTest(TestCase):
 
     def test_mixed(self):
         user_global_enabled = self.create_user()
-        UserOption.objects.set_value(user_global_enabled, "subscribe_by_default", "1")
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.ALWAYS,
+            user=user_global_enabled,
+        )
+
         user_global_disabled = self.create_user()
-        UserOption.objects.set_value(user_global_disabled, "subscribe_by_default", "0")
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=user_global_disabled,
+        )
+
         user_project_enabled = self.create_user()
-        UserOption.objects.set_value(user_project_enabled, "subscribe_by_default", "0")
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=user_project_enabled,
+        )
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
             NotificationSettingTypes.ISSUE_ALERTS,
@@ -352,8 +388,14 @@ class FilterToSubscribedUsersTest(TestCase):
             user=user_project_enabled,
             project=self.project,
         )
+
         user_project_disabled = self.create_user()
-        UserOption.objects.set_value(user_project_disabled, "subscribe_by_default", "1")
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.ALWAYS,
+            user=user_project_disabled,
+        )
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
             NotificationSettingTypes.ISSUE_ALERTS,

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -26,7 +26,6 @@ from sentry.notifications.types import (
     NotificationSettingTypes,
     NotificationSettingOptionValues,
 )
-from sentry.notifications.legacy_mappings import UserOptionValue
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.utils.compat import mock

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -18,7 +18,13 @@ from sentry.models import (
     GroupSnooze,
     GroupStatus,
     GroupSubscription,
+    NotificationSetting,
     UserOption,
+)
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import (
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
 )
 from sentry.notifications.legacy_mappings import UserOptionValue
 from sentry.testutils import APITestCase, SnubaTestCase
@@ -177,55 +183,113 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
         group = self.create_group()
 
         combinations = (
-            # ((default, project), (subscribed, details))
-            ((UserOptionValue.all_conversations, None), (True, None)),
-            ((UserOptionValue.all_conversations, UserOptionValue.all_conversations), (True, None)),
+            # (default, project, subscribed, has_details)
             (
-                (UserOptionValue.all_conversations, UserOptionValue.participating_only),
-                (False, None),
+                NotificationSettingOptionValues.ALWAYS,
+                NotificationSettingOptionValues.DEFAULT,
+                True,
+                False,
             ),
             (
-                (UserOptionValue.all_conversations, UserOptionValue.no_conversations),
-                (False, {"disabled": True}),
-            ),
-            ((None, None), (False, None)),
-            ((UserOptionValue.participating_only, None), (False, None)),
-            ((UserOptionValue.participating_only, UserOptionValue.all_conversations), (True, None)),
-            (
-                (UserOptionValue.participating_only, UserOptionValue.participating_only),
-                (False, None),
+                NotificationSettingOptionValues.ALWAYS,
+                NotificationSettingOptionValues.ALWAYS,
+                True,
+                False,
             ),
             (
-                (UserOptionValue.participating_only, UserOptionValue.no_conversations),
-                (False, {"disabled": True}),
+                NotificationSettingOptionValues.ALWAYS,
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                False,
+                False,
             ),
-            ((UserOptionValue.no_conversations, None), (False, {"disabled": True})),
-            ((UserOptionValue.no_conversations, UserOptionValue.all_conversations), (True, None)),
-            ((UserOptionValue.no_conversations, UserOptionValue.participating_only), (False, None)),
             (
-                (UserOptionValue.no_conversations, UserOptionValue.no_conversations),
-                (False, {"disabled": True}),
+                NotificationSettingOptionValues.ALWAYS,
+                NotificationSettingOptionValues.NEVER,
+                False,
+                True,
+            ),
+            (
+                NotificationSettingOptionValues.DEFAULT,
+                NotificationSettingOptionValues.DEFAULT,
+                False,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                NotificationSettingOptionValues.DEFAULT,
+                False,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                NotificationSettingOptionValues.ALWAYS,
+                True,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                False,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                NotificationSettingOptionValues.NEVER,
+                False,
+                True,
+            ),
+            (
+                NotificationSettingOptionValues.NEVER,
+                NotificationSettingOptionValues.DEFAULT,
+                False,
+                True,
+            ),
+            (
+                NotificationSettingOptionValues.NEVER,
+                NotificationSettingOptionValues.ALWAYS,
+                True,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.NEVER,
+                NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+                False,
+                False,
+            ),
+            (
+                NotificationSettingOptionValues.NEVER,
+                NotificationSettingOptionValues.NEVER,
+                False,
+                True,
             ),
         )
 
-        def maybe_set_value(project, value):
-            if value is not None:
-                UserOption.objects.set_value(
-                    user=user, project=project, key="workflow:notifications", value=value
-                )
-            else:
-                UserOption.objects.unset_value(
-                    user=user, project=project, key="workflow:notifications"
-                )
-
-        for options, (is_subscribed, subscription_details) in combinations:
-            default_value, project_value = options
+        for default_value, project_value, is_subscribed, has_details in combinations:
             UserOption.objects.clear_local_cache()
-            maybe_set_value(None, default_value)
-            maybe_set_value(group.project, project_value)
+
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.WORKFLOW,
+                default_value,
+                user=user,
+            )
+            NotificationSetting.objects.update_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.WORKFLOW,
+                project_value,
+                user=user,
+                project=group.project,
+            )
+
             result = serialize(group, user, serializer=GroupSerializerSnuba())
+            subscription_details = result.get("subscriptionDetails")
+
             assert result["isSubscribed"] is is_subscribed
-            assert result.get("subscriptionDetails") == subscription_details
+            assert (
+                subscription_details == {"disabled": True}
+                if has_details
+                else subscription_details is None
+            )
 
     def test_global_no_conversations_overrides_group_subscription(self):
         user = self.create_user()
@@ -235,11 +299,11 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
             user=user, group=group, project=group.project, is_active=True
         )
 
-        UserOption.objects.set_value(
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.NEVER,
             user=user,
-            project=None,
-            key="workflow:notifications",
-            value=UserOptionValue.no_conversations,
         )
 
         result = serialize(group, user, serializer=GroupSerializerSnuba())
@@ -254,11 +318,12 @@ class GroupSerializerSnubaTest(APITestCase, SnubaTestCase):
             user=user, group=group, project=group.project, is_active=True
         )
 
-        UserOption.objects.set_value(
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.NEVER,
             user=user,
             project=group.project,
-            key="workflow:notifications",
-            value=UserOptionValue.no_conversations,
         )
 
         result = serialize(group, user, serializer=GroupSerializerSnuba())


### PR DESCRIPTION
In the previous PR (https://github.com/getsentry/sentry/pull/24405), we intercepted all writes to the `UserOption` table and copied them to `NotificationSettings`. Now in this PR we find _every call_ to the `UserOption` table for the relevant keys (`workflow:notifications`, `mail:alert`, and `deploy-emails`) and _replace_ them with a new function. This new function `update_settings` writes identical data to both tables so that when we later read from the new table everything should be the same.