### PR TITLE
fix(async-csv): Validate fields during creation

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -81,7 +81,7 @@ class DataExportQuerySerializer(serializers.Serializer):
             try:
                 snuba_filter = get_filter(query_info["query"], processor.params)
                 resolve_field_list(
-                    fields,
+                    fields.copy(),
                     snuba_filter,
                     auto_fields=True,
                     auto_aggregations=True,

--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationDataExportPermission
-from sentry.api.event_search import get_filter, InvalidSearchQuery
+from sentry.api.event_search import get_filter, resolve_field_list, InvalidSearchQuery
 from sentry.api.serializers import serialize
 from sentry.api.utils import get_date_range_from_params, InvalidParams
 from sentry.models import Environment
@@ -79,7 +79,13 @@ class DataExportQuerySerializer(serializers.Serializer):
                 organization_id=organization.id,
             )
             try:
-                get_filter(query_info["query"], processor.params)
+                snuba_filter = get_filter(query_info["query"], processor.params)
+                resolve_field_list(
+                    fields,
+                    snuba_filter,
+                    auto_fields=True,
+                    auto_aggregations=True,
+                )
             except InvalidSearchQuery as err:
                 raise serializers.ValidationError(str(err))
 

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -138,6 +138,16 @@ class DataExportTest(APITestCase):
             ]
         }
 
+    def test_export_invalid_fields(self):
+        """
+        Ensures that if too many fields are requested, returns a 400 status code with the
+        corresponding error message.
+        """
+        payload = self.make_payload("discover", {"field": ["min()"]})
+        with self.feature("organizations:discover-query"):
+            response = self.get_valid_response(self.org.slug, status_code=400, **payload)
+        assert response.data == {"non_field_errors": ["min(): expected 1 argument(s)"]}
+
     @freeze_time("2020-02-27 12:07:37")
     def test_export_invalid_date_params(self):
         """


### PR DESCRIPTION
When starting an async csv task, make sure to validate the fields at creating
time so we can fail before starting the export.