### PR TITLE
ref(codeowners): Merge feature flags into 1 flag

### DIFF
--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -51,7 +51,7 @@ class ExternalTeamSerializer(CamelSnakeModelSerializer):
 class ExternalTeamMixin:
     def has_feature(self, request, team):
         return features.has(
-            "organizations:external-team-associations", team.organization, actor=request.user
+            "organizations:import-codeowners", team.organization, actor=request.user
         )
 
 

--- a/src/sentry/api/endpoints/external_user.py
+++ b/src/sentry/api/endpoints/external_user.py
@@ -61,9 +61,7 @@ class ExternalUserSerializer(CamelSnakeModelSerializer):
 
 class ExternalUserMixin:
     def has_feature(self, request, organization):
-        return features.has(
-            "organizations:external-user-associations", organization, actor=request.user
-        )
+        return features.has("organizations:import-codeowners", organization, actor=request.user)
 
 
 class ExternalUserEndpoint(OrganizationEndpoint, ExternalUserMixin):

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -153,7 +153,9 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
 
 class ProjectCodeOwnersMixin:
     def has_feature(self, request, project):
-        return features.has("projects:import-codeowners", project, actor=request.user)
+        return features.has(
+            "organizations:import-codeowners", project.organization, actor=request.user
+        )
 
 
 class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin, ProjectCodeOwnersMixin):

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -905,10 +905,8 @@ SENTRY_FEATURES = {
     "organizations:dashboards-edit": False,
     # Enable experimental performance improvements.
     "organizations:enterprise-perf": False,
-    # Enable the API to create/update/delete external team associations
-    "organizations:external-team-associations": False,
-    # Enable the API to create/update/delete external user associations
-    "organizations:external-user-associations": False,
+    # Enable the API to importing CODEOWNERS for a project
+    "organizations:import-codeowners": False,
     # Special feature flag primarily used on the sentry.io SAAS product for
     # easily enabling features while in early development.
     "organizations:internal-catchall": False,
@@ -988,8 +986,6 @@ SENTRY_FEATURES = {
     "projects:discard-groups": False,
     # DEPRECATED: pending removal
     "projects:dsym": False,
-    # Enable the API to importing CODEOWNERS for a project
-    "projects:import-codeowners": False,
     # Enable selection of members, teams or code owners as email targets for issue alerts.
     "projects:issue-alerts-targeting": True,
     # Enable functionality for attaching  minidumps to events and displaying

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -68,12 +68,11 @@ default_manager.add("organizations:enterprise-perf", OrganizationFeature)  # NOQ
 default_manager.add("organizations:event-attachments", OrganizationFeature)  # NOQA
 default_manager.add("organizations:event-attachments-viewer", OrganizationFeature)  # NOQA
 default_manager.add("organizations:events", OrganizationFeature)  # NOQA
-default_manager.add("organizations:external-team-associations", OrganizationFeature)  # NOQA
-default_manager.add("organizations:external-user-associations", OrganizationFeature)  # NOQA
 default_manager.add("organizations:filters-and-sampling", OrganizationFeature)  # NOQA
 default_manager.add("organizations:global-views", OrganizationFeature)  # NOQA
 default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
 default_manager.add("organizations:metric-alert-builder-aggregate", OrganizationFeature)  # NOQA
+default_manager.add("organizations:import-codeowners", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-event-hooks", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-issue-basic", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-issue-sync", OrganizationFeature)  # NOQA
@@ -134,7 +133,6 @@ default_manager.add("projects:alert-filters", ProjectFeature)  # NOQA
 default_manager.add("projects:custom-inbound-filters", ProjectFeature)  # NOQA
 default_manager.add("projects:data-forwarding", ProjectFeature)  # NOQA
 default_manager.add("projects:discard-groups", ProjectFeature)  # NOQA
-default_manager.add("projects:import-codeowners", ProjectFeature)  # NOQA
 default_manager.add("projects:issue-alerts-targeting", ProjectFeature)  # NOQA
 default_manager.add("projects:minidump", ProjectFeature)  # NOQA
 default_manager.add("projects:race-free-group-creation", ProjectFeature)  # NOQA

--- a/tests/sentry/api/endpoints/test_external_team.py
+++ b/tests/sentry/api/endpoints/test_external_team.py
@@ -18,7 +18,7 @@ class ExternalTeamTest(APITestCase):
 
     def test_basic_post(self):
         data = {"externalName": "@getsentry/ecosystem", "provider": "github"}
-        with self.feature({"organizations:external-team-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, data)
         assert response.status_code == 201, response.content
         assert response.data == {
@@ -34,20 +34,20 @@ class ExternalTeamTest(APITestCase):
         assert response.data == {"detail": "You do not have permission to perform this action."}
 
     def test_missing_provider(self):
-        with self.feature({"organizations:external-team-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, {"externalName": "@getsentry/ecosystem"})
         assert response.status_code == 400
         assert response.data == {"provider": ["This field is required."]}
 
     def test_missing_externalName(self):
-        with self.feature({"organizations:external-team-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, {"provider": "gitlab"})
         assert response.status_code == 400
         assert response.data == {"externalName": ["This field is required."]}
 
     def test_invalid_provider(self):
         data = {"externalName": "@getsentry/ecosystem", "provider": "git"}
-        with self.feature({"organizations:external-team-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, data)
         assert response.status_code == 400
         assert response.data == {"provider": ['"git" is not a valid choice.']}
@@ -62,7 +62,7 @@ class ExternalTeamTest(APITestCase):
             "externalName": self.external_team.external_name,
             "provider": ExternalTeam.get_provider_string(self.external_team.provider),
         }
-        with self.feature({"organizations:external-team-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, data)
         assert response.status_code == 200
         assert response.data == {

--- a/tests/sentry/api/endpoints/test_external_team_details.py
+++ b/tests/sentry/api/endpoints/test_external_team_details.py
@@ -20,20 +20,20 @@ class ExternalTeamDetailsTest(APITestCase):
         )
 
     def test_basic_delete(self):
-        with self.feature({"organizations:external-team-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             resp = self.client.delete(self.url)
         assert resp.status_code == 204
         assert not ExternalTeam.objects.filter(id=str(self.external_team.id)).exists()
 
     def test_basic_update(self):
-        with self.feature({"organizations:external-team-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             resp = self.client.put(self.url, {"externalName": "@getsentry/growth"})
         assert resp.status_code == 200
         assert resp.data["id"] == str(self.external_team.id)
         assert resp.data["externalName"] == "@getsentry/growth"
 
     def test_invalid_provider_update(self):
-        with self.feature({"organizations:external-team-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             resp = self.client.put(self.url, {"provider": "git"})
         assert resp.status_code == 400
         assert resp.data == {"provider": ['"git" is not a valid choice.']}

--- a/tests/sentry/api/endpoints/test_external_user.py
+++ b/tests/sentry/api/endpoints/test_external_user.py
@@ -20,7 +20,7 @@ class ExternalUserTest(APITestCase):
         }
 
     def test_basic_post(self):
-        with self.feature({"organizations:external-user-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 201, response.content
         assert response.data == {
@@ -36,28 +36,28 @@ class ExternalUserTest(APITestCase):
 
     def test_missing_provider(self):
         self.data.pop("provider")
-        with self.feature({"organizations:external-user-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"provider": ["This field is required."]}
 
     def test_missing_externalName(self):
         self.data.pop("externalName")
-        with self.feature({"organizations:external-user-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"externalName": ["This field is required."]}
 
     def test_missing_memberId(self):
         self.data.pop("memberId")
-        with self.feature({"organizations:external-user-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"memberId": ["This field is required."]}
 
     def test_invalid_provider(self):
         self.data.update(provider="unknown")
-        with self.feature({"organizations:external-user-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"provider": ['"unknown" is not a valid choice.']}
@@ -67,7 +67,7 @@ class ExternalUserTest(APITestCase):
             self.user, self.organization, external_name=self.data["externalName"]
         )
 
-        with self.feature({"organizations:external-user-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 200
         assert response.data == {

--- a/tests/sentry/api/endpoints/test_external_user_details.py
+++ b/tests/sentry/api/endpoints/test_external_user_details.py
@@ -16,20 +16,20 @@ class ExternalUserDetailsTest(APITestCase):
         )
 
     def test_basic_delete(self):
-        with self.feature({"organizations:external-user-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             resp = self.client.delete(self.url)
         assert resp.status_code == 204
         assert not ExternalUser.objects.filter(id=str(self.external_user.id)).exists()
 
     def test_basic_update(self):
-        with self.feature({"organizations:external-user-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             resp = self.client.put(self.url, {"externalName": "@new_username"})
         assert resp.status_code == 200
         assert resp.data["id"] == str(self.external_user.id)
         assert resp.data["externalName"] == "@new_username"
 
     def test_invalid_provider_update(self):
-        with self.feature({"organizations:external-user-associations": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             resp = self.client.put(self.url, {"provider": "unknown"})
         assert resp.status_code == 400
         assert resp.data == {"provider": ['"unknown" is not a valid choice.']}

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -54,7 +54,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         )
 
     def test_no_codeowners(self):
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             resp = self.client.get(self.url)
         assert resp.status_code == 200
         assert resp.data == []
@@ -66,7 +66,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
 
     def test_codeowners_without_integrations(self):
         code_owner = self.create_codeowners(self.project, self.code_mapping, raw="*.js @tiger-team")
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             resp = self.client.get(self.url)
         assert resp.status_code == 200
         resp_data = resp.data[0]
@@ -78,7 +78,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
 
     def test_codeowners_with_integration(self):
         self._create_codeowner_with_integration()
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             resp = self.client.get(self.url)
         assert resp.status_code == 200
         resp_data = resp.data[0]
@@ -89,7 +89,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert resp_data["provider"] == self.integration.provider
 
     def test_basic_post(self):
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 201, response.content
         assert response.data["id"]
@@ -101,21 +101,21 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
 
     def test_empty_codeowners_text(self):
         self.data["raw"] = ""
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"raw": ["This field may not be blank."]}
 
     def test_invalid_codeowners_text(self):
         self.data["raw"] = "docs/*"
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"raw": ["Parse error: 'ownership' (line 1, column 1)"]}
 
     def test_cannot_find_external_user_name_association(self):
         self.data["raw"] = "docs/*  @MeredithAnya "
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {
@@ -124,7 +124,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
 
     def test_cannot_find_sentry_user_with_email(self):
         self.data["raw"] = "docs/*  someuser@sentry.io"
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {
@@ -135,7 +135,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
 
     def test_cannot_find_external_team_name_association(self):
         self.data["raw"] = "docs/*  @getsentry/frontend"
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {
@@ -146,7 +146,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
 
     def test_cannot_find__multiple_external_name_association(self):
         self.data["raw"] = "docs/*  @AnotherUser @getsentry/frontend @getsentry/docs"
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {
@@ -157,27 +157,27 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
 
     def test_missing_code_mapping_id(self):
         self.data.pop("codeMappingId")
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"codeMappingId": ["This field is required."]}
 
     def test_invalid_code_mapping_id(self):
         self.data["codeMappingId"] = 500
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"codeMappingId": ["This code mapping does not exist."]}
 
     def test_default_project_ownership_record_created(self):
         assert ProjectOwnership.objects.filter(project=self.project).exists() is False
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 201, response.content
         assert ProjectOwnership.objects.filter(project=self.project).exists() is True
 
     def test_schema_is_correct(self):
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 201, response.content
         assert response.data["id"]
@@ -197,7 +197,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
 
     def test_schema_preserves_comments(self):
         self.data["raw"] = "docs/*    @NisanthanNanthakumar   @getsentry/ecosystem\n"
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 201, response.content
         assert response.data["id"]
@@ -217,7 +217,7 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
 
     def test_raw_email_correct_schema(self):
         self.data["raw"] = f"docs/*    {self.user.email}   @getsentry/ecosystem\n"
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 201, response.content
         assert response.data["id"]

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -36,7 +36,7 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         )
 
     def test_basic_delete(self):
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.delete(self.url)
         assert response.status_code == 204
         assert not ProjectCodeOwners.objects.filter(id=str(self.codeowners.id)).exists()
@@ -47,7 +47,7 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         data = {
             "raw": "\n# cool stuff comment\n*.js                    @getsentry/frontend @NisanthanNanthakumar\n# good comment\n\n\n  docs/*  @getsentry/docs @getsentry/ecosystem\n\n"
         }
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.put(self.url, data)
         assert response.status_code == 200
         assert response.data["id"] == str(self.codeowners.id)
@@ -62,7 +62,7 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
                 "codeowners_id": 1000,
             },
         )
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.put(self.url, self.data)
         assert response.status_code == 404
         assert response.data == {"detail": "The requested resource does not exist"}
@@ -71,7 +71,7 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         data = {
             "raw": "\n# cool stuff comment\n*.js                    @getsentry/frontend @NisanthanNanthakumar\n# good comment\n\n\n  docs/*  @getsentry/docs @getsentry/ecosystem\nsrc/sentry/*       @AnotherUser\n\n"
         }
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.put(self.url, data)
         assert response.status_code == 400
         assert response.data == {
@@ -81,14 +81,14 @@ class ProjectCodeOwnersDetailsEndpointTestCase(APITestCase):
         }
 
     def test_invalid_code_mapping_id_update(self):
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.put(self.url, {"codeMappingId": 500})
         assert response.status_code == 400
         assert response.data == {"codeMappingId": ["This code mapping does not exist."]}
 
     def test_codeowners_email_update(self):
         data = {"raw": f"\n# cool stuff comment\n*.js {self.user.email}\n# good comment\n\n\n"}
-        with self.feature({"projects:import-codeowners": True}):
+        with self.feature({"organizations:import-codeowners": True}):
             response = self.client.put(self.url, data)
         assert response.status_code == 200
         assert response.data["raw"] == "# cool stuff comment\n*.js admin@sentry.io\n# good comment"


### PR DESCRIPTION
## Objective:

Currently have the following flags for the CodeOwners feature.
```
projects:import-codeowners
organizations:external-user-associations
organizations:external-team-associations
```
This PR will merge them into 1 flag: `"organizations:import-codeowners"`

