### PR TITLE
fix(ui): Fix webpack warning about named exports

### DIFF
--- a/src/sentry/static/sentry/app/data/platforms.tsx
+++ b/src/sentry/static/sentry/app/data/platforms.tsx
@@ -1,5 +1,4 @@
-/* eslint import/no-unresolved:0 import/order:0 */
-import {platforms} from 'integration-docs-platforms';
+import platforms from 'integration-docs-platforms';
 
 import {t} from 'app/locale';
 import {PlatformIntegration} from 'app/types';
@@ -21,7 +20,7 @@ const otherPlatform = {
 
 export default ([] as PlatformIntegration[]).concat(
   [],
-  ...[...platforms, otherPlatform].map(platform =>
+  ...[...platforms.platforms, otherPlatform].map(platform =>
     platform.integrations
       .map(i => ({...i, language: platform.id}))
       // filter out any tracing platforms; as they're not meant to be used as a platform for


### PR DESCRIPTION
This fixes a webpack warning about using named exports

```
WARNING in ./app/data/platforms.tsx 24:106-115
Should not import the named export platforms (imported as platforms) from default-exporting module (only default export is available soon)

```