### PR TITLE
feat(trace-view): Include errors in the light trace

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -19,7 +19,6 @@ DETAILED_NODESTORE_KEYS = ["environment", "release"]
 ERROR_COLUMNS = [
     "id",
     "project",
-    "event.type",
     "timestamp",
     "trace.span",
     "transaction",
@@ -87,7 +86,6 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
         # selected_columns is a set list, since we only want to include the minimum to render the trace
         selected_columns = [
             "id",
-            "event.type",
             "timestamp",
             "transaction.duration",
             "transaction.op",

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -952,7 +952,8 @@ def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
                 return [["isNull", [name]], search_filter.operator, 1]
 
         is_null_condition = None
-        if search_filter.operator == "!=" and not search_filter.key.is_tag:
+        # TODO(wmak): Skip this for all non-nullable keys not just event.type
+        if search_filter.operator == "!=" and not search_filter.key.is_tag and name != "event.type":
             # Handle null columns on inequality comparisons. Any comparison
             # between a value and a null will result to null, so we need to
             # explicitly check for whether the condition is null, and OR it


### PR DESCRIPTION
- Refactored the *_map construction to share it between
  transactions/errors
- Accept errors for the event_id now, but the error will still be under
  the `errors` attribute of its corresponding transaction
- Also for the light view getting errors for the current transaction
- Some fixes:
    - Wasn't correctly returning generation for the light view
    - Removing isNull on !event.type:transaction