### PR TITLE
feat(ui): Link project badge to a project details page

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -931,6 +931,8 @@ SENTRY_FEATURES = {
     "organizations:performance-tag-explorer": False,
     # Enable the new Project Detail page
     "organizations:project-detail": False,
+    # Enable links to Project Detail page from all over the app
+    "organizations:project-detail-links": False,
     # Enable the new Related Events feature
     "organizations:related-events": False,
     # Enable usage of external relays, for use with Relay. See
@@ -940,8 +942,6 @@ SENTRY_FEATURES = {
     "organizations:releases-top-charts": False,
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
-    # Enable calculating release adoption based on sessions
-    "organizations:session-adoption": False,
     # Enable basic SSO functionality, providing configurable single sign on
     # using services like GitHub / Google. This is *not* the same as the signup
     # and login with Github / Azure DevOps that sentry.io provides.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -96,11 +96,11 @@ default_manager.add("organizations:performance-view", OrganizationFeature)  # NO
 default_manager.add("organizations:trace-view-quick", OrganizationFeature)  # NOQA
 default_manager.add("organizations:trace-view-summary", OrganizationFeature)  # NOQA
 default_manager.add("organizations:project-detail", OrganizationFeature)  # NOQA
+default_manager.add("organizations:project-detail-links", OrganizationFeature)  # NOQA
 default_manager.add("organizations:relay", OrganizationFeature)  # NOQA
 default_manager.add("organizations:releases-top-charts", OrganizationFeature)  # NOQA
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:rule-page", OrganizationFeature)  # NOQA
-default_manager.add("organizations:session-adoption", OrganizationFeature)  # NOQA
 default_manager.add("organizations:set-grouping-config", OrganizationFeature)  # NOQA
 default_manager.add("organizations:custom-event-title", OrganizationFeature)  # NOQA
 default_manager.add("organizations:slack-migration", OrganizationFeature)  # NOQA

--- a/src/sentry/static/sentry/app/components/idBadge/baseBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/baseBadge.tsx
@@ -61,6 +61,7 @@ export default BaseBadge;
 const Wrapper = styled('div')`
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 `;
 
 const StyledAvatar = styled(Avatar)<{hideName: boolean}>`

--- a/src/sentry/static/sentry/app/components/idBadge/projectBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/projectBadge.tsx
@@ -1,27 +1,73 @@
 import React from 'react';
+import styled from '@emotion/styled';
 
 import BadgeDisplayName from 'app/components/idBadge/badgeDisplayName';
 import BaseBadge from 'app/components/idBadge/baseBadge';
+import Link from 'app/components/links/link';
+import {Organization} from 'app/types';
+import withOrganization from 'app/utils/withOrganization';
 
 type BaseBadgeProps = React.ComponentProps<typeof BaseBadge>;
 type Project = NonNullable<BaseBadgeProps['project']>;
 
 type Props = Partial<Omit<BaseBadgeProps, 'project' | 'organization' | 'team'>> & {
   project: Project;
+  organization?: Organization;
   /**
    * If true, will use default max-width, or specify one as a string
    */
   hideOverflow?: boolean | string;
+  /**
+   * If true, this component will not be a link to project details page
+   */
+  disableLink?: boolean;
 };
 
-const ProjectBadge = ({hideOverflow = true, project, ...props}: Props) => (
-  <BaseBadge
-    displayName={
-      <BadgeDisplayName hideOverflow={hideOverflow}>{project.slug}</BadgeDisplayName>
-    }
-    project={project}
-    {...props}
-  />
-);
+const ProjectBadge = ({
+  project,
+  organization,
+  hideOverflow = true,
+  disableLink = false,
+  ...props
+}: Props) => {
+  const {slug, id} = project;
 
-export default ProjectBadge;
+  const badge = (
+    <BaseBadge
+      displayName={
+        <BadgeDisplayName hideOverflow={hideOverflow}>{slug}</BadgeDisplayName>
+      }
+      project={project}
+      {...props}
+    />
+  );
+
+  if (
+    !disableLink &&
+    organization?.features.includes('project-detail') &&
+    organization?.features.includes('project-detail-links')
+  ) {
+    // TODO: check new feature flag for allowing these links
+    return (
+      <StyledLink
+        to={`/organizations/${organization.slug}/projects/${slug}/${
+          id ? `?project=${id}` : ''
+        }`}
+      >
+        {badge}
+      </StyledLink>
+    );
+  }
+
+  return badge;
+};
+
+const StyledLink = styled(Link)`
+  flex-shrink: 0;
+
+  img:hover {
+    cursor: pointer;
+  }
+`;
+
+export default withOrganization(ProjectBadge);

--- a/src/sentry/static/sentry/app/components/idBadge/projectBadge.tsx
+++ b/src/sentry/static/sentry/app/components/idBadge/projectBadge.tsx
@@ -47,7 +47,6 @@ const ProjectBadge = ({
     organization?.features.includes('project-detail') &&
     organization?.features.includes('project-detail-links')
   ) {
-    // TODO: check new feature flag for allowing these links
     return (
       <StyledLink
         to={`/organizations/${organization.slug}/projects/${slug}/${

--- a/src/sentry/static/sentry/app/components/organizations/projectSelector/selectorItem.tsx
+++ b/src/sentry/static/sentry/app/components/organizations/projectSelector/selectorItem.tsx
@@ -123,6 +123,7 @@ class ProjectSelectorItem extends React.PureComponent<Props, State> {
               avatarSize={16}
               displayName={<Highlight text={inputValue}>{project.slug}</Highlight>}
               avatarProps={{consistentWidth: true}}
+              disableLink
             />
           </BadgeWrapper>
           <StyledBookmarkStar

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -198,6 +198,7 @@ export type SharedViewOrganization = {
 export type AvatarProject = {
   slug: string;
   platform?: PlatformKey;
+  id?: string | number;
 };
 
 /**

--- a/src/sentry/static/sentry/app/views/organizationStats/projectTable.tsx
+++ b/src/sentry/static/sentry/app/views/organizationStats/projectTable.tsx
@@ -41,7 +41,9 @@ const ProjectTable = ({projectMap, projectTotals, orgTotal, organization}: Props
         return null;
       }
 
-      const projectLink = `/organizations/${organization.slug}/issues/?project=${project.id}`;
+      const projectLink = organization.features.includes('project-detail')
+        ? `/organizations/${organization.slug}/projects/${project.slug}/?project=${project.id}`
+        : `/organizations/${organization.slug}/issues/?project=${project.id}`;
 
       return (
         <StyledProjectTableLayout key={index}>

--- a/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/performance/trends/changedTransactions.tsx
@@ -4,12 +4,12 @@ import styled from '@emotion/styled';
 import {Location, Query} from 'history';
 
 import {Client} from 'app/api';
-import ProjectAvatar from 'app/components/avatar/projectAvatar';
 import Button from 'app/components/button';
 import {HeaderTitleLegend} from 'app/components/charts/styles';
 import Count from 'app/components/count';
 import DropdownLink from 'app/components/dropdownLink';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
+import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import MenuItem from 'app/components/menuItem';
@@ -478,7 +478,7 @@ function TrendsListItem(props: TrendsListItemProps) {
       <ItemTransactionDurationChange>
         {project && (
           <Tooltip title={transaction.project}>
-            <ProjectAvatar project={project} />
+            <IdBadge avatarSize={16} project={project} hideName />
           </Tooltip>
         )}
         <CompareDurations {...props} />

--- a/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
@@ -163,6 +163,7 @@ class ProjectDetail extends AsyncView<Props, State> {
                         project={project}
                         avatarSize={28}
                         displayName={params.projectId}
+                        disableLink
                       />
                     )}
                   </TextOverflow>

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/index.tsx
@@ -356,6 +356,8 @@ class ReleaseOverview extends AsyncView<Props> {
                   <OtherProjects
                     projects={releaseMeta.projects.filter(p => p.slug !== project.slug)}
                     location={location}
+                    version={version}
+                    organization={organization}
                   />
                 )}
                 {hasHealthData && (

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/otherProjects.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/otherProjects.tsx
@@ -4,21 +4,23 @@ import {Location} from 'history';
 
 import Button from 'app/components/button';
 import Collapsible from 'app/components/collapsible';
-import ProjectBadge from 'app/components/idBadge/projectBadge';
-import Link from 'app/components/links/link';
+import IdBadge from 'app/components/idBadge';
 import {tn} from 'app/locale';
-import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
-import {ReleaseProject} from 'app/types';
+import {Organization, ReleaseProject} from 'app/types';
+
+import ProjectLink from '../../list/releaseHealth/projectLink';
 
 import {SectionHeading, Wrapper} from './styles';
 
 type Props = {
   projects: ReleaseProject[];
   location: Location;
+  version: string;
+  organization: Organization;
 };
 
-function OtherProjects({projects, location}: Props) {
+function OtherProjects({projects, location, version, organization}: Props) {
   return (
     <Wrapper>
       <SectionHeading>
@@ -42,14 +44,14 @@ function OtherProjects({projects, location}: Props) {
       >
         {projects.map(project => (
           <Row key={project.id}>
-            <StyledLink
-              to={{
-                pathname: location.pathname,
-                query: {...location.query, project: project.id, yAxis: undefined},
-              }}
-            >
-              <ProjectBadge project={project} avatarSize={16} />
-            </StyledLink>
+            <IdBadge project={project} avatarSize={16} />
+
+            <ProjectLink
+              location={location}
+              orgSlug={organization.slug}
+              releaseVersion={version}
+              project={project}
+            />
           </Row>
         ))}
       </Collapsible>
@@ -58,14 +60,19 @@ function OtherProjects({projects, location}: Props) {
 }
 
 const Row = styled('div')`
-  margin-bottom: ${space(0.25)};
+  margin-bottom: ${space(0.75)};
   font-size: ${p => p.theme.fontSizeMedium};
-  color: ${p => p.theme.blue300};
-  ${overflowEllipsis}
-`;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 
-const StyledLink = styled(Link)`
-  display: inline-block;
+  display: grid;
+  grid-template-columns: 1fr max-content;
+
+  @media (min-width: ${p => p.theme.breakpoints[1]}) and (max-width: ${p =>
+      p.theme.breakpoints[2]}) {
+    grid-template-columns: 200px max-content;
+  }
 `;
 
 export default OtherProjects;

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/otherProjects.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/otherProjects.tsx
@@ -60,14 +60,12 @@ function OtherProjects({projects, location, version, organization}: Props) {
 }
 
 const Row = styled('div')`
-  margin-bottom: ${space(0.75)};
-  font-size: ${p => p.theme.fontSizeMedium};
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-
   display: grid;
   grid-template-columns: 1fr max-content;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: ${space(0.75)};
+  font-size: ${p => p.theme.fontSizeMedium};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) and (max-width: ${p =>
       p.theme.breakpoints[2]}) {

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/otherProjects.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/otherProjects.tsx
@@ -45,7 +45,6 @@ function OtherProjects({projects, location, version, organization}: Props) {
         {projects.map(project => (
           <Row key={project.id}>
             <IdBadge project={project} avatarSize={16} />
-
             <ProjectLink
               location={location}
               orgSlug={organization.slug}

--- a/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/releaseHeader.tsx
@@ -86,31 +86,26 @@ const ReleaseHeader = ({
           ]}
         />
         <Layout.Title>
-          <IdBadge
-            project={project}
-            avatarSize={28}
-            displayName={
-              <ReleaseName>
-                <Version version={version} anchor={false} />
-                <IconWrapper>
-                  <Clipboard value={version}>
-                    <Tooltip title={version} containerDisplayMode="flex">
-                      <IconCopy size="xs" />
-                    </Tooltip>
-                  </Clipboard>
-                </IconWrapper>
-                {!!url && (
-                  <IconWrapper>
-                    <Tooltip title={url}>
-                      <ExternalLink href={url}>
-                        <IconOpen size="xs" />
-                      </ExternalLink>
-                    </Tooltip>
-                  </IconWrapper>
-                )}
-              </ReleaseName>
-            }
-          />
+          <ReleaseName>
+            <IdBadge project={project} avatarSize={28} hideName />
+            <StyledVersion version={version} anchor={false} truncate />
+            <IconWrapper>
+              <Clipboard value={version}>
+                <Tooltip title={version} containerDisplayMode="flex">
+                  <IconCopy size="xs" />
+                </Tooltip>
+              </Clipboard>
+            </IconWrapper>
+            {!!url && (
+              <IconWrapper>
+                <Tooltip title={url}>
+                  <ExternalLink href={url}>
+                    <IconOpen size="xs" />
+                  </ExternalLink>
+                </Tooltip>
+              </IconWrapper>
+            )}
+          </ReleaseName>
         </Layout.Title>
       </Layout.HeaderContent>
 
@@ -144,6 +139,10 @@ const ReleaseHeader = ({
 const ReleaseName = styled('div')`
   display: flex;
   align-items: center;
+`;
+
+const StyledVersion = styled(Version)`
+  margin-left: ${space(1)};
 `;
 
 const IconWrapper = styled('span')`

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/projectLink.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/projectLink.tsx
@@ -23,6 +23,7 @@ const ProjectLink = ({orgSlug, releaseVersion, project, location}: Props) => (
       query: {
         ...extractSelectionParameters(location.query),
         project: project.id,
+        yAxis: undefined,
       },
     }}
   >


### PR DESCRIPTION
This PR changes the project detail badge to be a link to the project details page.

This is for now feature flagged, we want to evaluate if all occurrences make sense.
getsentry flag: https://github.com/getsentry/getsentry/pull/5286