### PR TITLE
direnv(feat): Report "guided steps" as well as errors

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -23,6 +23,7 @@ trap notice ERR
 # This is used to group issues on Sentry.io.
 # If an issue does not call info() or die() it will be grouped under this
 error_message="Unknown issue"
+log_level="warning"
 
 notice() {
     [ $? -eq 0 ] && return
@@ -40,7 +41,7 @@ report_to_sentry() {
     if ! require sentry-cli; then
         curl -sL https://sentry.io/get-cli/ | bash
     fi
-    sentry-cli send-event -m "$error_message" --logfile "$_SENTRY_LOG_FILE"
+    sentry-cli send-event -m "$error_message" --logfile "$_SENTRY_LOG_FILE" --level $log_level
     rm "$_SENTRY_LOG_FILE"
 }
 
@@ -71,6 +72,7 @@ EOF
     # When reporting to Sentry, this will allow grouping the errors differently
     # NOTE: The first line of the output is used to group issues
     error_message=( "${@}" )
+    log_level="error"
     return 1
 }
 

--- a/.envrc
+++ b/.envrc
@@ -20,8 +20,9 @@ reset="$(tput sgr0)"
 #      consequently, using "exit" anywhere will skip this notice from showing.
 #      so need to use set -e, and return 1.
 trap notice ERR
-# If no message is given then we will use this as a default
-error_message="Error without message"
+# This is used to group issues on Sentry.io.
+# If an issue does not call info() or die() it will be grouped under this
+error_message="Unknown issue"
 
 notice() {
     [ $? -eq 0 ] && return
@@ -57,6 +58,9 @@ info() {
     cat <<EOF
 ${bold}direnv: ${@}${reset}
 EOF
+    # info() calls happen multiple times in this script. The last info statement
+    # is the one that will be used to group Sentry issues
+    error_message=( "${@}" )
 }
 
 die() {
@@ -65,6 +69,7 @@ ${red}${bold}direnv FATAL: ${@}
 ${reset}
 EOF
     # When reporting to Sentry, this will allow grouping the errors differently
+    # NOTE: The first line of the output is used to group issues
     error_message=( "${@}" )
     return 1
 }
@@ -155,7 +160,7 @@ if [ ! -f "${venv_name}/bin/activate" ]; then
     info "You don't seem to have a virtualenv."
     # If the version doesn't match the contents of .python-version it will fail
     [[ $(pyenv version) ]] || \
-        die "Please run:
+        die "pyenv does not have the right Python version installed. Please run:
     make setup-pyenv && python3.6 -m venv ${venv_name}"
     advice_init_venv "$venv_name"
 fi

--- a/.envrc
+++ b/.envrc
@@ -23,7 +23,7 @@ trap notice ERR
 # This is used to group issues on Sentry.io.
 # If an issue does not call info() or die() it will be grouped under this
 error_message="Unknown issue"
-log_level="warning"
+log_level="info"
 
 notice() {
     [ $? -eq 0 ] && return


### PR DESCRIPTION
This allows for tracking guiding steps that do not call the `die()` function.
<img width="465" alt="image" src="https://user-images.githubusercontent.com/44410/111000248-afcc7800-834f-11eb-8213-c86a362d626f.png">
