### PR TITLE
feat(trace-view): Support array responses too

### DIFF
--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/traceFullQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/traceFullQuery.tsx
@@ -51,7 +51,9 @@ function TraceFullQuery({traceId, start, end, children, ...props}: QueryProps) {
           // the client returns a empty string when the response
           // is 204. And we want the empty string, undefined and
           // null to be converted to null.
-          trace: tableData || null,
+          // TODO(wmak): replace once the backend starts returning arrays
+          // `(tableData || null)?.[0] ?? null,`
+          trace: (tableData || null)?.[0] ?? (tableData || null),
           type: 'full',
           ...rest,
         })


### PR DESCRIPTION
- This change is so that we can support an array response from the trace endpoint, so we don't break quick trace when https://github.com/getsentry/sentry/pull/24451 merges
- This is because We'll be including orphan traces in the response, so we need to accept an array of traces instead of just the root trace.