### PR TITLE
test(discover): Skip impossible Discover queries

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1,4 +1,5 @@
 import uuid
+import pytest
 
 from pytz import utc
 from datetime import timedelta
@@ -1220,6 +1221,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             [{"count": 0}],
         ]
 
+    @pytest.mark.skip(reason="A query with group_id will not return transactions")
     def test_top_events_none_filter(self):
         """When a field is None in one of the top events, make sure we filter by it
 
@@ -1257,6 +1259,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                 attrs for time, attrs in results["data"]
             ]
 
+    @pytest.mark.skip(reason="Invalid query - transaction events don't have group_id field")
     def test_top_events_one_field_with_none(self):
         with self.feature(self.enabled_features):
             response = self.client.get(


### PR DESCRIPTION
The `group_id` field is specific to errors, and you cannot make a query
for transaction events using this column.

This may temporarily work since errors and transactions are currently stored in
a shared table, but is not expected to work once the storages are split.