### PR TITLE
ref(quick-trace): Refactor quick trace as a single component

### DIFF
--- a/src/sentry/static/sentry/app/components/quickTrace/styles.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/styles.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {LocationDescriptor} from 'history';
+
+import MenuItem from 'app/components/menuItem';
+import Tag, {Background} from 'app/components/tag';
+import Truncate from 'app/components/truncate';
+import space from 'app/styles/space';
+import {getDuration} from 'app/utils/formatters';
+import {QuickTraceEvent} from 'app/utils/performance/quickTrace/types';
+import {Theme} from 'app/utils/theme';
+
+export const SectionSubtext = styled('div')<{type?: 'error' | 'default'}>`
+  color: ${p => (p.type === 'error' ? p.theme.error : p.theme.subText)};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+export const QuickTraceContainer = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const nodeColors = (theme: Theme) => {
+  return {
+    error: {
+      color: theme.white,
+      background: theme.red300,
+      border: theme.red300,
+    },
+    warning: {
+      color: theme.red300,
+      background: theme.white,
+      border: theme.red300,
+    },
+    white: {
+      color: theme.textColor,
+      background: theme.background,
+      border: theme.textColor,
+    },
+    black: {
+      color: theme.background,
+      background: theme.textColor,
+      border: theme.textColor,
+    },
+  };
+};
+
+export const EventNode = styled(Tag)<{pad?: 'left' | 'right'}>`
+  span {
+    color: ${p => nodeColors(p.theme)[p.type || 'white'].color};
+  }
+  & ${/* sc-selector */ Background} {
+    background-color: ${p => nodeColors(p.theme)[p.type || 'white'].background};
+    border: 1px solid ${p => nodeColors(p.theme)[p.type || 'white'].border};
+  }
+`;
+
+export const TraceConnector = styled('div')`
+  width: ${space(1)};
+  border-top: 1px solid ${p => p.theme.textColor};
+`;
+
+const StyledMenuItem = styled(MenuItem)<{first?: boolean}>`
+  border-top: ${p => (!p.first ? `1px solid ${p.theme.innerBorder}` : null)};
+  width: 350px;
+`;
+
+const MenuItemContent = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+type DropdownItemProps = {
+  children: React.ReactNode;
+  to?: string | LocationDescriptor;
+  onSelect?: (eventKey: any) => void;
+  first?: boolean;
+};
+
+export function DropdownItem({children, first, onSelect, to}: DropdownItemProps) {
+  return (
+    <StyledMenuItem to={to} onSelect={onSelect} first={first}>
+      <MenuItemContent>{children}</MenuItemContent>
+    </StyledMenuItem>
+  );
+}
+
+export const DropdownItemSubContainer = styled('div')`
+  display: flex;
+  flex-direction: row;
+`;
+
+export const StyledTruncate = styled(Truncate)`
+  margin-left: ${space(1)};
+`;
+
+export function SingleEventHoverText({event}: {event: QuickTraceEvent}) {
+  return (
+    <div>
+      <Truncate
+        value={event.transaction}
+        maxLength={30}
+        leftTrim
+        trimRegex={/\.|\//g}
+        expandable={false}
+      />
+      <div>
+        {getDuration(
+          event['transaction.duration'] / 1000,
+          event['transaction.duration'] < 1000 ? 0 : 2,
+          true
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/sentry/static/sentry/app/components/quickTrace/utils.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/utils.tsx
@@ -9,9 +9,8 @@ import {generateEventSlug} from 'app/utils/discover/urls';
 import {EventLite, TraceError} from 'app/utils/performance/quickTrace/types';
 import {getTraceTimeRangeFromEvent} from 'app/utils/performance/quickTrace/utils';
 import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
-
-import {getTraceDetailsUrl} from '../traceDetails/utils';
-import {getTransactionDetailsUrl} from '../utils';
+import {getTraceDetailsUrl} from 'app/views/performance/traceDetails/utils';
+import {getTransactionDetailsUrl} from 'app/views/performance/utils';
 
 export function generateSingleEventTarget(
   event: EventLite | TraceError,

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/eventMetas.tsx
@@ -15,7 +15,7 @@ import {QuickTraceQueryChildrenProps} from 'app/utils/performance/quickTrace/typ
 import {isTransaction} from 'app/utils/performance/quickTrace/utils';
 import Projects from 'app/utils/projects';
 
-import QuickTrace from './quickTrace';
+import QuickTraceMeta from './quickTraceMeta';
 import {MetaData} from './styles';
 
 type Props = {
@@ -82,7 +82,7 @@ function EventMetas({event, organization, projectId, location, quickTrace}: Prop
         />
       )}
       <QuickTraceContainer>
-        <QuickTrace
+        <QuickTraceMeta
           event={event}
           organization={organization}
           location={location}

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {Location} from 'history';
+
+import ErrorBoundary from 'app/components/errorBoundary';
+import Link from 'app/components/links/link';
+import Placeholder from 'app/components/placeholder';
+import QuickTrace from 'app/components/quickTrace';
+import {generateTraceTarget} from 'app/components/quickTrace/utils';
+import {t} from 'app/locale';
+import {OrganizationSummary} from 'app/types';
+import {Event} from 'app/types/event';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
+import {getShortEventId} from 'app/utils/events';
+import {QuickTraceQueryChildrenProps} from 'app/utils/performance/quickTrace/types';
+
+import {MetaData} from './styles';
+
+type Props = {
+  event: Event;
+  location: Location;
+  organization: OrganizationSummary;
+  quickTrace: QuickTraceQueryChildrenProps;
+};
+
+function handleTraceLink(organization: OrganizationSummary) {
+  trackAnalyticsEvent({
+    eventKey: 'quick_trace.trace_id.clicked',
+    eventName: 'Quick Trace: Trace ID clicked',
+    organization_id: parseInt(organization.id, 10),
+  });
+}
+
+export default function QuickTraceMeta({
+  event,
+  location,
+  organization,
+  quickTrace: {isLoading, error, trace, type},
+}: Props) {
+  const traceId = event.contexts?.trace?.trace_id ?? null;
+  const traceTarget = generateTraceTarget(event, organization);
+
+  const body = isLoading ? (
+    <Placeholder height="27px" />
+  ) : error || trace === null ? (
+    '\u2014'
+  ) : (
+    <ErrorBoundary mini>
+      <QuickTrace
+        event={event}
+        quickTrace={{type, trace}}
+        location={location}
+        organization={organization}
+      />
+    </ErrorBoundary>
+  );
+
+  return (
+    <MetaData
+      headingText={t('Quick Trace')}
+      tooltipText={t('A minified version of the full trace.')}
+      bodyText={body}
+      subtext={
+        traceId === null ? (
+          '\u2014'
+        ) : (
+          <Link to={traceTarget} onClick={() => handleTraceLink(organization)}>
+            {t('Trace ID: %s', getShortEventId(traceId))}
+          </Link>
+        )
+      }
+    />
+  );
+}

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
@@ -1,14 +1,9 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import {LocationDescriptor} from 'history';
 
 import {SectionHeading} from 'app/components/charts/styles';
-import MenuItem from 'app/components/menuItem';
 import QuestionTooltip from 'app/components/questionTooltip';
-import Tag, {Background} from 'app/components/tag';
-import Truncate from 'app/components/truncate';
 import space from 'app/styles/space';
-import {Theme} from 'app/utils/theme';
 
 type MetaDataProps = {
   headingText: string;
@@ -51,84 +46,4 @@ const SectionBody = styled('div')`
 export const SectionSubtext = styled('div')<{type?: 'error' | 'default'}>`
   color: ${p => (p.type === 'error' ? p.theme.error : p.theme.subText)};
   font-size: ${p => p.theme.fontSizeMedium};
-`;
-
-const nodeColors = (theme: Theme) => {
-  return {
-    error: {
-      color: theme.white,
-      background: theme.red300,
-      border: theme.red300,
-    },
-    warning: {
-      color: theme.red300,
-      background: theme.white,
-      border: theme.red300,
-    },
-    white: {
-      color: theme.textColor,
-      background: theme.background,
-      border: theme.textColor,
-    },
-    black: {
-      color: theme.background,
-      background: theme.textColor,
-      border: theme.textColor,
-    },
-  };
-};
-
-export const EventNode = styled(Tag)<{pad?: 'left' | 'right'}>`
-  span {
-    color: ${p => nodeColors(p.theme)[p.type || 'white'].color};
-  }
-  & ${/* sc-selector */ Background} {
-    background-color: ${p => nodeColors(p.theme)[p.type || 'white'].background};
-    border: 1px solid ${p => nodeColors(p.theme)[p.type || 'white'].border};
-  }
-`;
-
-export const TraceConnector = styled('div')`
-  width: ${space(1)};
-  border-top: 1px solid ${p => p.theme.textColor};
-`;
-
-export const QuickTraceContainer = styled('div')`
-  display: flex;
-  align-items: center;
-`;
-
-const StyledMenuItem = styled(MenuItem)<{first?: boolean}>`
-  border-top: ${p => (!p.first ? `1px solid ${p.theme.innerBorder}` : null)};
-  width: 350px;
-`;
-
-const MenuItemContent = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
-`;
-
-type DropdownItemProps = {
-  children: React.ReactNode;
-  to?: string | LocationDescriptor;
-  onSelect?: (eventKey: any) => void;
-  first?: boolean;
-};
-
-export function DropdownItem({children, first, onSelect, to}: DropdownItemProps) {
-  return (
-    <StyledMenuItem to={to} onSelect={onSelect} first={first}>
-      <MenuItemContent>{children}</MenuItemContent>
-    </StyledMenuItem>
-  );
-}
-
-export const DropdownItemSubContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
-`;
-
-export const StyledTruncate = styled(Truncate)`
-  margin-left: ${space(1)};
 `;


### PR DESCRIPTION
Quick trace is current wrapped inside the header component. This change
refactors quick into its own standalone component that can be reused in issues.