### PR TITLE
fix(discover): Remove truthy check for start/end in discover saved query

### DIFF
--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -43,10 +43,9 @@ class DiscoverSavedQuerySerializer(Serializer):
         # expire queries that are beyond the retention period
         if "start" in obj.query:
             start, end = parse_timestamp(obj.query["start"]), parse_timestamp(obj.query["end"])
-            if start and end:
-                data["expired"], data["start"] = outside_retention_with_modified_start(
-                    start, end, obj.organization
-                )
+            data["expired"], data["start"] = outside_retention_with_modified_start(
+                start, end, obj.organization
+            )
 
         if obj.query.get("all_projects"):
             data["projects"] = list(ALL_ACCESS_PROJECTS)


### PR DESCRIPTION
Legacy Discover Saved Query had different timestamp format that was being
parsed incorrectly. Fixed in migration 0177. We should no longer need
this check.

Blocked by: https://github.com/getsentry/sentry/pull/24418