### PR TITLE
fix(ui): Convert truncate to support dark mode

### DIFF
--- a/docs-ui/components/truncate.stories.js
+++ b/docs-ui/components/truncate.stories.js
@@ -9,7 +9,7 @@ export default {
 };
 
 export const TruncateAndExpandOnHover = () => (
-  <div>
+  <React.Fragment>
     <Wrapper position="start">
       <Truncate value="https://sentry.io/organizations/sentry/issues/" maxLength={30} />
     </Wrapper>
@@ -21,13 +21,13 @@ export const TruncateAndExpandOnHover = () => (
         expandDirection="left"
       />
     </Wrapper>
-  </div>
+  </React.Fragment>
 );
 
 TruncateAndExpandOnHover.storyName = 'Truncate and Expand on Hover';
 
 export const TruncateWithRegex = () => (
-  <div>
+  <React.Fragment>
     <Wrapper position="start">
       <Truncate
         value="https://sentry.io/organizations/sentry/issues/"
@@ -44,7 +44,7 @@ export const TruncateWithRegex = () => (
         expandDirection="left"
       />
     </Wrapper>
-  </div>
+  </React.Fragment>
 );
 
 TruncateWithRegex.storyName = 'Truncate with Regex';

--- a/docs-ui/components/truncate.stories.js
+++ b/docs-ui/components/truncate.stories.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import Truncate from 'app/components/truncate';
+
+export default {
+  title: 'Utilities/Truncate',
+  component: Truncate,
+};
+
+export const TruncateAndExpandOnHover = () => (
+  <div>
+    <Wrapper position="start">
+      <Truncate value="https://sentry.io/organizations/sentry/issues/" maxLength={30} />
+    </Wrapper>
+    <Wrapper position="end">
+      <Truncate
+        value="https://sentry.io/organizations/sentry/issues/"
+        maxLength={30}
+        leftTrim
+        expandDirection="left"
+      />
+    </Wrapper>
+  </div>
+);
+
+TruncateAndExpandOnHover.storyName = 'Truncate and Expand on Hover';
+
+export const TruncateWithRegex = () => (
+  <div>
+    <Wrapper position="start">
+      <Truncate
+        value="https://sentry.io/organizations/sentry/issues/"
+        maxLength={30}
+        trimRegex={/\.|\//g}
+      />
+    </Wrapper>
+    <Wrapper position="end">
+      <Truncate
+        value="https://sentry.io/organizations/sentry/issues/"
+        maxLength={30}
+        trimRegex={/\.|\//g}
+        leftTrim
+        expandDirection="left"
+      />
+    </Wrapper>
+  </div>
+);
+
+TruncateWithRegex.storyName = 'Truncate with Regex';
+
+const Wrapper = styled('div')`
+  display: flex;
+  justify-content: flex-${p => p.position || 'start'};
+`;

--- a/src/sentry/static/sentry/app/components/truncate.tsx
+++ b/src/sentry/static/sentry/app/components/truncate.tsx
@@ -130,7 +130,7 @@ export const FullValue = styled('span')<{
   ${p =>
     p.expanded &&
     `
-    z-index: 10;
+    z-index: ${p.theme.zIndex.truncationFullValue};
     display: block;
     `}
 `;

--- a/src/sentry/static/sentry/app/components/truncate.tsx
+++ b/src/sentry/static/sentry/app/components/truncate.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
+import styled from '@emotion/styled';
+
+import space from 'app/styles/space';
 
 type DefaultProps = {
   maxLength: number;
   leftTrim: boolean;
-  trimRegex?: RegExp;
   expandable: boolean;
+  expandDirection: 'left' | 'right';
 };
 
 type Props = DefaultProps & {
   value: string;
   className?: string;
+  trimRegex?: RegExp;
 };
 
 type State = {
@@ -21,6 +25,7 @@ class Truncate extends React.Component<Props, State> {
     maxLength: 50,
     leftTrim: false,
     expandable: true,
+    expandDirection: 'right',
   };
 
   state = {
@@ -42,7 +47,14 @@ class Truncate extends React.Component<Props, State> {
   };
 
   render() {
-    const {leftTrim, trimRegex, maxLength, value, expandable} = this.props;
+    const {
+      leftTrim,
+      trimRegex,
+      maxLength,
+      value,
+      expandable,
+      expandDirection,
+    } = this.props;
     const isTruncated = value.length > maxLength;
     let shortValue: React.ReactNode = '';
 
@@ -75,25 +87,52 @@ class Truncate extends React.Component<Props, State> {
       shortValue = value;
     }
 
-    let className = this.props.className || '';
-    className += ' truncated';
-    if (this.state.isExpanded) {
-      className += ' expanded';
-    }
+    const className = this.props.className || '';
 
     return (
-      <span
+      <TruncatedContainer
         className={className}
         onMouseOver={expandable ? this.onFocus : undefined}
         onMouseOut={expandable ? this.onBlur : undefined}
         onFocus={expandable ? this.onFocus : undefined}
         onBlur={expandable ? this.onBlur : undefined}
       >
-        <span className="short-value">{shortValue}</span>
-        {isTruncated && <span className="full-value">{value}</span>}
-      </span>
+        <span>{shortValue}</span>
+        {isTruncated && (
+          <FullValue expanded={this.state.isExpanded} expandDirection={expandDirection}>
+            {value}
+          </FullValue>
+        )}
+      </TruncatedContainer>
     );
   }
 }
+
+const TruncatedContainer = styled('span')`
+  position: relative;
+`;
+
+export const FullValue = styled('span')<{
+  expanded: boolean;
+  expandDirection: 'left' | 'right';
+}>`
+  display: none;
+  position: absolute;
+  background: ${p => p.theme.background};
+  padding: ${space(0.5)};
+  border: 1px solid ${p => p.theme.innerBorder};
+  white-space: nowrap;
+  border-radius: ${space(0.5)};
+  top: -5px;
+  ${p => p.expandDirection === 'left' && 'right: -5px;'}
+  ${p => p.expandDirection === 'right' && 'left: -5px;'}
+
+  ${p =>
+    p.expanded &&
+    `
+    z-index: 10;
+    display: block;
+    `}
+`;
 
 export default Truncate;

--- a/src/sentry/static/sentry/app/components/truncate.tsx
+++ b/src/sentry/static/sentry/app/components/truncate.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import space from 'app/styles/space';
 
 type DefaultProps = {
+  className: string;
   maxLength: number;
   leftTrim: boolean;
   expandable: boolean;
@@ -12,7 +13,6 @@ type DefaultProps = {
 
 type Props = DefaultProps & {
   value: string;
-  className?: string;
   trimRegex?: RegExp;
 };
 
@@ -22,6 +22,7 @@ type State = {
 
 class Truncate extends React.Component<Props, State> {
   static defaultProps: DefaultProps = {
+    className: '',
     maxLength: 50,
     leftTrim: false,
     expandable: true,
@@ -48,6 +49,7 @@ class Truncate extends React.Component<Props, State> {
 
   render() {
     const {
+      className,
       leftTrim,
       trimRegex,
       maxLength,
@@ -87,10 +89,8 @@ class Truncate extends React.Component<Props, State> {
       shortValue = value;
     }
 
-    const className = this.props.className || '';
-
     return (
-      <TruncatedContainer
+      <Wrapper
         className={className}
         onMouseOver={expandable ? this.onFocus : undefined}
         onMouseOut={expandable ? this.onBlur : undefined}
@@ -103,12 +103,12 @@ class Truncate extends React.Component<Props, State> {
             {value}
           </FullValue>
         )}
-      </TruncatedContainer>
+      </Wrapper>
     );
   }
 }
 
-const TruncatedContainer = styled('span')`
+const Wrapper = styled('span')`
   position: relative;
 `;
 

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -380,6 +380,9 @@ const commonTheme = {
       gridCellError: 1,
       iconWrapper: 1,
     },
+
+    truncationFullValue: 10,
+
     traceView: {
       spanTreeToggler: 900,
       dividerLine: 909,

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTrace.tsx
@@ -376,6 +376,7 @@ function EventNodeSelector({
                   maxLength={35}
                   leftTrim
                   trimRegex={/\.|\//g}
+                  expandDirection="left"
                 />
               </DropdownItemSubContainer>
               <SectionSubtext>

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
@@ -113,12 +113,4 @@ export const DropdownItemSubContainer = styled('div')`
 
 export const StyledTruncate = styled(Truncate)`
   margin-left: ${space(1)};
-
-  /**
-   * This is the class added to the element that is shown on hover.
-   */
-  .full-value {
-    left: auto;
-    right: -5px;
-  }
 `;

--- a/src/sentry/static/sentry/less/shared-components.less
+++ b/src/sentry/static/sentry/less/shared-components.less
@@ -1485,28 +1485,6 @@ ul.radio-inputs {
 }
 
 /**
- * Truncate component.
- */
-.truncated {
-  position: relative;
-  .full-value {
-    display: none;
-    position: absolute;
-    background: @white;
-    left: -5px;
-    top: -5px;
-    padding: 4px;
-    border: 1px solid @trim;
-    white-space: nowrap;
-    border-radius: 4px;
-  }
-  &.expanded .full-value {
-    z-index: 10;
-    display: block;
-  }
-}
-
-/**
 * Responsive small screens
 * ============================================================================
 */


### PR DESCRIPTION
The truncate component is currently styled in the less files. This means that it
is not respecting dark themes. This change moves the styling to use emotion so
it follows the dark theme colors.

# Before

https://user-images.githubusercontent.com/10239353/110511759-91a61400-80d2-11eb-922e-181d2c4c7b93.mp4

# After

https://user-images.githubusercontent.com/10239353/110511783-97035e80-80d2-11eb-8800-cfb9755f3327.mp4