### PR TITLE
feat(alert): Initial wizard options

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -3,13 +3,18 @@ import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
 import Feature from 'app/components/acl/feature';
+import CreateAlertButton from 'app/components/createAlertButton';
 import PageHeading from 'app/components/pageHeading';
+import {Panel, PanelBody} from 'app/components/panels';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import {t} from 'app/locale';
 import {PageContent, PageHeader} from 'app/styles/organization';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import BuilderBreadCrumbs from 'app/views/alerts/builder/builderBreadCrumbs';
+import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
+
+import {AlertType, descriptions, options} from './options';
 
 type RouteParams = {
   orgId: string;
@@ -22,13 +27,25 @@ type Props = RouteComponentProps<RouteParams, {}> & {
   hasMetricAlerts: boolean;
 };
 
-class AlertWizard extends React.Component<Props> {
+type State = {
+  alertOption: AlertType;
+};
+class AlertWizard extends React.Component<Props, State> {
+  state: State = {
+    alertOption: 'issues',
+  };
+
+  handleChangeAlertOption = (alertOption: AlertType) => {
+    this.setState({alertOption});
+  };
+
   render() {
     const {
       hasMetricAlerts,
       organization,
       params: {projectId},
     } = this.props;
+    const {alertOption} = this.state;
     const title = t('Alert Creation Wizard');
 
     return (
@@ -44,6 +61,33 @@ class AlertWizard extends React.Component<Props> {
             <StyledPageHeader>
               <PageHeading>{t('What do you want to alert on?')}</PageHeading>
             </StyledPageHeader>
+            <WizardBody>
+              <WizardOptions>
+                {Object.entries(options).map(([header, choices]) => {
+                  return (
+                    <OptionsWrapper key={header}>
+                      <Heading>{header}</Heading>
+                      <RadioGroup
+                        choices={choices}
+                        onChange={this.handleChangeAlertOption}
+                        value={alertOption}
+                        label="alert-option"
+                      />
+                    </OptionsWrapper>
+                  );
+                })}
+              </WizardOptions>
+              <WizardPanel>
+                <PanelBody>{descriptions[alertOption]}</PanelBody>
+                <StyledCreateAlertButton
+                  organization={organization}
+                  priority="primary"
+                  projectSlug={projectId}
+                >
+                  Create Alert
+                </StyledCreateAlertButton>
+              </WizardPanel>
+            </WizardBody>
           </Feature>
         </PageContent>
       </React.Fragment>
@@ -52,6 +96,35 @@ class AlertWizard extends React.Component<Props> {
 }
 
 const StyledPageHeader = styled(PageHeader)`
+  margin-bottom: ${space(4)};
+`;
+
+const Heading = styled('h1')`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  font-weight: normal;
+  margin-bottom: ${space(1)};
+`;
+
+const WizardBody = styled('div')`
+  display: flex;
+`;
+
+const WizardOptions = styled('div')`
+  flex: 3;
+`;
+
+const WizardPanel = styled(Panel)`
+  padding: ${space(3)};
+  flex: 5;
+  position: relative;
+`;
+
+const StyledCreateAlertButton = styled(CreateAlertButton)`
+  position: absolute;
+  bottom: ${space(3)};
+`;
+
+const OptionsWrapper = styled('div')`
   margin-bottom: ${space(4)};
 `;
 

--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -14,7 +14,7 @@ import {Organization, Project} from 'app/types';
 import BuilderBreadCrumbs from 'app/views/alerts/builder/builderBreadCrumbs';
 import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
 
-import {AlertType, descriptions, options} from './options';
+import {AlertType, AlertWizardDescriptions, AlertWizardOptions} from './options';
 
 type RouteParams = {
   orgId: string;
@@ -63,29 +63,27 @@ class AlertWizard extends React.Component<Props, State> {
             </StyledPageHeader>
             <WizardBody>
               <WizardOptions>
-                {Object.entries(options).map(([header, choices]) => {
-                  return (
-                    <OptionsWrapper key={header}>
-                      <Heading>{header}</Heading>
-                      <RadioGroup
-                        choices={choices}
-                        onChange={this.handleChangeAlertOption}
-                        value={alertOption}
-                        label="alert-option"
-                      />
-                    </OptionsWrapper>
-                  );
-                })}
+                {AlertWizardOptions.map(({categoryHeading, options}) => (
+                  <OptionsWrapper key={categoryHeading}>
+                    <Heading>{categoryHeading}</Heading>
+                    <RadioGroup
+                      choices={options}
+                      onChange={this.handleChangeAlertOption}
+                      value={alertOption}
+                      label="alert-option"
+                    />
+                  </OptionsWrapper>
+                ))}
               </WizardOptions>
               <WizardPanel>
-                <PanelBody>{descriptions[alertOption]}</PanelBody>
-                <StyledCreateAlertButton
+                <WizardPanelBody>{AlertWizardDescriptions[alertOption]}</WizardPanelBody>
+                <CreateAlertButton
                   organization={organization}
                   priority="primary"
                   projectSlug={projectId}
                 >
-                  Create Alert
-                </StyledCreateAlertButton>
+                  {t('Create Alert')}
+                </CreateAlertButton>
               </WizardPanel>
             </WizardBody>
           </Feature>
@@ -116,12 +114,13 @@ const WizardOptions = styled('div')`
 const WizardPanel = styled(Panel)`
   padding: ${space(3)};
   flex: 5;
-  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: start;
 `;
 
-const StyledCreateAlertButton = styled(CreateAlertButton)`
-  position: absolute;
-  bottom: ${space(3)};
+const WizardPanelBody = styled(PanelBody)`
+  flex: 1;
 `;
 
 const OptionsWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
@@ -1,0 +1,32 @@
+import {t} from 'app/locale';
+
+export type AlertType =
+  | 'issues'
+  | 'num_errors'
+  | 'users_experiencing_errors'
+  | 'throughput'
+  | 'trans_duration'
+  | 'lcp';
+
+export const options: Record<string, [AlertType, string][]> = {
+  [t('Errors')]: [
+    ['issues', t('Issues')],
+    ['num_errors', t('Number of Errors')],
+    ['users_experiencing_errors', t('Users Experiencing Errors')],
+  ],
+  [t('Performance')]: [
+    ['throughput', t('Throughput')],
+    ['trans_duration', t('Transaction Duration')],
+    ['lcp', t('Longest Contentful Paint')],
+  ],
+};
+
+// TODO(davidenwang): Once the copy is finalized for the wizard fill this in with real content
+export const descriptions: Record<AlertType, string> = {
+  issues: t('An issue alert allows you to alert on a group of error events in Sentry'),
+  num_errors: t('Alert on the number of errors coming into your Sentry dashboard'),
+  users_experiencing_errors: t('Alert on the number of users experiencing errors'),
+  throughput: t('Alert on the number of transactions happening in your application'),
+  trans_duration: t('Alert on the duration of transactions'),
+  lcp: t('Alert on longest contentful paint'),
+};

--- a/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
@@ -8,21 +8,30 @@ export type AlertType =
   | 'trans_duration'
   | 'lcp';
 
-export const options: Record<string, [AlertType, string][]> = {
-  [t('Errors')]: [
-    ['issues', t('Issues')],
-    ['num_errors', t('Number of Errors')],
-    ['users_experiencing_errors', t('Users Experiencing Errors')],
-  ],
-  [t('Performance')]: [
-    ['throughput', t('Throughput')],
-    ['trans_duration', t('Transaction Duration')],
-    ['lcp', t('Longest Contentful Paint')],
-  ],
-};
+export const AlertWizardOptions: {
+  categoryHeading: string;
+  options: [AlertType, string][];
+}[] = [
+  {
+    categoryHeading: t('Errors'),
+    options: [
+      ['issues', t('Issues')],
+      ['num_errors', t('Number of Errors')],
+      ['users_experiencing_errors', t('Users Experiencing Errors')],
+    ],
+  },
+  {
+    categoryHeading: t('Performance'),
+    options: [
+      ['throughput', t('Throughput')],
+      ['trans_duration', t('Transaction Duration')],
+      ['lcp', t('Longest Contentful Paint')],
+    ],
+  },
+];
 
 // TODO(davidenwang): Once the copy is finalized for the wizard fill this in with real content
-export const descriptions: Record<AlertType, string> = {
+export const AlertWizardDescriptions: Record<AlertType, string> = {
   issues: t('An issue alert allows you to alert on a group of error events in Sentry'),
   num_errors: t('Alert on the number of errors coming into your Sentry dashboard'),
   users_experiencing_errors: t('Alert on the number of users experiencing errors'),


### PR DESCRIPTION
Setting up the initial foundation for the alert wizard. Placeholder text and un-styled radio buttons. 

<img width="1439" alt="Screen Shot 2021-03-18 at 5 50 45 PM" src="https://user-images.githubusercontent.com/9372512/111702631-f409bd80-8812-11eb-8ff5-4970fe658979.png">
