### PR TITLE
fix(pipeline): The extra fields are not coming through in logs

### DIFF
--- a/src/sentry/integrations/pipeline.py
+++ b/src/sentry/integrations/pipeline.py
@@ -122,7 +122,7 @@ class IntegrationPipeline(Pipeline):
                 else:
                     self.get_logger().info(
                         "finish_pipeline.identity_linked_different_user",
-                        {
+                        extra={
                             "idp_id": idp.id,
                             "external_id": identity["external_id"],
                             "object_id": matched_identity.id,


### PR DESCRIPTION
This log line currently only produces the following log line:
```
{"name":"sentry.integration.gitlab","event":"finish_pipeline.identity_linked_different_user","level":"info"}
```
It doesn't log any of the extras. 

Put the extras in the `extra` parameter so they should up in the logs.

## Test plan
Before, here's what I saw locally:
```
18:32:40 server  | 18:32:40 [INFO] sentry.integration.gitlab: finish_pipeline.identity_linked_different_user
```

After this change, here's what I see locally:
```
23:03:32 server  | 23:03:32 [INFO] sentry.integration.gitlab: finish_pipeline.identity_linked_different_user (idp_id=12 external_id='gitlab.com:4900142' object_id=21 user_id=10 type='gitlab')
```