### PR TITLE
feat(workflow): Track query sort with transaction

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -49,6 +49,7 @@ import {analytics, logExperiment, metric, trackAnalyticsEvent} from 'app/utils/a
 import {callIfFunction} from 'app/utils/callIfFunction';
 import CursorPoller from 'app/utils/cursorPoller';
 import {getUtcDateString} from 'app/utils/dates';
+import getCurrentSentryReactTransaction from 'app/utils/getCurrentSentryReactTransaction';
 import parseApiError from 'app/utils/parseApiError';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
 import StreamManager from 'app/utils/streamManager';
@@ -515,6 +516,8 @@ class IssueListOverview extends React.Component<Props, State> {
   fetchData = (selectionChanged?: boolean) => {
     GroupStore.loadInitialData([]);
     this._streamManager.reset();
+    const transaction = getCurrentSentryReactTransaction();
+    transaction?.setTag('query.sort', this.getSort());
 
     this.setState({
       issuesLoading: true,


### PR DESCRIPTION
Looking to track which sort was used on `/organizations/:orgId/issues/` transactions via this tag. I'm not completely sure this works how I want it to.