### PR TITLE
fix(ui): qr code in dark mode

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
@@ -15,6 +15,7 @@ import CircleIndicator from 'app/components/circleIndicator';
 import {PanelItem} from 'app/components/panels';
 import U2fsign from 'app/components/u2f/u2fsign';
 import {t} from 'app/locale';
+import space from 'app/styles/space';
 import {Authenticator} from 'app/types';
 import getPendingInvite from 'app/utils/getPendingInvite';
 import AsyncView from 'app/views/asyncView';
@@ -418,7 +419,7 @@ class AccountSecurityEnroll extends AsyncView<Props, State> {
 
 const StyledQRCode = styled(QRCode)`
   background: white;
-  padding: 10px;
+  padding: ${space(2)};
 `;
 
 export default withRouter(AccountSecurityEnroll);

--- a/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {RouteComponentProps, withRouter} from 'react-router';
+import styled from '@emotion/styled';
 import QRCode from 'qrcode.react';
 
 import {
@@ -67,7 +68,7 @@ const getFields = ({
     return [
       () => (
         <PanelItem key="qrcode" justifyContent="center" p={2}>
-          <QRCode value={authenticator.qrcode} size={228} />
+          <StyledQRCode value={authenticator.qrcode} size={228} />
         </PanelItem>
       ),
       () => (
@@ -414,5 +415,10 @@ class AccountSecurityEnroll extends AsyncView<Props, State> {
     );
   }
 }
+
+const StyledQRCode = styled(QRCode)`
+  background: white;
+  padding: 10px;
+`;
 
 export default withRouter(AccountSecurityEnroll);


### PR DESCRIPTION
Fixes [this issue](https://getsentry.atlassian.net/browse/ISSUE-1141).

Confirmed that this worked with my phone, just needed 10px padding.

## Before
<img width="817" alt="CleanShot 2021-03-17 at 15 47 44@2x" src="https://user-images.githubusercontent.com/1900676/111548885-a0c33c80-8738-11eb-9426-89ffb49f4bc1.png">


## After 
<img width="828" alt="CleanShot 2021-03-17 at 15 47 40@2x" src="https://user-images.githubusercontent.com/1900676/111548903-a4ef5a00-8738-11eb-9fdd-0ab8b276f311.png">
