### PR TITLE
fix(ui): Fix displayed times on the alert rule details chart header

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -381,9 +381,9 @@ class DetailsBody extends React.Component<Props> {
                   </DropdownControl>
                   {timePeriod.custom && (
                     <StyledTimeRange>
-                      <DateTime date={timePeriod.start} timeAndDate />
+                      <DateTime date={moment.utc(timePeriod.start)} timeAndDate />
                       {' — '}
-                      <DateTime date={timePeriod.end} timeAndDate />
+                      <DateTime date={moment.utc(timePeriod.end)} timeAndDate />
                     </StyledTimeRange>
                   )}
                 </ChartControls>


### PR DESCRIPTION
This fixes the displayed times in the alert rule details chart header. Times are calculated using UTC, the chart and the tooltip shows local timezones if user has it set, so we need to do the same for these. Using the `utc` parameter in datetime converts the local time to UTC, but we need reverse here.

Solves: [WOR-716](https://getsentry.atlassian.net/browse/WOR-716)

BEFORE:
![Screen Shot 2021-03-08 at 7 02 34 PM](https://user-images.githubusercontent.com/15015880/110412837-b1d9c280-8041-11eb-87d0-29ab6e1ae7de.png)


AFTER:
![Screen Shot 2021-03-08 at 7 03 27 PM](https://user-images.githubusercontent.com/15015880/110412846-b900d080-8041-11eb-8f8c-2765d6a7a52c.png)
