### PR TITLE
logging(demo): adds info level logging for demo org setup

### DIFF
--- a/src/sentry/demo/data_population.py
+++ b/src/sentry/demo/data_population.py
@@ -305,12 +305,23 @@ def populate_connected_event_scenario_1(react_project: Project, python_project: 
     python_transaction = get_event_from_file("src/sentry/demo/data/python_transaction_1.json")
     python_error = get_event_from_file("src/sentry/demo/data/python_error_1.json")
 
+    log_extra = {
+        "organization_slug": react_project.organization.slug,
+        "MAX_DAYS": MAX_DAYS,
+        "SCALE_FACTOR": SCALE_FACTOR,
+    }
+    logger.info("populate_connected_event_scenario_1.start", extra=log_extra)
+
     for day in range(MAX_DAYS):
         for hour in range(24):
             base = distribution_v1(hour)
             # determine the number of events we want in this hour
             num_events = int((BASE_OFFSET + SCALE_FACTOR * base) * random.uniform(0.6, 1.0))
             for i in range(num_events):
+                logger.info(
+                    "populate_connected_event_scenario_1.send_event_series", extra=log_extra
+                )
+
                 # pick the minutes randomly (which means events will sent be out of order)
                 minute = random.randint(0, 60)
                 timestamp = timezone.now() - timedelta(days=day, hours=hour, minutes=minute)
@@ -403,3 +414,4 @@ def populate_connected_event_scenario_1(react_project: Project, python_project: 
                 )
                 fix_error_event(local_event)
                 safe_send_event(local_event)
+    logger.info("populate_connected_event_scenario_1.finished", extra=log_extra)

--- a/src/sentry/demo/demo_org_manager.py
+++ b/src/sentry/demo/demo_org_manager.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.db import transaction
 from django.db.models import F
@@ -22,6 +24,8 @@ from .data_population import (
 from .utils import NoDemoOrgReady, generate_random_name
 from .models import DemoUser, DemoOrganization, DemoOrgStatus
 
+logger = logging.getLogger(__name__)
+
 
 def create_demo_org() -> Organization:
     # wrap the main org setup in transaction
@@ -31,6 +35,8 @@ def create_demo_org() -> Organization:
         slug = slugify(name)
 
         org = DemoOrganization.create_org(name=name, slug=slug)
+
+        logger.info("create_demo_org.created_org", {"organization_slug": slug})
 
         owner = User.objects.get(email=settings.DEMO_ORG_OWNER_EMAIL)
         OrganizationMember.objects.create(organization=org, user=owner, role=roles.get_top_dog().id)
@@ -51,7 +57,6 @@ def create_demo_org() -> Organization:
         )
 
     # TODO: delete org if data population fails
-
     populate_connected_event_scenario_1(react_project, python_project)
 
     return org


### PR DESCRIPTION
For whatever reason, it seems that demo orgs being created on the GCP instance are being created with 0 events. It's yet unclear why this is happening. I'm hoping that adding some info-level log statements that I can read from Docker logs might help.