### PR TITLE
ref(images-loaded): Add minor changes to the dialog

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImage/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImage/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import Button from 'app/components/button';
 import NotAvailable from 'app/components/notAvailable';
+import Tooltip from 'app/components/tooltip';
 import {IconStack} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
@@ -36,7 +37,11 @@ function DebugImage({image, onOpenImageDetailsModal, style}: Props) {
         <Status status={status} />
       </StatusColumn>
       <ImageColumn>
-        {fileName && <FileName>{fileName}</FileName>}
+        {fileName && (
+          <Tooltip title={code_file}>
+            <FileName>{fileName}</FileName>
+          </Tooltip>
+        )}
         <ImageAddress>{imageAddress}</ImageAddress>
       </ImageColumn>
       <Column>

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
@@ -330,7 +330,7 @@ class Candidates extends React.Component<Props, State> {
         <StyledPanelTable
           headers={[
             t('Status'),
-            t('Debug File'),
+            t('Location'),
             t('Processing'),
             t('Features'),
             t('Actions'),

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
@@ -301,7 +301,7 @@ class Candidates extends React.Component<Props, State> {
       <Wrapper>
         <Header>
           <Title>
-            {t('Debug Files')}
+            {t('Debug File Candidates')}
             <QuestionTooltip
               title={tct(
                 'These are the Debug Information Files (DIFs) corresponding to this image which have been looked up on [docLink:symbol servers] during the processing of the stacktrace.',

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -8,6 +8,7 @@ import {addErrorMessage} from 'app/actionCreators/indicator';
 import {ModalRenderProps} from 'app/actionCreators/modal';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
+import ButtonBar from 'app/components/buttonBar';
 import NotAvailable from 'app/components/notAvailable';
 import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
@@ -45,6 +46,14 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
       debugFiles: [],
       builtinSymbolSources: [],
     };
+  }
+
+  componentDidUpdate(prevProps: Props, prevState: State) {
+    if (!prevProps.image && !!this.props.image) {
+      this.remountComponent();
+    }
+
+    super.componentDidUpdate(prevProps, prevState);
   }
 
   getUplodedDebugFiles(candidates: ImageCandidates) {
@@ -157,7 +166,7 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
         },
         location: `${INTERNAL_SOURCE_LOCATION}${debugFile.id}`,
         source: INTERNAL_SOURCE,
-        source_name: debugFile.objectName,
+        source_name: t('Sentry'),
       })) as ImageCandidates;
 
     // Check for deleted candidates (debug files)
@@ -277,20 +286,6 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
                 )}
               </Value>
             </GeneralInfo>
-            {debugFilesSettingsLink && (
-              <SearchInSettingsAction>
-                <Tooltip
-                  title={t(
-                    'Search for this debug file in all images for the %s project',
-                    projectId
-                  )}
-                >
-                  <Button to={debugFilesSettingsLink} size="small">
-                    {t('Search in Settings')}
-                  </Button>
-                </Tooltip>
-              </SearchInSettingsAction>
-            )}
             <Candidates
               imageStatus={status}
               candidates={candidates}
@@ -304,12 +299,24 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
           </Content>
         </Body>
         <Footer>
-          <Button
-            href="https://docs.sentry.io/platforms/native/data-management/debug-files/"
-            external
-          >
-            {t('Read the docs')}
-          </Button>
+          <StyledButtonBar>
+            <Button
+              href="https://docs.sentry.io/platforms/native/data-management/debug-files/"
+              external
+            >
+              {t('Read the docs')}
+            </Button>
+            {debugFilesSettingsLink && (
+              <Tooltip
+                title={t(
+                  'Search for this debug file in all images for the %s project',
+                  projectId
+                )}
+              >
+                <Button to={debugFilesSettingsLink}>{t('Search in Settings')}</Button>
+              </Tooltip>
+            )}
+          </StyledButtonBar>
         </Footer>
       </React.Fragment>
     );
@@ -322,11 +329,6 @@ const Content = styled('div')`
   display: grid;
   grid-gap: ${space(3)};
   font-size: ${p => p.theme.fontSizeMedium};
-`;
-
-const SearchInSettingsAction = styled('div')`
-  display: flex;
-  justify-content: flex-end;
 `;
 
 const GeneralInfo = styled('div')`
@@ -347,6 +349,11 @@ const Value = styled(Label)`
   font-family: ${p => p.theme.text.familyMono};
   white-space: pre-wrap;
   word-break: break-all;
+`;
+
+const StyledButtonBar = styled(ButtonBar)`
+  justify-content: space-between;
+  flex: 1;
 `;
 
 export const modalCss = css`

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -10,7 +10,6 @@ import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import NotAvailable from 'app/components/notAvailable';
-import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
@@ -307,14 +306,15 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
               {t('Read the docs')}
             </Button>
             {debugFilesSettingsLink && (
-              <Tooltip
+              <Button
                 title={t(
                   'Search for this debug file in all images for the %s project',
                   projectId
                 )}
+                to={debugFilesSettingsLink}
               >
-                <Button to={debugFilesSettingsLink}>{t('Search in Settings')}</Button>
-              </Tooltip>
+                {t('Search in Settings')}
+              </Button>
             )}
           </StyledButtonBar>
         </Footer>


### PR DESCRIPTION
- Fixes minor inconsistency when opening the dialog from a copied URL
- Renames the "Debug Files" column to "Location"
- Displays "Sentry" in the source_name of unapplied files
- Moves "Search in Settings Button" to the bottom of the dialog