### PR TITLE
ref(stacktrace-link): GA stacktrace link to am1 plans

### DIFF
--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -3,6 +3,7 @@ from rest_framework import status, serializers
 from sentry import integrations
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
+from sentry.integrations import IntegrationFeatures
 from sentry.models import Integration, Repository
 from sentry.utils.compat import filter, map
 
@@ -41,7 +42,9 @@ class PathMappingSerializer(CamelSnakeSerializer):
     @property
     def providers(self):
         # TODO: use feature flag in the future
-        providers = filter(lambda x: x.has_stacktrace_linking, list(integrations.all()))
+        providers = filter(
+            lambda x: x.has_feature(IntegrationFeatures.STACKTRACE_LINK), list(integrations.all())
+        )
         return map(lambda x: x.key, providers)
 
     @property

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -41,7 +41,6 @@ class PathMappingSerializer(CamelSnakeSerializer):
 
     @property
     def providers(self):
-        # TODO: use feature flag in the future
         providers = filter(
             lambda x: x.has_feature(IntegrationFeatures.STACKTRACE_LINK), list(integrations.all())
         )

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -2,6 +2,7 @@ from rest_framework.response import Response
 
 from sentry import analytics
 from sentry.api.bases.project import ProjectEndpoint
+from sentry.integrations import IntegrationFeatures
 from sentry.models import Integration, RepositoryProjectPathConfig
 from sentry.api.serializers import serialize
 from sentry.utils.compat import filter
@@ -51,7 +52,9 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
         # no longer feature gated and is added as an IntegrationFeature
         result["integrations"] = [
             serialize(i, request.user)
-            for i in filter(lambda i: i.get_provider().has_stacktrace_linking, integrations)
+            for i in filter(
+                lambda i: i.has_feature(IntegrationFeatures.STACKTRACE_LINK), integrations
+            )
         ]
 
         # xxx(meredith): if there are ever any changes to this query, make

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -130,7 +130,7 @@ class IntegrationProviderSerializer(Serializer):
         metadata = obj.metadata
         metadata = metadata and metadata._asdict() or None
 
-        output = {
+        return {
             "key": obj.key,
             "slug": obj.key,
             "name": obj.name,
@@ -143,17 +143,6 @@ class IntegrationProviderSerializer(Serializer):
                 **obj.setup_dialog_config,
             ),
         }
-
-        # until we GA the stack trace linking feature to everyone it's easier to
-        # control whether we show the feature this way
-        if obj.has_stacktrace_linking:
-            feature_flag_name = "organizations:integrations-stacktrace-link"
-            has_stacktrace_linking = features.has(feature_flag_name, organization, actor=user)
-            if has_stacktrace_linking:
-                # only putting the field in if it's true to minimize test changes
-                output["hasStacktraceLinking"] = True
-
-        return output
 
 
 class IntegrationIssueConfigSerializer(IntegrationSerializer):

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -1,7 +1,6 @@
 import logging
 from collections import defaultdict
 
-from sentry import features
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.models import (
     ExternalIssue,

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -96,6 +96,7 @@ class IntegrationFeatures(Enum):
     MOBILE = "mobile"
     SERVERLESS = "serverless"
     TICKET_RULES = "ticket-rules"
+    STACKTRACE_LINK = "stacktrace-link"
 
     # features currently only existing on plugins:
     DATA_FORWARDING = "data-forwarding"
@@ -161,10 +162,6 @@ class IntegrationProvider(PipelineProvider):
 
     # if this is hidden without the feature flag
     requires_feature_flag = False
-
-    # whether this integration can be used for stacktrace linking
-    # will eventually be replaced with a feature flag
-    has_stacktrace_linking = False
 
     @classmethod
     def get_installation(cls, model, organization_id, **kwargs):

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -158,9 +158,14 @@ class ExampleIntegrationProvider(IntegrationProvider):
     metadata = metadata
 
     integration_cls = ExampleIntegration
-    has_stacktrace_linking = True
 
-    features = frozenset([IntegrationFeatures.COMMITS, IntegrationFeatures.ISSUE_BASIC])
+    features = frozenset(
+        [
+            IntegrationFeatures.COMMITS,
+            IntegrationFeatures.ISSUE_BASIC,
+            IntegrationFeatures.STACKTRACE_LINK,
+        ]
+    )
 
     def get_pipeline_views(self):
         return [ExampleSetupView()]

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -48,6 +48,13 @@ FEATURES = [
         """,
         IntegrationFeatures.ISSUE_BASIC,
     ),
+    FeatureDescription(
+        """
+        Link your Sentry stack traces back to your GitHub source code with stack
+        trace linking.
+        """,
+        IntegrationFeatures.STACKTRACE_LINK,
+    ),
 ]
 
 
@@ -147,10 +154,15 @@ class GitHubIntegrationProvider(IntegrationProvider):
     name = "GitHub"
     metadata = metadata
     integration_cls = GitHubIntegration
-    features = frozenset([IntegrationFeatures.COMMITS, IntegrationFeatures.ISSUE_BASIC])
+    features = frozenset(
+        [
+            IntegrationFeatures.COMMITS,
+            IntegrationFeatures.ISSUE_BASIC,
+            IntegrationFeatures.STACKTRACE_LINK,
+        ]
+    )
 
     setup_dialog_config = {"width": 1030, "height": 1000}
-    has_stacktrace_linking = True
 
     def post_install(self, integration, organization, extra=None):
         repo_ids = Repository.objects.filter(

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -254,7 +254,7 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
     name = "GitHub Enterprise"
     metadata = metadata
     integration_cls = GitHubEnterpriseIntegration
-    has_stacktrace_linking = False
+    features = frozenset([IntegrationFeatures.COMMITS, IntegrationFeatures.ISSUE_BASIC])
 
     def _make_identity_pipeline_view(self):
         """

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -54,6 +54,13 @@ FEATURES = [
         """,
         IntegrationFeatures.ISSUE_BASIC,
     ),
+    FeatureDescription(
+        """
+        Link your Sentry stack traces back to your GitLab source code with stack
+        trace linking.
+        """,
+        IntegrationFeatures.STACKTRACE_LINK,
+    ),
 ]
 
 metadata = IntegrationMetadata(
@@ -246,9 +253,14 @@ class GitlabIntegrationProvider(IntegrationProvider):
     integration_cls = GitlabIntegration
 
     needs_default_identity = True
-    has_stacktrace_linking = True
 
-    features = frozenset([IntegrationFeatures.ISSUE_BASIC, IntegrationFeatures.COMMITS])
+    features = frozenset(
+        [
+            IntegrationFeatures.ISSUE_BASIC,
+            IntegrationFeatures.COMMITS,
+            IntegrationFeatures.STACKTRACE_LINK,
+        ]
+    )
 
     setup_dialog_config = {"width": 1030, "height": 1000}
 

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1158,7 +1158,6 @@ export type IntegrationProvider = BaseIntegrationProvider & {
     source_url: string;
     aspects: IntegrationAspects;
   };
-  hasStacktraceLinking?: boolean; // TODO: Remove when we GA the feature
 };
 
 export type IntegrationFeature = {

--- a/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -77,10 +77,6 @@ class ConfigureIntegration extends AsyncView<Props, State> {
       : 'Configure Integration';
   }
 
-  hasStacktraceLinking(provider: IntegrationProvider) {
-    return !!provider.hasStacktraceLinking;
-  }
-
   onTabChange = (value: Tab) => {
     this.setState({tab: value});
   };
@@ -208,7 +204,7 @@ class ConfigureIntegration extends AsyncView<Props, State> {
   renderMainContent(provider: IntegrationProvider) {
     const {integration} = this.state;
     //if no code mappings, render the single tab
-    if (!this.hasStacktraceLinking(provider)) {
+    if (!provider.features.includes('stacktrace-link')) {
       return this.renderMainTab(provider);
     }
     //otherwise render the tab view

--- a/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/src/sentry/static/sentry/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -77,6 +77,13 @@ class ConfigureIntegration extends AsyncView<Props, State> {
       : 'Configure Integration';
   }
 
+  hasStacktraceLinking(provider: IntegrationProvider) {
+    return (
+      provider.features.includes('stacktrace-link') &&
+      this.props.organization.features.includes('integrations-stacktrace-link')
+    );
+  }
+
   onTabChange = (value: Tab) => {
     this.setState({tab: value});
   };
@@ -204,7 +211,7 @@ class ConfigureIntegration extends AsyncView<Props, State> {
   renderMainContent(provider: IntegrationProvider) {
     const {integration} = this.state;
     //if no code mappings, render the single tab
-    if (!provider.features.includes('stacktrace-link')) {
+    if (!this.hasStacktraceLinking(provider)) {
       return this.renderMainTab(provider);
     }
     //otherwise render the tab view

--- a/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_integration_repository_project_path_configs.py
@@ -66,7 +66,7 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["commits", "issue-basic"],
+                "features": ["commits", "issue-basic", "stacktrace-link"],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",
@@ -87,7 +87,7 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["commits", "issue-basic"],
+                "features": ["commits", "issue-basic", "stacktrace-link"],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",
@@ -123,7 +123,7 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["commits", "issue-basic"],
+                "features": ["commits", "issue-basic", "stacktrace-link"],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",
@@ -185,7 +185,7 @@ class OrganizationIntegrationRepositoryProjectPathConfigTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["commits", "issue-basic"],
+                "features": ["commits", "issue-basic", "stacktrace-link"],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -86,7 +86,7 @@ class ProjectStacktraceLinkTest(APITestCase):
             "repoName": self.repo.name,
             "provider": {
                 "aspects": {},
-                "features": ["commits", "issue-basic"],
+                "features": ["commits", "issue-basic", "stacktrace-link"],
                 "name": "Example",
                 "canDisable": False,
                 "key": "example",
@@ -121,7 +121,7 @@ class ProjectStacktraceLinkTest(APITestCase):
             "repoName": self.repo.name,
             "provider": {
                 "aspects": {},
-                "features": ["commits", "issue-basic"],
+                "features": ["commits", "issue-basic", "stacktrace-link"],
                 "name": "Example",
                 "canDisable": False,
                 "key": "example",
@@ -154,7 +154,7 @@ class ProjectStacktraceLinkTest(APITestCase):
                 "repoName": self.repo.name,
                 "provider": {
                     "aspects": {},
-                    "features": ["commits", "issue-basic"],
+                    "features": ["commits", "issue-basic", "stacktrace-link"],
                     "name": "Example",
                     "canDisable": False,
                     "key": "example",
@@ -177,7 +177,7 @@ class ProjectStacktraceLinkTest(APITestCase):
             "accountType": None,
             "provider": {
                 "aspects": {},
-                "features": ["commits", "issue-basic"],
+                "features": ["commits", "issue-basic", "stacktrace-link"],
                 "name": "Example",
                 "canDisable": False,
                 "key": "example",


### PR DESCRIPTION
**Context**
Add the stack trace link as an `IntegrationFeature`, normally free features are not gated, but because this is on `am1` plans only, the feature flag will actually stay around. 
* `getsentry` counterpart https://github.com/getsentry/getsentry/pull/5264