### PR TITLE
ui(span-view): Ops breakdown overflowing into minimap

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -759,6 +759,7 @@ const HeaderContainer = styled('div')`
 `;
 
 const MinimapBackground = styled('div')`
+  background-color: ${p => p.theme.background};
   height: ${MINIMAP_HEIGHT}px;
   max-height: ${MINIMAP_HEIGHT}px;
   overflow: hidden;

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/header.tsx
@@ -759,7 +759,6 @@ const HeaderContainer = styled('div')`
 `;
 
 const MinimapBackground = styled('div')`
-  background-color: ${p => p.theme.background};
   height: ${MINIMAP_HEIGHT}px;
   max-height: ${MINIMAP_HEIGHT}px;
   overflow: hidden;
@@ -894,7 +893,6 @@ const OperationsBreakdown = styled('div')`
   position: absolute;
   left: 0;
   top: 0;
-  padding: ${space(2)} ${space(3)};
   overflow: hidden;
 `;
 

--- a/src/sentry/static/sentry/app/components/events/opsBreakdown.tsx
+++ b/src/sentry/static/sentry/app/components/events/opsBreakdown.tsx
@@ -272,13 +272,18 @@ class OpsBreakdown extends React.Component<Props> {
       );
     }
 
-    return <StyledBreakdown>{contents}</StyledBreakdown>;
+    return <StyledBreakdownNoHeader>{contents}</StyledBreakdownNoHeader>;
   }
 }
 
 const StyledBreakdown = styled('div')`
   font-size: ${p => p.theme.fontSizeMedium};
   margin-bottom: ${space(4)};
+`;
+
+const StyledBreakdownNoHeader = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  margin: ${space(2)} ${space(3)};
 `;
 
 const OpsLine = styled('div')`


### PR DESCRIPTION
The ops breakdown on the left side has padding set giving it a non zero width.
So when its resized to be smaller this, they overflow into the minimap which has
a transparent background. This change changes the padding to margin on to
so the container has 0 width.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/110375657-40d5e300-8020-11eb-8190-f059567e1fb1.png)

## After

![image](https://user-images.githubusercontent.com/10239353/110375612-33b8f400-8020-11eb-95fb-9cd9dd4d4abe.png)