### PR TITLE
fix(workflow): Fixing bug with inbox search

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -20,7 +20,7 @@ from sentry.api.helpers.group_index import (
     update_groups,
     ValidationError,
 )
-from sentry.api.paginator import DateTimePaginator
+from sentry.api.paginator import DateTimePaginator, Paginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import get_date_range_from_params, InvalidParams
@@ -29,11 +29,7 @@ from sentry.search.snuba.backend import (
     assigned_or_suggested_filter,
     EventsDatasetSnubaSearchBackend,
 )
-from sentry.search.snuba.executors import (
-    get_search_filter,
-    InvalidSearchQuery,
-    PostgresSnubaQueryExecutor,
-)
+from sentry.search.snuba.executors import get_search_filter, InvalidSearchQuery
 from sentry.snuba import discover
 from sentry.utils.compat import map
 from sentry.utils.cursors import Cursor, CursorResult
@@ -79,7 +75,7 @@ def inbox_search(
     end = max([earliest_date, end])
 
     if start >= end:
-        return PostgresSnubaQueryExecutor.empty_result
+        return Paginator(Group.objects.none()).get_result()
 
     # Make sure search terms are valid
     invalid_search_terms = [

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -874,17 +874,6 @@ class GroupListTest(APITestCase, SnubaTestCase):
             assert response.status_code == 200
             assert len(response.data) == 0
 
-            response = self.get_response(
-                sort="inbox",
-                limit=10,
-                query="is:unresolved is:for_review assigned_or_suggested:me_or_none",
-                expand=["inbox", "owners"],
-                start=iso_format(before_now(days=9)),
-                end=iso_format(before_now(days=8)),
-            )
-            assert response.status_code == 200
-            assert len(response.data) == 0
-
     def test_assigned_or_suggested_search(self):
         event = self.store_event(
             data={

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -859,6 +859,32 @@ class GroupListTest(APITestCase, SnubaTestCase):
             assert response.data[0]["inbox"] is not None
             assert response.data[0]["inbox"]["reason"] == GroupInboxReason.NEW.value
 
+    def test_inbox_search_outside_retention(self):
+        with self.feature("organizations:inbox"):
+            self.login_as(user=self.user)
+            response = self.get_response(
+                sort="inbox",
+                limit=10,
+                query="is:unresolved is:for_review",
+                collapse="stats",
+                expand=["inbox", "owners"],
+                start=iso_format(before_now(days=20)),
+                end=iso_format(before_now(days=15)),
+            )
+            assert response.status_code == 200
+            assert len(response.data) == 0
+
+            response = self.get_response(
+                sort="inbox",
+                limit=10,
+                query="is:unresolved is:for_review assigned_or_suggested:me_or_none",
+                expand=["inbox", "owners"],
+                start=iso_format(before_now(days=9)),
+                end=iso_format(before_now(days=8)),
+            )
+            assert response.status_code == 200
+            assert len(response.data) == 0
+
     def test_assigned_or_suggested_search(self):
         event = self.store_event(
             data={


### PR DESCRIPTION
It seems `PostgresSnubaQueryExecutor.empty_result` wasn't being evaluated correctly. Calling list(cursor_results) on it resulted in `'property' object is not iterable`.

Changed this to reference `Paginator(Group.objects.none()).get_result()` solves this issue. Added a test to verify the fix.

Fixes https://sentry.io/organizations/sentry/issues/2236512765/?project=1&query=is:unresolved+user.email:adhiraj@sentry.io&statsPeriod=14d