### PR TITLE
fix(ui): Set loading to false on error in internal stat chart

### DIFF
--- a/src/sentry/static/sentry/app/components/internalStatChart.tsx
+++ b/src/sentry/static/sentry/app/components/internalStatChart.tsx
@@ -46,7 +46,7 @@ class InternalStatChart extends React.Component<Props, State> {
     }
   }
 
-  fetchData() {
+  fetchData = () => {
     this.setState({loading: true});
     this.props.api.request('/internal/stats/', {
       method: 'GET',
@@ -61,9 +61,9 @@ class InternalStatChart extends React.Component<Props, State> {
           loading: false,
           error: false,
         }),
-      error: () => this.setState({error: true}),
+      error: () => this.setState({error: true, loading: false}),
     });
-  }
+  };
 
   render() {
     const {loading, error, data} = this.state;


### PR DESCRIPTION
render currently shows loading if it is true and error wasn't setting loading to false. Fixes retry not having the right scope.