### PR TITLE
fix(dev): Serve media directly out of uploaded files in dev

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -384,7 +384,7 @@ STATICFILES_FINDERS = (
 ASSET_VERSION = 0
 
 # setup a default media root to somewhere useless
-MEDIA_ROOT = "/tmp/sentry-files/media"
+MEDIA_ROOT = "/tmp/sentry-files"
 MEDIA_URL = "_media/"
 
 LOCALE_PATHS = (os.path.join(PROJECT_ROOT, "locale"),)


### PR DESCRIPTION
We upload files into /tmp/sentry-files when using filesystem storage.

When you put sentry into develop mode we also will serve thes files from /_media. This allows things like graph image uploads to work locally