### PR TITLE
fix(panel-table): make header font size consistent

### DIFF
--- a/src/sentry/static/sentry/app/components/panels/panelHeader.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelHeader.tsx
@@ -30,7 +30,7 @@ const PanelHeader = styled('div')<Props>`
   align-items: center;
   justify-content: space-between;
   color: ${p => (p.lightText ? p.theme.gray300 : p.theme.gray400)};
-  font-size: 13px;
+  font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 600;
   text-transform: uppercase;
   border-bottom: 1px solid ${p => p.theme.border};

--- a/src/sentry/static/sentry/app/components/panels/panelTable.tsx
+++ b/src/sentry/static/sentry/app/components/panels/panelTable.tsx
@@ -155,7 +155,7 @@ const Wrapper = styled(Panel, {
 
 export const PanelTableHeader = styled('div')`
   color: ${p => p.theme.subText};
-  font-size: 13px;
+  font-size: ${p => p.theme.fontSizeSmall};
   font-weight: 600;
   text-transform: uppercase;
   border-radius: ${p => p.theme.borderRadius} ${p => p.theme.borderRadius} 0 0;

--- a/src/sentry/static/sentry/less/shared/panel.less
+++ b/src/sentry/static/sentry/less/shared/panel.less
@@ -291,7 +291,7 @@
   }
   .panel-heading-bold {
     color: @60;
-    font-size: 13px;
+    font-size: 12px;
     font-weight: 600;
     text-transform: uppercase;
     line-height: 1;


### PR DESCRIPTION
- Make these headers consistent with 12px grid-editable header

**Before:**
![Screen Shot 2021-03-17 at 4 03 14 PM](https://user-images.githubusercontent.com/4830259/111549902-4cb95780-873a-11eb-8f83-6e3df89e9286.png)

**After:**
![Screen Shot 2021-03-17 at 4 00 38 PM](https://user-images.githubusercontent.com/4830259/111549813-14b21480-873a-11eb-937e-6907f343af17.png)
