### PR TITLE
feat(ci) Add an optional mypy check to Sentry

### DIFF
--- a/.github/workflows/backend-typing.yml
+++ b/.github/workflows/backend-typing.yml
@@ -65,10 +65,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
-      - name: Setup backend typing
+      - name: Setup sentry env
+        uses: ./.github/actions/setup-sentry
         if: steps.changes.outputs.backend == 'true'
-        run: |
-          pip install -r requirements-dev.txt
+        id: setup
+        with:
+          snuba: true
+          kafka: true
 
       - name: Run backend typing (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
         if: steps.changes.outputs.backend == 'true'

--- a/.github/workflows/backend-typing.yml
+++ b/.github/workflows/backend-typing.yml
@@ -65,13 +65,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
-      - name: Setup sentry env
-        uses: ./.github/actions/setup-sentry
+      - name: Setup backend typing
         if: steps.changes.outputs.backend == 'true'
-        id: setup
-        with:
-          snuba: true
-          kafka: true
+        run: |
+          pip install -r requirements-dev.txt
 
       - name: Run backend typing (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
         if: steps.changes.outputs.backend == 'true'

--- a/.github/workflows/backend-typing.yml
+++ b/.github/workflows/backend-typing.yml
@@ -1,0 +1,82 @@
+name: backend typing
+on:
+  push:
+    branches:
+      - master
+      - releases/**
+  pull_request:
+
+jobs:
+  test:
+    name: backend typing
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        instance: [0]
+
+    steps:
+      - uses: actions/checkout@v2
+
+        with:
+          # Avoid codecov error message related to SHA resolution:
+          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
+          fetch-depth: '2'
+
+      # If we make these jobs "required" to merge on GH, then on every PR, GitHub automatically
+      # creates a status check in the "pending" state. This means that the workflow needs to run
+      # for every PR in order to update the status checks.
+      #
+      # In order to optimize CI usage, we want the tests to only run when python files change,
+      # since frontend changes should have no effect on these test suites. We cannot use GH workflow
+      # path filters because entire workflow would be skipped vs skipping individual jobs which
+      # would still allow this status check to pass.
+      - name: Check for python file changes
+        uses: getsentry/paths-filter@v2
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
+      - name: Set python version output
+        id: python-version
+        if: steps.changes.outputs.backend == 'true'
+        run: |
+          echo "::set-output name=python-version::$(cat .python-version)"
+
+      # Until GH composite actions can use `uses`, we need to setup python here
+      - uses: actions/setup-python@v2
+        if: steps.changes.outputs.backend == 'true'
+        with:
+          python-version: ${{ steps.python-version.outputs.python-version }}
+
+      - name: Setup pip
+        uses: ./.github/actions/setup-pip
+        if: steps.changes.outputs.backend == 'true'
+        id: pip
+
+      - name: pip cache
+        uses: actions/cache@v2
+        if: steps.changes.outputs.backend == 'true'
+        with:
+          path: ${{ steps.pip.outputs.pip-cache-dir }}
+          key: |
+            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}-${{ hashFiles('requirements-*.txt', '!requirements-pre-commit.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
+
+      - name: Setup sentry env
+        uses: ./.github/actions/setup-sentry
+        if: steps.changes.outputs.backend == 'true'
+        id: setup
+        with:
+          snuba: true
+          kafka: true
+
+      - name: Run backend typing (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
+        if: steps.changes.outputs.backend == 'true'
+        run: |
+          make backend-typing
+
+      - name: Handle artifacts
+        uses: ./.github/actions/artifacts

--- a/.github/workflows/backend-typing.yml
+++ b/.github/workflows/backend-typing.yml
@@ -3,25 +3,16 @@ on:
   push:
     branches:
       - master
-      - releases/**
   pull_request:
 
 jobs:
   test:
     name: backend typing
     runs-on: ubuntu-20.04
-    timeout-minutes: 30
-    strategy:
-      matrix:
-        instance: [0]
+    timeout-minutes: 12
 
     steps:
       - uses: actions/checkout@v2
-
-        with:
-          # Avoid codecov error message related to SHA resolution:
-          # https://github.com/codecov/codecov-bash/blob/7100762afbc822b91806a6574658129fe0d23a7d/codecov#L891
-          fetch-depth: '2'
 
       # If we make these jobs "required" to merge on GH, then on every PR, GitHub automatically
       # creates a status check in the "pending" state. This means that the workflow needs to run
@@ -76,6 +67,3 @@ jobs:
         if: steps.changes.outputs.backend == 'true'
         run: |
           make backend-typing
-
-      - name: Handle artifacts
-        uses: ./.github/actions/artifacts

--- a/.github/workflows/backend-typing.yml
+++ b/.github/workflows/backend-typing.yml
@@ -65,13 +65,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-py${{ steps.python-version.outputs.python-version }}-pip${{ steps.pip.outputs.pip-version }}-${{ secrets.PIP_CACHE_VERSION }}
 
-      - name: Setup sentry env
-        uses: ./.github/actions/setup-sentry
+      - name: Setup backend typing
         if: steps.changes.outputs.backend == 'true'
-        id: setup
-        with:
-          snuba: true
-          kafka: true
+        run: |
+          python setup.py install_egg_info
+          pip install wheel # GitHub Actions does not have `wheel` installed by default
+          pip install -U -e ".[dev]"
 
       - name: Run backend typing (${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
         if: steps.changes.outputs.backend == 'true'

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,11 @@ test-snuba:
 	pytest tests/snuba tests/sentry/eventstream/kafka tests/sentry/snuba/test_discover.py -vv --cov . --cov-report="xml:.artifacts/snuba.coverage.xml" --junit-xml=".artifacts/snuba.junit.xml"
 	@echo ""
 
+backend-typing:
+	@echo "--> Running Python typing checks"
+	mypy --strict --warn-unreachable --config-file mypy.ini
+	@echo ""
+
 test-symbolicator:
 	@echo "--> Running symbolicator tests"
 	pytest tests/symbolicator -vv --cov . --cov-report="xml:.artifacts/symbolicator.coverage.xml" --junit-xml=".artifacts/symbolicator.junit.xml"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,6 +2,7 @@ docker>=3.7.0,<3.8.0
 exam>=0.5.1
 freezegun==1.1.0
 honcho>=1.0.0,<1.1.0
+mypy>=0.800
 openapi-core @ https://github.com/getsentry/openapi-core/archive/master.zip#egg=openapi-core
 pytest==6.1.0
 pytest-cov==2.11.1


### PR DESCRIPTION
Add an optional mypy check to Sentry. It will run on only the files specified in
the mypy config file.

Also I assume this won't block PRs at all, but I can't tell because I don't have access to the settings for the Sentry repo.