### PR TITLE
fix(alert rules): Changing async task to run outside of transaction and once per request

### DIFF
--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -6,7 +6,7 @@ from sentry.api.serializers.models.alert_rule import AlertRuleSerializer
 from sentry.incidents.endpoints.bases import ProjectAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.logic import (
-    alert_rule_data_requires_async_lookup,
+    alert_rule_has_async_lookups,
     AlreadyDeletedError,
     delete_alert_rule,
 )
@@ -36,7 +36,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
             partial=True,
         )
         if serializer.is_valid():
-            if alert_rule_data_requires_async_lookup(project.organization, request.user, data):
+            if alert_rule_has_async_lookups(project.organization, request.user, data):
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()
                 task_args = {

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -6,7 +6,7 @@ from sentry.api.serializers.models.alert_rule import AlertRuleSerializer
 from sentry.incidents.endpoints.bases import ProjectAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.logic import (
-    alert_rule_has_async_lookups,
+    get_slack_actions_with_async_lookups,
     AlreadyDeletedError,
     delete_alert_rule,
 )
@@ -36,7 +36,7 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
             partial=True,
         )
         if serializer.is_valid():
-            if alert_rule_has_async_lookups(project.organization, request.user, data):
+            if get_slack_actions_with_async_lookups(project.organization, request.user, data):
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()
                 task_args = {

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -13,7 +13,7 @@ from sentry.api.paginator import (
 )
 from sentry.api.serializers import serialize, CombinedRuleSerializer
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer
-from sentry.incidents.logic import alert_rule_data_requires_async_lookup
+from sentry.incidents.logic import alert_rule_has_async_lookups
 from sentry.incidents.models import AlertRule
 from sentry.integrations.slack import tasks
 from sentry.signals import alert_rule_created
@@ -93,7 +93,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
         )
 
         if serializer.is_valid():
-            if alert_rule_data_requires_async_lookup(project.organization, request.user, data):
+            if alert_rule_has_async_lookups(project.organization, request.user, data):
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()
                 task_args = {

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -91,7 +91,6 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
             },
             data=data,
         )
-
         if serializer.is_valid():
             if alert_rule_has_async_lookups(project.organization, request.user, data):
                 # need to kick off an async job for Slack

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -13,7 +13,7 @@ from sentry.api.paginator import (
 )
 from sentry.api.serializers import serialize, CombinedRuleSerializer
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer
-from sentry.incidents.logic import alert_rule_has_async_lookups
+from sentry.incidents.logic import get_slack_actions_with_async_lookups
 from sentry.incidents.models import AlertRule
 from sentry.integrations.slack import tasks
 from sentry.signals import alert_rule_created
@@ -92,7 +92,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
             data=data,
         )
         if serializer.is_valid():
-            if alert_rule_has_async_lookups(project.organization, request.user, data):
+            if get_slack_actions_with_async_lookups(project.organization, request.user, data):
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()
                 task_args = {

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -13,7 +13,7 @@ from sentry.api.paginator import (
 )
 from sentry.api.serializers import serialize, CombinedRuleSerializer
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer
-from sentry.incidents.logic import ChannelLookupTimeoutError
+from sentry.incidents.logic import alert_rule_data_requires_async_lookup
 from sentry.incidents.models import AlertRule
 from sentry.integrations.slack import tasks
 from sentry.signals import alert_rule_created
@@ -93,9 +93,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
         )
 
         if serializer.is_valid():
-            try:
-                alert_rule = serializer.save()
-            except ChannelLookupTimeoutError:
+            if alert_rule_data_requires_async_lookup(project.organization, request.user, data):
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()
                 task_args = {
@@ -107,6 +105,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
                 tasks.find_channel_id_for_alert_rule.apply_async(kwargs=task_args)
                 return Response({"uuid": client.uuid}, status=202)
             else:
+                alert_rule = serializer.save()
                 referrer = request.query_params.get("referrer")
                 session_id = request.query_params.get("sessionId")
                 alert_rule_created.send_robust(

--- a/src/sentry/incidents/endpoints/serializers.py
+++ b/src/sentry/incidents/endpoints/serializers.py
@@ -24,6 +24,7 @@ from sentry.incidents.logic import (
     CRITICAL_TRIGGER_LABEL,
     delete_alert_rule_trigger,
     delete_alert_rule_trigger_action,
+    rewrite_trigger_action_fields,
     translate_aggregate_field,
     update_alert_rule,
     update_alert_rule_trigger,
@@ -241,18 +242,14 @@ class AlertRuleTriggerSerializer(CamelSnakeModelSerializer):
                 delete_alert_rule_trigger_action(action)
 
             for action_data in actions:
-                if "integration_id" in action_data:
-                    action_data["integration"] = action_data.pop("integration_id")
-
-                if "sentry_app_id" in action_data:
-                    action_data["sentry_app"] = action_data.pop("sentry_app_id")
-
+                action_data = rewrite_trigger_action_fields(action_data)
                 if "id" in action_data:
                     action_instance = AlertRuleTriggerAction.objects.get(
                         alert_rule_trigger=alert_rule_trigger, id=action_data["id"]
                     )
                 else:
                     action_instance = None
+
                 action_serializer = AlertRuleTriggerActionSerializer(
                     context={
                         "alert_rule": alert_rule_trigger.alert_rule,

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -1477,9 +1477,12 @@ def get_slack_actions_with_async_lookups(organization, user, data):
                         and not a_s.validated_data["input_channel_id"]
                     ):
                         slack_actions.append(a_s.validated_data)
+        return slack_actions
     except KeyError:
-        pass
-    return slack_actions
+        # If we have any KeyErrors reading the data, we can just return nothing
+        # This will cause the endpoint to try creating the rule synchronously
+        # which will capture the error properly.
+        return {}
 
 
 def get_slack_channel_ids(organization, user, data):

--- a/src/sentry/integrations/slack/tasks.py
+++ b/src/sentry/integrations/slack/tasks.py
@@ -210,7 +210,7 @@ def find_channel_id_for_alert_rule(organization_id, uuid, data, alert_rule_id=No
     # we use SystemAccess here because we can't pass the access instance from the request into the task
     # this means at this point we won't raise any validation errors associated with permissions
     # however, we should only be calling this task after we tried saving the alert rule first
-    # which will catch those kinthatds of validation errors
+    # which will catch those kinds of validation errors
     serializer = AlertRuleSerializer(
         context={
             "organization": organization,

--- a/src/sentry/integrations/slack/tasks.py
+++ b/src/sentry/integrations/slack/tasks.py
@@ -177,7 +177,13 @@ def find_channel_id_for_alert_rule(organization_id, uuid, data, alert_rule_id=No
 
     # This function call will write "input_channel_id" to the appropriate actions before we create the serializer
     # I wasn't sure of a way to use the same loop to return True in the endpoints and to also do the lookup and didn't want to duplicate the loop
-    alert_rule_data_requires_async_lookup(organization, user, data, write_input_channel_id=True)
+    mapped_ids = alert_rule_data_requires_async_lookup(
+        organization, user, data, return_input_channel_id=True
+    )
+    for trigger in data["triggers"]:
+        for action in trigger["actions"]:
+            if action["targetIdentifier"] in mapped_ids:
+                action["input_channel_id"] = mapped_ids[action["targetIdentifier"]]
 
     # we use SystemAccess here because we can't pass the access instance from the request into the task
     # this means at this point we won't raise any validation errors associated with permissions

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -361,9 +361,7 @@ def get_channel_id(organization, integration, name, use_async_lookup=False):
         2. channel_id: string or `None`
         3. timed_out: boolean (whether we hit our self-imposed time limit)
     """
-
     name = strip_channel_name(name)
-
     # longer lookup for the async job
     if use_async_lookup:
         timeout = 3 * 60
@@ -389,7 +387,6 @@ def get_channel_id_with_timeout(integration, name, timeout):
         2. channel_id: string or `None`
         3. timed_out: boolean (whether we hit our self-imposed time limit)
     """
-
     headers = {"Authorization": "Bearer %s" % integration.metadata["access_token"]}
 
     payload = {

--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -361,7 +361,9 @@ def get_channel_id(organization, integration, name, use_async_lookup=False):
         2. channel_id: string or `None`
         3. timed_out: boolean (whether we hit our self-imposed time limit)
     """
+
     name = strip_channel_name(name)
+
     # longer lookup for the async job
     if use_async_lookup:
         timeout = 3 * 60
@@ -387,6 +389,7 @@ def get_channel_id_with_timeout(integration, name, timeout):
         2. channel_id: string or `None`
         3. timed_out: boolean (whether we hit our self-imposed time limit)
     """
+
     headers = {"Authorization": "Bearer %s" % integration.metadata["access_token"]}
 
     payload = {

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -400,7 +400,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
             assert (
                 mock_get_channel_id.call_count == 3
             )  # Did not increment from the last assertion because we early out on the validation error
-            # # Using get deliberately as there should only be one. Test should fail otherwise.
 
     def test_no_owner(self):
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -364,6 +364,8 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
         test_params = self.valid_params.copy()
         test_params["resolve_threshold"] = self.alert_rule.resolve_threshold
+        test_params["owner"] = None
+
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(
                 self.organization.slug, self.project.slug, alert_rule.id, **test_params
@@ -372,7 +374,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data == serialize(alert_rule, self.user)
         assert (
             resp.data["owner"] == self.user.actor.get_actor_identifier()
-        )  # Doesn't unassign because we didn't pass
+        )  # Doesn't unassign yet - TDB in future though
 
 
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -2,7 +2,14 @@ from exam import fixture
 from sentry.utils.compat.mock import patch
 
 from sentry.api.serializers import serialize
-from sentry.incidents.models import AlertRule, AlertRuleStatus, Incident, IncidentStatus
+from sentry.incidents.models import (
+    AlertRule,
+    AlertRuleTrigger,
+    AlertRuleTriggerAction,
+    AlertRuleStatus,
+    Incident,
+    IncidentStatus,
+)
 from sentry.models import Integration
 from sentry.testutils import APITestCase
 
@@ -234,7 +241,8 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
                 self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
             )
 
-        resp.data["uuid"] = "abc123"
+        # resp.data["uuid"] = "abc123" # TODO: @scefali: Does this do anything? I think it can be removed
+        assert resp.data["uuid"] == "abc123"  # TODO: @scefali: You probably meant to do this?
         kwargs = {
             "organization_id": self.organization.id,
             "uuid": "abc123",
@@ -243,6 +251,108 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
             "user_id": self.user.id,
         }
         mock_find_channel_id_for_alert_rule.assert_called_once_with(kwargs=kwargs)
+
+    @patch(
+        "sentry.integrations.slack.utils.get_channel_id_with_timeout",
+        side_effect=[("#", 10, False), ("#", 10, False), ("#", 20, False)],
+    )
+    @patch("sentry.integrations.slack.tasks.uuid4")
+    def test_async_slack_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):
+        class uuid:
+            hex = "abc123"
+
+        mock_uuid4.return_value = uuid
+
+        from sentry.integrations.slack.utils import get_channel_id_with_timeout
+
+        with patch(
+            "sentry.integrations.slack.utils.get_channel_id_with_timeout",
+            wraps=get_channel_id_with_timeout,
+        ) as mock_get_channel_id:
+            self.create_member(
+                user=self.user, organization=self.organization, role="owner", teams=[self.team]
+            )
+            self.login_as(self.user)
+            self.integration = Integration.objects.create(
+                provider="slack",
+                name="Team A",
+                external_id="TXXXXXXX1",
+                metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
+            )
+            self.integration.add_organization(self.organization, self.user)
+            test_params = self.valid_params.copy()
+            test_params["triggers"] = [
+                {
+                    "label": "critical",
+                    "alertThreshold": 200,
+                    "actions": [
+                        {
+                            "type": "slack",
+                            "targetIdentifier": "my-channel",
+                            "targetType": "specific",
+                            "integration": self.integration.id,
+                        },
+                    ],
+                },
+            ]
+
+            with self.feature("organizations:incidents"), self.tasks():
+                resp = self.get_response(
+                    self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
+                )
+            print("resp:", resp)
+            print("resp.data:", resp.data)
+            assert resp.data["uuid"] == "abc123"
+            assert mock_get_channel_id.call_count == 1
+            # Using get deliberately as there should only be one. Test should fail otherwise.
+            trigger = AlertRuleTrigger.objects.get(alert_rule_id=self.alert_rule.id)
+            action = AlertRuleTriggerAction.objects.get(alert_rule_trigger=trigger)
+            assert action.target_identifier == "10"
+            assert action.target_display == "my-channel"
+
+            # Now two actions with slack:
+            test_params = self.valid_params.copy()
+            test_params["triggers"] = [
+                {
+                    "label": "critical",
+                    "alertThreshold": 200,
+                    "actions": [
+                        {
+                            "type": "slack",
+                            "targetIdentifier": "my-channel",
+                            "targetType": "specific",
+                            "integration": self.integration.id,
+                        },
+                        {
+                            "type": "slack",
+                            "targetIdentifier": "another-channel",
+                            "targetType": "specific",
+                            "integration": self.integration.id,
+                        },
+                    ],
+                },
+            ]
+
+            with self.feature("organizations:incidents"), self.tasks():
+                resp = self.get_response(
+                    self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
+                )
+            print("resp:", resp)
+            print("resp.data:", resp.data)
+            assert resp.data["uuid"] == "abc123"
+            assert (
+                mock_get_channel_id.call_count == 3
+            )  # just made 2 calls, plus the call from the single action test
+
+            # Using get deliberately as there should only be one. Test should fail otherwise.
+            trigger = AlertRuleTrigger.objects.get(alert_rule_id=self.alert_rule.id)
+            actions = AlertRuleTriggerAction.objects.filter(alert_rule_trigger=trigger).order_by(
+                "id"
+            )
+            assert actions[0].target_identifier == "10"
+            assert actions[0].target_display == "my-channel"
+            assert actions[1].target_identifier == "20"
+            assert actions[1].target_display == "another-channel"
 
     def test_no_owner(self):
         self.create_member(
@@ -258,8 +368,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
 
         test_params = self.valid_params.copy()
         test_params["resolve_threshold"] = self.alert_rule.resolve_threshold
-        test_params["owner"] = None
-
         with self.feature("organizations:incidents"):
             resp = self.get_valid_response(
                 self.organization.slug, self.project.slug, alert_rule.id, **test_params
@@ -268,7 +376,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         assert resp.data == serialize(alert_rule, self.user)
         assert (
             resp.data["owner"] == self.user.actor.get_actor_identifier()
-        )  # Doesn't unassign yet - TDB in future though
+        )  # Doesn't unassign because we didn't pass
 
 
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase, APITestCase):

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -257,7 +257,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
         side_effect=[("#", 10, False), ("#", 10, False), ("#", 20, False)],
     )
     @patch("sentry.integrations.slack.tasks.uuid4")
-    def test_async_slack_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):
+    def test_async_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):
         class uuid:
             hex = "abc123"
 

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -300,8 +300,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
                 resp = self.get_response(
                     self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
                 )
-            print("resp:", resp)
-            print("resp.data:", resp.data)
             assert resp.data["uuid"] == "abc123"
             assert mock_get_channel_id.call_count == 1
             # Using get deliberately as there should only be one. Test should fail otherwise.
@@ -337,8 +335,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
                 resp = self.get_response(
                     self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
                 )
-            print("resp:", resp)
-            print("resp.data:", resp.data)
             assert resp.data["uuid"] == "abc123"
             assert (
                 mock_get_channel_id.call_count == 3

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -278,6 +278,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
 
             with self.feature("organizations:incidents"), self.tasks():
                 resp = self.get_response(self.organization.slug, self.project.slug, **test_params)
+            print("resp:", resp.data)
             assert resp.data["uuid"] == "abc123"
             assert mock_get_channel_id.call_count == 1
             # Using get deliberately as there should only be one. Test should fail otherwise.

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -316,7 +316,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
             assert (
                 mock_get_channel_id.call_count == 3
             )  # just made 2 calls, plus the call from the single action test
-            # # Using get deliberately as there should only be one. Test should fail otherwise.
+            # Using get deliberately as there should only be one. Test should fail otherwise.
             alert_rule = AlertRule.objects.get(name=name)
 
             trigger = AlertRuleTrigger.objects.get(alert_rule_id=alert_rule.id)
@@ -351,7 +351,6 @@ class AlertRuleCreateEndpointTest(APITestCase):
             assert (
                 mock_get_channel_id.call_count == 3
             )  # Did not increment from the last assertion because we early out on the validation error
-            # # Using get deliberately as there should only be one. Test should fail otherwise.
 
 
 class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestCase):

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -269,7 +269,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
                                 "type": "slack",
                                 "targetIdentifier": "my-channel",
                                 "targetType": "specific",
-                                "integration": self.integration.id,
+                                "integrationId": self.integration.id,
                             },
                         ],
                     },

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -228,7 +228,7 @@ class AlertRuleCreateEndpointTest(APITestCase):
         side_effect=[("#", 10, False), ("#", 10, False), ("#", 20, False)],
     )
     @patch("sentry.integrations.slack.tasks.uuid4")
-    def test_async_slack_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):
+    def test_async_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):
         class uuid:
             hex = "abc123"
 
@@ -278,7 +278,6 @@ class AlertRuleCreateEndpointTest(APITestCase):
 
             with self.feature("organizations:incidents"), self.tasks():
                 resp = self.get_response(self.organization.slug, self.project.slug, **test_params)
-            print("resp:", resp.data)
             assert resp.data["uuid"] == "abc123"
             assert mock_get_channel_id.call_count == 1
             # Using get deliberately as there should only be one. Test should fail otherwise.


### PR DESCRIPTION
A customer has been having issues saving their metric alerts. We believe the cause is the async lookup to slack to get slack id from channel name. This happens during a transaction, and the database closes the connection before Slack gets back to us.

Relevant Sentry Issue: https://sentry.io/organizations/sentry/issues/2235225148/

This PR solves that by moving the lookup so that it is done _before_ we save the AlertRuleSerializer. It parses the data, calls slack to get the ID, and then puts that ID in `input_channel_id`. Now when we save the serializer, within the transaction, we just grab input_channel_id and can immediately save.


While working on this, I noticed that the endpoint currently tries to save the alert first and only kicks off the async task if it times out. This leads to repeating the lookups done before the time out, and would greatly increase user waiting time. I've changed it so that we can do a quick check to see if there is a slack action requiring an async lookup, and queue the async task for all rules with slack actions. A part of me wonders if we should just _always_ save alert rules async to reduce some branching complexity here.


Currently, a customer saving an alert with two slack actions pointing to the same channel would make 4 calls (assuming they time out the initial save like we've been seeing):
- The endpoint gets the save / update request. It tries to save the rule. It'll make an api call to look up the critical trigger, then another to look up the warning trigger. It'll time out at some point. Potentially 2 api calls to slack made here.
- Since it timed out, the task is scheduled where we make the same calls again. 2 api calls to slack made here.

This PR would make 1 call in the same circumstance:
- The endpoint gets the save / update request. It checks if it has slack actions, if so, it schedules the task. 0 api calls made here.
- We will now look up the critical action and get the ID. We store that name:id map, and check against it for the warning action - since it is present, we don't do another lookup. 1 api call to slack made here.