### PR TITLE
feat(stats): Moving some utils from getsentry

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contexts/device/formatMemory.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device/formatMemory.tsx
@@ -1,4 +1,4 @@
-import {formatBytes} from 'app/utils';
+import {formatBytesBase2} from 'app/utils';
 
 function formatMemory(memory_size: number, free_memory: number, usable_memory: number) {
   if (
@@ -10,9 +10,11 @@ function formatMemory(memory_size: number, free_memory: number, usable_memory: n
     return null;
   }
 
-  let memory = `Total: ${formatBytes(memory_size)} / Free: ${formatBytes(free_memory)}`;
+  let memory = `Total: ${formatBytesBase2(memory_size)} / Free: ${formatBytesBase2(
+    free_memory
+  )}`;
   if (Number.isInteger(usable_memory) && usable_memory > 0) {
-    memory = `${memory} / Usable: ${formatBytes(usable_memory)}`;
+    memory = `${memory} / Usable: ${formatBytesBase2(usable_memory)}`;
   }
 
   return memory;

--- a/src/sentry/static/sentry/app/components/events/contexts/device/formatStorage.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/device/formatStorage.tsx
@@ -1,4 +1,4 @@
-import {formatBytes} from 'app/utils';
+import {formatBytesBase2} from 'app/utils';
 
 function formatStorage(
   storage_size: number,
@@ -10,9 +10,9 @@ function formatStorage(
     return null;
   }
 
-  let storage = `Total: ${formatBytes(storage_size)}`;
+  let storage = `Total: ${formatBytesBase2(storage_size)}`;
   if (Number.isInteger(free_storage) && free_storage > 0) {
-    storage = `${storage} / Free: ${formatBytes(free_storage)}`;
+    storage = `${storage} / Free: ${formatBytesBase2(free_storage)}`;
   }
 
   if (
@@ -21,9 +21,9 @@ function formatStorage(
     Number.isInteger(external_free_storage) &&
     external_free_storage > 0
   ) {
-    storage = `${storage} (External Total: ${formatBytes(
+    storage = `${storage} (External Total: ${formatBytesBase2(
       external_storage_size
-    )} / Free: ${formatBytes(external_free_storage)})`;
+    )} / Free: ${formatBytesBase2(external_free_storage)})`;
   }
 
   return storage;

--- a/src/sentry/static/sentry/app/components/events/contexts/gpu/formatMemory.tsx
+++ b/src/sentry/static/sentry/app/components/events/contexts/gpu/formatMemory.tsx
@@ -1,4 +1,4 @@
-import {formatBytes} from 'app/utils';
+import {formatBytesBase2} from 'app/utils';
 
 const MEGABYTE_IN_BYTES = 1048576;
 
@@ -8,7 +8,7 @@ function formatMemory(memory_size: number) {
   }
 
   // 'usable_memory' is in defined in MB
-  return formatBytes(memory_size * MEGABYTE_IN_BYTES);
+  return formatBytesBase2(memory_size * MEGABYTE_IN_BYTES);
 }
 
 export default formatMemory;

--- a/src/sentry/static/sentry/app/components/fileSize.tsx
+++ b/src/sentry/static/sentry/app/components/fileSize.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import {formatBytes} from 'app/utils';
+import {formatBytesBase2} from 'app/utils';
 import getDynamicText from 'app/utils/getDynamicText';
 
 type Props = {
@@ -13,7 +13,7 @@ function FileSize(props: Props) {
 
   return (
     <span className={className}>
-      {getDynamicText({value: formatBytes(bytes), fixed: 'xx KB'})}
+      {getDynamicText({value: formatBytesBase2(bytes), fixed: 'xx KB'})}
     </span>
   );
 }

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -685,6 +685,12 @@ export interface Config {
   demoMode: boolean;
 }
 
+export enum DataCategory {
+  ERRORS = 'errors',
+  TRANSACTIONS = 'transactions',
+  ATTACHMENTS = 'attachments',
+}
+
 export type EventOrGroupType =
   | 'error'
   | 'csp'

--- a/src/sentry/static/sentry/app/utils.tsx
+++ b/src/sentry/static/sentry/app/utils.tsx
@@ -157,7 +157,7 @@ export function toTitleCase(str: string): string {
  * Note the difference between *a-bytes (base 10) vs *i-bytes (base 2), which
  * means that:
  * - 1000 megabytes is equal to 1 gigabyte
- * - 1024 mebibytes is equal to 1024 gibibytes
+ * - 1024 mebibytes is equal to 1 gibibytes
  *
  * We will use base 10 throughout billing for attachments. This function formats
  * quota/usage values for display.
@@ -180,7 +180,7 @@ export function formatBytesBase10(bytes: number, u: number = 0) {
  * Note the difference between *a-bytes (base 10) vs *i-bytes (base 2), which
  * means that:
  * - 1000 megabytes is equal to 1 gigabyte
- * - 1024 mebibytes is equal to 1024 gibibytes
+ * - 1024 mebibytes is equal to 1 gibibytes
  *
  * We will use base 2 to display storage/memory/file sizes as that is commonly
  * used by Windows or RAM or CPU cache sizes, and it is more familiar to the user

--- a/src/sentry/static/sentry/app/utils.tsx
+++ b/src/sentry/static/sentry/app/utils.tsx
@@ -153,8 +153,43 @@ export function toTitleCase(str: string): string {
   );
 }
 
-export function formatBytes(bytes: number): string {
-  const units = ['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+/**
+ * Note the difference between *a-bytes (base 10) vs *i-bytes (base 2), which
+ * means that:
+ * - 1000 megabytes is equal to 1 gigabyte
+ * - 1024 mebibytes is equal to 1024 gibibytes
+ *
+ * We will use base 10 throughout billing for attachments. This function formats
+ * quota/usage values for display.
+ *
+ * For storage/memory/file sizes, please take a look at formatBytesBase2
+ */
+export function formatBytesBase10(bytes: number, u: number = 0) {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const threshold = 1000;
+
+  while (bytes >= threshold) {
+    bytes /= threshold;
+    u += 1;
+  }
+
+  return bytes.toLocaleString(undefined, {maximumFractionDigits: 2}) + ' ' + units[u];
+}
+
+/**
+ * Note the difference between *a-bytes (base 10) vs *i-bytes (base 2), which
+ * means that:
+ * - 1000 megabytes is equal to 1 gigabyte
+ * - 1024 mebibytes is equal to 1024 gibibytes
+ *
+ * We will use base 2 to display storage/memory/file sizes as that is commonly
+ * used by Windows or RAM or CPU cache sizes, and it is more familiar to the user
+ *
+ * For billing-related code around attachments. please take a look at
+ * formatBytesBase10
+ */
+export function formatBytesBase2(bytes: number): string {
+  const units = ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
   const thresh = 1024;
   if (bytes < thresh) {
     return bytes + ' B';

--- a/src/sentry/static/sentry/app/views/usageStats/utils.tsx
+++ b/src/sentry/static/sentry/app/views/usageStats/utils.tsx
@@ -1,0 +1,87 @@
+import {DataCategory} from 'app/types';
+
+export const MILLION = 10 ** 6;
+export const BILLION = 10 ** 9;
+export const UNLIMITED = '∞';
+
+export const GIGABYTE = 10 ** 9;
+
+type formatOptions = {
+  isAbbreviated?: boolean;
+  useUnitScaling?: boolean;
+};
+
+/**
+ * This expects values from CustomerUsageEndpoint, which contains usage
+ * quantities for the data categories that we sell.
+ *
+ * Note: usageQuantity for Attachments should be in BYTES
+ */
+export function formatUsageWithUnits(
+  usageQuantity: number = 0,
+  dataCategory: DataCategory,
+  options: formatOptions = {isAbbreviated: false, useUnitScaling: false}
+) {
+  if (dataCategory !== DataCategory.ATTACHMENTS) {
+    return options.isAbbreviated
+      ? _displayNumber(usageQuantity)
+      : usageQuantity.toLocaleString();
+  }
+
+  if (options.useUnitScaling) {
+    return _formatAttachmentUnits(usageQuantity);
+  }
+
+  const usageGb = usageQuantity / GIGABYTE;
+  return options.isAbbreviated
+    ? `${_displayNumber(usageGb)} GB`
+    : `${usageGb.toLocaleString(undefined, {maximumFractionDigits: 2})} GB`;
+}
+
+/**
+ * Do not use! Exporting only for re-use getsentry.
+ * Use formatReservedWithUnits or formatUsageWithUnits instead.
+ *
+ * This function is different from sentry/utils/formatBytes. Note the
+ * difference between *a-bytes (base 10) vs *i-bytes (base 2), which means that:
+ * - 1000 megabytes is equal to 1 gigabyte
+ * - 1024 mebibytes is equal to 1024 gibibytes
+ *
+ * We will use base 10 throughout billing for attachments. This function formats
+ * quota/usage values for display.
+ *
+ * For storage/memory/file sizes, please take a look at the function in
+ * sentry/utils/formatBytes.
+ */
+export function _formatAttachmentUnits(bytes: number, u: number = 0) {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const threshold = 1000;
+
+  while (bytes >= threshold) {
+    bytes /= threshold;
+    u += 1;
+  }
+
+  return bytes.toLocaleString(undefined, {maximumFractionDigits: 2}) + ' ' + units[u];
+}
+
+/**
+ * Do not use! Exporting only for re-use getsentry.
+ * Use formatReservedWithUnits or formatUsageWithUnits with options.isAbbreviated to true
+ */
+export function _displayNumber(n: number) {
+  if (n >= BILLION) {
+    return (n / BILLION).toLocaleString(undefined, {maximumFractionDigits: 2}) + 'B';
+  }
+
+  if (n >= MILLION) {
+    return (n / MILLION).toLocaleString(undefined, {maximumFractionDigits: 1}) + 'M';
+  }
+
+  if (n >= 1000) {
+    return (n / 1000).toFixed().toLocaleString() + 'K';
+  }
+
+  // Do not show decimals
+  return n.toFixed().toLocaleString();
+}

--- a/src/sentry/static/sentry/app/views/usageStats/utils.tsx
+++ b/src/sentry/static/sentry/app/views/usageStats/utils.tsx
@@ -19,8 +19,7 @@ type FormatOptions = {
 };
 
 /**
- * This expects usage values/quantities for the data categories that we sell and
- * the base unit for it is KB is different from reserved values/quantities
+ * This expects usage values/quantities for the data categories that we sell.
  *
  * Note: usageQuantity for Attachments should be in BYTES
  */
@@ -31,7 +30,7 @@ export function formatUsageWithUnits(
 ) {
   if (dataCategory !== DataCategory.ATTACHMENTS) {
     return options.isAbbreviated
-      ? _abbreviateUsageNumber(usageQuantity)
+      ? abbreviateUsageNumber(usageQuantity)
       : usageQuantity.toLocaleString();
   }
 
@@ -41,15 +40,21 @@ export function formatUsageWithUnits(
 
   const usageGb = usageQuantity / GIGABYTE;
   return options.isAbbreviated
-    ? `${_abbreviateUsageNumber(usageGb)} GB`
+    ? `${abbreviateUsageNumber(usageGb)} GB`
     : `${usageGb.toLocaleString(undefined, {maximumFractionDigits: 2})} GB`;
 }
 
 /**
- * Do not use! Exporting only for re-use getsentry.
- * Use formatReservedWithUnits or formatUsageWithUnits with options.isAbbreviated to true
+ * Instead of using this function directly, use formatReservedWithUnits or
+ * formatUsageWithUnits with options.isAbbreviated to true instead.
+ *
+ * This function display different precision for billion/million/thousand to
+ * provide clarity on usage of errors/transactions/attachments to the user.
+ *
+ * If you are not displaying usage numbers, it might be better to use
+ * `formatAbbreviatedNumber` in 'app/utils/formatters'
  */
-export function _abbreviateUsageNumber(n: number) {
+export function abbreviateUsageNumber(n: number) {
   if (n >= BILLION) {
     return (n / BILLION).toLocaleString(undefined, {maximumFractionDigits: 2}) + 'B';
   }

--- a/src/sentry/static/sentry/app/views/usageStats/utils.tsx
+++ b/src/sentry/static/sentry/app/views/usageStats/utils.tsx
@@ -3,7 +3,6 @@ import {formatBytesBase10} from 'app/utils';
 
 export const MILLION = 10 ** 6;
 export const BILLION = 10 ** 9;
-
 export const GIGABYTE = 10 ** 9;
 
 type FormatOptions = {

--- a/src/sentry/static/sentry/app/views/usageStats/utils.tsx
+++ b/src/sentry/static/sentry/app/views/usageStats/utils.tsx
@@ -1,75 +1,56 @@
 import {DataCategory} from 'app/types';
+import {formatBytesBase10} from 'app/utils';
 
 export const MILLION = 10 ** 6;
 export const BILLION = 10 ** 9;
-export const UNLIMITED = '∞';
 
 export const GIGABYTE = 10 ** 9;
 
-type formatOptions = {
+type FormatOptions = {
+  /**
+   * Truncate 1234 => 1.2k or 1,234,000 to 1.23M
+   */
   isAbbreviated?: boolean;
+
+  /**
+   * Convert attachments to use the most appropriate unit KB/MB/GB/TB/etc.
+   * Otherwise, it will default to GB
+   */
   useUnitScaling?: boolean;
 };
 
 /**
- * This expects values from CustomerUsageEndpoint, which contains usage
- * quantities for the data categories that we sell.
+ * This expects usage values/quantities for the data categories that we sell and
+ * the base unit for it is KB is different from reserved values/quantities
  *
  * Note: usageQuantity for Attachments should be in BYTES
  */
 export function formatUsageWithUnits(
   usageQuantity: number = 0,
   dataCategory: DataCategory,
-  options: formatOptions = {isAbbreviated: false, useUnitScaling: false}
+  options: FormatOptions = {isAbbreviated: false, useUnitScaling: false}
 ) {
   if (dataCategory !== DataCategory.ATTACHMENTS) {
     return options.isAbbreviated
-      ? _displayNumber(usageQuantity)
+      ? _abbreviateUsageNumber(usageQuantity)
       : usageQuantity.toLocaleString();
   }
 
   if (options.useUnitScaling) {
-    return _formatAttachmentUnits(usageQuantity);
+    return formatBytesBase10(usageQuantity);
   }
 
   const usageGb = usageQuantity / GIGABYTE;
   return options.isAbbreviated
-    ? `${_displayNumber(usageGb)} GB`
+    ? `${_abbreviateUsageNumber(usageGb)} GB`
     : `${usageGb.toLocaleString(undefined, {maximumFractionDigits: 2})} GB`;
-}
-
-/**
- * Do not use! Exporting only for re-use getsentry.
- * Use formatReservedWithUnits or formatUsageWithUnits instead.
- *
- * This function is different from sentry/utils/formatBytes. Note the
- * difference between *a-bytes (base 10) vs *i-bytes (base 2), which means that:
- * - 1000 megabytes is equal to 1 gigabyte
- * - 1024 mebibytes is equal to 1024 gibibytes
- *
- * We will use base 10 throughout billing for attachments. This function formats
- * quota/usage values for display.
- *
- * For storage/memory/file sizes, please take a look at the function in
- * sentry/utils/formatBytes.
- */
-export function _formatAttachmentUnits(bytes: number, u: number = 0) {
-  const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-  const threshold = 1000;
-
-  while (bytes >= threshold) {
-    bytes /= threshold;
-    u += 1;
-  }
-
-  return bytes.toLocaleString(undefined, {maximumFractionDigits: 2}) + ' ' + units[u];
 }
 
 /**
  * Do not use! Exporting only for re-use getsentry.
  * Use formatReservedWithUnits or formatUsageWithUnits with options.isAbbreviated to true
  */
-export function _displayNumber(n: number) {
+export function _abbreviateUsageNumber(n: number) {
   if (n >= BILLION) {
     return (n / BILLION).toLocaleString(undefined, {maximumFractionDigits: 2}) + 'B';
   }

--- a/tests/js/spec/views/usageStats/utils.spec.jsx
+++ b/tests/js/spec/views/usageStats/utils.spec.jsx
@@ -1,0 +1,126 @@
+import {DataCategory} from 'app/types';
+import {
+  BILLION,
+  formatUsageWithUnits,
+  GIGABYTE,
+  MILLION,
+} from 'app/views/usageStats/utils';
+
+describe('formatUsageWithUnits', function () {
+  it('returns correct strings for Errors', function () {
+    expect(formatUsageWithUnits(0, DataCategory.ERRORS)).toBe('0');
+    expect(formatUsageWithUnits(1000, DataCategory.ERRORS)).toBe('1,000');
+    expect(formatUsageWithUnits(MILLION, DataCategory.ERRORS)).toBe('1,000,000');
+    expect(formatUsageWithUnits(BILLION, DataCategory.ERRORS)).toBe('1,000,000,000');
+
+    expect(formatUsageWithUnits(0, DataCategory.ERRORS, {isAbbreviated: true})).toBe('0');
+    expect(formatUsageWithUnits(1000, DataCategory.ERRORS, {isAbbreviated: true})).toBe(
+      '1K'
+    );
+    expect(
+      formatUsageWithUnits(MILLION, DataCategory.ERRORS, {isAbbreviated: true})
+    ).toBe('1M');
+    expect(
+      formatUsageWithUnits(1.234 * MILLION, DataCategory.ERRORS, {
+        isAbbreviated: true,
+      })
+    ).toBe('1.2M');
+    expect(
+      formatUsageWithUnits(1.234 * BILLION, DataCategory.ERRORS, {
+        isAbbreviated: true,
+      })
+    ).toBe('1.23B');
+  });
+
+  it('returns correct strings for Transactions', function () {
+    expect(formatUsageWithUnits(0, DataCategory.TRANSACTIONS)).toBe('0');
+    expect(formatUsageWithUnits(1000, DataCategory.TRANSACTIONS)).toBe('1,000');
+    expect(formatUsageWithUnits(MILLION, DataCategory.TRANSACTIONS)).toBe('1,000,000');
+    expect(formatUsageWithUnits(BILLION, DataCategory.TRANSACTIONS)).toBe(
+      '1,000,000,000'
+    );
+
+    expect(
+      formatUsageWithUnits(0, DataCategory.TRANSACTIONS, {isAbbreviated: true})
+    ).toBe('0');
+    expect(
+      formatUsageWithUnits(1000, DataCategory.TRANSACTIONS, {isAbbreviated: true})
+    ).toBe('1K');
+    expect(
+      formatUsageWithUnits(MILLION, DataCategory.TRANSACTIONS, {isAbbreviated: true})
+    ).toBe('1M');
+    expect(
+      formatUsageWithUnits(1.234 * MILLION, DataCategory.TRANSACTIONS, {
+        isAbbreviated: true,
+      })
+    ).toBe('1.2M');
+    expect(
+      formatUsageWithUnits(1.234 * BILLION, DataCategory.TRANSACTIONS, {
+        isAbbreviated: true,
+      })
+    ).toBe('1.23B');
+  });
+
+  it('returns correct strings for Attachments', function () {
+    expect(formatUsageWithUnits(0, DataCategory.ATTACHMENTS)).toBe('0 GB');
+    expect(formatUsageWithUnits(MILLION, DataCategory.ATTACHMENTS)).toBe('0 GB');
+    expect(formatUsageWithUnits(BILLION, DataCategory.ATTACHMENTS)).toBe('1 GB');
+    expect(formatUsageWithUnits(1.234 * BILLION, DataCategory.ATTACHMENTS)).toBe(
+      '1.23 GB'
+    );
+    expect(formatUsageWithUnits(1234 * GIGABYTE, DataCategory.ATTACHMENTS)).toBe(
+      '1,234 GB'
+    );
+
+    expect(formatUsageWithUnits(0, DataCategory.ATTACHMENTS, {isAbbreviated: true})).toBe(
+      '0 GB'
+    );
+    expect(
+      formatUsageWithUnits(MILLION, DataCategory.ATTACHMENTS, {isAbbreviated: true})
+    ).toBe('0 GB');
+    expect(
+      formatUsageWithUnits(BILLION, DataCategory.ATTACHMENTS, {isAbbreviated: true})
+    ).toBe('1 GB');
+    expect(
+      formatUsageWithUnits(1.234 * BILLION, DataCategory.ATTACHMENTS, {
+        isAbbreviated: true,
+      })
+    ).toBe('1 GB');
+    expect(
+      formatUsageWithUnits(1234 * BILLION, DataCategory.ATTACHMENTS, {
+        isAbbreviated: true,
+      })
+    ).toBe('1K GB');
+
+    expect(
+      formatUsageWithUnits(0, DataCategory.ATTACHMENTS, {
+        useUnitScaling: true,
+      })
+    ).toBe('0 B');
+    expect(
+      formatUsageWithUnits(1000, DataCategory.ATTACHMENTS, {
+        useUnitScaling: true,
+      })
+    ).toBe('1 KB');
+    expect(
+      formatUsageWithUnits(MILLION, DataCategory.ATTACHMENTS, {
+        useUnitScaling: true,
+      })
+    ).toBe('1 MB');
+    expect(
+      formatUsageWithUnits(1.234 * MILLION, DataCategory.ATTACHMENTS, {
+        useUnitScaling: true,
+      })
+    ).toBe('1.23 MB');
+    expect(
+      formatUsageWithUnits(1.234 * BILLION, DataCategory.ATTACHMENTS, {
+        useUnitScaling: true,
+      })
+    ).toBe('1.23 GB');
+    expect(
+      formatUsageWithUnits(1234 * BILLION, DataCategory.ATTACHMENTS, {
+        useUnitScaling: true,
+      })
+    ).toBe('1.23 TB');
+  });
+});


### PR DESCRIPTION
Requires https://github.com/getsentry/getsentry/pull/5283

These methods were added to `getsentry` in getsentry/getsentry#4897. After merging, I'll need to open a PR to remove `formatUsageWithUnits` from `getsentry`.