### PR TITLE
perf: make transaction summary not wait for top-level query

### DIFF
--- a/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
+++ b/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
@@ -121,6 +121,10 @@ type Props = {
    * The callback for when Open in Discover is clicked.
    */
   handleOpenInDiscoverClick?: (e: React.MouseEvent<Element>) => void;
+  /**
+   * Show a loading indicator instead of the table, used for transaction summary p95.
+   */
+  forceLoading?: boolean;
 };
 
 class TransactionsList extends React.Component<Props> {
@@ -204,6 +208,7 @@ class TransactionsList extends React.Component<Props> {
       titles,
       generateLink,
       baseline,
+      forceLoading,
     } = this.props;
     const sortedEventView = eventView.withSorts([selected.sort]);
     const columnOrder = sortedEventView.getColumns();
@@ -242,6 +247,15 @@ class TransactionsList extends React.Component<Props> {
         />
       </React.Fragment>
     );
+
+    if (forceLoading) {
+      return tableRenderer({
+        isLoading: true,
+        pageLinks: null,
+        tableData: null,
+        baselineData: null,
+      });
+    }
 
     if (baselineTransactionName) {
       const orgTableRenderer = tableRenderer;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
@@ -11,6 +11,7 @@ import {
   SectionValue,
 } from 'app/components/charts/styles';
 import {Panel} from 'app/components/panels';
+import Placeholder from 'app/components/placeholder';
 import {t} from 'app/locale';
 import {OrganizationSummary, SelectValue} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
@@ -193,7 +194,13 @@ class TransactionSummaryCharts extends React.Component<Props> {
         <ChartControls>
           <InlineContainer>
             <SectionHeading key="total-heading">{t('Total Transactions')}</SectionHeading>
-            <SectionValue key="total-value">{calculateTotal(totalValues)}</SectionValue>
+            <SectionValue key="total-value">
+              {totalValues === null ? (
+                <Placeholder height="24px" />
+              ) : (
+                totalValues.toLocaleString()
+              )}
+            </SectionValue>
           </InlineContainer>
           <InlineContainer>
             {display === DisplayModes.TREND && (
@@ -223,13 +230,6 @@ class TransactionSummaryCharts extends React.Component<Props> {
       </Panel>
     );
   }
-}
-
-function calculateTotal(total: number | null) {
-  if (total === null) {
-    return '\u2014';
-  }
-  return total.toLocaleString();
 }
 
 export default TransactionSummaryCharts;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -10,6 +10,7 @@ import SearchBar from 'app/components/events/searchBar';
 import GlobalSdkUpdateAlert from 'app/components/globalSdkUpdateAlert';
 import * as Layout from 'app/components/layouts/thirds';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import Placeholder from 'app/components/placeholder';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
@@ -45,7 +46,7 @@ type Props = {
   eventView: EventView;
   transactionName: string;
   organization: Organization;
-  totalValues: Record<string, number>;
+  totalValues: Record<string, number> | null;
   projects: Project[];
 };
 
@@ -157,21 +158,18 @@ class SummaryContent extends React.Component<Props, State> {
     } = this.props;
     const {incompatibleAlertNotice} = this.state;
     const query = decodeScalar(location.query.query, '');
-    const totalCount = totalValues.count;
-    const slowDuration = totalValues?.p95;
+    const totalCount = totalValues === null ? null : totalValues.count;
 
     // NOTE: This is not a robust check for whether or not a transaction is a front end
     // transaction, however it will suffice for now.
-    const hasWebVitals = VITAL_GROUPS.some(group =>
-      group.vitals.some(vital => {
-        const alias = getAggregateAlias(`percentile(${vital}, ${VITAL_PERCENTILE})`);
-        return Number.isFinite(totalValues[alias]);
-      })
-    );
-
-    const {selectedSort, sortOptions} = getTransactionsListSort(location, {
-      p95: slowDuration,
-    });
+    const hasWebVitals =
+      totalValues !== null &&
+      VITAL_GROUPS.some(group =>
+        group.vitals.some(vital => {
+          const alias = getAggregateAlias(`percentile(${vital}, ${VITAL_PERCENTILE})`);
+          return Number.isFinite(totalValues[alias]);
+        })
+      );
 
     return (
       <React.Fragment>
@@ -204,22 +202,27 @@ class SummaryContent extends React.Component<Props, State> {
               eventView={eventView}
               totalValues={totalCount}
             />
-            <TransactionsList
-              location={location}
-              organization={organization}
-              eventView={eventView}
-              selected={selectedSort}
-              options={sortOptions}
-              titles={[t('id'), t('user'), t('duration'), t('timestamp')]}
-              handleDropdownChange={this.handleTransactionsListSortChange}
-              generateLink={{
-                id: generateTransactionLink(transactionName),
-              }}
-              baseline={transactionName}
-              handleBaselineClick={this.handleViewDetailsClick}
-              handleCellAction={this.handleCellAction}
-              handleOpenInDiscoverClick={this.handleDiscoverViewClick}
-            />
+            {totalValues === null ? (
+              <Placeholder height="352px" />
+            ) : (
+              <TransactionsList
+                location={location}
+                organization={organization}
+                eventView={eventView}
+                titles={[t('id'), t('user'), t('duration'), t('timestamp')]}
+                handleDropdownChange={this.handleTransactionsListSortChange}
+                generateLink={{
+                  id: generateTransactionLink(transactionName),
+                }}
+                baseline={transactionName}
+                handleBaselineClick={this.handleViewDetailsClick}
+                handleCellAction={this.handleCellAction}
+                handleOpenInDiscoverClick={this.handleDiscoverViewClick}
+                {...getTransactionsListSort(location, {
+                  p95: totalValues.p95,
+                })}
+              />
+            )}
             <RelatedIssues
               organization={organization}
               location={location}
@@ -297,14 +300,14 @@ function getFilterOptions({p95}: {p95: number}): DropdownOption[] {
 function getTransactionsListSort(
   location: Location,
   options: {p95: number}
-): {selectedSort: DropdownOption; sortOptions: DropdownOption[]} {
+): {selected: DropdownOption; options: DropdownOption[]} {
   const sortOptions = getFilterOptions(options);
   const urlParam = decodeScalar(
     location.query.showTransactions,
     TransactionFilterOptions.SLOW
   );
   const selectedSort = sortOptions.find(opt => opt.value === urlParam) || sortOptions[0];
-  return {selectedSort, sortOptions};
+  return {selected: selectedSort, options: sortOptions};
 }
 
 const StyledSearchBar = styled(SearchBar)`

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -10,7 +10,6 @@ import SearchBar from 'app/components/events/searchBar';
 import GlobalSdkUpdateAlert from 'app/components/globalSdkUpdateAlert';
 import * as Layout from 'app/components/layouts/thirds';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
-import Placeholder from 'app/components/placeholder';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
@@ -202,27 +201,24 @@ class SummaryContent extends React.Component<Props, State> {
               eventView={eventView}
               totalValues={totalCount}
             />
-            {totalValues === null ? (
-              <Placeholder height="352px" />
-            ) : (
-              <TransactionsList
-                location={location}
-                organization={organization}
-                eventView={eventView}
-                titles={[t('id'), t('user'), t('duration'), t('timestamp')]}
-                handleDropdownChange={this.handleTransactionsListSortChange}
-                generateLink={{
-                  id: generateTransactionLink(transactionName),
-                }}
-                baseline={transactionName}
-                handleBaselineClick={this.handleViewDetailsClick}
-                handleCellAction={this.handleCellAction}
-                handleOpenInDiscoverClick={this.handleDiscoverViewClick}
-                {...getTransactionsListSort(location, {
-                  p95: totalValues.p95,
-                })}
-              />
-            )}
+            <TransactionsList
+              location={location}
+              organization={organization}
+              eventView={eventView}
+              titles={[t('id'), t('user'), t('duration'), t('timestamp')]}
+              handleDropdownChange={this.handleTransactionsListSortChange}
+              generateLink={{
+                id: generateTransactionLink(transactionName),
+              }}
+              baseline={transactionName}
+              handleBaselineClick={this.handleViewDetailsClick}
+              handleCellAction={this.handleCellAction}
+              handleOpenInDiscoverClick={this.handleDiscoverViewClick}
+              {...getTransactionsListSort(location, {
+                p95: totalValues ? totalValues.p95 : 0,
+              })}
+              forceLoading={!totalValues}
+            />
             <RelatedIssues
               organization={organization}
               location={location}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -215,7 +215,7 @@ class SummaryContent extends React.Component<Props, State> {
               handleCellAction={this.handleCellAction}
               handleOpenInDiscoverClick={this.handleDiscoverViewClick}
               {...getTransactionsListSort(location, {
-                p95: totalValues ? totalValues.p95 : 0,
+                p95: totalValues?.p95 ?? 0,
               })}
               forceLoading={!totalValues}
             />

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -8,7 +8,6 @@ import isEqual from 'lodash/isEqual';
 import {loadOrganizationTags} from 'app/actionCreators/tags';
 import {Client} from 'app/api';
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
-import LoadingIndicator from 'app/components/loadingIndicator';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
@@ -16,12 +15,7 @@ import {PageContent} from 'app/styles/organization';
 import {GlobalSelection, Organization, Project} from 'app/types';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
-import {
-  Column,
-  getAggregateAlias,
-  isAggregateField,
-  WebVital,
-} from 'app/utils/discover/fields';
+import {Column, isAggregateField, WebVital} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
@@ -103,10 +97,7 @@ class TransactionSummary extends React.Component<Props, State> {
     return [t('Summary'), t('Performance')].join(' - ');
   }
 
-  getTotalsEventView(
-    organization: Organization,
-    eventView: EventView
-  ): [EventView, TotalValues] {
+  getTotalsEventView(organization: Organization, eventView: EventView): EventView {
     const threshold = organization.apdexThreshold.toString();
 
     const vitals = VITAL_GROUPS.map(({vitals: vs}) => vs).reduce(
@@ -117,7 +108,7 @@ class TransactionSummary extends React.Component<Props, State> {
       []
     );
 
-    const totalsView = eventView.withColumns([
+    return eventView.withColumns([
       {
         kind: 'function',
         function: ['apdex', threshold, undefined],
@@ -146,11 +137,6 @@ class TransactionSummary extends React.Component<Props, State> {
           } as Column)
       ),
     ]);
-    const emptyValues = totalsView.fields.reduce((values, field) => {
-      values[getAggregateAlias(field.field)] = 0;
-      return values;
-    }, {});
-    return [totalsView, emptyValues];
   }
 
   render() {
@@ -168,7 +154,7 @@ class TransactionSummary extends React.Component<Props, State> {
       });
       return null;
     }
-    const [totalsView, emptyValues] = this.getTotalsEventView(organization, eventView);
+    const totalsView = this.getTotalsEventView(organization, eventView);
 
     const shouldForceProject = eventView.project.length === 1;
     const forceProject = shouldForceProject
@@ -196,13 +182,10 @@ class TransactionSummary extends React.Component<Props, State> {
                 orgSlug={organization.slug}
                 location={location}
               >
-                {({tableData, isLoading}) => {
-                  if (isLoading) {
-                    return <LoadingIndicator />;
-                  }
+                {({tableData}) => {
                   const totals = (tableData && tableData.data.length
                     ? tableData.data[0]
-                    : emptyValues) as TotalValues;
+                    : null) as TotalValues;
                   return (
                     <SummaryContent
                       location={location}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -185,7 +185,7 @@ class TransactionSummary extends React.Component<Props, State> {
                 {({tableData}) => {
                   const totals = (tableData && tableData.data.length
                     ? tableData.data[0]
-                    : null) as TotalValues;
+                    : null) as TotalValues | null;
                   return (
                     <SummaryContent
                       location={location}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 import Feature from 'app/components/acl/feature';
 import {SectionHeading} from 'app/components/charts/styles';
 import Link from 'app/components/links/link';
+import Placeholder from 'app/components/placeholder';
 import QuestionTooltip from 'app/components/questionTooltip';
 import UserMisery from 'app/components/userMisery';
 import {IconOpen} from 'app/icons';
@@ -27,16 +28,16 @@ import VitalInfo from '../vitalDetail/vitalInfo';
 
 type Props = {
   eventView: EventView;
-  totals: Record<string, number>;
+  totals: Record<string, number> | null;
   location: Location;
   organization: Organization;
   transactionName: string;
 };
 
 function UserStats({eventView, totals, location, organization, transactionName}: Props) {
-  let userMisery = <StatNumber>{'\u2014'}</StatNumber>;
+  let userMisery = <Placeholder height="34px" />;
   const threshold = organization.apdexThreshold;
-  let apdex: React.ReactNode = <StatNumber>{'\u2014'}</StatNumber>;
+  let apdex: React.ReactNode = <Placeholder height="24px" />;
   let vitalsPassRate: React.ReactNode = null;
 
   if (totals) {

--- a/tests/js/spec/components/discover/transactionsList.spec.jsx
+++ b/tests/js/spec/components/discover/transactionsList.spec.jsx
@@ -373,4 +373,22 @@ describe('TransactionsList', function () {
       });
     });
   });
+
+  describe('Loading', function () {
+    it('renders loading indicator if forced', async function () {
+      wrapper = mountWithTheme(
+        <TransactionsList
+          api={api}
+          location={location}
+          organization={organization}
+          eventView={eventView}
+          selected={options[0]}
+          options={options}
+          handleDropdownChange={handleDropdownChange}
+          forceLoading
+        />
+      );
+      expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
+    });
+  });
 });

--- a/tests/js/spec/components/discover/transactionsList.spec.jsx
+++ b/tests/js/spec/components/discover/transactionsList.spec.jsx
@@ -301,6 +301,38 @@ describe('TransactionsList', function () {
         })
       );
     });
+
+    it('handles forceLoading correctly', async function () {
+      wrapper = mountWithTheme(
+        <TransactionsList
+          api={null}
+          location={location}
+          organization={organization}
+          eventView={eventView}
+          selected={options[0]}
+          options={options}
+          handleDropdownChange={handleDropdownChange}
+          forceLoading
+        />
+      );
+
+      expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
+      wrapper.setProps({api, forceLoading: false});
+
+      await tick();
+      wrapper.update();
+
+      expect(wrapper.find('LoadingIndicator')).toHaveLength(0);
+      expect(wrapper.find('DropdownControl')).toHaveLength(1);
+      expect(wrapper.find('DropdownItem')).toHaveLength(2);
+      expect(wrapper.find('DiscoverButton')).toHaveLength(1);
+      expect(wrapper.find('Pagination')).toHaveLength(1);
+      expect(wrapper.find('PanelTable')).toHaveLength(1);
+      // 2 for the transaction names
+      expect(wrapper.find('GridCell')).toHaveLength(2);
+      // 2 for the counts
+      expect(wrapper.find('GridCellNumber')).toHaveLength(2);
+    });
   });
 
   describe('Baseline', function () {
@@ -371,24 +403,6 @@ describe('TransactionsList', function () {
       cells.forEach((cell, i) => {
         expect(cell.text()).toEqual(cellTexts[i]);
       });
-    });
-  });
-
-  describe('Loading', function () {
-    it('renders loading indicator if forced', async function () {
-      wrapper = mountWithTheme(
-        <TransactionsList
-          api={api}
-          location={location}
-          organization={organization}
-          eventView={eventView}
-          selected={options[0]}
-          options={options}
-          handleDropdownChange={handleDropdownChange}
-          forceLoading
-        />
-      );
-      expect(wrapper.find('LoadingIndicator')).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
LoadingIndicator was added in #20956, probably because we need p95 to get the
transactions list. However, this unnecessarily holds up all the other API
requests. Optimize the transaction summary page to start those requests first
and wait for the p95 to get the transactions list.

While we're here, also migrate some things from em dashes to Placeholders to
improve consistency on this page.