### PR TITLE
feat(alerts): Add basic team/owner filter to the alerts page

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/filter.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/filter.tsx
@@ -25,14 +25,6 @@ type Props = {
 };
 
 class Filter extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-
-    this.state = {
-      selection: new Set(),
-    };
-  }
-
   toggleFilter = (filter: string) => {
     const {onFilterChange, selection} = this.props;
     const newSelection = new Set(selection);
@@ -46,12 +38,11 @@ class Filter extends React.Component<Props> {
 
   toggleAllFilters = () => {
     const {filterList, onFilterChange, selection} = this.props;
-    let newSelection: Set<string>;
-    if (selection.size === filterList.length) {
-      newSelection = new Set();
-    } else {
-      newSelection = new Set(filterList);
-    }
+    const newSelection =
+      selection.size === filterList.length
+        ? (new Set() as Set<string>)
+        : new Set(filterList);
+
     onFilterChange(newSelection);
   };
 

--- a/src/sentry/static/sentry/app/views/alerts/rules/filter.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/filter.tsx
@@ -39,9 +39,7 @@ class Filter extends React.Component<Props> {
   toggleAllFilters = () => {
     const {filterList, onFilterChange, selection} = this.props;
     const newSelection =
-      selection.size === filterList.length
-        ? (new Set() as Set<string>)
-        : new Set(filterList);
+      selection.size === filterList.length ? new Set<string>() : new Set(filterList);
 
     onFilterChange(newSelection);
   };
@@ -150,36 +148,6 @@ const StyledDropdownButton = styled(DropdownButton)<{hasDarkBorderBottomColor?: 
     `
       border-bottom-color: ${p.theme.button.primary.border};
     `}
-`;
-
-export const List = styled('ul')`
-  list-style: none;
-  margin: 0;
-  padding: 0;
-`;
-
-export const ListItem = styled('li')<{isChecked?: boolean}>`
-  display: grid;
-  grid-template-columns: 1fr max-content;
-  grid-column-gap: ${space(1)};
-  align-items: center;
-  padding: ${space(1)} ${space(2)};
-  border-bottom: 1px solid ${p => p.theme.border};
-  :hover {
-    background-color: ${p => p.theme.backgroundSecondary};
-  }
-  ${CheckboxFancy} {
-    opacity: ${p => (p.isChecked ? 1 : 0.3)};
-  }
-
-  &:hover ${CheckboxFancy} {
-    opacity: 1;
-  }
-
-  &:hover span {
-    color: ${p => p.theme.blue300};
-    text-decoration: underline;
-  }
 `;
 
 export default Filter;

--- a/src/sentry/static/sentry/app/views/alerts/rules/filter.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/filter.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import CheckboxFancy from 'app/components/checkboxFancy/checkboxFancy';
+import DropdownButton from 'app/components/dropdownButton';
+import DropdownControl from 'app/components/dropdownControl';
+import {IconFilter} from 'app/icons';
+import {t, tn} from 'app/locale';
+import space from 'app/styles/space';
+
+type DropdownButtonProps = React.ComponentProps<typeof DropdownButton>;
+
+export type RenderProps = {
+  toggleFilter: (filter: string) => void;
+};
+
+type RenderFunc = (props: RenderProps) => React.ReactElement;
+
+type Props = {
+  header: string;
+  onFilterChange: (filterSelection: Set<string>) => void;
+  filterList: string[];
+  children: RenderFunc;
+  selection: Set<string>;
+};
+
+class Filter extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+
+    this.state = {
+      selection: new Set(),
+    };
+  }
+
+  toggleFilter = (filter: string) => {
+    const {onFilterChange, selection} = this.props;
+    const newSelection = new Set(selection);
+    if (newSelection.has(filter)) {
+      newSelection.delete(filter);
+    } else {
+      newSelection.add(filter);
+    }
+    onFilterChange(newSelection);
+  };
+
+  toggleAllFilters = () => {
+    const {filterList, onFilterChange, selection} = this.props;
+    let newSelection: Set<string>;
+    if (selection.size === filterList.length) {
+      newSelection = new Set();
+    } else {
+      newSelection = new Set(filterList);
+    }
+    onFilterChange(newSelection);
+  };
+
+  getNumberOfActiveFilters = (): number => {
+    const {selection} = this.props;
+    return selection.size;
+  };
+
+  render() {
+    const {children, header, filterList} = this.props;
+    const checkedQuantity = this.getNumberOfActiveFilters();
+
+    const dropDownButtonProps: Pick<DropdownButtonProps, 'children' | 'priority'> & {
+      hasDarkBorderBottomColor: boolean;
+    } = {
+      children: (
+        <React.Fragment>
+          <IconFilter size="xs" />
+          <FilterLabel>{t('Filter')}</FilterLabel>
+        </React.Fragment>
+      ),
+      priority: 'default',
+      hasDarkBorderBottomColor: false,
+    };
+
+    if (checkedQuantity > 0) {
+      dropDownButtonProps.children = (
+        <span>{tn('%s Active Filter', '%s Active Filters', checkedQuantity)}</span>
+      );
+      dropDownButtonProps.priority = 'primary';
+      dropDownButtonProps.hasDarkBorderBottomColor = true;
+    }
+    return (
+      <DropdownControl
+        menuWidth="240px"
+        blendWithActor
+        button={({isOpen, getActorProps}) => (
+          <StyledDropdownButton
+            {...getActorProps()}
+            showChevron={false}
+            isOpen={isOpen}
+            hasDarkBorderBottomColor={dropDownButtonProps.hasDarkBorderBottomColor}
+            priority={dropDownButtonProps.priority as DropdownButtonProps['priority']}
+            data-test-id="filter-button"
+          >
+            {dropDownButtonProps.children}
+          </StyledDropdownButton>
+        )}
+      >
+        <Header>
+          <span>{header}</span>
+          <CheckboxFancy
+            isChecked={checkedQuantity > 0}
+            isIndeterminate={checkedQuantity > 0 && checkedQuantity !== filterList.length}
+            onClick={event => {
+              event.stopPropagation();
+              this.toggleAllFilters();
+            }}
+          />
+        </Header>
+        {children({toggleFilter: this.toggleFilter})}
+      </DropdownControl>
+    );
+  }
+}
+
+const Header = styled('div')`
+  display: grid;
+  grid-template-columns: auto min-content;
+  grid-column-gap: ${space(1)};
+  align-items: center;
+
+  margin: 0;
+  background-color: ${p => p.theme.backgroundSecondary};
+  color: ${p => p.theme.gray300};
+  font-weight: normal;
+  font-size: ${p => p.theme.fontSizeMedium};
+  padding: ${space(1)} ${space(2)};
+  border-bottom: 1px solid ${p => p.theme.border};
+`;
+
+const FilterLabel = styled('span')`
+  margin-left: ${space(1)};
+`;
+
+const StyledDropdownButton = styled(DropdownButton)<{hasDarkBorderBottomColor?: boolean}>`
+  white-space: nowrap;
+  max-width: 200px;
+
+  z-index: ${p => p.theme.zIndex.dropdown};
+
+  &:hover,
+  &:active {
+    ${p =>
+      !p.isOpen &&
+      p.hasDarkBorderBottomColor &&
+      `
+          border-bottom-color: ${p.theme.button.primary.border};
+        `}
+  }
+
+  ${p =>
+    !p.isOpen &&
+    p.hasDarkBorderBottomColor &&
+    `
+      border-bottom-color: ${p.theme.button.primary.border};
+    `}
+`;
+
+export const List = styled('ul')`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+export const ListItem = styled('li')<{isChecked?: boolean}>`
+  display: grid;
+  grid-template-columns: 1fr max-content;
+  grid-column-gap: ${space(1)};
+  align-items: center;
+  padding: ${space(1)} ${space(2)};
+  border-bottom: 1px solid ${p => p.theme.border};
+  :hover {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
+  ${CheckboxFancy} {
+    opacity: ${p => (p.isChecked ? 1 : 0.3)};
+  }
+
+  &:hover ${CheckboxFancy} {
+    opacity: 1;
+  }
+
+  &:hover span {
+    color: ${p => p.theme.blue300};
+    text-decoration: underline;
+  }
+`;
+
+export default Filter;


### PR DESCRIPTION
Adds a new filter on the alert rules page to filter by teams. Currently has no functionality until the backend supports the team/owner query param in the endpoint. This feature is also feature flagged under `team-alerts-ownership`

Note: A lot of this is taken from the span filter in `components/events/interfaces/spans/filter.tsx` and in the future we can probably work on generalizing these filter components.

![Kapture 2021-03-08 at 12 47 25](https://user-images.githubusercontent.com/9372512/110360234-77a1fe00-800c-11eb-9d08-6b6eda1607f8.gif)
