### PR TITLE
fix(ui): Add option to stop alert details redesign redirect

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {browserHistory, RouteComponentProps} from 'react-router';
+import {Location} from 'history';
 
 import {markIncidentAsSeen} from 'app/actionCreators/incident';
 import {addErrorMessage} from 'app/actionCreators/indicator';
@@ -25,6 +26,7 @@ import DetailsHeader from './header';
 
 type Props = {
   api: Client;
+  location: Location;
   organization: Organization;
 } & RouteComponentProps<{alertId: string; orgId: string}, {}>;
 
@@ -58,6 +60,7 @@ class IncidentDetails extends React.Component<Props, State> {
 
     const {
       api,
+      location: {query},
       params: {orgId, alertId},
     } = this.props;
 
@@ -66,7 +69,8 @@ class IncidentDetails extends React.Component<Props, State> {
         const hasRedesign =
           incident.alertRule &&
           this.props.organization.features.includes('alert-details-redesign');
-        if (hasRedesign) {
+        // only stop redirect if param is explicitly set to false
+        if (hasRedesign && query.redirect !== 'false') {
           browserHistory.replace({
             pathname: `/organizations/${orgId}/alerts/rules/details/${incident.alertRule?.id}/`,
             query: makeRuleDetailsQuery(incident),

--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -70,7 +70,8 @@ class IncidentDetails extends React.Component<Props, State> {
           incident.alertRule &&
           this.props.organization.features.includes('alert-details-redesign');
         // only stop redirect if param is explicitly set to false
-        const stopRedirect = location && location.query && location.query.redirect === 'false';
+        const stopRedirect =
+          location && location.query && location.query.redirect === 'false';
         if (hasRedesign && !stopRedirect) {
           browserHistory.replace({
             pathname: `/organizations/${orgId}/alerts/rules/details/${incident.alertRule?.id}/`,

--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -60,7 +60,7 @@ class IncidentDetails extends React.Component<Props, State> {
 
     const {
       api,
-      location: {query},
+      location,
       params: {orgId, alertId},
     } = this.props;
 
@@ -70,7 +70,8 @@ class IncidentDetails extends React.Component<Props, State> {
           incident.alertRule &&
           this.props.organization.features.includes('alert-details-redesign');
         // only stop redirect if param is explicitly set to false
-        if (hasRedesign && query.redirect !== 'false') {
+        const stopRedirect = location && location.query && location.query.redirect === 'false';
+        if (hasRedesign && !stopRedirect) {
           browserHistory.replace({
             pathname: `/organizations/${orgId}/alerts/rules/details/${incident.alertRule?.id}/`,
             query: makeRuleDetailsQuery(incident),


### PR DESCRIPTION
This adds an option to stop redirect for the incident page to still see the old page in production.