### PR TITLE
feat(span-view): Move ops breadown into span view header

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import OpsBreakdown from 'app/components/events/opsBreakdown';
 import space from 'app/styles/space';
+import {Organization} from 'app/types';
 import {EventTransaction} from 'app/types/event';
 
 import * as CursorGuideHandler from './cursorGuideHandler';
@@ -38,6 +40,7 @@ export const MINIMAP_CONTAINER_HEIGHT =
   MINIMAP_HEIGHT + TIME_AXIS_HEIGHT + SECONDARY_HEADER_HEIGHT + 1;
 
 type PropType = {
+  organization: Organization;
   minimapInteractiveRef: React.RefObject<HTMLDivElement>;
   virtualScrollBarContainerRef: React.RefObject<HTMLDivElement>;
   dragProps: DragManagerChildrenProps;
@@ -390,6 +393,10 @@ class TraceViewHeader extends React.Component<PropType, State> {
   }
 
   render() {
+    const hasQuickTraceView =
+      this.props.organization.features.includes('trace-view-quick') ||
+      this.props.organization.features.includes('trace-view-summary');
+
     return (
       <HeaderContainer>
         <DividerHandlerManager.Consumer>
@@ -401,7 +408,11 @@ class TraceViewHeader extends React.Component<PropType, State> {
                   style={{
                     width: `calc(${toPercent(dividerPosition)} - 0.5px)`,
                   }}
-                />
+                >
+                  {hasQuickTraceView && this.props.event && (
+                    <OpsBreakdown event={this.props.event} topN={3} hideHeader />
+                  )}
+                </OperationsBreakdown>
                 <DividerSpacer
                   style={{
                     position: 'absolute',
@@ -882,6 +893,8 @@ const OperationsBreakdown = styled('div')`
   position: absolute;
   left: 0;
   top: 0;
+  padding: ${space(2)} ${space(3)};
+  overflow: hidden;
 `;
 
 const RightSidePane = styled('div')`

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/traceView.tsx
@@ -173,6 +173,7 @@ class TraceView extends React.PureComponent<Props, State> {
 
   renderHeader = (dragProps: DragManagerChildrenProps, parsedTrace: ParsedTraceType) => (
     <TraceViewHeader
+      organization={this.props.organization}
       minimapInteractiveRef={this.minimapInteractiveRef}
       dragProps={dragProps}
       trace={parsedTrace}

--- a/src/sentry/static/sentry/app/components/events/opsBreakdown.tsx
+++ b/src/sentry/static/sentry/app/components/events/opsBreakdown.tsx
@@ -40,11 +40,21 @@ const TOP_N_SPANS = 4;
 
 type OpBreakdownType = OpStats[];
 
-type Props = {
+type DefaultProps = {
+  topN: number;
+  hideHeader: boolean;
+};
+
+type Props = DefaultProps & {
   event: Event;
 };
 
 class OpsBreakdown extends React.Component<Props> {
+  static defaultProps: DefaultProps = {
+    topN: TOP_N_SPANS,
+    hideHeader: false,
+  };
+
   getTransactionEvent(): EventTransaction | undefined {
     const {event} = this.props;
 
@@ -56,6 +66,7 @@ class OpsBreakdown extends React.Component<Props> {
   }
 
   generateStats(): OpBreakdownType {
+    const {topN} = this.props;
     const event = this.getTransactionEvent();
 
     if (!event) {
@@ -163,7 +174,7 @@ class OpsBreakdown extends React.Component<Props> {
       }
     );
 
-    const breakdown = sortedOpsBreakdown.slice(0, TOP_N_SPANS).map(
+    const breakdown = sortedOpsBreakdown.slice(0, topN).map(
       ([operationName, duration]: [OperationName, Duration]): OpStats => {
         return {
           name: operationName,
@@ -174,7 +185,7 @@ class OpsBreakdown extends React.Component<Props> {
       }
     );
 
-    const other = sortedOpsBreakdown.slice(TOP_N_SPANS).reduce(
+    const other = sortedOpsBreakdown.slice(topN).reduce(
       (accOther: OpStats, [_operationName, duration]: [OperationName, Duration]) => {
         accOther.totalInterval += duration;
 
@@ -208,6 +219,8 @@ class OpsBreakdown extends React.Component<Props> {
   }
 
   render() {
+    const {hideHeader} = this.props;
+
     const event = this.getTransactionEvent();
 
     if (!event) {
@@ -216,44 +229,50 @@ class OpsBreakdown extends React.Component<Props> {
 
     const breakdown = this.generateStats();
 
-    return (
-      <StyledBreakdown>
-        <SectionHeading>
-          {t('Operation Breakdown')}
-          <QuestionTooltip
-            position="top"
-            size="sm"
-            containerDisplayMode="block"
-            title={t(
-              'Durations are calculated by summing span durations over the course of the transaction. Percentages are then calculated by dividing the individual op duration by the sum of total op durations. Overlapping/parallel spans are only counted once.'
-            )}
-          />
-        </SectionHeading>
-        {breakdown.map(currOp => {
-          const {name, percentage, totalInterval} = currOp;
+    const contents = breakdown.map(currOp => {
+      const {name, percentage, totalInterval} = currOp;
 
-          const isOther = name === OtherOperation;
-          const operationName = typeof name === 'string' ? name : t('Other');
+      const isOther = name === OtherOperation;
+      const operationName = typeof name === 'string' ? name : t('Other');
 
-          const durLabel = Math.round(totalInterval * 1000 * 100) / 100;
-          const pctLabel = isFinite(percentage) ? Math.round(percentage * 100) : '∞';
-          const opsColor: string = pickSpanBarColour(operationName);
+      const durLabel = Math.round(totalInterval * 1000 * 100) / 100;
+      const pctLabel = isFinite(percentage) ? Math.round(percentage * 100) : '∞';
+      const opsColor: string = pickSpanBarColour(operationName);
 
-          return (
-            <OpsLine key={operationName}>
-              <OpsNameContainer>
-                <OpsDot style={{backgroundColor: isOther ? 'transparent' : opsColor}} />
-                <OpsName>{operationName}</OpsName>
-              </OpsNameContainer>
-              <OpsContent>
-                <Dur>{durLabel}ms</Dur>
-                <Pct>{pctLabel}%</Pct>
-              </OpsContent>
-            </OpsLine>
-          );
-        })}
-      </StyledBreakdown>
-    );
+      return (
+        <OpsLine key={operationName}>
+          <OpsNameContainer>
+            <OpsDot style={{backgroundColor: isOther ? 'transparent' : opsColor}} />
+            <OpsName>{operationName}</OpsName>
+          </OpsNameContainer>
+          <OpsContent>
+            <Dur>{durLabel}ms</Dur>
+            <Pct>{pctLabel}%</Pct>
+          </OpsContent>
+        </OpsLine>
+      );
+    });
+
+    if (!hideHeader) {
+      return (
+        <StyledBreakdown>
+          <SectionHeading>
+            {t('Operation Breakdown')}
+            <QuestionTooltip
+              position="top"
+              size="sm"
+              containerDisplayMode="block"
+              title={t(
+                'Durations are calculated by summing span durations over the course of the transaction. Percentages are then calculated by dividing the individual op duration by the sum of total op durations. Overlapping/parallel spans are only counted once.'
+              )}
+            />
+          </SectionHeading>
+          {contents}
+        </StyledBreakdown>
+      );
+    }
+
+    return <StyledBreakdown>{contents}</StyledBreakdown>;
   }
 }
 

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
@@ -198,9 +198,9 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
                     projectId={this.projectId}
                   />
                   <RootSpanStatus event={event} />
+                  <OpsBreakdown event={event} />
                 </React.Fragment>
               )}
-              <OpsBreakdown event={event} />
               <EventVitals event={event} />
               <TagsTable event={event} query={query} generateUrl={this.generateTagUrl} />
             </Layout.Side>


### PR DESCRIPTION
In conjunction to the new trace view mocks, the ops breakdown should be moved
from the sidebar into the span view header.