### PR TITLE
feat(alerts): Improves team selector for creating issue alerts

### DIFF
--- a/src/sentry/static/sentry/app/components/selectMembers/index.tsx
+++ b/src/sentry/static/sentry/app/components/selectMembers/index.tsx
@@ -8,11 +8,12 @@ import Button from 'app/components/button';
 import SelectControl from 'app/components/forms/selectControl';
 import IdBadge from 'app/components/idBadge';
 import Tooltip from 'app/components/tooltip';
-import {IconAdd} from 'app/icons';
+import {IconAdd, IconUser} from 'app/icons';
 import {t} from 'app/locale';
 import MemberListStore from 'app/stores/memberListStore';
 import ProjectsStore from 'app/stores/projectsStore';
 import TeamStore from 'app/stores/teamStore';
+import space from 'app/styles/space';
 import {Member, Organization, Project, Team, User} from 'app/types';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import withApi from 'app/utils/withApi';
@@ -33,6 +34,29 @@ type Mentionable<T> = {
   actor: Actor<T>;
 };
 
+const UnassignedWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const StyledIconUser = styled(IconUser)`
+  margin-left: ${space(0.25)};
+  margin-right: ${space(1)};
+`;
+
+const unassignedOption = {
+  value: undefined,
+  label: (
+    <UnassignedWrapper>
+      <StyledIconUser size="20px" color="gray400" />
+      {t('Unassigned')}
+    </UnassignedWrapper>
+  ),
+  searchKey: 'unassigned',
+  actor: undefined,
+};
+type MentionableUnassigned = typeof unassignedOption;
+
 type Unmentionable = {
   disabled: boolean;
   label: React.ReactElement;
@@ -43,7 +67,8 @@ type UnmentionableTeam = MentionableTeam & Unmentionable;
 type MentionableUser = Mentionable<'user'>;
 type UnmentionableUser = MentionableUser & Unmentionable;
 
-type AllMentionable = (MentionableUser | MentionableTeam) & Partial<Unmentionable>;
+type AllMentionable = (MentionableUser | MentionableTeam | MentionableUnassigned) &
+  Partial<Unmentionable>;
 
 type Props = {
   api: Client;
@@ -56,6 +81,9 @@ type Props = {
   disabled?: boolean;
   placeholder?: string;
   styles?: {control?: (provided: any) => any};
+  filteredTeamIds?: Set<string>;
+  // Used to display an additional unassigned option
+  includeUnassigned?: boolean;
 };
 
 type State = {
@@ -241,7 +269,7 @@ class SelectMembers extends React.Component<Props, State> {
 
         // Remove add to project button without changing order
         const newOptions = options!.map(option => {
-          if (option.actor.id === team.id) {
+          if (option.actor?.id === team.id) {
             option.disabled = false;
             option.label = <IdBadge team={team} />;
           }
@@ -289,10 +317,17 @@ class SelectMembers extends React.Component<Props, State> {
   }, 250);
 
   handleLoadOptions = (): Promise<AllMentionable[]> => {
-    if (this.props.showTeam) {
+    const {showTeam, filteredTeamIds, includeUnassigned} = this.props;
+    if (showTeam) {
       const teamsInProject = this.getMentionableTeams();
       const teamsNotInProject = this.getTeamsNotInProject(teamsInProject);
-      const options = [...teamsInProject, ...teamsNotInProject];
+      const unfilteredOptions = [...teamsInProject, ...teamsNotInProject];
+      const options: AllMentionable[] = filteredTeamIds
+        ? unfilteredOptions.filter(({value}) => !value || filteredTeamIds.has(value))
+        : unfilteredOptions;
+      if (includeUnassigned) {
+        options.push(unassignedOption);
+      }
       this.setState({options});
       return Promise.resolve(options);
     }

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
@@ -129,7 +129,8 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   }
 
   getDefaultState() {
-    return {
+    const {teams} = this.props;
+    const defaultState = {
       ...super.getDefaultState(),
       configs: null,
       detailedError: null,
@@ -137,6 +138,9 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       environments: [],
       uuid: null,
     };
+    const userTeam = teams.find(({isMember}) => !!isMember);
+    defaultState.rule.owner = userTeam ? `team:${userTeam.id}` : undefined;
+    return defaultState;
   }
 
   getEndpoints(): ReturnType<AsyncView['getEndpoints']> {
@@ -451,9 +455,14 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     return owner.split(':')[1];
   };
 
-  handleOwnerChange = (optionRecord: {value: string; label: string}) => {
-    // currently only supporting teams as owners
-    this.handleChange('owner', `team:${optionRecord.value}`);
+  handleOwnerChange = ({value}: {value?: string; label: string}) => {
+    if (value) {
+      // currently only supporting teams as owners
+      this.handleChange('owner', `team:${value}`);
+    } else {
+      // allow owner to be set to undefined (unassigned option)
+      this.handleChange('owner', value);
+    }
   };
 
   renderLoading() {
@@ -552,6 +561,8 @@ class IssueRuleEditor extends AsyncView<Props, State> {
                       organization={organization}
                       value={this.getTeamId()}
                       onChange={this.handleOwnerChange}
+                      filteredTeamIds={userTeams}
+                      includeUnassigned
                     />
                   </StyledField>
                 </Feature>


### PR DESCRIPTION
This PR:
- Adds a new unassigned option to the team selector (passes `owner:undefined` to the backend)
- Adds ability to filter team selector to a set of teams, which we use to filter the team selector to just the teams that the user belongs to
- Defaults the team selector option to the first team that the user belongs to (to encourage teams to select an owner)

**Before:**
<img width="1198" alt="Screen Shot 2021-03-11 at 6 52 32 PM" src="https://user-images.githubusercontent.com/9372512/110870680-f14f1b80-829a-11eb-934b-e3cfe79e84ba.png">

**After:**
<img width="1174" alt="Screen Shot 2021-03-11 at 6 52 03 PM" src="https://user-images.githubusercontent.com/9372512/110870690-f7dd9300-829a-11eb-8f64-7c8c4c78370d.png">