### PR TITLE
ref(msteams): Add referrer to issue alert link

### DIFF
--- a/src/sentry/integrations/msteams/card_builder.py
+++ b/src/sentry/integrations/msteams/card_builder.py
@@ -328,7 +328,7 @@ def build_group_title(group):
     else:
         text = group.title
 
-    link = group.get_absolute_url()
+    link = group.get_absolute_url(params={"referrer": "msteams"})
 
     title_text = f"[{text}]({link})"
     return {


### PR DESCRIPTION
So as to know when users are clicking links to Sentry issues via Microsoft Teams, add a referrer to the URL. 