### PR TITLE
ref(ui): Change `react-bootstrap` `Modal` import

### DIFF
--- a/src/sentry/static/sentry/app/components/globalModal.tsx
+++ b/src/sentry/static/sentry/app/components/globalModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 // eslint-disable-next-line no-restricted-imports
-import {Modal} from 'react-bootstrap';
+import Modal from 'react-bootstrap/lib/Modal';
 import {browserHistory} from 'react-router';
 import {ClassNames} from '@emotion/core';
 import createReactClass from 'create-react-class';


### PR DESCRIPTION
Changing this import as otherwise we get core-js errors with `webpack@5`