### PR TITLE
fix(ui) Fix darkmode on progress bar and ring

### DIFF
--- a/src/sentry/static/sentry/app/components/progressBar.tsx
+++ b/src/sentry/static/sentry/app/components/progressBar.tsx
@@ -44,7 +44,7 @@ const getVariantStyle = ({
   return `
     height: 6px;
     border-radius: 100px;
-    background: ${theme.gray100};
+    background: ${theme.progressBackground};
     :before {
       top: 0;
       left: 0;

--- a/src/sentry/static/sentry/app/components/progressRing.tsx
+++ b/src/sentry/static/sentry/app/components/progressRing.tsx
@@ -57,7 +57,7 @@ const Text = styled('div')<Omit<TextProps, 'theme'>>`
   justify-content: center;
   height: 100%;
   width: 100%;
-  color: ${p => p.theme.subText};
+  color: ${p => p.theme.chartLabel};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   padding-top: 1px;
   transition: color 100ms;

--- a/src/sentry/static/sentry/app/components/progressRing.tsx
+++ b/src/sentry/static/sentry/app/components/progressRing.tsx
@@ -57,7 +57,7 @@ const Text = styled('div')<Omit<TextProps, 'theme'>>`
   justify-content: center;
   height: 100%;
   width: 100%;
-  color: ${p => p.theme.gray200};
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeExtraSmall};
   padding-top: 1px;
   transition: color 100ms;

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -180,6 +180,11 @@ const aliases = {
    * Default Progressbar color
    */
   progressBar: colors.purple300,
+
+  /**
+   * Default Progressbar color
+   */
+  progressBackground: colors.gray100,
 } as const;
 
 const warning = {
@@ -528,6 +533,7 @@ const darkAliases = {
   chartLineColor: colors.gray500,
   chartLabel: colors.gray400,
   progressBar: colors.purple200,
+  progressBackground: colors.gray500,
 } as const;
 
 const theme = {


### PR DESCRIPTION
I didn't want to conflict too much with Alex's changes so I didn't do more invasive changes to progress ring.

### Before

![Screen Shot 2021-03-05 at 1 04 33 PM](https://user-images.githubusercontent.com/24086/110155283-690cda00-7db3-11eb-9173-c5e21eac01a5.png)

### After

![Screen Shot 2021-03-05 at 1 04 42 PM](https://user-images.githubusercontent.com/24086/110155306-71651500-7db3-11eb-93c9-978732332cc3.png)
