### PR TITLE
fix(ui) Improve NavTabs in darkmode

### DIFF
--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -82,6 +82,9 @@ const styles = (theme: Theme, isDark: boolean) => css`
               color: ${theme.textColor} !important;
             }
           }
+          &.border-bottom {
+            border-color: ${theme.border};
+          }
         }
 
         ul.crumbs li .table.key-value pre {

--- a/src/sentry/static/sentry/less/includes/bootstrap/navs.less
+++ b/src/sentry/static/sentry/less/includes/bootstrap/navs.less
@@ -105,11 +105,6 @@
       }
     }
   }
-  // pulling this in mainly for less shorthand
-  &.nav-justified {
-    .nav-justified();
-    .nav-tabs-justified();
-  }
 }
 
 // Pills
@@ -145,70 +140,6 @@
     + li {
       margin-top: 2px;
       margin-left: 0; // no need for this gap between nav items
-    }
-  }
-}
-
-// Nav variations
-// --------------------------------------------------
-
-// Justified nav links
-// -------------------------
-
-.nav-justified {
-  width: 100%;
-
-  > li {
-    float: none;
-    > a {
-      margin-bottom: 5px;
-      text-align: center;
-    }
-  }
-
-  > .dropdown .dropdown-menu {
-    top: auto;
-    left: auto;
-  }
-
-  @media (min-width: @screen-sm-min) {
-    > li {
-      display: table-cell;
-      width: 1%;
-      > a {
-        margin-bottom: 0;
-      }
-    }
-  }
-}
-
-// Move borders to anchors instead of bottom of list
-//
-// Mixin for adding on top the shared `.nav-justified` styles for our tabs
-.nav-tabs-justified {
-  border-bottom: 0;
-
-  > li > a {
-    // Override margin from .nav-tabs
-    margin-right: 0;
-    border-radius: @border-radius-base;
-  }
-
-  > .active > a,
-  > .active > a:hover,
-  > .active > a:focus {
-    border: 1px solid @nav-tabs-justified-link-border-color;
-  }
-
-  @media (min-width: @screen-sm-min) {
-    > li > a {
-      border-bottom: 1px solid @nav-tabs-justified-link-border-color;
-      border-radius: @border-radius-base @border-radius-base 0 0;
-    }
-    > .active > a,
-    > .active > a:hover,
-    > .active > a:focus {
-      border-bottom-color: @nav-tabs-justified-active-link-border-color;
     }
   }
 }

--- a/src/sentry/static/sentry/less/includes/bootstrap/variables.less
+++ b/src/sentry/static/sentry/less/includes/bootstrap/variables.less
@@ -406,9 +406,6 @@
 @nav-tabs-active-link-hover-color: @gray;
 @nav-tabs-active-link-hover-border-color: #ddd;
 
-@nav-tabs-justified-link-border-color: #ddd;
-@nav-tabs-justified-active-link-border-color: @body-bg;
-
 //== Pills
 @nav-pills-border-radius: @border-radius-base;
 @nav-pills-active-link-hover-bg: @component-active-bg;


### PR DESCRIPTION
Make the bottom-border match the theme. I contemplated switching NavTabs to a styled component but there are ~80 hits for `nav-tabs` and more in getsentry. Building a new component and incrementally replacing is likely a safer strategy for navtabs.

### Before

![Screen Shot 2021-03-05 at 2 08 33 PM](https://user-images.githubusercontent.com/24086/110162142-534fe280-7dbc-11eb-8507-13b961960d70.png)

### After
![Screen Shot 2021-03-05 at 2 08 02 PM](https://user-images.githubusercontent.com/24086/110162167-5a76f080-7dbc-11eb-93ec-10be358d05d2.png)
