### PR TITLE
feat(alerts): Set default param 'myteams' and 'unassigned' upon visiting the alert list

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -277,6 +277,16 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
 
 class AlertRulesListContainer extends React.Component<Props> {
   componentDidMount() {
+    const {organization, router, location} = this.props;
+    if (organization.features.includes('team-alerts')) {
+      router.replace({
+        pathname: location.pathname,
+        query: {
+          ...location.query,
+          team: ['myteams', 'unassigned'],
+        },
+      });
+    }
     this.trackView();
   }
 

--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -279,7 +279,7 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
 class AlertRulesListContainer extends React.Component<Props> {
   componentDidMount() {
     const {organization, router, location} = this.props;
-    if (organization.features.includes('team-alerts')) {
+    if (organization.features.includes('team-alerts-ownership')) {
       router.replace({
         pathname: location.pathname,
         query: {

--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -35,6 +35,7 @@ const DEFAULT_SORT: {asc: boolean; field: 'date_added'} = {
   field: 'date_added',
 };
 const DOCS_URL = 'https://docs.sentry.io/product/alerts-notifications/metric-alerts/';
+const ALERT_LIST_QUERY_DEFAULT_TEAMS = ['myteams', 'unassigned'];
 
 type Props = RouteComponentProps<{orgId: string}, {}> & {
   organization: Organization;
@@ -283,7 +284,7 @@ class AlertRulesListContainer extends React.Component<Props> {
         pathname: location.pathname,
         query: {
           ...location.query,
-          team: ['myteams', 'unassigned'],
+          team: ALERT_LIST_QUERY_DEFAULT_TEAMS,
         },
       });
     }


### PR DESCRIPTION
Makes `myteams` and `unassigned` the default for the team filter here 

![image](https://user-images.githubusercontent.com/9372512/111811962-f9681600-88ad-11eb-8a13-034f7073ca66.png)
