### PR TITLE
ref(js): Avoid direct usage of the window global in locale.tsx

### DIFF
--- a/src/sentry/static/sentry/app/components/search/sources/commandSource.tsx
+++ b/src/sentry/static/sentry/app/components/search/sources/commandSource.tsx
@@ -49,7 +49,10 @@ const ACTIONS: Action[] = [
     title: 'Toggle Translation Markers',
     description: 'Toggles translation markers on or off in the application',
     requiresSuperuser: true,
-    action: () => toggleLocaleDebug(),
+    action: () => {
+      toggleLocaleDebug();
+      window.location.reload();
+    },
   },
 
   {

--- a/src/sentry/static/sentry/app/locale.tsx
+++ b/src/sentry/static/sentry/app/locale.tsx
@@ -7,25 +7,28 @@ import isString from 'lodash/isString';
 import {sprintf} from 'sprintf-js';
 
 import {getTranslations} from 'app/translations';
+import localStorage from 'app/utils/localStorage';
 
 const markerCss = css`
   background: #ff801790;
   outline: 2px solid #ff801790;
 `;
 
-const sessionStorage = window.sessionStorage;
-const LOCALE_DEBUG = sessionStorage && sessionStorage.getItem('localeDebug') === '1';
+const LOCALE_DEBUG = localStorage.getItem('localeDebug') === '1';
 
 export function setLocaleDebug(value: boolean) {
-  sessionStorage.setItem('localeDebug', value ? '1' : '0');
+  localStorage.setItem('localeDebug', value ? '1' : '0');
   // eslint-disable-next-line no-console
   console.log(`Locale debug is: ${value ? 'on' : 'off'}. Reload page to apply changes!`);
 }
 
+/**
+ * Toggles the locale debug flag in local storage, but does _not_ reload the
+ * page. The caller should do this.
+ */
 export function toggleLocaleDebug() {
-  const currentValue = sessionStorage.getItem('localeDebug');
+  const currentValue = localStorage.getItem('localeDebug');
   setLocaleDebug(currentValue !== '1');
-  window.location.reload();
 }
 
 /**

--- a/src/sentry/static/sentry/app/utils/localStorage.tsx
+++ b/src/sentry/static/sentry/app/utils/localStorage.tsx
@@ -5,8 +5,9 @@ interface LocalStorage {
 }
 
 function createLocalStorage(): LocalStorage {
-  const localStorage = window.localStorage;
   try {
+    const localStorage = window.localStorage;
+
     const mod = 'sentry';
     localStorage.setItem(mod, mod);
     localStorage.removeItem(mod);


### PR DESCRIPTION
This is a helper change for https://github.com/getsentry/sentry/pull/24112 which needs to avoid having any modules bundled which directly use the `window` global.

Unfortuantely The locale module is imported for some chart title things.