### PR TITLE
fix(grouping): Pass down only_contributing in iter_subcomponents()

### DIFF
--- a/src/sentry/grouping/component.py
+++ b/src/sentry/grouping/component.py
@@ -106,7 +106,9 @@ class GroupingComponent:
                 if value.id == id:
                     yield value
                 if recursive:
-                    yield from value.iter_subcomponents(id, recursive=True)
+                    yield from value.iter_subcomponents(
+                        id, recursive=True, only_contributing=only_contributing
+                    )
 
     def update(
         self,


### PR DESCRIPTION
`GroupingComponents.iter_subcomponents` produces too many components when `only_contributing` is set to `True`. This apparently hasn't caused any damage yet, because it is only called with `id="stacktrace"` by `remove_non_stacktrace_variants()`.