### PR TITLE
fix(release-adoption): tooltip order

### DIFF
--- a/src/sentry/static/sentry/app/views/releases/list/releaseAdoption.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseAdoption.tsx
@@ -54,16 +54,6 @@ function ReleaseAdoption({
           <TooltipWrapper>
             <TooltipRow>
               <Title>
-                <Dot color={theme.progressBackground} />
-                {t('Total Project')}
-              </Title>
-              <Value>
-                <Count value={projectCount} />{' '}
-                {releaseDisplayLabel(displayOption, projectCount)}
-              </Value>
-            </TooltipRow>
-            <TooltipRow>
-              <Title>
                 <Dot color={theme.progressBar} />
                 {t('This Release')}
               </Title>
@@ -72,7 +62,16 @@ function ReleaseAdoption({
                 {releaseDisplayLabel(displayOption, releaseCount)}
               </Value>
             </TooltipRow>
-
+            <TooltipRow>
+              <Title>
+                <Dot color={theme.progressBackground} />
+                {t('Total Project')}
+              </Title>
+              <Value>
+                <Count value={projectCount} />{' '}
+                {releaseDisplayLabel(displayOption, projectCount)}
+              </Value>
+            </TooltipRow>
             <Divider />
 
             <Time>{t('Last 24 hours')}</Time>

--- a/tests/js/spec/views/releases/list/releaseAdoption.spec.jsx
+++ b/tests/js/spec/views/releases/list/releaseAdoption.spec.jsx
@@ -15,10 +15,10 @@ describe('ReleasesList > ReleaseAdoption', function () {
 
     const tooltipContent = mountWithTheme(wrapper.find('Tooltip').prop('title'));
 
-    expect(tooltipContent.find('Title').at(0).text()).toBe('Total Project');
-    expect(tooltipContent.find('Value').at(0).text()).toBe('1k sessions');
-    expect(tooltipContent.find('Title').at(1).text()).toBe('This Release');
-    expect(tooltipContent.find('Value').at(1).text()).toBe('100 sessions');
+    expect(tooltipContent.find('Title').at(0).text()).toBe('This Release');
+    expect(tooltipContent.find('Value').at(0).text()).toBe('100 sessions');
+    expect(tooltipContent.find('Title').at(1).text()).toBe('Total Project');
+    expect(tooltipContent.find('Value').at(1).text()).toBe('1k sessions');
   });
 
   it('renders with users', function () {


### PR DESCRIPTION
- Total usually goes last 

**Before:**
![Screen Shot 2021-03-19 at 1 37 11 PM](https://user-images.githubusercontent.com/4830259/111839580-40f39f80-88b8-11eb-837b-c701a7bfbde9.png)

**After:**
![Screen Shot 2021-03-19 at 1 37 01 PM](https://user-images.githubusercontent.com/4830259/111839598-44872680-88b8-11eb-8713-e12eb7930ead.png)