### PR TITLE
fix(monitors): Correctly return GUID as ID

### DIFF
--- a/src/sentry/api/endpoints/monitor_checkins.py
+++ b/src/sentry/api/endpoints/monitor_checkins.py
@@ -88,6 +88,6 @@ class MonitorCheckInsEndpoint(MonitorEndpoint):
                 ).update(**monitor_params)
 
         if isinstance(request.auth, ProjectKey):
-            return self.respond({"id": str(checkin.id)}, status=201)
+            return self.respond({"id": str(checkin.guid)}, status=201)
 
         return self.respond(serialize(checkin, request.user), status=201)

--- a/tests/sentry/api/endpoints/test_monitor_checkins.py
+++ b/tests/sentry/api/endpoints/test_monitor_checkins.py
@@ -2,6 +2,7 @@ import pytest
 from datetime import timedelta
 from django.utils import timezone
 from freezegun import freeze_time
+from uuid import UUID
 
 from sentry.models import CheckInStatus, Monitor, MonitorCheckIn, MonitorStatus, MonitorType
 from sentry.testutils import APITestCase
@@ -166,9 +167,9 @@ class CreateMonitorCheckInTest(APITestCase):
             )
 
         assert resp.status_code == 201, resp.content
-        assert type(resp.data["id"]) == str
         # DSN auth should only return id
         assert list(resp.data.keys()) == ["id"]
+        assert UUID(resp.data["id"])
 
     @pytest.mark.xfail(
         reason="There's a bug in sentry/api/bases/monitor that needs fixed, until then, this returns 500"


### PR DESCRIPTION
Fixes SENTRY-P41

The original fix (37e1492a1c9a69166e3d634a297d1c086e816480) was not correct - gotta put on reading glasses in the future.