### PR TITLE
fix(alerts): Send null on unassigned owner and correct default owner rule

### DIFF
--- a/src/sentry/static/sentry/app/components/selectMembers/index.tsx
+++ b/src/sentry/static/sentry/app/components/selectMembers/index.tsx
@@ -257,7 +257,7 @@ class SelectMembers extends React.Component<Props, State> {
     const {options} = this.state;
 
     // Copy old value
-    const oldValue = [...value];
+    const oldValue = value ? [...value] : {value};
 
     // Optimistic update
     this.props.onChange(this.createMentionableTeam(team));

--- a/src/sentry/static/sentry/app/components/selectMembers/index.tsx
+++ b/src/sentry/static/sentry/app/components/selectMembers/index.tsx
@@ -45,7 +45,7 @@ const StyledIconUser = styled(IconUser)`
 `;
 
 const unassignedOption = {
-  value: undefined,
+  value: null,
   label: (
     <UnassignedWrapper>
       <StyledIconUser size="20px" color="gray400" />
@@ -53,7 +53,7 @@ const unassignedOption = {
     </UnassignedWrapper>
   ),
   searchKey: 'unassigned',
-  actor: undefined,
+  actor: null,
 };
 type MentionableUnassigned = typeof unassignedOption;
 

--- a/src/sentry/static/sentry/app/types/alerts.tsx
+++ b/src/sentry/static/sentry/app/types/alerts.tsx
@@ -70,7 +70,7 @@ export type UnsavedIssueAlertRule = {
   environment?: null | string;
   frequency: number;
   name: string;
-  owner?: string;
+  owner?: string | null;
 };
 
 // Issue-based alert rule

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
@@ -46,7 +46,9 @@ class IncidentRulesCreate extends React.Component<Props> {
     const userTeamIds = new Set(userTeamIdArr);
 
     if (props.organization.features.includes('team-alerts-ownership')) {
-      defaultRule.owner = userTeamIdArr[0] && `team:${userTeamIdArr[0]}`;
+      const projectTeamIds = new Set(project.teams.map(({id}) => id));
+      const defaultOwnerId = userTeamIdArr.find(id => projectTeamIds.has(id)) ?? null;
+      defaultRule.owner = defaultOwnerId && `team:${defaultOwnerId}`;
     }
 
     return (

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -62,7 +62,7 @@ export type UnsavedIncidentRule = {
   thresholdType: AlertRuleThresholdType;
   resolveThreshold: number | '' | null;
   eventTypes?: EventTypes[];
-  owner?: string;
+  owner?: string | null;
 };
 
 export type SavedIncidentRule = UnsavedIncidentRule & {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
@@ -129,7 +129,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   }
 
   getDefaultState() {
-    const {organization, teams} = this.props;
+    const {organization, teams, project} = this.props;
     const defaultState = {
       ...super.getDefaultState(),
       configs: null,
@@ -139,8 +139,10 @@ class IssueRuleEditor extends AsyncView<Props, State> {
       uuid: null,
     };
     if (organization.features.includes('team-alerts-ownership')) {
-      const userTeam = teams.find(({isMember}) => !!isMember);
-      defaultState.rule.owner = userTeam ? `team:${userTeam.id}` : undefined;
+      const projectTeamIds = new Set(project.teams.map(({id}) => id));
+      const userTeam =
+        teams.find(({isMember, id}) => !!isMember && projectTeamIds.has(id)) ?? null;
+      defaultState.rule.owner = userTeam && `team:${userTeam.id}`;
     }
     return defaultState;
   }
@@ -452,9 +454,9 @@ class IssueRuleEditor extends AsyncView<Props, State> {
 
   getTeamId = () => {
     const {rule} = this.state;
-    const owner = rule?.owner ?? '';
+    const owner = rule?.owner;
     // ownership follows the format team:<id>, just grab the id
-    return owner.split(':')[1];
+    return owner && owner.split(':')[1];
   };
 
   handleOwnerChange = ({value}: {value?: string; label: string}) => {

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
@@ -459,7 +459,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
     return owner && owner.split(':')[1];
   };
 
-  handleOwnerChange = ({value}: {value?: string; label: string}) => {
+  handleOwnerChange = ({value}: {value: string; label: string}) => {
     const ownerValue = value && `team:${value}`;
     this.handleChange('owner', ownerValue);
   };

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
@@ -458,13 +458,8 @@ class IssueRuleEditor extends AsyncView<Props, State> {
   };
 
   handleOwnerChange = ({value}: {value?: string; label: string}) => {
-    if (value) {
-      // currently only supporting teams as owners
-      this.handleChange('owner', `team:${value}`);
-    } else {
-      // allow owner to be set to undefined (unassigned option)
-      this.handleChange('owner', value);
-    }
+    const ownerValue = value && `team:${value}`;
+    this.handleChange('owner', ownerValue);
   };
 
   renderLoading() {


### PR DESCRIPTION
To be more consistent with other "empty" values on the frontend we send `null` on an unassigned owner instead of undefined which gets dropped upon reaching the backend.

Additionally I corrected the default owner in a new rule to be the first team that the user is a part of and is also a part of the project. Previously, it would pick any team the user is a member of which could result in that team not being part of the project.

In the below example, none of the teams I am a member of belong to the selected project so unassigned should be the default `owner` instead of `sentry`

**Before:**
<img width="1180" alt="Screen Shot 2021-03-16 at 1 58 12 PM" src="https://user-images.githubusercontent.com/9372512/111357530-c6c8de00-865f-11eb-96ba-dc430efcacab.png">


**After:**
<img width="1188" alt="Screen Shot 2021-03-16 at 1 54 41 PM" src="https://user-images.githubusercontent.com/9372512/111357503-c16b9380-865f-11eb-988d-224f16af106c.png">
