### PR TITLE
fix(queries): Prevent group_id queries

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -784,6 +784,11 @@ def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
     name = search_filter.key.name if key is None else key
     value = search_filter.value.value
 
+    # We want to use group_id elsewhere so shouldn't be removed from the dataset
+    # but if a user has a tag with the same name we want to make sure that works
+    if name in {"group_id"}:
+        name = f"tags[{name}]"
+
     if name in no_conversion:
         return
     elif name == "id" and search_filter.value.is_wildcard():

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -716,6 +716,8 @@ class SnubaTagStorage(TagStorage):
         #               enters 2020-07 we can generate the following conditions:
         #               >= 2020-07-01T00:00:00 AND <= 2020-07-31T23:59:59
         # time:         This is a column computed from timestamp so it suffers the same issues
+        if snuba_key in {"group_id"}:
+            snuba_key = f"tags[{snuba_key}]"
         if snuba_key in {"event_id", "timestamp", "time"}:
             return SequencePaginator([])
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2190,6 +2190,20 @@ class GetSnubaQueryArgsTest(TestCase):
         result = get_filter("trace:a0fa8803753e40fd8124b21eeb2986b5")
         assert result.conditions == [["trace", "=", "a0fa8803-753e-40fd-8124-b21eeb2986b5"]]
 
+    def test_group_id_query(self):
+        # If a user queries on group_id, make sure it gets turned into a tag not the actual group_id field
+        assert get_filter("group_id:not-a-group-id-but-a-string").conditions == [
+            [["ifNull", ["tags[group_id]", "''"]], "=", "not-a-group-id-but-a-string"]
+        ]
+
+        assert get_filter("group_id:wildcard-string*").conditions == [
+            [
+                ["match", [["ifNull", ["tags[group_id]", "''"]], "'(?i)^wildcard\\-string.*$'"]],
+                "=",
+                1,
+            ]
+        ]
+
 
 class ResolveFieldListTest(unittest.TestCase):
     def test_non_string_field_error(self):

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -213,6 +213,16 @@ class OrganizationTagKeyValuesTest(OrganizationTagKeyTestCase):
         self.run_test("time", expected=[])
         self.run_test("time", qs_params={"query": "z"}, expected=[])
 
+    def test_group_id_tag(self):
+        self.store_event(
+            data={
+                "timestamp": iso_format(self.day_ago - timedelta(minutes=1)),
+                "tags": {"group_id": "not-a-group-id-but-a-string"},
+            },
+            project_id=self.project.id,
+        )
+        self.run_test("group_id", expected=[("not-a-group-id-but-a-string", 1)])
+
     def test_user_display(self):
         self.store_event(
             data={


### PR DESCRIPTION
- This prevents group_id from being queried by the frontend, as its only for internal use
- Instead this means that when group_id is used on the frontend(ie. search + autocomplete) its intepreted as a tag instead.