### PR TITLE
Revert "fix(alert rules): Changing async task to run outside of transaction and once per request"

### DIFF
--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -5,11 +5,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.alert_rule import AlertRuleSerializer
 from sentry.incidents.endpoints.bases import ProjectAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
-from sentry.incidents.logic import (
-    get_slack_actions_with_async_lookups,
-    AlreadyDeletedError,
-    delete_alert_rule,
-)
+from sentry.incidents.logic import AlreadyDeletedError, ChannelLookupTimeoutError, delete_alert_rule
 from sentry.integrations.slack import tasks
 
 
@@ -35,8 +31,11 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
             data=data,
             partial=True,
         )
+
         if serializer.is_valid():
-            if get_slack_actions_with_async_lookups(project.organization, request.user, data):
+            try:
+                alert_rule = serializer.save()
+            except ChannelLookupTimeoutError:
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()
                 task_args = {
@@ -49,7 +48,6 @@ class ProjectAlertRuleDetailsEndpoint(ProjectAlertRuleEndpoint):
                 tasks.find_channel_id_for_alert_rule.apply_async(kwargs=task_args)
                 return Response({"uuid": client.uuid}, status=202)
             else:
-                alert_rule = serializer.save()
                 return Response(serialize(alert_rule, request.user), status=status.HTTP_200_OK)
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -13,7 +13,7 @@ from sentry.api.paginator import (
 )
 from sentry.api.serializers import serialize, CombinedRuleSerializer
 from sentry.incidents.endpoints.serializers import AlertRuleSerializer
-from sentry.incidents.logic import get_slack_actions_with_async_lookups
+from sentry.incidents.logic import ChannelLookupTimeoutError
 from sentry.incidents.models import AlertRule
 from sentry.integrations.slack import tasks
 from sentry.signals import alert_rule_created
@@ -91,8 +91,11 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
             },
             data=data,
         )
+
         if serializer.is_valid():
-            if get_slack_actions_with_async_lookups(project.organization, request.user, data):
+            try:
+                alert_rule = serializer.save()
+            except ChannelLookupTimeoutError:
                 # need to kick off an async job for Slack
                 client = tasks.RedisRuleStatus()
                 task_args = {
@@ -104,7 +107,6 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint):
                 tasks.find_channel_id_for_alert_rule.apply_async(kwargs=task_args)
                 return Response({"uuid": client.uuid}, status=202)
             else:
-                alert_rule = serializer.save()
                 referrer = request.query_params.get("referrer")
                 session_id = request.query_params.get("sessionId")
                 alert_rule_created.send_robust(

--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 
 from sentry import analytics, quotas
 from sentry.api.event_search import get_filter, resolve_field
-from sentry.auth.access import SystemAccess
 from sentry.constants import SentryAppInstallationStatus, SentryAppStatus
 from sentry.incidents import tasks
 from sentry.incidents.models import (
@@ -1296,7 +1295,7 @@ def get_alert_rule_trigger_action_slack_channel_id(
 
         raise InvalidTriggerActionError(
             'Multiple users were found with display name "%s". Please use your username, found at %s/account/settings.'
-            % (e, domain)
+            % (e.message, domain)
         )
 
     if timed_out:
@@ -1453,66 +1452,3 @@ def translate_aggregate_field(aggregate, reverse=False):
                 if translated_field == column:
                     return aggregate.replace(column, field)
     return aggregate
-
-
-def get_slack_actions_with_async_lookups(organization, user, data):
-    try:
-        from sentry.incidents.endpoints.serializers import AlertRuleTriggerActionSerializer
-
-        slack_actions = []
-        for trigger in data["triggers"]:
-            for action in trigger["actions"]:
-                action = rewrite_trigger_action_fields(action)
-                a_s = AlertRuleTriggerActionSerializer(
-                    context={
-                        "organization": organization,
-                        "access": SystemAccess(),
-                        "user": user,
-                    },
-                    data=action,
-                )
-                if a_s.is_valid():
-                    if (
-                        a_s.validated_data["type"].value == AlertRuleTriggerAction.Type.SLACK.value
-                        and not a_s.validated_data["input_channel_id"]
-                    ):
-                        slack_actions.append(a_s.validated_data)
-        return slack_actions
-    except KeyError:
-        # If we have any KeyErrors reading the data, we can just return nothing
-        # This will cause the endpoint to try creating the rule synchronously
-        # which will capture the error properly.
-        return {}
-
-
-def get_slack_channel_ids(organization, user, data):
-    slack_actions = get_slack_actions_with_async_lookups(organization, user, data)
-    mapped_slack_channels = {}
-    for action in slack_actions:
-        if not action["target_identifier"] in mapped_slack_channels:
-            (
-                mapped_slack_channels[action["target_identifier"]],
-                _,
-            ) = get_target_identifier_display_for_integration(
-                action["type"].value,
-                action["target_identifier"],
-                organization,
-                action["integration"].id,
-                use_async_lookup=True,
-                input_channel_id=None,
-            )
-    return mapped_slack_channels
-
-
-def rewrite_trigger_action_fields(action_data):
-    if "integration_id" in action_data:
-        action_data["integration"] = action_data.pop("integration_id")
-    elif "integrationId" in action_data:
-        action_data["integration"] = action_data.pop("integrationId")
-
-    if "sentry_app_id" in action_data:
-        action_data["sentry_app"] = action_data.pop("sentry_app_id")
-    elif "sentryAppId" in action_data:
-        action_data["sentry_app"] = action_data.pop("sentryAppId")
-
-    return action_data

--- a/src/sentry/integrations/slack/tasks.py
+++ b/src/sentry/integrations/slack/tasks.py
@@ -1,5 +1,3 @@
-import logging
-
 from uuid import uuid4
 
 from django.conf import settings
@@ -18,20 +16,12 @@ from sentry.models import (
     Organization,
     User,
 )
-from sentry.incidents.endpoints.serializers import (
-    AlertRuleSerializer,
-)
+from sentry.incidents.endpoints.serializers import AlertRuleSerializer
 from sentry.incidents.models import AlertRule
-from sentry.incidents.logic import (
-    get_slack_channel_ids,
-    ChannelLookupTimeoutError,
-    InvalidTriggerActionError,
-)
+from sentry.incidents.logic import ChannelLookupTimeoutError
 from sentry.integrations.slack.utils import get_channel_id_with_timeout, strip_channel_name
 from sentry.utils.redis import redis_clusters
 from sentry.shared_integrations.exceptions import DuplicateDisplayNameError
-
-logger = logging.getLogger("sentry.integrations.slack.tasks")
 
 
 class RedisRuleStatus:
@@ -179,30 +169,6 @@ def find_channel_id_for_alert_rule(organization_id, uuid, data, alert_rule_id=No
         except AlertRule.DoesNotExist:
             redis_rule_status.set_value("failed")
             return
-
-    try:
-        mapped_ids = get_slack_channel_ids(organization, user, data)
-    except (serializers.ValidationError, ChannelLookupTimeoutError, InvalidTriggerActionError) as e:
-        # channel doesn't exist error or validation error
-        logger.info(
-            "get_slack_channel_ids.failed",
-            extra={
-                "exception": e,
-            },
-        )
-        redis_rule_status.set_value("failed")
-        return
-
-    for trigger in data["triggers"]:
-        for action in trigger["actions"]:
-            if action["type"] == "slack":
-                if action["targetIdentifier"] in mapped_ids:
-                    action["input_channel_id"] = mapped_ids[action["targetIdentifier"]]
-                    # We can early exit because we couldn't map this action's slack channel name to a slack id
-                    # This is a fail safe, but I think we shouldn't really hit this.
-                else:
-                    redis_rule_status.set_value("failed")
-                    return
 
     # we use SystemAccess here because we can't pass the access instance from the request into the task
     # this means at this point we won't raise any validation errors associated with permissions

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -2,14 +2,7 @@ from exam import fixture
 from sentry.utils.compat.mock import patch
 
 from sentry.api.serializers import serialize
-from sentry.incidents.models import (
-    AlertRule,
-    AlertRuleTrigger,
-    AlertRuleTriggerAction,
-    AlertRuleStatus,
-    Incident,
-    IncidentStatus,
-)
+from sentry.incidents.models import AlertRule, AlertRuleStatus, Incident, IncidentStatus
 from sentry.models import Integration
 from sentry.testutils import APITestCase
 
@@ -241,8 +234,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
                 self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
             )
 
-        # resp.data["uuid"] = "abc123" # TODO: @scefali: Does this do anything? I think it can be removed
-        assert resp.data["uuid"] == "abc123"  # TODO: @scefali: You probably meant to do this?
+        resp.data["uuid"] = "abc123"
         kwargs = {
             "organization_id": self.organization.id,
             "uuid": "abc123",
@@ -251,155 +243,6 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase, APITestCase):
             "user_id": self.user.id,
         }
         mock_find_channel_id_for_alert_rule.assert_called_once_with(kwargs=kwargs)
-
-    @patch(
-        "sentry.integrations.slack.utils.get_channel_id_with_timeout",
-        side_effect=[("#", 10, False), ("#", 10, False), ("#", 20, False)],
-    )
-    @patch("sentry.integrations.slack.tasks.uuid4")
-    def test_async_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):
-        class uuid:
-            hex = "abc123"
-
-        mock_uuid4.return_value = uuid
-
-        from sentry.integrations.slack.utils import get_channel_id_with_timeout
-
-        with patch(
-            "sentry.integrations.slack.utils.get_channel_id_with_timeout",
-            wraps=get_channel_id_with_timeout,
-        ) as mock_get_channel_id:
-            self.create_member(
-                user=self.user, organization=self.organization, role="owner", teams=[self.team]
-            )
-            self.login_as(self.user)
-            self.integration = Integration.objects.create(
-                provider="slack",
-                name="Team A",
-                external_id="TXXXXXXX1",
-                metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
-            )
-            self.integration.add_organization(self.organization, self.user)
-            test_params = self.valid_params.copy()
-            test_params["triggers"] = [
-                {
-                    "label": "critical",
-                    "alertThreshold": 200,
-                    "actions": [
-                        {
-                            "type": "slack",
-                            "targetIdentifier": "my-channel",
-                            "targetType": "specific",
-                            "integration": self.integration.id,
-                        },
-                    ],
-                },
-            ]
-
-            with self.feature("organizations:incidents"), self.tasks():
-                resp = self.get_response(
-                    self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
-                )
-            assert resp.data["uuid"] == "abc123"
-            assert mock_get_channel_id.call_count == 1
-            # Using get deliberately as there should only be one. Test should fail otherwise.
-            trigger = AlertRuleTrigger.objects.get(alert_rule_id=self.alert_rule.id)
-            action = AlertRuleTriggerAction.objects.get(alert_rule_trigger=trigger)
-            assert action.target_identifier == "10"
-            assert action.target_display == "my-channel"
-
-            # Now two actions with slack:
-            test_params = self.valid_params.copy()
-            test_params["triggers"] = [
-                {
-                    "label": "critical",
-                    "alertThreshold": 200,
-                    "actions": [
-                        {
-                            "type": "slack",
-                            "targetIdentifier": "my-channel",
-                            "targetType": "specific",
-                            "integration": self.integration.id,
-                        },
-                        {
-                            "type": "slack",
-                            "targetIdentifier": "another-channel",
-                            "targetType": "specific",
-                            "integration": self.integration.id,
-                        },
-                        {
-                            "type": "slack",
-                            "targetIdentifier": "another-channel",
-                            "targetType": "specific",
-                            "integration": self.integration.id,
-                        },
-                    ],
-                },
-                {
-                    "label": "warning",
-                    "alertThreshold": 200,
-                    "actions": [
-                        {
-                            "type": "slack",
-                            "targetIdentifier": "my-channel",  # same channel, but only one lookup made per channel
-                            "targetType": "specific",
-                            "integration": self.integration.id,
-                        },
-                    ],
-                },
-            ]
-
-            with self.feature("organizations:incidents"), self.tasks():
-                resp = self.get_response(
-                    self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
-                )
-            assert resp.data["uuid"] == "abc123"
-            assert (
-                mock_get_channel_id.call_count == 3
-            )  # just made 2 calls, plus the call from the single action test
-
-            # Using get deliberately as there should only be one. Test should fail otherwise.
-            triggers = AlertRuleTrigger.objects.filter(alert_rule_id=self.alert_rule.id)
-            actions = AlertRuleTriggerAction.objects.filter(
-                alert_rule_trigger__in=triggers
-            ).order_by("id")
-            # The 3 critical trigger actions:
-            assert actions[0].target_identifier == "10"
-            assert actions[0].target_display == "my-channel"
-            assert actions[1].target_identifier == "20"
-            assert actions[1].target_display == "another-channel"
-            assert actions[2].target_identifier == "20"
-            assert actions[2].target_display == "another-channel"
-
-            # This is the warning trigger action:
-            assert actions[3].target_identifier == "10"
-            assert actions[3].target_display == "my-channel"
-
-            # Now an invalid action (we want to early out with a good validationerror and not schedule the task):
-            name = "MyInvalidActionRule"
-            test_params["name"] = name
-            test_params["triggers"] = [
-                {
-                    "label": "critical",
-                    "alertThreshold": 75,
-                    "actions": [
-                        {
-                            "type": "element",
-                            "targetIdentifier": "my-channel",
-                            "targetType": "arbitrary",
-                            "integrationId": self.integration.id,
-                        },
-                    ],
-                },
-            ]
-            with self.feature("organizations:incidents"), self.tasks():
-                resp = self.get_response(
-                    self.organization.slug, self.project.slug, self.alert_rule.id, **test_params
-                )
-            assert resp.status_code == 400
-            assert (
-                mock_get_channel_id.call_count == 3
-            )  # Did not increment from the last assertion because we early out on the validation error
 
     def test_no_owner(self):
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -7,7 +7,7 @@ from sentry.utils.compat.mock import patch
 
 from sentry.utils import json
 from sentry.api.serializers import serialize
-from sentry.incidents.models import AlertRule, AlertRuleTrigger, AlertRuleTriggerAction
+from sentry.incidents.models import AlertRule
 from sentry.models import Integration
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils import APITestCase
@@ -222,135 +222,6 @@ class AlertRuleCreateEndpointTest(APITestCase):
         assert "id" in resp.data
         alert_rule = AlertRule.objects.get(id=resp.data["id"])
         assert resp.data == serialize(alert_rule, self.user)
-
-    @patch(
-        "sentry.integrations.slack.utils.get_channel_id_with_timeout",
-        side_effect=[("#", 10, False), ("#", 10, False), ("#", 20, False)],
-    )
-    @patch("sentry.integrations.slack.tasks.uuid4")
-    def test_async_lookup_outside_transaction(self, mock_uuid4, mock_get_channel_id):
-        class uuid:
-            hex = "abc123"
-
-        mock_uuid4.return_value = uuid
-
-        from sentry.integrations.slack.utils import get_channel_id_with_timeout
-
-        with patch(
-            "sentry.integrations.slack.utils.get_channel_id_with_timeout",
-            wraps=get_channel_id_with_timeout,
-        ) as mock_get_channel_id:
-            self.create_member(
-                user=self.user, organization=self.organization, role="owner", teams=[self.team]
-            )
-            self.login_as(self.user)
-            self.integration = Integration.objects.create(
-                provider="slack",
-                name="Team A",
-                external_id="TXXXXXXX1",
-                metadata={"access_token": "xoxp-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx"},
-            )
-            self.integration.add_organization(self.organization, self.user)
-            name = "MySpecialAsyncTestRule"
-            test_params = {
-                "aggregate": "count()",
-                "query": "",
-                "timeWindow": "300",
-                "projects": [self.project.slug],
-                "name": name,
-                "resolveThreshold": 100,
-                "thresholdType": 1,
-                "triggers": [
-                    {
-                        "label": "critical",
-                        "alertThreshold": 75,
-                        "actions": [
-                            {
-                                "type": "slack",
-                                "targetIdentifier": "my-channel",
-                                "targetType": "specific",
-                                "integrationId": self.integration.id,
-                            },
-                        ],
-                    },
-                ],
-            }
-
-            with self.feature("organizations:incidents"), self.tasks():
-                resp = self.get_response(self.organization.slug, self.project.slug, **test_params)
-            assert resp.data["uuid"] == "abc123"
-            assert mock_get_channel_id.call_count == 1
-            # Using get deliberately as there should only be one. Test should fail otherwise.
-            alert_rule = AlertRule.objects.get(name=name)
-            trigger = AlertRuleTrigger.objects.get(alert_rule_id=alert_rule.id)
-            action = AlertRuleTriggerAction.objects.get(alert_rule_trigger=trigger)
-            assert action.target_identifier == "10"
-            assert action.target_display == "my-channel"
-
-            # Now two actions with slack:
-            name = "MySpecialAsyncTestRuleTakeTwo"
-            test_params["name"] = name
-            test_params["triggers"] = [
-                {
-                    "label": "critical",
-                    "alertThreshold": 75,
-                    "actions": [
-                        {
-                            "type": "slack",
-                            "targetIdentifier": "my-channel",
-                            "targetType": "specific",
-                            "integrationId": self.integration.id,
-                        },
-                        {
-                            "type": "slack",
-                            "targetIdentifier": "another-channel",
-                            "targetType": "specific",
-                            "integrationId": self.integration.id,
-                        },
-                    ],
-                },
-            ]
-            with self.feature("organizations:incidents"), self.tasks():
-                resp = self.get_response(self.organization.slug, self.project.slug, **test_params)
-            assert resp.data["uuid"] == "abc123"
-            assert (
-                mock_get_channel_id.call_count == 3
-            )  # just made 2 calls, plus the call from the single action test
-            # Using get deliberately as there should only be one. Test should fail otherwise.
-            alert_rule = AlertRule.objects.get(name=name)
-
-            trigger = AlertRuleTrigger.objects.get(alert_rule_id=alert_rule.id)
-            actions = AlertRuleTriggerAction.objects.filter(alert_rule_trigger=trigger).order_by(
-                "id"
-            )
-            assert actions[0].target_identifier == "10"
-            assert actions[0].target_display == "my-channel"
-            assert actions[1].target_identifier == "20"
-            assert actions[1].target_display == "another-channel"
-
-            # Now an invalid action (we want to early out with a good validationerror and not schedule the task):
-            name = "MyInvalidActionRule"
-            test_params["name"] = name
-            test_params["triggers"] = [
-                {
-                    "label": "critical",
-                    "alertThreshold": 75,
-                    "actions": [
-                        {
-                            "type": "element",
-                            "targetIdentifier": "my-channel",
-                            "targetType": "arbitrary",
-                            "integrationId": self.integration.id,
-                        },
-                    ],
-                },
-            ]
-            with self.feature("organizations:incidents"), self.tasks():
-                resp = self.get_response(self.organization.slug, self.project.slug, **test_params)
-            assert resp.status_code == 400
-            assert (
-                mock_get_channel_id.call_count == 3
-            )  # Did not increment from the last assertion because we early out on the validation error
 
 
 class ProjectCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, APITestCase):


### PR DESCRIPTION
Reverts getsentry/sentry#24489

Creating just in case things are really borked.