### PR TITLE
fix(ui): Update activity badge to indicate comment count

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
@@ -257,11 +257,13 @@ class GroupHeader extends React.Component<Props, State> {
             isActive={() => currentTab === TAB.ACTIVITY}
             disabled={isGroupBeingReprocessing}
           >
-            {t('Activity')} <span>{group.numComments}</span>
+            {t('Activity')} <TabCount>{group.numComments}</TabCount>
             <IconChat
               size="xs"
               color={
-                group.subscriptionDetails?.reason === 'mentioned' ? 'green300' : undefined
+                group.subscriptionDetails?.reason === 'mentioned'
+                  ? 'green300'
+                  : 'purple300'
               }
             />
           </StyledListLink>
@@ -270,7 +272,7 @@ class GroupHeader extends React.Component<Props, State> {
             isActive={() => currentTab === TAB.USER_FEEDBACK}
             disabled={isGroupBeingReprocessing}
           >
-            {t('User Feedback')} <span>{group.userReportCount}</span>
+            {t('User Feedback')} <TabCount>{group.userReportCount}</TabCount>
           </StyledListLink>
           {hasEventAttachments && (
             <ListLink
@@ -343,13 +345,13 @@ const StyledTagAndMessageWrapper = styled(TagAndMessageWrapper)`
 `;
 
 const StyledListLink = styled(ListLink)`
-  span {
-    color: #6c5fc7;
-  }
   svg {
-    color: #6c5fc7;
     margin-left: ${space(0.5)};
   }
+`;
+
+const TabCount = styled('span')`
+  color: ${p => p.theme.purple300};
 `;
 
 const StyledProjectBadge = styled(ProjectBadge)`

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
@@ -7,7 +7,6 @@ import {fetchOrgMembers} from 'app/actionCreators/members';
 import {Client} from 'app/api';
 import AssigneeSelector from 'app/components/assigneeSelector';
 import GuideAnchor from 'app/components/assistant/guideAnchor';
-import Badge from 'app/components/badge';
 import Count from 'app/components/count';
 import EventOrGroupTitle from 'app/components/eventOrGroupTitle';
 import ErrorLevel from 'app/components/events/errorLevel';
@@ -23,6 +22,7 @@ import NavTabs from 'app/components/navTabs';
 import SeenByList from 'app/components/seenByList';
 import ShortId from 'app/components/shortId';
 import Tooltip from 'app/components/tooltip';
+import {IconChat} from 'app/icons';
 import {t} from 'app/locale';
 import SentryTypes from 'app/sentryTypes';
 import space from 'app/styles/space';
@@ -252,20 +252,26 @@ class GroupHeader extends React.Component<Props, State> {
           >
             {t('Details')}
           </ListLink>
-          <ListLink
+          <StyledListLink
             to={`${baseUrl}activity/${location.search}`}
             isActive={() => currentTab === TAB.ACTIVITY}
             disabled={isGroupBeingReprocessing}
           >
-            {t('Activity')} <Badge text={group.numComments} />
-          </ListLink>
-          <ListLink
+            {t('Activity')} <span>{group.numComments}</span>
+            <IconChat
+              size="xs"
+              color={
+                group.subscriptionDetails?.reason === 'mentioned' ? 'green300' : undefined
+              }
+            />
+          </StyledListLink>
+          <StyledListLink
             to={`${baseUrl}feedback/${location.search}`}
             isActive={() => currentTab === TAB.USER_FEEDBACK}
             disabled={isGroupBeingReprocessing}
           >
-            {t('User Feedback')} <Badge text={group.userReportCount} />
-          </ListLink>
+            {t('User Feedback')} <span>{group.userReportCount}</span>
+          </StyledListLink>
           {hasEventAttachments && (
             <ListLink
               to={`${baseUrl}attachments/${location.search}`}
@@ -333,6 +339,16 @@ const StyledTagAndMessageWrapper = styled(TagAndMessageWrapper)`
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     margin-bottom: ${space(2)};
+  }
+`;
+
+const StyledListLink = styled(ListLink)`
+  span {
+    color: #6c5fc7;
+  }
+  svg {
+    color: #6c5fc7;
+    margin-left: ${space(0.5)};
   }
 `;
 


### PR DESCRIPTION
Update activity badge to use the chat icon and indicate comment count.

### Before
<img width="792" alt="Screen Shot 2021-03-15 at 6 09 51 PM" src="https://user-images.githubusercontent.com/20312973/111241116-b52cfb00-85b9-11eb-8b80-67d7eb4bbd8a.png">

### After
<img width="666" alt="Screen Shot 2021-03-15 at 5 49 13 PM" src="https://user-images.githubusercontent.com/20312973/111241022-86168980-85b9-11eb-964f-b56a36dfa869.png">
<img width="666" alt="Screen Shot 2021-03-15 at 5 48 29 PM" src="https://user-images.githubusercontent.com/20312973/111241049-9464a580-85b9-11eb-99fc-0793d169937a.png">

_*Icon will turn green if the logged in user is "@mentioned"_

FIXES [WOR-218](https://getsentry.atlassian.net/browse/WOR-218)