### PR TITLE
ref(integrations): Simplify More Notifications Tests

### DIFF
--- a/src/sentry/api/bases/user.py
+++ b/src/sentry/api/bases/user.py
@@ -49,6 +49,12 @@ class OrganizationUserPermission(UserPermission):
 
 
 class UserEndpoint(Endpoint):
+    """
+    The base endpoint for APIs that deal with Users. Inherit from this class to
+    get permission checks and to automatically convert user ID "me" to the
+    currently logged in user's ID.
+    """
+
     permission_classes = (UserPermission,)
 
     def convert_args(self, request, user_id, *args, **kwargs):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -61,6 +61,7 @@ def _remove_ids_from_dynamic_rules(dynamic_rules):
         del dynamic_rules["next_id"]
     for rule in dynamic_rules["rules"]:
         del rule["id"]
+    return dynamic_rules
 
 
 class ProjectDetailsTest(APITestCase):
@@ -588,12 +589,12 @@ class ProjectUpdateTest(APITestCase):
         """
         Tests that we get the same dynamic sampling rules that previously set
         """
+        data = _dyn_sampling_data()
         with Feature({"organizations:filters-and-sampling": True}):
-            response = self.get_valid_response(
-                self.org_slug, self.proj_slug, dynamicSampling=_dyn_sampling_data()
-            )
+            self.get_valid_response(self.org_slug, self.proj_slug, dynamicSampling=data)
+            response = self.get_valid_response(self.org_slug, self.proj_slug, method="get")
         saved_config = _remove_ids_from_dynamic_rules(response.data["dynamicSampling"])
-        original_data = _remove_ids_from_dynamic_rules(_dyn_sampling_data())
+        original_data = _remove_ids_from_dynamic_rules(data)
         assert saved_config == original_data
 
     def test_dynamic_sampling_rule_id_handling(self):

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -372,7 +372,6 @@ class ProjectUpdateTest(APITestCase):
 
     def test_subscription(self):
         self.get_valid_response(self.org_slug, self.proj_slug, isSubscribed="true")
-        # TODO MARCOS
         assert UserOption.objects.get(user=self.user, project=self.project).value == 1
 
         self.get_valid_response(self.org_slug, self.proj_slug, isSubscribed="false")
@@ -389,11 +388,8 @@ class ProjectUpdateTest(APITestCase):
         assert resp.data["securityToken"] == ""
 
     def test_security_token_header(self):
-        resp = self.get_valid_response(
-            self.org_slug,
-            self.proj_slug,
-            securityTokenHeader="X-Hello-World",
-        )
+        value = "X-Hello-World"
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, securityTokenHeader=value)
         assert self.project.get_option("sentry:token_header") == "X-Hello-World"
         assert resp.data["securityTokenHeader"] == "X-Hello-World"
 
@@ -441,11 +437,8 @@ class ProjectUpdateTest(APITestCase):
         assert resp.data["resolveAge"] == 0
 
     def test_allowed_domains(self):
-        resp = self.get_valid_response(
-            self.org_slug,
-            self.proj_slug,
-            allowedDomains=["foobar.com", "https://example.com"],
-        )
+        value = ["foobar.com", "https://example.com"]
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, allowedDomains=value)
         assert self.project.get_option("sentry:origins") == ["foobar.com", "https://example.com"]
         assert resp.data["allowedDomains"] == ["foobar.com", "https://example.com"]
 
@@ -467,11 +460,8 @@ class ProjectUpdateTest(APITestCase):
         assert resp.data["allowedDomains"] == ["*"]
 
     def test_safe_fields(self):
-        resp = self.get_valid_response(
-            self.org_slug,
-            self.proj_slug,
-            safeFields=["foobar.com", "https://example.com"],
-        )
+        value = ["foobar.com", "https://example.com"]
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, safeFields=value)
         assert self.project.get_option("sentry:safe_fields") == [
             "foobar.com",
             "https://example.com",

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -1,32 +1,29 @@
-from sentry.utils.compat import mock
-from sentry.testutils.helpers import Feature
 import pytest
-
-from django.core.urlresolvers import reverse
 
 from sentry.constants import RESERVED_PROJECT_SLUGS
 from sentry.models import (
+    AuditLogEntry,
+    AuditLogEntryEvent,
+    DeletedProject,
+    EnvironmentProject,
     OrganizationMember,
     OrganizationOption,
     Project,
-    EnvironmentProject,
-    ProjectOwnership,
     ProjectBookmark,
+    ProjectOwnership,
+    ProjectRedirect,
     ProjectStatus,
     ProjectTeam,
     Rule,
     UserOption,
-    DeletedProject,
-    ProjectRedirect,
-    AuditLogEntry,
-    AuditLogEntryEvent,
 )
 from sentry.api.endpoints.project_details import (
     DynamicSamplingSerializer,
     DynamicSamplingConditionSerializer,
 )
 from sentry.testutils import APITestCase
-from sentry.utils.compat import zip
+from sentry.testutils.helpers import Feature
+from sentry.utils.compat import mock, zip
 
 
 def _dyn_sampling_data():
@@ -67,15 +64,13 @@ def _remove_ids_from_dynamic_rules(dynamic_rules):
 
 
 class ProjectDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-project-details"
+
     def test_simple(self):
         project = self.project  # force creation
         self.login_as(user=self.user)
-        url = reverse(
-            "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
-        )
-        response = self.client.get(url)
-        assert response.status_code == 200
+
+        response = self.get_valid_response(project.organization.slug, project.slug)
         assert response.data["id"] == str(project.id)
 
     def test_numeric_org_slug(self):
@@ -84,6 +79,7 @@ class ProjectDetailsTest(APITestCase):
         org = self.create_organization(name="baz", slug="1", owner=self.user)
         team = self.create_team(organization=org, name="foo", slug="foo")
         project = self.create_project(name="Bar", slug="bar", teams=[team])
+
         # We want to make sure we don't hit the LegacyProjectRedirect view at all.
         url = f"/api/0/projects/{org.slug}/{project.slug}/"
         response = self.client.get(url)
@@ -94,40 +90,30 @@ class ProjectDetailsTest(APITestCase):
         project = self.create_project()
         self.create_group(project=project)
         self.login_as(user=self.user)
-        url = reverse(
-            "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+
+        response = self.get_valid_response(
+            project.organization.slug, project.slug, qs_params={"include": "stats"}
         )
-        response = self.client.get(url + "?include=stats")
-        assert response.status_code == 200
         assert response.data["stats"]["unresolved"] == 1
 
     def test_with_dynamic_sampling_rules(self):
         project = self.project  # force creation
         project.update_option("sentry:dynamic_sampling", _dyn_sampling_data())
         self.login_as(user=self.user)
-        url = reverse(
-            "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
-        )
-        response = self.client.get(url)
-        assert response.status_code == 200
+
+        response = self.get_valid_response(project.organization.slug, project.slug)
         assert response.data["dynamicSampling"] == _dyn_sampling_data()
 
     def test_project_renamed_302(self):
         project = self.create_project()
         self.login_as(user=self.user)
 
-        url = reverse(
-            "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+        # Rename the project
+        self.get_valid_response(
+            project.organization.slug, project.slug, method="put", slug="foobar"
         )
 
-        # Rename the project
-        self.client.put(url, data={"slug": "foobar"})
-
-        response = self.client.get(url)
-        assert response.status_code == 302
+        response = self.get_valid_response(project.organization.slug, project.slug, status_code=302)
         assert response.data["slug"] == "foobar"
         assert (
             response.data["detail"]["extra"]["url"]
@@ -147,50 +133,40 @@ class ProjectDetailsTest(APITestCase):
         other_org = self.create_organization()
         other_project = self.create_project(organization=other_org)
         ProjectRedirect.record(other_project, "old_slug")
-
-        url = reverse(
-            "sentry-api-0-project-details",
-            kwargs={"organization_slug": other_org.slug, "project_slug": "old_slug"},
-        )
         self.login_as(user=user)
-        response = self.client.get(url)
-        assert response.status_code == 403
+
+        self.get_valid_response(other_org.slug, "old_slug", status_code=403)
 
 
 class ProjectUpdateTest(APITestCase):
+    endpoint = "sentry-api-0-project-details"
+    method = "put"
+
     def setUp(self):
         super().setUp()
-        self.path = reverse(
-            "sentry-api-0-project-details",
-            kwargs={
-                "organization_slug": self.project.organization.slug,
-                "project_slug": self.project.slug,
-            },
-        )
+        self.org_slug = self.project.organization.slug
+        self.proj_slug = self.project.slug
         self.login_as(user=self.user)
 
     def test_blank_subject_prefix(self):
         project = Project.objects.get(id=self.project.id)
         options = {"mail:subject_prefix": "[Sentry]"}
-        resp = self.client.put(self.path, data={"options": options})
-        assert resp.status_code == 200, resp.content
+
+        self.get_valid_response(self.org_slug, self.proj_slug, options=options)
         assert project.get_option("mail:subject_prefix") == "[Sentry]"
 
         options["mail:subject_prefix"] = ""
-        resp = self.client.put(self.path, data={"options": options})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, options=options)
         assert project.get_option("mail:subject_prefix") == ""
 
     def test_team_changes_deprecated(self):
         project = self.create_project()
         team = self.create_team(members=[self.user])
         self.login_as(user=self.user)
-        url = reverse(
-            "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+
+        resp = self.get_valid_response(
+            self.org_slug, self.proj_slug, team=team.slug, status_code=400
         )
-        resp = self.client.put(url, data={"team": team.slug})
-        assert resp.status_code == 400, resp.content
         assert resp.data["detail"][0] == "Editing a team via this endpoint has been deprecated."
 
         project = Project.objects.get(id=project.id)
@@ -206,8 +182,14 @@ class ProjectUpdateTest(APITestCase):
             role="member",
         )
         self.login_as(user)
-        resp = self.client.put(self.path, data={"slug": "zzz", "isBookmarked": "true"})
-        assert resp.status_code == 403
+
+        self.get_valid_response(
+            self.org_slug,
+            self.proj_slug,
+            slug="zzz",
+            isBookmarked="true",
+            status_code=403,
+        )
         assert not ProjectBookmark.objects.filter(user=user, project_id=self.project.id).exists()
 
     def test_member_changes_permission_denied(self):
@@ -220,54 +202,59 @@ class ProjectUpdateTest(APITestCase):
             role="member",
         )
         self.login_as(user=user)
-        url = reverse(
-            "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
+
+        self.get_valid_response(
+            self.org_slug,
+            self.proj_slug,
+            slug="zzz",
+            isBookmarked="true",
+            status_code=403,
         )
-        response = self.client.put(url, data={"slug": "zzz", "isBookmarked": "true"})
-        assert response.status_code == 403
 
         assert Project.objects.get(id=project.id).slug != "zzz"
 
         assert not ProjectBookmark.objects.filter(user=user, project_id=project.id).exists()
 
     def test_name(self):
-        resp = self.client.put(self.path, data={"name": "hello world"})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, name="hello world")
         project = Project.objects.get(id=self.project.id)
         assert project.name == "hello world"
 
     def test_slug(self):
-        resp = self.client.put(self.path, data={"slug": "foobar"})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, slug="foobar")
         project = Project.objects.get(id=self.project.id)
         assert project.slug == "foobar"
-        assert ProjectRedirect.objects.filter(project=self.project, redirect_slug=self.project.slug)
+        assert ProjectRedirect.objects.filter(project=self.project, redirect_slug=self.proj_slug)
         assert AuditLogEntry.objects.filter(
             organization=project.organization, event=AuditLogEntryEvent.PROJECT_EDIT
         ).exists()
 
     def test_invalid_slug(self):
         new_project = self.create_project()
-        resp = self.client.put(self.path, data={"slug": new_project.slug})
-
-        assert resp.status_code == 400
+        self.get_valid_response(
+            self.org_slug,
+            self.proj_slug,
+            slug=new_project.slug,
+            status_code=400,
+        )
         project = Project.objects.get(id=self.project.id)
         assert project.slug != new_project.slug
 
     def test_reserved_slug(self):
-        resp = self.client.put(self.path, data={"slug": list(RESERVED_PROJECT_SLUGS)[0]})
-        assert resp.status_code == 400, resp.content
+        self.get_valid_response(
+            self.org_slug,
+            self.proj_slug,
+            slug=list(RESERVED_PROJECT_SLUGS)[0],
+            status_code=400,
+        )
 
     def test_platform(self):
-        resp = self.client.put(self.path, data={"platform": "python"})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, platform="python")
         project = Project.objects.get(id=self.project.id)
         assert project.platform == "python"
 
     def test_platform_invalid(self):
-        resp = self.client.put(self.path, data={"platform": "lol"})
-        assert resp.status_code == 400, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, platform="lol", status_code=400)
 
     def test_options(self):
         options = {
@@ -293,8 +280,8 @@ class ProjectUpdateTest(APITestCase):
             "sentry:verify_ssl": False,
         }
         with self.feature("projects:custom-inbound-filters"):
-            resp = self.client.put(self.path, data={"options": options})
-        assert resp.status_code == 200, resp.content
+            self.get_valid_response(self.org_slug, self.proj_slug, options=options)
+
         project = Project.objects.get(id=self.project.id)
         assert project.get_option("sentry:origins", []) == options["sentry:origins"].split("\n")
         assert project.get_option("sentry:resolve_age", 0) == options["sentry:resolve_age"]
@@ -378,117 +365,113 @@ class ProjectUpdateTest(APITestCase):
         ).exists()
 
     def test_bookmarks(self):
-        resp = self.client.put(self.path, data={"isBookmarked": "false"})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, isBookmarked="false")
         assert not ProjectBookmark.objects.filter(
             project_id=self.project.id, user=self.user
         ).exists()
 
     def test_subscription(self):
-        resp = self.client.put(self.path, data={"isSubscribed": "true"})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, isSubscribed="true")
+        # TODO MARCOS
         assert UserOption.objects.get(user=self.user, project=self.project).value == 1
 
-        resp = self.client.put(self.path, data={"isSubscribed": "false"})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, isSubscribed="false")
         assert UserOption.objects.get(user=self.user, project=self.project).value == 0
 
     def test_security_token(self):
-        resp = self.client.put(self.path, data={"securityToken": "fizzbuzz"})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, securityToken="fizzbuzz")
         assert self.project.get_security_token() == "fizzbuzz"
         assert resp.data["securityToken"] == "fizzbuzz"
 
         # can delete
-        resp = self.client.put(self.path, data={"securityToken": ""})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, securityToken="")
         assert self.project.get_security_token() == ""
         assert resp.data["securityToken"] == ""
 
     def test_security_token_header(self):
-        resp = self.client.put(self.path, data={"securityTokenHeader": "X-Hello-World"})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(
+            self.org_slug,
+            self.proj_slug,
+            securityTokenHeader="X-Hello-World",
+        )
         assert self.project.get_option("sentry:token_header") == "X-Hello-World"
         assert resp.data["securityTokenHeader"] == "X-Hello-World"
 
         # can delete
-        resp = self.client.put(self.path, data={"securityTokenHeader": ""})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, securityTokenHeader="")
         assert self.project.get_option("sentry:token_header") == ""
         assert resp.data["securityTokenHeader"] == ""
 
     def test_verify_ssl(self):
-        resp = self.client.put(self.path, data={"verifySSL": False})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, verifySSL=False)
         assert self.project.get_option("sentry:verify_ssl") is False
         assert resp.data["verifySSL"] is False
 
     def test_scrub_ip_address(self):
-        resp = self.client.put(self.path, data={"scrubIPAddresses": True})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, scrubIPAddresses=True)
         assert self.project.get_option("sentry:scrub_ip_address") is True
         assert resp.data["scrubIPAddresses"] is True
 
-        resp = self.client.put(self.path, data={"scrubIPAddresses": False})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, scrubIPAddresses=False)
         assert self.project.get_option("sentry:scrub_ip_address") is False
         assert resp.data["scrubIPAddresses"] is False
 
     def test_scrape_javascript(self):
-        resp = self.client.put(self.path, data={"scrapeJavaScript": False})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, scrapeJavaScript=False)
         assert self.project.get_option("sentry:scrape_javascript") is False
         assert resp.data["scrapeJavaScript"] is False
 
     def test_default_environment(self):
-        resp = self.client.put(self.path, data={"defaultEnvironment": "dev"})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, defaultEnvironment="dev")
         assert self.project.get_option("sentry:default_environment") == "dev"
         assert resp.data["defaultEnvironment"] == "dev"
 
-        resp = self.client.put(self.path, data={"defaultEnvironment": ""})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, defaultEnvironment="")
         assert self.project.get_option("sentry:default_environment") == ""
         assert resp.data["defaultEnvironment"] == ""
 
     def test_resolve_age(self):
-        resp = self.client.put(self.path, data={"resolveAge": 5})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, resolveAge=5)
         assert self.project.get_option("sentry:resolve_age") == 5
         assert resp.data["resolveAge"] == 5
 
         # can set to 0 or delete
-        resp = self.client.put(self.path, data={"resolveAge": ""})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, resolveAge="")
         assert self.project.get_option("sentry:resolve_age") == 0
         assert resp.data["resolveAge"] == 0
 
     def test_allowed_domains(self):
-        resp = self.client.put(
-            self.path, data={"allowedDomains": ["foobar.com", "https://example.com"]}
+        resp = self.get_valid_response(
+            self.org_slug,
+            self.proj_slug,
+            allowedDomains=["foobar.com", "https://example.com"],
         )
-        assert resp.status_code == 200, resp.content
         assert self.project.get_option("sentry:origins") == ["foobar.com", "https://example.com"]
         assert resp.data["allowedDomains"] == ["foobar.com", "https://example.com"]
 
         # cannot be empty
-        resp = self.client.put(self.path, data={"allowedDomains": ""})
-        assert resp.status_code == 400, resp.content
+        resp = self.get_valid_response(
+            self.org_slug, self.proj_slug, allowedDomains="", status_code=400
+        )
         assert self.project.get_option("sentry:origins") == ["foobar.com", "https://example.com"]
         assert resp.data["allowedDomains"] == [
             "Empty value will block all requests, use * to accept from all domains"
         ]
 
-        resp = self.client.put(self.path, data={"allowedDomains": ["*", ""]})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(
+            self.org_slug,
+            self.proj_slug,
+            allowedDomains=["*", ""],
+        )
         assert self.project.get_option("sentry:origins") == ["*"]
         assert resp.data["allowedDomains"] == ["*"]
 
     def test_safe_fields(self):
-        resp = self.client.put(
-            self.path, data={"safeFields": ["foobar.com", "https://example.com"]}
+        resp = self.get_valid_response(
+            self.org_slug,
+            self.proj_slug,
+            safeFields=["foobar.com", "https://example.com"],
         )
-        assert resp.status_code == 200, resp.content
         assert self.project.get_option("sentry:safe_fields") == [
             "foobar.com",
             "https://example.com",
@@ -496,23 +479,19 @@ class ProjectUpdateTest(APITestCase):
         assert resp.data["safeFields"] == ["foobar.com", "https://example.com"]
 
     def test_store_crash_reports(self):
-        resp = self.client.put(self.path, data={"storeCrashReports": 10})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, storeCrashReports=10)
         assert self.project.get_option("sentry:store_crash_reports") == 10
         assert resp.data["storeCrashReports"] == 10
 
     def test_relay_pii_config(self):
         value = '{"applications": {"freeform": []}}'
-        resp = self.client.put(self.path, data={"relayPiiConfig": value})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, relayPiiConfig=value)
         assert self.project.get_option("sentry:relay_pii_config") == value
         assert resp.data["relayPiiConfig"] == value
 
     def test_sensitive_fields(self):
-        resp = self.client.put(
-            self.path, data={"sensitiveFields": ["foobar.com", "https://example.com"]}
-        )
-        assert resp.status_code == 200, resp.content
+        value = ["foobar.com", "https://example.com"]
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, sensitiveFields=value)
         assert self.project.get_option("sentry:sensitive_fields") == [
             "foobar.com",
             "https://example.com",
@@ -520,39 +499,34 @@ class ProjectUpdateTest(APITestCase):
         assert resp.data["sensitiveFields"] == ["foobar.com", "https://example.com"]
 
     def test_data_scrubber(self):
-        resp = self.client.put(self.path, data={"dataScrubber": False})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, dataScrubber=False)
         assert self.project.get_option("sentry:scrub_data") is False
         assert resp.data["dataScrubber"] is False
 
     def test_data_scrubber_defaults(self):
-        resp = self.client.put(self.path, data={"dataScrubberDefaults": False})
-        assert resp.status_code == 200, resp.content
+        resp = self.get_valid_response(self.org_slug, self.proj_slug, dataScrubberDefaults=False)
         assert self.project.get_option("sentry:scrub_defaults") is False
         assert resp.data["dataScrubberDefaults"] is False
 
     def test_digests_delay(self):
-        resp = self.client.put(self.path, data={"digestsMinDelay": 1000})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, digestsMinDelay=1000)
         assert self.project.get_option("digests:mail:minimum_delay") == 1000
 
-        resp = self.client.put(self.path, data={"digestsMaxDelay": 1200})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, digestsMaxDelay=1200)
         assert self.project.get_option("digests:mail:maximum_delay") == 1200
 
-        resp = self.client.put(self.path, data={"digestsMinDelay": 300, "digestsMaxDelay": 600})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(
+            self.org_slug, self.proj_slug, digestsMinDelay=300, digestsMaxDelay=600
+        )
         assert self.project.get_option("digests:mail:minimum_delay") == 300
         assert self.project.get_option("digests:mail:maximum_delay") == 600
 
     def test_digests_min_without_max(self):
-        resp = self.client.put(self.path, data={"digestsMinDelay": 1200})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, digestsMinDelay=1200)
         assert self.project.get_option("digests:mail:minimum_delay") == 1200
 
     def test_digests_max_without_min(self):
-        resp = self.client.put(self.path, data={"digestsMaxDelay": 1200})
-        assert resp.status_code == 200, resp.content
+        self.get_valid_response(self.org_slug, self.proj_slug, digestsMaxDelay=1200)
         assert self.project.get_option("digests:mail:maximum_delay") == 1200
 
     def test_invalid_digests_min_delay(self):
@@ -560,11 +534,11 @@ class ProjectUpdateTest(APITestCase):
 
         self.project.update_option("digests:mail:minimum_delay", min_delay)
 
-        resp = self.client.put(self.path, data={"digestsMinDelay": 59})
-        assert resp.status_code == 400
+        self.get_valid_response(self.org_slug, self.proj_slug, digestsMinDelay=59, status_code=400)
+        self.get_valid_response(
+            self.org_slug, self.proj_slug, digestsMinDelay=3601, status_code=400
+        )
 
-        resp = self.client.put(self.path, data={"digestsMinDelay": 3601})
-        assert resp.status_code == 400
         assert self.project.get_option("digests:mail:minimum_delay") == min_delay
 
     def test_invalid_digests_max_delay(self):
@@ -574,35 +548,37 @@ class ProjectUpdateTest(APITestCase):
         self.project.update_option("digests:mail:minimum_delay", min_delay)
         self.project.update_option("digests:mail:maximum_delay", max_delay)
 
-        resp = self.client.put(self.path, data={"digestsMaxDelay": 59})
-        assert resp.status_code == 400
+        self.get_valid_response(self.org_slug, self.proj_slug, digestsMaxDelay=59, status_code=400)
+        self.get_valid_response(
+            self.org_slug, self.proj_slug, digestsMaxDelay=3601, status_code=400
+        )
 
-        resp = self.client.put(self.path, data={"digestsMaxDelay": 3601})
-        assert resp.status_code == 400
         assert self.project.get_option("digests:mail:maximum_delay") == max_delay
 
         # test sending only max
-        resp = self.client.put(self.path, data={"digestsMaxDelay": 100})
-        assert resp.status_code == 400
+        self.get_valid_response(self.org_slug, self.proj_slug, digestsMaxDelay=100, status_code=400)
         assert self.project.get_option("digests:mail:maximum_delay") == max_delay
 
         # test sending min + invalid max
-        resp = self.client.put(self.path, data={"digestsMinDelay": 120, "digestsMaxDelay": 100})
-        assert resp.status_code == 400
+        self.get_valid_response(
+            self.org_slug, self.proj_slug, digestsMinDelay=120, digestsMaxDelay=100, status_code=400
+        )
         assert self.project.get_option("digests:mail:minimum_delay") == min_delay
         assert self.project.get_option("digests:mail:maximum_delay") == max_delay
 
     def test_dynamic_sampling_requires_feature_enabled(self):
-        resp = self.client.put(self.path, data={"dynamicSampling": _dyn_sampling_data()})
-        assert resp.status_code == 403
+        self.get_valid_response(
+            self.org_slug, self.proj_slug, dynamicSampling=_dyn_sampling_data(), status_code=403
+        )
 
     def test_setting_dynamic_sampling_rules(self):
         """
         Test that we can set sampling rules
         """
         with Feature({"organizations:filters-and-sampling": True}):
-            resp = self.client.put(self.path, data={"dynamicSampling": _dyn_sampling_data()})
-            assert resp.status_code == 200, resp.content
+            self.get_valid_response(
+                self.org_slug, self.proj_slug, dynamicSampling=_dyn_sampling_data()
+            )
         original_config = _dyn_sampling_data()
         saved_config = self.project.get_option("sentry:dynamic_sampling")
         # test that we have unique ids
@@ -623,10 +599,9 @@ class ProjectUpdateTest(APITestCase):
         Tests that we get the same dynamic sampling rules that previously set
         """
         with Feature({"organizations:filters-and-sampling": True}):
-            resp = self.client.put(self.path, data={"dynamicSampling": _dyn_sampling_data()})
-            assert resp.status_code == 200, resp.content
-        response = self.client.get(self.path)
-        assert response.status_code == 200
+            response = self.get_valid_response(
+                self.org_slug, self.proj_slug, dynamicSampling=_dyn_sampling_data()
+            )
         saved_config = _remove_ids_from_dynamic_rules(response.data["dynamicSampling"])
         original_data = _remove_ids_from_dynamic_rules(_dyn_sampling_data())
         assert saved_config == original_data
@@ -673,9 +648,8 @@ class ProjectUpdateTest(APITestCase):
             ]
         }
         with Feature({"organizations:filters-and-sampling": True}):
-            resp = self.client.put(self.path, data={"dynamicSampling": config})
-            assert resp.status_code == 200, resp.content
-        response = self.client.get(self.path)
+            self.get_valid_response(self.org_slug, self.proj_slug, dynamicSampling=config)
+        response = self.get_valid_response(self.org_slug, self.proj_slug, method="get")
         saved_config = response.data["dynamicSampling"]
         next_id = saved_config["next_id"]
         id1 = saved_config["rules"][0]["id"]
@@ -720,9 +694,8 @@ class ProjectUpdateTest(APITestCase):
             # turn it back from ordered dict to dict (both main obj and rules)
             saved_config = dict(saved_config)
             saved_config["rules"] = [dict(rule) for rule in saved_config["rules"]]
-            resp = self.client.put(self.path, data={"dynamicSampling": saved_config})
-            assert resp.status_code == 200, resp.content
-        response = self.client.get(self.path)
+            self.get_valid_response(self.org_slug, self.proj_slug, dynamicSampling=saved_config)
+        response = self.get_valid_response(self.org_slug, self.proj_slug, method="get")
         saved_config = response.data["dynamicSampling"]
         new_ids = [rule["id"] for rule in saved_config["rules"]]
         # first rule is new, second rule got a new id because it is changed,
@@ -733,6 +706,9 @@ class ProjectUpdateTest(APITestCase):
 
 
 class CopyProjectSettingsTest(APITestCase):
+    endpoint = "sentry-api-0-project-details"
+    method = "put"
+
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
@@ -765,12 +741,6 @@ class CopyProjectSettingsTest(APITestCase):
         Rule.objects.create(project=self.other_project, label="rule3")
         # there is a default rule added to project
         self.rules = Rule.objects.filter(project_id=self.other_project.id).order_by("label")
-
-    def path(self, project):
-        return reverse(
-            "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
-        )
 
     def assert_other_project_settings_not_changed(self):
         # other_project should not have changed. This should check that.
@@ -815,26 +785,25 @@ class CopyProjectSettingsTest(APITestCase):
 
     def test_simple(self):
         project = self.create_project()
-        resp = self.client.put(
-            self.path(project), data={"copy_from_project": self.other_project.id}
+        self.get_valid_response(
+            project.organization.slug, project.slug, copy_from_project=self.other_project.id
         )
-        assert resp.status_code == 200
         self.assert_settings_copied(project)
         self.assert_other_project_settings_not_changed()
 
     def test_additional_params_in_payload(self):
         # Right now these are overwritten with the copied project's settings
         project = self.create_project()
-        resp = self.client.put(
-            self.path(project),
-            data={
+        self.get_valid_response(
+            project.organization.slug,
+            project.slug,
+            **{
                 "copy_from_project": self.other_project.id,
                 "sentry:resolve_age": 2,
                 "sentry:scrub_data": True,
                 "sentry:scrub_defaults": True,
             },
         )
-        assert resp.status_code == 200
         self.assert_settings_copied(project)
         self.assert_other_project_settings_not_changed()
 
@@ -843,16 +812,21 @@ class CopyProjectSettingsTest(APITestCase):
         other_project = self.create_project(
             organization=self.create_organization(), fire_project_created=True
         )
-        resp = self.client.put(self.path(project), data={"copy_from_project": other_project.id})
-        assert resp.status_code == 400
+        resp = self.get_valid_response(
+            project.organization.slug,
+            project.slug,
+            copy_from_project=other_project.id,
+            status_code=400,
+        )
         assert resp.data == {"copy_from_project": ["Project to copy settings from not found."]}
         self.assert_settings_not_copied(project)
         self.assert_settings_not_copied(other_project)
 
     def test_project_does_not_exist(self):
         project = self.create_project(fire_project_created=True)
-        resp = self.client.put(self.path(project), data={"copy_from_project": 1234567890})
-        assert resp.status_code == 400
+        resp = self.get_valid_response(
+            project.organization.slug, project.slug, copy_from_project=1234567890, status_code=400
+        )
         assert resp.data == {"copy_from_project": ["Project to copy settings from not found."]}
         self.assert_settings_not_copied(project)
 
@@ -867,10 +841,12 @@ class CopyProjectSettingsTest(APITestCase):
 
         self.organization.flags.allow_joinleave = False
         self.organization.save()
-        resp = self.client.put(
-            self.path(project), data={"copy_from_project": self.other_project.id}
+        resp = self.get_valid_response(
+            project.organization.slug,
+            project.slug,
+            copy_from_project=self.other_project.id,
+            status_code=400,
         )
-        assert resp.status_code == 400
         assert resp.data == {
             "copy_from_project": [
                 "Project settings cannot be copied from a project you do not have access to."
@@ -896,10 +872,13 @@ class CopyProjectSettingsTest(APITestCase):
         self.organization.flags.allow_joinleave = False
         self.organization.save()
 
-        resp = self.client.put(
-            self.path(project), data={"copy_from_project": self.other_project.id}
+        resp = self.get_valid_response(
+            project.organization.slug,
+            project.slug,
+            copy_from_project=self.other_project.id,
+            status_code=400,
         )
-        assert resp.status_code == 400
+
         assert resp.data == {
             "copy_from_project": [
                 "Project settings cannot be copied from a project with a team you do not have write access to."
@@ -912,16 +891,21 @@ class CopyProjectSettingsTest(APITestCase):
     def test_copy_project_settings_fails(self, mock_copy_settings_from):
         mock_copy_settings_from.return_value = False
         project = self.create_project(fire_project_created=True)
-        resp = self.client.put(
-            self.path(project), data={"copy_from_project": self.other_project.id}
+        resp = self.get_valid_response(
+            project.organization.slug,
+            project.slug,
+            copy_from_project=self.other_project.id,
+            status_code=409,
         )
-        assert resp.status_code == 409
         assert resp.data == {"detail": ["Copy project settings failed."]}
         self.assert_settings_not_copied(project)
         self.assert_other_project_settings_not_changed()
 
 
 class ProjectDeleteTest(APITestCase):
+    endpoint = "sentry-api-0-project-details"
+    method = "delete"
+
     @mock.patch("sentry.db.mixin.uuid4")
     @mock.patch("sentry.api.endpoints.project_details.uuid4")
     @mock.patch("sentry.api.endpoints.project_details.delete_project")
@@ -935,15 +919,8 @@ class ProjectDeleteTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = reverse(
-            "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
-        )
-
         with self.settings(SENTRY_PROJECT=0):
-            response = self.client.delete(url)
-
-        assert response.status_code == 204
+            self.get_valid_response(project.organization.slug, project.slug, status_code=204)
 
         mock_delete_project.apply_async.assert_called_once_with(
             kwargs={"object_id": project.id, "transaction_id": "abc123"}, countdown=3600
@@ -965,17 +942,10 @@ class ProjectDeleteTest(APITestCase):
 
         self.login_as(user=self.user)
 
-        url = reverse(
-            "sentry-api-0-project-details",
-            kwargs={"organization_slug": project.organization.slug, "project_slug": project.slug},
-        )
-
         with self.settings(SENTRY_PROJECT=project.id):
-            response = self.client.delete(url)
+            self.get_valid_response(project.organization.slug, project.slug, status_code=403)
 
         assert not mock_delete_project.delay.mock_calls
-
-        assert response.status_code == 403
 
 
 @pytest.mark.parametrize(

--- a/tests/sentry/api/endpoints/test_user_details.py
+++ b/tests/sentry/api/endpoints/test_user_details.py
@@ -1,4 +1,9 @@
-from sentry.models import Organization, OrganizationStatus, User, UserOption
+from sentry.models import (
+    Organization,
+    OrganizationStatus,
+    User,
+    UserOption,
+)
 from sentry.testutils import APITestCase
 
 
@@ -12,6 +17,11 @@ class UserDetailsTest(APITestCase):
 
 
 class UserDetailsGetTest(UserDetailsTest):
+    # TODO(dcramer): theres currently no way to look up other users
+    def test_look_up_other_user(self):
+        user2 = self.create_user(email="b@example.com")
+        self.get_valid_response(user2.id, status_code=403)
+
     def test_lookup_self(self):
         resp = self.get_valid_response("me")
 

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -31,8 +31,7 @@ class ReleaseTestCase(TestCase):
 
         assert UserEmail.objects.filter(user=user, email=user.email).update(is_verified=True)
 
-        if team:
-            self.create_member(user=user, organization=self.org, teams=[team])
+        self.create_member(user=user, organization=self.org, teams=[team] if team else None)
 
         return user
 


### PR DESCRIPTION
The Dual Write Migration is still too large after splitting into multiple PRs. This PR isolates refactors of tests files that are pretty verbose but change no logic. The two main themes are:
- Use `get_valid_response`
- DRY repeated logic into helper functions