### PR TITLE
build(feat): Run make bootstrap in CI

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -82,6 +82,9 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-yarn-
 
-      - name: Set up development environment (mostly as per docs)
+      # make develop calls "ensure-venv", thus, needing to be within a venv
+      - name: Set up development environment
         run: |
+          python -m venv .venv
+          source .venv/bin/activate
           make bootstrap

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -43,6 +43,7 @@ jobs:
         # If you want to speed up the CI for your PR, you can use --no-upgrade and HOMEBREW_NO_AUTO_UPDATE=1
         run: |
           brew bundle || brew update && brew bundle
+          make init-docker
 
       - name: Install Python (via Pyenv)
         id: python-version
@@ -81,13 +82,6 @@ jobs:
           restore-keys: |
             ${{ matrix.os }}-yarn-
 
-      # We cannot call make bootstrap directly since run-dependent-services requires some Docker magic.
-      # We have the magic in the getsentry/bootstrap-develop. We will handle this situation in the next pass of this.
-      # make init-config will *not* prompt about overwriting ~/.sentry/config.yml' since we're on a pristine state
-      # We cannot test the git hooks until the `sentry.lint.engine` gets installed
       - name: Set up development environment (mostly as per docs)
         run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          curl https://get.volta.sh | bash
-          make develop
+          make bootstrap

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,9 @@ setup-git-config:
 setup-git: ensure-venv setup-git-config
 	@./scripts/do.sh setup-git
 
+init-docker:
+	@./scripts/do.sh init-docker
+
 node-version-check:
 	@# Checks to see if node's version matches the one specified in package.json for Volta.
 	@node -pe "process.exit(Number(!(process.version == 'v' + require('./package.json').volta.node )))" || \

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -9,6 +9,34 @@ require() {
     command -v "$1" >/dev/null 2>&1
 }
 
+sudo_askpass() {
+  if [ -n "$SUDO_ASKPASS" ]; then
+    sudo --askpass "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+# After using homebrew to install docker, we need to do some magic to remove the need to interact with the GUI
+# See: https://github.com/docker/for-mac/issues/2359#issuecomment-607154849 for why we need to do things below
+init-docker() {
+  # Need to start docker if it was freshly installed (docker server is not running)
+  if ! command -v docker &>/dev/null && [ -d "/Applications/Docker.app" ]; then
+    echo "Making some changes to complete Docker initialization"
+    # allow the app to run without confirmation
+    xattr -d -r com.apple.quarantine /Applications/Docker.app
+
+    # preemptively do docker.app's setup to avoid any gui prompts
+    sudo_askpass /bin/mkdir -p /Library/PrivilegedHelperTools
+    sudo_askpass /bin/chmod 754 /Library/PrivilegedHelperTools
+    sudo_askpass /bin/cp /Applications/Docker.app/Contents/Library/LaunchServices/com.docker.vmnetd /Library/PrivilegedHelperTools/
+    sudo_askpass /bin/cp /Applications/Docker.app/Contents/Resources/com.docker.vmnetd.plist /Library/LaunchDaemons/
+    sudo_askpass /bin/chmod 544 /Library/PrivilegedHelperTools/com.docker.vmnetd
+    sudo_askpass /bin/chmod 644 /Library/LaunchDaemons/com.docker.vmnetd.plist
+    sudo_askpass /bin/launchctl load /Library/LaunchDaemons/com.docker.vmnetd.plist
+  fi
+}
+
 query_big_sur() {
     if require sw_vers && sw_vers -productVersion | grep -E "11\." > /dev/null; then
         return 0

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -10,7 +10,7 @@ require() {
 }
 
 sudo_askpass() {
-  if [ -n "$SUDO_ASKPASS" ]; then
+  if [ -z "${SUDO_ASKPASS-x}" ]; then
     sudo --askpass "$@"
   else
     sudo "$@"


### PR DESCRIPTION
Until now we could not do so because we had not yet automated the Docker set up after installation.