### PR TITLE
fix(dashboards): Remove react-lazyload from Dashboards which is conflicting with framer-motion

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import LazyLoad from 'react-lazyload';
 import {closestCenter, DndContext} from '@dnd-kit/core';
 import {arrayMove, rectSortingStrategy, SortableContext} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
@@ -106,15 +105,14 @@ class Dashboard extends React.Component<Props> {
     const dragId = key;
 
     return (
-      <LazyLoad key={key} once height={240} offset={100}>
-        <SortableWidget
-          widget={widget}
-          dragId={dragId}
-          isEditing={isEditing}
-          onDelete={this.handleDeleteWidget(index)}
-          onEdit={this.handleEditWidget(widget, index)}
-        />
-      </LazyLoad>
+      <SortableWidget
+        key={key}
+        widget={widget}
+        dragId={dragId}
+        isEditing={isEditing}
+        onDelete={this.handleDeleteWidget(index)}
+        onEdit={this.handleEditWidget(widget, index)}
+      />
     );
   }
 


### PR DESCRIPTION
react-lazyload is interfering with framer motion's `motion.div` in a way that's not allowing it to reset `transform` css values after the drag and drop is completed. Removing this wrapper component for now.

Below is a visualization of this bug:

https://user-images.githubusercontent.com/139499/110626753-1e061480-816f-11eb-917b-64c4e5676aa0.mp4

