### PR TITLE
fix(api): Allow cursors to contain floats.

### DIFF
--- a/src/sentry/utils/cursors.py
+++ b/src/sentry/utils/cursors.py
@@ -37,7 +37,8 @@ class Cursor:
         if len(bits) != 3:
             raise ValueError
         try:
-            bits = int(bits[0]), int(bits[1]), int(bits[2])
+            value = float(bits[0]) if "." in bits[0] else int(bits[0])
+            bits = value, int(bits[1]), int(bits[2])
         except (TypeError, ValueError):
             raise ValueError
         return cls(*bits)

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -78,16 +78,65 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert response.data[0]["id"] == str(group.id)
 
     def test_sort_by_trend(self):
-        event = self.store_event(
-            data={"event_id": "a" * 32, "timestamp": iso_format(before_now(seconds=1))},
+        group = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=10)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        ).group
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=10)),
+                "fingerprint": ["group-1"],
+            },
             project_id=self.project.id,
         )
-        group = event.group
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(hours=13)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+
+        group_2 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=5)),
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+        ).group
+        self.store_event(
+            data={
+                "timestamp": iso_format(before_now(hours=13)),
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+        )
         self.login_as(user=self.user)
 
-        response = self.get_valid_response(sort="trend", query="is:unresolved")
+        response = self.get_valid_response(
+            sort="trend",
+            query="is:unresolved",
+            limit=1,
+            start=iso_format(before_now(days=1)),
+            end=iso_format(before_now(seconds=1)),
+        )
         assert len(response.data) == 1
-        assert response.data[0]["id"] == str(group.id)
+        assert [item["id"] for item in response.data] == [str(group.id)]
+
+        header_links = parse_link_header(response["Link"])
+        cursor = [link for link in header_links.values() if link["rel"] == "next"][0]["cursor"]
+        response = self.get_valid_response(
+            sort="trend",
+            query="is:unresolved",
+            limit=1,
+            start=iso_format(before_now(days=1)),
+            end=iso_format(before_now(seconds=1)),
+            cursor=cursor,
+        )
+        assert [item["id"] for item in response.data] == [str(group_2.id)]
 
     def test_sort_by_inbox(self):
         group_1 = self.store_event(


### PR DESCRIPTION
We added an experimental trend sort in https://github.com/getsentry/sentry/pull/23106. This breaks
on pagination because the cursor contains a float instead of an int. This pr adds a small tweak to
allow floats to work.