### PR TITLE
fix(discover): Return 400 during invalid Discover Query save

### DIFF
--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -1,9 +1,10 @@
 from django.db.models import Case, When
 from rest_framework.response import Response
+from rest_framework.exceptions import ParseError
 
 from sentry import features
 from sentry.api.serializers import serialize
-from sentry.api.bases import OrganizationEndpoint
+from sentry.api.bases import OrganizationEndpoint, NoProjects
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.discover.models import DiscoverSavedQuery
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
@@ -88,13 +89,16 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
         if not self.has_feature(organization, request):
             return self.respond(status=404)
 
+        try:
+            params = self.get_filter_params(
+                request, organization, project_ids=request.data.get("projects")
+            )
+        except NoProjects:
+            raise ParseError(detail="NoProjects: Join a Team.")
+
         serializer = DiscoverSavedQuerySerializer(
             data=request.data,
-            context={
-                "params": self.get_filter_params(
-                    request, organization, project_ids=request.data.get("projects")
-                )
-            },
+            context={"params": params},
         )
 
         if not serializer.is_valid():

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -94,7 +94,7 @@ class DiscoverSavedQueriesEndpoint(OrganizationEndpoint):
                 request, organization, project_ids=request.data.get("projects")
             )
         except NoProjects:
-            raise ParseError(detail="NoProjects: Join a Team.")
+            raise ParseError(detail="No Projects found, join a Team")
 
         serializer = DiscoverSavedQuerySerializer(
             data=request.data,

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -49,7 +49,7 @@ class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):
                 request, organization, project_ids=request.data.get("projects")
             )
         except NoProjects:
-            raise ParseError(detail="NoProjects: Join a Team.")
+            raise ParseError(detail="No Projects found, join a Team")
 
         serializer = DiscoverSavedQuerySerializer(
             data=request.data,

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -417,7 +417,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
             response = self.client.post(
                 url,
                 {
-                    "name": "project query",
+                    "name": "with team query",
                     "projects": [project.id],
                     "fields": ["title", "count()"],
                     "range": "24h",
@@ -425,7 +425,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
                 },
             )
         assert response.status_code == 201, response.content
-        assert DiscoverSavedQuery.objects.filter(name="project query").exists()
+        assert DiscoverSavedQuery.objects.filter(name="with team query").exists()
 
     def test_save_without_team(self):
         team = self.create_team(organization=self.org, members=[])
@@ -435,7 +435,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
             response = self.client.post(
                 url,
                 {
-                    "name": "project query",
+                    "name": "without team query",
                     "projects": [],
                     "fields": ["title", "count()"],
                     "range": "24h",

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -417,7 +417,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
             response = self.client.post(
                 url,
                 {
-                    "name": "with team query",
+                    "name": "project query",
                     "projects": [project.id],
                     "fields": ["title", "count()"],
                     "range": "24h",
@@ -425,7 +425,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
                 },
             )
         assert response.status_code == 201, response.content
-        assert DiscoverSavedQuery.objects.filter(name="with team query").exists()
+        assert DiscoverSavedQuery.objects.filter(name="project query").exists()
 
     def test_save_without_team(self):
         team = self.create_team(organization=self.org, members=[])
@@ -454,7 +454,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
             response = self.client.post(
                 url,
                 {
-                    "name": "project query",
+                    "name": "with team query",
                     "projects": [],
                     "fields": ["title", "count()"],
                     "range": "24h",
@@ -463,7 +463,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
             )
 
         assert response.status_code == 201, response.content
-        assert DiscoverSavedQuery.objects.filter(name="project query").exists()
+        assert DiscoverSavedQuery.objects.filter(name="with team query").exists()
 
     def test_save_with_wrong_projects(self):
         other_org = self.create_organization(owner=self.user)

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -427,7 +427,7 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
         assert response.status_code == 201, response.content
         assert DiscoverSavedQuery.objects.filter(name="project query").exists()
 
-    def test_save_with_no_team(self):
+    def test_save_without_team(self):
         team = self.create_team(organization=self.org, members=[])
         self.create_project(organization=self.org, teams=[team])
         with self.feature(self.feature_name):
@@ -445,6 +445,25 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
 
         assert response.status_code == 400
         assert "No Projects found, join a Team" == response.data["detail"]
+
+    def test_save_with_team_and_without_project(self):
+        team = self.create_team(organization=self.org, members=[self.user])
+        self.create_project(organization=self.org, teams=[team])
+        with self.feature(self.feature_name):
+            url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
+            response = self.client.post(
+                url,
+                {
+                    "name": "project query",
+                    "projects": [],
+                    "fields": ["title", "count()"],
+                    "range": "24h",
+                    "version": 2,
+                },
+            )
+
+        assert response.status_code == 201, response.content
+        assert DiscoverSavedQuery.objects.filter(name="project query").exists()
 
     def test_save_with_wrong_projects(self):
         other_org = self.create_organization(owner=self.user)

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -427,6 +427,25 @@ class DiscoverSavedQueriesVersion2Test(DiscoverSavedQueryBase):
         assert response.status_code == 201, response.content
         assert DiscoverSavedQuery.objects.filter(name="project query").exists()
 
+    def test_save_with_no_team(self):
+        team = self.create_team(organization=self.org, members=[])
+        self.create_project(organization=self.org, teams=[team])
+        with self.feature(self.feature_name):
+            url = reverse("sentry-api-0-discover-saved-queries", args=[self.org.slug])
+            response = self.client.post(
+                url,
+                {
+                    "name": "project query",
+                    "projects": [],
+                    "fields": ["title", "count()"],
+                    "range": "24h",
+                    "version": 2,
+                },
+            )
+
+        assert response.status_code == 400
+        assert "No Projects found, join a Team" == response.data["detail"]
+
     def test_save_with_wrong_projects(self):
         other_org = self.create_organization(owner=self.user)
         project = self.create_project(organization=other_org)

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -173,6 +173,7 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
             response = self.client.put(url, {"name": "New query", "projects": [], "range": "24h"})
 
             assert response.status_code == 400
+            assert "No Projects found, join a Team" == response.data["detail"]
 
     def test_put_org_without_access(self):
         with self.feature(self.feature_name):

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -132,6 +132,48 @@ class DiscoverSavedQueryDetailTest(APITestCase, SnubaTestCase):
 
             assert response.status_code == 404
 
+    def test_put_query_with_team(self):
+        team = self.create_team(organization=self.org, members=[self.user])
+        project = self.create_project(organization=self.org, teams=[team])
+        query = DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            created_by=self.user,
+            name="Test query",
+            query={"fields": ["test"], "conditions": [], "limit": 10},
+        )
+        query.set_projects([project.id])
+
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-discover-saved-query-detail",
+                args=[self.org.slug, query.id],
+            )
+
+            response = self.client.put(url, {"name": "New query", "projects": [], "range": "24h"})
+
+            assert response.status_code == 200
+
+    def test_put_query_without_team(self):
+        team = self.create_team(organization=self.org, members=[])
+        project = self.create_project(organization=self.org, teams=[team])
+        query = DiscoverSavedQuery.objects.create(
+            organization=self.org,
+            created_by=self.user,
+            name="Test query",
+            query={"fields": ["test"], "conditions": [], "limit": 10},
+        )
+        query.set_projects([project.id])
+
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-discover-saved-query-detail",
+                args=[self.org.slug, query.id],
+            )
+
+            response = self.client.put(url, {"name": "New query", "projects": [], "range": "24h"})
+
+            assert response.status_code == 400
+
     def test_put_org_without_access(self):
         with self.feature(self.feature_name):
             url = reverse(


### PR DESCRIPTION
Members who are not a part of any team cannot save Discover
Query. Return a 400 with a helpful error message suggesting
they join a team.