### PR TITLE
feat(trace-view): Render trace tree

### DIFF
--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/types.ts
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/types.ts
@@ -25,7 +25,11 @@ export type TraceLite = EventLite[];
  * The `events-trace` endpoint returns a tree structure that gives
  * the parent-child relationships between events.
  */
-export type TraceFull = EventLite & {
+export type TraceFull = Omit<EventLite, 'generation'> & {
+  /**
+   * In the full trace, generation is always defined.
+   */
+  generation: number;
   children: TraceFull[];
 };
 

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
@@ -15,6 +15,7 @@ import {decodeScalar} from 'app/utils/queryString';
 import Breadcrumb from 'app/views/performance/breadcrumb';
 import {MetaData} from 'app/views/performance/transactionDetails/styles';
 
+import TraceView from './traceView';
 import {getTraceInfo} from './utils';
 
 type Props = {
@@ -37,7 +38,7 @@ class TraceDetailsContent extends React.Component<Props> {
     return <LoadingError message={t('The trace you are looking for was not found.')} />;
   }
 
-  renderTrace(trace) {
+  renderTraceHeader(trace) {
     const traceInfo = getTraceInfo(trace);
 
     return (
@@ -57,6 +58,14 @@ class TraceDetailsContent extends React.Component<Props> {
           )}
         />
       </TraceDetailHeader>
+    );
+  }
+
+  renderTraceView(trace) {
+    return (
+      <TraceDetailBody>
+        <TraceView trace={trace} />
+      </TraceDetailBody>
     );
   }
 
@@ -86,7 +95,12 @@ class TraceDetailsContent extends React.Component<Props> {
           } else if (error !== null || trace === null) {
             return this.renderTraceNotFound();
           } else {
-            return this.renderTrace(trace);
+            return (
+              <React.Fragment>
+                {this.renderTraceHeader(trace)}
+                {this.renderTraceView(trace)}
+              </React.Fragment>
+            );
           }
         }}
       </TraceFullQuery>
@@ -130,6 +144,10 @@ const TraceDetailHeader = styled('div')`
     grid-row-gap: 0;
     margin-bottom: 0;
   }
+`;
+
+const TraceDetailBody = styled('div')`
+  margin-top: ${space(3)};
 `;
 
 export default TraceDetailsContent;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
@@ -1,0 +1,33 @@
+import styled from '@emotion/styled';
+
+import {IconChevron} from 'app/icons';
+import space from 'app/styles/space';
+
+export {
+  ConnectorBar,
+  DividerLine,
+  DividerLineGhostContainer,
+  SpanBarTitle as TransactionBarTitle,
+  SpanBarTitleContainer as TransactionBarTitleContainer,
+  SpanRowCell as TransactionRowCell,
+  SpanRowCellContainer as TransactionRowCellContainer,
+  SpanTreeConnector as TransactionTreeConnector,
+  SpanTreeToggler as TransactionTreeToggle,
+  SpanTreeTogglerContainer as TransactionTreeToggleContainer,
+} from 'app/components/events/interfaces/spans/spanBar';
+export {
+  SPAN_ROW_HEIGHT as TRANSACTION_ROW_HEIGHT,
+  SPAN_ROW_PADDING as TRANSACTION_ROW_PADDING,
+  SpanRow as TransactionRow,
+} from 'app/components/events/interfaces/spans/styles';
+
+export const TraceViewContainer = styled('div')`
+  overflow-x: hidden;
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+`;
+
+export const StyledIconChevron = styled(IconChevron)`
+  width: 7px;
+  margin-left: ${space(0.25)};
+`;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/traceView.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/traceView.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import * as DividerHandlerManager from 'app/components/events/interfaces/spans/dividerHandlerManager';
+import {Panel} from 'app/components/panels';
+import {TraceFull} from 'app/utils/performance/quickTrace/types';
+
+import {TraceViewContainer} from './styles';
+import TransactionGroup from './transactionGroup';
+
+type Props = {
+  trace: TraceFull;
+};
+
+class TraceView extends React.Component<Props> {
+  traceViewRef = React.createRef<HTMLDivElement>();
+
+  renderTrace() {
+    const {trace} = this.props;
+    return <TransactionGroup transaction={trace} />;
+  }
+
+  render() {
+    return (
+      <Panel>
+        <DividerHandlerManager.Provider interactiveLayerRef={this.traceViewRef}>
+          <TraceViewContainer ref={this.traceViewRef}>
+            {this.renderTrace()}
+          </TraceViewContainer>
+        </DividerHandlerManager.Provider>
+      </Panel>
+    );
+  }
+}
+
+export default TraceView;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
@@ -1,0 +1,270 @@
+import React from 'react';
+
+import Count from 'app/components/count';
+import * as DividerHandlerManager from 'app/components/events/interfaces/spans/dividerHandlerManager';
+import {TraceFull} from 'app/utils/performance/quickTrace/types';
+
+import {
+  ConnectorBar,
+  DividerLine,
+  DividerLineGhostContainer,
+  StyledIconChevron,
+  TRANSACTION_ROW_HEIGHT,
+  TransactionBarTitle,
+  TransactionBarTitleContainer,
+  TransactionRow,
+  TransactionRowCell,
+  TransactionRowCellContainer,
+  TransactionTreeConnector,
+  TransactionTreeToggle,
+  TransactionTreeToggleContainer,
+} from './styles';
+import {toPercent} from './utils';
+
+const TOGGLE_BUTTON_MARGIN_RIGHT = 16;
+const TOGGLE_BUTTON_MAX_WIDTH = 30;
+export const TOGGLE_BORDER_BOX = TOGGLE_BUTTON_MAX_WIDTH + TOGGLE_BUTTON_MARGIN_RIGHT;
+const MARGIN_LEFT = 0;
+
+type Props = {
+  transaction: TraceFull;
+  isLast: boolean;
+  continuingDepths: Array<number>;
+  isExpanded: boolean;
+  toggleExpandedState: () => void;
+};
+
+function getOffset(generation) {
+  return generation * (TOGGLE_BORDER_BOX / 2) + MARGIN_LEFT;
+}
+
+class TransactionBar extends React.Component<Props> {
+  getCurrentOffset() {
+    const {transaction} = this.props;
+    const {generation} = transaction;
+
+    return getOffset(generation);
+  }
+
+  renderConnector(hasToggle: boolean) {
+    const {continuingDepths, isExpanded, isLast, transaction} = this.props;
+    const {event_id, generation} = transaction;
+
+    if (generation === 0) {
+      if (hasToggle) {
+        return (
+          <ConnectorBar
+            style={{right: '16px', height: '10px', bottom: '-5px', top: 'auto'}}
+            orphanBranch={false}
+          />
+        );
+      }
+      return null;
+    }
+
+    const connectorBars: Array<React.ReactNode> = continuingDepths.map(depth => {
+      if (generation - depth <= 1) {
+        // If the difference is less than or equal to 1, then it means that the continued
+        // bar is from its direct parent. In this case, do not render a connector bar
+        // because the tree connector below will suffice.
+        return null;
+      }
+
+      const left = -1 * getOffset(generation - depth - 1) - 1;
+
+      return (
+        <ConnectorBar style={{left}} key={`${event_id}-${depth}`} orphanBranch={false} />
+      );
+    });
+
+    if (hasToggle && isExpanded) {
+      connectorBars.push(
+        <ConnectorBar
+          style={{
+            right: '16px',
+            height: '10px',
+            bottom: isLast ? `-${TRANSACTION_ROW_HEIGHT / 2}px` : '0',
+            top: 'auto',
+          }}
+          key={`${event_id}-last`}
+          orphanBranch={false}
+        />
+      );
+    }
+
+    return (
+      <TransactionTreeConnector
+        isLast={isLast}
+        hasToggler={hasToggle}
+        orphanBranch={false} // TODO(tonyx): what does an orphan mean here?
+      >
+        {connectorBars}
+      </TransactionTreeConnector>
+    );
+  }
+
+  renderToggle() {
+    const {isExpanded, transaction, toggleExpandedState} = this.props;
+    const {children, generation} = transaction;
+    const left = this.getCurrentOffset();
+
+    if (children.length <= 0) {
+      return (
+        <TransactionTreeToggleContainer style={{left: `${left}px`}}>
+          {this.renderConnector(false)}
+        </TransactionTreeToggleContainer>
+      );
+    }
+
+    const isRoot = generation === 0;
+
+    return (
+      <TransactionTreeToggleContainer style={{left: `${left}px`}} hasToggler>
+        {this.renderConnector(true)}
+        <TransactionTreeToggle
+          disabled={isRoot}
+          isExpanded={isExpanded}
+          onClick={event => {
+            event.stopPropagation();
+
+            if (isRoot) {
+              return;
+            }
+
+            toggleExpandedState();
+          }}
+        >
+          <Count value={children.length} />
+          {isRoot && (
+            <div>
+              <StyledIconChevron direction={isExpanded ? 'up' : 'down'} />
+            </div>
+          )}
+        </TransactionTreeToggle>
+      </TransactionTreeToggleContainer>
+    );
+  }
+
+  renderTitle() {
+    const {transaction} = this.props;
+    const left = this.getCurrentOffset();
+
+    return (
+      <TransactionBarTitleContainer>
+        {this.renderToggle()}
+        <TransactionBarTitle
+          style={{
+            left: `${left}px`,
+            width: '100%',
+          }}
+        >
+          <span>{transaction.transaction}</span>
+        </TransactionBarTitle>
+      </TransactionBarTitleContainer>
+    );
+  }
+
+  renderDivider(
+    dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
+  ) {
+    const {addDividerLineRef} = dividerHandlerChildrenProps;
+
+    return (
+      <DividerLine
+        ref={addDividerLineRef()}
+        style={{
+          position: 'relative',
+        }}
+        onMouseEnter={() => {
+          dividerHandlerChildrenProps.setHover(true);
+        }}
+        onMouseLeave={() => {
+          dividerHandlerChildrenProps.setHover(false);
+        }}
+        onMouseOver={() => {
+          dividerHandlerChildrenProps.setHover(true);
+        }}
+        onMouseDown={dividerHandlerChildrenProps.onDragStart}
+        onClick={event => {
+          // we prevent the propagation of the clicks from this component to prevent
+          // the span detail from being opened.
+          event.stopPropagation();
+        }}
+      />
+    );
+  }
+
+  renderGhostDivider(
+    dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps
+  ) {
+    const {dividerPosition, addGhostDividerLineRef} = dividerHandlerChildrenProps;
+
+    return (
+      <DividerLineGhostContainer
+        style={{
+          width: `calc(${toPercent(dividerPosition)} + 0.5px)`,
+          display: 'none',
+        }}
+      >
+        <DividerLine
+          ref={addGhostDividerLineRef()}
+          style={{
+            right: 0,
+          }}
+          className="hovering"
+          onClick={event => {
+            // the ghost divider line should not be interactive.
+            // we prevent the propagation of the clicks from this component to prevent
+            // the span detail from being opened.
+            event.stopPropagation();
+          }}
+        />
+      </DividerLineGhostContainer>
+    );
+  }
+
+  renderHeader({
+    dividerHandlerChildrenProps,
+  }: {
+    dividerHandlerChildrenProps: DividerHandlerManager.DividerHandlerManagerChildrenProps;
+  }) {
+    const {dividerPosition} = dividerHandlerChildrenProps;
+
+    return (
+      <TransactionRowCellContainer>
+        <TransactionRowCell
+          style={{
+            width: `calc(${toPercent(dividerPosition)} - 0.5px)`,
+            paddingTop: 0,
+          }}
+        >
+          {this.renderTitle()}
+        </TransactionRowCell>
+        {this.renderDivider(dividerHandlerChildrenProps)}
+        <TransactionRowCell
+          style={{
+            width: `calc(${toPercent(1 - dividerPosition)} - 0.5px)`,
+            paddingTop: 0,
+          }}
+        >
+          <React.Fragment />
+        </TransactionRowCell>
+        {this.renderGhostDivider(dividerHandlerChildrenProps)}
+      </TransactionRowCellContainer>
+    );
+  }
+
+  render() {
+    return (
+      <TransactionRow visible>
+        <DividerHandlerManager.Consumer>
+          {dividerHandlerChildrenProps =>
+            this.renderHeader({dividerHandlerChildrenProps})
+          }
+        </DividerHandlerManager.Consumer>
+      </TransactionRow>
+    );
+  }
+}
+
+export default TransactionBar;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
@@ -135,7 +135,7 @@ class TransactionBar extends React.Component<Props> {
           }}
         >
           <Count value={children.length} />
-          {isRoot && (
+          {!isRoot && (
             <div>
               <StyledIconChevron direction={isExpanded ? 'up' : 'down'} />
             </div>

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/transactionGroup.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/transactionGroup.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import {TraceFull} from 'app/utils/performance/quickTrace/types';
+
+import TransactionBar from './transactionBar';
+
+type DefaultProps = {
+  isLast: boolean;
+  continuingDepths: Array<number>;
+};
+
+type Props = DefaultProps & {
+  transaction: TraceFull;
+};
+
+type State = {
+  isExpanded: boolean;
+};
+
+class TransactionGroup extends React.Component<Props, State> {
+  static defaultProps: DefaultProps = {
+    isLast: true,
+    continuingDepths: [],
+  };
+
+  state = {
+    isExpanded: true,
+  };
+
+  toggleExpandedState = () => {
+    this.setState(({isExpanded}) => ({isExpanded: !isExpanded}));
+  };
+
+  render() {
+    const {continuingDepths, isLast, transaction} = this.props;
+    const {isExpanded} = this.state;
+    const {children} = transaction;
+
+    return (
+      <React.Fragment>
+        <TransactionBar
+          transaction={transaction}
+          continuingDepths={continuingDepths}
+          isLast={isLast}
+          isExpanded={isExpanded}
+          toggleExpandedState={this.toggleExpandedState}
+        />
+        {isExpanded &&
+          children.map((child, index) => {
+            const isLastChild = index === children.length - 1;
+            const hasChildren = child.children.length > 0;
+
+            const newContinuingDepths =
+              !isLastChild && hasChildren
+                ? [...continuingDepths, transaction.generation]
+                : [...continuingDepths];
+
+            return (
+              <TransactionGroup
+                key={child.event_id}
+                transaction={child}
+                isLast={isLastChild}
+                continuingDepths={newContinuingDepths}
+              />
+            );
+          })}
+      </React.Fragment>
+    );
+  }
+}
+
+export default TransactionGroup;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/utils.ts
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/utils.ts
@@ -50,3 +50,5 @@ export function getTraceInfo(trace) {
     relevantTransactions: 0,
   });
 }
+
+export {toPercent} from 'app/components/events/interfaces/spans/utils';


### PR DESCRIPTION
This change adds in the panel where the full trace view will be rendered and
begins the rendering of the full trace tree on the left. This includes support
for the resizable divider as well.

https://user-images.githubusercontent.com/10239353/110712006-7a4c5100-81ce-11eb-8aaf-4170c84354e1.mp4

