### PR TITLE
feat(codeowners): Evaluate CodeOwner rules alongside IssuerOwner rules

### DIFF
--- a/src/sentry/models/projectcodeowners.py
+++ b/src/sentry/models/projectcodeowners.py
@@ -1,15 +1,13 @@
 import logging
 
 from django.db import models
-from sentry.db.models import (
-    FlexibleForeignKey,
-    DefaultFieldsModel,
-    JSONField,
-)
 from django.utils import timezone
 
+from sentry.db.models import FlexibleForeignKey, DefaultFieldsModel, JSONField, sane_repr
+from sentry.utils.cache import cache
 
 logger = logging.getLogger(__name__)
+READ_CACHE_DURATION = 3600
 
 
 class ProjectCodeOwners(DefaultFieldsModel):
@@ -30,3 +28,28 @@ class ProjectCodeOwners(DefaultFieldsModel):
     class Meta:
         app_label = "sentry"
         db_table = "sentry_projectcodeowners"
+
+    __repr__ = sane_repr("project_id", "id")
+
+    @classmethod
+    def get_cache_key(self, project_id):
+        return f"projectcodewoners_project_id:1:{project_id}"
+
+    @classmethod
+    def get_codeowners_cached(self, project_id):
+        """
+        Cached read access to sentry_projectcodeowners.
+
+        This method implements a negative cache which saves us
+        a pile of read queries in post_processing as most projects
+        don't have CODEOWNERS.
+        """
+        cache_key = self.get_cache_key(project_id)
+        codeowners = cache.get(cache_key)
+        if codeowners is None:
+            try:
+                codeowners = self.objects.get(project_id=project_id)
+            except self.DoesNotExist:
+                codeowners = False
+            cache.set(cache_key, codeowners, READ_CACHE_DURATION)
+        return codeowners or None

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -12,7 +12,6 @@ from sentry.ownership.grammar import load_schema
 from sentry.utils import metrics
 from sentry.utils.cache import cache
 from functools import reduce
-from .projectcodeowners import ProjectCodeOwners
 
 READ_CACHE_DURATION = 3600
 
@@ -75,6 +74,8 @@ class ProjectOwnership(Model):
         If an empty list is returned, this means there are explicitly
         no owners.
         """
+        from sentry.models import ProjectCodeOwners
+
         ownership = cls.get_ownership_cached(project_id)
         if not ownership:
             ownership = cls(project_id=project_id)
@@ -116,6 +117,8 @@ class ProjectOwnership(Model):
 
         Returns a tuple of (auto_assignment_enabled, list_of_owners).
         """
+        from sentry.models import ProjectCodeOwners
+
         with metrics.timer("projectownership.get_autoassign_owners"):
             ownership = cls.get_ownership_cached(project_id)
             codeowners = ProjectCodeOwners.get_codeowners_cached(project_id)

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -83,6 +83,7 @@ class ProjectOwnership(Model):
     def get_owners(cls, project_id, data):
         """
         For a given project_id, and event data blob.
+        We combine the schemas from IssueOwners and CodeOwners.
 
         If Everyone is returned, this means we implicitly are
         falling through our rules and everyone is responsible.
@@ -119,6 +120,8 @@ class ProjectOwnership(Model):
     def get_autoassign_owners(cls, project_id, data, limit=2):
         """
         Get the auto-assign owner for a project if there are any.
+
+        We combine the schemas from IssueOwners and CodeOwners.
 
         Returns a tuple of (auto_assignment_enabled, list_of_owners).
         """

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -96,7 +96,7 @@ class ProjectOwnershipTestCase(TestCase):
                 self.project.id, {"stacktrace": {"frames": [{"filename": "src/foo.js"}]}}
             ),
             (
-                [Actor(self.team.id, Team)],
+                [ActorTuple(self.team.id, Team)],
                 [rule_a],
             ),
         )
@@ -130,7 +130,7 @@ class ProjectOwnershipTestCase(TestCase):
                 self.project.id, {"stacktrace": {"frames": [{"filename": "api/foo.py"}]}}
             ),
             (
-                [Actor(self.team.id, Team), Actor(self.team2.id, Team)],
+                [ActorTuple(self.team.id, Team), ActorTuple(self.team2.id, Team)],
                 [rule_a, rule_c],
             ),
         )

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -19,7 +19,6 @@ class ProjectOwnershipTestCase(TestCase):
 
     def test_get_owners_no_record(self):
         assert ProjectOwnership.get_owners(self.project.id, {}) == (ProjectOwnership.Everyone, None)
-        assert ProjectOwnership.get_owners(self.project.id, {}) == (ProjectOwnership.Everyone, None)
 
     def test_get_owners_basic(self):
         rule_a = Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)])
@@ -74,6 +73,174 @@ class ProjectOwnershipTestCase(TestCase):
                 self.project.id, {"stacktrace": {"frames": [{"filename": "src/foo.py"}]}}
             ),
             ([ActorTuple(self.team.id, Team), ActorTuple(self.user.id, User)], [rule_a, rule_b]),
+        )
+
+    def test_get_owners_when_codeowners_exists_and_no_issueowners(self):
+        # This case will never exist bc we create a ProjectOwnership record if none exists when creating a ProjectCodeOwner record.
+        # We have this testcase for potential corrupt data.
+        self.team = self.create_team(
+            organization=self.organization, slug="tiger-team", members=[self.user]
+        )
+        self.code_mapping = self.create_code_mapping(project=self.project)
+
+        rule_a = Rule(Matcher("path", "*.js"), [Owner("team", self.team.slug)])
+
+        self.create_codeowners(
+            self.project,
+            self.code_mapping,
+            raw="*.js @tiger-team",
+            schema=dump_schema([rule_a]),
+        )
+        self.assert_ownership_equals(
+            ProjectOwnership.get_owners(
+                self.project.id, {"stacktrace": {"frames": [{"filename": "src/foo.js"}]}}
+            ),
+            (
+                [Actor(self.team.id, Team)],
+                [rule_a],
+            ),
+        )
+
+    def test_get_owners_when_codeowners_and_issueowners_exists(self):
+        self.team = self.create_team(
+            organization=self.organization, slug="tiger-team", members=[self.user]
+        )
+        self.team2 = self.create_team(
+            organization=self.organization, slug="dolphin-team", members=[self.user]
+        )
+        self.project = self.create_project(
+            organization=self.organization, teams=[self.team, self.team2]
+        )
+        self.code_mapping = self.create_code_mapping(project=self.project)
+
+        rule_a = Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)])
+        rule_b = Rule(Matcher("path", "src/*"), [Owner("user", self.user.email)])
+        rule_c = Rule(Matcher("path", "*.py"), [Owner("team", self.team2.slug)])
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id, schema=dump_schema([rule_a, rule_b]), fallthrough=True
+        )
+
+        self.create_codeowners(
+            self.project, self.code_mapping, raw="*.py @tiger-team", schema=dump_schema([rule_c])
+        )
+
+        self.assert_ownership_equals(
+            ProjectOwnership.get_owners(
+                self.project.id, {"stacktrace": {"frames": [{"filename": "api/foo.py"}]}}
+            ),
+            (
+                [Actor(self.team.id, Team), Actor(self.team2.id, Team)],
+                [rule_a, rule_c],
+            ),
+        )
+
+    def test_get_autoassign_owners_no_codeowners_or_issueowners(self):
+        assert ProjectOwnership.get_autoassign_owners(self.project.id, {}) == (
+            False,
+            [],
+        )
+
+    def test_get_autoassign_owners_only_issueowners_exists(self):
+        rule_a = Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)])
+        rule_b = Rule(Matcher("path", "src/*"), [Owner("user", self.user.email)])
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id,
+            schema=dump_schema([rule_a, rule_b]),
+        )
+
+        # No data matches
+        assert ProjectOwnership.get_autoassign_owners(self.project.id, {}) == (False, [])
+
+        # No autoassignment on match
+        assert ProjectOwnership.get_autoassign_owners(
+            self.project.id, {"stacktrace": {"frames": [{"filename": "foo.py"}]}}
+        ) == (False, [self.team])
+
+        # autoassignment is True
+        owner = ProjectOwnership.objects.get(project_id=self.project.id)
+        owner.auto_assignment = True
+        owner.save()
+
+        assert ProjectOwnership.get_autoassign_owners(
+            self.project.id, {"stacktrace": {"frames": [{"filename": "foo.py"}]}}
+        ) == (True, [self.team])
+
+    def test_get_autoassign_owners_only_codeowners_exists(self):
+        # This case will never exist bc we create a ProjectOwnership record if none exists when creating a ProjectCodeOwner record.
+        # We have this testcase for potential corrupt data.
+        self.team = self.create_team(
+            organization=self.organization, slug="tiger-team", members=[self.user]
+        )
+        self.code_mapping = self.create_code_mapping(project=self.project)
+
+        rule_a = Rule(Matcher("path", "*.js"), [Owner("team", self.team.slug)])
+
+        self.create_codeowners(
+            self.project,
+            self.code_mapping,
+            raw="*.js @tiger-team",
+            schema=dump_schema([rule_a]),
+        )
+        # No data matches
+        assert ProjectOwnership.get_autoassign_owners(self.project.id, {}) == (False, [])
+
+        # No autoassignment on match
+        assert ProjectOwnership.get_autoassign_owners(
+            self.project.id, {"stacktrace": {"frames": [{"filename": "foo.js"}]}}
+        ) == (False, [self.team])
+
+    def test_get_autoassign_owners_when_codeowners_and_issueowners_exists(self):
+        self.team = self.create_team(
+            organization=self.organization, slug="tiger-team", members=[self.user]
+        )
+        self.team2 = self.create_team(
+            organization=self.organization, slug="dolphin-team", members=[self.user]
+        )
+        self.project = self.create_project(
+            organization=self.organization, teams=[self.team, self.team2]
+        )
+        self.code_mapping = self.create_code_mapping(project=self.project)
+
+        rule_a = Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)])
+        rule_b = Rule(Matcher("path", "src/*"), [Owner("user", self.user.email)])
+        rule_c = Rule(Matcher("path", "*.py"), [Owner("team", self.team2.slug)])
+
+        ProjectOwnership.objects.create(
+            project_id=self.project.id, schema=dump_schema([rule_a, rule_b]), fallthrough=True
+        )
+
+        self.create_codeowners(
+            self.project, self.code_mapping, raw="*.py @tiger-team", schema=dump_schema([rule_c])
+        )
+
+        # No autoassignment on match
+        assert ProjectOwnership.get_autoassign_owners(
+            self.project.id, {"stacktrace": {"frames": [{"filename": "api/foo.py"}]}}
+        ) == (
+            False,
+            [self.team, self.team2],
+        )
+
+        # autoassignment is True
+        owner = ProjectOwnership.objects.get(project_id=self.project.id)
+        owner.auto_assignment = True
+        owner.save()
+
+        assert ProjectOwnership.get_autoassign_owners(
+            self.project.id, {"stacktrace": {"frames": [{"filename": "api/foo.py"}]}}
+        ) == (
+            True,
+            [self.team, self.team2],
+        )
+
+        # more than 2 matches
+        assert ProjectOwnership.get_autoassign_owners(
+            self.project.id, {"stacktrace": {"frames": [{"filename": "src/foo.py"}]}}
+        ) == (
+            True,
+            [self.user, self.team],
         )
 
 

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -19,6 +19,7 @@ class ProjectOwnershipTestCase(TestCase):
 
     def test_get_owners_no_record(self):
         assert ProjectOwnership.get_owners(self.project.id, {}) == (ProjectOwnership.Everyone, None)
+        assert ProjectOwnership.get_owners(self.project.id, {}) == (ProjectOwnership.Everyone, None)
 
     def test_get_owners_basic(self):
         rule_a = Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)])


### PR DESCRIPTION
## Objective:
We need to evaluate our CodeOwner rules wherever the Issuer Owner rules are currently being evaluated. The code is architected such that if we update the ProjectOwnership Model  `get_autoassign_owners` and `get_owners` functions to include the CodeOwner rules, it updates everywhere they are called (EventOwnersEndpoint, post process task, etc.)


## Tests
I wrote tests for the functionality combining both IssueOwners and CodeOwners. I also added base case tests for the `get_autoassign_owners` function.