### PR TITLE
fix(trace-view): Adding analytics to single nodes

### DIFF
--- a/src/sentry/static/sentry/app/components/tag.tsx
+++ b/src/sentry/static/sentry/app/components/tag.tsx
@@ -32,6 +32,10 @@ type Props = React.HTMLAttributes<HTMLSpanElement> & {
    */
   to?: React.ComponentProps<typeof Link>['to'];
   /**
+   * Triggered when the item is clicked
+   */
+  onClick?: (eventKey: any) => void;
+  /**
    * Makes the tag clickable. Use for external links.
    * If no icon is passed, it defaults to IconOpen (can be removed by passing icon={null})
    */
@@ -51,6 +55,7 @@ function Tag({
   icon,
   tooltipText,
   to,
+  onClick,
   href,
   onDismiss,
   children,
@@ -111,7 +116,13 @@ function Tag({
       return <ExternalLink href={href}>{tag}</ExternalLink>;
     }
 
-    if (defined(to)) {
+    if (defined(to) && defined(onClick)) {
+      return (
+        <Link to={to} onClick={onClick}>
+          {tag}
+        </Link>
+      );
+    } else if (defined(to)) {
       return <Link to={to}>{tag}</Link>;
     }
 

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
@@ -165,6 +165,7 @@ function QuickTracePills({
         text={t('Root')}
         hoverText={singleEventHoverText(root)}
         pad="right"
+        nodeKey="root"
       />
     );
     nodes.push(<TraceConnector key="root-connector" />);
@@ -191,6 +192,7 @@ function QuickTracePills({
           'Ancestor'
         )}
         pad="right"
+        nodeKey="ancestors"
       />
     );
     nodes.push(<TraceConnector key="ancestors-connector" />);
@@ -206,6 +208,7 @@ function QuickTracePills({
         text={t('Parent')}
         hoverText={singleEventHoverText(parent)}
         pad="right"
+        nodeKey="parent"
       />
     );
     nodes.push(<TraceConnector key="parent-connector" />);
@@ -239,6 +242,7 @@ function QuickTracePills({
           'Children'
         )}
         pad="left"
+        nodeKey="children"
       />
     );
   }
@@ -265,6 +269,7 @@ function QuickTracePills({
           'Descendant'
         )}
         pad="left"
+        nodeKey="descendants"
       />
     );
   }
@@ -272,8 +277,18 @@ function QuickTracePills({
   return <QuickTraceContainer>{nodes}</QuickTraceContainer>;
 }
 
+function handleNode(key: string, organization: OrganizationSummary) {
+  trackAnalyticsEvent({
+    eventKey: 'quick_trace.node.clicked',
+    eventName: 'Quick Trace: Node clicked',
+    organization_id: parseInt(organization.id, 10),
+    node_key: key,
+  });
+}
+
 function handleDropdownItem(
   target: LocationDescriptor,
+  key: string,
   organization: OrganizationSummary,
   extra: boolean
 ) {
@@ -281,6 +296,7 @@ function handleDropdownItem(
     eventKey: 'quick_trace.dropdown.clicked' + (extra ? '_extra' : ''),
     eventName: 'Quick Trace: Dropdown clicked',
     organization_id: parseInt(organization.id, 10),
+    node_key: key,
   });
   ReactRouter.browserHistory.push(target);
 }
@@ -294,6 +310,7 @@ type EventNodeSelectorProps = {
   hoverText?: React.ReactNode;
   extrasTarget?: LocationDescriptor;
   numEvents?: number;
+  nodeKey: string;
 };
 
 function EventNodeSelector({
@@ -304,6 +321,7 @@ function EventNodeSelector({
   pad,
   hoverText,
   extrasTarget,
+  nodeKey,
   numEvents = 5,
 }: EventNodeSelectorProps) {
   if (events.length === 1) {
@@ -312,7 +330,15 @@ function EventNodeSelector({
      * the event without additional steps.
      */
     const target = generateSingleEventTarget(events[0], organization, location);
-    return <StyledEventNode text={text} pad={pad} hoverText={hoverText} to={target} />;
+    return (
+      <StyledEventNode
+        text={text}
+        pad={pad}
+        hoverText={hoverText}
+        to={target}
+        onClick={() => handleNode(nodeKey, organization)}
+      />
+    );
   } else {
     /**
      * When there is more than 1 event, clicking the node should expand a dropdown to
@@ -329,7 +355,7 @@ function EventNodeSelector({
           return (
             <DropdownItem
               key={event.event_id}
-              onSelect={() => handleDropdownItem(target, organization, false)}
+              onSelect={() => handleDropdownItem(target, nodeKey, organization, false)}
               first={i === 0}
             >
               <DropdownItemSubContainer>
@@ -364,7 +390,7 @@ function EventNodeSelector({
         })}
         {events.length > numEvents && hoverText && extrasTarget && (
           <DropdownItem
-            onSelect={() => handleDropdownItem(extrasTarget, organization, true)}
+            onSelect={() => handleDropdownItem(extrasTarget, nodeKey, organization, true)}
           >
             {hoverText}
           </DropdownItem>
@@ -379,13 +405,21 @@ type EventNodeProps = {
   pad: 'left' | 'right';
   hoverText: React.ReactNode;
   to?: LocationDescriptor;
+  onClick?: (eventKey: any) => void;
   type?: keyof Theme['tag'];
 };
 
-function StyledEventNode({text, hoverText, pad, to, type = 'white'}: EventNodeProps) {
+function StyledEventNode({
+  text,
+  hoverText,
+  pad,
+  to,
+  onClick,
+  type = 'white',
+}: EventNodeProps) {
   return (
     <Tooltip position="top" containerDisplayMode="inline-flex" title={hoverText}>
-      <EventNode type={type} pad={pad} icon={null} to={to}>
+      <EventNode type={type} pad={pad} icon={null} to={to} onClick={onClick}>
         {text}
       </EventNode>
     </Tooltip>


### PR DESCRIPTION
- Adds `onClick` to the tag component, so that I could hook analytics into trace node clicks
- Added a nodeKey so that we'd know which node/event type is being called
- Corresponding reload PR https://github.com/getsentry/reload/pull/196