### PR TITLE
feat: improve timestamp.to_{hour,day} formatting

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -175,6 +175,8 @@ type SpecialFields = {
   release: SpecialField;
   key_transaction: SpecialField;
   'trend_percentage()': SpecialField;
+  'timestamp.to_hour': SpecialField;
+  'timestamp.to_day': SpecialField;
 };
 
 /**
@@ -339,6 +341,28 @@ const SPECIAL_FIELDS: SpecialFields = {
           ? formatPercentage(data.trend_percentage - 1)
           : emptyValue}
       </NumberContainer>
+    ),
+  },
+  'timestamp.to_hour': {
+    sortField: 'timestamp.to_hour',
+    renderFunc: data => (
+      <Container>
+        {getDynamicText({
+          value: <StyledDateTime date={data['timestamp.to_hour']} format="lll z" />,
+          fixed: 'timestamp.to_hour',
+        })}
+      </Container>
+    ),
+  },
+  'timestamp.to_day': {
+    sortField: 'timestamp.to_day',
+    renderFunc: data => (
+      <Container>
+        {getDynamicText({
+          value: <StyledDateTime date={data['timestamp.to_day']} format="MMM D, YYYY" />,
+          fixed: 'timestamp.to_day',
+        })}
+      </Container>
     ),
   },
 };


### PR DESCRIPTION
Use format instead of dateOnly/seconds in order to maintain consistency with other discover formats. Also assume timestamp.to_hour/day is non-null (because it is in the database).

<img width="565" alt="Screen Shot 2021-03-18 at 10 17 35 AM" src="https://user-images.githubusercontent.com/78757344/111641149-42976780-87d3-11eb-95f9-f9ba63b6714c.png">
