### PR TITLE
fix(perf): Fix specialized landing conditions applying to trends

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -12,6 +12,8 @@ import {
   getVitalDetailTablePoorStatusFunction,
   vitalNameFromLocation,
 } from './vitalDetail/utils';
+import {FilterViews} from './landing';
+import {getCurrentPerformanceView} from './utils';
 
 export const DEFAULT_STATS_PERIOD = '24h';
 
@@ -463,7 +465,11 @@ function generateFrontendOtherPerformanceEventView(
 
 export function generatePerformanceEventView(organization, location, projects) {
   const eventView = generateGenericPerformanceEventView(organization, location);
-  if (!organization.features.includes('performance-landing-v2')) {
+  const currentPerformanceView = getCurrentPerformanceView(location);
+  if (
+    !organization.features.includes('performance-landing-v2') ||
+    currentPerformanceView === FilterViews.TRENDS
+  ) {
     return eventView;
   }
 

--- a/src/sentry/static/sentry/app/views/performance/landing.tsx
+++ b/src/sentry/static/sentry/app/views/performance/landing.tsx
@@ -41,7 +41,7 @@ import {
 } from './trends/utils';
 import {DEFAULT_STATS_PERIOD, generatePerformanceEventView} from './data';
 import Onboarding from './onboarding';
-import {addRoutePerformanceContext} from './utils';
+import {addRoutePerformanceContext, getCurrentPerformanceView} from './utils';
 
 export enum FilterViews {
   ALL_TRANSACTIONS = 'ALL_TRANSACTIONS',
@@ -164,11 +164,7 @@ class PerformanceLanding extends React.Component<Props, State> {
 
   getCurrentView(): string {
     const {location} = this.props;
-    const currentView = location.query.view as FilterViews;
-    if (Object.values(FilterViews).includes(currentView)) {
-      return currentView;
-    }
-    return FilterViews.ALL_TRANSACTIONS;
+    return getCurrentPerformanceView(location);
   }
 
   handleViewChange(viewKey: FilterViews) {

--- a/src/sentry/static/sentry/app/views/performance/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/utils.tsx
@@ -5,12 +5,22 @@ import {statsPeriodToDays} from 'app/utils/dates';
 import getCurrentSentryReactTransaction from 'app/utils/getCurrentSentryReactTransaction';
 import {decodeScalar} from 'app/utils/queryString';
 
+import {FilterViews} from './landing';
+
 export function getPerformanceLandingUrl(organization: OrganizationSummary): string {
   return `/organizations/${organization.slug}/performance/`;
 }
 
 export function getTransactionSearchQuery(location: Location, query: string = '') {
   return decodeScalar(location.query.query, query).trim();
+}
+
+export function getCurrentPerformanceView(location: Location): string {
+  const currentView = location.query.view as FilterViews;
+  if (Object.values(FilterViews).includes(currentView)) {
+    return currentView;
+  }
+  return FilterViews.ALL_TRANSACTIONS;
 }
 
 export function getTransactionDetailsUrl(


### PR DESCRIPTION
### Summary
This should fix the hidden conditions on trends when navigating from pageload or other landing v2 pages. They were previously being applied since the derived state event view was only looking at whether the display was set.

Refs VIS-680