### PR TITLE
py38: upgrade simplejson to latest

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -50,7 +50,7 @@ rfc3986-validator==0.1.1
 # [end] jsonschema format validators
 sentry-relay==0.8.4
 sentry-sdk>=0.20.0,<0.21.0
-simplejson==3.11.1
+simplejson==3.17.2
 statsd==3.1
 structlog==17.1.0
 symbolic==8.0.3

--- a/src/sentry/shared_integrations/exceptions.py
+++ b/src/sentry/shared_integrations/exceptions.py
@@ -2,7 +2,6 @@ from bs4 import BeautifulSoup
 from collections import OrderedDict
 from requests.exceptions import RequestException
 
-from simplejson.decoder import JSONDecodeError
 from urllib.parse import urlparse
 from sentry.utils import json
 
@@ -22,7 +21,7 @@ class ApiError(Exception):
         if text:
             try:
                 self.json = json.loads(text, object_pairs_hook=OrderedDict)
-            except (JSONDecodeError, ValueError):
+            except (json.JSONDecodeError, ValueError):
                 if self.text[:5] == "<?xml":
                     # perhaps it's XML?
                     self.xml = BeautifulSoup(self.text, "xml")

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -68,26 +68,18 @@ class JSONEncoderForHTML(JSONEncoder):
 
 
 _default_encoder = JSONEncoder(
+    # upstream: (', ', ': ')
+    # Ours eliminates whitespace.
     separators=(",", ":"),
+    # upstream: False
+    # True makes nan, inf, -inf serialize as null in compliance with ECMA-262.
     ignore_nan=True,
-    skipkeys=False,
-    ensure_ascii=True,
-    check_circular=True,
-    allow_nan=True,
-    indent=None,
-    encoding="utf-8",
     default=better_default_encoder,
 )
 
 _default_escaped_encoder = JSONEncoderForHTML(
     separators=(",", ":"),
     ignore_nan=True,
-    skipkeys=False,
-    ensure_ascii=True,
-    check_circular=True,
-    allow_nan=True,
-    indent=None,
-    encoding="utf-8",
     default=better_default_encoder,
 )
 

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -50,15 +50,12 @@ def better_default_encoder(o):
 
 class JSONEncoderForHTML(JSONEncoder):
     # Our variant of JSONEncoderForHTML that also accounts for apostrophes
-    # See: https://github.com/simplejson/simplejson/blob/master/simplejson/encoder.py#L380-L386
+    # See: https://github.com/simplejson/simplejson/blob/master/simplejson/encoder.py
     def encode(self, o):
         # Override JSONEncoder.encode because it has hacks for
         # performance that make things more complicated.
         chunks = self.iterencode(o, True)
-        if self.ensure_ascii:
-            return "".join(chunks)
-        else:
-            return "".join(chunks)
+        return "".join(chunks)
 
     def iterencode(self, o, _one_shot=False):
         chunks = super().iterencode(o, _one_shot)


### PR DESCRIPTION
They added 3.8 testing in 3.17.0, but actually in 3.17.2 (latest) they provide py38 wheels, so that's preferred. Nothing in the changelog really stands out to me.

Also did some cleanup in my due dilligence.
