### PR TITLE
fix(auth): return 404 on auth when user is not member of organization

### DIFF
--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -387,7 +387,7 @@ def handle_unknown_identity(request, organization, auth_provider, provider, stat
     # to consider if 'email_verified' can be trusted or not
     if acting_user and identity.get("email_verified"):
         # we only allow this flow to happen if the existing user has
-        # membership, otherwise we short circuit because it might be
+        # membership, otherwise we return 404 because it might be
         # an attempt to hijack membership of another organization
         has_membership = OrganizationMember.objects.filter(
             user=acting_user, organization=organization
@@ -407,8 +407,10 @@ def handle_unknown_identity(request, organization, auth_provider, provider, stat
                 # assume they've confirmed they want to attach the identity
                 op = "confirm"
         else:
-            # force them to create a new account
-            acting_user = None
+            # return with 404 page not found
+            return respond(
+                "sentry/404.html", organization=organization, status=404, request=request
+            )
     # without a usable password they cant login, so let's clear the acting_user
     elif acting_user and not acting_user.has_usable_password():
         acting_user = None

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -558,9 +558,8 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         # updated to be something else)
         resp = self.client.post(path, {"email": "adfadsf@example.com", "email_verified": "1"})
 
-        self.assertTemplateUsed(resp, "sentry/auth-confirm-link.html")
-        assert resp.status_code == 200
-        assert resp.context["existing_user"] == user
+        self.assertTemplateUsed(resp, "sentry/404.html")
+        assert resp.status_code == 404
 
     def test_swapped_identities(self):
         """


### PR DESCRIPTION
This PR aims to prevent creation of duplicate user accounts when a user attempts to authenticate via SSO into an organization he/she is not part of.

### Background and current behavior:
- We have a multi-organization, on-premise Sentry installation (version 21.2.0).
- In the current state, on the login flow, when a user attempts to authenticate via SSO into an organization he/she is not part of, Sentry forces a new user account creation for that user.
- Each time a user tries to login to an organization he is not part of, this causes creation of additional user accounts (with generated UUIDs) connected to the user's email address.
- This results in duplicated user accounts which needs to be manually handled by Sentry on-premise administrators.

### Suggested / Desired behavior:
- When a user tries to login to an organization he is not part of, we return a 404 response, similar to how GitHub/GitLab works with repositories.

cc @max-wittig @bufferoverflow @fh1ch @dlouzan