### PR TITLE
fix(2fa): Send custom u2f device name on enrollment

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
@@ -252,8 +252,7 @@ class AccountSecurityEnroll extends AsyncView<Props, State> {
 
   // Handle u2f device tap
   handleU2fTap = async (tapData: any) => {
-    const data = {...tapData, ...this.formModel.fields.toJS()};
-
+    const data = {deviceName: this.formModel.fields.get('deviceName'), ...tapData};
     this.setState({loading: true});
 
     try {


### PR DESCRIPTION
This small change fixes #24001.
The device name hasn't been sent to the server from UI, because spread with mobx observable map doesn't work. Using `toJSON()` instead of `toJS()` also works, though since `tapData` contains challenge as a string (as expected by serializer), it should come the last to overwrite the `challenge` object value from `formModel.fields`.

This is my first PR to Sentry, not sure if I have to mention Enterprise team (its label is assigned to the original issue) or add more tests/format PR somehow differently.