### PR TITLE
fix proguard regex

### DIFF
--- a/src/sentry/static/sentry/app/components/events/eventEntries.tsx
+++ b/src/sentry/static/sentry/app/components/events/eventEntries.tsx
@@ -47,7 +47,7 @@ import findBestThread from './interfaces/threads/threadSelector/findBestThread';
 import getThreadException from './interfaces/threads/threadSelector/getThreadException';
 import EventEntry from './eventEntry';
 
-const MINIFIED_DATA_JAVA_EVENT_REGEX_MATCH = /^(\w|(\w|\$){2}\.(\w|\$)|(\w|\$){3}((\.(\w|\$))|((\w|\$)){2}))(\.|$)/g;
+const MINIFIED_DATA_JAVA_EVENT_REGEX_MATCH = /^(([\w\$]\.[\w\$]{1,2})|([\w\$]{2}\.[\w\$]\.[\w\$]))(\.|$)/g;
 
 const defaultProps = {
   isShare: false,

--- a/tests/js/spec/views/organizationGroupDetails/groupEventEntries.spec.tsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupEventEntries.spec.tsx
@@ -37,6 +37,7 @@ async function renderComponent(event: Event, errors?: Array<Error>) {
   const toggleButton = bannerSummary
     .find('[data-test-id="event-error-toggle"]')
     .hostNodes();
+
   toggleButton.simulate('click');
 
   // @ts-expect-error
@@ -178,7 +179,7 @@ describe('GroupEventEntries', function () {
                             colNo: null,
                             vars: {},
                             symbol: null,
-                            module: 'aB.a.Class',
+                            module: 'a.$a.a.a',
                           },
                         ],
                         framesOmitted: null,
@@ -229,7 +230,7 @@ describe('GroupEventEntries', function () {
                             colNo: null,
                             vars: {},
                             symbol: null,
-                            module: 'aB.a.Class',
+                            module: 'a.$a.a.a',
                           },
                         ],
                         framesOmitted: null,
@@ -258,7 +259,7 @@ describe('GroupEventEntries', function () {
                           {
                             function: 'start',
                             package: 'libdyld.dylib',
-                            module: 'aB.a.Class',
+                            module: 'a.$a.a.a',
                           },
                           {
                             function: 'main',


### PR DESCRIPTION
I made a mistake in the old regex and it was matching some frames it shouldn't

After some investigation we came up with this which is a much more conservative match that should anyway work on most cases:

![image](https://user-images.githubusercontent.com/1633368/111800562-77bebb00-88a2-11eb-8e0f-45b090327c07.png)

regex: https://regex101.com/r/erYWdl/1