### PR TITLE
feat(integrations): Dual Write Notification Preferences

### DIFF
--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -1,42 +1,13 @@
 from collections import defaultdict
+from rest_framework import serializers
+from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers import serialize, Serializer
-from sentry.models import UserOption, UserOptionValue
-
-
-from rest_framework.response import Response
-
-from rest_framework import serializers
-
-USER_OPTION_SETTINGS = {
-    "deployNotifications": {
-        "key": "deploy-emails",
-        "default": UserOptionValue.committed_deploys_only,  # '3'
-        "type": int,
-    },
-    "personalActivityNotifications": {
-        "key": "self_notifications",
-        "default": UserOptionValue.all_conversations,  # '0'
-        "type": bool,
-    },
-    "selfAssignOnResolve": {
-        "key": "self_assign_issue",
-        "default": UserOptionValue.all_conversations,  # '0'
-        "type": bool,
-    },
-    "subscribeByDefault": {
-        "key": "subscribe_by_default",
-        "default": UserOptionValue.participating_only,  # '1'
-        "type": bool,
-    },
-    "workflowNotifications": {
-        "key": "workflow:notifications",
-        "default": UserOptionValue.participating_only,  # '1'
-        "type": int,
-    },
-}
+from sentry.models import UserOption
+from sentry.notifications.legacy_mappings import USER_OPTION_SETTINGS
+from sentry.notifications.types import UserOptionsSettingsKey
 
 
 class UserNotificationsSerializer(Serializer):
@@ -58,13 +29,12 @@ class UserNotificationsSerializer(Serializer):
         raw_data = {option.key: option.value for option in attrs}
 
         data = {}
-        for key in USER_OPTION_SETTINGS:
-            uo = USER_OPTION_SETTINGS[key]
+        for key, uo in USER_OPTION_SETTINGS.items():
             val = raw_data.get(uo["key"], uo["default"])
             if uo["type"] == bool:
-                data[key] = bool(int(val))  # '1' is true, '0' is false
+                data[key.value] = bool(int(val))  # '1' is true, '0' is false
             elif uo["type"] == int:
-                data[key] = int(val)
+                data[key.value] = int(val)
 
         data["weeklyReports"] = True  # This cannot be overridden
 
@@ -92,13 +62,12 @@ class UserNotificationDetailsEndpoint(UserEndpoint):
         serializer = UserNotificationDetailsSerializer(data=request.data)
 
         if serializer.is_valid():
-            for key in serializer.validated_data:
-                db_key = USER_OPTION_SETTINGS[key]["key"]
-                val = str(int(serializer.validated_data[key]))
+            for key, value in serializer.validated_data:
+                db_key = USER_OPTION_SETTINGS[UserOptionsSettingsKey(key)]["key"]
                 (uo, created) = UserOption.objects.get_or_create(
                     user=user, key=db_key, project=None, organization=None
                 )
-                uo.update(value=val)
+                uo.update(value=str(int(value)))
 
             return self.get(request, user)
         else:

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -62,11 +62,12 @@ class UserNotificationDetailsEndpoint(UserEndpoint):
         serializer = UserNotificationDetailsSerializer(data=request.data)
 
         if serializer.is_valid():
-            for key, value in serializer.validated_data:
+            for key, value in serializer.validated_data.items():
                 db_key = USER_OPTION_SETTINGS[UserOptionsSettingsKey(key)]["key"]
                 (uo, created) = UserOption.objects.get_or_create(
                     user=user, key=db_key, project=None, organization=None
                 )
+                # Convert integers and booleans to string representations of ints.
                 uo.update(value=str(int(value)))
 
             return self.get(request, user)

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -71,7 +71,7 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
         key = get_legacy_key_from_fine_tuning_key(notification_type)
         filter_args = {"user": user, "key": key}
 
-        if notification_type == "reports":
+        if notification_type == FineTuningAPIKey.REPORTS:
             (user_option, created) = UserOption.objects.get_or_create(**filter_args)
 
             value = set(user_option.value or [])
@@ -105,7 +105,11 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
             user_option.update(value=list(value))
             return Response(status=status.HTTP_204_NO_CONTENT)
 
-        if notification_type in ["alerts", "workflow", "email"]:
+        if notification_type in [
+            FineTuningAPIKey.ALERTS,
+            FineTuningAPIKey.WORKFLOW,
+            FineTuningAPIKey.EMAIL,
+        ]:
             update_key = "project"
             parent_ids = set(self.get_project_ids(user))
         else:
@@ -134,7 +138,7 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
                 status=status.HTTP_403_FORBIDDEN,
             )
 
-        if notification_type == "email":
+        if notification_type == FineTuningAPIKey.EMAIL:
             # make sure target emails exist and are verified
             emails_to_check = set(request.data.values())
             emails = UserEmail.objects.filter(
@@ -154,7 +158,7 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
         with transaction.atomic():
             for id in request.data:
                 val = request.data[id]
-                int_val = int(val) if notification_type != "email" else None
+                int_val = int(val) if notification_type != FineTuningAPIKey.EMAIL else None
 
                 filter_args["%s_id" % update_key] = id
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -41,10 +41,10 @@ from sentry.models import (
     SentryAppInstallationToken,
     User,
     UserOption,
-    UserOptionValue,
 )
 from sentry.models.groupinbox import get_inbox_details
 from sentry.models.groupowner import get_owner_details
+from sentry.notifications.legacy_mappings import UserOptionValue
 from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tsdb.snuba import SnubaTSDB
 from sentry.utils import snuba

--- a/src/sentry/api/serializers/models/user_notifications.py
+++ b/src/sentry/api/serializers/models/user_notifications.py
@@ -15,7 +15,7 @@ class UserNotificationsSerializer(Serializer):
         notification_option_key = kwargs["notification_option_key"]
         filter_args = {}
 
-        if notification_option_key in ["alerts", "workflow", "email"]:
+        if notification_option_key in ["mail:alert", "workflow:notifications", "mail:email"]:
             filter_args["project__isnull"] = False
         elif notification_option_key == "deploy":
             filter_args["organization__isnull"] = False

--- a/src/sentry/mail/activity/release.py
+++ b/src/sentry/mail/activity/release.py
@@ -1,8 +1,6 @@
 from collections import defaultdict
-from itertools import chain
-
-
 from django.db.models import Count, Q
+from itertools import chain
 
 from sentry.db.models.query import in_iexact
 from sentry.models import (
@@ -20,12 +18,12 @@ from sentry.models import (
     User,
     UserEmail,
     UserOption,
-    UserOptionValue,
 )
+from sentry.notifications.legacy_mappings import UserOptionValue
+from sentry.utils.compat import zip
 from sentry.utils.http import absolute_uri
 
 from .base import ActivityEmail
-from sentry.utils.compat import zip
 
 
 class ReleaseActivityEmail(ActivityEmail):

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -126,7 +126,8 @@ class GroupSubscriptionManager(BaseManager):
         """
         Identify all users who are participating with a given issue.
         """
-        from sentry.models import User, UserOptionValue
+        from sentry.models import User
+        from sentry.notifications.legacy_mappings import UserOptionValue
 
         users = {
             user.id: user

--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -89,3 +89,7 @@ class NotificationSetting(Model):
         "type",
         "value",
     )
+
+
+# REQUIRED for migrations to run
+from sentry.trash import *  # NOQA

--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -1,5 +1,4 @@
 from django.db import models
-from enum import Enum
 
 from sentry.db.models import (
     BoundedBigIntegerField,
@@ -9,68 +8,11 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.models.integration import ExternalProviders
-
-
-class NotificationSettingTypes(Enum):
-    # top level config of on/off
-    # for workflow also includes SUBSCRIBE_ONLY
-    # for deploy also includes COMMITTED_ONLY
-    DEFAULT = 0
-    # send deploy notifications
-    DEPLOY = 10
-    # notifications for issues
-    ISSUE_ALERTS = 20
-    # notifications for changes in assignment, resolution, comments
-    WORKFLOW = 30
-
-
-NOTIFICATION_SETTING_TYPES = {
-    NotificationSettingTypes.DEFAULT: "default",
-    NotificationSettingTypes.DEPLOY: "deploy",
-    NotificationSettingTypes.ISSUE_ALERTS: "issue",
-    NotificationSettingTypes.WORKFLOW: "workflow",
-}
-
-
-class NotificationSettingOptionValues(Enum):
-    DEFAULT = 0  # Defer to a setting one level up.
-    NEVER = 10
-    ALWAYS = 20
-    SUBSCRIBE_ONLY = 30  # workflow
-    COMMITTED_ONLY = 40  # deploy
-
-
-NOTIFICATION_SETTING_OPTION_VALUES = {
-    NotificationSettingOptionValues.DEFAULT: "default",
-    NotificationSettingOptionValues.NEVER: "off",
-    NotificationSettingOptionValues.ALWAYS: "on",
-    NotificationSettingOptionValues.SUBSCRIBE_ONLY: "subscribe_only",
-    NotificationSettingOptionValues.COMMITTED_ONLY: "committed_only",
-}
-
-
-class NotificationScopeType(Enum):
-    USER = 0
-    ORGANIZATION = 10
-    PROJECT = 20
-
-
-NOTIFICATION_SCOPE_TYPE = {
-    NotificationScopeType.USER: "user",
-    NotificationScopeType.ORGANIZATION: "organization",
-    NotificationScopeType.PROJECT: "project",
-}
-
-
-class NotificationTargetType(Enum):
-    USER = 0
-    TEAM = 10
-
-
-NOTIFICATION_TARGET_TYPE = {
-    NotificationTargetType.USER: "user",
-    NotificationTargetType.TEAM: "team",
-}
+from sentry.notifications.types import (
+    NotificationScopeType,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+)
 
 
 class NotificationSetting(Model):

--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -8,6 +8,7 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.models.integration import ExternalProviders
+from sentry.notifications.manager import NotificationsManager
 from sentry.notifications.types import (
     NotificationScopeType,
     NotificationSettingOptionValues,
@@ -64,6 +65,8 @@ class NotificationSetting(Model):
         ),
         null=False,
     )
+
+    objects = NotificationsManager()
 
     class Meta:
         app_label = "sentry"

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -5,7 +5,6 @@ from sentry.db.models import FlexibleForeignKey, Model, sane_repr
 from sentry.db.models.fields import EncryptedPickledObjectField
 from sentry.db.models.manager import OptionManager
 from sentry.models.integration import ExternalProviders
-from sentry.models.notificationsetting import NotificationSetting
 from sentry.notifications.legacy_mappings import get_key_value_from_legacy, get_key_from_legacy
 
 
@@ -50,6 +49,8 @@ class UserOptionManager(OptionManager):
         """
         This isn't implemented for user-organization scoped options yet, because it hasn't been needed.
         """
+        from sentry.models.notificationsetting import NotificationSetting
+
         with transaction.atomic():
             if key in [
                 "workflow:notifications",
@@ -77,6 +78,8 @@ class UserOptionManager(OptionManager):
         self._option_cache[metakey].pop(key, None)
 
     def set_value(self, user, key, value, **kwargs):
+        from sentry.models.notificationsetting import NotificationSetting
+
         project = kwargs.get("project")
         organization = kwargs.get("organization")
 

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -8,17 +8,6 @@ from sentry.models.integration import ExternalProviders
 from sentry.notifications.legacy_mappings import get_key_value_from_legacy, get_key_from_legacy
 
 
-class UserOptionValue:
-    # 'workflow:notifications'
-    all_conversations = "0"
-    participating_only = "1"
-    no_conversations = "2"
-    # 'deploy-emails
-    all_deploys = "2"
-    committed_deploys_only = "3"
-    no_deploys = "4"
-
-
 option_scope_error = "this is not a supported use case, scope to project OR organization"
 
 

--- a/src/sentry/models/useroption.py
+++ b/src/sentry/models/useroption.py
@@ -55,7 +55,7 @@ class UserOptionManager(OptionManager):
                     project=project,
                 )
 
-                self.filter(user=user, project=project, key=key).delete()
+            self.filter(user=user, project=project, key=key).delete()
 
         if not hasattr(self, "_metadata"):
             return

--- a/src/sentry/notifications/legacy_mappings.py
+++ b/src/sentry/notifications/legacy_mappings.py
@@ -1,0 +1,161 @@
+from sentry.models.useroption import UserOptionValue
+from sentry.notifications.types import (
+    FineTuningAPIKey,
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
+    UserOptionsSettingsKey,
+)
+
+
+USER_OPTION_SETTINGS = {
+    UserOptionsSettingsKey.DEPLOY: {
+        "key": "deploy-emails",
+        "default": UserOptionValue.committed_deploys_only,  # '3'
+        "type": int,
+    },
+    UserOptionsSettingsKey.SELF_ACTIVITY: {
+        "key": "self_notifications",
+        "default": UserOptionValue.all_conversations,  # '0'
+        "type": bool,
+    },
+    UserOptionsSettingsKey.SELF_ASSIGN: {
+        "key": "self_assign_issue",
+        "default": UserOptionValue.all_conversations,  # '0'
+        "type": bool,
+    },
+    UserOptionsSettingsKey.SUBSCRIBE_BY_DEFAULT: {
+        "key": "subscribe_by_default",
+        "default": UserOptionValue.participating_only,  # '1'
+        "type": bool,
+    },
+    UserOptionsSettingsKey.WORKFLOW: {
+        "key": "workflow:notifications",
+        "default": UserOptionValue.participating_only,  # '1'
+        "type": int,
+    },
+}
+
+FINE_TUNING_KEY_MAP = {
+    FineTuningAPIKey.ALERTS: "mail:alert",
+    FineTuningAPIKey.DEPLOY: "deploy-emails",
+    FineTuningAPIKey.EMAIL: "mail:email",
+    FineTuningAPIKey.REPORTS: "reports:disabled-organizations",
+    FineTuningAPIKey.WORKFLOW: "workflow:notifications",
+}
+
+KEYS_TO_LEGACY_KEYS = {
+    NotificationSettingTypes.DEPLOY: "deploy-emails",
+    NotificationSettingTypes.ISSUE_ALERTS: "mail:alert",
+    NotificationSettingTypes.WORKFLOW: "workflow:notifications",
+}
+
+
+KEY_VALUE_TO_LEGACY_VALUE = {
+    NotificationSettingTypes.DEPLOY: {
+        NotificationSettingOptionValues.ALWAYS: 2,
+        NotificationSettingOptionValues.COMMITTED_ONLY: 3,
+        NotificationSettingOptionValues.NEVER: 4,
+    },
+    NotificationSettingTypes.ISSUE_ALERTS: {
+        NotificationSettingOptionValues.ALWAYS: 1,
+        NotificationSettingOptionValues.NEVER: 0,
+    },
+    NotificationSettingTypes.WORKFLOW: {
+        NotificationSettingOptionValues.ALWAYS: 0,
+        NotificationSettingOptionValues.SUBSCRIBE_ONLY: 1,
+        NotificationSettingOptionValues.NEVER: 2,
+    },
+}
+
+LEGACY_VALUE_TO_KEY = {
+    NotificationSettingTypes.DEPLOY: {
+        -1: NotificationSettingOptionValues.DEFAULT,
+        2: NotificationSettingOptionValues.ALWAYS,
+        3: NotificationSettingOptionValues.COMMITTED_ONLY,
+        4: NotificationSettingOptionValues.NEVER,
+    },
+    NotificationSettingTypes.ISSUE_ALERTS: {
+        -1: NotificationSettingOptionValues.DEFAULT,
+        0: NotificationSettingOptionValues.NEVER,
+        1: NotificationSettingOptionValues.ALWAYS,
+    },
+    NotificationSettingTypes.WORKFLOW: {
+        -1: NotificationSettingOptionValues.DEFAULT,
+        0: NotificationSettingOptionValues.ALWAYS,
+        1: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+        2: NotificationSettingOptionValues.NEVER,
+    },
+}
+
+
+def get_legacy_key(type: NotificationSettingTypes) -> str:
+    """
+    Temporary mapping from new enum types to legacy strings.
+
+    :param type: NotificationSettingTypes enum
+    :return: String
+    """
+
+    return KEYS_TO_LEGACY_KEYS.get(type)
+
+
+def get_legacy_value(type: NotificationSettingTypes, value: NotificationSettingOptionValues) -> str:
+    """
+    Temporary mapping from new enum types to legacy strings. Each type has a separate mapping.
+
+    :param type: NotificationSettingTypes enum
+    :param value: NotificationSettingOptionValues enum
+    :return: String
+    """
+
+    return str(KEY_VALUE_TO_LEGACY_VALUE.get(type, {}).get(value))
+
+
+def get_option_value_from_boolean(value: bool) -> NotificationSettingOptionValues:
+    if value:
+        return NotificationSettingOptionValues.ALWAYS
+    else:
+        return NotificationSettingOptionValues.NEVER
+
+
+def get_option_value_from_int(
+    type: NotificationSettingTypes, value: int
+) -> NotificationSettingOptionValues:
+    return LEGACY_VALUE_TO_KEY.get(type, {}).get(value)
+
+
+def get_type_from_fine_tuning_key(key: FineTuningAPIKey) -> NotificationSettingTypes:
+    return {
+        FineTuningAPIKey.ALERTS: NotificationSettingTypes.ISSUE_ALERTS,
+        FineTuningAPIKey.DEPLOY: NotificationSettingTypes.DEPLOY,
+        FineTuningAPIKey.WORKFLOW: NotificationSettingTypes.WORKFLOW,
+    }.get(key)
+
+
+def get_legacy_key_from_fine_tuning_key(key: FineTuningAPIKey) -> str:
+    return FINE_TUNING_KEY_MAP.get(key)
+
+
+def get_type_from_user_option_settings_key(key: UserOptionsSettingsKey) -> NotificationSettingTypes:
+    return {
+        UserOptionsSettingsKey.DEPLOY: NotificationSettingTypes.DEPLOY,
+        UserOptionsSettingsKey.WORKFLOW: NotificationSettingTypes.WORKFLOW,
+    }.get(key)
+
+
+def get_key_from_legacy(key: str) -> NotificationSettingTypes:
+    return {
+        "deploy-emails": NotificationSettingTypes.DEPLOY,
+        "mail:alert": NotificationSettingTypes.ISSUE_ALERTS,
+        "subscribe_by_default": NotificationSettingTypes.ISSUE_ALERTS,
+        "workflow:notifications": NotificationSettingTypes.WORKFLOW,
+    }.get(key)
+
+
+def get_key_value_from_legacy(
+    key: str, value: any
+) -> (NotificationSettingTypes, NotificationSettingOptionValues):
+    type = get_key_from_legacy(key)
+    option_value = LEGACY_VALUE_TO_KEY.get(type, {}).get(int(value))
+
+    return type, option_value

--- a/src/sentry/notifications/legacy_mappings.py
+++ b/src/sentry/notifications/legacy_mappings.py
@@ -1,10 +1,20 @@
-from sentry.models.useroption import UserOptionValue
 from sentry.notifications.types import (
     FineTuningAPIKey,
     NotificationSettingTypes,
     NotificationSettingOptionValues,
     UserOptionsSettingsKey,
 )
+
+
+class UserOptionValue:
+    # 'workflow:notifications'
+    all_conversations = "0"
+    participating_only = "1"
+    no_conversations = "2"
+    # 'deploy-emails
+    all_deploys = "2"
+    committed_deploys_only = "3"
+    no_deploys = "4"
 
 
 USER_OPTION_SETTINGS = {

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -1,0 +1,296 @@
+from django.db import transaction
+
+from sentry.db.models import BaseManager
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import (
+    NotificationScopeType,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+    NotificationTargetType,
+)
+from sentry.models.useroption import UserOption
+from sentry.notifications.legacy_mappings import KEYS_TO_LEGACY_KEYS, KEY_VALUE_TO_LEGACY_VALUE
+
+
+def validate(type: NotificationSettingTypes, value: NotificationSettingOptionValues):
+    """
+    :return: boolean. True if the "value" is valid for the "type".
+    """
+    return _get_legacy_value(type, value) is not None
+
+
+def _get_scope(user_id, project=None, organization=None):
+    """
+    Figure out the scope from parameters and return it as a tuple,
+    TODO(mgaeta): Make sure user_id is in the project or organization.
+    :param user_id: The user's ID
+    :param project: (Optional) Project object
+    :param organization: (Optional) Organization object
+    :return: (int, int): (scope_type, scope_identifier)
+    """
+
+    if project:
+        return NotificationScopeType.PROJECT.value, project.id
+
+    if organization:
+        return NotificationScopeType.ORGANIZATION.value, organization.id
+
+    if user_id:
+        return NotificationScopeType.USER.value, user_id
+
+    raise Exception("scope must be either user, organization, or project")
+
+
+def _get_target(user_id=None, team_id=None):
+    """
+    Figure out the target from parameters and return it as a tuple.
+    :return: (int, int): (target_type, target_identifier)
+    """
+
+    if user_id:
+        return NotificationTargetType.USER.value, user_id
+
+    if team_id:
+        return NotificationTargetType.TEAM.value, team_id
+
+    raise Exception("target must be either a user or a team")
+
+
+def _get_legacy_key(type: NotificationSettingTypes):
+    """
+    Temporary mapping from new enum types to legacy strings.
+    :param type: NotificationSettingTypes enum
+    :return: String
+    """
+
+    return KEYS_TO_LEGACY_KEYS.get(type)
+
+
+def _get_legacy_value(type: NotificationSettingTypes, value: NotificationSettingOptionValues):
+    """
+    Temporary mapping from new enum types to legacy strings. Each type has a separate mapping.
+    :param type: NotificationSettingTypes enum
+    :param value: NotificationSettingOptionValues enum
+    :return: String
+    """
+
+    return str(KEY_VALUE_TO_LEGACY_VALUE.get(type, {}).get(value))
+
+
+class NotificationsManager(BaseManager):
+    """
+    TODO(mgaeta): Add a caching layer for notification settings
+    """
+
+    @staticmethod
+    def notify(
+        provider: ExternalProviders,
+        type: NotificationSettingTypes,
+        user_id=None,
+        team_id=None,
+        data=None,
+    ):
+        """
+        Something noteworthy has happened. Let the targets know about what
+        happened on their own terms. For each target, check their notification
+        preferences and send them a message (or potentially do nothing and
+        return False if this kind of correspondence is muted.)
+        :param provider: ExternalProviders enum
+        :param type: NotificationSettingTypes enum
+        :param user_id: (optional) User object's ID
+        :param team_id: (optional) Team object's ID
+        :param data: The payload depends on the notification type.
+        :return: Boolean. Was a notification sent?
+        """
+        return False
+
+    def get_settings(
+        self,
+        provider: ExternalProviders,
+        type: NotificationSettingTypes,
+        user=None,
+        team=None,
+        project=None,
+        organization=None,
+    ):
+        """
+        In this temporary implementation, always read EMAIL settings from
+        UserOptions. One and only one of (user, team, project, or organization)
+        must not be null. This function automatically translates a missing DB
+        row to NotificationSettingOptionValues.DEFAULT.
+        :param provider: ExternalProviders enum
+        :param type: NotificationSetting.type enum
+        :param user: (optional) A User object
+        :param team: (optional) A Team object
+        :param project: (optional) A Project object
+        :param organization: (optional) An Organization object
+        :return: NotificationSettingOptionValues enum
+        """
+
+        user_id_option = getattr(user, "id", None)
+        team_id_option = getattr(team, "id", None)
+        scope_type, scope_identifier = _get_scope(
+            user_id_option, project=project, organization=organization
+        )
+        target_type, target_identifier = _get_target(user_id_option, team_id_option)
+
+        value = (  # NOQA
+            self.filter(
+                provider=provider.value,
+                type=type.value,
+                scope_type=scope_type,
+                scope_identifier=scope_identifier,
+                target_type=target_type,
+                target_identifier=target_identifier,
+            ).first()
+            or NotificationSettingOptionValues.DEFAULT
+        )
+
+        legacy_value = UserOption.objects.get_value(
+            user, _get_legacy_key(type), project=project, organization=organization
+        )
+
+        # TODO(mgaeta): This line will be valid after the "copy migration".
+        # assert value == legacy_value
+
+        return legacy_value
+
+    def update_settings(
+        self,
+        provider: ExternalProviders,
+        type: NotificationSettingTypes,
+        value: NotificationSettingOptionValues,
+        user_id=None,
+        team_id=None,
+        **kwargs,
+    ):
+        """
+        Save a target's notification preferences.
+        Examples:
+          * Updating a user's org-independent preferences
+          * Updating a user's per-project preferences
+          * Updating a user's per-organization preferences
+        :param provider: ExternalProviders enum
+        :param type: NotificationSettingTypes enum
+        :param value: NotificationSettingOptionValues enum
+        :param user_id: User object's ID
+        :param team_id: Team object's ID
+        :param kwargs: (deprecated) User object
+        """
+        # A missing DB row is equivalent to DEFAULT.
+        if value == NotificationSettingOptionValues.DEFAULT:
+            return self.remove_settings(provider, type, user_id=user_id, team_id=team_id, **kwargs)
+
+        kwargs = kwargs or {}
+        project_option = kwargs.get("project")
+        organization_option = kwargs.get("organization")
+        user_id_option = user_id or getattr(kwargs.get("user"), "id", None)
+        team_id_option = team_id or getattr(kwargs.get("team"), "id", None)
+
+        if not validate(type, value):
+            raise Exception(f"value '{value}' is not valid for type '{type}'")
+
+        scope_type, scope_identifier = _get_scope(
+            user_id_option, project=project_option, organization=organization_option
+        )
+        target_type, target_identifier = _get_target(user_id_option, team_id_option)
+
+        with transaction.atomic():
+            setting, created = self.get_or_create(
+                provider=provider.value,
+                type=type.value,
+                scope_type=scope_type,
+                scope_identifier=scope_identifier,
+                target_type=target_type,
+                target_identifier=target_identifier,
+                defaults={"value": value.value},
+            )
+            if not created and setting.value != value.value:
+                setting.update(value=value.value)
+
+    def remove_settings(
+        self,
+        provider: ExternalProviders,
+        type: NotificationSettingTypes,
+        user_id=None,
+        team_id=None,
+        **kwargs,
+    ):
+        """
+        We don't anticipate this function will be used by the API but is useful
+        for tests. This can also be called by `update_settings` when attempting
+        to set a notification preference to DEFAULT.
+        :param provider: ExternalProviders enum
+        :param type: NotificationSettingTypes enum
+        :param user_id: User object's ID
+        :param team_id: Team object's ID
+        :param kwargs: (deprecated) User object
+        """
+
+        kwargs = kwargs or {}
+        project_option = kwargs.get("project")
+        user_id_option = user_id or getattr(kwargs.get("user"), "id", None)
+        team_id_option = team_id or getattr(kwargs.get("team"), "id", None)
+        scope_type, scope_identifier = _get_scope(user_id_option, project=project_option)
+        target_type, target_identifier = _get_target(user_id_option, team_id_option)
+
+        user = kwargs.pop("user")
+
+        with transaction.atomic():
+            self.filter(
+                provider=provider.value,
+                type=type.value,
+                scope_type=scope_type,
+                scope_identifier=scope_identifier,
+                target_type=target_type,
+                target_identifier=target_identifier,
+            ).delete()
+
+            UserOption.objects.unset_value(user, project_option, _get_legacy_key(type))
+
+    def remove_settings_for_user(self, user, type: NotificationSettingTypes = None):
+        if type:
+            # We don't need a transaction because this is only used in tests.
+            UserOption.objects.filter(user=user, key=_get_legacy_key(type)).delete()
+            self.filter(
+                target_type=NotificationTargetType.USER.value,
+                target_identifier=user.id,
+                type=type.value,
+            ).delete()
+        else:
+            UserOption.objects.filter(user=user, key__in=KEYS_TO_LEGACY_KEYS.values()).delete()
+            self.filter(
+                target_type=NotificationTargetType.USER.value,
+                target_identifier=user.id,
+            ).delete()
+
+    @staticmethod
+    def remove_settings_for_team():
+        pass
+
+    @staticmethod
+    def remove_settings_for_project():
+        pass
+
+    @staticmethod
+    def remove_settings_for_organization():
+        pass
+
+    def get_settings_for_users(
+        self, provider: ExternalProviders, type: NotificationSettingTypes, users, project
+    ):
+        """
+        Get some users' notification preferences for a given project.
+        :param provider: ExternalProviders enum
+        :param type: NotificationSettingTypes enum
+        :param users: List of user objects
+        :param project: Project object
+        :return: Object mapping users' IDs to their notification preferences
+        """
+
+        return {
+            user_id: value
+            for user_id, value in UserOption.objects.filter(
+                user__in=users, project=project, key=type.value
+            ).values_list("user_id", "value")
+        }

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -211,9 +211,10 @@ class NotificationsManager(BaseManager):
         self,
         provider: ExternalProviders,
         type: NotificationSettingTypes,
-        user_id=None,
-        team_id=None,
-        **kwargs,
+        user=None,
+        team=None,
+        project=None,
+        organization=None,
     ):
         """
         We don't anticipate this function will be used by the API but is useful
@@ -221,17 +222,16 @@ class NotificationsManager(BaseManager):
         to set a notification preference to DEFAULT.
         :param provider: ExternalProviders enum
         :param type: NotificationSettingTypes enum
-        :param user_id: User object's ID
-        :param team_id: Team object's ID
-        :param kwargs: (deprecated) User object
+        :param user: (Optional) User object
+        :param team: (Optional) Team object
+        :param project: (Optional) Project object
+        :param organization: (Optional) Organization object
         """
-
-        kwargs = kwargs or {}
-        project_option = kwargs.get("project")
-        user_id_option = user_id or getattr(kwargs.get("user"), "id", None)
-        team_id_option = team_id or getattr(kwargs.get("team"), "id", None)
-        scope_type, scope_identifier = _get_scope(user_id_option, project=project_option)
-        target = _get_target(user_id_option, team_id_option)
+        user_id_option = getattr(user, "id", None)
+        scope_type, scope_identifier = _get_scope(
+            user_id_option, project=project, organization=organization
+        )
+        target = _get_target(user, team)
 
         self.filter(
             provider=provider.value,

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -234,19 +234,14 @@ class NotificationsManager(BaseManager):
         scope_type, scope_identifier = _get_scope(user_id_option, project=project_option)
         target_type, target_identifier = _get_target(user_id_option, team_id_option)
 
-        user = kwargs.pop("user")
-
-        with transaction.atomic():
-            self.filter(
-                provider=provider.value,
-                type=type.value,
-                scope_type=scope_type,
-                scope_identifier=scope_identifier,
-                target_type=target_type,
-                target_identifier=target_identifier,
-            ).delete()
-
-            UserOption.objects.unset_value(user, project_option, _get_legacy_key(type))
+        self.filter(
+            provider=provider.value,
+            type=type.value,
+            scope_type=scope_type,
+            scope_identifier=scope_identifier,
+            target_type=target_type,
+            target_identifier=target_identifier,
+        ).delete()
 
     def remove_settings_for_user(self, user, type: NotificationSettingTypes = None):
         if type:

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -1,0 +1,99 @@
+from enum import Enum
+
+"""
+TODO(postgres): We've encoded these enums as integers to facilitate
+communication with the DB. We'd prefer to encode them as strings to facilitate
+communication with the API and plan to do so as soon as we use native enums in
+Postgres. In the meantime each enum has an adjacent object that maps the
+integers to their string values.
+"""
+
+
+class NotificationSettingTypes(Enum):
+    """
+    Each of these categories of Notification settings has at least an option for
+    "on" or "off". Workflow also includes SUBSCRIBE_ONLY and Deploy also
+    includes COMMITTED_ONLY and both of these values are described below.
+    """
+
+    # Control all notification types. Currently unused.
+    DEFAULT = 0
+
+    # When Sentry sees there is a new code deploy.
+    DEPLOY = 10
+
+    # When Sentry sees and issue that triggers an Alert Rule.
+    ISSUE_ALERTS = 20
+
+    # Notifications for changes in assignment, resolution, comments, etc.
+    WORKFLOW = 30
+
+
+NOTIFICATION_SETTING_TYPES = {
+    NotificationSettingTypes.DEFAULT: "default",
+    NotificationSettingTypes.DEPLOY: "deploy",
+    NotificationSettingTypes.ISSUE_ALERTS: "issue",
+    NotificationSettingTypes.WORKFLOW: "workflow",
+}
+
+
+class NotificationSettingOptionValues(Enum):
+    """
+    An empty row in the DB should be represented as
+    NotificationSettingOptionValues.DEFAULT.
+    """
+
+    # Defer to a setting one level up.
+    DEFAULT = 0
+
+    # Mute this kind of notification.
+    NEVER = 10
+
+    # Un-mute this kind of notification.
+    ALWAYS = 20
+
+    # Workflow only. Only send notifications about Issues that the target has
+    # explicitly or implicitly opted-into.
+    SUBSCRIBE_ONLY = 30
+
+    # Deploy only. Only send notifications when the set of changes in the deploy
+    # included a commit authored by the target.
+    COMMITTED_ONLY = 40
+
+
+NOTIFICATION_SETTING_OPTION_VALUES = {
+    NotificationSettingOptionValues.DEFAULT: "default",
+    NotificationSettingOptionValues.NEVER: "off",
+    NotificationSettingOptionValues.ALWAYS: "on",
+    NotificationSettingOptionValues.SUBSCRIBE_ONLY: "subscribe_only",
+    NotificationSettingOptionValues.COMMITTED_ONLY: "committed_only",
+}
+
+
+class NotificationScopeType(Enum):
+    USER = 0
+    ORGANIZATION = 10
+    PROJECT = 20
+
+
+NOTIFICATION_SCOPE_TYPE = {
+    NotificationScopeType.USER: "user",
+    NotificationScopeType.ORGANIZATION: "organization",
+    NotificationScopeType.PROJECT: "project",
+}
+
+
+class FineTuningAPIKey(Enum):
+    ALERTS = "alerts"
+    DEPLOY = "deploy"
+    EMAIL = "email"
+    REPORTS = "reports"
+    WORKFLOW = "workflow"
+
+
+class UserOptionsSettingsKey(Enum):
+    DEPLOY = "deployNotifications"
+    SELF_ACTIVITY = "personalActivityNotifications"
+    SELF_ASSIGN = "selfAssignOnResolve"
+    SUBSCRIBE_BY_DEFAULT = "subscribeByDefault"
+    WORKFLOW = "workflowNotifications"

--- a/src/sentry/trash/__init__.py
+++ b/src/sentry/trash/__init__.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+"""
+Place any dead code that is still required for migrations here.
+"""
+
+
+class NotificationTargetType(Enum):
+    USER = 0
+    TEAM = 10

--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -1,4 +1,5 @@
-from sentry.models import UserOption, UserOptionValue
+from sentry.models import UserOption
+from sentry.notifications.legacy_mappings import UserOptionValue
 from sentry.testutils import APITestCase
 
 

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -12,8 +12,8 @@ from sentry.models import (
     GroupStatus,
     GroupSubscription,
     UserOption,
-    UserOptionValue,
 )
+from sentry.notifications.legacy_mappings import UserOptionValue
 from sentry.testutils import TestCase
 from sentry.utils.compat import mock
 from sentry.utils.compat.mock import patch

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -13,9 +13,9 @@ from sentry.models import (
     Repository,
     UserEmail,
     UserOption,
-    UserOptionValue,
 )
 from sentry.mail.activity.release import ReleaseActivityEmail
+from sentry.notifications.legacy_mappings import UserOptionValue
 from sentry.testutils import TestCase
 
 

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -23,9 +23,9 @@ from sentry.models import (
     Rule,
     User,
     UserOption,
-    UserOptionValue,
     UserReport,
 )
+from sentry.notifications.legacy_mappings import UserOptionValue
 from sentry.ownership import grammar
 from sentry.ownership.grammar import dump_schema, Matcher, Owner
 from sentry.plugins.base import Notification

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -1,7 +1,8 @@
 import functools
 import itertools
 
-from sentry.models import GroupSubscription, GroupSubscriptionReason, UserOption, UserOptionValue
+from sentry.models import GroupSubscription, GroupSubscriptionReason, UserOption
+from sentry.notifications.legacy_mappings import UserOptionValue
 from sentry.testutils import TestCase
 
 

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -19,8 +19,8 @@ from sentry.models import (
     GroupStatus,
     GroupSubscription,
     UserOption,
-    UserOptionValue,
 )
+from sentry.notifications.legacy_mappings import UserOptionValue
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.utils.compat import mock


### PR DESCRIPTION
Part (2/5) of Notifications Platform Migration (migrating from UserOption to NotificationSetting.) See #24162, #24107.

This PR intercepts every write to the `senty_useroptions` table for the relevant keys (`workflow:notifications`, `mail:alert`, `subscribe_by_default`, and `deploy-emails`) and also write to the newly created `sentry_notificationsetting` table.
As a next step, we'll find every usage of `UserOption.set_value` and `UserOption.unset_value` and swap them out with a modified call to `NotificationSetting.update_settings` that will still write to both tables.
In order to test that this is working, we'll also intercept reads via `UserOption.get_value` and assert that the values are identical on both tables. Other reads made with custom queries are out of scope for this PR.