### PR TITLE
fix(ui): reduced font-weight of stacktrace

### DIFF
--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -553,7 +553,6 @@ div.traceback > ul {
 
       code {
         font-family: inherit;
-        font-weight: bold;
       }
 
       .informal {


### PR DESCRIPTION
Too much bold text is difficult to read and if everything is bold then nothing is.

## Before
<img width="999" alt="CleanShot 2021-03-09 at 11 25 46@2x" src="https://user-images.githubusercontent.com/1900676/110526104-40922200-80ca-11eb-885e-de51af74e82b.png">

## After
<img width="1006" alt="CleanShot 2021-03-09 at 11 26 01@2x" src="https://user-images.githubusercontent.com/1900676/110526118-4425a900-80ca-11eb-99bf-1b6c81110735.png">
