### PR TITLE
ref(document-title): Add org and project name to the doc page title - Part 1

### DIFF
--- a/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/headerItem.tsx
@@ -6,6 +6,7 @@ import omit from 'lodash/omit';
 
 import Tooltip from 'app/components/tooltip';
 import {IconChevron, IconClose, IconInfo, IconLock, IconSettings} from 'app/icons';
+import {t} from 'app/locale';
 import space from 'app/styles/space';
 
 type DefaultProps = {
@@ -95,7 +96,10 @@ class HeaderItem extends React.Component<Props> {
           </ChevronWrapper>
         )}
         {locked && (
-          <Tooltip title={lockedMessage || 'This selection is locked'} position="bottom">
+          <Tooltip
+            title={lockedMessage || t('This selection is locked')}
+            position="bottom"
+          >
             <StyledLock color="gray300" />
           </Tooltip>
         )}

--- a/src/sentry/static/sentry/app/components/sentryDocumentTitle.tsx
+++ b/src/sentry/static/sentry/app/components/sentryDocumentTitle.tsx
@@ -1,19 +1,34 @@
-import React, {FunctionComponent} from 'react';
+import React from 'react';
 import DocumentTitle from 'react-document-title';
 
-type DocumentTitleProps = {
+type Props = {
   // Main page title
   title: string;
-  // Organization or project slug to give title some context
-  objSlug: string;
+  orgSlug?: string;
+  projectSlug?: string;
   children?: React.ReactNode;
 };
 
-const SentryDocumentTitle: FunctionComponent<DocumentTitleProps> = (
-  props: DocumentTitleProps
-) => {
-  const _title = `${props.title} - ${props.objSlug} - Sentry`;
-  return <DocumentTitle title={_title}>{props.children}</DocumentTitle>;
-};
+function SentryDocumentTitle({title, orgSlug, projectSlug, children}: Props) {
+  function getDocTitle() {
+    if (!orgSlug && !projectSlug) {
+      return title;
+    }
+
+    if (orgSlug && projectSlug) {
+      return `${title} - ${orgSlug} - ${projectSlug}`;
+    }
+
+    if (orgSlug) {
+      return `${title} - ${orgSlug}`;
+    }
+
+    return `${title} - ${projectSlug}`;
+  }
+
+  const docTitle = getDocTitle();
+
+  return <DocumentTitle title={`${docTitle} - Sentry`}>{children}</DocumentTitle>;
+}
 
 export default SentryDocumentTitle;

--- a/src/sentry/static/sentry/app/utils/routeTitle.tsx
+++ b/src/sentry/static/sentry/app/utils/routeTitle.tsx
@@ -1,9 +1,12 @@
 function routeTitleGen(
   routeName: string,
   orgSlug: string,
-  withSentry: boolean = true
+  withSentry: boolean = true,
+  projectSlug?: string
 ): string {
-  const tmpl = `${routeName} - ${orgSlug}`;
+  const tmplBase = `${routeName} - ${orgSlug}`;
+  const tmpl = projectSlug ? `${tmplBase} - ${projectSlug}` : tmplBase;
+
   return withSentry ? `${tmpl} - Sentry` : tmpl;
 }
 

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -265,7 +265,7 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
     const status = getQueryStatus(query.status);
 
     return (
-      <SentryDocumentTitle title={t('Alerts')} objSlug={orgId}>
+      <SentryDocumentTitle title={t('Alerts')} orgSlug={orgId}>
         <GlobalSelectionHeader organization={organization} showDateSelector={false}>
           <AlertHeader organization={organization} router={router} activeTab="stream" />
           <Layout.Body>

--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -246,7 +246,7 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
     const {orgId} = params;
 
     return (
-      <SentryDocumentTitle title={t('Alerts')} objSlug={orgId}>
+      <SentryDocumentTitle title={t('Alerts')} orgSlug={orgId}>
         <GlobalSelectionHeader organization={organization} showDateSelector={false}>
           <AlertHeader organization={organization} router={router} activeTab="rules" />
           {this.renderList()}

--- a/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/orgDashboards.tsx
@@ -144,7 +144,7 @@ class OrgDashboards extends AsyncComponent<Props, State> {
     }
 
     return (
-      <SentryDocumentTitle title={t('Dashboards')} objSlug={organization.slug}>
+      <SentryDocumentTitle title={t('Dashboards')} orgSlug={organization.slug}>
         {super.renderComponent()}
       </SentryDocumentTitle>
     );

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -312,7 +312,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     const title = generateTitle({eventView, event, organization});
 
     return (
-      <SentryDocumentTitle title={title} objSlug={organization.slug}>
+      <SentryDocumentTitle title={title} orgSlug={organization.slug}>
         {super.renderComponent()}
       </SentryDocumentTitle>
     );

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/index.tsx
@@ -44,11 +44,17 @@ class EventDetails extends React.Component<Props> {
   render() {
     const {organization, location, params} = this.props;
     const eventView = this.getEventView();
+    const eventSlug = this.getEventSlug();
 
     const documentTitle = this.getDocumentTitle(eventView.name).join(' - ');
+    const projectSlug = eventSlug.split(':')[0];
 
     return (
-      <SentryDocumentTitle title={documentTitle} objSlug={organization.slug}>
+      <SentryDocumentTitle
+        title={documentTitle}
+        orgSlug={organization.slug}
+        projectSlug={projectSlug}
+      >
         <StyledPageContent>
           <LightWeightNoProjectMessage organization={organization}>
             <EventDetailsContent
@@ -56,7 +62,7 @@ class EventDetails extends React.Component<Props> {
               location={location}
               params={params}
               eventView={eventView}
-              eventSlug={this.getEventSlug()}
+              eventSlug={eventSlug}
             />
           </LightWeightNoProjectMessage>
         </StyledPageContent>

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -345,7 +345,7 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
         features={['discover-query']}
         renderDisabled={this.renderNoAccess}
       >
-        <SentryDocumentTitle title={t('Discover')} objSlug={organization.slug}>
+        <SentryDocumentTitle title={t('Discover')} orgSlug={organization.slug}>
           <StyledPageContent>
             <LightWeightNoProjectMessage organization={organization}>
               <PageContent>

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -387,7 +387,7 @@ class Results extends React.Component<Props, State> {
     const title = this.getDocumentTitle();
 
     return (
-      <SentryDocumentTitle title={title} objSlug={organization.slug}>
+      <SentryDocumentTitle title={title} orgSlug={organization.slug}>
         <StyledPageContent>
           <LightWeightNoProjectMessage organization={organization}>
             <ResultsHeader

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -120,9 +120,11 @@ export function generateTitle({
   }
 
   const eventTitle = event ? getTitle(event, organization).title : undefined;
+
   if (eventTitle) {
     titles.push(eventTitle);
   }
+
   titles.reverse();
 
   return titles.join(' - ');

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -331,11 +331,14 @@ class GroupDetails extends React.Component<Props, State> {
     const {title} = getTitle(group, organization);
     const message = getMessage(group);
 
+    const {project} = group;
+    const eventDetails = `${organization.slug} - ${project.slug}`;
+
     if (title && message) {
-      return `${title}: ${message}`;
+      return `${title}: ${message} - ${eventDetails}`;
     }
 
-    return title || message || defaultTitle;
+    return `${title || message || defaultTitle} - ${eventDetails}`;
   }
 
   renderError() {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationListDirectory.tsx
@@ -469,7 +469,7 @@ export class IntegrationListDirectory extends AsyncComponent<
 
     return (
       <React.Fragment>
-        <SentryDocumentTitle title={title} objSlug={orgId} />
+        <SentryDocumentTitle title={title} orgSlug={orgId} />
 
         {!this.props.hideHeader && (
           <SettingsPageHeader

--- a/src/sentry/static/sentry/app/views/performance/compare/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/compare/index.tsx
@@ -121,7 +121,7 @@ class TransactionComparisonPage extends React.PureComponent<Props> {
     return (
       <SentryDocumentTitle
         title={this.getDocumentTitle({baselineEventSlug, regressionEventSlug})}
-        objSlug={organization.slug}
+        orgSlug={organization.slug}
       >
         <React.Fragment>
           <StyledPageContent>

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -306,7 +306,7 @@ class PerformanceLanding extends React.Component<Props, State> {
     const showOnboarding = this.shouldShowOnboarding();
 
     return (
-      <SentryDocumentTitle title={t('Performance')} objSlug={organization.slug}>
+      <SentryDocumentTitle title={t('Performance')} orgSlug={organization.slug}>
         <GlobalSelectionHeader
           defaultSelection={{
             datetime: {

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/index.tsx
@@ -33,7 +33,7 @@ class TraceSummary extends React.Component<Props> {
     this.getTraceSlug();
 
     return (
-      <SentryDocumentTitle title={this.getDocumentTitle()} objSlug={organization.slug}>
+      <SentryDocumentTitle title={this.getDocumentTitle()} orgSlug={organization.slug}>
         <StyledPageContent>
           <LightWeightNoProjectMessage organization={organization}>
             <TraceDetailsContent

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/content.tsx
@@ -251,7 +251,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     return (
       <SentryDocumentTitle
         title={t('Performance - Event Details')}
-        objSlug={organization.slug}
+        orgSlug={organization.slug}
       >
         {super.renderComponent()}
       </SentryDocumentTitle>

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/index.tsx
@@ -29,7 +29,7 @@ class EventDetails extends React.Component<Props> {
     const documentTitle = t('Performance Details');
 
     return (
-      <SentryDocumentTitle title={documentTitle} objSlug={organization.slug}>
+      <SentryDocumentTitle title={documentTitle} orgSlug={organization.slug}>
         <StyledPageContent>
           <LightWeightNoProjectMessage organization={organization}>
             <EventDetailsContent

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -168,13 +168,18 @@ class TransactionSummary extends React.Component<Props, State> {
     const forceProject = shouldForceProject
       ? projects.find(p => parseInt(p.id, 10) === eventView.project[0])
       : undefined;
+
     const projectSlugs = eventView.project
       .map(projectId => projects.find(p => parseInt(p.id, 10) === projectId))
       .filter((p: Project | undefined): p is Project => p !== undefined)
       .map(p => p.slug);
 
     return (
-      <SentryDocumentTitle title={this.getDocumentTitle()} objSlug={organization.slug}>
+      <SentryDocumentTitle
+        title={this.getDocumentTitle()}
+        orgSlug={organization.slug}
+        projectSlug={forceProject?.slug}
+      >
         <GlobalSelectionHeader
           lockedMessageSubject={t('transaction')}
           shouldForceProject={shouldForceProject}

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/index.tsx
@@ -95,7 +95,7 @@ class TransactionVitals extends React.Component<Props> {
       .map(p => p.slug);
 
     return (
-      <SentryDocumentTitle title={this.getDocumentTitle()} objSlug={organization.slug}>
+      <SentryDocumentTitle title={this.getDocumentTitle()} orgSlug={organization.slug}>
         <Feature
           features={['performance-view']}
           organization={organization}

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/index.tsx
@@ -109,7 +109,7 @@ class VitalDetail extends React.Component<Props, State> {
         : (vitalNameQuery as WebVital);
 
     return (
-      <SentryDocumentTitle title={this.getDocumentTitle()} objSlug={organization.slug}>
+      <SentryDocumentTitle title={this.getDocumentTitle()} orgSlug={organization.slug}>
         <GlobalSelectionHeader>
           <StyledPageContent>
             <LightWeightNoProjectMessage organization={organization}>

--- a/src/sentry/static/sentry/app/views/projectInstall/overview.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/overview.tsx
@@ -61,7 +61,7 @@ class ProjectInstallOverview extends AsyncComponent<Props, State> {
 
     return (
       <div>
-        <SentryDocumentTitle title={t('Instrumentation')} objSlug={projectId} />
+        <SentryDocumentTitle title={t('Instrumentation')} projectSlug={projectId} />
         <SettingsPageHeader title={t('Configure your application')} />
         <TextBlock>
           {t(

--- a/src/sentry/static/sentry/app/views/projectInstall/platform.tsx
+++ b/src/sentry/static/sentry/app/views/projectInstall/platform.tsx
@@ -137,7 +137,7 @@ class ProjectInstallPlatform extends React.Component<Props, State> {
             <React.Fragment>
               <SentryDocumentTitle
                 title={`${t('Configure')} ${platform.name}`}
-                objSlug={projectId}
+                projectSlug={projectId}
               />
               <DocumentationWrapper dangerouslySetInnerHTML={{__html: this.state.html}} />
             </React.Fragment>

--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.tsx
@@ -76,7 +76,7 @@ class Dashboard extends React.Component<Props> {
       <React.Fragment>
         <SentryDocumentTitle
           title={t('Projects Dashboard')}
-          objSlug={organization.slug}
+          orgSlug={organization.slug}
         />
         {projects.length > 0 && (
           <ProjectsHeader>

--- a/src/sentry/static/sentry/app/views/releases/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.tsx
@@ -66,11 +66,17 @@ class ReleasesDetail extends AsyncView<Props, State> {
   shouldReload = true;
 
   getTitle() {
-    const {params, organization} = this.props;
+    const {params, organization, selection} = this.props;
+    const {release} = this.state;
+
+    // The release details page will always have only one project selected
+    const project = release?.projects.find(p => p.id === selection.projects[0]);
+
     return routeTitleGen(
       t('Release %s', formatVersion(params.release)),
       organization.slug,
-      false
+      false,
+      project?.slug
     );
   }
 

--- a/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationGeneralSettings/index.tsx
@@ -65,7 +65,7 @@ class OrganizationGeneralSettings extends React.Component<Props> {
 
     return (
       <React.Fragment>
-        <SentryDocumentTitle title={t('General Settings')} objSlug={orgId} />
+        <SentryDocumentTitle title={t('General Settings')} orgSlug={orgId} />
         <div>
           <SettingsPageHeader title={t('Organization Settings')} />
           <PermissionAlert />

--- a/src/sentry/static/sentry/app/views/settings/organizationSecurityAndPrivacy/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationSecurityAndPrivacy/index.tsx
@@ -44,7 +44,7 @@ class OrganizationSecurityAndPrivacyContent extends AsyncView<Props> {
 
     return (
       <React.Fragment>
-        <SentryDocumentTitle title={title} objSlug={organization.slug} />
+        <SentryDocumentTitle title={title} orgSlug={organization.slug} />
         <SettingsPageHeader title={title} />
         <Form
           data-test-id="organization-settings-security-and-privacy"

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/organizationTeams.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/organizationTeams.tsx
@@ -65,7 +65,7 @@ function OrganizationTeams({
 
   return (
     <div data-test-id="team-list">
-      <SentryDocumentTitle title={title} objSlug={organization.slug} />
+      <SentryDocumentTitle title={title} orgSlug={organization.slug} />
       <SettingsPageHeader title={title} action={action} />
       <Panel>
         <PanelHeader>{t('Your Teams')}</PanelHeader>

--- a/src/sentry/static/sentry/app/views/settings/organizationTeams/teamDetails.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationTeams/teamDetails.tsx
@@ -172,7 +172,7 @@ class TeamDetails extends React.Component<Props, State> {
     const routePrefix = recreateRoute('', {routes, params, stepBack: -1}); //`/organizations/${orgId}/teams/${teamId}`;
     return (
       <div>
-        <SentryDocumentTitle title={t('Team Details')} objSlug={params.orgId} />
+        <SentryDocumentTitle title={t('Team Details')} orgSlug={params.orgId} />
         <h3>
           <IdBadge hideAvatar team={team} avatarSize={36} />
         </h3>

--- a/src/sentry/static/sentry/app/views/settings/project/projectEnvironments.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectEnvironments.tsx
@@ -188,7 +188,7 @@ class ProjectEnvironments extends React.Component<Props, State> {
     const baseUrl = recreateRoute('', {routes, params, stepBack: -1});
     return (
       <div>
-        <SentryDocumentTitle title={t('Environments')} objSlug={params.projectId} />
+        <SentryDocumentTitle title={t('Environments')} projectSlug={params.projectId} />
         <SettingsPageHeader
           title={t('Manage Environments')}
           tabs={

--- a/src/sentry/static/sentry/app/views/settings/project/projectFilters/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectFilters/index.tsx
@@ -29,7 +29,7 @@ class ProjectFilters extends React.Component<Props> {
 
     return (
       <React.Fragment>
-        <SentryDocumentTitle title={t('Inbound Filters')} objSlug={projectId} />
+        <SentryDocumentTitle title={t('Inbound Filters')} projectSlug={projectId} />
         <SettingsPageHeader title={t('Inbound Data Filters')} />
         <PermissionAlert />
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectProcessingIssues.tsx
@@ -450,7 +450,7 @@ class ProjectProcessingIssues extends React.Component<Props, State> {
     const title = t('Processing Issues');
     return (
       <div>
-        <SentryDocumentTitle title={title} objSlug={projectId} />
+        <SentryDocumentTitle title={title} projectSlug={projectId} />
         <SettingsPageHeader title={title} />
         <TextBlock>
           {t(

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/create.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/create.tsx
@@ -85,7 +85,7 @@ class Create extends React.Component<Props, State> {
 
     return (
       <React.Fragment>
-        <SentryDocumentTitle title={title} objSlug={projectId} />
+        <SentryDocumentTitle title={title} projectSlug={projectId} />
         <PageContent>
           <BuilderBreadCrumbs
             hasMetricAlerts={hasMetricAlerts}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/edit.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/edit.tsx
@@ -47,9 +47,7 @@ class ProjectAlertsEditor extends React.Component<Props, State> {
       return defaultTitle;
     }
 
-    const title = `${ruleName}`;
-
-    return `${defaultTitle}: ${title}`;
+    return `${defaultTitle}: ${ruleName}`;
   }
 
   render() {
@@ -61,7 +59,7 @@ class ProjectAlertsEditor extends React.Component<Props, State> {
 
     return (
       <React.Fragment>
-        <SentryDocumentTitle title={this.getTitle()} objSlug={projectId} />
+        <SentryDocumentTitle title={this.getTitle()} projectSlug={projectId} />
         <PageContent>
           <BuilderBreadCrumbs
             hasMetricAlerts={hasMetricAlerts}

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
@@ -34,6 +34,7 @@ import {
 } from 'app/types/alerts';
 import {getDisplayName} from 'app/utils/environment';
 import recreateRoute from 'app/utils/recreateRoute';
+import routeTitleGen from 'app/utils/routeTitle';
 import withOrganization from 'app/utils/withOrganization';
 import withTeams from 'app/utils/withTeams';
 import AsyncView from 'app/views/asyncView';
@@ -96,7 +97,6 @@ type Props = {
 } & RouteComponentProps<{orgId: string; projectId: string; ruleId?: string}, {}>;
 
 type State = AsyncView['state'] & {
-  rule?: UnsavedIssueAlertRule | IssueAlertRule | null;
   detailedError: null | {
     [key: string]: string[];
   };
@@ -107,6 +107,7 @@ type State = AsyncView['state'] & {
     conditions: IssueAlertRuleConditionTemplate[];
   } | null;
   uuid: null | string;
+  rule?: UnsavedIssueAlertRule | IssueAlertRule | null;
 };
 
 function isSavedAlertRule(rule: State['rule']): rule is IssueAlertRule {
@@ -114,6 +115,19 @@ function isSavedAlertRule(rule: State['rule']): rule is IssueAlertRule {
 }
 
 class IssueRuleEditor extends AsyncView<Props, State> {
+  getTitle() {
+    const {organization, project} = this.props;
+    const {rule} = this.state;
+    const ruleName = rule?.name;
+
+    return routeTitleGen(
+      ruleName ? t('Alert %s', ruleName) : '',
+      organization.slug,
+      false,
+      project?.slug
+    );
+  }
+
   getDefaultState() {
     return {
       ...super.getDefaultState(),

--- a/src/sentry/static/sentry/app/views/settings/projectDataForwarding.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectDataForwarding.tsx
@@ -59,7 +59,7 @@ class DataForwardingStats extends AsyncComponent<StatProps, StatState> {
 
     return (
       <Panel>
-        <SentryDocumentTitle title={t('Data Forwarding')} objSlug={projectId} />
+        <SentryDocumentTitle title={t('Data Forwarding')} projectSlug={projectId} />
         <PanelHeader>{t('Forwarded events in the last 30 days (by day)')}</PanelHeader>
         <PanelBody withPadding>
           {forwardedAny ? (

--- a/src/sentry/static/sentry/app/views/settings/projectPlugins/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectPlugins/index.tsx
@@ -57,7 +57,7 @@ class ProjectPluginsContainer extends React.Component<Props> {
 
     return (
       <React.Fragment>
-        <SentryDocumentTitle title={title} objSlug={orgId} />
+        <SentryDocumentTitle title={title} orgSlug={orgId} />
         <SettingsPageHeader title={title} />
         <PermissionAlert />
 

--- a/src/sentry/static/sentry/app/views/settings/projectSecurityAndPrivacy/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectSecurityAndPrivacy/index.tsx
@@ -41,7 +41,7 @@ class ProjectSecurityAndPrivacy extends React.Component<ProjectSecurityAndPrivac
 
     return (
       <React.Fragment>
-        <SentryDocumentTitle title={title} objSlug={projectSlug} />
+        <SentryDocumentTitle title={title} projectSlug={projectSlug} />
         <SettingsPageHeader title={title} />
         <Form
           saveOnBlur


### PR DESCRIPTION
Add orgSlug and projectSlug in the document Title if available.

it covers the following pages:

. Issue Details
. Release Details
. New Alert Rule
. Edit Alert
. Transaction Summary details
. Event Details