### PR TITLE
fix(integrations): Fix migration file

### DIFF
--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -1,42 +1,13 @@
 from collections import defaultdict
+from rest_framework import serializers
+from rest_framework.response import Response
 
 from sentry.api.bases.user import UserEndpoint
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers import serialize, Serializer
-from sentry.models import UserOption, UserOptionValue
-
-
-from rest_framework.response import Response
-
-from rest_framework import serializers
-
-USER_OPTION_SETTINGS = {
-    "deployNotifications": {
-        "key": "deploy-emails",
-        "default": UserOptionValue.committed_deploys_only,  # '3'
-        "type": int,
-    },
-    "personalActivityNotifications": {
-        "key": "self_notifications",
-        "default": UserOptionValue.all_conversations,  # '0'
-        "type": bool,
-    },
-    "selfAssignOnResolve": {
-        "key": "self_assign_issue",
-        "default": UserOptionValue.all_conversations,  # '0'
-        "type": bool,
-    },
-    "subscribeByDefault": {
-        "key": "subscribe_by_default",
-        "default": UserOptionValue.participating_only,  # '1'
-        "type": bool,
-    },
-    "workflowNotifications": {
-        "key": "workflow:notifications",
-        "default": UserOptionValue.participating_only,  # '1'
-        "type": int,
-    },
-}
+from sentry.models import UserOption
+from sentry.notifications.legacy_mappings import USER_OPTION_SETTINGS
+from sentry.notifications.types import UserOptionsSettingsKey
 
 
 class UserNotificationsSerializer(Serializer):
@@ -58,13 +29,12 @@ class UserNotificationsSerializer(Serializer):
         raw_data = {option.key: option.value for option in attrs}
 
         data = {}
-        for key in USER_OPTION_SETTINGS:
-            uo = USER_OPTION_SETTINGS[key]
+        for key, uo in USER_OPTION_SETTINGS.items():
             val = raw_data.get(uo["key"], uo["default"])
             if uo["type"] == bool:
-                data[key] = bool(int(val))  # '1' is true, '0' is false
+                data[key.value] = bool(int(val))  # '1' is true, '0' is false
             elif uo["type"] == int:
-                data[key] = int(val)
+                data[key.value] = int(val)
 
         data["weeklyReports"] = True  # This cannot be overridden
 
@@ -92,13 +62,12 @@ class UserNotificationDetailsEndpoint(UserEndpoint):
         serializer = UserNotificationDetailsSerializer(data=request.data)
 
         if serializer.is_valid():
-            for key in serializer.validated_data:
-                db_key = USER_OPTION_SETTINGS[key]["key"]
-                val = str(int(serializer.validated_data[key]))
+            for key, value in serializer.validated_data:
+                db_key = USER_OPTION_SETTINGS[UserOptionsSettingsKey(key)]["key"]
                 (uo, created) = UserOption.objects.get_or_create(
                     user=user, key=db_key, project=None, organization=None
                 )
-                uo.update(value=val)
+                uo.update(value=str(int(value)))
 
             return self.get(request, user)
         else:

--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -86,3 +86,7 @@ class NotificationSetting(Model):
         "type",
         "value",
     )
+
+
+# REQUIRED for migrations to run
+from sentry.trash.migration_enums import *  # NOQA

--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -1,5 +1,4 @@
 from django.db import models
-from enum import Enum
 
 from sentry.db.models import (
     BoundedBigIntegerField,
@@ -9,68 +8,11 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.models.integration import ExternalProviders
-
-
-class NotificationSettingTypes(Enum):
-    # top level config of on/off
-    # for workflow also includes SUBSCRIBE_ONLY
-    # for deploy also includes COMMITTED_ONLY
-    DEFAULT = 0
-    # send deploy notifications
-    DEPLOY = 10
-    # notifications for issues
-    ISSUE_ALERTS = 20
-    # notifications for changes in assignment, resolution, comments
-    WORKFLOW = 30
-
-
-NOTIFICATION_SETTING_TYPES = {
-    NotificationSettingTypes.DEFAULT: "default",
-    NotificationSettingTypes.DEPLOY: "deploy",
-    NotificationSettingTypes.ISSUE_ALERTS: "issue",
-    NotificationSettingTypes.WORKFLOW: "workflow",
-}
-
-
-class NotificationSettingOptionValues(Enum):
-    DEFAULT = 0  # Defer to a setting one level up.
-    NEVER = 10
-    ALWAYS = 20
-    SUBSCRIBE_ONLY = 30  # workflow
-    COMMITTED_ONLY = 40  # deploy
-
-
-NOTIFICATION_SETTING_OPTION_VALUES = {
-    NotificationSettingOptionValues.DEFAULT: "default",
-    NotificationSettingOptionValues.NEVER: "off",
-    NotificationSettingOptionValues.ALWAYS: "on",
-    NotificationSettingOptionValues.SUBSCRIBE_ONLY: "subscribe_only",
-    NotificationSettingOptionValues.COMMITTED_ONLY: "committed_only",
-}
-
-
-class NotificationScopeType(Enum):
-    USER = 0
-    ORGANIZATION = 10
-    PROJECT = 20
-
-
-NOTIFICATION_SCOPE_TYPE = {
-    NotificationScopeType.USER: "user",
-    NotificationScopeType.ORGANIZATION: "organization",
-    NotificationScopeType.PROJECT: "project",
-}
-
-
-class NotificationTargetType(Enum):
-    USER = 0
-    TEAM = 10
-
-
-NOTIFICATION_TARGET_TYPE = {
-    NotificationTargetType.USER: "user",
-    NotificationTargetType.TEAM: "team",
-}
+from sentry.notifications.types import (
+    NotificationScopeType,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+)
 
 
 class NotificationSetting(Model):

--- a/src/sentry/notifications/legacy_mappings.py
+++ b/src/sentry/notifications/legacy_mappings.py
@@ -1,0 +1,161 @@
+from sentry.models.useroption import UserOptionValue
+from sentry.notifications.types import (
+    FineTuningAPIKey,
+    NotificationSettingTypes,
+    NotificationSettingOptionValues,
+    UserOptionsSettingsKey,
+)
+
+
+USER_OPTION_SETTINGS = {
+    UserOptionsSettingsKey.DEPLOY: {
+        "key": "deploy-emails",
+        "default": UserOptionValue.committed_deploys_only,  # '3'
+        "type": int,
+    },
+    UserOptionsSettingsKey.SELF_ACTIVITY: {
+        "key": "self_notifications",
+        "default": UserOptionValue.all_conversations,  # '0'
+        "type": bool,
+    },
+    UserOptionsSettingsKey.SELF_ASSIGN: {
+        "key": "self_assign_issue",
+        "default": UserOptionValue.all_conversations,  # '0'
+        "type": bool,
+    },
+    UserOptionsSettingsKey.SUBSCRIBE_BY_DEFAULT: {
+        "key": "subscribe_by_default",
+        "default": UserOptionValue.participating_only,  # '1'
+        "type": bool,
+    },
+    UserOptionsSettingsKey.WORKFLOW: {
+        "key": "workflow:notifications",
+        "default": UserOptionValue.participating_only,  # '1'
+        "type": int,
+    },
+}
+
+FINE_TUNING_KEY_MAP = {
+    FineTuningAPIKey.ALERTS: "mail:alert",
+    FineTuningAPIKey.DEPLOY: "deploy-emails",
+    FineTuningAPIKey.EMAIL: "mail:email",
+    FineTuningAPIKey.REPORTS: "reports:disabled-organizations",
+    FineTuningAPIKey.WORKFLOW: "workflow:notifications",
+}
+
+KEYS_TO_LEGACY_KEYS = {
+    NotificationSettingTypes.DEPLOY: "deploy-emails",
+    NotificationSettingTypes.ISSUE_ALERTS: "mail:alert",
+    NotificationSettingTypes.WORKFLOW: "workflow:notifications",
+}
+
+
+KEY_VALUE_TO_LEGACY_VALUE = {
+    NotificationSettingTypes.DEPLOY: {
+        NotificationSettingOptionValues.ALWAYS: 2,
+        NotificationSettingOptionValues.COMMITTED_ONLY: 3,
+        NotificationSettingOptionValues.NEVER: 4,
+    },
+    NotificationSettingTypes.ISSUE_ALERTS: {
+        NotificationSettingOptionValues.ALWAYS: 1,
+        NotificationSettingOptionValues.NEVER: 0,
+    },
+    NotificationSettingTypes.WORKFLOW: {
+        NotificationSettingOptionValues.ALWAYS: 0,
+        NotificationSettingOptionValues.SUBSCRIBE_ONLY: 1,
+        NotificationSettingOptionValues.NEVER: 2,
+    },
+}
+
+LEGACY_VALUE_TO_KEY = {
+    NotificationSettingTypes.DEPLOY: {
+        -1: NotificationSettingOptionValues.DEFAULT,
+        2: NotificationSettingOptionValues.ALWAYS,
+        3: NotificationSettingOptionValues.COMMITTED_ONLY,
+        4: NotificationSettingOptionValues.NEVER,
+    },
+    NotificationSettingTypes.ISSUE_ALERTS: {
+        -1: NotificationSettingOptionValues.DEFAULT,
+        0: NotificationSettingOptionValues.NEVER,
+        1: NotificationSettingOptionValues.ALWAYS,
+    },
+    NotificationSettingTypes.WORKFLOW: {
+        -1: NotificationSettingOptionValues.DEFAULT,
+        0: NotificationSettingOptionValues.ALWAYS,
+        1: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+        2: NotificationSettingOptionValues.NEVER,
+    },
+}
+
+
+def get_legacy_key(type: NotificationSettingTypes) -> str:
+    """
+    Temporary mapping from new enum types to legacy strings.
+
+    :param type: NotificationSettingTypes enum
+    :return: String
+    """
+
+    return KEYS_TO_LEGACY_KEYS.get(type)
+
+
+def get_legacy_value(type: NotificationSettingTypes, value: NotificationSettingOptionValues) -> str:
+    """
+    Temporary mapping from new enum types to legacy strings. Each type has a separate mapping.
+
+    :param type: NotificationSettingTypes enum
+    :param value: NotificationSettingOptionValues enum
+    :return: String
+    """
+
+    return str(KEY_VALUE_TO_LEGACY_VALUE.get(type, {}).get(value))
+
+
+def get_option_value_from_boolean(value: bool) -> NotificationSettingOptionValues:
+    if value:
+        return NotificationSettingOptionValues.ALWAYS
+    else:
+        return NotificationSettingOptionValues.NEVER
+
+
+def get_option_value_from_int(
+    type: NotificationSettingTypes, value: int
+) -> NotificationSettingOptionValues:
+    return LEGACY_VALUE_TO_KEY.get(type, {}).get(value)
+
+
+def get_type_from_fine_tuning_key(key: FineTuningAPIKey) -> NotificationSettingTypes:
+    return {
+        FineTuningAPIKey.ALERTS: NotificationSettingTypes.ISSUE_ALERTS,
+        FineTuningAPIKey.DEPLOY: NotificationSettingTypes.DEPLOY,
+        FineTuningAPIKey.WORKFLOW: NotificationSettingTypes.WORKFLOW,
+    }.get(key)
+
+
+def get_legacy_key_from_fine_tuning_key(key: FineTuningAPIKey) -> str:
+    return FINE_TUNING_KEY_MAP.get(key)
+
+
+def get_type_from_user_option_settings_key(key: UserOptionsSettingsKey) -> NotificationSettingTypes:
+    return {
+        UserOptionsSettingsKey.DEPLOY: NotificationSettingTypes.DEPLOY,
+        UserOptionsSettingsKey.WORKFLOW: NotificationSettingTypes.WORKFLOW,
+    }.get(key)
+
+
+def get_key_from_legacy(key: str) -> NotificationSettingTypes:
+    return {
+        "deploy-emails": NotificationSettingTypes.DEPLOY,
+        "mail:alert": NotificationSettingTypes.ISSUE_ALERTS,
+        "subscribe_by_default": NotificationSettingTypes.ISSUE_ALERTS,
+        "workflow:notifications": NotificationSettingTypes.WORKFLOW,
+    }.get(key)
+
+
+def get_key_value_from_legacy(
+    key: str, value: any
+) -> (NotificationSettingTypes, NotificationSettingOptionValues):
+    type = get_key_from_legacy(key)
+    option_value = LEGACY_VALUE_TO_KEY.get(type, {}).get(int(value))
+
+    return type, option_value

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -1,0 +1,99 @@
+from enum import Enum
+
+"""
+TODO(postgres): We've encoded these enums as integers to facilitate
+communication with the DB. We'd prefer to encode them as strings to facilitate
+communication with the API and plan to do so as soon as we use native enums in
+Postgres. In the meantime each enum has an adjacent object that maps the
+integers to their string values.
+"""
+
+
+class NotificationSettingTypes(Enum):
+    """
+    Each of these categories of Notification settings has at least an option for
+    "on" or "off". Workflow also includes SUBSCRIBE_ONLY and Deploy also
+    includes COMMITTED_ONLY and both of these values are described below.
+    """
+
+    # Control all notification types. Currently unused.
+    DEFAULT = 0
+
+    # When Sentry sees there is a new code deploy.
+    DEPLOY = 10
+
+    # When Sentry sees and issue that triggers an Alert Rule.
+    ISSUE_ALERTS = 20
+
+    # Notifications for changes in assignment, resolution, comments, etc.
+    WORKFLOW = 30
+
+
+NOTIFICATION_SETTING_TYPES = {
+    NotificationSettingTypes.DEFAULT: "default",
+    NotificationSettingTypes.DEPLOY: "deploy",
+    NotificationSettingTypes.ISSUE_ALERTS: "issue",
+    NotificationSettingTypes.WORKFLOW: "workflow",
+}
+
+
+class NotificationSettingOptionValues(Enum):
+    """
+    An empty row in the DB should be represented as
+    NotificationSettingOptionValues.DEFAULT.
+    """
+
+    # Defer to a setting one level up.
+    DEFAULT = 0
+
+    # Mute this kind of notification.
+    NEVER = 10
+
+    # Un-mute this kind of notification.
+    ALWAYS = 20
+
+    # Workflow only. Only send notifications about Issues that the target has
+    # explicitly or implicitly opted-into.
+    SUBSCRIBE_ONLY = 30
+
+    # Deploy only. Only send notifications when the set of changes in the deploy
+    # included a commit authored by the target.
+    COMMITTED_ONLY = 40
+
+
+NOTIFICATION_SETTING_OPTION_VALUES = {
+    NotificationSettingOptionValues.DEFAULT: "default",
+    NotificationSettingOptionValues.NEVER: "off",
+    NotificationSettingOptionValues.ALWAYS: "on",
+    NotificationSettingOptionValues.SUBSCRIBE_ONLY: "subscribe_only",
+    NotificationSettingOptionValues.COMMITTED_ONLY: "committed_only",
+}
+
+
+class NotificationScopeType(Enum):
+    USER = 0
+    ORGANIZATION = 10
+    PROJECT = 20
+
+
+NOTIFICATION_SCOPE_TYPE = {
+    NotificationScopeType.USER: "user",
+    NotificationScopeType.ORGANIZATION: "organization",
+    NotificationScopeType.PROJECT: "project",
+}
+
+
+class FineTuningAPIKey(Enum):
+    ALERTS = "alerts"
+    DEPLOY = "deploy"
+    EMAIL = "email"
+    REPORTS = "reports"
+    WORKFLOW = "workflow"
+
+
+class UserOptionsSettingsKey(Enum):
+    DEPLOY = "deployNotifications"
+    SELF_ACTIVITY = "personalActivityNotifications"
+    SELF_ASSIGN = "selfAssignOnResolve"
+    SUBSCRIBE_BY_DEFAULT = "subscribeByDefault"
+    WORKFLOW = "workflowNotifications"

--- a/src/sentry/trash/migration_enums.py
+++ b/src/sentry/trash/migration_enums.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class NotificationTargetType(Enum):
+    USER = 0
+    TEAM = 10


### PR DESCRIPTION
Copy enum definitions from the models directory and into the migrations that use them.

It's better to have copies of enums inside the migration. This allows us to change or remove the enums without breaking past migrations.