### PR TITLE
fix: Merge custom legend chart options last

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/components/legend.tsx
+++ b/src/sentry/static/sentry/app/components/charts/components/legend.tsx
@@ -17,23 +17,26 @@ export default function Legend(
   const {truncate, theme, ...rest} = props ?? {};
   const formatter = (value: string) => truncationFormatter(value, truncate ?? 0);
 
-  return merge(rest, {
-    show: true,
-    type: 'scroll' as const,
-    padding: 0,
-    formatter,
-    icon: 'circle',
-    itemHeight: 14,
-    itemWidth: 8,
-    itemGap: 12,
-    align: 'left' as const,
-    textStyle: {
-      color: theme.textColor,
-      verticalAlign: 'top',
-      fontSize: 11,
-      fontFamily: theme.text.family,
-      lineHeight: 14,
+  return merge(
+    {
+      show: true,
+      type: 'scroll' as const,
+      padding: 0,
+      formatter,
+      icon: 'circle',
+      itemHeight: 14,
+      itemWidth: 8,
+      itemGap: 12,
+      align: 'left' as const,
+      textStyle: {
+        color: theme.textColor,
+        verticalAlign: 'top',
+        fontSize: 11,
+        fontFamily: theme.text.family,
+        lineHeight: 14,
+      },
+      inactiveColor: theme.inactive,
     },
-    inactiveColor: theme.inactive,
-  });
+    rest
+  );
 }

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
@@ -259,7 +259,6 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
     const legend = {
       left: 0,
       top: 0,
-      type: 'plain',
       selected: getSeriesSelection(location),
       formatter: (seriesName: string) => {
         const arg = getAggregateArg(seriesName);


### PR DESCRIPTION
I noticed that custom legend chart options wasn't respected in Dashboards.

Looks like a regression from https://github.com/getsentry/sentry/pull/24019

