### PR TITLE
fix(monitors): Ensure checkin ID is returned correctly as a string

### DIFF
--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -88,6 +88,6 @@ class MonitorCheckInsEndpoint(MonitorEndpoint):
                 ).update(**monitor_params)
 
         if isinstance(request.auth, ProjectKey):
-            return self.respond({"id": checkin.id}, status=201)
+            return self.respond({"id": str(checkin.id)}, status=201)
 
         return self.respond(serialize(checkin, request.user), status=201)

--- a/tests/sentry/api/endpoints/test_monitor_checkins.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkins.py
@@ -166,6 +166,7 @@ class CreateMonitorCheckInTest(APITestCase):
             )
 
         assert resp.status_code == 201, resp.content
+        assert type(resp.data["id"]) == str
         # DSN auth should only return id
         assert list(resp.data.keys()) == ["id"]
 


### PR DESCRIPTION
Fixes SENTRY-JX5