### PR TITLE
fix(reports) Reduce the tsdb batch size to avoid sending queries beyond the max size to Snuba

### DIFF
--- a/src/sentry/tasks/reports.py
+++ b/src/sentry/tasks/reports.py
@@ -42,7 +42,7 @@ date_format = partial(dateformat.format, format_string="F jS, Y")
 
 logger = logging.getLogger(__name__)
 
-BATCH_SIZE = 30000
+BATCH_SIZE = 20000
 
 
 def _get_organization_queryset():


### PR DESCRIPTION
https://github.com/getsentry/sentry/pull/14379 set the group id batch size for the tsdb queries to 30000.
This would work with a max query size of 500kb. The problem is that clickhouse is set to 262kb. Thus we have several weekly reports whose queries are being rejected as too long.

This reduces the batch size to 20000, which should fit in the current query size limit.

Fixes:
SENTRY-MR3