### PR TITLE
fix(quicktrace): dark mode and vertical alignment

### DIFF
--- a/src/sentry/static/sentry/app/components/dropdownLink.tsx
+++ b/src/sentry/static/sentry/app/components/dropdownLink.tsx
@@ -114,7 +114,7 @@ const DropdownLink = withTheme(
             >
               {customTitle || (
                 <div className="dropdown-actor-title">
-                  <span>{title}</span>
+                  {title}
                   {caret && <IconChevron direction={isOpen ? 'up' : 'down'} size="xs" />}
                 </div>
               )}

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/eventMetas.tsx
@@ -103,8 +103,8 @@ const EventDetailHeader = styled('div')<{type?: 'transaction' | 'event'}>`
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     ${p =>
       p.type === 'transaction'
-        ? 'grid-template-columns: minmax(160px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr) 6fr;'
-        : 'grid-template-columns: minmax(160px, 1fr) minmax(160px, 1fr) 6fr;'};
+        ? 'grid-template-columns: minmax(190px, 1fr) minmax(190px, 1fr) minmax(190px, 1fr) 6fr;'
+        : 'grid-template-columns: minmax(190px, 1fr) minmax(190px, 1fr) 6fr;'};
     grid-row-gap: 0;
     margin-bottom: 0;
   }

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
@@ -8,7 +8,7 @@ import QuestionTooltip from 'app/components/questionTooltip';
 import Tag, {Background} from 'app/components/tag';
 import Truncate from 'app/components/truncate';
 import space from 'app/styles/space';
-import theme from 'app/utils/theme';
+import {Theme} from 'app/utils/theme';
 
 type MetaDataProps = {
   headingText: string;
@@ -53,36 +53,38 @@ export const SectionSubtext = styled('div')<{type?: 'error' | 'default'}>`
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
-const nodeColors = {
-  error: {
-    color: theme.white,
-    background: theme.red300,
-    border: theme.red300,
-  },
-  warning: {
-    color: theme.red300,
-    background: theme.white,
-    border: theme.red300,
-  },
-  white: {
-    color: theme.gray500,
-    background: theme.white,
-    border: theme.gray500,
-  },
-  black: {
-    color: theme.white,
-    background: theme.gray500,
-    border: theme.gray500,
-  },
+const nodeColors = (theme: Theme) => {
+  return {
+    error: {
+      color: theme.white,
+      background: theme.red300,
+      border: theme.red300,
+    },
+    warning: {
+      color: theme.red300,
+      background: theme.white,
+      border: theme.red300,
+    },
+    white: {
+      color: theme.textColor,
+      background: theme.background,
+      border: theme.textColor,
+    },
+    black: {
+      color: theme.background,
+      background: theme.textColor,
+      border: theme.textColor,
+    },
+  };
 };
 
 export const EventNode = styled(Tag)<{pad?: 'left' | 'right'}>`
-  div {
-    color: ${p => nodeColors[p.type || 'white'].color};
+  span {
+    color: ${p => nodeColors(p.theme)[p.type || 'white'].color};
   }
   & ${/* sc-selector */ Background} {
-    background-color: ${p => nodeColors[p.type || 'white'].background};
-    border: 1px solid ${p => nodeColors[p.type || 'white'].border};
+    background-color: ${p => nodeColors(p.theme)[p.type || 'white'].background};
+    border: 1px solid ${p => nodeColors(p.theme)[p.type || 'white'].border};
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
@@ -8,7 +8,7 @@ import QuestionTooltip from 'app/components/questionTooltip';
 import Tag, {Background} from 'app/components/tag';
 import Truncate from 'app/components/truncate';
 import space from 'app/styles/space';
-import theme, {aliases} from 'app/utils/theme';
+import theme from 'app/utils/theme';
 
 type MetaDataProps = {
   headingText: string;
@@ -72,7 +72,7 @@ const nodeColors = {
   black: {
     color: theme.white,
     background: theme.gray500,
-    border: aliases.border,
+    border: theme.gray500,
   },
 };
 
@@ -88,7 +88,7 @@ export const EventNode = styled(Tag)<{pad?: 'left' | 'right'}>`
 
 export const TraceConnector = styled('div')`
   width: ${space(1)};
-  border-top: 1px solid ${p => p.theme.border};
+  border-top: 1px solid ${p => p.theme.textColor};
 `;
 
 export const QuickTraceContainer = styled('div')`

--- a/tests/js/spec/components/dropdownLink.spec.jsx
+++ b/tests/js/spec/components/dropdownLink.spec.jsx
@@ -251,7 +251,7 @@ describe('DropdownLink', function () {
       wrapper.find('a.nested-menu').simulate('mouseEnter');
       jest.runAllTimers();
       wrapper.update();
-      wrapper.find('a.nested-menu-2 span').simulate('click');
+      wrapper.find('a.nested-menu-2').simulate('click');
       expect(wrapper.find('.dropdown-menu')).toHaveLength(2);
     });
 


### PR DESCRIPTION
- Removing the extra span wrapper in the dropdown that causes vertical spacing issues
- Widening the max header section width from 160px to 190px so it doesn't break the timestamp into a new line
- Dark mode

**Before:**
![Screen Shot 2021-03-18 at 4 22 02 PM](https://user-images.githubusercontent.com/4830259/111710065-1c3eef80-8806-11eb-8d37-c521adec3aca.png)

**After:**
![Screen Shot 2021-03-18 at 4 21 17 PM](https://user-images.githubusercontent.com/4830259/111710014-fe718a80-8805-11eb-8880-ae415211fdf1.png)