### PR TITLE
ref(event-reprocess): Fix Reprocess info is not visible with dark mode

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/reprocessingProgress.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/reprocessingProgress.tsx
@@ -70,7 +70,7 @@ const Inner = styled('div')`
 const Header = styled('div')`
   display: grid;
   grid-gap: ${space(1)};
-  color: ${p => p.theme.gray500};
+  color: ${p => p.theme.textColor};
   max-width: 557px;
 `;
 


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/29228205/111804094-08f85680-88d0-11eb-9fbf-2b7c39fdf56c.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/111804038-fb42d100-88cf-11eb-83ab-c37205015d22.png)
