### PR TITLE
ci(gcb): Prolong build times for Sentry wheel

### DIFF
--- a/docker/cloudbuild.yaml
+++ b/docker/cloudbuild.yaml
@@ -16,7 +16,7 @@ steps:
     id: builder-run
     env:
       - 'SOURCE_COMMIT=$COMMIT_SHA'
-    timeout: 360s
+    timeout: 600s
   - name: 'gcr.io/kaniko-project/executor:v1.3.0'
     id: runtime-image
     waitFor:
@@ -101,7 +101,7 @@ steps:
         [[ ! "$BRANCH_NAME" =~ ^releases/ ]] && exit 0
         npx -p "@zeus-ci/cli" zeus job update --build $BUILD_ID --job 1 --ref $COMMIT_SHA --build-label GCB --job-label "OSS Packages" --status passed
         npx -p "@zeus-ci/cli" zeus upload --build $BUILD_ID --job 1 --type "application/x-pywheel+zip" dist/*.whl
-timeout: 2400s
+timeout: 2640s
 options:
   # We need more memory for Webpack builds & e2e onpremise tests
   machineType: 'N1_HIGHCPU_8'


### PR DESCRIPTION
We've been getting 'context deadline exceeded' errors a bit too frequently recently so this extends the allowed build time for the wheel from 6 minutes to 10 minutes.
