### PR TITLE
feat(alerts): Restrict editing/deleting alerts to team members for team alerts

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -161,6 +161,7 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
       params: {orgId},
       location: {query},
       organization,
+      teams,
     } = this.props;
     const {loading, ruleList = [], ruleListPageLinks} = this.state;
 
@@ -174,6 +175,7 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
       // Currently only supported sorting field is 'date_added'
     };
 
+    const userTeams = new Set(teams.filter(({isMember}) => isMember).map(({id}) => id));
     return (
       <StyledLayoutBody>
         <Layout.Main fullWidth>
@@ -224,6 +226,7 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
                           orgId={orgId}
                           onDelete={this.handleDeleteRule}
                           organization={organization}
+                          userTeams={userTeams}
                         />
                       ))
                     }

--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -29,6 +29,8 @@ type Props = {
   orgId: string;
   organization: Organization;
   onDelete: (projectId: string, rule: IssueAlertRule) => void;
+  // Set of team ids that the user belongs to
+  userTeams: Set<string>;
 };
 
 type State = {};
@@ -42,7 +44,15 @@ class RuleListRow extends React.Component<Props, State> {
   );
 
   render() {
-    const {rule, projectsLoaded, projects, organization, orgId, onDelete} = this.props;
+    const {
+      rule,
+      projectsLoaded,
+      projects,
+      organization,
+      orgId,
+      onDelete,
+      userTeams,
+    } = this.props;
     const dateCreated = moment(rule.dateCreated).format('ll');
     const slug = rule.projects[0];
     const editLink = `/organizations/${orgId}/alerts/${
@@ -57,6 +67,8 @@ class RuleListRow extends React.Component<Props, State> {
     const teamActor = ownerId
       ? {type: 'team' as Actor['type'], id: ownerId, name: ''}
       : null;
+
+    const canEdit = ownerId ? userTeams.has(ownerId) : true;
 
     return (
       <ErrorBoundary>
@@ -84,7 +96,7 @@ class RuleListRow extends React.Component<Props, State> {
             {({hasAccess}) => (
               <ButtonBar gap={1}>
                 <Confirm
-                  disabled={!hasAccess}
+                  disabled={!hasAccess || !canEdit}
                   message={tct(
                     "Are you sure you want to delete [name]? You won't be able to view the history of this alert once it's deleted.",
                     {
@@ -105,6 +117,7 @@ class RuleListRow extends React.Component<Props, State> {
                 </Confirm>
                 <Button
                   size="small"
+                  type="button"
                   icon={<IconSettings />}
                   title={t('Edit')}
                   to={editLink}


### PR DESCRIPTION
If an alert is owned by a team that you are a not a member of, then you should not be able to edit or delete it.
**Restricted from deletion on the alert rules page(but may view the alert rule):**
<img width="1182" alt="Screen Shot 2021-03-09 at 5 46 41 PM" src="https://user-images.githubusercontent.com/9372512/110549593-4e629a00-8100-11eb-8fb5-72a2d06286ef.png">

**Restricted from editing on the issue alert form page:** 
<img width="1188" alt="Screen Shot 2021-03-09 at 5 48 29 PM" src="https://user-images.githubusercontent.com/9372512/110549596-4f93c700-8100-11eb-8cb2-e23479e18feb.png">
