### PR TITLE
feat(dashboards): Widget modal v2

### DIFF
--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -123,12 +123,12 @@ PREBUILT_DASHBOARDS = {
                         {
                             "name": "Known Users",
                             "conditions": "has:user.email !event.type:transaction",
-                            "fields": ["count_unique(user.email)"],
+                            "fields": ["count_unique(user)"],
                         },
                         {
                             "name": "Anonymous Users",
                             "conditions": "!has:user.email !event.type:transaction",
-                            "fields": ["count()"],
+                            "fields": ["count_unique(user)"],
                         },
                     ],
                 },

--- a/src/sentry/static/sentry/app/actionCreators/modal.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/modal.tsx
@@ -219,7 +219,7 @@ export async function openAddDashboardWidgetModal(options: DashboardWidgetModalO
   const mod = await import(
     /* webpackChunkName: "AddDashboardWidgetModal" */ 'app/components/modals/addDashboardWidgetModal'
   );
-  const {default: Modal} = mod;
+  const {default: Modal, modalCss} = mod;
 
-  openModal(deps => <Modal {...deps} {...options} />, {backdrop: 'static'});
+  openModal(deps => <Modal {...deps} {...options} />, {backdrop: 'static', modalCss});
 }

--- a/src/sentry/static/sentry/app/components/charts/components/legend.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/legend.tsx
@@ -23,7 +23,7 @@ export default function Legend(
     padding: 0,
     formatter,
     icon: 'circle',
-    itemHeight: 8,
+    itemHeight: 14,
     itemWidth: 8,
     itemGap: 12,
     align: 'left' as const,
@@ -32,6 +32,7 @@ export default function Legend(
       verticalAlign: 'top',
       fontSize: 11,
       fontFamily: theme.text.family,
+      lineHeight: 14,
     },
     inactiveColor: theme.inactive,
   });

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueriesForm.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueriesForm.tsx
@@ -41,10 +41,10 @@ type Props = {
 };
 
 /**
- * Contain widget query interactions and signal changes via the onChange
+ * Contain widget queries interactions and signal changes via the onChange
  * callback. This component's state should live in the parent.
  */
-class WidgetQueryForm extends React.Component<Props> {
+class WidgetQueriesForm extends React.Component<Props> {
   // Handle scalar field values changing.
   handleFieldChange = (queryIndex: number, field: string) => {
     const {queries, onChange} = this.props;
@@ -206,4 +206,4 @@ const LegendAliasInput = styled(Input)`
   width: 33%;
 `;
 
-export default WidgetQueryForm;
+export default WidgetQueriesForm;

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 
 import Button from 'app/components/button';
-import {IconDelete} from 'app/icons';
+import {IconAdd, IconDelete} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {
@@ -85,9 +85,10 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
     );
   }
 
-  const showAddYAxisButton = !(
-    ['world_map', 'big_number'].includes(displayType) && fields.length === 1
-  );
+  const hideAddYAxisButton =
+    (['world_map', 'big_number'].includes(displayType) && fields.length === 1) ||
+    (['line', 'area', 'stacked_area', 'bar'].includes(displayType) &&
+      fields.length === 3);
 
   return (
     <Field
@@ -121,13 +122,13 @@ function WidgetQueryFields({displayType, errors, fields, fieldOptions, onChange}
           )}
         </QueryFieldWrapper>
       ))}
-      <div>
-        {showAddYAxisButton && (
-          <Button size="small" onClick={handleAdd}>
+      {!hideAddYAxisButton && (
+        <div>
+          <Button size="small" icon={<IconAdd isCircled />} onClick={handleAdd}>
             {t('Add Overlay')}
           </Button>
-        )}
-      </div>
+        </div>
+      )}
     </Field>
   );
 }

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryForm.tsx
@@ -102,7 +102,7 @@ class WidgetQueryForm extends React.Component<Props> {
                   onBlur={this.handleFieldChange(queryIndex, 'conditions')}
                   useFormWrapper={false}
                 />
-                <Input
+                <LegendAliasInput
                   type="text"
                   name="name"
                   required
@@ -199,7 +199,11 @@ export const SearchConditionsWrapper = styled('div')`
 `;
 
 const StyledSearchBar = styled(SearchBar)`
-  width: 100%;
+  width: 67%;
+`;
+
+const LegendAliasInput = styled(Input)`
+  width: 33%;
 `;
 
 export default WidgetQueryForm;

--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -12,7 +12,7 @@ import {ModalRenderProps} from 'app/actionCreators/modal';
 import {Client} from 'app/api';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
-import WidgetQueryForm from 'app/components/dashboards/widgetQueryForm';
+import WidgetQueriesForm from 'app/components/dashboards/widgetQueriesForm';
 import SelectControl from 'app/components/forms/selectControl';
 import {PanelAlert} from 'app/components/panels';
 import {t} from 'app/locale';
@@ -366,7 +366,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
               const measurementKeys = Object.values(measurements).map(({key}) => key);
               const amendedFieldOptions = fieldOptions(measurementKeys);
               return (
-                <WidgetQueryForm
+                <WidgetQueriesForm
                   organization={organization}
                   selection={selection}
                   fieldOptions={amendedFieldOptions}

--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
 import set from 'lodash/set';
 
@@ -13,7 +14,6 @@ import ButtonBar from 'app/components/buttonBar';
 import WidgetQueryForm from 'app/components/dashboards/widgetQueryForm';
 import SelectControl from 'app/components/forms/selectControl';
 import {PanelAlert} from 'app/components/panels';
-import {IconAdd} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {GlobalSelection, Organization, TagCollection} from 'app/types';
@@ -89,6 +89,85 @@ function mapErrors(
   return update;
 }
 
+function normalizeQueries(
+  displayType: Widget['displayType'],
+  queries: Widget['queries']
+): Widget['queries'] {
+  const isTimeseriesChart = ['line', 'area', 'stacked_area', 'bar'].includes(displayType);
+
+  if (['table', 'world_map', 'big_number'].includes(displayType)) {
+    // Some display types may only support at most 1 query.
+    queries = queries.slice(0, 1);
+  } else if (isTimeseriesChart) {
+    // Timeseries charts supports at most 3 queries.
+    queries = queries.slice(0, 3);
+  }
+
+  if (displayType === 'table') {
+    return queries;
+  }
+
+  // Filter out non-aggregate fields
+  queries = queries.map(query => {
+    let fields = query.fields.filter(isAggregateField);
+
+    if (isTimeseriesChart && fields.length && fields.length > 3) {
+      // Timeseries charts supports at most 3 fields.
+      fields = fields.slice(0, 3);
+    }
+
+    return {
+      ...query,
+      fields: fields.length ? fields : ['count()'],
+    };
+  });
+
+  if (isTimeseriesChart) {
+    // For timeseries widget, all queries must share identical set of fields.
+
+    const referenceFields = [...queries[0].fields];
+
+    queryLoop: for (const query of queries) {
+      if (referenceFields.length >= 3) {
+        break;
+      }
+
+      if (isEqual(referenceFields, query.fields)) {
+        continue;
+      }
+
+      for (const field of query.fields) {
+        if (referenceFields.length >= 3) {
+          break queryLoop;
+        }
+
+        if (!referenceFields.includes(field)) {
+          referenceFields.push(field);
+        }
+      }
+    }
+
+    queries = queries.map(query => {
+      return {
+        ...query,
+        fields: referenceFields,
+      };
+    });
+  }
+
+  if (['world_map', 'big_number'].includes(displayType)) {
+    // For world map chart, cap fields of the queries to only one field.
+    queries = queries.map(query => {
+      return {
+        ...query,
+        fields: query.fields.slice(0, 1),
+      };
+    });
+  }
+
+  return queries;
+}
+
 class AddDashboardWidgetModal extends React.Component<Props, State> {
   constructor(props: Props) {
     super(props);
@@ -111,7 +190,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       title: widget.title,
       displayType: widget.displayType,
       interval: widget.interval,
-      queries: widget.queries,
+      queries: normalizeQueries(widget.displayType, widget.queries),
       errors: undefined,
       loading: false,
     };
@@ -164,41 +243,11 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       set(newState, field, value);
 
       if (field === 'displayType') {
-        let newQueries = prevState.queries;
-
-        if (['table', 'world_map', 'big_number'].includes(value)) {
-          // Some display types may only support at most 1 query.
-          set(newState, 'queries', prevState.queries.slice(0, 1));
-          newQueries = newState.queries;
-        }
-
-        if (value === 'table') {
-          return newState;
-        }
-
-        // Filter out non-aggregate fields
-        newQueries = newQueries.map(query => {
-          const fields = query.fields.filter(isAggregateField);
-          return {
-            ...query,
-            fields: fields.length ? fields : ['count()'],
-          };
-        });
-
-        if (['world_map', 'big_number'].includes(value)) {
-          // For world map chart, cap fields of the queries to only one field.
-          newQueries = newQueries.map(query => {
-            return {
-              ...query,
-              fields: query.fields.slice(0, 1),
-            };
-          });
-        }
-
-        set(newState, 'queries', newQueries);
+        const displayType = value as Widget['displayType'];
+        set(newState, 'queries', normalizeQueries(displayType, prevState.queries));
       }
 
-      return newState;
+      return {...newState, errors: undefined};
     });
   };
 
@@ -207,7 +256,7 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       const newState = cloneDeep(prevState);
       set(newState, `queries.${index}`, widgetQuery);
 
-      return newState;
+      return {...newState, errors: undefined};
     });
   };
 
@@ -216,16 +265,11 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
       const newState = cloneDeep(prevState);
       newState.queries.splice(index, index + 1);
 
-      // If there is only one query, then its name will not be visible.
-      if (newState.queries.length === 1) {
-        newState.queries[0].name = '';
-      }
-
-      return newState;
+      return {...newState, errors: undefined};
     });
   };
 
-  handleAddOverlay = () => {
+  handleAddSearchConditions = () => {
     this.setState(prevState => {
       const newState = cloneDeep(prevState);
       newState.queries.push(cloneDeep(newQuery));
@@ -234,8 +278,13 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
     });
   };
 
-  canAddOverlay() {
-    return ['line', 'area', 'stacked_area', 'bar'].includes(this.state.displayType);
+  canAddSearchConditions() {
+    const rightDisplayType = ['line', 'area', 'stacked_area', 'bar'].includes(
+      this.state.displayType
+    );
+    const underQueryLimit = this.state.queries.length < 3;
+
+    return rightDisplayType && underQueryLimit;
   }
 
   render() {
@@ -316,41 +365,23 @@ class AddDashboardWidgetModal extends React.Component<Props, State> {
               const measurementKeys = Object.values(measurements).map(({key}) => key);
               const amendedFieldOptions = fieldOptions(measurementKeys);
               return (
-                <React.Fragment>
-                  {state.queries.map((query, i) => {
-                    return (
-                      <WidgetQueryForm
-                        key={i}
-                        api={api}
-                        organization={organization}
-                        selection={selection}
-                        fieldOptions={amendedFieldOptions}
-                        displayType={state.displayType}
-                        widgetQuery={query}
-                        canRemove={state.queries.length > 1}
-                        onRemove={() => this.handleQueryRemove(i)}
-                        onChange={(widgetQuery: WidgetQuery) =>
-                          this.handleQueryChange(widgetQuery, i)
-                        }
-                        errors={errors?.queries?.[i]}
-                      />
-                    );
-                  })}
-                </React.Fragment>
+                <WidgetQueryForm
+                  organization={organization}
+                  selection={selection}
+                  fieldOptions={amendedFieldOptions}
+                  displayType={state.displayType}
+                  queries={state.queries}
+                  errors={errors?.queries}
+                  onChange={(queryIndex: number, widgetQuery: WidgetQuery) =>
+                    this.handleQueryChange(widgetQuery, queryIndex)
+                  }
+                  canAddSearchConditions={this.canAddSearchConditions()}
+                  handleAddSearchConditions={this.handleAddSearchConditions}
+                  handleDeleteQuery={this.handleQueryRemove}
+                />
               );
             }}
           </Measurements>
-          {this.canAddOverlay() && (
-            <AddOverlayButton
-              icon={<IconAdd isCircled />}
-              onClick={(event: React.MouseEvent) => {
-                event.preventDefault();
-                this.handleAddOverlay();
-              }}
-            >
-              {t('New Query Overlay')}
-            </AddOverlayButton>
-          )}
           <WidgetCard
             api={api}
             organization={organization}
@@ -395,10 +426,6 @@ const DoubleFieldWrapper = styled('div')`
   grid-template-columns: repeat(2, 1fr);
   grid-column-gap: ${space(1)};
   width: 100%;
-`;
-
-const AddOverlayButton = styled(Button)`
-  margin-bottom: ${space(2)};
 `;
 
 export default withApi(withGlobalSelection(withTags(AddDashboardWidgetModal)));

--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';
@@ -426,6 +427,17 @@ const DoubleFieldWrapper = styled('div')`
   grid-template-columns: repeat(2, 1fr);
   grid-column-gap: ${space(1)};
   width: 100%;
+`;
+
+export const modalCss = css`
+  padding: 50px;
+
+  .modal-dialog {
+    position: unset;
+    width: 100%;
+    max-width: 875px;
+    margin: 50px auto;
+  }
 `;
 
 export default withApi(withGlobalSelection(withTags(AddDashboardWidgetModal)));

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
@@ -249,7 +249,7 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
 
     const legend = {
       left: 0,
-      top: 3,
+      top: 0,
       type: 'plain',
       selected: getSeriesSelection(location),
       formatter: (seriesName: string) => {

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -50,6 +50,8 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     {name: 'custom-field', key: 'custom-field'},
   ];
 
+  let eventsStatsMock;
+
   beforeEach(function () {
     TagStore.onLoadTagsSuccess(tags);
     MockApiClient.addMockResponse({
@@ -58,13 +60,17 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       statusCode: 200,
       body: [],
     });
-    MockApiClient.addMockResponse({
+    eventsStatsMock = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-stats/',
       body: [],
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/eventsv2/',
       body: {data: [{'event.type': 'error'}], meta: {'event.type': 'string'}},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
     });
   });
 
@@ -184,8 +190,18 @@ describe('Modals -> AddDashboardWidgetModal', function () {
       interval: '5m',
       displayType: 'line',
       queries: [
-        {id: '9', name: 'errors', conditions: 'event.type:error', fields: ['count()']},
-        {id: '9', name: 'csp', conditions: 'event.type:csp', fields: ['count()']},
+        {
+          id: '9',
+          name: 'errors',
+          conditions: 'event.type:error',
+          fields: ['count()', 'count_unique(id)'],
+        },
+        {
+          id: '9',
+          name: 'csp',
+          conditions: 'event.type:csp',
+          fields: ['count()', 'count_unique(id)'],
+        },
       ],
     };
     const onAdd = jest.fn();
@@ -210,7 +226,30 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     );
     expect(wrapper.find('WidgetQueriesForm')).toHaveLength(1);
     expect(wrapper.find('StyledSearchBar')).toHaveLength(2);
-    expect(wrapper.find('QueryField')).toHaveLength(1);
+    expect(wrapper.find('QueryField')).toHaveLength(2);
+
+    // Expect events-stats endpoint to be called for each search conditions with
+    // the same y-axis parameters
+    expect(eventsStatsMock).toHaveBeenNthCalledWith(
+      1,
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: 'event.type:error',
+          yAxis: ['count()', 'count_unique(id)'],
+        }),
+      })
+    );
+    expect(eventsStatsMock).toHaveBeenNthCalledWith(
+      2,
+      '/organizations/org-slug/events-stats/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: 'event.type:csp',
+          yAxis: ['count()', 'count_unique(id)'],
+        }),
+      })
+    );
 
     title.simulate('change', {target: {value: 'New title'}});
     await clickSubmit(wrapper);

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -208,7 +208,9 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     expect(wrapper.find('input[name="displayType"]').props().value).toEqual(
       widget.displayType
     );
-    expect(wrapper.find('WidgetQueryForm')).toHaveLength(2);
+    expect(wrapper.find('WidgetQueryForm')).toHaveLength(1);
+    expect(wrapper.find('StyledSearchBar')).toHaveLength(2);
+    expect(wrapper.find('QueryField')).toHaveLength(1);
 
     title.simulate('change', {target: {value: 'New title'}});
     await clickSubmit(wrapper);

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -256,6 +256,8 @@ describe('Modals -> AddDashboardWidgetModal', function () {
 
     expect(onAdd).not.toHaveBeenCalled();
     expect(widget.title).toEqual('New title');
+
+    expect(eventsStatsMock).toHaveBeenCalledTimes(2);
   });
 
   it('renders column inputs for table widgets', async function () {

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -173,7 +173,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     expect(errors).toHaveLength(2);
 
     // Nested object error should display
-    const conditionError = wrapper.find('WidgetQueryForm FieldErrorReason');
+    const conditionError = wrapper.find('WidgetQueriesForm FieldErrorReason');
     expect(conditionError).toHaveLength(1);
   });
 
@@ -208,7 +208,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     expect(wrapper.find('input[name="displayType"]').props().value).toEqual(
       widget.displayType
     );
-    expect(wrapper.find('WidgetQueryForm')).toHaveLength(1);
+    expect(wrapper.find('WidgetQueriesForm')).toHaveLength(1);
     expect(wrapper.find('StyledSearchBar')).toHaveLength(2);
     expect(wrapper.find('QueryField')).toHaveLength(1);
 
@@ -263,9 +263,11 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     expect(wrapper.find('input[name="displayType"]').props().value).toEqual(
       widget.displayType
     );
-    expect(wrapper.find('WidgetQueryForm')).toHaveLength(1);
+    expect(wrapper.find('WidgetQueriesForm')).toHaveLength(1);
     // Should have an orderby select
-    expect(wrapper.find('WidgetQueryForm SelectControl[name="orderby"]')).toHaveLength(1);
+    expect(wrapper.find('WidgetQueriesForm SelectControl[name="orderby"]')).toHaveLength(
+      1
+    );
 
     // Add a column, and choose a value,
     wrapper.find('button[aria-label="Add a Column"]').simulate('click');


### PR DESCRIPTION
This PR updates the Dashboards v2 widget builder modal such that, for timeseries based widgets (i.e. line, bar, and area charts), the generated queries (i.e. timeseries graphs) is the cartesian product of the search conditions and the fields.

The behaviour of all other widget display types remains unchanged.

For timeseries based widgets, the limits to the number of search conditions and fields are:

- 3 search conditions
- 3 fields

Thus, the limit is at most 9 queries per timeseries widget.

The widget modal has been expanded width-wise to match the width of the upsell modals (as advised by @doralchan ).

![Screen Shot 2021-03-05 at 4 36 18 PM](https://user-images.githubusercontent.com/139499/110176446-4a1d4080-7dd1-11eb-8393-3dc58b077a2a.png)

------

For compatibility purposes, the widget modal will translate and normalize any existing widget queries based on their display types. For example:

https://user-images.githubusercontent.com/139499/110177469-062b3b00-7dd3-11eb-933e-1a62c12050c8.mp4

------

The legend of the timeseries charts are adjusted to address and avoid clipping. The clipping looks like this:

<img width="829" alt="Screen Shot 2021-03-05 at 4 56 39 PM" src="https://user-images.githubusercontent.com/139499/110178007-d3357700-7dd3-11eb-8c07-312680a70362.png">



## TODO

- [x] Update "User Affected" widget queries for the prebuilt Dashboard
- [x] update tests