### PR TITLE
feat: Add a feature flag for minute-resolution sessions

### DIFF
--- a/src/sentry/api/endpoints/organization_sessions.py
+++ b/src/sentry/api/endpoints/organization_sessions.py
@@ -5,6 +5,7 @@ from rest_framework.exceptions import ParseError
 
 import sentry_sdk
 
+from sentry import features
 from sentry.api.bases import OrganizationEventsEndpointBase, NoProjects
 from sentry.snuba.sessions_v2 import (
     InvalidField,
@@ -37,7 +38,10 @@ class OrganizationSessionsEndpoint(OrganizationEventsEndpointBase):
         except NoProjects:
             raise NoProjects("No projects available")  # give it a description
 
-        return QueryDefinition(request.GET, params)
+        allow_minute_resolution = features.has(
+            "organizations:minute-resolution-sessions", organization, actor=request.user
+        )
+        return QueryDefinition(request.GET, params, allow_minute_resolution=allow_minute_resolution)
 
     @contextmanager
     def handle_query_errors(self):

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -940,6 +940,8 @@ SENTRY_FEATURES = {
     "organizations:relay": True,
     # Enable the new charts on top of the Releases page
     "organizations:releases-top-charts": False,
+    # Enable Session Stats down to a minute resolution
+    "organizations:minute-resolution-sessions": False,
     # Enable version 2 of reprocessing (completely distinct from v1)
     "organizations:reprocessing-v2": False,
     # Enable basic SSO functionality, providing configurable single sign on

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -99,6 +99,7 @@ default_manager.add("organizations:project-detail", OrganizationFeature)  # NOQA
 default_manager.add("organizations:project-detail-links", OrganizationFeature)  # NOQA
 default_manager.add("organizations:relay", OrganizationFeature)  # NOQA
 default_manager.add("organizations:releases-top-charts", OrganizationFeature)  # NOQA
+default_manager.add("organizations:minute-resolution-sessions", OrganizationFeature)  # NOQA
 default_manager.add("organizations:reprocessing-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:rule-page", OrganizationFeature)  # NOQA
 default_manager.add("organizations:set-grouping-config", OrganizationFeature)  # NOQA
@@ -157,6 +158,7 @@ requires_snuba = (
     "organizations:performance-view",
     "organizations:global-views",
     "organizations:incidents",
+    "organizations:minute-resolution-sessions",
 )
 
 # expose public api


### PR DESCRIPTION
Adds a new `organizations:minute-resolution-sessions` feature flag. These are behind a feature flag in snuba as well currently. Some safeguards need to be added to snuba as well.

Enabling the tests is blocked on https://github.com/getsentry/snuba/pull/1767 which removes the snuba feature flag, enabling the feature by default in snuba.