### PR TITLE
feat(trace-view): Add trace id to transaction summary table

### DIFF
--- a/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
+++ b/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
@@ -445,7 +445,6 @@ class TransactionsTable extends React.PureComponent<TableProps> {
       handleCellAction,
     } = this.props;
     const fields = eventView.getFields();
-    const tableTitles = this.getTitles();
 
     const resultsRow = columnOrder.map((column, index) => {
       const field = String(column.key);
@@ -456,11 +455,7 @@ class TransactionsTable extends React.PureComponent<TableProps> {
       const fieldRenderer = getFieldRenderer(field, tableMeta);
       let rendered = fieldRenderer(row, {organization, location});
 
-      const target = generateLink?.[tableTitles[index]]?.(
-        organization,
-        row,
-        location.query
-      );
+      const target = generateLink?.[field]?.(organization, row, location.query);
 
       if (target) {
         rendered = (

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -900,8 +900,7 @@ class EventView {
     return payload;
   }
 
-  // Takes an EventView instance and converts it into the format required for the events API
-  getEventsAPIPayload(location: Location): EventQuery & LocationQuery {
+  normalizeDateSelection(location: Location) {
     const query = (location && location.query) || {};
 
     // pick only the query strings that we care about
@@ -924,10 +923,19 @@ class EventView {
         };
 
     // normalize datetime selection
-    const normalizedTimeWindowParams = getParams({
+    return getParams({
       ...dateSelection,
       utc: decodeScalar(query.utc),
     });
+  }
+
+  // Takes an EventView instance and converts it into the format required for the events API
+  getEventsAPIPayload(location: Location): EventQuery & LocationQuery {
+    // pick only the query strings that we care about
+    const picked = pickRelevantLocationQueryStrings(location);
+
+    // normalize datetime selection
+    const normalizedTimeWindowParams = this.normalizeDateSelection(location);
 
     const sort =
       this.sorts.length <= 0

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -166,6 +166,7 @@ type SpecialField = {
 
 type SpecialFields = {
   id: SpecialField;
+  trace: SpecialField;
   project: SpecialField;
   user: SpecialField;
   'user.display': SpecialField;
@@ -188,6 +189,17 @@ const SPECIAL_FIELDS: SpecialFields = {
     sortField: 'id',
     renderFunc: data => {
       const id: string | unknown = data?.id;
+      if (typeof id !== 'string') {
+        return null;
+      }
+
+      return <Container>{getShortEventId(id)}</Container>;
+    },
+  },
+  trace: {
+    sortField: 'trace',
+    renderFunc: data => {
+      const id: string | unknown = data?.trace;
       if (typeof id !== 'string') {
         return null;
       }

--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/traceFullQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/traceFullQuery.tsx
@@ -30,12 +30,19 @@ function EmptyTrace({children}: Pick<QueryProps, 'children'>) {
   );
 }
 
-function TraceFullQuery({traceId, start, end, children, ...props}: QueryProps) {
+function TraceFullQuery({
+  traceId,
+  start,
+  end,
+  statsPeriod,
+  children,
+  ...props
+}: QueryProps) {
   if (!traceId) {
     return <EmptyTrace>{children}</EmptyTrace>;
   }
 
-  const eventView = makeEventView(start, end);
+  const eventView = makeEventView({start, end, statsPeriod});
 
   return (
     <GenericDiscoverQuery<TraceFull, {}>

--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/traceLiteQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/traceLiteQuery.tsx
@@ -45,6 +45,7 @@ function TraceLiteQuery({
   traceId,
   start,
   end,
+  statsPeriod,
   children,
   shouldSkipQuery,
   ...props
@@ -53,7 +54,7 @@ function TraceLiteQuery({
     return <EmptyTrace>{children}</EmptyTrace>;
   }
 
-  const eventView = makeEventView(start, end);
+  const eventView = makeEventView({start, end, statsPeriod});
 
   return (
     <GenericDiscoverQuery<TraceLite, {eventId: string}>

--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/types.ts
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/types.ts
@@ -52,8 +52,9 @@ export type TraceFull = Omit<QuickTraceEvent, 'generation' | 'errors'> & {
 export type TraceProps = {
   eventId: string;
   traceId: string;
-  start: string;
-  end: string;
+  start?: string;
+  end?: string;
+  statsPeriod?: string;
 };
 
 export type TraceRequestProps = DiscoverQueryProps & TraceProps;

--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/utils.ts
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/utils.ts
@@ -228,7 +228,15 @@ export function getQuickTraceRequestPayload({eventView, location}: DiscoverQuery
   return omit(eventView.getEventsAPIPayload(location), ['field', 'sort', 'per_page']);
 }
 
-export function makeEventView(start: string, end: string) {
+export function makeEventView({
+  start,
+  end,
+  statsPeriod,
+}: {
+  start?: string;
+  end?: string;
+  statsPeriod?: string;
+}) {
   return EventView.fromSavedQuery({
     id: undefined,
     version: 2,
@@ -239,9 +247,9 @@ export function makeEventView(start: string, end: string) {
     projects: [ALL_ACCESS_PROJECTS],
     query: '',
     environment: [],
-    range: '',
     start,
     end,
+    range: statsPeriod,
   });
 }
 

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
@@ -35,6 +35,7 @@ type Props = {
   traceSlug: string;
   start: string | undefined;
   end: string | undefined;
+  statsPeriod: string | undefined;
   isLoading: boolean;
   error: string | null;
   trace: TraceFull | null;
@@ -171,9 +172,9 @@ class TraceDetailsContent extends React.Component<Props> {
   }
 
   renderContent() {
-    const {traceSlug, start, end, isLoading, error, trace} = this.props;
+    const {traceSlug, start, end, statsPeriod, isLoading, error, trace} = this.props;
 
-    if (!start || !end) {
+    if (!statsPeriod && (!start || !end)) {
       Sentry.setTag('current.trace_id', traceSlug);
       Sentry.captureException(new Error('No date range selection found.'));
       return this.renderTraceRequiresDateRangeSelection();

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/index.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 
 import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMessage';
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
 import {PageContent} from 'app/styles/organization';
@@ -33,8 +34,10 @@ class TraceSummary extends React.Component<Props> {
   renderContent() {
     const {location, organization, params} = this.props;
     const traceSlug = this.getTraceSlug();
-    const start = decodeScalar(location.query.start);
-    const end = decodeScalar(location.query.end);
+    const queryParams = getParams(location.query);
+    const start = decodeScalar(queryParams.start);
+    const end = decodeScalar(queryParams.end);
+    const statsPeriod = decodeScalar(queryParams.statsPeriod);
 
     const content = ({isLoading, error, trace}) => (
       <TraceDetailsContent
@@ -44,16 +47,17 @@ class TraceSummary extends React.Component<Props> {
         traceSlug={traceSlug}
         start={start}
         end={end}
+        statsPeriod={statsPeriod}
         isLoading={isLoading}
         error={error}
         trace={trace}
       />
     );
 
-    if (!start || !end) {
+    if (!statsPeriod && (!start || !end)) {
       return content({
         isLoading: false,
-        error: 'start/end not specified',
+        error: 'date selection not specified',
         trace: null,
       });
     }
@@ -65,6 +69,7 @@ class TraceSummary extends React.Component<Props> {
         traceId={traceSlug}
         start={start}
         end={end}
+        statsPeriod={statsPeriod}
       >
         {content}
       </TraceFullQuery>

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/utils.ts
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/utils.ts
@@ -9,13 +9,12 @@ import {TraceInfo} from './types';
 export function getTraceDetailsUrl(
   organization: OrganizationSummary,
   traceSlug: string,
-  start: string,
-  end: string,
+  dateSelection,
   query: Query
 ): LocationDescriptor {
   return {
     pathname: `/organizations/${organization.slug}/performance/trace/${traceSlug}/`,
-    query: {...query, start, end},
+    query: {...query, ...dateSelection},
   };
 }
 

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/utils.tsx
@@ -1,5 +1,6 @@
 import {Location, LocationDescriptor} from 'history';
 
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import {OrganizationSummary} from 'app/types';
 import {Event} from 'app/types/event';
@@ -71,10 +72,10 @@ export function generateTraceTarget(
 ): LocationDescriptor {
   const traceId = event.contexts?.trace?.trace_id ?? '';
 
-  const {start, end} = getTraceTimeRangeFromEvent(event);
+  const dateSelection = getParams(getTraceTimeRangeFromEvent(event));
 
   if (organization.features.includes('trace-view-summary')) {
-    return getTraceDetailsUrl(organization, traceId, start, end, {});
+    return getTraceDetailsUrl(organization, traceId, dateSelection, {});
   }
 
   const eventView = EventView.fromSavedQuery({
@@ -85,8 +86,7 @@ export function generateTraceTarget(
     query: `event.type:transaction trace:${traceId}`,
     projects: [ALL_ACCESS_PROJECTS],
     version: 2,
-    start,
-    end,
+    ...dateSelection,
   });
   return eventView.getResultsViewUrlTarget(organization.slug);
 }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -26,6 +26,7 @@ import withProjects from 'app/utils/withProjects';
 import {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 import Tags from 'app/views/eventsV2/tags';
+import {getTraceDetailsUrl} from 'app/views/performance/traceDetails/utils';
 import {
   PERCENTILE as VITAL_PERCENTILE,
   VITAL_GROUPS,
@@ -211,10 +212,15 @@ class SummaryContent extends React.Component<Props, State> {
               location={location}
               organization={organization}
               eventView={eventView}
-              titles={[t('id'), t('user'), t('duration'), t('timestamp')]}
+              titles={
+                organization.features.includes('trace-view-summary')
+                  ? [t('id'), t('user'), t('duration'), t('trace id'), t('timestamp')]
+                  : [t('id'), t('user'), t('duration'), t('timestamp')]
+              }
               handleDropdownChange={this.handleTransactionsListSortChange}
               generateLink={{
                 id: generateTransactionLink(transactionName),
+                trace: generateTraceLink(eventView.normalizeDateSelection(location)),
               }}
               baseline={transactionName}
               handleBaselineClick={this.handleViewDetailsClick}
@@ -271,6 +277,21 @@ class SummaryContent extends React.Component<Props, State> {
       </React.Fragment>
     );
   }
+}
+
+function generateTraceLink(dateSelection) {
+  return (
+    organization: Organization,
+    tableRow: TableDataRow,
+    _query: Query
+  ): LocationDescriptor => {
+    const traceId = `${tableRow.trace}`;
+    if (!traceId) {
+      return {};
+    }
+
+    return getTraceDetailsUrl(organization, traceId, dateSelection, {});
+  };
 }
 
 function generateTransactionLink(transactionName: string) {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/index.tsx
@@ -53,7 +53,8 @@ class TransactionSummary extends React.Component<Props, State> {
   state: State = {
     eventView: generateSummaryEventView(
       this.props.location,
-      getTransactionName(this.props.location)
+      getTransactionName(this.props.location),
+      this.props.organization
     ),
   };
 
@@ -62,7 +63,8 @@ class TransactionSummary extends React.Component<Props, State> {
       ...prevState,
       eventView: generateSummaryEventView(
         nextProps.location,
-        getTransactionName(nextProps.location)
+        getTransactionName(nextProps.location),
+        nextProps.organization
       ),
     };
   }
@@ -224,7 +226,8 @@ const StyledPageContent = styled(PageContent)`
 
 function generateSummaryEventView(
   location: Location,
-  transactionName: string | undefined
+  transactionName: string | undefined,
+  organization: Organization
 ): EventView | undefined {
   if (transactionName === undefined) {
     return undefined;
@@ -259,7 +262,9 @@ function generateSummaryEventView(
       id: undefined,
       version: 2,
       name: transactionName,
-      fields: ['id', 'user.display', 'transaction.duration', 'timestamp'],
+      fields: organization.features.includes('trace-view-summary')
+        ? ['id', 'user.display', 'transaction.duration', 'trace', 'timestamp']
+        : ['id', 'user.display', 'transaction.duration', 'timestamp'],
       query: stringifyQueryObject(conditions),
       projects: [],
     },


### PR DESCRIPTION
This change adds trace id to the table in transaction summary table linking to
the trace view, and links the trace column in discover to the trace view.

# Screenshot

![image](https://user-images.githubusercontent.com/10239353/111684738-77b8af80-87fd-11eb-831b-16989d78f7f0.png)
