### PR TITLE
feat(discover): Allow numeric shorthand on numeric queries

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -20,6 +20,7 @@ from sentry.search.utils import (
     parse_datetime_range,
     parse_datetime_string,
     parse_datetime_value,
+    parse_numeric_value,
     parse_release,
     InvalidQuery,
 )
@@ -144,7 +145,7 @@ numeric_filter       = search_key sep operator? numeric_value
 # Boolean comparison filter
 boolean_filter       = negation? search_key sep boolean_value
 # Aggregate numeric filter
-aggregate_filter          = negation? aggregate_key sep operator? (numeric_value / duration_format / percentage_format)
+aggregate_filter          = negation? aggregate_key sep operator? (duration_format / numeric_value / percentage_format)
 aggregate_date_filter     = negation? aggregate_key sep operator? (date_format / alt_date_format)
 aggregate_rel_date_filter = negation? aggregate_key sep operator? rel_date_format
 
@@ -157,7 +158,7 @@ aggregate_key        = key open_paren function_arg* closed_paren
 search_key           = key / quoted_key
 search_value         = quoted_value / value
 value                = ~r"[^()\s]*"
-numeric_value        = ~r"[-]?[0-9\.]+(?=\s|\)|$)"
+numeric_value        = ~r"[-]?[0-9\.]+[k|m]?(?=\s|\)|$)"
 boolean_value        = ~r"(true|1|false|0)(?=\s|\)|$)"i
 quoted_value         = ~r"\"((?:[^\"]|(?<=\\)[\"])*)?\""s
 key                  = ~r"[a-zA-Z0-9_\.-]+"
@@ -443,9 +444,9 @@ class SearchVisitor(NodeVisitor):
 
         if self.is_numeric_key(search_key.name):
             try:
-                search_value = SearchValue(float(search_value.text))
-            except ValueError:
-                raise InvalidSearchQuery(f"Invalid numeric query: {search_key}")
+                search_value = SearchValue(parse_numeric_value(search_value.text))
+            except InvalidQuery as exc:
+                raise InvalidSearchQuery(str(exc))
             return SearchFilter(search_key, operator, search_value)
         else:
             search_value = SearchValue(
@@ -483,7 +484,7 @@ class SearchVisitor(NodeVisitor):
                         aggregate_value = parse_duration(*search_value.match.groups())
 
             if aggregate_value is None:
-                aggregate_value = float(search_value.text)
+                aggregate_value = parse_numeric_value(search_value.text)
         except ValueError:
             raise InvalidSearchQuery(f"Invalid aggregate query condition: {search_key}")
         except InvalidQuery as exc:
@@ -541,7 +542,7 @@ class SearchVisitor(NodeVisitor):
             return self._handle_basic_filter(search_key, "=", SearchValue(search_value))
 
     def visit_duration_filter(self, node, children):
-        (search_key, _, operator, search_value) = children
+        (search_key, sep, operator, search_value) = children
 
         operator = operator[0] if not isinstance(operator, Node) else "="
         if self.is_duration_key(search_key.name):
@@ -550,6 +551,8 @@ class SearchVisitor(NodeVisitor):
             except InvalidQuery as exc:
                 raise InvalidSearchQuery(str(exc))
             return SearchFilter(search_key, operator, SearchValue(search_value))
+        elif self.is_numeric_key(search_key.name):
+            return self.visit_numeric_filter(node, (search_key, sep, operator, search_value))
         else:
             search_value = operator + search_value.text if operator != "=" else search_value.text
             return self._handle_basic_filter(search_key, "=", SearchValue(search_value))

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -158,7 +158,7 @@ aggregate_key        = key open_paren function_arg* closed_paren
 search_key           = key / quoted_key
 search_value         = quoted_value / value
 value                = ~r"[^()\s]*"
-numeric_value        = ~r"[-]?[0-9\.]+[k|m]?(?=\s|\)|$)"
+numeric_value        = ~r"([-]?[0-9\.]+)([k|m|b])?(?=\s|\)|$)"
 boolean_value        = ~r"(true|1|false|0)(?=\s|\)|$)"i
 quoted_value         = ~r"\"((?:[^\"]|(?<=\\)[\"])*)?\""s
 key                  = ~r"[a-zA-Z0-9_\.-]+"
@@ -444,7 +444,7 @@ class SearchVisitor(NodeVisitor):
 
         if self.is_numeric_key(search_key.name):
             try:
-                search_value = SearchValue(parse_numeric_value(search_value.text))
+                search_value = SearchValue(parse_numeric_value(*search_value.match.groups()))
             except InvalidQuery as exc:
                 raise InvalidSearchQuery(str(exc))
             return SearchFilter(search_key, operator, search_value)
@@ -484,7 +484,7 @@ class SearchVisitor(NodeVisitor):
                         aggregate_value = parse_duration(*search_value.match.groups())
 
             if aggregate_value is None:
-                aggregate_value = parse_numeric_value(search_value.text)
+                aggregate_value = parse_numeric_value(*search_value.match.groups())
         except ValueError:
             raise InvalidSearchQuery(f"Invalid aggregate query condition: {search_key}")
         except InvalidQuery as exc:

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -72,6 +72,27 @@ def parse_percentage(value):
     return value / 100
 
 
+def parse_numeric_value(value):
+    try:
+        value = float(value)
+    except ValueError:
+        pass
+    else:
+        return value
+
+    numeric_multiples = {"k": 10.0 ** 3, "m": 10.0 ** 6}
+    value, suffix = value[:-1], value[-1]
+    if suffix not in numeric_multiples:
+        raise InvalidQuery("Invalid format for numeric field")
+
+    try:
+        value = float(value)
+    except ValueError:
+        raise InvalidQuery("Invalid format for numeric field")
+
+    return value * numeric_multiples[suffix]
+
+
 def parse_datetime_range(value):
     try:
         flag, count, interval = value[0], int(value[1:-1]), value[-1]

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -72,22 +72,17 @@ def parse_percentage(value):
     return value / 100
 
 
-def parse_numeric_value(value):
+def parse_numeric_value(value, suffix=None):
     try:
         value = float(value)
     except ValueError:
-        pass
-    else:
-        return value
-
-    numeric_multiples = {"k": 10.0 ** 3, "m": 10.0 ** 6}
-    value, suffix = value[:-1], value[-1]
-    if suffix not in numeric_multiples:
         raise InvalidQuery("Invalid format for numeric field")
 
-    try:
-        value = float(value)
-    except ValueError:
+    if not suffix:
+        return value
+
+    numeric_multiples = {"k": 10.0 ** 3, "m": 10.0 ** 6, "b": 10.0 ** 9}
+    if suffix not in numeric_multiples:
         raise InvalidQuery("Invalid format for numeric field")
 
     return value * numeric_multiples[suffix]

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -83,7 +83,7 @@ def parse_numeric_value(value, suffix=None):
 
     numeric_multiples = {"k": 10.0 ** 3, "m": 10.0 ** 6, "b": 10.0 ** 9}
     if suffix not in numeric_multiples:
-        raise InvalidQuery("Invalid format for numeric field")
+        raise InvalidQuery(f"{suffix} is not a valid number suffix, must be k, m or b")
 
     return value * numeric_multiples[suffix]
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -712,8 +712,29 @@ class ParseSearchQueryTest(unittest.TestCase):
             )
         ]
 
+    def test_numeric_filter_with_shorthand(self):
+        assert parse_search_query("stack.colno:>3k") == [
+            SearchFilter(
+                key=SearchKey(name="stack.colno"),
+                operator=">",
+                value=SearchValue(raw_value=3000.0),
+            )
+        ]
+        assert parse_search_query("stack.colno:>3m") == [
+            SearchFilter(
+                key=SearchKey(name="stack.colno"),
+                operator=">",
+                value=SearchValue(raw_value=3000000.0),
+            )
+        ]
+
     def test_invalid_numeric_fields(self):
-        invalid_queries = ["project.id:one", "issue.id:two", "transaction.duration:>hotdog"]
+        invalid_queries = [
+            "project.id:one",
+            "issue.id:two",
+            "transaction.duration:>hotdog",
+            "stack.colno:>3s",
+        ]
         for invalid_query in invalid_queries:
             with self.assertRaisesRegexp(InvalidSearchQuery, "Invalid format for numeric field"):
                 parse_search_query(invalid_query)
@@ -754,12 +775,32 @@ class ParseSearchQueryTest(unittest.TestCase):
             )
         ]
 
+    def test_duration_filter_overrides_numeric_shorthand(self):
+        # 2m should mean 2 minutes for duration filters (as opposed to 2 million)
+        assert parse_search_query("transaction.duration:>2m") == [
+            SearchFilter(
+                key=SearchKey(name="transaction.duration"),
+                operator=">",
+                value=SearchValue(raw_value=120000.0),
+            )
+        ]
+
     def test_aggregate_duration_filter(self):
         assert parse_search_query("avg(transaction.duration):>500s") == [
             SearchFilter(
                 key=AggregateKey(name="avg(transaction.duration)"),
                 operator=">",
                 value=SearchValue(raw_value=500000.0),
+            )
+        ]
+
+    def test_aggregate_duration_filter_overrides_numeric_shorthand(self):
+        # 2m should mean 2 minutes for duration filters (as opposed to 2 million)
+        assert parse_search_query("avg(transaction.duration):>2m") == [
+            SearchFilter(
+                key=AggregateKey(name="avg(transaction.duration)"),
+                operator=">",
+                value=SearchValue(raw_value=120000.0),
             )
         ]
 
@@ -829,6 +870,26 @@ class ParseSearchQueryTest(unittest.TestCase):
                 value=SearchValue(raw_value=3.1415),
             )
         ]
+
+        assert parse_search_query("min(measurements.size):<3k") == [
+            SearchFilter(
+                key=SearchKey(name="min(measurements.size)"),
+                operator="<",
+                value=SearchValue(raw_value=3000.0),
+            )
+        ]
+
+        assert parse_search_query("min(measurements.size):2m") == [
+            SearchFilter(
+                key=SearchKey(name="min(measurements.size)"),
+                operator="=",
+                value=SearchValue(raw_value=2000000.0),
+            )
+        ]
+
+    def test_invalid_numeric_aggregate_filter(self):
+        with self.assertRaisesRegexp(InvalidSearchQuery, "Invalid format for numeric field"):
+            parse_search_query("min(measurements.size):3s")
 
     def test_duration_measurements_filter(self):
         assert parse_search_query("measurements.fp:1.5s") == [

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -727,6 +727,13 @@ class ParseSearchQueryTest(unittest.TestCase):
                 value=SearchValue(raw_value=3000000.0),
             )
         ]
+        assert parse_search_query("stack.colno:>3b") == [
+            SearchFilter(
+                key=SearchKey(name="stack.colno"),
+                operator=">",
+                value=SearchValue(raw_value=3000000000.0),
+            )
+        ]
 
     def test_invalid_numeric_fields(self):
         invalid_queries = [

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -743,7 +743,7 @@ class ParseSearchQueryTest(unittest.TestCase):
 
     def test_invalid_numeric_shorthand(self):
         with self.assertRaisesRegexp(
-            InvalidSearchQuery, "is not a valid number suffix, must be k, m or b"
+            InvalidSearchQuery, expected_regex="is not a valid number suffix, must be k, m or b"
         ):
             parse_search_query("stack.colno:>3s")
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -736,15 +736,16 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
     def test_invalid_numeric_fields(self):
-        invalid_queries = [
-            "project.id:one",
-            "issue.id:two",
-            "transaction.duration:>hotdog",
-            "stack.colno:>3s",
-        ]
+        invalid_queries = ["project.id:one", "issue.id:two", "transaction.duration:>hotdog"]
         for invalid_query in invalid_queries:
             with self.assertRaisesRegexp(InvalidSearchQuery, "Invalid format for numeric field"):
                 parse_search_query(invalid_query)
+
+    def test_invalid_numeric_shorthand(self):
+        with self.assertRaisesRegexp(
+            InvalidSearchQuery, "is not a valid number suffix, must be k, m or b"
+        ):
+            parse_search_query("stack.colno:>3s")
 
     def test_negated_on_boolean_values_and_non_boolean_field(self):
         assert parse_search_query("!user.id:true") == [
@@ -895,7 +896,9 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
     def test_invalid_numeric_aggregate_filter(self):
-        with self.assertRaisesRegexp(InvalidSearchQuery, "Invalid format for numeric field"):
+        with self.assertRaisesRegexp(
+            InvalidSearchQuery, expected_regex="is not a valid number suffix, must be k, m or b"
+        ):
             parse_search_query("min(measurements.size):3s")
 
     def test_duration_measurements_filter(self):

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -278,9 +278,17 @@ class GroupListTest(APITestCase, SnubaTestCase):
         self.create_group(checksum="a" * 32, last_seen=now - timedelta(seconds=1))
         self.login_as(user=self.user)
 
-        response = self.get_response(sort_by="date", query="timesSeen:>1k")
+        response = self.get_response(sort_by="date", query="timesSeen:>1t")
         assert response.status_code == 400
         assert "Invalid format for numeric field" in response.data["detail"]
+
+    def test_valid_numeric_query(self):
+        now = timezone.now()
+        self.create_group(checksum="a" * 32, last_seen=now - timedelta(seconds=1))
+        self.login_as(user=self.user)
+
+        response = self.get_response(sort_by="date", query="timesSeen:>1k")
+        assert response.status_code == 200
 
     def test_invalid_sort_key(self):
         now = timezone.now()

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -67,7 +67,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         self.create_group(checksum="a" * 32, last_seen=before_now(seconds=1))
         self.login_as(user=self.user)
 
-        response = self.client.get(f"{self.path}?sort_by=date&query=timesSeen:>1k", format="json")
+        response = self.client.get(f"{self.path}?sort_by=date&query=timesSeen:>1t", format="json")
         assert response.status_code == 400
         assert "could not" in response.data["detail"]
 


### PR DESCRIPTION
Allow user to enter '2k' instead of '2000' or '2m' instead of
2000000 on numeric and numeric aggregate queries. In case of
clashes with the duration format (where 'm' can mean 'minutes'
or 'million'), we check the search key type and parse the value
accordingly.