### PR TITLE
fix(ui): Add metric definition in the alert rule details chart

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -346,7 +346,14 @@ class DetailsBody extends React.Component<Props> {
       return this.renderLoading();
     }
 
-    const {query, environment, aggregate, projects: projectSlugs, timeWindow, triggers} = rule;
+    const {
+      query,
+      environment,
+      aggregate,
+      projects: projectSlugs,
+      timeWindow,
+      triggers,
+    } = rule;
 
     const criticalTrigger = triggers.find(({label}) => label === 'critical');
     const warningTrigger = triggers.find(({label}) => label === 'warning');
@@ -386,7 +393,7 @@ class DetailsBody extends React.Component<Props> {
                       </PresetName>
                       {tct(' [metric] over [window]', {
                         metric: aggregate,
-                        window: (<Duration seconds={timeWindow * 60} />),
+                        window: <Duration seconds={timeWindow * 60} />,
                       })}
                     </ChartHeader>
                     <EventsRequest

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -21,7 +21,7 @@ import TimeSince from 'app/components/timeSince';
 import {IconCheckmark} from 'app/icons/iconCheckmark';
 import {IconFire} from 'app/icons/iconFire';
 import {IconWarning} from 'app/icons/iconWarning';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import {defined} from 'app/utils';
@@ -346,7 +346,7 @@ class DetailsBody extends React.Component<Props> {
       return this.renderLoading();
     }
 
-    const {query, environment, aggregate, projects: projectSlugs, triggers} = rule;
+    const {query, environment, aggregate, projects: projectSlugs, timeWindow, triggers} = rule;
 
     const criticalTrigger = triggers.find(({label}) => label === 'critical');
     const warningTrigger = triggers.find(({label}) => label === 'warning');
@@ -381,7 +381,13 @@ class DetailsBody extends React.Component<Props> {
                 <ChartPanel>
                   <PanelBody withPadding>
                     <ChartHeader>
-                      {this.metricPreset?.name ?? t('Custom metric')}
+                      <PresetName>
+                        {this.metricPreset?.name ?? t('Custom metric')}
+                      </PresetName>
+                      {tct(' [metric] over [window]', {
+                        metric: aggregate,
+                        window: (<Duration seconds={timeWindow * 60} />),
+                      })}
                     </ChartHeader>
                     <EventsRequest
                       api={api}
@@ -549,6 +555,13 @@ const ChartPanel = styled(Panel)`
 
 const ChartHeader = styled('header')`
   margin-bottom: ${space(1)};
+  display: flex;
+  flex-direction: row;
+`;
+
+const PresetName = styled('div')`
+  text-transform: capitalize;
+  margin-right: ${space(0.5)};
 `;
 
 const ChartActions = styled(PanelFooter)`

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/incidentRulePresets.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/incidentRulePresets.tsx
@@ -103,7 +103,7 @@ export const ALERT_RULE_PRESET_AGGREGATES: Preset[] = [
       }),
   },
   {
-    name: t('Transaction Count'),
+    name: t('Transaction count'),
     match: /^count\(\)/,
     validDataset: [Dataset.TRANSACTIONS],
     default: 'count()',


### PR DESCRIPTION
This adds metric definition alongside metric name in the alert rule details page.

![Screen Shot 2021-03-05 at 2 48 57 PM](https://user-images.githubusercontent.com/15015880/110182590-eccdc300-7dc1-11eb-91a3-95a3a64c12a2.png)
![Screen Shot 2021-03-05 at 2 49 20 PM](https://user-images.githubusercontent.com/15015880/110182619-f9eab200-7dc1-11eb-952d-8bb314a7ce1d.png)


[WOR-633](https://getsentry.atlassian.net/browse/WOR-633)
[Figma](https://www.figma.com/file/9bqoJ1hNQZWudZUNjf72qe/Handover%3A-Metric-Alerts-Detail?node-id=264%3A0)