### PR TITLE
ref(direnv): Break sentry.io notice onto two lines

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -120,7 +120,7 @@ export SENTRY_UI_HOT_RELOAD=1
 if [ "$SENTRY_DEVENV_NO_REPORT" ]; then
     info "No development environment errors will be reported (since you've defined SENTRY_DEVENV_NO_REPORT)."
 else
-    info "Development errors will be reported to Sentry.io. If you wish to opt-out, set SENTRY_DEVENV_NO_REPORT as an env variable."
+    info "Development errors will be reported to Sentry.io."$'\n'"        If you wish to opt-out, set SENTRY_DEVENV_NO_REPORT as an env variable."
     export SENTRY_DSN=https://23670f54c6254bfd9b7de106637808e9@o1.ingest.sentry.io/1492057
 fi
 


### PR DESCRIPTION
Before 

```
direnv: loading ~/Coding/sentry/.envrc
direnv: Development errors will be reported to Sentry.io. If you wish to opt-out, set SENTRY_DEVENV_NO_REPORT as an env variable.
direnv: Configuring git...
direnv: Activating virtualenv...
direnv: Ensuring proper virtualenv...
direnv: Checking pre-commit...
direnv: Checking node...
direnv: SUCCESS!
```

After 

```
direnv: loading ~/Coding/sentry/.envrc
direnv: Development errors will be reported to Sentry.io.
        If you wish to opt-out, set SENTRY_DEVENV_NO_REPORT as an env variable.
direnv: Configuring git...
direnv: Activating virtualenv...
direnv: Ensuring proper virtualenv...
direnv: Checking pre-commit...
direnv: Checking node...
direnv: SUCCESS!
```