### PR TITLE
ref(ui): Remove unused type exports

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/draggableList/index.tsx
@@ -122,4 +122,3 @@ class DraggableList extends React.Component<Props, State> {
 }
 
 export default DraggableList;
-export {ItemProps, SortableItemProps};


### PR DESCRIPTION
These are unused afaict and throws some warnings in webpack.