### PR TITLE
fix(dashboards): Fix spacing between sort by field and the widget card

### DIFF
--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueriesForm.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueriesForm.tsx
@@ -162,6 +162,7 @@ class WidgetQueriesForm extends React.Component<Props> {
             flexibleControlStateSize
             stacked
             error={this.getFirstQueryError('orderby')?.orderby}
+            style={{marginBottom: space(1)}}
           >
             <SelectControl
               value={queries[0].orderby}


### PR DESCRIPTION
When in table widget builder mode, need margin spacing between the sort by field and the widget card preview.

**Before:**

<img width="733" alt="Screen Shot 2021-03-10 at 8 15 31 AM" src="https://user-images.githubusercontent.com/139499/110635346-fcaa2600-8178-11eb-8e3c-665d19d00305.png">


**After:**

<img width="765" alt="Screen Shot 2021-03-10 at 8 15 39 AM" src="https://user-images.githubusercontent.com/139499/110635342-fb78f900-8178-11eb-8195-4f02fe65ca7a.png">
