### PR TITLE
feat(alerts): Make team filter scrollable

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/filter.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/filter.tsx
@@ -90,22 +90,31 @@ class Filter extends React.Component<Props> {
           </StyledDropdownButton>
         )}
       >
-        <Header>
-          <span>{header}</span>
-          <CheckboxFancy
-            isChecked={checkedQuantity > 0}
-            isIndeterminate={checkedQuantity > 0 && checkedQuantity !== filterList.length}
-            onClick={event => {
-              event.stopPropagation();
-              this.toggleAllFilters();
-            }}
-          />
-        </Header>
-        {children({toggleFilter: this.toggleFilter})}
+        <MenuContent>
+          <Header>
+            <span>{header}</span>
+            <CheckboxFancy
+              isChecked={checkedQuantity > 0}
+              isIndeterminate={
+                checkedQuantity > 0 && checkedQuantity !== filterList.length
+              }
+              onClick={event => {
+                event.stopPropagation();
+                this.toggleAllFilters();
+              }}
+            />
+          </Header>
+          {children({toggleFilter: this.toggleFilter})}
+        </MenuContent>
       </DropdownControl>
     );
   }
 }
+
+const MenuContent = styled('div')`
+  max-height: 250px;
+  overflow-y: auto;
+`;
 
 const Header = styled('div')`
   display: grid;


### PR DESCRIPTION
Realized I didn't make this scrollable so a super long list of teams would end up looking real bad in this filter menu. Capped it at 250px to match the span filter menu.

**Before:**
<img width="323" alt="Screen Shot 2021-03-09 at 5 13 42 PM" src="https://user-images.githubusercontent.com/9372512/110545431-14db6000-80fb-11eb-981a-482bfa95d60d.png">

**After:**
<img width="352" alt="Screen Shot 2021-03-09 at 5 13 22 PM" src="https://user-images.githubusercontent.com/9372512/110545439-173dba00-80fb-11eb-8e69-e0b9640d1d52.png">

