### PR TITLE
fix: calendar dark mode using style-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -261,7 +261,21 @@ let appConfig = {
       },
       {
         test: /\.css/,
-        use: ['style-loader', 'css-loader'],
+        use: [
+          {
+            loader: 'style-loader',
+            options: {
+              // allow emotion to override style-loader
+              // style-loader 1.0.0 uses 'insert' but we're on 0.23.1
+              // insertAt: 'top' breaks onboarding prism styling. it needs to be
+              // injected *before* emotion, but *after* sentry.css.
+              insertAt: {
+                before: 'style',
+              },
+            },
+          },
+          'css-loader',
+        ],
       },
       {
         test: /\.less$/,


### PR DESCRIPTION
After #23240, react-date-range is now lazy-loaded. Unfortunately, this causes
its CSS to non-deterministically override GlobalStyles. Adjust the injection so
that it happens before emotion's injected styles.