### PR TITLE
test: Rewrite test_top_events_with_error_handled to return consistent result

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1317,6 +1317,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "orderby": ["-count()"],
                     "field": ["count()", "error.handled"],
                     "topEvents": 5,
+                    "query": "!event.type:transaction",
                 },
                 format="json",
             )
@@ -1326,7 +1327,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         assert len(data) == 3
 
         results = data[""]
-        assert [attrs for time, attrs in results["data"]] == [[{"count": 22}], [{"count": 6}]]
+        assert [attrs for time, attrs in results["data"]] == [[{"count": 19}], [{"count": 6}]]
         assert results["order"] == 0
 
         results = data["1"]


### PR DESCRIPTION
The `error.handled` field is not relevant for transaction events and a query with this field
will not always include transactions in the returned count. We add the type != transaction
condition here to ensure there is no ambiguity in the query.