### PR TITLE
fix(bigtable): Throw on unsuccessful set/delete operations

### DIFF
--- a/src/sentry/nodestore/bigtable/backend.py
+++ b/src/sentry/nodestore/bigtable/backend.py
@@ -172,7 +172,10 @@ class BigtableNodeStorage(NodeStorage):
 
     def _set_bytes(self, id, data, ttl=None):
         row = self.encode_row(id, data, ttl)
-        row.commit()
+
+        status = row.commit()
+        if status.code != 0:
+            raise Exception(status.code, status.message)
 
     def encode_row(self, id, data, ttl=None):
         row = self.connection.row(id)
@@ -231,7 +234,11 @@ class BigtableNodeStorage(NodeStorage):
 
         row = self.connection.row(id)
         row.delete()
-        row.commit()
+
+        status = row.commit()
+        if status.code != 0:
+            raise Exception(status.code, status.message)
+
         self._delete_cache_item(id)
 
     def delete_multi(self, id_list):

--- a/src/sentry/nodestore/bigtable/backend.py
+++ b/src/sentry/nodestore/bigtable/backend.py
@@ -65,6 +65,10 @@ def get_connection(project, instance, table, options):
     return _connection_cache[key]
 
 
+class BigtableError(Exception):
+    pass
+
+
 class BigtableNodeStorage(NodeStorage):
     """
     A Bigtable-based backend for storing node data.
@@ -175,7 +179,7 @@ class BigtableNodeStorage(NodeStorage):
 
         status = row.commit()
         if status.code != 0:
-            raise Exception(status.code, status.message)
+            raise BigtableError(status.code, status.message)
 
     def encode_row(self, id, data, ttl=None):
         row = self.connection.row(id)
@@ -237,7 +241,7 @@ class BigtableNodeStorage(NodeStorage):
 
         status = row.commit()
         if status.code != 0:
-            raise Exception(status.code, status.message)
+            raise BigtableError(status.code, status.message)
 
         self._delete_cache_item(id)
 

--- a/tests/sentry/nodestore/bigtable/backend/tests.py
+++ b/tests/sentry/nodestore/bigtable/backend/tests.py
@@ -1,5 +1,5 @@
 import pytest
-
+from google.rpc.status_pb2 import Status
 from sentry.nodestore.bigtable.backend import BigtableNodeStorage
 from sentry.utils.cache import memoize
 from sentry.utils.compat import mock
@@ -27,7 +27,7 @@ class MockedBigtableNodeStorage(BigtableNodeStorage):
 
         def commit(self):
             # commits not implemented, changes are applied immediately
-            pass
+            return Status(code=0)
 
         @property
         def cells(self):
@@ -49,7 +49,7 @@ class MockedBigtableNodeStorage(BigtableNodeStorage):
 
         def mutate_rows(self, rows):
             # commits not implemented, changes are applied immediately
-            pass
+            return [Status(code=0) for row in rows]
 
     @memoize
     def connection(self):


### PR DESCRIPTION
The [`commit` method on direct row operations](https://googleapis.dev/python/bigtable/latest/row.html#google.cloud.bigtable.row.DirectRow.commit) will only throw in the case when a request is determined to be inherently unable to succeed before it performed. Operations that fail on the server side are returned as [`Status` values](https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto) which must be handled by the caller.

Internally, [`commit` calls `Table.mutate_rows`](https://github.com/googleapis/python-bigtable/blob/cf3b9a1820780863911f4741fca4e9936cb79670/google/cloud/bigtable/row.py#L466) which more clearly highlights this behavior in the API documentation: https://googleapis.dev/python/bigtable/latest/table.html#google.cloud.bigtable.table.Table.mutate_rows

These operations are [retried internally with a fairly comprehensive retry policy](https://github.com/googleapis/python-bigtable/blob/cf3b9a1820780863911f4741fca4e9936cb79670/google/cloud/bigtable/table.py#L60-L66) but given the importance of this component, we should be extra mindful of failure handling here.

I have manually verified the client behavior is as documented by using the `cbtemulator` backend and attempting to write a value against a column family that does not exist (this is the easiest type of error I could think of to reproduce, I am not sure what others may exist in an actual environment):

```
Traceback (most recent call last)
<ipython-input-1-e5166fac7e8c> in <module>
---> 11 ns.set("key", "value")

~/workspaces/sentry/sentry/src/sentry/nodestore/base.py in set(self, id, data, ttl)
    202         >>> nodestore.set('key1', {'foo': 'bar'})
    203         """
--> 204         return self.set_subkeys(id, {None: data}, ttl=ttl)
    205 
    206     def set_subkeys(self, id, data, ttl=None):

~/workspaces/sentry/sentry/src/sentry/nodestore/base.py in set_subkeys(self, id, data, ttl)
    220         cache_item = data.get(None)
    221         bytes_data = self._encode(data)
--> 222         self._set_bytes(id, bytes_data, ttl=ttl)
    223         # set cache only after encoding and write to nodestore has succeeded
    224         self._set_cache_item(id, cache_item)

~/workspaces/sentry/sentry/src/sentry/nodestore/bigtable/backend.py in _set_bytes(self, id, data, ttl)
    180         status = row.commit()
    181         if status.code != 0:
--> 182             raise BigtableError(status.code, status.message)
    183 
    184     def encode_row(self, id, data, ttl=None):

BigtableError: (13, 'unknown family "x"')
```

I am actively working on extracting the key/value storage parts of this class so that it can be reused in other contexts and will be replacing the existing tests with tests that actually use a running emulator and exercise the real bigtable client rather than the mocked backend, so I did the minimum to get the existing tests to pass as written.