### PR TITLE
ref(Slack): Add exc_info to invalid issue logger

### DIFF
--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -192,7 +192,7 @@ class SlackActionEndpoint(Endpoint):
                 id=group_id,
             )
         except Group.DoesNotExist:
-            logger.error("slack.action.invalid-issue", extra=logging_data)
+            logger.error("slack.action.invalid-issue", extra=logging_data, exc_info=True)
             return self.respond(status=403)
 
         logging_data["organization_id"] = group.organization.id

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -128,7 +128,7 @@ class SlackEventEndpoint(Endpoint):
         try:
             client.post("/chat.unfurl", data=payload)
         except ApiError as e:
-            logger.error("slack.event.unfurl-error", extra={"error": str(e)})
+            logger.error("slack.event.unfurl-error", extra={"error": str(e)}, exc_info=True)
 
         return self.respond()
 


### PR DESCRIPTION
Add the `exc_info` to a couple Slack loggers to try to figure out what's going on with [SENTRY-P2J](https://sentry.io/organizations/sentry/issues/2276926574/?project=1&referrer=slack) and [SENTRY-P2K](https://sentry.io/organizations/sentry/issues/2277014929/?project=1&referrer=slack).