### PR TITLE
feat(metric_alerts): p95 Default metric for transactions

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -98,7 +98,11 @@ export function createRuleFromEventView(eventView: EventView): UnsavedIncidentRu
     ...createDefaultRule(),
     ...datasetAndEventtypes,
     query: parsedQuery?.query ?? eventView.query,
-    aggregate: eventView.getYAxis(),
+    // If creating a metric alert for transactions, default to the p95 metric
+    aggregate:
+      datasetAndEventtypes.dataset === 'transactions'
+        ? 'p95(transaction.duration)'
+        : eventView.getYAxis(),
     environment: eventView.environment.length ? eventView.environment[0] : null,
   };
 }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -15,6 +15,7 @@ import {
 } from 'app/views/settings/incidentRules/types';
 
 export const DEFAULT_AGGREGATE = 'count()';
+export const DEFAULT_TRANSACTION_AGGREGATE = 'p95(transaction.duration)';
 
 export const DATASET_EVENT_TYPE_FILTERS = {
   [Dataset.ERRORS]: 'event.type:error',

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsForm.tsx
@@ -22,7 +22,7 @@ import {
 import FormField from 'app/views/settings/components/forms/formField';
 import SelectField from 'app/views/settings/components/forms/selectField';
 
-import {DEFAULT_AGGREGATE} from './constants';
+import {DEFAULT_AGGREGATE, DEFAULT_TRANSACTION_AGGREGATE} from './constants';
 import MetricField from './metricField';
 import {Datasource, TimeWindow} from './types';
 
@@ -204,7 +204,9 @@ class RuleConditionsFormWithGuiFilters extends React.PureComponent<Props, State>
                         // Reset the aggregate to the default (which works across
                         // datatypes), otherwise we may send snuba an invalid query
                         // (transaction aggregate on events datasource = bad).
-                        model.setValue('aggregate', DEFAULT_AGGREGATE);
+                        optionValue === 'transaction'
+                          ? model.setValue('aggregate', DEFAULT_TRANSACTION_AGGREGATE)
+                          : model.setValue('aggregate', DEFAULT_AGGREGATE);
 
                         // set the value of the dataset and event type from data source
                         const {dataset, eventTypes} =


### PR DESCRIPTION
Make p95 the default metric for transactions.

FIXES [WOR-56](https://getsentry.atlassian.net/browse/WOR-56)

### Before
<img width="1152" alt="Screen Shot 2021-03-16 at 3 59 54 PM" src="https://user-images.githubusercontent.com/20312973/111390867-b53c0200-8670-11eb-90f7-78b466677901.png">

### After
<img width="1146" alt="Screen Shot 2021-03-16 at 3 52 56 PM" src="https://user-images.githubusercontent.com/20312973/111390915-c8e76880-8670-11eb-9f73-1f6c2e29e2c9.png">