### PR TITLE
feat(alerts): Redirect alert details to alert rule details for the interim

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {RouteComponentProps} from 'react-router';
+import {browserHistory, RouteComponentProps} from 'react-router';
 
 import {markIncidentAsSeen} from 'app/actionCreators/incident';
 import {addErrorMessage} from 'app/actionCreators/indicator';
@@ -9,6 +9,7 @@ import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
+import {makeRuleDetailsQuery} from 'app/views/alerts/list/row';
 
 import {Incident, IncidentStats, IncidentStatus} from '../types';
 import {
@@ -62,6 +63,15 @@ class IncidentDetails extends React.Component<Props, State> {
 
     try {
       const incidentPromise = fetchIncident(api, orgId, alertId).then(incident => {
+        const hasRedesign = incident.alertRule &&
+          this.props.organization.features.includes('alert-details-redesign');
+        if(hasRedesign) {
+          browserHistory.replace({
+            pathname: `/organizations/${orgId}/alerts/rules/details/${incident.alertRule?.id}/`,
+            query: makeRuleDetailsQuery(incident),
+          });
+        }
+
         this.setState({incident});
         markIncidentAsSeen(api, orgId, incident);
       });

--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -63,9 +63,10 @@ class IncidentDetails extends React.Component<Props, State> {
 
     try {
       const incidentPromise = fetchIncident(api, orgId, alertId).then(incident => {
-        const hasRedesign = incident.alertRule &&
+        const hasRedesign =
+          incident.alertRule &&
           this.props.organization.features.includes('alert-details-redesign');
-        if(hasRedesign) {
+        if (hasRedesign) {
           browserHistory.replace({
             pathname: `/organizations/${orgId}/alerts/rules/details/${incident.alertRule?.id}/`,
             query: makeRuleDetailsQuery(incident),

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -34,7 +34,9 @@ import {TableLayout, TitleAndSparkLine} from './styles';
  * Retrieve the start/end for showing the graph of the metric
  * Will show at least 150 and no more than 10,000 data points
  */
-export const makeRuleDetailsQuery = (incident: Incident): {start: string; end: string} => {
+export const makeRuleDetailsQuery = (
+  incident: Incident
+): {start: string; end: string} => {
   const {timeWindow} = incident.alertRule;
   const timeWindowMillis = timeWindow * 60 * 1000;
   const minRange = timeWindowMillis * API_INTERVAL_POINTS_MIN;
@@ -51,7 +53,7 @@ export const makeRuleDetailsQuery = (incident: Incident): {start: string; end: s
     start: getUtcDateString(startDate.subtract(halfRange)),
     end: getUtcDateString(moment.min(endDate.add(halfRange), now)),
   };
-}
+};
 
 type Props = {
   incident: Incident;

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -30,6 +30,29 @@ import {getIncidentMetricPreset, isIssueAlert} from '../utils';
 import SparkLine from './sparkLine';
 import {TableLayout, TitleAndSparkLine} from './styles';
 
+/**
+ * Retrieve the start/end for showing the graph of the metric
+ * Will show at least 150 and no more than 10,000 data points
+ */
+export const makeRuleDetailsQuery = (incident: Incident): {start: string; end: string} => {
+  const {timeWindow} = incident.alertRule;
+  const timeWindowMillis = timeWindow * 60 * 1000;
+  const minRange = timeWindowMillis * API_INTERVAL_POINTS_MIN;
+  const maxRange = timeWindowMillis * API_INTERVAL_POINTS_LIMIT;
+  const now = moment.utc();
+  const startDate = moment.utc(incident.dateStarted);
+  // make a copy of now since we will modify endDate and use now for comparing
+  const endDate = incident.dateClosed ? moment.utc(incident.dateClosed) : moment(now);
+  const incidentRange = Math.max(endDate.diff(startDate), 3 * timeWindowMillis);
+  const range = Math.min(maxRange, Math.max(minRange, incidentRange));
+  const halfRange = moment.duration(range / 2);
+
+  return {
+    start: getUtcDateString(startDate.subtract(halfRange)),
+    end: getUtcDateString(moment.min(endDate.add(halfRange), now)),
+  };
+}
+
 type Props = {
   incident: Incident;
   projects: Project[];
@@ -175,29 +198,6 @@ function ErrorLoadingStatsIcon() {
       <IconWarning />
     </Tooltip>
   );
-}
-
-/**
- * Retrieve the start/end for showing the graph of the metric
- * Will show at least 150 and no more than 10,000 data points
- */
-export const makeRuleDetailsQuery = (incident: Incident): {start: string; end: string} => {
-  const {timeWindow} = incident.alertRule;
-  const timeWindowMillis = timeWindow * 60 * 1000;
-  const minRange = timeWindowMillis * API_INTERVAL_POINTS_MIN;
-  const maxRange = timeWindowMillis * API_INTERVAL_POINTS_LIMIT;
-  const now = moment.utc();
-  const startDate = moment.utc(incident.dateStarted);
-  // make a copy of now since we will modify endDate and use now for comparing
-  const endDate = incident.dateClosed ? moment.utc(incident.dateClosed) : moment(now);
-  const incidentRange = Math.max(endDate.diff(startDate), 3 * timeWindowMillis);
-  const range = Math.min(maxRange, Math.max(minRange, incidentRange));
-  const halfRange = moment.duration(range / 2);
-
-  return {
-    start: getUtcDateString(startDate.subtract(halfRange)),
-    end: getUtcDateString(moment.min(endDate.add(halfRange), now)),
-  };
 }
 
 const CreatedResolvedTime = styled('div')`

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -68,30 +68,6 @@ class AlertListRow extends AsyncComponent<Props, State> {
     projects.find(project => project.slug === slug)
   );
 
-  /**
-   * Retrieve the start/end for showing the graph of the metric
-   * Will show at least 150 and no more than 10,000 data points
-   */
-  getRuleDetailsQuery(): {start: string; end: string} {
-    const {incident} = this.props;
-    const {timeWindow} = incident.alertRule;
-    const timeWindowMillis = timeWindow * 60 * 1000;
-    const minRange = timeWindowMillis * API_INTERVAL_POINTS_MIN;
-    const maxRange = timeWindowMillis * API_INTERVAL_POINTS_LIMIT;
-    const now = moment.utc();
-    const startDate = moment.utc(incident.dateStarted);
-    // make a copy of now since we will modify endDate and use now for comparing
-    const endDate = incident.dateClosed ? moment.utc(incident.dateClosed) : moment(now);
-    const incidentRange = Math.max(endDate.diff(startDate), 3 * timeWindowMillis);
-    const range = Math.min(maxRange, Math.max(minRange, incidentRange));
-    const halfRange = moment.duration(range / 2);
-
-    return {
-      start: getUtcDateString(startDate.subtract(halfRange)),
-      end: getUtcDateString(moment.min(endDate.add(halfRange), now)),
-    };
-  }
-
   renderLoading() {
     return this.renderBody();
   }
@@ -147,7 +123,7 @@ class AlertListRow extends AsyncComponent<Props, State> {
     const alertLink = hasRedesign
       ? {
           pathname: `/organizations/${orgId}/alerts/rules/details/${incident.alertRule?.id}/`,
-          query: this.getRuleDetailsQuery(),
+          query: makeRuleDetailsQuery(incident),
         }
       : {
           pathname: `/organizations/${orgId}/alerts/${incident.identifier}/`,
@@ -199,6 +175,29 @@ function ErrorLoadingStatsIcon() {
       <IconWarning />
     </Tooltip>
   );
+}
+
+/**
+ * Retrieve the start/end for showing the graph of the metric
+ * Will show at least 150 and no more than 10,000 data points
+ */
+export const makeRuleDetailsQuery = (incident: Incident): {start: string; end: string} => {
+  const {timeWindow} = incident.alertRule;
+  const timeWindowMillis = timeWindow * 60 * 1000;
+  const minRange = timeWindowMillis * API_INTERVAL_POINTS_MIN;
+  const maxRange = timeWindowMillis * API_INTERVAL_POINTS_LIMIT;
+  const now = moment.utc();
+  const startDate = moment.utc(incident.dateStarted);
+  // make a copy of now since we will modify endDate and use now for comparing
+  const endDate = incident.dateClosed ? moment.utc(incident.dateClosed) : moment(now);
+  const incidentRange = Math.max(endDate.diff(startDate), 3 * timeWindowMillis);
+  const range = Math.min(maxRange, Math.max(minRange, incidentRange));
+  const halfRange = moment.duration(range / 2);
+
+  return {
+    start: getUtcDateString(startDate.subtract(halfRange)),
+    end: getUtcDateString(moment.min(endDate.add(halfRange), now)),
+  };
 }
 
 const CreatedResolvedTime = styled('div')`


### PR DESCRIPTION
This adds a redirect to the `:orgId/alerts/:alertId` route component, incident page, for the alert details redesign. After fetching the incident user gets redirected to the alert rule details page. This is mainly to fix the issue for the slack alert links, but there are quite a few places where we link to the incident page, so this addresses all of them. It's fine until we release to GA at which point we will need a better solution.

Solves: [WOR-709](https://getsentry.atlassian.net/browse/WOR-709)