### PR TITLE
feat(consumers): Allow to override consumer topics from command line

### DIFF
--- a/src/sentry/runner/commands/run.py
+++ b/src/sentry/runner/commands/run.py
@@ -400,7 +400,7 @@ def batching_kafka_options(group):
             "--consumer-group",
             "group_id",
             default=group,
-            help="Kafka consumer group for the outcomes consumer. ",
+            help="Kafka consumer group for the consumer.",
         )(f)
 
         f = click.option(
@@ -425,6 +425,22 @@ def batching_kafka_options(group):
             default="latest",
             type=click.Choice(["earliest", "latest", "error"]),
             help="Position in the commit log topic to begin reading from when no prior offset has been recorded.",
+        )(f)
+
+        f = click.option(
+            "--force-topic",
+            "force_topic",
+            default=None,
+            type=str,
+            help="Override the Kafka topic the consumer will read from.",
+        )(f)
+
+        f = click.option(
+            "--force-cluster",
+            "force_cluster",
+            default=None,
+            type=str,
+            help="Kafka cluster ID of the overriden topic. Configure clusters via KAFKA_CLUSTERS in server settings.",
         )(f)
 
         return f

--- a/src/sentry/utils/kafka.py
+++ b/src/sentry/utils/kafka.py
@@ -54,7 +54,20 @@ producers = ProducerManager()
 
 
 def create_batching_kafka_consumer(topic_names, worker, **options):
-    cluster_names = {settings.KAFKA_TOPICS[topic_name]["cluster"] for topic_name in topic_names}
+    # In some cases we want to override the configuration stored in settings from the command line
+    force_topic = options.pop("force_topic", None)
+    force_cluster = options.pop("force_cluster", None)
+
+    if force_topic and force_cluster:
+        topic_names = {force_topic}
+        cluster_names = {force_cluster}
+    elif force_topic or force_cluster:
+        raise ValueError(
+            "Both 'force_topic' and 'force_cluster' have to be provided to override the configuration"
+        )
+    else:
+        cluster_names = {settings.KAFKA_TOPICS[topic_name]["cluster"] for topic_name in topic_names}
+
     if len(cluster_names) > 1:
         raise ValueError(
             f"Cannot launch Kafka consumer listening to multiple topics ({topic_names}) on different clusters ({cluster_names})"

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -201,10 +201,11 @@ def test_ingest_topic_can_be_overridden(
             consumer._run_once()
             i += 1
 
-    # check that we got the message
+    # Check that we got the message
     assert message.data["event_id"] == event_id
     assert message.data["extra"]["the_id"] == event_id
 
+    # Check that the default topic was not created
     all_topics = admin.admin_client.list_topics().topics.keys()
     assert new_event_topic in all_topics
     assert default_event_topic not in all_topics

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_kafka.py
@@ -72,6 +72,11 @@ def get_test_message(default_project):
     return inner
 
 
+@pytest.fixture
+def random_group_id():
+    return f"test-consumer-{random.randint(0, 2 ** 16)}"
+
+
 @pytest.mark.django_db(transaction=True)
 def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
     task_runner,
@@ -80,8 +85,8 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
     requires_kafka,
     default_project,
     get_test_message,
+    random_group_id,
 ):
-    group_id = f"test-consumer-{random.randint(0, 2 ** 16)}"
     topic_event_name = ConsumerType.get_topic_name(ConsumerType.Events)
 
     admin = kafka_admin(settings)
@@ -98,7 +103,7 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
         consumer = get_ingest_consumer(
             max_batch_size=2,
             max_batch_time=5000,
-            group_id=group_id,
+            group_id=random_group_id,
             consumer_types={ConsumerType.Events},
             auto_offset_reset="earliest",
         )
@@ -127,10 +132,8 @@ def test_ingest_consumer_reads_from_topic_and_calls_celery_task(
 
 
 def test_ingest_consumer_fails_when_not_autocreating_topics(
-    kafka_admin,
-    requires_kafka,
+    kafka_admin, requires_kafka, random_group_id
 ):
-    group_id = f"test-consumer-{random.randint(0, 2 ** 16)}"
     topic_event_name = ConsumerType.get_topic_name(ConsumerType.Events)
 
     admin = kafka_admin(settings)
@@ -140,7 +143,7 @@ def test_ingest_consumer_fails_when_not_autocreating_topics(
         consumer = get_ingest_consumer(
             max_batch_size=2,
             max_batch_time=5000,
-            group_id=group_id,
+            group_id=random_group_id,
             consumer_types={ConsumerType.Events},
             auto_offset_reset="earliest",
         )
@@ -150,3 +153,58 @@ def test_ingest_consumer_fails_when_not_autocreating_topics(
 
     kafka_error = err.value.args[0]
     assert kafka_error.code() == KafkaError.UNKNOWN_TOPIC_OR_PART
+
+
+@pytest.mark.django_db(transaction=True)
+def test_ingest_topic_can_be_overridden(
+    task_runner,
+    kafka_admin,
+    requires_kafka,
+    random_group_id,
+    default_project,
+    get_test_message,
+    kafka_producer,
+):
+    """
+    Tests that 'force_topic' overrides the value provided in settings
+    """
+    default_event_topic = ConsumerType.get_topic_name(ConsumerType.Events)
+    new_event_topic = default_event_topic + "-new"
+
+    admin = kafka_admin(settings)
+    admin.delete_topic(default_event_topic)
+    admin.delete_topic(new_event_topic)
+
+    producer = kafka_producer(settings)
+    message, event_id = get_test_message(type="event")
+    producer.produce(new_event_topic, message)
+
+    with override_settings(KAFKA_CONSUMER_AUTO_CREATE_TOPICS=True):
+        consumer = get_ingest_consumer(
+            max_batch_size=2,
+            max_batch_time=5000,
+            group_id=random_group_id,
+            consumer_types={ConsumerType.Events},
+            auto_offset_reset="earliest",
+            force_topic=new_event_topic,
+            force_cluster="default",
+        )
+
+    with task_runner():
+        i = 0
+        while i < MAX_POLL_ITERATIONS:
+            message = eventstore.get_event_by_id(default_project.id, event_id)
+
+            if message:
+                break
+
+            consumer._run_once()
+            i += 1
+
+    # check that we got the message
+    assert message.data["event_id"] == event_id
+    assert message.data["extra"]["the_id"] == event_id
+
+    all_topics = admin.admin_client.list_topics().topics.keys()
+    assert new_event_topic in all_topics
+    assert default_event_topic not in all_topics


### PR DESCRIPTION
Overriding topics from the CLI (versus via the config) might be useful in various cases. Example: having multiple consumers consuming from different topics to process in parallel new events from one topic, and the backlog from another.