### PR TITLE
fix(ui): admin dark mode fixes and refactor

### DIFF
--- a/src/sentry/static/sentry/app/routes.tsx
+++ b/src/sentry/static/sentry/app/routes.tsx
@@ -1886,6 +1886,7 @@ function routes() {
 
           {/* Admin/manage routes */}
           <Route
+            name="Admin"
             path="/manage/"
             componentPromise={() =>
               import(/* webpackChunkName: "AdminLayout" */ 'app/views/admin/adminLayout')
@@ -1901,6 +1902,7 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
             <Route
+              name="Buffer"
               path="buffer/"
               componentPromise={() =>
                 import(
@@ -1910,6 +1912,7 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
             <Route
+              name="Relays"
               path="relays/"
               componentPromise={() =>
                 import(
@@ -1919,6 +1922,7 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
             <Route
+              name="Organizations"
               path="organizations/"
               componentPromise={() =>
                 import(
@@ -1928,6 +1932,7 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
             <Route
+              name="Projects"
               path="projects/"
               componentPromise={() =>
                 import(
@@ -1937,6 +1942,7 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
             <Route
+              name="Queue"
               path="queue/"
               componentPromise={() =>
                 import(/* webpackChunkName: "AdminQueue" */ 'app/views/admin/adminQueue')
@@ -1944,6 +1950,7 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
             <Route
+              name="Quotas"
               path="quotas/"
               componentPromise={() =>
                 import(
@@ -1953,6 +1960,7 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
             <Route
+              name="Settings"
               path="settings/"
               componentPromise={() =>
                 import(
@@ -1961,7 +1969,7 @@ function routes() {
               }
               component={errorHandler(LazyLoad)}
             />
-            <Route path="users/">
+            <Route name="Users" path="users/">
               <IndexRoute
                 componentPromise={() =>
                   import(
@@ -1981,6 +1989,7 @@ function routes() {
               />
             </Route>
             <Route
+              name="Mail"
               path="status/mail/"
               componentPromise={() =>
                 import(/* webpackChunkName: "AdminMail" */ 'app/views/admin/adminMail')
@@ -1988,6 +1997,7 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
             <Route
+              name="Environment"
               path="status/environment/"
               componentPromise={() =>
                 import(
@@ -1997,6 +2007,7 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
             <Route
+              name="Packages"
               path="status/packages/"
               componentPromise={() =>
                 import(
@@ -2006,6 +2017,7 @@ function routes() {
               component={errorHandler(LazyLoad)}
             />
             <Route
+              name="Warnings"
               path="status/warnings/"
               componentPromise={() =>
                 import(

--- a/src/sentry/static/sentry/app/styles/global.tsx
+++ b/src/sentry/static/sentry/app/styles/global.tsx
@@ -62,6 +62,9 @@ const styles = (theme: Theme, isDark: boolean) => css`
   /* Override css in LESS files here as we want to manually control dark mode for now */
   ${isDark
     ? css`
+        .box {
+          background: ${theme.background};
+        }
         .loading .loading-indicator {
           border-color: ${theme.background};
           border-left-color: ${theme.purple300};

--- a/src/sentry/static/sentry/app/views/admin/adminLayout.tsx
+++ b/src/sentry/static/sentry/app/views/admin/adminLayout.tsx
@@ -40,20 +40,15 @@ type Props = {
   children: React.ReactNode;
 } & RouteComponentProps<{}, {}>;
 
-class AdminLayout extends React.Component<Props> {
-  render() {
-    const {children, ...props} = this.props;
-    return (
-      <DocumentTitle title="Sentry Admin">
-        <Page>
-          <SettingsLayout renderNavigation={AdminNavigation} {...props}>
-            {children}
-          </SettingsLayout>
-        </Page>
-      </DocumentTitle>
-    );
-  }
-}
+const AdminLayout: React.FC<Props> = ({children, ...props}) => (
+  <DocumentTitle title="Sentry Admin">
+    <Page>
+      <SettingsLayout renderNavigation={AdminNavigation} {...props}>
+        {children}
+      </SettingsLayout>
+    </Page>
+  </DocumentTitle>
+);
 
 const Page = styled('div')`
   display: flex;

--- a/src/sentry/static/sentry/app/views/admin/adminLayout.tsx
+++ b/src/sentry/static/sentry/app/views/admin/adminLayout.tsx
@@ -1,64 +1,64 @@
 import React from 'react';
 import DocumentTitle from 'react-document-title';
+import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
-import space from 'app/styles/space';
+import SettingsLayout from 'app/views/settings/components/settingsLayout';
 import SettingsNavigation from 'app/views/settings/components/settingsNavigation';
 
-const AdminLayout: React.FC = ({children}) => (
-  <DocumentTitle title="Sentry Admin">
-    <Page>
-      <NavWrapper>
-        <SettingsNavigation
-          stickyTop="0"
-          navigationObjects={[
-            {
-              name: 'System Status',
-              items: [
-                {path: '/manage/', index: true, title: 'Overview'},
-                {path: '/manage/buffer/', title: 'Buffer'},
-                {path: '/manage/queue/', title: 'Queue'},
-                {path: '/manage/quotas/', title: 'Quotas'},
-                {path: '/manage/status/environment/', title: 'Environment'},
-                {path: '/manage/status/packages/', title: 'Packages'},
-                {path: '/manage/status/mail/', title: 'Mail'},
-                {path: '/manage/status/warnings/', title: 'Warnings'},
-                {path: '/manage/settings/', title: 'Settings'},
-              ],
-            },
-            {
-              name: 'Manage',
-              items: [
-                {path: '/manage/organizations/', title: 'Organizations'},
-                {path: '/manage/projects/', title: 'Projects'},
-                {path: '/manage/users/', title: 'Users'},
-              ],
-            },
-          ]}
-        />
-      </NavWrapper>
-      <Content>{children}</Content>
-    </Page>
-  </DocumentTitle>
+const AdminNavigation = () => (
+  <SettingsNavigation
+    stickyTop="0"
+    navigationObjects={[
+      {
+        name: 'System Status',
+        items: [
+          {path: '/manage/', index: true, title: 'Overview'},
+          {path: '/manage/buffer/', title: 'Buffer'},
+          {path: '/manage/queue/', title: 'Queue'},
+          {path: '/manage/quotas/', title: 'Quotas'},
+          {path: '/manage/status/environment/', title: 'Environment'},
+          {path: '/manage/status/packages/', title: 'Packages'},
+          {path: '/manage/status/mail/', title: 'Mail'},
+          {path: '/manage/status/warnings/', title: 'Warnings'},
+          {path: '/manage/settings/', title: 'Settings'},
+        ],
+      },
+      {
+        name: 'Manage',
+        items: [
+          {path: '/manage/organizations/', title: 'Organizations'},
+          {path: '/manage/projects/', title: 'Projects'},
+          {path: '/manage/users/', title: 'Users'},
+        ],
+      },
+    ]}
+  />
 );
 
-const NavWrapper = styled('div')`
-  flex-shrink: 0;
-  flex-grow: 0;
-  width: ${p => p.theme.settings.sidebarWidth};
-  background: ${p => p.theme.white};
-  border-right: 1px solid ${p => p.theme.border};
-`;
+type Props = {
+  children: React.ReactNode;
+} & RouteComponentProps<{}, {}>;
+
+class AdminLayout extends React.Component<Props> {
+  render() {
+    const {children, ...props} = this.props;
+    return (
+      <DocumentTitle title="Sentry Admin">
+        <Page>
+          <SettingsLayout renderNavigation={AdminNavigation} {...props}>
+            {children}
+          </SettingsLayout>
+        </Page>
+      </DocumentTitle>
+    );
+  }
+}
 
 const Page = styled('div')`
   display: flex;
   flex-grow: 1;
   margin-bottom: -20px;
-`;
-
-const Content = styled('div')`
-  flex-grow: 1;
-  padding: ${space(4)};
 `;
 
 export default AdminLayout;

--- a/src/sentry/static/sentry/app/views/admin/adminLayout.tsx
+++ b/src/sentry/static/sentry/app/views/admin/adminLayout.tsx
@@ -40,20 +40,22 @@ type Props = {
   children: React.ReactNode;
 } & RouteComponentProps<{}, {}>;
 
-const AdminLayout: React.FC<Props> = ({children, ...props}) => (
-  <DocumentTitle title="Sentry Admin">
-    <Page>
-      <SettingsLayout renderNavigation={AdminNavigation} {...props}>
-        {children}
-      </SettingsLayout>
-    </Page>
-  </DocumentTitle>
-);
+function AdminLayout({children, ...props}: Props) {
+  return (
+    <DocumentTitle title="Sentry Admin">
+      <Page>
+        <SettingsLayout renderNavigation={AdminNavigation} {...props}>
+          {children}
+        </SettingsLayout>
+      </Page>
+    </DocumentTitle>
+  );
+}
+
+export default AdminLayout;
 
 const Page = styled('div')`
   display: flex;
   flex-grow: 1;
   margin-bottom: -20px;
 `;
-
-export default AdminLayout;


### PR DESCRIPTION
Fixes #24954.

Admin page also unnecessarily duplicates many settings components which can be
reused, so refactor it.

Some pages still aren't perfect but it should be an improvement.

Before:

![image](https://user-images.githubusercontent.com/78757344/111882048-c004d880-8989-11eb-8547-de334772f2e2.png)

After:

![image](https://user-images.githubusercontent.com/78757344/111882058-cdba5e00-8989-11eb-9820-9f69b5855972.png)
