### PR TITLE
dev_env(feat): Report issues from sentry runner

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -39,7 +39,8 @@ report_to_sentry() {
     if ! require sentry-cli; then
         curl -sL https://sentry.io/get-cli/ | bash
     fi
-    sentry-cli send-event -m "$error_message" --logfile "$_SENTRY_LOG_FILE"
+    SENTRY_DSN=${SENTRY_DEVENV_DSN} \
+        sentry-cli send-event -m "$error_message" --logfile "$_SENTRY_LOG_FILE"
     rm "$_SENTRY_LOG_FILE"
 }
 
@@ -121,7 +122,7 @@ if [ "$SENTRY_DEVENV_NO_REPORT" ]; then
     info "No development environment errors will be reported (since you've defined SENTRY_DEVENV_NO_REPORT)."
 else
     info "Development errors will be reported to Sentry.io. If you wish to opt-out, set SENTRY_DEVENV_NO_REPORT as an env variable."
-    export SENTRY_DSN=https://23670f54c6254bfd9b7de106637808e9@o1.ingest.sentry.io/1492057
+    export SENTRY_DEVENV_DSN=https://23670f54c6254bfd9b7de106637808e9@o1.ingest.sentry.io/1492057
 fi
 
 ### System ###

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -3,8 +3,17 @@ import click
 import sys
 import sentry
 import datetime
+import sentry_sdk
 from sentry.utils.imports import import_string
 from sentry.utils.compat import map
+
+if not os.environ.get("SENTRY_DEVENV_NO_REPORT"):
+    # This reports to the project sentry-dev-env
+    sentry_sdk.init(
+        dsn="https://23670f54c6254bfd9b7de106637808e9@o1.ingest.sentry.io/1492057",
+    )
+    if os.environ.get("USER"):
+        sentry_sdk.set_user({"username": os.environ.get("USER")})
 
 # We need to run this here because of a concurrency bug in Python's locale
 # with the lazy initialization.

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -7,10 +7,12 @@ import sentry_sdk
 from sentry.utils.imports import import_string
 from sentry.utils.compat import map
 
-if not os.environ.get("SENTRY_DEVENV_NO_REPORT"):
+# SENTRY_DEVENV_DSN gets set up automatically by direnv/.envrc
+# This check prevents executing this code unintentionally (e.g. CI or production)
+if os.environ.get("SENTRY_DEVENV_DSN") and not os.environ.get("SENTRY_DEVENV_NO_REPORT"):
     # This reports to the project sentry-dev-env
     sentry_sdk.init(
-        dsn="https://23670f54c6254bfd9b7de106637808e9@o1.ingest.sentry.io/1492057",
+        dsn=os.environ["SENTRY_DEVENV_DSN"],
     )
     if os.environ.get("USER"):
         sentry_sdk.set_user({"username": os.environ.get("USER")})

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -166,8 +166,6 @@ def configure_sdk():
     from sentry_sdk.integrations.celery import CeleryIntegration
     from sentry_sdk.integrations.redis import RedisIntegration
 
-    assert sentry_sdk.Hub.main.client is None
-
     sdk_options = dict(settings.SENTRY_SDK_CONFIG)
 
     relay_dsn = sdk_options.pop("relay_dsn", None)


### PR DESCRIPTION
Engineers can prevent reporting issues by using the env variable SENTRY_DEVENV_NO_REPORT.