### PR TITLE
fix(performance): Transaction summary not finishing loading state

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
@@ -3,6 +3,7 @@ import {Location} from 'history';
 
 import {EventQuery} from 'app/actionCreators/events';
 import {Client} from 'app/api';
+import {t} from 'app/locale';
 import EventView, {
   isAPIPayloadSimilar,
   LocationQuery,
@@ -185,7 +186,7 @@ class GenericDiscoverQuery<T, P> extends React.Component<Props<T, P>, State<T>> 
         tableData,
       }));
     } catch (err) {
-      const error = err?.responseJSON?.detail ?? null;
+      const error = err?.responseJSON?.detail || t('An unknown error occurred.');
       this.setState({
         isLoading: false,
         tableFetchID: undefined,

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetQueries.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
 
 import {doEventsRequest} from 'app/actionCreators/events';
@@ -255,11 +254,6 @@ class WidgetQueries extends React.Component<Props, State> {
       } catch (err) {
         const errorMessage = err?.responseJSON?.detail || t('An unknown error occurred.');
         this.setState({errorMessage});
-
-        // We always want to make sure an useful error message is set.
-        if (!err?.responseJSON?.detail) {
-          Sentry.captureException(err);
-        }
       }
     });
   }

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 import {Location} from 'history';
 
 import {Client} from 'app/api';
@@ -145,11 +144,6 @@ class Table extends React.PureComponent<TableProps, TableState> {
           tableData: null,
         });
         setError(message, err.status);
-
-        // We always want to make sure an useful error message is set.
-        if (!err?.responseJSON?.detail) {
-          Sentry.captureException(err);
-        }
       });
   };
 

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -45,6 +45,8 @@ type Props = {
   eventView: EventView;
   transactionName: string;
   organization: Organization;
+  isLoading: boolean;
+  error: string | null;
   totalValues: Record<string, number> | null;
   projects: Project[];
 };
@@ -153,6 +155,8 @@ class SummaryContent extends React.Component<Props, State> {
       eventView,
       organization,
       projects,
+      isLoading,
+      error,
       totalValues,
     } = this.props;
     const {incompatibleAlertNotice} = this.state;
@@ -217,7 +221,7 @@ class SummaryContent extends React.Component<Props, State> {
               {...getTransactionsListSort(location, {
                 p95: totalValues?.p95 ?? 0,
               })}
-              forceLoading={!totalValues}
+              forceLoading={isLoading}
             />
             <RelatedIssues
               organization={organization}
@@ -232,6 +236,8 @@ class SummaryContent extends React.Component<Props, State> {
             <UserStats
               organization={organization}
               location={location}
+              isLoading={isLoading}
+              error={error}
               totals={totalValues}
               transactionName={transactionName}
               eventView={eventView}
@@ -239,6 +245,8 @@ class SummaryContent extends React.Component<Props, State> {
             <SidebarSpacer />
             <SidebarCharts
               organization={organization}
+              isLoading={isLoading}
+              error={error}
               totals={totalValues}
               eventView={eventView}
             />

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -195,16 +195,16 @@ class TransactionSummary extends React.Component<Props, State> {
                 orgSlug={organization.slug}
                 location={location}
               >
-                {({tableData}) => {
-                  const totals = (tableData && tableData.data.length
-                    ? tableData.data[0]
-                    : null) as TotalValues | null;
+                {({isLoading, error, tableData}) => {
+                  const totals = tableData?.data?.[0] ?? null;
                   return (
                     <SummaryContent
                       location={location}
                       organization={organization}
                       eventView={eventView}
                       transactionName={transactionName}
+                      isLoading={isLoading}
+                      error={error}
                       totalValues={totals}
                     />
                   );

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/sidebarCharts.tsx
@@ -37,10 +37,21 @@ type Props = ReactRouter.WithRouterProps & {
   organization: LightWeightOrganization;
   location: Location;
   eventView: EventView;
+  isLoading: boolean;
+  error: string | null;
   totals: Record<string, number> | null;
 };
 
-function SidebarCharts({theme, api, eventView, organization, router, totals}: Props) {
+function SidebarCharts({
+  theme,
+  api,
+  eventView,
+  organization,
+  router,
+  isLoading,
+  error,
+  totals,
+}: Props) {
   const statsPeriod = eventView.statsPeriod;
   const start = eventView.start ? getUtcToLocalDateObject(eventView.start) : undefined;
   const end = eventView.end ? getUtcToLocalDateObject(eventView.end) : undefined;
@@ -158,11 +169,11 @@ function SidebarCharts({theme, api, eventView, organization, router, totals}: Pr
             size="sm"
           />
         </ChartTitle>
-        {totals ? (
-          <ChartValue>{formatFloat(totals[`apdex_${threshold}`], 4)}</ChartValue>
-        ) : (
-          <Placeholder height="24px" />
-        )}
+        <ChartSummaryValue
+          isLoading={isLoading}
+          error={error}
+          value={totals ? formatFloat(totals[`apdex_${threshold}`], 4) : null}
+        />
       </ChartLabel>
 
       <ChartLabel top="160px">
@@ -174,11 +185,11 @@ function SidebarCharts({theme, api, eventView, organization, router, totals}: Pr
             size="sm"
           />
         </ChartTitle>
-        {totals ? (
-          <ChartValue>{formatPercentage(totals.failure_rate)}</ChartValue>
-        ) : (
-          <Placeholder height="24px" />
-        )}
+        <ChartSummaryValue
+          isLoading={isLoading}
+          error={error}
+          value={totals ? formatPercentage(totals.failure_rate) : null}
+        />
       </ChartLabel>
 
       <ChartLabel top="320px">
@@ -190,11 +201,11 @@ function SidebarCharts({theme, api, eventView, organization, router, totals}: Pr
             size="sm"
           />
         </ChartTitle>
-        {totals ? (
-          <ChartValue>{tct('[tpm] tpm', {tpm: formatFloat(totals.tpm, 4)})}</ChartValue>
-        ) : (
-          <Placeholder height="24px" />
-        )}
+        <ChartSummaryValue
+          isLoading={isLoading}
+          error={error}
+          value={totals ? tct('[tpm] tpm', {tpm: formatFloat(totals.tpm, 4)}) : null}
+        />
       </ChartLabel>
 
       <ChartZoom
@@ -248,6 +259,22 @@ function SidebarCharts({theme, api, eventView, organization, router, totals}: Pr
       </ChartZoom>
     </RelativeBox>
   );
+}
+
+type ChartValueProps = {
+  isLoading: boolean;
+  error: string | null;
+  value: React.ReactNode;
+};
+
+function ChartSummaryValue({error, isLoading, value}: ChartValueProps) {
+  if (error) {
+    return <div>{'\u2014'}</div>;
+  } else if (isLoading) {
+    return <Placeholder height="24px" />;
+  } else {
+    return <ChartValue>{value}</ChartValue>;
+  }
 }
 
 const RelativeBox = styled('div')`

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -29,19 +29,30 @@ import VitalInfo from '../vitalDetail/vitalInfo';
 
 type Props = {
   eventView: EventView;
+  isLoading: boolean;
+  error: string | null;
   totals: Record<string, number> | null;
   location: Location;
   organization: Organization;
   transactionName: string;
 };
 
-function UserStats({eventView, totals, location, organization, transactionName}: Props) {
-  let userMisery = <Placeholder height="34px" />;
+function UserStats({
+  eventView,
+  isLoading,
+  error,
+  totals,
+  location,
+  organization,
+  transactionName,
+}: Props) {
+  let userMisery = error !== null ? <div>{'\u2014'}</div> : <Placeholder height="34px" />;
   const threshold = organization.apdexThreshold;
-  let apdex: React.ReactNode = <Placeholder height="24px" />;
+  let apdex: React.ReactNode =
+    error !== null ? <div>{'\u2014'}</div> : <Placeholder height="24px" />;
   let vitalsPassRate: React.ReactNode = null;
 
-  if (totals) {
+  if (!isLoading && error === null && totals) {
     const miserableUsers = Number(totals[`user_misery_${threshold}`]);
     const totalUsers = Number(totals.count_unique_user);
     if (!isNaN(miserableUsers) && !isNaN(totalUsers)) {


### PR DESCRIPTION
When a `NaN` is returned to the transaction summary page, it results in the page
being stuck in a loading state. This change ensures to propagate the error state
and renders the appropriately.