### PR TITLE
feat(workflow): Use larger graph when sort is relative change

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -334,10 +334,16 @@ class IssueListOverview extends React.Component<Props, State> {
   }
 
   getGroupStatsPeriod(): string {
-    const currentPeriod =
-      typeof this.props.location.query?.groupStatsPeriod === 'string'
-        ? this.props.location.query?.groupStatsPeriod
-        : DEFAULT_GRAPH_STATS_PERIOD;
+    let currentPeriod: string;
+    if (typeof this.props.location.query?.groupStatsPeriod === 'string') {
+      currentPeriod = this.props.location.query.groupStatsPeriod;
+    } else if (this.getSort() === IssueSortOptions.TREND) {
+      // Default to the larger graph when sorting by relative change
+      currentPeriod = 'auto';
+    } else {
+      currentPeriod = DEFAULT_GRAPH_STATS_PERIOD;
+    }
+
     return DYNAMIC_COUNTS_STATS_PERIODS.has(currentPeriod)
       ? currentPeriod
       : DEFAULT_GRAPH_STATS_PERIOD;

--- a/tests/js/spec/views/issueList/overview.spec.jsx
+++ b/tests/js/spec/views/issueList/overview.spec.jsx
@@ -1812,4 +1812,16 @@ describe('IssueList', function () {
       expect(paginationWrapper.text()).toBe('Showing 49 of 74 issues');
     });
   });
+
+  describe('with relative change feature', function () {
+    it('defaults to larger graph selection', function () {
+      organization.features = ['issue-list-trend-sort'];
+      props.location = {
+        query: {query: 'is:unresolved', sort: 'trend'},
+        search: 'query=is:unresolved',
+      };
+      wrapper = mountWithTheme(<IssueListOverview {...props} />);
+      expect(wrapper.instance().getGroupStatsPeriod()).toBe('auto');
+    });
+  });
 });


### PR DESCRIPTION
Instead of the default graph stats period, use 'auto' by default when sorting issues by "Relative Change".