### PR TITLE
feat(statics): Serve MEDIA at _media/ in debug mode

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -384,7 +384,8 @@ STATICFILES_FINDERS = (
 ASSET_VERSION = 0
 
 # setup a default media root to somewhere useless
-MEDIA_ROOT = "/tmp/sentry-media"
+MEDIA_ROOT = "/tmp/sentry-files/media"
+MEDIA_URL = "_media/"
 
 LOCALE_PATHS = (os.path.join(PROJECT_ROOT, "locale"),)
 

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.conf.urls import include, url
+from django.conf.urls.static import static
 from django.http import HttpResponse
 from django.views.generic import RedirectView
 
@@ -57,15 +58,21 @@ if getattr(settings, "DEBUG_VIEWS", settings.DEBUG):
 
     urlpatterns += debug_urls
 
-# Special favicon in debug mode
 if settings.DEBUG:
     urlpatterns += [
+        # Special favicon in debug mode
         url(
             r"^_static/[^/]+/[^/]+/images/favicon\.(ico|png)$",
             generic.dev_favicon,
             name="sentry-dev-favicon",
-        )
+        ),
     ]
+    # Serve FileSystemStorage files in development. In production this
+    # would typically be handled by some static server.
+    urlpatterns += static(
+        settings.MEDIA_URL,
+        document_root=settings.MEDIA_ROOT,
+    )
 
 urlpatterns += [
     url(


### PR DESCRIPTION
Will need this for testing out some public user uploaded file features.

Enables serving files from the MEDIA_ROOT (which is where the FileSystemStorage driver uploads files) in development mode