### PR TITLE
fix(alerts): Alert List Row make a copy of  for end date

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -80,7 +80,8 @@ class AlertListRow extends AsyncComponent<Props, State> {
     const maxRange = timeWindowMillis * API_INTERVAL_POINTS_LIMIT;
     const now = moment.utc();
     const startDate = moment.utc(incident.dateStarted);
-    const endDate = incident.dateClosed ? moment.utc(incident.dateClosed) : now;
+    // make a copy of now since we will modify endDate and use now for comparing
+    const endDate = incident.dateClosed ? moment.utc(incident.dateClosed) : moment(now);
     const incidentRange = Math.max(endDate.diff(startDate), 3 * timeWindowMillis);
     const range = Math.min(maxRange, Math.max(minRange, incidentRange));
     const halfRange = moment.duration(range / 2);


### PR DESCRIPTION
This fixes the endDate on the alert rule details page query, we need to make a copy of the moment object instead.