### PR TITLE
fix(demo): fix reference to previous migration

### DIFF
--- a/src/sentry/demo/migrations/0001_add_demo_org_user_models.py
+++ b/src/sentry/demo/migrations/0001_add_demo_org_user_models.py
@@ -33,7 +33,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ("sentry", "0172_remove_demo_flag"),
+        ("sentry", "0173_remove_demo_flag"),
     ]
 
     operations = [


### PR DESCRIPTION
This PR fixes a bug that the migration for demo users and orgs references a non-existent migration. This happened when I fixed a merge conflict from a new migration but didn't update every reference. Related PR: https://github.com/getsentry/sentry/pull/24376