### PR TITLE
ref(events): Update Proguard regex

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.tsx
@@ -47,7 +47,7 @@ import findBestThread from './interfaces/threads/threadSelector/findBestThread';
 import getThreadException from './interfaces/threads/threadSelector/getThreadException';
 import EventEntry from './eventEntry';
 
-const MINIFIED_DATA_JAVA_EVENT_REGEX_MATCH = /^(\w|\w{2}\.\w{1,2}|\w{3}((\.\w)|(\.\w{2}){2}))(\.|$)/g;
+const MINIFIED_DATA_JAVA_EVENT_REGEX_MATCH = /^(\w|(\w|\$){2}\.(\w|\$)|(\w|\$){3}((\.(\w|\$))|((\w|\$)){2}))(\.|$)/g;
 
 const defaultProps = {
   isShare: false,


### PR DESCRIPTION
This PR improves the Regex that searches for minified stack traces. It will now validate only a single-character top level domain, thus decreasing the number of  false positive results.

Reason behind this change:

We spotted a couple of cases where the app has countries domain with a 2 character subdomajn such as: kr.co.Something. The current regex was matching this information, giving a falso positive.

closes: https://app.asana.com/0/search/1200081324764084/1200035710292618

