### PR TITLE
ref(vercel): Allow uninstall from Sentry

### DIFF
--- a/src/sentry/api/endpoints/organization_integration_details.py
+++ b/src/sentry/api/endpoints/organization_integration_details.py
@@ -28,6 +28,10 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
         # integrations and all linked issues.
         org_integration = self.get_organization_integration(organization, integration_id)
 
+        integration = org_integration.integration
+        # do any integration specific deleting steps
+        integration.get_installation(organization.id).uninstall()
+
         updated = OrganizationIntegration.objects.filter(
             id=org_integration.id, status=ObjectStatus.VISIBLE
         ).update(status=ObjectStatus.PENDING_DELETION)
@@ -41,7 +45,6 @@ class OrganizationIntegrationDetailsEndpoint(OrganizationIntegrationBaseEndpoint
                 },
                 countdown=0,
             )
-            integration = org_integration.integration
             create_audit_entry(
                 request=request,
                 organization=organization,

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -360,3 +360,11 @@ class IntegrationInstallation:
     @property
     def metadata(self):
         return self.model.metadata
+
+    def uninstall(self):
+        """
+        For integrations that need additional steps for uninstalling
+        that are not covered in the `delete_organization_integration`
+        task.
+        """
+        pass

--- a/src/sentry/integrations/vercel/client.py
+++ b/src/sentry/integrations/vercel/client.py
@@ -21,6 +21,7 @@ class VercelClient(ApiClient):
     GET_ENV_VAR_URL = "/v6/projects/%s/env"
     SECRETS_URL = "/v2/now/secrets"
     UPDATE_ENV_VAR_URL = "/v6/projects/%s/env/%s"
+    UNINSTALL = "/v1/integrations/configuration/%s"
 
     def __init__(self, access_token, team_id=None):
         super().__init__()
@@ -94,3 +95,6 @@ class VercelClient(ApiClient):
 
     def update_env_variable(self, vercel_project_id, env_var_id, data):
         return self.patch(self.UPDATE_ENV_VAR_URL % (vercel_project_id, env_var_id), data=data)
+
+    def uninstall(self, configuration_id):
+        return self.delete(self.UNINSTALL % configuration_id)

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -107,20 +107,8 @@ class VercelIntegration(IntegrationInstallation):
                     create_project_instruction.format(add_project_link),
                     install_source_code_integration.format(source_code_link),
                 ]
-            },
-            "integration_detail": {"uninstallationUrl": self.get_manage_url()},
+            }
         }
-
-    def get_manage_url(self):
-        slug = self.get_slug()
-        configuration_id = self.get_configuration_id()
-        if configuration_id:
-            if self.metadata["installation_type"] == "team":
-                dashboard_url = "https://vercel.com/dashboard/%s/" % slug
-            else:
-                dashboard_url = "https://vercel.com/dashboard/"
-            return f"{dashboard_url}integrations/{configuration_id}"
-        return None
 
     def get_client(self):
         access_token = self.metadata["access_token"]

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -69,15 +69,6 @@ install_source_code_integration = _(
     "Install a [source code integration]({}) and configure your repositories."
 )
 
-disable_dialog = {
-    "actionText": _("Visit Vercel"),
-    "body": _(
-        "In order to uninstall this integration, you must go"
-        " to Vercel and uninstall there by clicking 'Remove Configuration'."
-    ),
-}
-
-
 metadata = IntegrationMetadata(
     description=DESCRIPTION.strip(),
     features=FEATURES,
@@ -88,7 +79,6 @@ metadata = IntegrationMetadata(
     aspects={
         "externalInstall": external_install,
         "configure_integration": configure_integration,
-        "disable_dialog": disable_dialog,
     },
 )
 
@@ -297,12 +287,16 @@ class VercelIntegration(IntegrationInstallation):
             f"Could not update environment variable {key} in Vercel project {vercel_project_id}."
         )
 
+    def uninstall(self):
+        client = self.get_client()
+        client.uninstall(self.get_configuration_id())
+
 
 class VercelIntegrationProvider(IntegrationProvider):
     key = "vercel"
     name = "Vercel"
     can_add = False
-    can_disable = True
+    can_disable = False
     metadata = metadata
     integration_cls = VercelIntegration
     features = frozenset([IntegrationFeatures.DEPLOYMENT])

--- a/src/sentry/integrations/vercel/uninstall.py
+++ b/src/sentry/integrations/vercel/uninstall.py
@@ -4,7 +4,6 @@ from django.views.decorators.csrf import csrf_exempt
 from sentry.api.base import Endpoint
 from sentry.models import AuditLogEntryEvent, Integration, OrganizationIntegration, Organization
 from sentry.utils.audit import create_audit_entry
-from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger("sentry.integrations.vercel.uninstall")
 
@@ -17,12 +16,21 @@ class VercelUninstallEndpoint(Endpoint):
     def dispatch(self, request, *args, **kwargs):
         return super().dispatch(request, *args, **kwargs)
 
-    @transaction_start("VercelUninstallEndpoint")
+    def post(self, request):
+        # userId should always be present
+        external_id = request.data.get("teamId") or request.data.get("userId")
+        configuration_id = request.data["payload"]["configuration"]["id"]
+
+        return self._delete(external_id, configuration_id, request)
+
     def delete(self, request):
         # userId should always be present
         external_id = request.data.get("teamId") or request.data.get("userId")
         configuration_id = request.data.get("configurationId")
 
+        return self._delete(external_id, configuration_id, request)
+
+    def _delete(self, external_id, configuration_id, request):
         try:
             integration = Integration.objects.get(provider="vercel", external_id=external_id)
         except Integration.DoesNotExist:
@@ -34,22 +42,47 @@ class VercelUninstallEndpoint(Endpoint):
 
         orgs = integration.organizations.all()
 
-        if len(orgs) == 1:
-            create_audit_entry(
-                request=request,
-                organization=orgs[0],
-                target_object=integration.id,
-                event=AuditLogEntryEvent.INTEGRATION_REMOVE,
-                # TODO(meredith): If we create vercel identities from the userId
-                # we could attempt to find the user in Sentry and pass that in for
-                # the actor instead.
-                actor_label="Vercel User",
-                data={"provider": integration.provider, "name": integration.name},
-            )
+        if len(orgs) == 0:
+            # we already deleted the organization integration and
+            # there was only one to begin with
             integration.delete()
             return self.respond(status=204)
 
         configuration = integration.metadata["configurations"].pop(configuration_id)
+        # one of two cases:
+        #  1.) someone is deleting from vercel's end and we still need to delete the
+        #      organization integration AND the integration (since there is only one)
+        #  2.) we already deleted the organization integration tied to this configuration
+        #      and the remaining one is for a different org (and configuration)
+        if len(orgs) == 1:
+            try:
+                # Case no. 1: do the deleting and return
+                organization_integration = OrganizationIntegration.objects.get(
+                    organization_id=configuration["organization_id"], integration_id=integration.id
+                )
+                organization_integration.delete()
+                create_audit_entry(
+                    request=request,
+                    organization=orgs[0],
+                    target_object=integration.id,
+                    event=AuditLogEntryEvent.INTEGRATION_REMOVE,
+                    actor_label="Vercel User",
+                    data={"provider": integration.provider, "name": integration.name},
+                )
+                integration.delete()
+                return self.respond(status=204)
+            except OrganizationIntegration.DoesNotExist:
+                # Case no. 2: continue onto updating integration.metadata
+                logger.info(
+                    "vercel.uninstall.org-integration-already-deleted",
+                    extra={
+                        "configuration_id": configuration_id,
+                        "external_id": external_id,
+                        "integration_id": integration.id,
+                        "organization_id": configuration["organization_id"],
+                    },
+                )
+
         if configuration_id == integration.metadata["installation_id"]:
             # if we are uninstalling a primary configuration, and there are
             # multiple orgs connected to this integration we must update
@@ -60,13 +93,27 @@ class VercelUninstallEndpoint(Endpoint):
             integration.metadata["webhook_id"] = next_config["webhook_id"]
             integration.metadata["installation_id"] = next_config_id
 
+        integration.save()
+
+        # At this point we can consider if len(orgs) > 1. We have already updated the
+        # integration.metadata, but we may not have deleted the OrganizationIntegration
         try:
             OrganizationIntegration.objects.get(
                 organization_id=configuration["organization_id"], integration_id=integration.id
             ).delete()
+
+            organization = Organization.objects.get(id=configuration["organization_id"])
+            create_audit_entry(
+                request=request,
+                organization=organization,
+                target_object=integration.id,
+                event=AuditLogEntryEvent.INTEGRATION_REMOVE,
+                actor_label="Vercel User",
+                data={"provider": integration.provider, "name": integration.name},
+            )
         except OrganizationIntegration.DoesNotExist:
-            logger.error(
-                "vercel.uninstall.missing-org-integration",
+            logger.info(
+                "vercel.uninstall.org-integration-already-deleted",
                 extra={
                     "configuration_id": configuration_id,
                     "external_id": external_id,
@@ -74,21 +121,5 @@ class VercelUninstallEndpoint(Endpoint):
                     "organization_id": configuration["organization_id"],
                 },
             )
-            return self.respond(status=404)
-
-        integration.save()
-
-        organization = Organization.objects.get(id=configuration["organization_id"])
-        create_audit_entry(
-            request=request,
-            organization=organization,
-            target_object=integration.id,
-            event=AuditLogEntryEvent.INTEGRATION_REMOVE,
-            # TODO(meredith): If we create vercel identities from the userId
-            # we could attempt to find the user in Sentry and pass that in for
-            # the actor instead.
-            actor_label="Vercel User",
-            data={"provider": integration.provider, "name": integration.name},
-        )
 
         return self.respond(status=204)

--- a/src/sentry/integrations/vercel/uninstall.py
+++ b/src/sentry/integrations/vercel/uninstall.py
@@ -57,10 +57,9 @@ class VercelUninstallEndpoint(Endpoint):
         if len(orgs) == 1:
             try:
                 # Case no. 1: do the deleting and return
-                organization_integration = OrganizationIntegration.objects.get(
+                OrganizationIntegration.objects.get(
                     organization_id=configuration["organization_id"], integration_id=integration.id
                 )
-                organization_integration.delete()
                 create_audit_entry(
                     request=request,
                     organization=orgs[0],

--- a/src/sentry/integrations/vercel/urls.py
+++ b/src/sentry/integrations/vercel/urls.py
@@ -7,8 +7,12 @@ from sentry.web.frontend.vercel_extension_configuration import VercelExtensionCo
 
 
 urlpatterns = [
-    url(r"^webhook/$", VercelWebhookEndpoint.as_view()),
-    url(r"^configure/$", VercelExtensionConfigurationView.as_view()),
-    url(r"^delete/$", VercelUninstallEndpoint.as_view()),
-    url(r"^ui-hook/$", VercelUIHook.as_view()),
+    url(r"^webhook/$", VercelWebhookEndpoint.as_view(), name="sentry-extensions-vercel-webhook"),
+    url(
+        r"^configure/$",
+        VercelExtensionConfigurationView.as_view(),
+        name="sentry-extensions-vercel-configure",
+    ),
+    url(r"^delete/$", VercelUninstallEndpoint.as_view(), name="sentry-extensions-vercel-delete"),
+    url(r"^ui-hook/$", VercelUIHook.as_view(), name="sentry-extensions-vercel-ui-hook"),
 ]

--- a/src/sentry/integrations/vercel/webhook.py
+++ b/src/sentry/integrations/vercel/webhook.py
@@ -16,7 +16,6 @@ from sentry.models import (
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 from sentry.utils.compat import filter
-from sentry.web.decorators import transaction_start
 
 logger = logging.getLogger("sentry.integrations.vercel.webhooks")
 
@@ -103,7 +102,6 @@ class VercelWebhookEndpoint(Endpoint):
         }
         return [release_payload, sentry_app_installation_token.api_token.token]
 
-    @transaction_start("VercelWebhookEndpoint")
     def post(self, request):
         if not request.META.get("HTTP_X_ZEIT_SIGNATURE"):
             logger.error("vercel.webhook.missing-signature")

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationDetailedView.tsx
@@ -139,18 +139,11 @@ class IntegrationDetailedView extends AbstractIntegrationDetailedView<
   onDisable = (integration: Integration) => {
     let url: string;
 
-    // some integrations have a custom uninstalltion URL we show
-    const uninstallationUrl =
-      integration.dynamicDisplayInformation?.integration_detail?.uninstallationUrl;
-    if (uninstallationUrl) {
-      url = uninstallationUrl;
+    const [domainName, orgName] = integration.domainName.split('/');
+    if (integration.accountType === 'User') {
+      url = `https://${domainName}/settings/installations/`;
     } else {
-      const [domainName, orgName] = integration.domainName.split('/');
-      if (integration.accountType === 'User') {
-        url = `https://${domainName}/settings/installations/`;
-      } else {
-        url = `https://${domainName}/organizations/${orgName}/settings/installations/`;
-      }
+      url = `https://${domainName}/organizations/${orgName}/settings/installations/`;
     }
 
     window.open(url, '_blank');

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -30,6 +30,10 @@ SAMPLED_URL_NAMES = {
     "sentry-api-0-project-release-details",
     # integrations
     "sentry-extensions-jira-issue-hook",
+    "sentry-extensions-vercel-webhook",
+    "sentry-extensions-vercel-delete",
+    "sentry-extensions-vercel-configure",
+    "sentry-extensions-vercel-ui-hook",
     "sentry-api-0-group-integration-details",
     # integration platform
     "external-issues",

--- a/tests/sentry/integrations/vercel/test_uninstall.py
+++ b/tests/sentry/integrations/vercel/test_uninstall.py
@@ -1,3 +1,4 @@
+import responses
 from sentry.models import (
     Integration,
     OrganizationIntegration,
@@ -31,6 +32,7 @@ class VercelUninstallTest(APITestCase):
         metadata = {
             "access_token": "my_access_token",
             "installation_id": "my_config_id",
+            "installation_type": "team",
             "webhook_id": "my_webhook_id",
             "configurations": {
                 "my_config_id": {
@@ -78,6 +80,7 @@ class VercelUninstallTest(APITestCase):
         assert integration.metadata == {
             "access_token": "my_access_token2",
             "installation_id": "my_config_id2",
+            "installation_type": "team",
             "webhook_id": "my_webhook_id2",
             "configurations": {
                 "my_config_id2": {
@@ -109,6 +112,7 @@ class VercelUninstallTest(APITestCase):
         assert integration.metadata == {
             "access_token": "my_access_token",
             "installation_id": "my_config_id",
+            "installation_type": "team",
             "webhook_id": "my_webhook_id",
             "configurations": {
                 "my_config_id": {
@@ -128,6 +132,7 @@ class VercelUninstallTest(APITestCase):
         metadata = {
             "access_token": "my_access_token",
             "installation_id": "my_config_id",
+            "installation_type": "user",
             "webhook_id": "my_webhook_id",
             "configurations": {
                 "my_config_id": {
@@ -156,3 +161,73 @@ class VercelUninstallTest(APITestCase):
         assert not OrganizationIntegration.objects.filter(
             integration_id=integration.id, organization_id=org.id
         ).exists()
+
+    @responses.activate
+    def test_uninstall_from_sentry(self):
+        """
+        Test flows of uninstalling from sentry first to make sure
+        that uninstall webhook is valid even if the OrganizationIntegration
+        was deleted prior.
+          1. Uninstall the primary configuration
+          2. Check that integration metadata still updated
+          3. Uninstall remaining configuration
+          4. Check that integration is removed
+        """
+        self.login_as(self.user)
+        with self.tasks():
+            responses.add(
+                responses.DELETE,
+                "https://api.vercel.com/v1/integrations/configuration/my_config_id",
+                json={},
+            )
+            path = (
+                f"/api/0/organizations/{self.organization.slug}/integrations/{self.integration.id}/"
+            )
+            response = self.client.delete(path, format="json")
+            assert response.status_code == 204
+
+        assert len(OrganizationIntegration.objects.filter(integration=self.integration)) == 1
+
+        response = self.client.delete(
+            path=self.url,
+            data=PRIMARY_UNINSTALL_RESPONSE,
+            content_type="application/json",
+        )
+        assert response.status_code == 204
+
+        integration = Integration.objects.get(id=self.integration.id)
+        assert integration.metadata == {
+            "access_token": "my_access_token2",
+            "installation_id": "my_config_id2",
+            "installation_type": "team",
+            "webhook_id": "my_webhook_id2",
+            "configurations": {
+                "my_config_id2": {
+                    "access_token": "my_access_token2",
+                    "webhook_id": "my_webhook_id2",
+                    "organization_id": self.second_org.id,
+                }
+            },
+        }
+
+        with self.tasks():
+            responses.add(
+                responses.DELETE,
+                "https://api.vercel.com/v1/integrations/configuration/my_config_id2",
+                json={},
+            )
+            path = (
+                f"/api/0/organizations/{self.second_org.slug}/integrations/{self.integration.id}/"
+            )
+            response = self.client.delete(path, format="json")
+            assert response.status_code == 204
+
+        assert len(OrganizationIntegration.objects.filter(integration=self.integration)) == 0
+
+        response = self.client.delete(
+            path=self.url,
+            data=NONPRIMARY_UNINSTALL_RESPONSE,
+            content_type="application/json",
+        )
+        assert response.status_code == 204
+        assert not Integration.objects.filter(id=self.integration.id).exists()


### PR DESCRIPTION
**Context:**
_current Vercel delete flow: implementation [here](https://github.com/getsentry/sentry/pull/19606)_
1. Click **uninstall** in Sentry
2. Redirected to Vercel
3. Click **Remove Configuration** in Vercel
4. Sentry receives Delete Hook (legacy now?) and we do deletion within that endpoint

_problem:_
User got into a state where there was no configuration in Vercel, but Sentry still thought there was, so no way to uninstall from Sentry. (I think this was probably due to us failing somewhere when trying to remove the `OrganizationIntegration`  when we got the delete hook) 

**Solution**
Allow uninstalling from Sentry. Vercel has an endpoint (undocumented) `"/v1/integrations/configuration/%s"` that we can use to remove a configuration. Still handle if people uninstall from Vercel's end.

**Vercel Changes**
* The `Delete Hook` is no more, instead there is a generic Webhook with a [`integration-configuration-removed`](https://vercel.com/docs/api#integrations/webhooks/event-payloads/integration-configuration-removed) event.

    * This generic Webhook sends `POST` events, whereas the delete hook was a `DELETE` event.
    * We still get the `DELETE` event if a user uninstalls from Vercel, but if we use the API to delete, we get the `POST` event.
* No need to [handle multiple installations](https://github.com/getsentry/sentry/pull/19534) cause now you can only install Sentry once per Vercel org (either user or team).

**Changes in this PR**
* Add a `uninstall` method to the `IntegrationInstallation`
* Add the `POST` route to our delete endpoint because unfortunately the `Delete Hook` route became the generic Webhook route 

**Notes**
Because deleting the organization integration is an async task, it's possible that double audit log entries could show up. But if the `OrganizationIntegration` is deleted when we get the webhook before the task is executed it should still be fine cause if `OrganizationIntegration` doesn't exists it just aborts the task.