### PR TITLE
fix(metric_alerts): Fix threshold chart horizontal offset

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -165,7 +165,8 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
     const yAxisPosition = typeof yAxisPixelPosition === 'number' ? yAxisPixelPosition : 0;
     // As the yAxis gets larger we want to start our line/area further to the right
     // Handle case where the graph max is 1 and includes decimals
-    const yAxisMax = Math.max(maxValue ?? 1, this.state.yAxisMax ?? 1);
+    const yAxisMax =
+      (Math.round(Math.max(maxValue ?? 1, this.state.yAxisMax ?? 1)) * 100) / 100;
     const yAxisSize = 15 + (yAxisMax <= 1 ? 15 : `${yAxisMax ?? ''}`.length * 8);
     // Shave off the right margin and yAxisSize from the width to get the actual area we want to render content in
     const graphAreaWidth =


### PR DESCRIPTION
Fix threshold chart horizontal offset.

FIXES [WOR-513](https://getsentry.atlassian.net/browse/WOR-513)

### Before
<img width="1184" alt="Screen Shot 2021-03-16 at 1 06 24 PM" src="https://user-images.githubusercontent.com/20312973/111383804-f844a800-8665-11eb-84f3-17d94c8b3c35.png">

### After
<img width="1151" alt="Screen Shot 2021-03-16 at 2 32 59 PM" src="https://user-images.githubusercontent.com/20312973/111383836-04c90080-8666-11eb-9c1f-ea02ff034af5.png">