### PR TITLE
fix(ui): Change stability score card interval to 1d

### DIFF
--- a/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -122,7 +122,7 @@ class ProjectStabilityScoreCard extends AsyncComponent<Props, State> {
           project: selection.projects[0],
           field: 'sum(session)',
           statsPeriod: '90d',
-          interval: '90d',
+          interval: '1d',
         },
       }
     );


### PR DESCRIPTION
Sessions API is now strict about not allowing intervals to be bigger than 1d.
The logic remains unchanged as we only care about totals, not actual buckets.