### PR TITLE
ref(trace-view): Add a min length to truncation

### DIFF
--- a/src/sentry/static/sentry/app/components/truncate.tsx
+++ b/src/sentry/static/sentry/app/components/truncate.tsx
@@ -5,6 +5,7 @@ import space from 'app/styles/space';
 
 type DefaultProps = {
   className: string;
+  minLength: number;
   maxLength: number;
   leftTrim: boolean;
   expandable: boolean;
@@ -23,6 +24,7 @@ type State = {
 class Truncate extends React.Component<Props, State> {
   static defaultProps: DefaultProps = {
     className: '',
+    minLength: 15,
     maxLength: 50,
     leftTrim: false,
     expandable: true,
@@ -52,6 +54,7 @@ class Truncate extends React.Component<Props, State> {
       className,
       leftTrim,
       trimRegex,
+      minLength,
       maxLength,
       value,
       expandable,
@@ -66,20 +69,25 @@ class Truncate extends React.Component<Props, State> {
         : value.slice(0, maxLength - 4);
 
       // Try to trim to values from the regex
-      if (trimRegex && slicedValue.search(trimRegex) >= 0) {
-        if (leftTrim) {
-          shortValue = (
-            <span>
-              … {slicedValue.slice(slicedValue.search(trimRegex), slicedValue.length)}
-            </span>
-          );
-        } else {
-          const matches = slicedValue.match(trimRegex);
-          const lastIndex = matches
-            ? slicedValue.lastIndexOf(matches[matches.length - 1]) + 1
-            : slicedValue.length;
-          shortValue = <span>{slicedValue.slice(0, lastIndex)} …</span>;
+      if (
+        trimRegex &&
+        leftTrim &&
+        slicedValue.search(trimRegex) <= maxLength - minLength
+      ) {
+        shortValue = (
+          <span>
+            … {slicedValue.slice(slicedValue.search(trimRegex), slicedValue.length)}
+          </span>
+        );
+      } else if (trimRegex && !leftTrim) {
+        const matches = slicedValue.match(trimRegex);
+        let lastIndex = matches
+          ? slicedValue.lastIndexOf(matches[matches.length - 1]) + 1
+          : slicedValue.length;
+        if (lastIndex <= minLength) {
+          lastIndex = slicedValue.length;
         }
+        shortValue = <span>{slicedValue.slice(0, lastIndex)} …</span>;
       } else if (leftTrim) {
         shortValue = <span>… {slicedValue}</span>;
       } else {


### PR DESCRIPTION
- This is so that we show more of the transaction name when they're very
  short eg. `something-very-long.short` and to avoid the case that a
  transaction has a truncation character near the end
  `something-very-long.1`
Before:
<img width="354" alt="image" src="https://user-images.githubusercontent.com/4205004/110854080-6d893500-8282-11eb-8613-92a932481920.png">
After:
<img width="368" alt="image" src="https://user-images.githubusercontent.com/4205004/110853997-4d597600-8282-11eb-9856-0afa0641f613.png">
