### PR TITLE
fix: show whole settings sidebar in short windows

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsNavigation.tsx
@@ -6,8 +6,6 @@ import space from 'app/styles/space';
 import SettingsNavigationGroup from 'app/views/settings/components/settingsNavigationGroup';
 import {NavigationProps, NavigationSection} from 'app/views/settings/types';
 
-const FOOTER_HEIGHT = 93;
-
 type DefaultProps = {
   /**
    * Additional navigation configuration driven by hooks
@@ -71,7 +69,6 @@ const PositionStickyWrapper = styled('div')<{stickyTop: string}>`
     position: sticky;
     top: ${p => p.stickyTop};
     overflow: scroll;
-    height: calc(100vh - ${p => p.stickyTop} - ${FOOTER_HEIGHT}px);
     -ms-overflow-style: none;
     scrollbar-width: none;
 


### PR DESCRIPTION
In #24217, the height of the settings sidebar was reduced in order to not push
down the footer. Unfortunately, this makes it not fully render if the
window is shorter than the settings sidebar. As far as I can tell, the height
doesn't actually need to be calculated. The footer is pushed down by flex-grow:
1 in layout.less, and in fact I'm not sure it makes sense for the sidebar to
need to push down the footer, since that would mean that on sidebar-less pages,
the footer wouldn't be pushed down.

![localhost_8000_settings_account_details_](https://user-images.githubusercontent.com/78757344/111854753-550ac180-88f7-11eb-9efe-febce436ccd7.png)
