### PR TITLE
feat(demo): make DEMO_MODE off by default

### DIFF
--- a/src/sentry/demo/settings.py
+++ b/src/sentry/demo/settings.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from sentry.conf.server import *
 
+
 """
 To get this file to load, add the follwing to your sentry.conf.py file:
 
@@ -19,3 +20,4 @@ CELERYBEAT_SCHEDULE["demo_delete_users_orgs"] = {
     "options": {"expires": 3600, "queue": "cleanup"},
 }
 INSTALLED_APPS = INSTALLED_APPS + ("sentry.demo.apps.Config",)
+ROOT_URLCONF = "sentry.demo.urls"

--- a/src/sentry/demo/urls.py
+++ b/src/sentry/demo/urls.py
@@ -1,0 +1,9 @@
+from django.conf.urls import url
+
+from sentry.conf.urls import urlpatterns as conf_urlpatterns
+from sentry.web.frontend.demo_start import DemoStartView
+
+urlpatterns = [
+    url(r"^demo/start/$", DemoStartView.as_view(), name="sentry-demo-start"),
+]
+urlpatterns += conf_urlpatterns

--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -167,9 +167,6 @@ def pytest_configure(config):
     # this isn't the real secret
     settings.SENTRY_OPTIONS["github.integration-hook-secret"] = "b3002c3e321d4b7880360d397db2ccfd"
 
-    # enable demo mode so we boot up tests with the demo routes
-    settings.DEMO_MODE = True
-
     # django mail uses socket.getfqdn which doesn't play nice if our
     # networking isn't stable
     patcher = mock.patch("socket.getfqdn", return_value="localhost")

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -67,13 +67,6 @@ if settings.DEBUG:
         )
     ]
 
-if settings.DEMO_MODE:
-    from sentry.web.frontend.demo_start import DemoStartView
-
-    urlpatterns += [
-        url(r"^demo/start/$", DemoStartView.as_view(), name="sentry-demo-start"),
-    ]
-
 urlpatterns += [
     url(
         r"^api/(?P<project_id>[\w_-]+)/crossdomain\.xml$",

--- a/tests/sentry/api/endpoints/test_prompts_activity.py
+++ b/tests/sentry/api/endpoints/test_prompts_activity.py
@@ -1,5 +1,4 @@
 from django.core.urlresolvers import reverse
-from django.test.utils import override_settings
 
 from sentry.testutils import APITestCase
 
@@ -21,7 +20,6 @@ class PromptsActivityTest(APITestCase):
         )
         self.path = reverse("sentry-api-0-prompts-activity")
 
-    @override_settings(DEMO_MODE=False)
     def test_invalid_feature(self):
         # Invalid feature prompt name
         resp = self.client.put(
@@ -36,7 +34,6 @@ class PromptsActivityTest(APITestCase):
 
         assert resp.status_code == 400
 
-    @override_settings(DEMO_MODE=False)
     def test_invalid_project(self):
         # Invalid project id
         data = {
@@ -59,7 +56,6 @@ class PromptsActivityTest(APITestCase):
         )
         assert resp.status_code == 400
 
-    @override_settings(DEMO_MODE=False)
     def test_dismiss(self):
         data = {
             "organization_id": self.org.id,
@@ -85,7 +81,6 @@ class PromptsActivityTest(APITestCase):
         assert "data" in resp.data
         assert "dismissed_ts" in resp.data["data"]
 
-    @override_settings(DEMO_MODE=False)
     def test_snooze(self):
         data = {
             "organization_id": self.org.id,

--- a/tests/sentry/demo/test_demo_org_manager.py
+++ b/tests/sentry/demo/test_demo_org_manager.py
@@ -25,7 +25,7 @@ org_name = "Org Name"
 
 
 class DemoOrgManagerTeest(TestCase):
-    @override_settings(DEMO_ORG_OWNER_EMAIL=org_owner_email)
+    @override_settings(DEMO_MODE=True, DEMO_ORG_OWNER_EMAIL=org_owner_email)
     @mock.patch("sentry.demo.demo_org_manager.generate_random_name", return_value=org_name)
     def test_create_demo_org(self, mock_generate_name):
         owner = User.objects.create(email=org_owner_email)
@@ -44,7 +44,7 @@ class DemoOrgManagerTeest(TestCase):
         assert len(Project.objects.filter(organization=org)) == 2
         assert not ProjectKey.objects.filter(project__organization=org).exists()
 
-    @override_settings(DEMO_ORG_OWNER_EMAIL=org_owner_email)
+    @override_settings(DEMO_MODE=True, DEMO_ORG_OWNER_EMAIL=org_owner_email)
     @mock.patch("sentry.demo.demo_org_manager.generate_random_name", return_value=org_name)
     def test_no_owner(self, mock_generate_name):
         with pytest.raises(User.DoesNotExist):
@@ -53,6 +53,7 @@ class DemoOrgManagerTeest(TestCase):
         # verify we are using atomic transactions
         assert not Organization.objects.filter(name=org_name).exists()
 
+    @override_settings(DEMO_MODE=True)
     @mock.patch("django.utils.timezone.now")
     @mock.patch("sentry.demo.tasks.build_up_org_buffer.apply_async")
     def test_assign_demo_org(self, mock_build_up_org_buffer, mock_now):
@@ -80,6 +81,7 @@ class DemoOrgManagerTeest(TestCase):
 
         mock_build_up_org_buffer.assert_called_once_with()
 
+    @override_settings(DEMO_MODE=True)
     def test_no_org_ready(self):
         with pytest.raises(NoDemoOrgReady):
             assign_demo_org()

--- a/tests/sentry/demo/test_demo_org_manager.py
+++ b/tests/sentry/demo/test_demo_org_manager.py
@@ -24,8 +24,8 @@ org_owner_email = "james@example.com"
 org_name = "Org Name"
 
 
+@override_settings(DEMO_MODE=True, DEMO_ORG_OWNER_EMAIL=org_owner_email)
 class DemoOrgManagerTeest(TestCase):
-    @override_settings(DEMO_MODE=True, DEMO_ORG_OWNER_EMAIL=org_owner_email)
     @mock.patch("sentry.demo.demo_org_manager.generate_random_name", return_value=org_name)
     def test_create_demo_org(self, mock_generate_name):
         owner = User.objects.create(email=org_owner_email)
@@ -44,7 +44,6 @@ class DemoOrgManagerTeest(TestCase):
         assert len(Project.objects.filter(organization=org)) == 2
         assert not ProjectKey.objects.filter(project__organization=org).exists()
 
-    @override_settings(DEMO_MODE=True, DEMO_ORG_OWNER_EMAIL=org_owner_email)
     @mock.patch("sentry.demo.demo_org_manager.generate_random_name", return_value=org_name)
     def test_no_owner(self, mock_generate_name):
         with pytest.raises(User.DoesNotExist):
@@ -53,7 +52,6 @@ class DemoOrgManagerTeest(TestCase):
         # verify we are using atomic transactions
         assert not Organization.objects.filter(name=org_name).exists()
 
-    @override_settings(DEMO_MODE=True)
     @mock.patch("django.utils.timezone.now")
     @mock.patch("sentry.demo.tasks.build_up_org_buffer.apply_async")
     def test_assign_demo_org(self, mock_build_up_org_buffer, mock_now):
@@ -81,7 +79,6 @@ class DemoOrgManagerTeest(TestCase):
 
         mock_build_up_org_buffer.assert_called_once_with()
 
-    @override_settings(DEMO_MODE=True)
     def test_no_org_ready(self):
         with pytest.raises(NoDemoOrgReady):
             assign_demo_org()

--- a/tests/sentry/demo/test_tasks.py
+++ b/tests/sentry/demo/test_tasks.py
@@ -21,6 +21,7 @@ class DemoTaskBaseClass(TestCase):
 
 
 class DeleteUsersOrgTest(DemoTaskBaseClass):
+    @override_settings(DEMO_MODE=True)
     def test_delete_success(self):
         date_assigned = before_now(hours=30)
 
@@ -46,6 +47,7 @@ class DeleteUsersOrgTest(DemoTaskBaseClass):
         assert Organization.objects.filter(id=org.id).exists()
         assert User.objects.filter(id=user.id).exists()
 
+    @override_settings(DEMO_MODE=True)
     def test_recently_created(self):
         date_assigned = before_now(hours=20)
 
@@ -58,6 +60,7 @@ class DeleteUsersOrgTest(DemoTaskBaseClass):
         assert Organization.objects.filter(id=org.id).exists()
         assert User.objects.filter(id=user.id).exists()
 
+    @override_settings(DEMO_MODE=True)
     def test_pending_org(self):
         date_assigned = before_now(hours=30)
         org = self.create_demo_org(date_assigned=date_assigned, status=DemoOrgStatus.PENDING)
@@ -69,6 +72,7 @@ class DeleteUsersOrgTest(DemoTaskBaseClass):
 
 
 class BuildUpOrgBufferTest(DemoTaskBaseClass):
+    @override_settings(DEMO_MODE=True)
     @mock.patch("sentry.demo.tasks.create_demo_org")
     def test_add_one_fill_buffer(self, mock_create_demo_org):
         for i in range(ORG_BUFFER_SIZE - 1):
@@ -87,6 +91,7 @@ class BuildUpOrgBufferTest(DemoTaskBaseClass):
         )
         mock_create_demo_org.assert_called_once_with()
 
+    @override_settings(DEMO_MODE=True)
     @mock.patch("sentry.demo.tasks.create_demo_org")
     def test_add_two_fill_buffer(self, mock_create_demo_org):
         for i in range(ORG_BUFFER_SIZE - 2):
@@ -102,6 +107,7 @@ class BuildUpOrgBufferTest(DemoTaskBaseClass):
         )
         assert mock_create_demo_org.call_count == 2
 
+    @override_settings(DEMO_MODE=True)
     @mock.patch("sentry.demo.tasks.create_demo_org")
     def test_buffer_full(self, mock_create_demo_org):
         for i in range(ORG_BUFFER_SIZE):

--- a/tests/sentry/demo/test_tasks.py
+++ b/tests/sentry/demo/test_tasks.py
@@ -8,6 +8,7 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.compat import mock
 
 
+@override_settings(DEMO_MODE=True)
 class DemoTaskBaseClass(TestCase):
     def create_demo_org(self, org_args=None, **kwargs):
         org = self.create_organization(**(org_args or {}))
@@ -21,7 +22,6 @@ class DemoTaskBaseClass(TestCase):
 
 
 class DeleteUsersOrgTest(DemoTaskBaseClass):
-    @override_settings(DEMO_MODE=True)
     def test_delete_success(self):
         date_assigned = before_now(hours=30)
 
@@ -47,7 +47,6 @@ class DeleteUsersOrgTest(DemoTaskBaseClass):
         assert Organization.objects.filter(id=org.id).exists()
         assert User.objects.filter(id=user.id).exists()
 
-    @override_settings(DEMO_MODE=True)
     def test_recently_created(self):
         date_assigned = before_now(hours=20)
 
@@ -60,7 +59,6 @@ class DeleteUsersOrgTest(DemoTaskBaseClass):
         assert Organization.objects.filter(id=org.id).exists()
         assert User.objects.filter(id=user.id).exists()
 
-    @override_settings(DEMO_MODE=True)
     def test_pending_org(self):
         date_assigned = before_now(hours=30)
         org = self.create_demo_org(date_assigned=date_assigned, status=DemoOrgStatus.PENDING)
@@ -72,7 +70,6 @@ class DeleteUsersOrgTest(DemoTaskBaseClass):
 
 
 class BuildUpOrgBufferTest(DemoTaskBaseClass):
-    @override_settings(DEMO_MODE=True)
     @mock.patch("sentry.demo.tasks.create_demo_org")
     def test_add_one_fill_buffer(self, mock_create_demo_org):
         for i in range(ORG_BUFFER_SIZE - 1):
@@ -91,7 +88,6 @@ class BuildUpOrgBufferTest(DemoTaskBaseClass):
         )
         mock_create_demo_org.assert_called_once_with()
 
-    @override_settings(DEMO_MODE=True)
     @mock.patch("sentry.demo.tasks.create_demo_org")
     def test_add_two_fill_buffer(self, mock_create_demo_org):
         for i in range(ORG_BUFFER_SIZE - 2):
@@ -107,7 +103,6 @@ class BuildUpOrgBufferTest(DemoTaskBaseClass):
         )
         assert mock_create_demo_org.call_count == 2
 
-    @override_settings(DEMO_MODE=True)
     @mock.patch("sentry.demo.tasks.create_demo_org")
     def test_buffer_full(self, mock_create_demo_org):
         for i in range(ORG_BUFFER_SIZE):

--- a/tests/sentry/web/frontend/test_demo_start.py
+++ b/tests/sentry/web/frontend/test_demo_start.py
@@ -11,9 +11,11 @@ class AuthLoginTest(TestCase):
     def path(self):
         return "/demo/start/"
 
+    @override_settings(DEMO_MODE=True, ROOT_URLCONF="sentry.demo.urls")
     @mock.patch("sentry.web.frontend.demo_start.auth.login")
     @mock.patch("sentry.demo.demo_org_manager.assign_demo_org")
     def test_basic(self, mock_assign_demo_org, mock_auth_login):
+
         user = self.create_user()
         org = self.create_organization()
 
@@ -23,7 +25,7 @@ class AuthLoginTest(TestCase):
 
         mock_auth_login.assert_called_once_with(mock.ANY, user)
 
-    @override_settings(DEMO_MODE=False)
+    @override_settings(DEMO_MODE=False, ROOT_URLCONF="sentry.demo.urls")
     def test_disabled(self):
         resp = self.client.post(self.path)
         assert resp.status_code == 404


### PR DESCRIPTION
Previously, I had added `DEMO_MODE=True` in our pytest file so that all tests boot up in demo mode. This was because I needed the demo start route exposed and simply using `@override_settings(DEMO_MODE=True)` wasn't enough. Instead, I am making a separate URL file that demo mode will use and use `@override_settings(DEMO_MODE=True, ROOT_URLCONF="sentry.demo.urls")` to the routes in tests. This has the impact of making demo mode off by default which is preferable.