### PR TITLE
fix(inbox): Add assistant guide anchor on inbox tab

### DIFF
--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -103,7 +103,6 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
     },
     {
       guide: 'inbox_guide',
-      carryAssistantForward: true,
       requiredTargets: ['inbox_guide_tab'],
       dateThreshold: new Date(2021, 1, 26),
       steps: [

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -118,7 +118,7 @@ export default function getGuidesContent(orgSlug: string | null): GuidesContent 
     },
     {
       guide: 'for_review_guide',
-      requiredTargets: ['for_review_guide_tab', 'inbox_guide_reason'],
+      requiredTargets: ['for_review_guide_tab', 'inbox_guide_reason', 'is_inbox_tab'],
       steps: [
         {
           target: 'for_review_guide_tab',

--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
@@ -152,12 +152,7 @@ const GuideAnchor = createReactClass<Props, State>({
           <div>
             {lastStep ? (
               <React.Fragment>
-                <StyledButton
-                  size="small"
-                  href={currentGuide.carryAssistantForward ? '#assistant' : '#'} // to clear `#assistant` from the url
-                  to={to}
-                  onClick={this.handleFinish}
-                >
+                <StyledButton size="small" to={to} onClick={this.handleFinish}>
                   {currentStep.nextText ||
                     (hasManySteps ? t('Enough Already') : t('Got It'))}
                 </StyledButton>

--- a/src/sentry/static/sentry/app/components/assistant/types.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/types.tsx
@@ -18,7 +18,6 @@ export type Guide = {
   guide: string;
   requiredTargets: string[];
   dateThreshold?: Date;
-  carryAssistantForward?: boolean;
   steps: GuideStep[];
   seen: boolean;
 };
@@ -31,7 +30,6 @@ export type GuidesContent = {
    */
   requiredTargets: string[];
   dateThreshold?: Date;
-  carryAssistantForward?: boolean;
   steps: GuideStep[];
 }[];
 

--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
@@ -60,11 +60,13 @@ function EventOrGroupExtraDetails({
 
   return (
     <GroupExtra hasInbox={hasInbox}>
-      {hasInbox && inbox && hasGuideAnchor ? (
-        <GuideAnchor target="inbox_guide_reason">{inboxReason}</GuideAnchor>
-      ) : (
-        inboxReason
-      )}
+      {hasInbox &&
+        inbox &&
+        (hasGuideAnchor ? (
+          <GuideAnchor target="inbox_guide_reason">{inboxReason}</GuideAnchor>
+        ) : (
+          inboxReason
+        ))}
       {shortId &&
         (hasInbox ? (
           <InboxShortId

--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
@@ -54,13 +54,16 @@ function EventOrGroupExtraDetails({
 
   const issuesPath = `/organizations/${params.orgId}/issues/`;
   const hasInbox = organization.features.includes('inbox');
+  const inboxReason = inbox && (
+    <InboxReason inbox={inbox} showDateAdded={showInboxTime} />
+  );
 
   return (
     <GroupExtra hasInbox={hasInbox}>
-      {hasInbox && inbox && hasGuideAnchor && (
-        <GuideAnchor target="inbox_guide_reason">
-          <InboxReason inbox={inbox} showDateAdded={showInboxTime} />
-        </GuideAnchor>
+      {hasInbox && inbox && hasGuideAnchor ? (
+        <GuideAnchor target="inbox_guide_reason">{inboxReason}</GuideAnchor>
+      ) : (
+        inboxReason
       )}
       {shortId &&
         (hasInbox ? (

--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
@@ -57,8 +57,8 @@ function EventOrGroupExtraDetails({
 
   return (
     <GroupExtra hasInbox={hasInbox}>
-      {hasInbox && inbox && (
-        <GuideAnchor target="inbox_guide_reason" disabled={!hasGuideAnchor}>
+      {hasInbox && inbox && hasGuideAnchor && (
+        <GuideAnchor target="inbox_guide_reason">
           <InboxReason inbox={inbox} showDateAdded={showInboxTime} />
         </GuideAnchor>
       )}

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -25,6 +25,25 @@ import {
   TAB_MAX_COUNT,
 } from './utils';
 
+type WrapGuideProps = {
+  children: React.ReactElement;
+  tabQuery: string;
+  query: string;
+  to: React.ComponentProps<typeof GuideAnchor>['to'];
+};
+
+function WrapGuideTabs({children, tabQuery, query, to}: WrapGuideProps) {
+  if (isForReviewQuery(tabQuery)) {
+    return (
+      <GuideAnchor target="inbox_guide_tab" disabled={isForReviewQuery(query)} to={to}>
+        <GuideAnchor target="for_review_guide_tab">{children}</GuideAnchor>
+      </GuideAnchor>
+    );
+  }
+
+  return children;
+}
+
 type Props = {
   organization: Organization;
   query: string;
@@ -102,8 +121,6 @@ function IssueListHeader({
         <Layout.HeaderNavTabs underlined>
           {visibleTabs.map(
             ([tabQuery, {name: queryName, tooltipTitle, tooltipHoverable}]) => {
-              const inboxGuideStepOne = queryName === 'For Review' && query !== tabQuery;
-              const inboxGuideStepTwo = queryName === 'For Review' && query === tabQuery;
               const to = {
                 query: {
                   ...queryParms,
@@ -116,39 +133,30 @@ function IssueListHeader({
               return (
                 <li key={tabQuery} className={query === tabQuery ? 'active' : ''}>
                   <Link to={to} onClick={() => trackTabClick(tabQuery)}>
-                    <GuideAnchor
-                      target={inboxGuideStepOne ? 'inbox_guide_tab' : 'none'}
-                      disabled={!inboxGuideStepOne}
-                      to={to}
-                    >
-                      <GuideAnchor
-                        target={inboxGuideStepTwo ? 'for_review_guide_tab' : 'none'}
-                        disabled={!inboxGuideStepTwo}
+                    <WrapGuideTabs query={query} tabQuery={tabQuery} to={to}>
+                      <Tooltip
+                        title={tooltipTitle}
+                        position="bottom"
+                        isHoverable={tooltipHoverable}
+                        delay={1000}
                       >
-                        <Tooltip
-                          title={tooltipTitle}
-                          position="bottom"
-                          isHoverable={tooltipHoverable}
-                          delay={1000}
-                        >
-                          {queryName}{' '}
-                          {queryCounts[tabQuery] && (
-                            <StyledQueryCount
-                              isTag
-                              tagProps={{
-                                type:
-                                  isForReviewQuery(tabQuery) &&
-                                  queryCounts[tabQuery].count > 0
-                                    ? 'warning'
-                                    : 'default',
-                              }}
-                              count={queryCounts[tabQuery].count}
-                              max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
-                            />
-                          )}
-                        </Tooltip>
-                      </GuideAnchor>
-                    </GuideAnchor>
+                        {queryName}{' '}
+                        {queryCounts[tabQuery] && (
+                          <StyledQueryCount
+                            isTag
+                            tagProps={{
+                              type:
+                                isForReviewQuery(tabQuery) &&
+                                queryCounts[tabQuery].count > 0
+                                  ? 'warning'
+                                  : 'default',
+                            }}
+                            count={queryCounts[tabQuery].count}
+                            max={queryCounts[tabQuery].hasMore ? TAB_MAX_COUNT : 1000}
+                          />
+                        )}
+                      </Tooltip>
+                    </WrapGuideTabs>
                   </Link>
                 </li>
               );

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -21,6 +21,7 @@ import {fetchTagValues, loadOrganizationTags} from 'app/actionCreators/tags';
 import GroupActions from 'app/actions/groupActions';
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import {extractSelectionParameters} from 'app/components/organizations/globalSelectionHeader/utils';
@@ -1034,6 +1035,9 @@ class IssueListOverview extends React.Component<Props, State> {
       <Feature organization={organization} features={['organizations:inbox']}>
         {({hasFeature}) => (
           <React.Fragment>
+            {hasFeature && isForReviewQuery(query) && (
+              <GuideAnchor target="is_inbox_tab" />
+            )}
             {hasFeature && (
               <IssueListHeader
                 organization={organization}

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -1035,9 +1035,6 @@ class IssueListOverview extends React.Component<Props, State> {
       <Feature organization={organization} features={['organizations:inbox']}>
         {({hasFeature}) => (
           <React.Fragment>
-            {hasFeature && isForReviewQuery(query) && (
-              <GuideAnchor target="is_inbox_tab" />
-            )}
             {hasFeature && (
               <IssueListHeader
                 organization={organization}
@@ -1131,6 +1128,10 @@ class IssueListOverview extends React.Component<Props, State> {
                 )}
               </SidebarContainer>
             </StyledPageContent>
+
+            {hasFeature && isForReviewQuery(query) && (
+              <GuideAnchor target="is_inbox_tab" />
+            )}
           </React.Fragment>
         )}
       </Feature>

--- a/tests/js/spec/components/streamGroup.spec.jsx
+++ b/tests/js/spec/components/streamGroup.spec.jsx
@@ -38,7 +38,7 @@ describe('StreamGroup', function () {
     trackAnalyticsEvent.mockClear();
   });
 
-  it('renders with anchors', function () {
+  it('renders with anchors', async function () {
     const {routerContext} = initializeOrg();
     const component = mountWithTheme(
       <StreamGroup
@@ -52,6 +52,8 @@ describe('StreamGroup', function () {
       />,
       routerContext
     );
+    component.update();
+    await tick();
 
     expect(component.find('GuideAnchor').exists()).toBe(true);
     expect(component.find('GuideAnchor')).toHaveLength(3);


### PR DESCRIPTION
Refactoring when we decide to display the for review tab guide, instead of using disable, add another anchor that is displayed on the inbox tab.

Attempting to fix the inbox guide not showing up after switching tabs as seen here.


https://user-images.githubusercontent.com/1400464/110403547-1e4cc580-8032-11eb-84b0-0beb7e17ae3e.mp4


