### PR TITLE
fix(alerts): adjust stat count color for dark mode

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -641,7 +641,7 @@ const StatItem = styled('div')`
 const StatCount = styled('span')`
   margin-left: ${space(0.5)};
   margin-top: ${space(0.25)};
-  color: black;
+  color: ${p => p.theme.textColor};
 `;
 
 const RuleText = styled('div')`


### PR DESCRIPTION
Before:

![localhost_8000_organizations_sentry_alerts_rules_details_1__end=2021-03-20T14%3A44%3A52 start=2021-03-05T13%3A45%3A52](https://user-images.githubusercontent.com/78757344/111873998-7dcb9f00-8969-11eb-812f-5f6949554807.png)

After:

![localhost_8000_organizations_sentry_alerts_rules_details_1__end=2021-03-20T14%3A44%3A52 start=2021-03-05T13%3A45%3A52 (1)](https://user-images.githubusercontent.com/78757344/111874000-83c18000-8969-11eb-88ec-de25b7504cdd.png)
