### PR TITLE
feat(alerts): Order metric alert actions by date created

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -45,9 +45,11 @@ type Props = {
 /**
  * When a new action is added, all of it's settings should be set to their default values.
  * @param actionConfig
+ * @param dateCreated kept to maintain order of unsaved actions
  */
-const getCleanAction = (actionConfig): Action => {
+const getCleanAction = (actionConfig, dateCreated?: string): Action => {
   return {
+    unsavedDateCreated: dateCreated ?? new Date().toISOString(),
     type: actionConfig.type,
     targetType:
       actionConfig &&
@@ -156,11 +158,7 @@ class ActionsPanel extends React.PureComponent<Props> {
   ) => {
     const {triggers, onChange} = this.props;
     const action = triggers[triggerIndex].actions[index];
-
-    // Because we're moving it between two different triggers the position of the
-    // action could change, try to change it less by pushing or unshifting
-    const position = value.value === 1 ? 'unshift' : 'push';
-    triggers[value.value].actions[position](action);
+    triggers[value.value].actions.push(action);
     onChange(value.value, triggers, triggers[value.value].actions);
     this.handleDeleteAction(triggerIndex, index);
   };
@@ -181,7 +179,9 @@ class ActionsPanel extends React.PureComponent<Props> {
       return;
     }
 
-    const newAction: Action = getCleanAction(actionConfig);
+    const existingDateCreated =
+      actions[index].dateCreated ?? actions[index].unsavedDateCreated;
+    const newAction: Action = getCleanAction(actionConfig, existingDateCreated);
     onChange(triggerIndex, triggers, replaceAtArrayIndex(actions, index, newAction));
   };
 
@@ -213,17 +213,36 @@ class ActionsPanel extends React.PureComponent<Props> {
     } = this.props;
 
     const project = projects.find(({slug}) => slug === currentProject);
-    const items =
-      availableActions &&
-      availableActions.map(availableAction => ({
-        value: getActionUniqueKey(availableAction),
-        label: getFullActionTitle(availableAction),
-      }));
+    const items = availableActions?.map(availableAction => ({
+      value: getActionUniqueKey(availableAction),
+      label: getFullActionTitle(availableAction),
+    }));
 
     const levels = [
       {value: 0, label: 'Critical Status'},
       {value: 1, label: 'Warning Status'},
     ];
+
+    // Create single array of unsaved and saved trigger actions
+    // Sorted by date created ascending
+    const actions = triggers
+      .flatMap((trigger, triggerIndex) => {
+        return trigger.actions.map((action, actionIdx) => {
+          const availableAction = availableActions?.find(
+            a => getActionUniqueKey(a) === getActionUniqueKey(action)
+          );
+          return {
+            dateCreated: new Date(
+              action.dateCreated ?? action.unsavedDateCreated
+            ).getTime(),
+            triggerIndex,
+            action,
+            actionIdx,
+            availableAction,
+          };
+        });
+      })
+      .sort((a, b) => a.dateCreated - b.dateCreated);
 
     return (
       <Panel>
@@ -238,91 +257,81 @@ class ActionsPanel extends React.PureComponent<Props> {
         </PanelBody>
         <PanelBody>
           {loading && <LoadingIndicator />}
-          {triggers.map((trigger, triggerIndex) => {
-            const {actions} = trigger;
+          {actions.map(({action, actionIdx, triggerIndex, availableAction}, idx) => {
             return (
-              actions &&
-              actions.map((action: Action, i: number) => {
-                const availableAction = availableActions?.find(
-                  a => getActionUniqueKey(a) === getActionUniqueKey(action)
-                );
+              <PanelItemWrapper key={idx}>
+                <RuleRowContainer>
+                  <PanelItemGrid>
+                    <PanelItemSelects>
+                      <SelectControl
+                        name="select-level"
+                        aria-label={t('Select a status level')}
+                        isDisabled={disabled || loading}
+                        placeholder={t('Select Level')}
+                        onChange={this.handleChangeActionLevel.bind(
+                          this,
+                          triggerIndex,
+                          actionIdx
+                        )}
+                        value={triggerIndex}
+                        options={levels}
+                      />
 
-                return (
-                  <PanelItemWrapper key={i}>
-                    <RuleRowContainer>
-                      <PanelItemGrid>
-                        <PanelItemSelects>
-                          <SelectControl
-                            name="select-level"
-                            aria-label={t('Select a status level')}
-                            isDisabled={disabled || loading}
-                            placeholder={t('Select Level')}
-                            onChange={this.handleChangeActionLevel.bind(
-                              this,
-                              triggerIndex,
-                              i
-                            )}
-                            value={triggerIndex}
-                            options={levels}
-                          />
+                      <SelectControl
+                        name="select-action"
+                        aria-label={t('Select an Action')}
+                        isDisabled={disabled || loading}
+                        placeholder={t('Select Action')}
+                        onChange={this.handleChangeActionType.bind(
+                          this,
+                          triggerIndex,
+                          actionIdx
+                        )}
+                        value={getActionUniqueKey(action)}
+                        options={items ?? []}
+                      />
 
-                          <SelectControl
-                            name="select-action"
-                            aria-label={t('Select an Action')}
-                            isDisabled={disabled || loading}
-                            placeholder={t('Select Action')}
-                            onChange={this.handleChangeActionType.bind(
-                              this,
-                              triggerIndex,
-                              i
-                            )}
-                            value={getActionUniqueKey(action)}
-                            options={items ?? []}
-                          />
-
-                          {availableAction &&
-                          availableAction.allowedTargetTypes.length > 1 ? (
-                            <SelectControl
-                              isDisabled={disabled || loading}
-                              value={action.targetType}
-                              options={availableAction?.allowedTargetTypes?.map(
-                                allowedType => ({
-                                  value: allowedType,
-                                  label: TargetLabel[allowedType],
-                                })
-                              )}
-                              onChange={this.handleChangeTarget.bind(
-                                this,
-                                triggerIndex,
-                                i
-                              )}
-                            />
-                          ) : null}
-                          <ActionTargetSelector
-                            action={action}
-                            availableAction={availableAction}
-                            disabled={disabled}
-                            loading={loading}
-                            onChange={this.handleChangeTargetIdentifier.bind(
-                              this,
-                              triggerIndex,
-                              i
-                            )}
-                            organization={organization}
-                            project={project}
-                          />
-                        </PanelItemSelects>
-                        <DeleteActionButton
-                          triggerIndex={triggerIndex}
-                          index={i}
-                          onClick={this.handleDeleteAction}
-                          disabled={disabled}
+                      {availableAction &&
+                      availableAction.allowedTargetTypes.length > 1 ? (
+                        <SelectControl
+                          isDisabled={disabled || loading}
+                          value={action.targetType}
+                          options={availableAction?.allowedTargetTypes?.map(
+                            allowedType => ({
+                              value: allowedType,
+                              label: TargetLabel[allowedType],
+                            })
+                          )}
+                          onChange={this.handleChangeTarget.bind(
+                            this,
+                            triggerIndex,
+                            actionIdx
+                          )}
                         />
-                      </PanelItemGrid>
-                    </RuleRowContainer>
-                  </PanelItemWrapper>
-                );
-              })
+                      ) : null}
+                      <ActionTargetSelector
+                        action={action}
+                        availableAction={availableAction}
+                        disabled={disabled}
+                        loading={loading}
+                        onChange={this.handleChangeTargetIdentifier.bind(
+                          this,
+                          triggerIndex,
+                          actionIdx
+                        )}
+                        organization={organization}
+                        project={project}
+                      />
+                    </PanelItemSelects>
+                    <DeleteActionButton
+                      triggerIndex={triggerIndex}
+                      index={actionIdx}
+                      onClick={this.handleDeleteAction}
+                      disabled={disabled}
+                    />
+                  </PanelItemGrid>
+                </RuleRowContainer>
+              </PanelItemWrapper>
             );
           })}
           <StyledPanelItem>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -11,6 +11,7 @@ import {IconAdd} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project, SelectValue} from 'app/types';
+import {uniqueId} from 'app/utils/guid';
 import {removeAtArrayIndex} from 'app/utils/removeAtArrayIndex';
 import {replaceAtArrayIndex} from 'app/utils/replaceAtArrayIndex';
 import withOrganization from 'app/utils/withOrganization';
@@ -49,6 +50,7 @@ type Props = {
  */
 const getCleanAction = (actionConfig, dateCreated?: string): Action => {
   return {
+    unsavedId: uniqueId(),
     unsavedDateCreated: dateCreated ?? new Date().toISOString(),
     type: actionConfig.type,
     targetType:
@@ -257,9 +259,9 @@ class ActionsPanel extends React.PureComponent<Props> {
         </PanelBody>
         <PanelBody>
           {loading && <LoadingIndicator />}
-          {actions.map(({action, actionIdx, triggerIndex, availableAction}, idx) => {
+          {actions.map(({action, actionIdx, triggerIndex, availableAction}) => {
             return (
-              <PanelItemWrapper key={idx}>
+              <PanelItemWrapper key={action.id ?? action.unsavedId}>
                 <RuleRowContainer>
                   <PanelItemGrid>
                     <PanelItemSelects>

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/index.tsx
@@ -159,7 +159,9 @@ class ActionsPanel extends React.PureComponent<Props> {
     value: SelectValue<number>
   ) => {
     const {triggers, onChange} = this.props;
-    const action = triggers[triggerIndex].actions[index];
+    // Convert saved action to unsaved by removing id
+    const {id: _, ...action} = triggers[triggerIndex].actions[index];
+    action.unsavedId = uniqueId();
     triggers[value.value].actions.push(action);
     onChange(value.value, triggers, triggers[value.value].actions);
     this.handleDeleteAction(triggerIndex, index);

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -45,7 +45,7 @@ export type ThresholdControlValue = {
   threshold: number | '' | null;
 };
 
-export type SavedTrigger = Omit<UnsavedTrigger, 'actions'> & {
+export type SavedTrigger = Omit<UnsavedTrigger, 'actions' | 'unsavedId'> & {
   id: string;
   dateCreated: string;
   actions: Action[];
@@ -190,7 +190,7 @@ export type MetricActionTemplate = {
  * This is the user's configured action
  */
 export type Action = UnsavedAction & Partial<SavedActionFields>;
-export type SavedAction = UnsavedAction & SavedActionFields;
+export type SavedAction = Omit<UnsavedAction, 'unsavedId'> & SavedActionFields;
 
 type SavedActionFields = {
   /**
@@ -215,6 +215,8 @@ type SavedActionFields = {
 };
 
 export type UnsavedAction = {
+  /** Used to maintain order of unsaved actions */
+  unsavedDateCreated: string;
   type: ActionType;
 
   targetType: TargetType | null;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -45,7 +45,7 @@ export type ThresholdControlValue = {
   threshold: number | '' | null;
 };
 
-export type SavedTrigger = Omit<UnsavedTrigger, 'actions' | 'unsavedId'> & {
+export type SavedTrigger = Omit<UnsavedTrigger, 'actions'> & {
   id: string;
   dateCreated: string;
   actions: Action[];
@@ -190,7 +190,7 @@ export type MetricActionTemplate = {
  * This is the user's configured action
  */
 export type Action = UnsavedAction & Partial<SavedActionFields>;
-export type SavedAction = Omit<UnsavedAction, 'unsavedId'> & SavedActionFields;
+export type SavedAction = Omit<UnsavedAction, 'unsavedDateCreated'> & SavedActionFields;
 
 type SavedActionFields = {
   /**

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -190,7 +190,8 @@ export type MetricActionTemplate = {
  * This is the user's configured action
  */
 export type Action = UnsavedAction & Partial<SavedActionFields>;
-export type SavedAction = Omit<UnsavedAction, 'unsavedDateCreated'> & SavedActionFields;
+export type SavedAction = Omit<UnsavedAction, 'unsavedDateCreated' | 'unsavedId'> &
+  SavedActionFields;
 
 type SavedActionFields = {
   /**
@@ -215,6 +216,7 @@ type SavedActionFields = {
 };
 
 export type UnsavedAction = {
+  unsavedId: string;
   /** Used to maintain order of unsaved actions */
   unsavedDateCreated: string;
   type: ActionType;

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -126,13 +126,13 @@ describe('Incident Rules Details', function () {
           triggers: [
             expect.objectContaining({
               actions: [
-                {
+                expect.objectContaining({
                   integrationId: null,
                   targetIdentifier: '',
                   targetType: 'user',
                   type: 'email',
                   options: null,
-                },
+                }),
               ],
               alertRuleId: '4',
               alertThreshold: 70,
@@ -187,13 +187,13 @@ describe('Incident Rules Details', function () {
           triggers: [
             expect.objectContaining({
               actions: [
-                {
+                expect.objectContaining({
                   integrationId: null,
                   targetIdentifier: '',
                   targetType: 'user',
                   type: 'email',
                   options: null,
-                },
+                }),
               ],
               alertRuleId: '4',
               alertThreshold: 70,


### PR DESCRIPTION
actions jump around because we are merging two arrays into one. This is noticeable when adding a new action (defaults to critical), and when switching an action between critical and warning.

What we had was somewhat similar to this
```ts
[
 ...criticalActions,
 ...warningActions
]
```

This PR adds an "unsavedDateCreated" to each new object and the flattened array of actions is sorted by date keeping them in the same order between changes.