### PR TITLE
fix(inbox): Adjust saved search size for ultrawide screens

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
@@ -90,20 +90,20 @@ const TabWrapper = styled('li')<{isActive?: boolean}>`
   }
   & > span > .dropdown-menu {
     margin-top: ${space(1)};
-    min-width: 30vw;
-    max-width: 35vw;
+    min-width: 20vw;
+    max-width: 25vw;
     z-index: ${p => p.theme.zIndex.globalSelectionHeader};
+  }
+
+  @media (max-width: ${p => p.theme.breakpoints[4]}) {
+    & > span > .dropdown-menu {
+      min-width: 35vw;
+    }
   }
 
   @media (max-width: ${p => p.theme.breakpoints[3]}) {
     & > span > .dropdown-menu {
       max-width: 50vw;
-    }
-  }
-
-  @media (max-width: ${p => p.theme.breakpoints[2]}) {
-    & > span > .dropdown-menu {
-      max-width: 55vw;
     }
   }
 

--- a/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/savedSearchTab.tsx
@@ -97,7 +97,7 @@ const TabWrapper = styled('li')<{isActive?: boolean}>`
 
   @media (max-width: ${p => p.theme.breakpoints[4]}) {
     & > span > .dropdown-menu {
-      min-width: 35vw;
+      max-width: 35vw;
     }
   }
 


### PR DESCRIPTION
on monitors over 3k pixels wide the saved search menu would sneak under the sidebar.