### PR TITLE
feat(integrations): Bulk Remove Settings

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -25,7 +25,14 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializerSnuba
 from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.constants import ALLOWED_FUTURE_DELTA
-from sentry.models import Environment, Group, GroupEnvironment, GroupInbox, GroupStatus, Project
+from sentry.models import (
+    Environment,
+    Group,
+    GroupEnvironment,
+    GroupInbox,
+    GroupStatus,
+    Project,
+}
 from sentry.search.snuba.backend import (
     EventsDatasetSnubaSearchBackend,
     assigned_or_suggested_filter,

--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -32,7 +32,7 @@ from sentry.models import (
     GroupInbox,
     GroupStatus,
     Project,
-}
+)
 from sentry.search.snuba.backend import (
     EventsDatasetSnubaSearchBackend,
     assigned_or_suggested_filter,

--- a/src/sentry/deletions/defaults/organization.py
+++ b/src/sentry/deletions/defaults/organization.py
@@ -3,28 +3,28 @@ from ..base import ModelDeletionTask, ModelRelation
 
 class OrganizationDeletionTask(ModelDeletionTask):
     def get_child_relations(self, instance):
+        from sentry.discover.models import DiscoverSavedQuery, KeyTransaction
+        from sentry.incidents.models import AlertRule, Incident
         from sentry.models import (
-            OrganizationMember,
             Commit,
             CommitAuthor,
             CommitFileChange,
+            Dashboard,
+            Distribution,
             Environment,
+            ExternalIssue,
+            OrganizationMember,
+            Project,
+            PromptsActivity,
+            PullRequest,
             Release,
             ReleaseCommit,
             ReleaseEnvironment,
             ReleaseFile,
-            Distribution,
             ReleaseHeadCommit,
             Repository,
             Team,
-            Project,
-            PullRequest,
-            Dashboard,
-            ExternalIssue,
-            PromptsActivity,
         )
-        from sentry.incidents.models import AlertRule, Incident
-        from sentry.discover.models import DiscoverSavedQuery, KeyTransaction
 
         # Team must come first
         relations = [ModelRelation(Team, {"organization_id": instance.id})]

--- a/src/sentry/interfaces/stacktrace.py
+++ b/src/sentry/interfaces/stacktrace.py
@@ -5,8 +5,8 @@ from django.utils.translation import ugettext as _
 
 from sentry.app import env
 from sentry.interfaces.base import Interface
-from sentry.utils.json import prune_empty_keys
 from sentry.models import UserOption
+from sentry.utils.json import prune_empty_keys
 from sentry.web.helpers import render_to_string
 
 

--- a/src/sentry/mail/activity/new_processing_issues.py
+++ b/src/sentry/mail/activity/new_processing_issues.py
@@ -1,4 +1,7 @@
-from sentry.models import GroupSubscriptionReason, EventError
+from sentry.models import (
+    EventError,
+    GroupSubscriptionReason,
+)
 from sentry.utils.http import absolute_uri
 
 from .base import ActivityEmail

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+from typing import Set
 
 from django.utils import dateformat
 from django.utils.encoding import force_text
@@ -16,6 +17,7 @@ from sentry.models import (
     GroupSubscription,
     GroupSubscriptionReason,
     Integration,
+    Project,
     ProjectOption,
     ProjectOwnership,
     Release,
@@ -218,7 +220,8 @@ class MailAdapter:
             )
             return self.get_send_to_all_in_project(project)
 
-    def disabled_users_from_project(self, project):
+    def disabled_users_from_project(self, project: Project) -> Set[User]:
+        """ Get a set of users that have disabled Issue Alert notifications for a given project. """
         alert_settings = project.get_member_alert_settings(self.alert_option_key)
         disabled_users = {user for user, setting in alert_settings.items() if setting == 0}
         return disabled_users

--- a/src/sentry/management/commands/check_notifications.py
+++ b/src/sentry/management/commands/check_notifications.py
@@ -1,7 +1,11 @@
 from django.core.management.base import BaseCommand, CommandError
 
 from sentry.mail import mail_adapter
-from sentry.models import Project, Organization, User
+from sentry.models import (
+    Organization,
+    Project,
+    User,
+)
 from sentry.utils.email import get_email_addresses
 
 

--- a/src/sentry/management/commands/check_notifications.py
+++ b/src/sentry/management/commands/check_notifications.py
@@ -9,7 +9,12 @@ from sentry.models import (
 from sentry.utils.email import get_email_addresses
 
 
-def handle_project(project, stream):
+def handle_project(project: Project, stream) -> None:
+    """
+    For every user that should receive ISSUE_ALERT notifications for a given
+    project, write a map of usernames to email addresses to the given stream
+    one entry per line.
+    """
     stream.write("# Project: %s\n" % project)
 
     user_ids = mail_adapter.get_sendable_users(project)

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.db import IntegrityError, models, transaction
 from django.db.models import Q
 from django.utils import timezone
+from typing import Mapping
 
 from sentry.db.models import (
     BaseManager,
@@ -122,9 +123,12 @@ class GroupSubscriptionManager(BaseManager):
                 if i == 0:
                     raise e
 
-    def get_participants(self, group):
+    @staticmethod
+    def get_participants(group) -> Mapping[any]:
         """
         Identify all users who are participating with a given issue.
+        :param group: Group object
+        :returns Map of User objects to GroupSubscriptionReason
         """
         from sentry.models import User
         from sentry.notifications.legacy_mappings import UserOptionValue

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -124,7 +124,7 @@ class GroupSubscriptionManager(BaseManager):
                     raise e
 
     @staticmethod
-    def get_participants(group) -> Mapping[any]:
+    def get_participants(group) -> Mapping[any, GroupSubscriptionReason]:
         """
         Identify all users who are participating with a given issue.
         :param group: Group object

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -164,10 +164,16 @@ class Organization(Model):
         else:
             super().save(*args, **kwargs)
 
-    def delete(self):
+    def delete(self, **kwargs):
+        from sentry.models import NotificationSetting
+
         if self.is_default:
             raise Exception("You cannot delete the the default organization.")
-        return super().delete()
+
+        # There is no foreign key relationship so we have to manually cascade.
+        NotificationSetting.objects.remove_for_organization(self)
+
+        return super().delete(**kwargs)
 
     @cached_property
     def is_default(self):

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -196,6 +196,7 @@ class Project(Model, PendingDeletionMixin):
 
     @property
     def member_set(self):
+        """ :returns a QuerySet of all Users that belong to this Project """
         from sentry.models import OrganizationMember
 
         return self.organization.member_set.filter(

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -471,5 +471,13 @@ class Project(Model, PendingDeletionMixin):
             return True
         return integration_doc_exists(value)
 
+    def delete(self, **kwargs):
+        from sentry.models import NotificationSetting
+
+        # There is no foreign key relationship so we have to manually cascade.
+        NotificationSetting.objects.remove_for_project(self)
+
+        return super().delete(**kwargs)
+
 
 pre_delete.connect(delete_pending_deletion_option, sender=Project, weak=False)

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -133,9 +133,7 @@ class Team(Model):
             lock = locks.get("slug:team", duration=5)
             with TimedRetryPolicy(10)(lock.acquire):
                 slugify_instance(self, self.name, organization=self.organization)
-            super().save(*args, **kwargs)
-        else:
-            super().save(*args, **kwargs)
+        super().save(*args, **kwargs)
 
     @property
     def member_set(self):

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -137,6 +137,7 @@ class Team(Model):
 
     @property
     def member_set(self):
+        """ :returns a QuerySet of all Users that belong to this Team """
         return self.organization.member_set.filter(
             organizationmemberteam__team=self,
             organizationmemberteam__is_active=True,

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -19,7 +19,7 @@ audit_logger = logging.getLogger("sentry.audit.user")
 
 class UserManager(BaseManager, DjangoUserManager):
     def get_from_teams(self, organization_id, teams):
-        return User.objects.filter(
+        return self.filter(
             sentry_orgmember_set__organization_id=organization_id,
             sentry_orgmember_set__organizationmemberteam__team__in=teams,
             sentry_orgmember_set__organizationmemberteam__is_active=True,
@@ -30,7 +30,7 @@ class UserManager(BaseManager, DjangoUserManager):
         """
         Returns users associated with a project based on their teams.
         """
-        return User.objects.filter(
+        return self.filter(
             sentry_orgmember_set__organization_id=organization_id,
             sentry_orgmember_set__organizationmemberteam__team__projectteam__project__in=projects,
             sentry_orgmember_set__organizationmemberteam__is_active=True,

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -3,7 +3,7 @@ import warnings
 
 from bitfield import BitField
 from django.contrib.auth.signals import user_logged_out
-from django.contrib.auth.models import AbstractBaseUser, UserManager
+from django.contrib.auth.models import AbstractBaseUser, UserManager as DjangoUserManager
 from django.core.urlresolvers import reverse
 from django.dispatch import receiver
 from django.db import IntegrityError, models, transaction
@@ -17,7 +17,7 @@ from sentry.utils.http import absolute_uri
 audit_logger = logging.getLogger("sentry.audit.user")
 
 
-class UserManager(BaseManager, UserManager):
+class UserManager(BaseManager, DjangoUserManager):
     def get_from_teams(self, organization_id, teams):
         return User.objects.filter(
             sentry_orgmember_set__organization_id=organization_id,

--- a/src/sentry/notifications/legacy_mappings.py
+++ b/src/sentry/notifications/legacy_mappings.py
@@ -20,27 +20,27 @@ class UserOptionValue:
 USER_OPTION_SETTINGS = {
     UserOptionsSettingsKey.DEPLOY: {
         "key": "deploy-emails",
-        "default": UserOptionValue.committed_deploys_only,  # '3'
+        "default": "3",
         "type": int,
     },
     UserOptionsSettingsKey.SELF_ACTIVITY: {
         "key": "self_notifications",
-        "default": UserOptionValue.all_conversations,  # '0'
+        "default": "0",
         "type": bool,
     },
     UserOptionsSettingsKey.SELF_ASSIGN: {
         "key": "self_assign_issue",
-        "default": UserOptionValue.all_conversations,  # '0'
+        "default": "0",
         "type": bool,
     },
     UserOptionsSettingsKey.SUBSCRIBE_BY_DEFAULT: {
         "key": "subscribe_by_default",
-        "default": UserOptionValue.participating_only,  # '1'
+        "default": "1",
         "type": bool,
     },
     UserOptionsSettingsKey.WORKFLOW: {
         "key": "workflow:notifications",
-        "default": UserOptionValue.participating_only,  # '1'
+        "default": "1",
         "type": int,
     },
 }

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -226,7 +226,7 @@ class NotificationsManager(BaseManager):
         type: Optional[NotificationSettingTypes] = None,
         scope_type: Optional[NotificationScopeType] = None,
         scope_identifier: Optional[int] = None,
-        targets: Optional[Iterable[any]] = None,
+        targets: Optional[Iterable] = None,
     ) -> QuerySet:
         """ Wrapper for .filter that translates types to actual attributes to column types. """
         filters = {}
@@ -255,19 +255,17 @@ class NotificationsManager(BaseManager):
             kwargs["key__in"] = KEYS_TO_LEGACY_KEYS.values()
         return kwargs
 
-    def remove_for_user(self, user: any, type: Optional[NotificationSettingTypes] = None) -> None:
+    def remove_for_user(self, user, type: Optional[NotificationSettingTypes] = None) -> None:
         """ Bulk delete all Notification Settings for a USER, optionally by type. """
         # We don't need a transaction because this is only used in tests.
         UserOption.objects.filter(**self._get_legacy_filters(type, user=user)).delete()
         self._filter(targets=[user.actor], type=type).delete()
 
-    def remove_for_team(self, team: any, type: Optional[NotificationSettingTypes] = None) -> None:
+    def remove_for_team(self, team, type: Optional[NotificationSettingTypes] = None) -> None:
         """ Bulk delete all Notification Settings for a TEAM, optionally by type. """
         self._filter(targets=[team.actor], type=type).delete()
 
-    def remove_for_project(
-        self, project: any, type: Optional[NotificationSettingTypes] = None
-    ) -> None:
+    def remove_for_project(self, project, type: Optional[NotificationSettingTypes] = None) -> None:
         """ Bulk delete all Notification Settings for a PROJECT, optionally by type. """
         UserOption.objects.filter(**self._get_legacy_filters(type, project=project)).delete()
         self._filter(
@@ -277,7 +275,7 @@ class NotificationsManager(BaseManager):
         ).delete()
 
     def remove_for_organization(
-        self, organization: any, type: Optional[NotificationSettingTypes] = None
+        self, organization, type: Optional[NotificationSettingTypes] = None
     ) -> None:
         """ Bulk delete all Notification Settings for a ENTIRE ORGANIZATION, optionally by type. """
         UserOption.objects.filter(**self._get_legacy_filters(type, project=organization)).delete()

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -64,28 +64,6 @@ class NotificationsManager(BaseManager):
     TODO(mgaeta): Add a caching layer for notification settings
     """
 
-    @staticmethod
-    def notify(
-        provider: ExternalProviders,
-        type: NotificationSettingTypes,
-        user_id=None,
-        team_id=None,
-        data=None,
-    ):
-        """
-        Something noteworthy has happened. Let the targets know about what
-        happened on their own terms. For each target, check their notification
-        preferences and send them a message (or potentially do nothing and
-        return False if this kind of correspondence is muted.)
-        :param provider: ExternalProviders enum
-        :param type: NotificationSettingTypes enum
-        :param user_id: (optional) User object's ID
-        :param team_id: (optional) Team object's ID
-        :param data: The payload depends on the notification type.
-        :return: Boolean. Was a notification sent?
-        """
-        return False
-
     def get_settings(
         self,
         provider: ExternalProviders,

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -28,6 +28,7 @@ def _get_scope(user_id, project=None, organization=None):
     """
     Figure out the scope from parameters and return it as a tuple,
     TODO(mgaeta): Make sure user_id is in the project or organization.
+    TODO(mgaeta): Add Team scope.
     :param user_id: The user's ID
     :param project: (Optional) Project object
     :param organization: (Optional) Organization object
@@ -179,9 +180,10 @@ class NotificationsManager(BaseManager):
             if not created and setting.value != value.value:
                 setting.update(value=value.value)
 
-            UserOption.objects.set_value(
-                user, key=key, value=legacy_value, project=project, organization=organization
-            )
+            if target.type == 1:
+                UserOption.objects.set_value(
+                    user, key=key, value=legacy_value, project=project, organization=organization
+                )
 
     def remove_settings(
         self,
@@ -278,7 +280,9 @@ class NotificationsManager(BaseManager):
         self, organization, type: Optional[NotificationSettingTypes] = None
     ) -> None:
         """ Bulk delete all Notification Settings for a ENTIRE ORGANIZATION, optionally by type. """
-        UserOption.objects.filter(**self._get_legacy_filters(type, project=organization)).delete()
+        UserOption.objects.filter(
+            **self._get_legacy_filters(type, organization=organization)
+        ).delete()
         self._filter(
             scope_type=NotificationScopeType.ORGANIZATION,
             scope_identifier=organization.id,

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -3,6 +3,7 @@ from django.db.models.query import QuerySet
 from typing import Iterable, Optional
 
 from sentry.db.models import BaseManager
+from sentry.models.actor import ACTOR_TYPES
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
     NotificationScopeType,
@@ -180,7 +181,7 @@ class NotificationsManager(BaseManager):
             if not created and setting.value != value.value:
                 setting.update(value=value.value)
 
-            if target.type == 1:
+            if target.type == ACTOR_TYPES["user"]:
                 UserOption.objects.set_value(
                     user, key=key, value=legacy_value, project=project, organization=organization
                 )
@@ -279,7 +280,7 @@ class NotificationsManager(BaseManager):
     def remove_for_organization(
         self, organization, type: Optional[NotificationSettingTypes] = None
     ) -> None:
-        """ Bulk delete all Notification Settings for a ENTIRE ORGANIZATION, optionally by type. """
+        """ Bulk delete all Notification Settings for an ENTIRE ORGANIZATION, optionally by type. """
         UserOption.objects.filter(
             **self._get_legacy_filters(type, organization=organization)
         ).delete()

--- a/src/sentry/notifications/notify.py
+++ b/src/sentry/notifications/notify.py
@@ -1,0 +1,30 @@
+from typing import Optional
+
+from sentry.models.integration import ExternalProviders
+from sentry.models import (
+    Team,
+    User,
+)
+from sentry.notifications.types import NotificationSettingTypes
+
+
+def notify(
+    provider: ExternalProviders,
+    type: NotificationSettingTypes,
+    user: Optional[User] = None,
+    team: Optional[Team] = None,
+    data: Optional[object] = None,
+) -> bool:
+    """
+    Something noteworthy has happened. Let the targets know about what
+    happened on their own terms. For each target, check their notification
+    preferences and send them a message (or potentially do nothing and
+    return False if this kind of correspondence is muted.)
+    :param provider: ExternalProviders enum
+    :param type: NotificationSettingTypes enum
+    :param user: (optional) User object
+    :param team: (optional) Team object
+    :param data: The payload depends on the notification type.
+    :returns Was a notification sent?
+    """
+    return False

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -1,9 +1,8 @@
 import logging
-from urllib.error import HTTPError as UrllibHTTPError
-from urllib.parse import urlparse, urlencode, urlunparse, parse_qs
-
 from django import forms
 from requests.exceptions import SSLError, HTTPError
+from urllib.error import HTTPError as UrllibHTTPError
+from urllib.parse import urlparse, urlencode, urlunparse, parse_qs
 
 from sentry import digests, ratelimits
 from sentry.exceptions import PluginError

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -21,7 +21,14 @@ from django.utils.encoding import force_bytes, force_str, force_text
 
 from sentry import options
 from sentry.logging import LoggingFormat
-from sentry.models import Activity, Group, GroupEmailThread, Project, User, UserOption
+from sentry.models import (
+    Activity,
+    Group,
+    GroupEmailThread,
+    Project,
+    User,
+    UserOption,
+)
 from sentry.utils import metrics
 from sentry.utils.safe import safe_execute
 from sentry.utils.strings import is_valid_dot_atom

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -190,7 +190,7 @@ class ListResolver:
 
     class UnregisteredTypeError(Exception):
         """
-        Error raised when attempting to build a list-id from an unregisted object type.
+        Error raised when attempting to build a list-id from an unregistered object type.
         """
 
     def __init__(self, namespace, type_handlers):

--- a/src/sentry/utils/email.py
+++ b/src/sentry/utils/email.py
@@ -8,6 +8,7 @@ from email.utils import parseaddr
 from functools import partial
 from operator import attrgetter
 from random import randrange
+from typing import Iterable, Mapping
 
 import lxml
 import toronado
@@ -164,7 +165,11 @@ def is_fake_email(email):
     return email.endswith(FAKE_EMAIL_TLD)
 
 
-def get_email_addresses(user_ids, project=None):
+def get_email_addresses(user_ids: Iterable[int], project: Project = None) -> Mapping[int, str]:
+    """
+    Find the best email addresses for a collection of users. If a project is
+    provided, prefer their project-specific notification preferences.
+    """
     pending = set(user_ids)
     results = {}
 

--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -1,5 +1,5 @@
 from sentry.notifications.legacy_mappings import UserOptionValue
-from sentry.models import NotificationSetting, UserOption
+from sentry.models import NotificationSetting
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
     NotificationSettingTypes,
@@ -88,9 +88,11 @@ class UserNotificationDetailsTest(APITestCase):
         assert response.data.get("workflowNotifications") == int(UserOptionValue.participating_only)
 
         assert (
-            UserOption.objects.get(
-                user=user, project=None, organization=None, key="deploy-emails"
-            ).value
+            NotificationSetting.objects.get_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.DEPLOY,
+                user=user,
+            )
             == "2"
         )
 
@@ -110,15 +112,20 @@ class UserNotificationDetailsTest(APITestCase):
 
         assert response.data.get("deployNotifications") == 2
         assert (
-            UserOption.objects.get(
-                user=user, project=None, organization=org, key="deploy-emails"
-            ).value
+            NotificationSetting.objects.get_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.DEPLOY,
+                user=user,
+                organization=org,
+            )
             == "4"
         )
         assert (
-            UserOption.objects.get(
-                user=user, project=None, organization=None, key="deploy-emails"
-            ).value
+            NotificationSetting.objects.get_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.DEPLOY,
+                user=user,
+            )
             == "2"
         )
 

--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -1,4 +1,3 @@
-from sentry.notifications.legacy_mappings import UserOptionValue
 from sentry.models import NotificationSetting
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
@@ -51,7 +50,7 @@ class UserNotificationDetailsTest(APITestCase):
             organization=org,
         )
 
-        # default is UserOptionValue.participating_only
+        # default is NotificationSettingOptionValues.COMMITTED_ONLY
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
             NotificationSettingTypes.WORKFLOW,
@@ -68,7 +67,7 @@ class UserNotificationDetailsTest(APITestCase):
         assert response.data.get("personalActivityNotifications") is False
         assert response.data.get("selfAssignOnResolve") is False
         assert response.data.get("subscribeByDefault") is True
-        assert response.data.get("workflowNotifications") == int(UserOptionValue.participating_only)
+        assert response.data.get("workflowNotifications") == 1
 
     def test_saves_and_returns_values(self):
         user = self.create_user(email="a@example.com")
@@ -85,7 +84,7 @@ class UserNotificationDetailsTest(APITestCase):
         assert response.data.get("personalActivityNotifications") is True
         assert response.data.get("selfAssignOnResolve") is True
         assert response.data.get("subscribeByDefault") is True
-        assert response.data.get("workflowNotifications") == int(UserOptionValue.participating_only)
+        assert response.data.get("workflowNotifications") == 1
 
         assert (
             NotificationSetting.objects.get_settings(

--- a/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
+++ b/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
@@ -1,8 +1,12 @@
-from sentry.models import NotificationSetting, UserEmail, UserOption
+from sentry.models import (
+    NotificationSetting,
+    UserEmail,
+    UserOption,
+)
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
-    NotificationSettingTypes,
     NotificationSettingOptionValues,
+    NotificationSettingTypes,
 )
 from sentry.testutils import APITestCase
 
@@ -75,12 +79,22 @@ class UserNotificationFineTuningTest(APITestCase):
         )
 
         assert (
-            UserOption.objects.get(user=self.user, project=self.project, key="mail:alert").value
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.ISSUE_ALERTS,
+                user=self.user,
+                project=self.project,
+            )
             == 1
         )
 
         assert (
-            UserOption.objects.get(user=self.user, project=self.project2, key="mail:alert").value
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.ISSUE_ALERTS,
+                user=self.user,
+                project=self.project2,
+            )
             == 0
         )
 
@@ -89,12 +103,23 @@ class UserNotificationFineTuningTest(APITestCase):
             "me", "alerts", method="put", status_code=204, **{str(self.project.id): -1}
         )
 
-        assert not UserOption.objects.filter(
-            user=self.user, project=self.project, key="mail:alert"
-        ).exists()
+        assert (
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.ISSUE_ALERTS,
+                user=self.user,
+                project=self.project,
+            )
+            is None
+        )
 
         assert (
-            UserOption.objects.get(user=self.user, project=self.project2, key="mail:alert").value
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.ISSUE_ALERTS,
+                user=self.user,
+                project=self.project2,
+            )
             == 0
         )
 
@@ -108,16 +133,22 @@ class UserNotificationFineTuningTest(APITestCase):
         )
 
         assert (
-            UserOption.objects.get(
-                user=self.user, project=self.project, key="workflow:notifications"
-            ).value
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.WORKFLOW,
+                user=self.user,
+                project=self.project,
+            )
             == "1"
         )
 
         assert (
-            UserOption.objects.get(
-                user=self.user, project=self.project2, key="workflow:notifications"
-            ).value
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.WORKFLOW,
+                user=self.user,
+                project=self.project2,
+            )
             == "2"
         )
 
@@ -126,14 +157,23 @@ class UserNotificationFineTuningTest(APITestCase):
             "me", "workflow", method="put", status_code=204, **{str(self.project.id): -1}
         )
 
-        assert not UserOption.objects.filter(
-            user=self.user, project=self.project, key="workflow:notifications"
+        assert (
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.WORKFLOW,
+                user=self.user,
+                project=self.project,
+            )
+            is None
         )
 
         assert (
-            UserOption.objects.get(
-                user=self.user, project=self.project2, key="workflow:notifications"
-            ).value
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.WORKFLOW,
+                user=self.user,
+                project=self.project2,
+            )
             == "2"
         )
 
@@ -184,7 +224,12 @@ class UserNotificationFineTuningTest(APITestCase):
         )
 
         assert (
-            UserOption.objects.get(user=self.user, organization=self.org, key="deploy-emails").value
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.DEPLOY,
+                user=self.user,
+                organization=self.org,
+            )
             == "4"
         )
 
@@ -192,7 +237,12 @@ class UserNotificationFineTuningTest(APITestCase):
             "me", "deploy", method="put", status_code=204, **{str(self.org.id): 2}
         )
         assert (
-            UserOption.objects.get(user=self.user, organization=self.org, key="deploy-emails").value
+            NotificationSetting.objects.get_settings(
+                provider=ExternalProviders.EMAIL,
+                type=NotificationSettingTypes.DEPLOY,
+                user=self.user,
+                organization=self.org,
+            )
             == "2"
         )
 
@@ -281,6 +331,12 @@ class UserNotificationFineTuningTest(APITestCase):
             "me", "alerts", method="put", status_code=403, **{str(new_project.id): 1}
         )
 
-        assert not UserOption.objects.filter(
-            user=self.user, project=new_project, key="mail:alert"
-        ).exists()
+        assert (
+            NotificationSetting.objects.get_settings(
+                ExternalProviders.EMAIL,
+                NotificationSettingTypes.ISSUE_ALERTS,
+                user=self.user,
+                project=new_project,
+            )
+            is None
+        )

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -14,7 +14,7 @@ from sentry.testutils import TestCase
 
 
 def clear_workflow_options(user):
-    NotificationSetting.objects.remove_settings_for_user(user, NotificationSettingTypes.WORKFLOW)
+    NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
 
 
 class SubscribeTest(TestCase):

--- a/tests/sentry/models/test_notificationsetting.py
+++ b/tests/sentry/models/test_notificationsetting.py
@@ -1,0 +1,51 @@
+from sentry.models import NotificationSetting
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import NotificationSettingTypes, NotificationSettingOptionValues
+from sentry.testutils import TestCase
+
+
+def _get_kwargs(kwargs):
+    return dict(
+        provider=ExternalProviders.EMAIL, type=NotificationSettingTypes.ISSUE_ALERTS, **kwargs
+    )
+
+
+def assert_no_notification_settings(**kwargs):
+    assert NotificationSetting.objects._filter(**kwargs).count() == 0
+
+
+def create_setting(**kwargs):
+    NotificationSetting.objects.update_settings(
+        value=NotificationSettingOptionValues.ALWAYS,
+        **_get_kwargs(kwargs),
+    )
+
+
+class NotificationSettingTest(TestCase):
+    def test_remove_for_user(self):
+        create_setting(user=self.user)
+
+        # Deletion is deferred and tasks aren't run in tests.
+        self.user.delete()
+        self.user.actor.delete()
+
+        assert_no_notification_settings()
+
+    def test_remove_for_team(self):
+        create_setting(team=self.team, project=self.project)
+
+        # Deletion is deferred and tasks aren't run in tests.
+        self.team.delete()
+        self.team.actor.delete()
+
+        assert_no_notification_settings()
+
+    def test_remove_for_project(self):
+        create_setting(user=self.user, project=self.project)
+        self.project.delete()
+        assert_no_notification_settings()
+
+    def test_remove_for_organization(self):
+        create_setting(user=self.user, organization=self.organization)
+        self.organization.delete()
+        assert_no_notification_settings()


### PR DESCRIPTION
My "switch over reads" PR is getting too large so I'm splitting it into parts. This is part one. This PR combines a few things: 
 - functions to remove notification settings
 - linting files and cleaning imports
 - adding and updating tests
 - writing documentation and function typing

In order to migrate settings from `UserOption` to `NotificationSetting`, we dropped the `FlexibleForeignKey`s to `project` and `organization`. That means no more automatic cascading deletes.
The new code manually removes `NotificationSetting` rows in bulk when the objects they rely on are deleted.