### PR TITLE
fix(metric alerts): Handle SIGTERM in subscription consumer

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -382,6 +382,7 @@ def query_subscription_consumer(**options):
         subscriber.shutdown()
 
     signal.signal(signal.SIGINT, handler)
+    signal.signal(signal.SIGTERM, handler)
 
     subscriber.run()
 

--- a/tests/snuba/snuba/test_query_subscription_consumer.py
+++ b/tests/snuba/snuba/test_query_subscription_consumer.py
@@ -113,11 +113,11 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
         producer = Producer(conf)
         producer.produce(self.topic, json.dumps(self.old_valid_wrapper))
         producer.flush()
-        mock_callback = Mock()
-        mock_callback.side_effect = KeyboardInterrupt()
+
+        consumer = QuerySubscriptionConsumer("hi", topic=self.topic, commit_batch_size=1)
+        mock_callback = Mock(side_effect=lambda *a, **k: consumer.shutdown())
         register_subscriber(self.registration_key)(mock_callback)
         sub = self.create_subscription()
-        consumer = QuerySubscriptionConsumer("hi", topic=self.topic, commit_batch_size=1)
         consumer.run()
 
         payload = self.old_payload
@@ -137,11 +137,11 @@ class QuerySubscriptionConsumerTest(TestCase, SnubaTestCase):
         producer = Producer(conf)
         producer.produce(self.topic, json.dumps(self.valid_wrapper))
         producer.flush()
-        mock_callback = Mock()
-        mock_callback.side_effect = KeyboardInterrupt()
+
+        consumer = QuerySubscriptionConsumer("hi", topic=self.topic, commit_batch_size=1)
+        mock_callback = Mock(side_effect=lambda *a, **k: consumer.shutdown())
         register_subscriber(self.registration_key)(mock_callback)
         sub = self.create_subscription()
-        consumer = QuerySubscriptionConsumer("hi", topic=self.topic, commit_batch_size=1)
         consumer.run()
 
         payload = self.valid_payload


### PR DESCRIPTION
The thing that was going to happen has now happened: https://github.com/getsentry/sentry/pull/14383#discussion_r314545467

See also GH-24244.