### PR TITLE
build(dev): Change pgsql health check arguments

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1576,7 +1576,7 @@ SENTRY_DEVSERVICES = {
         "environment": {"POSTGRES_DB": "sentry", "POSTGRES_HOST_AUTH_METHOD": "trust"},
         "volumes": {"postgres": {"bind": "/var/lib/postgresql/data"}},
         "healthcheck": {
-            "test": ["CMD-SHELL", "pg_isready -U postgres"],
+            "test": ["CMD", "pg_isready", "-U", "postgres"],
             "interval": 30000000000,  # Test every 30 seconds (in ns).
             "timeout": 5000000000,  # Time we should expect the test to take.
             "retries": 3,

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1576,10 +1576,10 @@ SENTRY_DEVSERVICES = {
         "environment": {"POSTGRES_DB": "sentry", "POSTGRES_HOST_AUTH_METHOD": "trust"},
         "volumes": {"postgres": {"bind": "/var/lib/postgresql/data"}},
         "healthcheck": {
-            "test": ["CMD", "pg_isready"],
-            "interval": 1000000000,  # Test every 1 second (in ns).
-            "timeout": 1000000000,  # Time we should expect the test to take.
-            "retries": 5,
+            "test": ["CMD-SHELL", "pg_isready -U postgres"],
+            "interval": 30000000000,  # Test every 30 seconds (in ns).
+            "timeout": 5000000000,  # Time we should expect the test to take.
+            "retries": 3,
         },
     },
     "zookeeper": {


### PR DESCRIPTION
Introduced in https://github.com/getsentry/sentry/pull/21741 - I have had issues with the health check flooding my logs with `FATAL:  role "root" does not exist`. This is because `pg_isready` is trying to connect using the `root` role by default. This satisfies the health check because `pg_isready` only checks that it is able to connect independent of the auth credentials.

I've also increased the interval to 30 seconds (default) as having at 1s was burning my CPU, I've increased the timeout to 5 seconds, and lowered the retries to 3 (default).
