### PR TITLE
fix(ui): Add a no padding empty state message for panels

### DIFF
--- a/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
+++ b/src/sentry/static/sentry/app/components/emptyStateWarning.tsx
@@ -7,6 +7,7 @@ import EmptyMessage from 'app/views/settings/components/emptyMessage';
 
 type Props = {
   small?: boolean;
+  noPadding?: boolean;
   children?: React.ReactNode;
   withIcon?: boolean;
   className?: string;
@@ -14,12 +15,13 @@ type Props = {
 
 const EmptyStateWarning = ({
   small = false,
+  noPadding = false,
   withIcon = true,
   children,
   className,
 }: Props) =>
   small ? (
-    <EmptyMessage className={className}>
+    <EmptyMessage className={className} noPadding={noPadding}>
       <SmallMessage>
         {withIcon && <StyledIconSearch color="gray300" size="lg" />}
         {children}

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
@@ -7,8 +7,8 @@ import {Client} from 'app/api';
 import {SectionHeading} from 'app/components/charts/styles';
 import DateTime from 'app/components/dateTime';
 import Duration from 'app/components/duration';
-import {Panel, PanelBody} from 'app/components/panels';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
+import {Panel, PanelBody} from 'app/components/panels';
 import SeenByList from 'app/components/seenByList';
 import TimeSince from 'app/components/timeSince';
 import {IconEllipse} from 'app/icons';
@@ -215,9 +215,11 @@ type Props = {
 
 class Timeline extends React.Component<Props> {
   renderEmptyMessage = () => {
-    return <EmptyStateWarning small withIcon={false} noPadding>
-      <p>{t('No alerts triggered during this time')}</p>
-    </EmptyStateWarning>;
+    return (
+      <EmptyStateWarning small withIcon={false} noPadding>
+        <p>{t('No alerts triggered during this time')}</p>
+      </EmptyStateWarning>
+    );
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
@@ -8,6 +8,7 @@ import {SectionHeading} from 'app/components/charts/styles';
 import DateTime from 'app/components/dateTime';
 import Duration from 'app/components/duration';
 import {Panel, PanelBody} from 'app/components/panels';
+import EmptyStateWarning from 'app/components/emptyStateWarning';
 import SeenByList from 'app/components/seenByList';
 import TimeSince from 'app/components/timeSince';
 import {IconEllipse} from 'app/icons';
@@ -214,7 +215,9 @@ type Props = {
 
 class Timeline extends React.Component<Props> {
   renderEmptyMessage = () => {
-    return <p>{t('No alerts triggered during this time')}</p>;
+    return <EmptyStateWarning small withIcon={false} noPadding>
+      <p>{t('No alerts triggered during this time')}</p>
+    </EmptyStateWarning>;
   };
 
   render() {

--- a/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/emptyMessage.tsx
@@ -12,6 +12,7 @@ type Props = {
   action?: React.ReactElement;
   size?: 'large' | 'medium';
   leftAligned?: boolean;
+  noPadding?: boolean;
 };
 
 type EmptyMessageProps = Omit<React.HTMLProps<HTMLDivElement>, keyof Props> & Props;
@@ -42,12 +43,12 @@ const EmptyMessage = styled(
       ? css`
           max-width: 70%;
           align-items: flex-start;
-          padding: ${space(4)};
+          padding: ${p.noPadding ? 0 : space(4)};
         `
       : css`
           text-align: center;
           align-items: center;
-          padding: ${space(4)} 15%;
+          padding: ${p.noPadding ? 0 : `${space(4)} 15%`};
         `};
   flex-direction: column;
   color: ${p => p.theme.textColor};


### PR DESCRIPTION
Empty alert message looks like this:
![](https://user-images.githubusercontent.com/15015880/111005425-a2a78d00-833f-11eb-8475-b4197872f999.png)
It should look like this to be consistent with panel styles, but we don't want the extra padding since this is a sidebar element
![](https://user-images.githubusercontent.com/15015880/111005467-b94de400-833f-11eb-89eb-831aef10ee67.png)

