### PR TITLE
feat(alert): Blank wizard page and route (WOR-664)

### DIFF
--- a/src/sentry/static/sentry/app/routes.tsx
+++ b/src/sentry/static/sentry/app/routes.tsx
@@ -1568,6 +1568,16 @@ function routes() {
                   )
                 }
               />
+              <Route
+                path="wizard/"
+                name="Alert Creation Wizard"
+                component={errorHandler(LazyLoad)}
+                componentPromise={() =>
+                  import(
+                    /* webpackChunkName: "ProjectAlertsCreate" */ 'app/views/alerts/wizard'
+                  )
+                }
+              />
             </Route>
           </Route>
 

--- a/src/sentry/static/sentry/app/routes.tsx
+++ b/src/sentry/static/sentry/app/routes.tsx
@@ -1574,7 +1574,7 @@ function routes() {
                 component={errorHandler(LazyLoad)}
                 componentPromise={() =>
                   import(
-                    /* webpackChunkName: "ProjectAlertsCreate" */ 'app/views/alerts/wizard'
+                    /* webpackChunkName: "ProjectAlertsWizard" */ 'app/views/alerts/wizard'
                   )
                 }
               />

--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {RouteComponentProps} from 'react-router';
+import styled from '@emotion/styled';
+
+import Feature from 'app/components/acl/feature';
+import PageHeading from 'app/components/pageHeading';
+import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
+import {t} from 'app/locale';
+import {PageContent, PageHeader} from 'app/styles/organization';
+import space from 'app/styles/space';
+import {Organization, Project} from 'app/types';
+import BuilderBreadCrumbs from 'app/views/alerts/builder/builderBreadCrumbs';
+
+type RouteParams = {
+  orgId: string;
+  projectId: string;
+};
+
+type Props = RouteComponentProps<RouteParams, {}> & {
+  organization: Organization;
+  project: Project;
+  hasMetricAlerts: boolean;
+};
+
+class AlertWizard extends React.Component<Props> {
+  render() {
+    const {
+      hasMetricAlerts,
+      organization,
+      params: {projectId},
+    } = this.props;
+    const title = t('Alert Creation Wizard');
+
+    return (
+      <React.Fragment>
+        <SentryDocumentTitle title={title} projectSlug={projectId} />
+        <PageContent>
+          <Feature features={['organizations:alert-wizard']}>
+            <BuilderBreadCrumbs
+              hasMetricAlerts={hasMetricAlerts}
+              orgSlug={organization.slug}
+              title={t('Create Alert Rule')}
+            />
+            <StyledPageHeader>
+              <PageHeading>{t('What do you want to alert on?')}</PageHeading>
+            </StyledPageHeader>
+          </Feature>
+        </PageContent>
+      </React.Fragment>
+    );
+  }
+}
+
+const StyledPageHeader = styled(PageHeader)`
+  margin-bottom: ${space(4)};
+`;
+
+export default AlertWizard;


### PR DESCRIPTION
Setting up the beginning of the wizard page. Currently blank and feature flagged to `organizations:alert-wizard`

Accessible via `/organizations/<:orgSlug>/alerts/<:projSlug>/wizard/`

![image](https://user-images.githubusercontent.com/9372512/111543998-3c10dd80-874a-11eb-9882-8dc09ee1712e.png)

designs: https://www.figma.com/file/uG4rQ7ZYMIigVaPLcqVHAZ/Handover%3A-Alerts-Wizard?node-id=0%3A1

Fixes: WOR-664