### PR TITLE
feat(save_event): Turn on race-free group creation for all projects

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -996,7 +996,7 @@ SENTRY_FEATURES = {
     # Enable functionality for project plugins.
     "projects:plugins": True,
     # Enable alternative version of group creation that is supposed to be less racy.
-    "projects:race-free-group-creation": False,
+    "projects:race-free-group-creation": True,
     # Enable functionality for rate-limiting events on projects.
     "projects:rate-limits": True,
     # Enable functionality for sampling of events on projects.


### PR DESCRIPTION
We have not seen any issues when turning this on for various high-volume native customers + our own projects, so let's just turn it on everywhere.

**Killswitch** to disable creating DB transactions and revert to racy version:

```
from sentry import options
options.set("store.race-free-group-creation-force-disable", True)
```

^ that should always be safe to do, no product impact

Ref #5085 