### PR TITLE
feat(discover): add timestamp.to_{hour,day}

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1398,6 +1398,12 @@ FIELD_ALIASES = {
     for field in [
         PseudoField("project", "project.id"),
         PseudoField("issue", "issue.id"),
+        PseudoField(
+            "timestamp.to_hour", "timestamp.to_hour", expression=["toStartOfHour", ["timestamp"]]
+        ),
+        PseudoField(
+            "timestamp.to_day", "timestamp.to_day", expression=["toStartOfDay", ["timestamp"]]
+        ),
         PseudoField(ERROR_UNHANDLED_ALIAS, ERROR_UNHANDLED_ALIAS, expression=["notHandled", []]),
         PseudoField(
             USER_DISPLAY_ALIAS,

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -397,6 +397,8 @@ enum FieldKey {
   STACK_PACKAGE = 'stack.package',
   STACK_STACK_LEVEL = 'stack.stack_level',
   TIMESTAMP = 'timestamp',
+  TIMESTAMP_TO_HOUR = 'timestamp.to_hour',
+  TIMESTAMP_TO_DAY = 'timestamp.to_day',
   TITLE = 'title',
   TRACE = 'trace',
   TRACE_PARENT_SPAN = 'trace.parent_span',
@@ -424,6 +426,8 @@ export const FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
   // to the rollup period (usually 3600 seconds) and presented as
   // seconds since epoch.
   // Customers should almost always use `timestamp`.
+  [FieldKey.TIMESTAMP_TO_HOUR]: 'date',
+  [FieldKey.TIMESTAMP_TO_DAY]: 'date',
 
   [FieldKey.CULPRIT]: 'string',
   [FieldKey.LOCATION]: 'string',

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1130,6 +1130,8 @@ JSON_TYPE_MAP = {
     "Float32": "number",
     "Float64": "number",
     "DateTime": "date",
+    # toStartOf{Hour,Day} return this, used for timestamp.to_{hour,day}
+    "DateTime('UTC')": "date",
 }
 
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2319,6 +2319,8 @@ class ResolveFieldListTest(unittest.TestCase):
             "issue",
             "user.display",
             "message",
+            "timestamp.to_hour",
+            "timestamp.to_day",
         ]
         result = resolve_field_list(fields, eventstore.Filter())
         assert result["selected_columns"] == [
@@ -2326,6 +2328,8 @@ class ResolveFieldListTest(unittest.TestCase):
             "issue.id",
             ["coalesce", ["user.email", "user.username", "user.ip"], "user.display"],
             "message",
+            ["toStartOfHour", ["timestamp"], "timestamp.to_hour"],
+            ["toStartOfDay", ["timestamp"], "timestamp.to_day"],
             "project.id",
             [
                 "transform",
@@ -2342,6 +2346,8 @@ class ResolveFieldListTest(unittest.TestCase):
             "issue.id",
             ["coalesce", ["user.email", "user.username", "user.ip"], "user.display"],
             "message",
+            "timestamp.to_hour",
+            "timestamp.to_day",
             "project.id",
         ]
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -17,6 +17,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         self.environment = self.create_environment(self.project, name="prod")
         self.release = self.create_release(self.project, version="first-release")
 
+        self.event_time = before_now(minutes=1)
         self.event = self.store_event(
             data={
                 "message": "oh no",
@@ -24,7 +25,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
                 "environment": "prod",
                 "platform": "python",
                 "user": {"id": "99", "email": "bruce@example.com", "username": "brucew"},
-                "timestamp": iso_format(before_now(minutes=1)),
+                "timestamp": iso_format(self.event_time),
             },
             project_id=self.project.id,
         )
@@ -132,26 +133,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
     def test_field_aliasing_in_selected_columns(self):
         result = discover.query(
-            selected_columns=["project.id", "user", "release"],
-            query="",
-            params={"project_id": [self.project.id]},
-        )
-        data = result["data"]
-        assert len(data) == 1
-        assert data[0]["project.id"] == self.project.id
-        assert data[0]["user"] == "id:99"
-        assert data[0]["release"] == "first-release"
-
-        assert len(result["meta"]) == 3
-        assert result["meta"] == {
-            "project.id": "integer",
-            "user": "string",
-            "release": "string",
-        }
-
-    def test_field_alias_with_component(self):
-        result = discover.query(
-            selected_columns=["project.id", "user", "user.email"],
+            selected_columns=["project.id", "user", "user.email", "release", "timestamp.to_hour"],
             query="",
             params={"project_id": [self.project.id]},
         )
@@ -160,12 +142,18 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         assert data[0]["project.id"] == self.project.id
         assert data[0]["user"] == "id:99"
         assert data[0]["user.email"] == "bruce@example.com"
+        assert data[0]["release"] == "first-release"
 
-        assert len(result["meta"]) == 3
+        event_hour = self.event_time.replace(minute=0, second=0)
+        assert data[0]["timestamp.to_hour"] == iso_format(event_hour) + "+00:00"
+
+        assert len(result["meta"]) == 5
         assert result["meta"] == {
             "project.id": "integer",
             "user": "string",
             "user.email": "string",
+            "release": "string",
+            "timestamp.to_hour": "date",
         }
 
     def test_field_aliasing_in_aggregate_functions_and_groupby(self):


### PR DESCRIPTION
The "time" field was removed in #24136 due to being confusing and poorly
defined. However, the concept of grouping events by hour is still valuable.
Therefore, add a new field to support this concept. Grouping by day is also
reasonable and can easily be added at the same time, so do it here. Grouping by
month is also plausible, but Sentry currently only stores data up to 90 days,
so showing only three months (two of which are truncated) is likely of limited
value.

This is exposed to the user as a field instead of a function because for
backend implementation simplicity, it does not aggregate results (i.e. there
will likely be semi-identical output rows). Users will generally want to add an
aggregation function, such as count(), when using these fields.

timestamp.to_day is currently displayed as a full date and time, always at
00:00 UTC. This is not great, but it's not that easy to fix it cleanly and I
think this is likely to be infrequently used anyways.

<img width="1486" alt="Screen Shot 2021-03-11 at 5 38 03 PM" src="https://user-images.githubusercontent.com/78757344/110864832-ac25ec00-8290-11eb-91ff-989d0714ace0.png">
