### PR TITLE
fix(dashboards): Dashboard widgets not finish loading state

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
@@ -239,7 +239,6 @@ class WidgetQueries extends React.Component<Props, State> {
         // Overwrite the local var to work around state being stale in tests.
         tableResults = [...tableResults, tableData];
 
-        completed++;
         this.setState(prevState => {
           if (prevState.queryFetchID !== queryFetchID) {
             // invariant: a different request was initiated after this request
@@ -249,7 +248,6 @@ class WidgetQueries extends React.Component<Props, State> {
           return {
             ...prevState,
             tableResults,
-            loading: completed === promises.length ? false : true,
           };
         });
       } catch (err) {
@@ -260,6 +258,19 @@ class WidgetQueries extends React.Component<Props, State> {
         if (!err?.responseJSON?.detail) {
           Sentry.captureException(err);
         }
+      } finally {
+        completed++;
+        this.setState(prevState => {
+          if (prevState.queryFetchID !== queryFetchID) {
+            // invariant: a different request was initiated after this request
+            return prevState;
+          }
+
+          return {
+            ...prevState,
+            loading: completed === promises.length ? false : true,
+          };
+        });
       }
     });
   }
@@ -297,7 +308,6 @@ class WidgetQueries extends React.Component<Props, State> {
     promises.forEach(async (promise, i) => {
       try {
         const rawResults = await promise;
-        completed++;
         this.setState(prevState => {
           if (prevState.queryFetchID !== queryFetchID) {
             // invariant: a different request was initiated after this request
@@ -312,12 +322,24 @@ class WidgetQueries extends React.Component<Props, State> {
             ...prevState,
             timeseriesResults,
             rawResults: (prevState.rawResults ?? []).concat(rawResults),
-            loading: completed === promises.length ? false : true,
           };
         });
       } catch (err) {
         const errorMessage = err?.responseJSON?.detail || t('An unknown error occurred.');
         this.setState({errorMessage});
+      } finally {
+        completed++;
+        this.setState(prevState => {
+          if (prevState.queryFetchID !== queryFetchID) {
+            // invariant: a different request was initiated after this request
+            return prevState;
+          }
+
+          return {
+            ...prevState,
+            loading: completed === promises.length ? false : true,
+          };
+        });
       }
     });
   }

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -302,6 +302,70 @@ describe('Dashboards > WidgetQueries', function () {
     expect(childProps.tableResults[1].data[0].title).toBeDefined();
   });
 
+  it('stops loading state once all queries finish even if some fail', async function () {
+    const firstQuery = MockApiClient.addMockResponse(
+      {
+        statusCode: 500,
+        url: '/organizations/org-slug/eventsv2/',
+        body: {detail: 'it didnt work'},
+      },
+      {
+        predicate(_url, options) {
+          return options.query.query === 'event.type:error';
+        },
+      }
+    );
+    const secondQuery = MockApiClient.addMockResponse(
+      {
+        url: '/organizations/org-slug/eventsv2/',
+        body: {
+          meta: {title: 'string'},
+          data: [{title: 'ValueError'}],
+        },
+      },
+      {
+        predicate(_url, options) {
+          return options.query.query === 'title:ValueError';
+        },
+      }
+    );
+
+    const widget = {
+      title: 'SDK',
+      interval: '5m',
+      displayType: 'table',
+      queries: [
+        {conditions: 'event.type:error', fields: ['sdk.name'], name: 'sdk'},
+        {conditions: 'title:ValueError', fields: ['title'], name: 'title'},
+      ],
+    };
+
+    let childProps = undefined;
+    const wrapper = mountWithTheme(
+      <WidgetQueries
+        api={api}
+        widget={widget}
+        organization={initialData.organization}
+        selection={selection}
+      >
+        {props => {
+          childProps = props;
+          return <div data-test-id="child" />;
+        }}
+      </WidgetQueries>,
+      initialData.routerContext
+    );
+    await tick();
+    await tick();
+
+    // Child should be rendered and 2 requests should be sent.
+    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(firstQuery).toHaveBeenCalledTimes(1);
+    expect(secondQuery).toHaveBeenCalledTimes(1);
+
+    expect(childProps.loading).toEqual(false);
+  });
+
   it('sets bar charts to 1d interval', async function () {
     const errorMock = MockApiClient.addMockResponse(
       {


### PR DESCRIPTION
Dashboard widgets wait for all of their queries to succeed before making it as
not loading. This means that if any of the queries fail, the widget will never
leave the loading state. This change makes it so that the widget is moved out
of the loading state as long as all of the corresponding queries are complete,
even if they fail.