### PR TITLE
ref(document-title): Add org and project slug to the doc page title - Part 2

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -6,6 +6,7 @@ import {markIncidentAsSeen} from 'app/actionCreators/incident';
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {fetchOrgMembers} from 'app/actionCreators/members';
 import {Client} from 'app/api';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
@@ -82,6 +83,7 @@ class IncidentDetails extends React.Component<Props, State> {
         this.setState({incident});
         markIncidentAsSeen(api, orgId, incident);
       });
+
       const statsPromise = fetchIncidentStats(api, orgId, alertId).then(stats =>
         this.setState({stats})
       );
@@ -157,10 +159,18 @@ class IncidentDetails extends React.Component<Props, State> {
 
   render() {
     const {incident, stats, hasError} = this.state;
-    const {params} = this.props;
+    const {params, organization} = this.props;
+    const {alertId} = params;
+
+    const project = incident?.projects?.[0];
 
     return (
       <React.Fragment>
+        <SentryDocumentTitle
+          title={t('Alert %s', alertId)}
+          orgSlug={organization.slug}
+          projectSlug={project}
+        />
         <DetailsHeader
           hasIncidentDetailsError={hasError}
           params={params}

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -305,14 +305,30 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     return super.renderError(error, true, true);
   }
 
+  getEventSlug = (): string => {
+    const {eventSlug} = this.props.params;
+
+    if (typeof eventSlug === 'string') {
+      return eventSlug.trim();
+    }
+
+    return '';
+  };
+
   renderComponent() {
     const {eventView, organization} = this.props;
     const {event} = this.state;
+    const eventSlug = this.getEventSlug();
+    const projectSlug = eventSlug.split(':')[0];
 
     const title = generateTitle({eventView, event, organization});
 
     return (
-      <SentryDocumentTitle title={title} orgSlug={organization.slug}>
+      <SentryDocumentTitle
+        title={title}
+        orgSlug={organization.slug}
+        projectSlug={projectSlug}
+      >
         {super.renderComponent()}
       </SentryDocumentTitle>
     );

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/index.tsx
@@ -27,16 +27,22 @@ class EventDetails extends React.Component<Props> {
   render() {
     const {organization, location, params} = this.props;
     const documentTitle = t('Performance Details');
+    const eventSlug = this.getEventSlug();
+    const projectSlug = eventSlug.split(':')[0];
 
     return (
-      <SentryDocumentTitle title={documentTitle} orgSlug={organization.slug}>
+      <SentryDocumentTitle
+        title={documentTitle}
+        orgSlug={organization.slug}
+        projectSlug={projectSlug}
+      >
         <StyledPageContent>
           <LightWeightNoProjectMessage organization={organization}>
             <EventDetailsContent
               organization={organization}
               location={location}
               params={params}
-              eventSlug={this.getEventSlug()}
+              eventSlug={eventSlug}
             />
           </LightWeightNoProjectMessage>
         </StyledPageContent>

--- a/src/sentry/static/sentry/app/views/performance/transactionVitals/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionVitals/index.tsx
@@ -95,7 +95,11 @@ class TransactionVitals extends React.Component<Props> {
       .map(p => p.slug);
 
     return (
-      <SentryDocumentTitle title={this.getDocumentTitle()} orgSlug={organization.slug}>
+      <SentryDocumentTitle
+        title={this.getDocumentTitle()}
+        orgSlug={organization.slug}
+        projectSlug={forceProject?.slug}
+      >
         <Feature
           features={['performance-view']}
           organization={organization}

--- a/src/sentry/static/sentry/app/views/releases/detail/commits.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/commits.tsx
@@ -32,13 +32,14 @@ type State = {
 
 class Commits extends AsyncView<Props, State> {
   getTitle() {
-    const {params} = this.props;
+    const {params, projectSlug} = this.props;
     const {orgId} = params;
 
     return routeTitleGen(
       t('Commits - Release %s', formatVersion(params.release)),
       orgId,
-      false
+      false,
+      projectSlug
     );
   }
 

--- a/src/sentry/static/sentry/app/views/releases/detail/filesChanged.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/filesChanged.tsx
@@ -8,7 +8,7 @@ import {Body, Main} from 'app/components/layouts/thirds';
 import Pagination from 'app/components/pagination';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t, tn} from 'app/locale';
-import {CommitFile, Organization, Repository} from 'app/types';
+import {CommitFile, Organization, Project, Repository} from 'app/types';
 import {formatVersion} from 'app/utils/formatters';
 import routeTitleGen from 'app/utils/routeTitle';
 import AsyncView from 'app/views/asyncView';
@@ -22,6 +22,7 @@ type Props = RouteComponentProps<{orgId: string; release: string}, {}> & {
   location: Location;
   router: InjectedRouter;
   orgSlug: Organization['slug'];
+  projectSlug: Project['slug'];
   release: string;
   releaseRepos: Repository[];
   activeReleaseRepo?: Repository;
@@ -33,13 +34,14 @@ type State = {
 
 class FilesChanged extends AsyncView<Props, State> {
   getTitle() {
-    const {params} = this.props;
+    const {params, projectSlug} = this.props;
     const {orgId} = params;
 
     return routeTitleGen(
       t('Files Changed - Release %s', formatVersion(params.release)),
       orgId,
-      false
+      false,
+      projectSlug
     );
   }
 

--- a/src/sentry/static/sentry/app/views/releases/detail/withReleaseRepos.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/withReleaseRepos.tsx
@@ -212,10 +212,10 @@ const withReleaseRepos = <P extends DependentProps>(
               <WrappedComponent
                 {...(this.props as P)} // this is just to satisfy the compiler
                 orgSlug={orgSlug}
+                projectSlug={this.context.project.slug}
                 release={release}
                 router={router}
                 location={location}
-                projectSlug={this.context.project.slug}
                 releaseRepos={releaseRepos}
                 activeReleaseRepo={activeReleaseRepo}
               />

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/edit.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/edit.tsx
@@ -51,15 +51,18 @@ class ProjectAlertsEditor extends React.Component<Props, State> {
   }
 
   render() {
-    const {hasMetricAlerts, location, params, organization, project} = this.props;
-    const {projectId} = params;
+    const {hasMetricAlerts, location, organization, project} = this.props;
+
     const alertType = location.pathname.includes('/alerts/metric-rules/')
       ? 'metric'
       : 'issue';
 
     return (
-      <React.Fragment>
-        <SentryDocumentTitle title={this.getTitle()} projectSlug={projectId} />
+      <SentryDocumentTitle
+        title={this.getTitle()}
+        orgSlug={organization.slug}
+        projectSlug={project.slug}
+      >
         <PageContent>
           <BuilderBreadCrumbs
             hasMetricAlerts={hasMetricAlerts}
@@ -84,7 +87,7 @@ class ProjectAlertsEditor extends React.Component<Props, State> {
             />
           )}
         </PageContent>
-      </React.Fragment>
+      </SentryDocumentTitle>
     );
   }
 }


### PR DESCRIPTION
Add org and project slug to the doc page title , if available.

Part 1 was done in this PR https://github.com/getsentry/sentry/pull/24366

this PR covers:

. Web Vitals
. Discover - Event Details
. Release Details - Commits
. Release Details - Files Changed
. Alert Details