### PR TITLE
fix(files): Handle DatabaseError when cleaning up files

### DIFF
--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -258,13 +258,13 @@ class FileBlob(Model):
         return "/".join(pieces)
 
     def delete(self, *args, **kwargs):
+        if self.path:
+            self.deletefile(commit=False)
         lock = locks.get(f"fileblob:upload:{self.checksum}", duration=UPLOAD_RETRY_TIME)
         with TimedRetryPolicy(UPLOAD_RETRY_TIME, metric_instance="lock.fileblob.delete")(
             lock.acquire
         ):
             super().delete(*args, **kwargs)
-        if self.path:
-            self.deletefile(commit=False)
 
     def deletefile(self, commit=False):
         assert self.path

--- a/src/sentry/tasks/files.py
+++ b/src/sentry/tasks/files.py
@@ -9,6 +9,7 @@ from sentry.tasks.deletion import MAX_RETRIES
     default_retry_delay=60 * 5,
     max_retries=MAX_RETRIES,
     autoretry_for=(DatabaseError, IntegrityError),
+    acks_late=True,
 )
 def delete_file(path, checksum, **kwargs):
     from sentry.models.file import get_storage, FileBlob

--- a/tests/sentry/models/test_file.py
+++ b/tests/sentry/models/test_file.py
@@ -1,8 +1,11 @@
 import os
+import pytest
 
 from django.core.files.base import ContentFile
+from django.db import DatabaseError
+from unittest.mock import patch
 
-from sentry.models import File, FileBlob, FileBlobIndex
+from sentry.models import File, FileBlob, FileBlobIndex, get_storage
 from sentry.testutils import TestCase
 from sentry.utils.compat import map
 
@@ -69,6 +72,25 @@ class FileTest(TestCase):
 
         # Check that raz_file blob indexes are there.
         assert len(raz_file.blobs.all()) == 3
+
+    @patch("sentry.models.FileBlob.delete")
+    def test_delete_handles_blob_deletion_error(self, blob_delete):
+        fileobj = ContentFile(b"foo bar")
+        baz_file = File.objects.create(name="baz-v1.js", type="default", size=7)
+        baz_file.putfile(fileobj)
+        baz_id = baz_file.id
+        blob_path = baz_file.blobs.all()[0].path
+
+        blob_delete.side_effect = DatabaseError("server closed connection")
+
+        with self.tasks(), self.capture_on_commit_callbacks(execute=True):
+            baz_file.delete()
+
+        assert FileBlobIndex.objects.filter(file_id=baz_id).count() == 0
+        assert FileBlob.objects.count() == 1
+
+        with pytest.raises(FileNotFoundError):
+            get_storage().open(blob_path)
 
     def test_file_handling(self):
         fileobj = ContentFile(b"foo bar")


### PR DESCRIPTION
During 'bad times' postgres can drop connections leaving us in an unknown state around file blobs.

If the postgres record was deleted and the file was not we are left with orphaned files in filestore that we can never vaccuum. If the postgres record was not deleted, the unreferenced blob cleanup task will reap the postgres record and filestore object.

To better handle the scenario where postgres did delete the blob record, but our connection was dropped waiting for a response we catch the DatabaseError and remove the filestore object. This ensures we don't have orphaned filestore objects.

Fixes SENTRY-MHA