### PR TITLE
feat: use color-scheme

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,12 +1,12 @@
 import 'focus-visible';
+import '../docs-ui/index.js';
+
 import React from 'react';
+import {addDecorator, addParameters} from '@storybook/react';
 import {ThemeProvider} from 'emotion-theming';
 
-import {addParameters, addDecorator} from '@storybook/react';
-
-import {lightTheme, darkTheme} from '../src/sentry/static/sentry/app/utils/theme';
 import GlobalStyles from '../src/sentry/static/sentry/app/styles/global';
-import '../docs-ui/index.js';
+import {darkTheme, lightTheme} from '../src/sentry/static/sentry/app/utils/theme';
 
 const withTheme = (Story, context) => {
   const isDark = context.globals.theme === 'dark';
@@ -20,7 +20,7 @@ const withTheme = (Story, context) => {
   return (
     <ThemeProvider theme={currentTheme}>
       <GlobalStyles isDark={isDark} theme={currentTheme} />
-      <div style={{'colorScheme': context.globals.theme}}>
+      <div style={{colorScheme: context.globals.theme}}>
         <Story {...context} />
       </div>
     </ThemeProvider>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -20,7 +20,9 @@ const withTheme = (Story, context) => {
   return (
     <ThemeProvider theme={currentTheme}>
       <GlobalStyles isDark={isDark} theme={currentTheme} />
-      <Story {...context} />
+      <div style={{'colorScheme': context.globals.theme}}>
+        <Story {...context} />
+      </div>
     </ThemeProvider>
   );
 };

--- a/src/sentry/static/sentry/app/actionCreators/account.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/account.tsx
@@ -17,17 +17,6 @@ export async function disconnectIdentity(identity: Identity) {
 }
 
 export function updateUser(user: User) {
-  const previousUser = ConfigStore.get('user');
-
-  // If the user changed their theme preferences, we should also update
-  // the config store
-  if (
-    previousUser.options.theme !== user.options.theme &&
-    user.options.theme !== 'system'
-  ) {
-    ConfigStore.set('theme', user.options.theme);
-  }
-
   // Ideally we'd fire an action but this is gonna get refactored soon anyway
   ConfigStore.set('user', user);
 }

--- a/src/sentry/static/sentry/app/components/dateTime.tsx
+++ b/src/sentry/static/sentry/app/components/dateTime.tsx
@@ -22,7 +22,7 @@ class DateTime extends React.Component<Props> {
     seconds: true,
   };
 
-  getFormat = ({clock24Hours}: {clock24Hours: boolean}): string => {
+  getFormat = ({clock24Hours}: {clock24Hours?: boolean}): string => {
     const {dateOnly, timeOnly, seconds, shortDate, timeAndDate, format} = this.props;
 
     if (format) {

--- a/src/sentry/static/sentry/app/stores/configStore.tsx
+++ b/src/sentry/static/sentry/app/stores/configStore.tsx
@@ -48,13 +48,13 @@ const configStoreConfig: Reflux.StoreDefinition &
    */
   updateTheme(theme) {
     this.systemTheme = theme;
-    if (this.config.user?.options.theme === 'system' && theme !== this.config.theme) {
+    if (this.config.user.options.theme === 'system' && theme !== this.config.theme) {
       this.set('theme', theme);
     }
   },
 
   getTheme() {
-    // options?. to work around tests
+    // ?. to work around tests
     const themeOption = this.config.user?.options?.theme;
     return (themeOption === 'system' ? this.systemTheme : themeOption) || 'light';
   },

--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -60,6 +60,9 @@ const styles = (theme: Theme, isDark: boolean) => css`
     : ''}
 
   /* Override css in LESS files here as we want to manually control dark mode for now */
+  html {
+    color-scheme: ${isDark ? 'dark' : 'light'};
+  }
   ${isDark
     ? css`
         .loading .loading-indicator {

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -396,7 +396,7 @@ export type AvatarUser = {
   // Compatibility shim with EventUser serializer
   ipAddress?: string;
   options?: {
-    avatarType: string;
+    avatarType?: string;
   };
   lastSeen?: string;
 };
@@ -649,8 +649,7 @@ export interface Config {
   urlPrefix: string;
   needsUpgrade: boolean;
   supportEmail: string;
-  // ?: to work around tests
-  user?: User;
+  user: User;
 
   invitesEnabled: boolean;
   privacyUrl: string | null;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -430,12 +430,12 @@ export type User = Omit<AvatarUser, 'options'> & {
   authenticators: UserEnrolledAuthenticator[];
   dateJoined: string;
   options: {
-    theme: 'system' | 'light' | 'dark';
-    timezone: string;
-    stacktraceOrder: number;
-    language: string;
-    clock24Hours: boolean;
-    avatarType: string;
+    theme?: 'system' | 'light' | 'dark';
+    timezone?: string;
+    stacktraceOrder?: number;
+    language?: string;
+    clock24Hours?: boolean;
+    avatarType?: string;
   };
   flags: {newsletter_consent_prompt: boolean};
   hasPasswordAuth: boolean;
@@ -649,7 +649,8 @@ export interface Config {
   urlPrefix: string;
   needsUpgrade: boolean;
   supportEmail: string;
-  user: User;
+  // ?: to work around tests
+  user?: User;
 
   invitesEnabled: boolean;
   privacyUrl: string | null;

--- a/src/sentry/static/sentry/app/utils/dates.tsx
+++ b/src/sentry/static/sentry/app/utils/dates.tsx
@@ -47,7 +47,7 @@ export function getFormattedDate(
  */
 export function getUserTimezone(): string {
   const user = ConfigStore.get('user');
-  return user && user.options && user.options.timezone;
+  return user.options?.timezone ?? 'UTC';
 }
 
 /**

--- a/src/sentry/static/sentry/app/views/admin/installWizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/admin/installWizard/index.tsx
@@ -15,9 +15,7 @@ import AsyncView from 'app/views/asyncView';
 
 import {getForm, getOptionDefault, getOptionField} from '../options';
 
-type Props = {
-  onConfigured: () => void;
-} & AsyncView['props'];
+type Props = {} & AsyncView['props'];
 
 type State = {} & AsyncView['state'];
 
@@ -126,7 +124,7 @@ export default class InstallWizard extends AsyncView<Props, State> {
         apiEndpoint={this.getEndpoints()[0][1]}
         submitLabel={t('Continue')}
         initialData={this.getInitialData()}
-        onSubmitSuccess={this.props.onConfigured}
+        onSubmitSuccess={() => ConfigStore.set('needsUpgrade', false)}
       >
         <p>{t('Complete setup by filling out the required configuration.')}</p>
 

--- a/src/sentry/static/sentry/app/views/app/index.tsx
+++ b/src/sentry/static/sentry/app/views/app/index.tsx
@@ -140,8 +140,6 @@ class App extends React.Component<Props, State> {
     ConfigStore.set('theme', ConfigStore.get('theme') === 'light' ? 'dark' : 'light');
   }
 
-  onConfigured = () => this.setState({needsUpgrade: false});
-
   handleGlobalModalClose = () => {
     if (typeof this.mainContainerRef.current?.focus === 'function') {
       // Focus the main container to get hotkeys to keep working after modal closes

--- a/src/sentry/static/sentry/app/views/newsletterConsent.tsx
+++ b/src/sentry/static/sentry/app/views/newsletterConsent.tsx
@@ -4,6 +4,7 @@ import {ApiForm, RadioBooleanField} from 'app/components/forms';
 import ExternalLink from 'app/components/links/externalLink';
 import NarrowLayout from 'app/components/narrowLayout';
 import {t, tct} from 'app/locale';
+import ConfigStore from 'app/stores/configStore';
 
 type Props = {
   onSubmitSuccess?: () => void;
@@ -29,7 +30,9 @@ export default class NewsletterConsent extends React.Component<Props> {
         <ApiForm
           apiMethod="POST"
           apiEndpoint="/users/me/subscriptions/"
-          onSubmitSuccess={() => this.props.onSubmitSuccess?.()}
+          onSubmitSuccess={() => {
+            ConfigStore.get('user').flags.newsletter_consent_prompt = false;
+          }}
           submitLabel={t('Continue')}
         >
           <RadioBooleanField

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -15,6 +15,7 @@
   <meta name="robots" content="NONE,NOARCHIVE">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#000000">
+  <meta name="color-scheme" content="{% color_scheme %}">
 
   <link rel="icon" type="image/png" href="{% absolute_asset_url "sentry" "images/favicon.png" %}">
 

--- a/src/sentry/templatetags/sentry_react.py
+++ b/src/sentry/templatetags/sentry_react.py
@@ -11,3 +11,14 @@ def get_react_config(context):
     context = get_client_config(context.get("request", None))
 
     return json.dumps_htmlsafe(context)
+
+
+@register.simple_tag(takes_context=True)
+def color_scheme(context):
+    request = context.get("request", None)
+    user = getattr(request, "user", None)
+    theme = getattr(user, "theme", None)
+    if theme == "dark":
+        return "dark light"
+
+    return "light dark"

--- a/tests/js/spec/utils/withConfig.spec.jsx
+++ b/tests/js/spec/utils/withConfig.spec.jsx
@@ -12,8 +12,8 @@ describe('withConfig HoC', function () {
     const Container = withConfig(MyComponent);
     const wrapper = mountWithTheme(<Container />);
     expect(wrapper.find('MyComponent').prop('config')).toEqual({});
-    ConfigStore.set('user', 'foo');
+    ConfigStore.set('languageCode', 'en');
     wrapper.update();
-    expect(wrapper.find('MyComponent').prop('config')).toEqual({user: 'foo'});
+    expect(wrapper.find('MyComponent').prop('config')).toEqual({languageCode: 'en'});
   });
 });


### PR DESCRIPTION
1. Fix ugly light scroll bars on dark mode for WebKit-based browsers

This uses both `<meta name="color-scheme">` and CSS color-scheme for maximum
compatibility and to set dark mode as early as possible (minimizing FOLC, flash
of light content). Chrome and Safari were tested working on Mac, Firefox was
tested not working.

2. Make switching to "Default to system" take effect immediately

The previous logic here was not correct when defaulting to system, and would
only work after refreshing. Refactor so it works immediately.