### PR TITLE
fix(alerts): Disable autocomplete for alert actions text input

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/actionTargetSelector.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/actionsPanel/actionTargetSelector.tsx
@@ -83,6 +83,8 @@ export default function ActionTargetSelector(props: Props) {
         />
       ) : (
         <Input
+          type="text"
+          autoComplete="off"
           disabled={disabled}
           key={action.type}
           value={action.targetIdentifier || ''}


### PR DESCRIPTION
This only slightly fixes 1password extension, but should fix the built in password manager

![image](https://user-images.githubusercontent.com/1400464/111521454-65b01180-8716-11eb-8b73-57402f7db8e6.png)
