### PR TITLE
fix(span-view): The indentation in span view in not correct

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanBar.tsx
@@ -1034,9 +1034,9 @@ type TogglerTypes = OmitHtmlDivProps<{
 export const SpanTreeTogglerContainer = styled('div')<TogglerTypes>`
   position: relative;
   height: ${SPAN_ROW_HEIGHT}px;
-  width: ${p => (p.hasToggler ? '40px' : '12px')};
-  min-width: ${p => (p.hasToggler ? '40px' : '12px')};
-  margin-right: ${p => (p.hasToggler ? space(0.5) : space(1))};
+  width: 40px;
+  min-width: 40px;
+  margin-right: ${space(1)};
   z-index: ${zIndex.spanTreeToggler};
   display: flex;
   justify-content: flex-end;
@@ -1121,6 +1121,7 @@ export const SpanTreeToggler = styled('div')<SpanTreeTogglerAndDivProps>`
   align-items: center;
   justify-content: center;
   border-radius: 99px;
+  padding: 0px ${space(0.5)};
   transition: all 0.15s ease-in-out;
   font-size: 10px;
   line-height: 0;


### PR DESCRIPTION
Span view is currently not showing the proper indentation for the parent/child
relationships. Spans that have children are indented further due to the
expand/collapse ui to left causing them to be rendered at the same indentation
as their children. This change indents the children further to make the
hierarchy clearer.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/110999511-7b0bf100-834e-11eb-9423-39a4b0456cf2.png)

## After

![image](https://user-images.githubusercontent.com/10239353/110999472-6b8ca800-834e-11eb-94fc-f97899736918.png)
