### PR TITLE
ref(csp) Remove COOP header and align on frame-ancestors

### DIFF
--- a/src/sentry/integrations/jira/base_hook.py
+++ b/src/sentry/integrations/jira/base_hook.py
@@ -8,8 +8,6 @@ class JiraBaseHook(View):
     def get_response(self, context):
         context["ac_js_src"] = "https://connect-cdn.atl-paas.net/all.js"
         response = render_to_response(self.html_file, context, self.request)
-        # COOP blocks the Jira glance view links from opening
-        response["Cross-Origin-Opener-Policy"] = "same-origin-allow-popups"
         sources = [
             self.request.GET.get("xdm_e"),
             options.get("system.url-prefix"),

--- a/src/sentry_plugins/jira_ac/views.py
+++ b/src/sentry_plugins/jira_ac/views.py
@@ -7,6 +7,7 @@ from django.views.generic import View
 from django.core.urlresolvers import reverse
 from django.utils.decorators import method_decorator
 
+from sentry import options
 from sentry.utils import json
 from sentry.models import Organization
 from sentry.utils.http import absolute_uri
@@ -40,7 +41,14 @@ class BaseJiraWidgetView(View):
     def get_response(self, template, context=None):
         context = context or self.get_context()
         res = render_to_response(template, context, self.request)
-        res["X-Frame-Options"] = "ALLOW-FROM %s" % self.request.GET["xdm_e"]
+
+        sources = [
+            self.request.GET.get("xdm_e"),
+            options.get("system.url-prefix"),
+        ]
+        sources_string = " ".join([s for s in sources if s])
+        res["Content-Security-Policy"] = "frame-ancestors 'self' %s" % sources_string
+
         return res
 
 


### PR DESCRIPTION
Update the jira-ac plugin to use frame-ancestors like the jira integration does. X-Frame-Options is deprectated and frame-ancestors provides protection against nested framing.