### PR TITLE
docs: adjust FIELDS "time" comment

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -422,10 +422,8 @@ export const FIELDS: Readonly<Record<FieldKey, ColumnType>> = {
   // issue.id and project.id are omitted on purpose.
   // Customers should use `issue` and `project` instead.
   [FieldKey.TIMESTAMP]: 'date',
-  // time is omitted on purpose. time is timestamp rounded down
-  // to the rollup period (usually 3600 seconds) and presented as
-  // seconds since epoch.
-  // Customers should almost always use `timestamp`.
+  // time is omitted on purpose.
+  // Customers should use `timestamp` or `timestamp.to_hour`.
   [FieldKey.TIMESTAMP_TO_HOUR]: 'date',
   [FieldKey.TIMESTAMP_TO_DAY]: 'date',
 


### PR DESCRIPTION
Now that timestamp.to_hour is implemented, mention that instead.