### PR TITLE
Fix/enforce limit on query length

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -4,7 +4,6 @@ from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
 from sentry import features
-
 from sentry.api.bases import (
     OrganizationEventsV2EndpointBase,
     NoProjects,

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -4,6 +4,7 @@ from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
 
 from sentry import features
+
 from sentry.api.bases import (
     OrganizationEventsV2EndpointBase,
     NoProjects,

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -248,6 +248,11 @@ type Props = {
    * such as the stream view where it is a top level concept
    */
   excludeEnvironment?: boolean;
+  /**
+   * Used to enforce length on the query
+   */
+  maxQueryLength?: number;
+  queryCharsLeft?: number;
 };
 
 type State = {
@@ -918,7 +923,7 @@ class SmartSearchBar extends React.Component<Props, State> {
     tagName: string,
     type: ItemType
   ) => {
-    const {hasRecentSearches, maxSearchItems} = this.props;
+    const {hasRecentSearches, maxSearchItems, queryCharsLeft} = this.props;
 
     this.setState(
       createSearchGroups(
@@ -926,7 +931,8 @@ class SmartSearchBar extends React.Component<Props, State> {
         hasRecentSearches ? recentSearchItems : undefined,
         tagName,
         type,
-        maxSearchItems
+        maxSearchItems,
+        queryCharsLeft
       )
     );
   };
@@ -1084,6 +1090,7 @@ class SmartSearchBar extends React.Component<Props, State> {
       onSidebarToggle,
       inlineLabel,
       sort,
+      maxQueryLength,
     } = this.props;
 
     const pinTooltip = !!pinnedSearch ? t('Unpin this search') : t('Pin this search');
@@ -1111,6 +1118,7 @@ class SmartSearchBar extends React.Component<Props, State> {
           onChange={this.onQueryChange}
           onClick={this.onInputClick}
           disabled={disabled}
+          maxLength={maxQueryLength}
         />
         {(this.state.loading || this.state.searchGroups.length > 0) && (
           <DropdownWrapper visible={this.state.dropdownVisible}>

--- a/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/index.tsx
@@ -252,7 +252,6 @@ type Props = {
    * Used to enforce length on the query
    */
   maxQueryLength?: number;
-  queryCharsLeft?: number;
 };
 
 type State = {
@@ -923,7 +922,11 @@ class SmartSearchBar extends React.Component<Props, State> {
     tagName: string,
     type: ItemType
   ) => {
-    const {hasRecentSearches, maxSearchItems, queryCharsLeft} = this.props;
+    const {hasRecentSearches, maxSearchItems, maxQueryLength} = this.props;
+    const query = this.state.query;
+
+    const queryCharsLeft =
+      maxQueryLength && query ? maxQueryLength - query.length : undefined;
 
     this.setState(
       createSearchGroups(

--- a/src/sentry/static/sentry/app/components/smartSearchBar/utils.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/utils.tsx
@@ -67,7 +67,8 @@ export function createSearchGroups(
   recentSearchItems: SearchItem[] | undefined,
   tagName: string,
   type: ItemType,
-  maxSearchItems: number | undefined
+  maxSearchItems: number | undefined,
+  queryCharsLeft: number | undefined
 ) {
   const activeSearchItem = 0;
 
@@ -76,6 +77,17 @@ export function createSearchGroups(
       (value: SearchItem, index: number) =>
         index < maxSearchItems || value.ignoreMaxSearchItems
     );
+  }
+
+  if (queryCharsLeft || queryCharsLeft === 0) {
+    searchItems = searchItems.filter(
+      (value: SearchItem) => value.value.length <= queryCharsLeft
+    );
+    if (recentSearchItems) {
+      recentSearchItems = recentSearchItems.filter(
+        (value: SearchItem) => value.value.length <= queryCharsLeft
+      );
+    }
   }
 
   const searchGroup: SearchGroup = {

--- a/src/sentry/static/sentry/app/components/smartSearchBar/utils.tsx
+++ b/src/sentry/static/sentry/app/components/smartSearchBar/utils.tsx
@@ -68,7 +68,7 @@ export function createSearchGroups(
   tagName: string,
   type: ItemType,
   maxSearchItems: number | undefined,
-  queryCharsLeft: number | undefined
+  queryCharsLeft?: number
 ) {
   const activeSearchItem = 0;
 

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -218,6 +218,8 @@ export const MAX_AUTOCOMPLETE_RELEASES = 5;
 export const DEFAULT_PER_PAGE = 50;
 export const TEAMS_PER_PAGE = 25;
 
+// Limit the query length so paginated response headers don't
+// go over 4 kb
 export const MAX_QUERY_LENGTH = 400;
 
 // Webpack configures DEPLOY_PREVIEW_CONFIG for deploy preview builds.

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -218,7 +218,7 @@ export const MAX_AUTOCOMPLETE_RELEASES = 5;
 export const DEFAULT_PER_PAGE = 50;
 export const TEAMS_PER_PAGE = 25;
 
-// Limit the query length so paginated response headers don't
+// Limit query length so paginated response headers don't
 // go over HTTP header size limits (4Kb)
 export const MAX_QUERY_LENGTH = 400;
 

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -218,6 +218,8 @@ export const MAX_AUTOCOMPLETE_RELEASES = 5;
 export const DEFAULT_PER_PAGE = 50;
 export const TEAMS_PER_PAGE = 25;
 
+export const MAX_QUERY_LENGTH = 400;
+
 // Webpack configures DEPLOY_PREVIEW_CONFIG for deploy preview builds.
 export const DEPLOY_PREVIEW_CONFIG = (process.env.DEPLOY_PREVIEW_CONFIG as unknown) as
   | undefined

--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -219,7 +219,7 @@ export const DEFAULT_PER_PAGE = 50;
 export const TEAMS_PER_PAGE = 25;
 
 // Limit the query length so paginated response headers don't
-// go over 4 kb
+// go over HTTP header size limits (4Kb)
 export const MAX_QUERY_LENGTH = 400;
 
 // Webpack configures DEPLOY_PREVIEW_CONFIG for deploy preview builds.

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -61,7 +61,6 @@ type State = {
   needConfirmation: boolean;
   confirmedQuery: boolean;
   incompatibleAlertNotice: React.ReactNode;
-  charsLeft: number;
 };
 const SHOW_TAGS_STORAGE_KEY = 'discover2:show-tags';
 
@@ -85,7 +84,6 @@ class Results extends React.Component<Props, State> {
     needConfirmation: false,
     confirmedQuery: false,
     incompatibleAlertNotice: null,
-    charsLeft: MAX_QUERY_LENGTH,
   };
 
   componentDidMount() {
@@ -296,13 +294,6 @@ class Results extends React.Component<Props, State> {
     }
   };
 
-  handleQueryLength = (value: string) => {
-    const charCount = value.length;
-    const maxChar = MAX_QUERY_LENGTH;
-    const charLength = maxChar - charCount;
-    this.setState({charsLeft: charLength});
-  };
-
   getDocumentTitle(): string {
     const {organization} = this.props;
     const {eventView} = this.state;
@@ -389,7 +380,6 @@ class Results extends React.Component<Props, State> {
       showTags,
       incompatibleAlertNotice,
       confirmedQuery,
-      charsLeft,
     } = this.state;
     const fields = eventView.hasAggregateField()
       ? generateAggregateFields(organization, eventView.fields)
@@ -418,9 +408,7 @@ class Results extends React.Component<Props, State> {
                   query={query}
                   fields={fields}
                   onSearch={this.handleSearch}
-                  onChange={this.handleQueryLength}
                   maxQueryLength={MAX_QUERY_LENGTH}
-                  queryCharsLeft={charsLeft}
                 />
                 <ResultsChart
                   router={router}

--- a/src/sentry/static/sentry/app/views/eventsV2/results.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/results.tsx
@@ -19,6 +19,7 @@ import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMess
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
+import {MAX_QUERY_LENGTH} from 'app/constants';
 import {IconFlag} from 'app/icons';
 import {t, tct} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
@@ -60,6 +61,7 @@ type State = {
   needConfirmation: boolean;
   confirmedQuery: boolean;
   incompatibleAlertNotice: React.ReactNode;
+  charsLeft: number;
 };
 const SHOW_TAGS_STORAGE_KEY = 'discover2:show-tags';
 
@@ -83,6 +85,7 @@ class Results extends React.Component<Props, State> {
     needConfirmation: false,
     confirmedQuery: false,
     incompatibleAlertNotice: null,
+    charsLeft: MAX_QUERY_LENGTH,
   };
 
   componentDidMount() {
@@ -293,6 +296,13 @@ class Results extends React.Component<Props, State> {
     }
   };
 
+  handleQueryLength = (value: string) => {
+    const charCount = value.length;
+    const maxChar = MAX_QUERY_LENGTH;
+    const charLength = maxChar - charCount;
+    this.setState({charsLeft: charLength});
+  };
+
   getDocumentTitle(): string {
     const {organization} = this.props;
     const {eventView} = this.state;
@@ -379,6 +389,7 @@ class Results extends React.Component<Props, State> {
       showTags,
       incompatibleAlertNotice,
       confirmedQuery,
+      charsLeft,
     } = this.state;
     const fields = eventView.hasAggregateField()
       ? generateAggregateFields(organization, eventView.fields)
@@ -407,6 +418,9 @@ class Results extends React.Component<Props, State> {
                   query={query}
                   fields={fields}
                   onSearch={this.handleSearch}
+                  onChange={this.handleQueryLength}
+                  maxQueryLength={MAX_QUERY_LENGTH}
+                  queryCharsLeft={charsLeft}
                 />
                 <ResultsChart
                   router={router}

--- a/src/sentry/static/sentry/app/views/performance/landing/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/content.tsx
@@ -6,6 +6,7 @@ import {Location} from 'history';
 import Feature from 'app/components/acl/feature';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import SearchBar from 'app/components/events/searchBar';
+import {MAX_QUERY_LENGTH} from 'app/constants';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
@@ -50,8 +51,12 @@ type Props = {
   handleSearch: (searchQuery: string) => void;
 } & WithRouterProps;
 
-type State = {};
+type State = {
+  charsLeft?: number;
+};
 class LandingContent extends React.Component<Props, State> {
+  state: State = {charsLeft: MAX_QUERY_LENGTH};
+
   componentDidMount() {
     const {organization} = this.props;
     trackAnalyticsEvent({
@@ -69,6 +74,13 @@ class LandingContent extends React.Component<Props, State> {
 
     return stringifyQueryObject(parsed);
   }
+
+  handleQueryLength = (value: string) => {
+    const charCount = value.length;
+    const maxChar = MAX_QUERY_LENGTH;
+    const charLength = maxChar - charCount;
+    this.setState({charsLeft: charLength});
+  };
 
   handleLandingDisplayChange = (field: string) => {
     const {location, organization, eventView, projects} = this.props;
@@ -128,6 +140,9 @@ class LandingContent extends React.Component<Props, State> {
               ['epm()', 'eps()']
             )}
             onSearch={handleSearch}
+            onChange={this.handleQueryLength}
+            maxQueryLength={MAX_QUERY_LENGTH}
+            queryCharsLeft={this.state.charsLeft}
           />
           <ProjectTypeDropdown>
             <DropdownControl
@@ -296,6 +311,7 @@ class LandingContent extends React.Component<Props, State> {
             ['epm()', 'eps()']
           )}
           onSearch={handleSearch}
+          maxQueryLength={MAX_QUERY_LENGTH}
         />
         <Feature features={['performance-vitals-overview']}>
           <FrontendCards

--- a/src/sentry/static/sentry/app/views/performance/landing/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing/content.tsx
@@ -51,12 +51,8 @@ type Props = {
   handleSearch: (searchQuery: string) => void;
 } & WithRouterProps;
 
-type State = {
-  charsLeft?: number;
-};
+type State = {};
 class LandingContent extends React.Component<Props, State> {
-  state: State = {charsLeft: MAX_QUERY_LENGTH};
-
   componentDidMount() {
     const {organization} = this.props;
     trackAnalyticsEvent({
@@ -74,13 +70,6 @@ class LandingContent extends React.Component<Props, State> {
 
     return stringifyQueryObject(parsed);
   }
-
-  handleQueryLength = (value: string) => {
-    const charCount = value.length;
-    const maxChar = MAX_QUERY_LENGTH;
-    const charLength = maxChar - charCount;
-    this.setState({charsLeft: charLength});
-  };
 
   handleLandingDisplayChange = (field: string) => {
     const {location, organization, eventView, projects} = this.props;
@@ -140,9 +129,7 @@ class LandingContent extends React.Component<Props, State> {
               ['epm()', 'eps()']
             )}
             onSearch={handleSearch}
-            onChange={this.handleQueryLength}
             maxQueryLength={MAX_QUERY_LENGTH}
-            queryCharsLeft={this.state.charsLeft}
           />
           <ProjectTypeDropdown>
             <DropdownControl

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -10,6 +10,7 @@ import SearchBar from 'app/components/events/searchBar';
 import GlobalSdkUpdateAlert from 'app/components/globalSdkUpdateAlert';
 import * as Layout from 'app/components/layouts/thirds';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import {MAX_QUERY_LENGTH} from 'app/constants';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
@@ -194,6 +195,7 @@ class SummaryContent extends React.Component<Props, State> {
               query={query}
               fields={eventView.fields}
               onSearch={this.handleSearch}
+              maxQueryLength={MAX_QUERY_LENGTH}
             />
             <TransactionSummaryCharts
               organization={organization}

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -45,6 +45,7 @@ type State = {
 
 class TrendsContent extends React.Component<Props, State> {
   state: State = {};
+
   handleSearch = (searchQuery: string) => {
     const {location} = this.props;
 

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -41,12 +41,10 @@ type Props = {
 
 type State = {
   previousTrendFunction?: TrendFunctionField;
-  charsLeft?: number;
 };
 
 class TrendsContent extends React.Component<Props, State> {
-  state: State = {charsLeft: MAX_QUERY_LENGTH};
-
+  state: State = {};
   handleSearch = (searchQuery: string) => {
     const {location} = this.props;
 
@@ -60,13 +58,6 @@ class TrendsContent extends React.Component<Props, State> {
         query: String(searchQuery).trim() || undefined,
       },
     });
-  };
-
-  handleQueryLength = (value: string) => {
-    const charCount = value.length;
-    const maxChar = MAX_QUERY_LENGTH;
-    const charLength = maxChar - charCount;
-    this.setState({charsLeft: charLength});
   };
 
   handleTrendFunctionChange = (field: string) => {
@@ -166,9 +157,7 @@ class TrendsContent extends React.Component<Props, State> {
             query={query}
             fields={fields}
             onSearch={this.handleSearch}
-            onChange={this.handleQueryLength}
             maxQueryLength={MAX_QUERY_LENGTH}
-            queryCharsLeft={this.state.charsLeft}
           />
           <TrendsDropdown>
             <DropdownControl

--- a/src/sentry/static/sentry/app/views/performance/trends/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/content.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import SearchBar from 'app/components/events/searchBar';
+import {MAX_QUERY_LENGTH} from 'app/constants';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {GlobalSelection, Organization} from 'app/types';
@@ -40,10 +41,11 @@ type Props = {
 
 type State = {
   previousTrendFunction?: TrendFunctionField;
+  charsLeft?: number;
 };
 
 class TrendsContent extends React.Component<Props, State> {
-  state: State = {};
+  state: State = {charsLeft: MAX_QUERY_LENGTH};
 
   handleSearch = (searchQuery: string) => {
     const {location} = this.props;
@@ -58,6 +60,13 @@ class TrendsContent extends React.Component<Props, State> {
         query: String(searchQuery).trim() || undefined,
       },
     });
+  };
+
+  handleQueryLength = (value: string) => {
+    const charCount = value.length;
+    const maxChar = MAX_QUERY_LENGTH;
+    const charLength = maxChar - charCount;
+    this.setState({charsLeft: charLength});
   };
 
   handleTrendFunctionChange = (field: string) => {
@@ -157,6 +166,9 @@ class TrendsContent extends React.Component<Props, State> {
             query={query}
             fields={fields}
             onSearch={this.handleSearch}
+            onChange={this.handleQueryLength}
+            maxQueryLength={MAX_QUERY_LENGTH}
+            queryCharsLeft={this.state.charsLeft}
           />
           <TrendsDropdown>
             <DropdownControl

--- a/tests/js/spec/components/events/searchBar.spec.jsx
+++ b/tests/js/spec/components/events/searchBar.spec.jsx
@@ -169,11 +169,7 @@ describe('Events > SearchBar', function () {
   });
 
   it('filters dropdown to accomodate for num characters left in query', async function () {
-    const onChange = jest.fn();
-    const wrapper = mountWithTheme(
-      <SearchBar {...props} queryCharsLeft={4} onChange={onChange} />,
-      options
-    );
+    const wrapper = mountWithTheme(<SearchBar {...props} maxQueryLength={5} />, options);
     await tick();
     await wrapper.update();
     wrapper.setState;
@@ -187,16 +183,10 @@ describe('Events > SearchBar', function () {
     expect(
       wrapper.find('SearchListItem[data-test-id="search-autocomplete-item"]')
     ).toHaveLength(1);
-
-    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   it('returns zero dropdown suggestions if out of characters', async function () {
-    const onChange = jest.fn();
-    const wrapper = mountWithTheme(
-      <SearchBar {...props} queryCharsLeft={0} onChange={onChange} />,
-      options
-    );
+    const wrapper = mountWithTheme(<SearchBar {...props} maxQueryLength={2} />, options);
     await tick();
     await wrapper.update();
     wrapper.setState;
@@ -210,14 +200,10 @@ describe('Events > SearchBar', function () {
     expect(
       wrapper.find('SearchListItem[data-test-id="search-autocomplete-item"]')
     ).toHaveLength(0);
-
-    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   it('sets maxLength property', async function () {
-    const onChange = jest.fn();
-    props.maxQueryLength = 10;
-    const wrapper = mountWithTheme(<SearchBar {...props} onChange={onChange} />, options);
+    const wrapper = mountWithTheme(<SearchBar {...props} maxQueryLength={10} />, options);
     await tick();
     expect(wrapper.find('input').prop('maxLength')).toBe(10);
   });

--- a/tests/js/spec/components/events/searchBar.spec.jsx
+++ b/tests/js/spec/components/events/searchBar.spec.jsx
@@ -168,6 +168,60 @@ describe('Events > SearchBar', function () {
     expect(onSearch).toHaveBeenCalledTimes(1);
   });
 
+  it('filters dropdown to accomodate for num characters left in query', async function () {
+    const onChange = jest.fn();
+    const wrapper = mountWithTheme(
+      <SearchBar {...props} queryCharsLeft={4} onChange={onChange} />,
+      options
+    );
+    await tick();
+    await wrapper.update();
+    wrapper.setState;
+
+    setQuery(wrapper, 'g');
+    await tick();
+    await wrapper.update();
+
+    expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('g');
+    expect(wrapper.find('SearchDropdown Description')).toEqual({});
+    expect(
+      wrapper.find('SearchListItem[data-test-id="search-autocomplete-item"]')
+    ).toHaveLength(1);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns zero dropdown suggestions if out of characters', async function () {
+    const onChange = jest.fn();
+    const wrapper = mountWithTheme(
+      <SearchBar {...props} queryCharsLeft={0} onChange={onChange} />,
+      options
+    );
+    await tick();
+    await wrapper.update();
+    wrapper.setState;
+
+    setQuery(wrapper, 'g');
+    await tick();
+    await wrapper.update();
+
+    expect(wrapper.find('SearchDropdown').prop('searchSubstring')).toEqual('g');
+    expect(wrapper.find('SearchDropdown Description')).toEqual({});
+    expect(
+      wrapper.find('SearchListItem[data-test-id="search-autocomplete-item"]')
+    ).toHaveLength(0);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('sets maxLength property', async function () {
+    const onChange = jest.fn();
+    props.maxQueryLength = 10;
+    const wrapper = mountWithTheme(<SearchBar {...props} onChange={onChange} />, options);
+    await tick();
+    expect(wrapper.find('input').prop('maxLength')).toBe(10);
+  });
+
   it('does not requery for event field values if query does not change', async function () {
     const wrapper = mountWithTheme(<SearchBar {...props} />, options);
     await tick();


### PR DESCRIPTION
We can pretty easily hit the 4kb on our response header since we use header pagination linking and it includes the query in the querystring params. We are going to limit the length of the querystring params so that the header size doesn't go over 4kb. We are only implementing the limit/validation on the frontend because there are some saved queries in our database that are longer than the imposed limit and we don't want those to break, so this limit is for new queries created going forward. Assuming a query for 20 fields, we have about 600 bytes leeway for the query length to hit the 4kb mark. The current limit is set to 400.