### PR TITLE
feat(alerts): Add my teams and unassigned to filter list options

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -124,17 +124,37 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
     const teamQuery = location.query?.team;
     const filteredTeams: Set<string> =
       typeof teamQuery === 'string' ? new Set([teamQuery]) : new Set(teamQuery);
-    const teamIds = teams.map(({id}) => id);
+    const additionalOptions = [
+      {label: t('My Teams'), value: 'myteams'},
+      {label: t('Unassigned'), value: 'unassigned'},
+    ];
+    const optionValues = [
+      ...teams.map(({id}) => id),
+      ...additionalOptions.map(({value}) => value),
+    ];
     return (
       <FilterWrapper>
         <Filter
           header={t('Team')}
           onFilterChange={this.handleChangeFilter}
-          filterList={teamIds}
+          filterList={optionValues}
           selection={filteredTeams}
         >
           {({toggleFilter}) => (
             <List>
+              {additionalOptions.map(({label, value}) => (
+                <ListItem
+                  key={value}
+                  isChecked={filteredTeams.has(value)}
+                  onClick={event => {
+                    event.stopPropagation();
+                    toggleFilter(value);
+                  }}
+                >
+                  <TeamName>{label}</TeamName>
+                  <CheckboxFancy isChecked={filteredTeams.has(value)} />
+                </ListItem>
+              ))}
               {teams.map(({id, name}) => (
                 <ListItem
                   key={id}


### PR DESCRIPTION
Adds `My Teams` and `Unassigned` which will be supported in the backend once https://github.com/getsentry/sentry/pull/24318 merges 

**Before:**
<img width="315" alt="Screen Shot 2021-03-11 at 7 12 07 PM" src="https://user-images.githubusercontent.com/9372512/110872583-16915900-829e-11eb-9f5e-ab7b4aa7fa1a.png">

**After:**
<img width="274" alt="Screen Shot 2021-03-11 at 7 12 26 PM" src="https://user-images.githubusercontent.com/9372512/110872586-1729ef80-829e-11eb-85a3-758e4ce76a77.png">

