### PR TITLE
fix(workflow): Cleaning up SLO metrics

### DIFF
--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -16,11 +16,12 @@ from sentry.models import (
     Activity,
     Group,
     GroupSeen,
+    Organization,
     Release,
     User,
     UserReport,
 )
-from sentry.api.helpers.group_index import rate_limit_endpoint
+from sentry.api.helpers.group_index import prep_search, rate_limit_endpoint, update_groups
 from sentry.plugins.base import plugins
 from sentry.plugins.bases import IssueTrackingPlugin2
 from sentry.signals import issue_deleted
@@ -303,14 +304,12 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
         """
         try:
             discard = request.data.get("discard")
-
-            # TODO(dcramer): we need to implement assignedTo in the bulk mutation
-            # endpoint
-            response = client.put(
-                path=f"/projects/{group.project.organization.slug}/{group.project.slug}/issues/",
-                params={"id": group.id},
-                data=request.data,
-                request=request,
+            project = group.project
+            search_fn = functools.partial(prep_search, self, request, project)
+            organization = Organization.objects.get_from_cache(id=project.organization_id)
+            has_inbox = features.has("organizations:inbox", organization, actor=request.user)
+            response = update_groups(
+                request, [group.id], [project], project.organization_id, search_fn, has_inbox
             )
 
             # if action was discard, there isn't a group to serialize anymore
@@ -340,18 +339,8 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
                 "group_details:put client.ApiError",
                 exc_info=True,
             )
-            metrics.incr(
-                "workflowslo.http_response",
-                sample_rate=1.0,
-                tags={"status": e.status_code, "detail": "group_details:put:client.ApiError"},
-            )
             return Response(e.body, status=e.status_code)
         except Exception:
-            metrics.incr(
-                "group.update.http_response",
-                sample_rate=1.0,
-                tags={"status": 500, "detail": "group_details:put:Exception"},
-            )
             raise
 
     @rate_limit_endpoint(limit=5, window=1)

--- a/src/sentry/api/endpoints/group_details.py
+++ b/src/sentry/api/endpoints/group_details.py
@@ -16,7 +16,6 @@ from sentry.models import (
     Activity,
     Group,
     GroupSeen,
-    Organization,
     Release,
     User,
     UserReport,
@@ -306,8 +305,9 @@ class GroupDetailsEndpoint(GroupEndpoint, EnvironmentMixin):
             discard = request.data.get("discard")
             project = group.project
             search_fn = functools.partial(prep_search, self, request, project)
-            organization = Organization.objects.get_from_cache(id=project.organization_id)
-            has_inbox = features.has("organizations:inbox", organization, actor=request.user)
+            has_inbox = features.has(
+                "organizations:inbox", project.organization, actor=request.user
+            )
             response = update_groups(
                 request, [group.id], [project], project.organization_id, search_fn, has_inbox
             )

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -2,13 +2,14 @@ import functools
 
 from rest_framework.response import Response
 
-from sentry import analytics, eventstore, search, features
+from sentry import analytics, eventstore, features
 from sentry.api.base import EnvironmentMixin
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.api.helpers.group_index import (
-    build_query_params_from_request,
     delete_groups,
     get_by_short_id,
+    prep_search,
+    track_slo_response,
     update_groups,
     ValidationError,
 )
@@ -16,7 +17,6 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializer
 from sentry.models import Environment, Group, GroupStatus, Organization
 from sentry.signals import advanced_search
-from sentry.utils.cursors import CursorResult
 from sentry.utils.validators import normalize_event_id
 
 ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', and '14d'"
@@ -25,28 +25,7 @@ ERR_INVALID_STATS_PERIOD = "Invalid stats_period. Valid choices are '', '24h', a
 class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
     permission_classes = (ProjectEventPermission,)
 
-    def _search(self, request, project, extra_query_kwargs=None):
-        try:
-            environment = self._get_environment_from_request(request, project.organization_id)
-        except Environment.DoesNotExist:
-            # XXX: The 1000 magic number for `max_hits` is an abstraction leak
-            # from `sentry.api.paginator.BasePaginator.get_result`.
-            result = CursorResult([], None, None, hits=0, max_hits=1000)
-            query_kwargs = {}
-        else:
-            environments = [environment] if environment is not None else environment
-            query_kwargs = build_query_params_from_request(
-                request, project.organization, [project], environments
-            )
-            if extra_query_kwargs is not None:
-                assert "environment" not in extra_query_kwargs
-                query_kwargs.update(extra_query_kwargs)
-
-            query_kwargs["environments"] = environments
-            result = search.query(**query_kwargs)
-        return result, query_kwargs
-
-    # statsPeriod=24h
+    @track_slo_response("workflow")
     def get(self, request, project):
         """
         List a Project's Issues
@@ -142,7 +121,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                 return response
 
         try:
-            cursor_result, query_kwargs = self._search(request, project, {"count_hits": True})
+            cursor_result, query_kwargs = prep_search(self, request, project, {"count_hits": True})
         except ValidationError as exc:
             return Response({"detail": str(exc)}, status=400)
 
@@ -177,6 +156,7 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
 
         return response
 
+    @track_slo_response("workflow")
     def put(self, request, project):
         """
         Bulk Mutate a List of Issues
@@ -235,11 +215,19 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
         :auth: required
         """
 
-        search_fn = functools.partial(self._search, request, project)
+        search_fn = functools.partial(prep_search, self, request, project)
         organization = Organization.objects.get_from_cache(id=project.organization_id)
         has_inbox = features.has("organizations:inbox", organization, actor=request.user)
-        return update_groups(request, [project], project.organization_id, search_fn, has_inbox)
+        return update_groups(
+            request,
+            request.GET.getlist("id"),
+            [project],
+            project.organization_id,
+            search_fn,
+            has_inbox,
+        )
 
+    @track_slo_response("workflow")
     def delete(self, request, project):
         """
         Bulk Remove a List of Issues
@@ -262,5 +250,5 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
                                      belong to.
         :auth: required
         """
-        search_fn = functools.partial(self._search, request, project)
+        search_fn = functools.partial(prep_search, self, request, project)
         return delete_groups(request, [project], project.organization_id, search_fn)

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -11,7 +11,7 @@ from rest_framework import serializers
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
-from sentry import eventstream, features
+from sentry import eventstream, features, search
 from sentry.app import ratelimiter
 from sentry.api.base import audit_logger
 from sentry.api.fields import ActorField
@@ -24,6 +24,7 @@ from sentry.models import (
     ActorTuple,
     Activity,
     Commit,
+    Environment,
     Group,
     GroupAssignee,
     GroupHash,
@@ -64,7 +65,7 @@ from sentry.tasks.integrations import kick_off_status_syncs
 from sentry.tasks.merge import merge_groups
 from sentry.utils import metrics
 from sentry.utils.audit import create_audit_entry
-from sentry.utils.cursors import Cursor
+from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.functional import extract_lazy_object
 from sentry.utils.compat import zip
 
@@ -429,44 +430,43 @@ def self_subscribe_and_assign_issue(acting_user, group):
             return ActorTuple(type=User, id=acting_user.id)
 
 
-def track_update_groups(function):
-    def wrapper(request, projects, *args, **kwargs):
-        from sentry.utils import snuba
+def track_slo_response(name):
+    def inner_func(function):
+        def wrapper(request, *args, **kwargs):
+            from sentry.utils import snuba
 
-        try:
-            response = function(request, projects, *args, **kwargs)
-        except snuba.RateLimitExceeded:
+            try:
+                response = function(request, *args, **kwargs)
+            except snuba.RateLimitExceeded:
+                metrics.incr(
+                    f"{name}.slo.http_response",
+                    sample_rate=1.0,
+                    tags={
+                        "status": 429,
+                        "detail": "snuba.RateLimitExceeded",
+                        "func": function,
+                    },
+                )
+                raise
+            except Exception:
+                metrics.incr(
+                    f"{name}.slo.http_response",
+                    sample_rate=1.0,
+                    tags={"status": 500, "detail": "Exception"},
+                )
+                # Continue raising the error now that we've incr the metric
+                raise
+
             metrics.incr(
-                "group.update.http_response",
+                f"{name}.slo.http_response",
                 sample_rate=1.0,
-                tags={
-                    "status": 429,
-                    "detail": "group_index:track_update_groups:snuba.RateLimitExceeded",
-                },
+                tags={"status": response.status_code, "detail": "response"},
             )
-            raise
-        except Exception:
-            metrics.incr(
-                "group.update.http_response",
-                sample_rate=1.0,
-                tags={"status": 500, "detail": "group_index:track_update_groups:Exception"},
-            )
-            # Continue raising the error now that we've incr the metric
-            raise
+            return response
 
-        serializer = GroupValidator(
-            data=request.data,
-            partial=True,
-            context={"project": projects[0], "access": getattr(request, "access", None)},
-        )
-        results = dict(serializer.validated_data) if serializer.is_valid() else {}
-        tags = {key: True for key in results.keys()}
-        tags["status"] = response.status_code
-        tags["detail"] = "group_index:track_update_groups:response"
-        metrics.incr("group.update.http_response", sample_rate=1.0, tags=tags)
-        return response
+        return wrapper
 
-    return wrapper
+    return inner_func
 
 
 def rate_limit_endpoint(limit=1, window=1):
@@ -492,9 +492,7 @@ def rate_limit_endpoint(limit=1, window=1):
     return inner
 
 
-@track_update_groups
-def update_groups(request, projects, organization_id, search_fn, has_inbox=False):
-    group_ids = request.GET.getlist("id")
+def update_groups(request, group_ids, projects, organization_id, search_fn, has_inbox=False):
     if group_ids:
         group_list = Group.objects.filter(
             project__organization_id=organization_id, project__in=projects, id__in=group_ids
@@ -505,7 +503,6 @@ def update_groups(request, projects, organization_id, search_fn, has_inbox=False
             return Response(status=204)
     else:
         group_list = None
-
     # TODO(jess): We may want to look into refactoring GroupValidator
     # to support multiple projects, but this is pretty complicated
     # because of the assignee validation. Punting on this for now.
@@ -1032,3 +1029,25 @@ def calculate_stats_period(stats_period, start, end):
         stats_period_start = None
         stats_period_end = None
     return stats_period, stats_period_start, stats_period_end
+
+
+def prep_search(cls, request, project, extra_query_kwargs=None):
+    try:
+        environment = cls._get_environment_from_request(request, project.organization_id)
+    except Environment.DoesNotExist:
+        # XXX: The 1000 magic number for `max_hits` is an abstraction leak
+        # from `sentry.api.paginator.BasePaginator.get_result`.
+        result = CursorResult([], None, None, hits=0, max_hits=1000)
+        query_kwargs = {}
+    else:
+        environments = [environment] if environment is not None else environment
+        query_kwargs = build_query_params_from_request(
+            request, project.organization, [project], environments
+        )
+        if extra_query_kwargs is not None:
+            assert "environment" not in extra_query_kwargs
+            query_kwargs.update(extra_query_kwargs)
+
+        query_kwargs["environments"] = environments
+        result = search.query(**query_kwargs)
+    return result, query_kwargs

--- a/src/sentry/integrations/slack/tasks.py
+++ b/src/sentry/integrations/slack/tasks.py
@@ -198,9 +198,9 @@ def find_channel_id_for_alert_rule(organization_id, uuid, data, alert_rule_id=No
             if action["type"] == "slack":
                 if action["targetIdentifier"] in mapped_ids:
                     action["input_channel_id"] = mapped_ids[action["targetIdentifier"]]
+                else:
                     # We can early exit because we couldn't map this action's slack channel name to a slack id
                     # This is a fail safe, but I think we shouldn't really hit this.
-                else:
                     redis_rule_status.set_value("failed")
                     return
 

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -431,7 +431,7 @@ class GroupUpdateTest(APITestCase):
         team = self.create_team(organization=group.project.organization, members=[self.user])
 
         url = f"/api/0/issues/{group.id}/"
-
+        print("making request.")
         response = self.client.put(url, data={"assignedTo": f"team:{team.id}"}, format="json")
 
         assert response.status_code == 400, response.content

--- a/tests/sentry/api/endpoints/test_group_details.py
+++ b/tests/sentry/api/endpoints/test_group_details.py
@@ -431,7 +431,6 @@ class GroupUpdateTest(APITestCase):
         team = self.create_team(organization=group.project.organization, members=[self.user])
 
         url = f"/api/0/issues/{group.id}/"
-        print("making request.")
         response = self.client.put(url, data={"assignedTo": f"team:{team.id}"}, format="json")
 
         assert response.status_code == 400, response.content

--- a/tests/sentry/api/helpers/test_group_index.py
+++ b/tests/sentry/api/helpers/test_group_index.py
@@ -77,7 +77,9 @@ class UpdateGroupsTest(TestCase):
         request.GET = QueryDict(query_string=f"id={resolved_group.id}")
 
         search_fn = Mock()
-        update_groups(request, [self.project], self.organization.id, search_fn)
+        update_groups(
+            request, request.GET.getlist("id"), [self.project], self.organization.id, search_fn
+        )
 
         resolved_group.refresh_from_db()
 
@@ -97,7 +99,9 @@ class UpdateGroupsTest(TestCase):
         request.GET = QueryDict(query_string=f"id={unresolved_group.id}")
 
         search_fn = Mock()
-        update_groups(request, [self.project], self.organization.id, search_fn)
+        update_groups(
+            request, request.GET.getlist("id"), [self.project], self.organization.id, search_fn
+        )
 
         unresolved_group.refresh_from_db()
 
@@ -116,7 +120,9 @@ class UpdateGroupsTest(TestCase):
         request.GET = QueryDict(query_string=f"id={group.id}")
 
         search_fn = Mock()
-        update_groups(request, [self.project], self.organization.id, search_fn)
+        update_groups(
+            request, request.GET.getlist("id"), [self.project], self.organization.id, search_fn
+        )
 
         group.refresh_from_db()
 
@@ -134,7 +140,9 @@ class UpdateGroupsTest(TestCase):
         request.GET = QueryDict(query_string=f"id={group.id}")
 
         search_fn = Mock()
-        update_groups(request, [self.project], self.organization.id, search_fn)
+        update_groups(
+            request, request.GET.getlist("id"), [self.project], self.organization.id, search_fn
+        )
 
         group.refresh_from_db()
 
@@ -153,7 +161,9 @@ class UpdateGroupsTest(TestCase):
             request.GET = QueryDict(query_string=f"id={group.id}")
 
             search_fn = Mock()
-            update_groups(request, [self.project], self.organization.id, search_fn)
+            update_groups(
+                request, request.GET.getlist("id"), [self.project], self.organization.id, search_fn
+            )
 
             group.refresh_from_db()
 


### PR DESCRIPTION
Currently, the workflow SLO stats are tracking requests made through our public API (hitting group_details.py). This is because 1) we had tracking in that file, and 2) it called our internal endpoint (which has tracking).

This PR decouples it from our internal endpoint by calling the `update_groups` function directly (there was some refactoring done to make this possible). I had to remove the decorator around `update_groups` that tracked SLO stats because there are cases we use it that we don't want to track.

I also tried to make this decorator something that could be used to track any sort of view, and maybe other teams can use it. But for now, it just takes a string (like "workflow") and tracks some slo stats in datadog. As part of this, I also changed the strings that represent these metrics in SLO, so I'll be going to update our metrics to include the old and the new ones for the next 90 days, then eventually dropping the old metrics.