### PR TITLE
fix(utils/sdk): Recursion breaker gets its own tag

### DIFF
--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -9,7 +9,7 @@ from sentry import quotas
 from sentry.eventstream.base import EventStream
 from sentry.utils import snuba, json
 from sentry.utils.safe import get_path
-from sentry.utils.sdk import set_current_project
+from sentry.utils.sdk import set_current_event_project
 
 
 logger = logging.getLogger(__name__)
@@ -86,7 +86,7 @@ class SnubaProtocolEventStream(EventStream):
         skip_consume=False,
     ):
         project = event.project
-        set_current_project(project.id)
+        set_current_event_project(project.id)
         retention_days = quotas.get_event_retention(organization=project.organization)
 
         event_data = event.get_raw_data(for_stream=True)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -9,7 +9,7 @@ from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.utils.safe import safe_execute
-from sentry.utils.sdk import set_current_project, bind_organization_context
+from sentry.utils.sdk import set_current_event_project, bind_organization_context
 
 logger = logging.getLogger("sentry")
 
@@ -195,7 +195,7 @@ def post_process_group(
             project_id=data["project"], event_id=data["event_id"], group_id=group_id, data=data
         )
 
-        set_current_project(event.project_id)
+        set_current_event_project(event.project_id)
 
         is_reprocessed = is_reprocessed_event(event.data)
 
@@ -407,7 +407,7 @@ def plugin_post_process_group(plugin_slug, event, **kwargs):
     """
     Fires post processing hooks for a group.
     """
-    set_current_project(event.project_id)
+    set_current_event_project(event.project_id)
 
     from sentry.plugins.base import plugins
 

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -2,7 +2,7 @@ import logging
 
 from django.conf import settings
 import sentry_sdk
-from sentry.utils.sdk import set_current_project
+from sentry.utils.sdk import set_current_event_project
 
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
@@ -32,7 +32,7 @@ def update_config_cache(generate, organization_id=None, project_id=None, update_
     from sentry.relay.config import get_project_config
 
     if project_id:
-        set_current_project(project_id)
+        set_current_event_project(project_id)
 
     if organization_id:
         # Cannot use bind_organization_context here because we do not have a

--- a/src/sentry/tasks/store.py
+++ b/src/sentry/tasks/store.py
@@ -19,7 +19,7 @@ from sentry.utils.safe import safe_execute
 from sentry.stacktraces.processing import process_stacktraces, should_process_for_stacktraces
 from sentry.utils.canonical import CanonicalKeyDict, CANONICAL_TYPES
 from sentry.utils.dates import to_datetime
-from sentry.utils.sdk import set_current_project
+from sentry.utils.sdk import set_current_event_project
 from sentry.models import ProjectOption, Activity, Project, Organization
 from sentry.eventstore.processing import event_processing_store
 
@@ -126,7 +126,7 @@ def _do_preprocess_event(cache_key, data, start_time, event_id, process_task, pr
     original_data = data
     data = CanonicalKeyDict(data)
     project_id = data["project"]
-    set_current_project(project_id)
+    set_current_event_project(project_id)
 
     if project is None:
         project = Project.objects.get_from_cache(id=project_id)
@@ -215,7 +215,7 @@ def _do_symbolicate_event(cache_key, start_time, event_id, symbolicate_task, dat
     data = CanonicalKeyDict(data)
 
     project_id = data["project"]
-    set_current_project(project_id)
+    set_current_event_project(project_id)
 
     event_id = data["event_id"]
 
@@ -413,7 +413,7 @@ def _do_process_event(
     data = CanonicalKeyDict(data)
 
     project_id = data["project"]
-    set_current_project(project_id)
+    set_current_event_project(project_id)
 
     event_id = data["event_id"]
 
@@ -596,7 +596,7 @@ def process_event_from_reprocessing(
 
 
 def delete_raw_event(project_id, event_id, allow_hint_clear=False):
-    set_current_project(project_id)
+    set_current_event_project(project_id)
 
     if event_id is None:
         error_logger.error("process.failed_delete_raw_event", extra={"project_id": project_id})
@@ -628,7 +628,7 @@ def create_failed_event(
     """If processing failed we put the original data from the cache into a
     raw event.  Returns `True` if a failed event was inserted
     """
-    set_current_project(project_id)
+    set_current_event_project(project_id)
 
     # We can only create failed events for events that can potentially
     # create failed events.
@@ -719,7 +719,7 @@ def _do_save_event(
     Saves an event to the database.
     """
 
-    set_current_project(project_id)
+    set_current_event_project(project_id)
 
     from sentry.event_manager import EventManager, HashDiscarded
 
@@ -742,7 +742,7 @@ def _do_save_event(
         # the task.
         if project_id is None:
             project_id = data.pop("project")
-            set_current_project(project_id)
+            set_current_event_project(project_id)
 
         # We only need to delete raw events for events that support
         # reprocessing.  If the data cannot be found we want to assume

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -59,7 +59,7 @@ def is_current_event_safe():
         if scope._tags.get(UNSAFE_TAG):
             return False
 
-        project_id = scope._tags.get("project")
+        project_id = scope._tags.get("processing_event_for_project")
 
         if project_id and project_id == settings.SENTRY_PROJECT:
             return False
@@ -82,7 +82,7 @@ def mark_scope_as_unsafe():
         scope.set_tag(UNSAFE_TAG, True)
 
 
-def set_current_project(project_id):
+def set_current_event_project(project_id):
     """
     Set the current project on the SDK scope for outgoing crash reports.
 
@@ -92,6 +92,7 @@ def set_current_project(project_id):
     sentry-internal errors, causing infinite recursion.
     """
     with configure_scope() as scope:
+        scope.set_tag("processing_event_for_project", project_id)
         scope.set_tag("project", project_id)
 
 


### PR DESCRIPTION
Rename project tag to "event project" to avoid collisions in random
endpoints that are totally fine to instrument.

`set_current_project` is already only used in event pipeline and not those random endpoints.