### PR TITLE
ref(event-details-page): Add new router logic in case of empty reprocessed issue

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
@@ -241,7 +241,7 @@ class Actions extends React.Component<Props, State> {
       <Wrapper>
         {orgFeatures.has('inbox') && (
           <Tooltip disabled={!!group.inbox} title={t('Issue has been reviewed')}>
-            <ReviewAction onUpdate={this.onUpdate} disabled={!group.inbox} />
+            <ReviewAction onUpdate={this.onUpdate} disabled={!group.inbox || disabled} />
           </Tooltip>
         )}
         <GuideAnchor target="resolve" position="bottom" offset={space(3)}>

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupDetails.tsx
@@ -506,7 +506,7 @@ class GroupDetails extends React.Component<Props, State> {
     const {error: isError, group, project, loading} = this.state;
     const isLoading = loading || (!group && !isError);
 
-    if (isLoading || !group) {
+    if (isLoading) {
       return <LoadingIndicator />;
     }
 
@@ -527,7 +527,7 @@ class GroupDetails extends React.Component<Props, State> {
             fetchError ? (
               <LoadingError message={t('Error loading the specified project')} />
             ) : (
-              this.renderContent(projects[0], group)
+              this.renderContent(projects[0], group!) // TODO(ts): Update renderContent function to deal with empty group
             )
           ) : (
             <LoadingIndicator />

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/groupEventDetails/index.tsx
@@ -13,6 +13,8 @@ import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
 
+import {ReprocessingStatus} from '../utils';
+
 import GroupEventDetails from './groupEventDetails';
 
 type Props = RouteComponentProps<
@@ -25,6 +27,7 @@ type Props = RouteComponentProps<
   project: Project;
   group: Group;
   event: Event;
+  groupReprocessingStatus: ReprocessingStatus;
   loadingEvent: boolean;
   eventError: boolean;
   onRetry: () => void;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
@@ -33,7 +33,7 @@ import withApi from 'app/utils/withApi';
 
 import GroupActions from './actions';
 import UnhandledTag, {TagAndMessageWrapper} from './unhandledTag';
-import {getGroupReprocessingStatus, ReprocessingStatus} from './utils';
+import {ReprocessingStatus} from './utils';
 
 const TAB = {
   DETAILS: 'details',
@@ -50,6 +50,8 @@ type Props = {
   currentTab: string;
   baseUrl: string;
   group: Group;
+  groupReprocessingStatus: ReprocessingStatus;
+  eventError: boolean;
   project: Project;
   api: Client;
   event?: Event;
@@ -82,6 +84,47 @@ class GroupHeader extends React.Component<Props, State> {
     });
   }
 
+  getDisabledTabs() {
+    const {organization} = this.context;
+
+    const hasReprocessingV2Feature = organization.features.includes('reprocessing-v2');
+
+    if (!hasReprocessingV2Feature) {
+      return [];
+    }
+
+    const {groupReprocessingStatus, eventError} = this.props;
+
+    if (groupReprocessingStatus === ReprocessingStatus.REPROCESSING) {
+      return [
+        TAB.ACTIVITY,
+        TAB.USER_FEEDBACK,
+        TAB.ATTACHMENTS,
+        TAB.EVENTS,
+        TAB.MERGED,
+        TAB.SIMILAR_ISSUES,
+        TAB.TAGS,
+      ];
+    }
+
+    if (
+      (eventError &&
+        groupReprocessingStatus === ReprocessingStatus.REPROCESSED_AND_HAS_EVENT) ||
+      groupReprocessingStatus === ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT
+    ) {
+      return [
+        TAB.DETAILS,
+        TAB.ATTACHMENTS,
+        TAB.EVENTS,
+        TAB.MERGED,
+        TAB.SIMILAR_ISSUES,
+        TAB.TAGS,
+      ];
+    }
+
+    return [];
+  }
+
   render() {
     const {project, group, currentTab, baseUrl, event} = this.props;
     const {organization, location} = this.context;
@@ -89,17 +132,8 @@ class GroupHeader extends React.Component<Props, State> {
     const organizationFeatures = new Set(organization ? organization.features : []);
     const userCount = group.userCount;
 
-    const hasReprocessingV2Feature = organizationFeatures.has('reprocessing-v2');
     const hasSimilarView = projectFeatures.has('similarity-view');
     const hasEventAttachments = organizationFeatures.has('event-attachments');
-
-    // Reprocessing
-    const reprocessingStatus = getGroupReprocessingStatus(group);
-    const hasGroupBeenReprocessedAndHasntEvent =
-      hasReprocessingV2Feature &&
-      reprocessingStatus === ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT;
-    const isGroupBeingReprocessing =
-      hasReprocessingV2Feature && reprocessingStatus === ReprocessingStatus.REPROCESSING;
 
     let className = 'group-detail';
 
@@ -125,6 +159,9 @@ class GroupHeader extends React.Component<Props, State> {
       pathname: `${baseUrl}events/`,
       query: searchTermWithoutQuery,
     };
+
+    const disabledTabs = this.getDisabledTabs();
+    const disableActions = !!disabledTabs.length;
 
     return (
       <div className={className}>
@@ -201,7 +238,7 @@ class GroupHeader extends React.Component<Props, State> {
               )}
               <div className="count align-right m-l-1">
                 <h6 className="nav-header">{t('Events')}</h6>
-                {isGroupBeingReprocessing ? (
+                {disableActions ? (
                   <Count className="count" value={group.count} />
                 ) : (
                   <Link to={eventRouteToObject}>
@@ -212,7 +249,7 @@ class GroupHeader extends React.Component<Props, State> {
               <div className="count align-right m-l-1">
                 <h6 className="nav-header">{t('Users')}</h6>
                 {userCount !== 0 ? (
-                  isGroupBeingReprocessing ? (
+                  disableActions ? (
                     <Count className="count" value={userCount} />
                   ) : (
                     <Link to={`${baseUrl}tags/user/${location.search}`}>
@@ -228,7 +265,7 @@ class GroupHeader extends React.Component<Props, State> {
                 <AssigneeSelector
                   id={group.id}
                   memberList={memberList}
-                  disabled={isGroupBeingReprocessing}
+                  disabled={disableActions}
                 />
               </div>
             </div>
@@ -241,21 +278,21 @@ class GroupHeader extends React.Component<Props, State> {
         <GroupActions
           group={group}
           project={project}
-          disabled={isGroupBeingReprocessing}
+          disabled={disableActions}
           event={event}
         />
         <NavTabs>
           <ListLink
             to={`${baseUrl}${location.search}`}
             isActive={() => currentTab === TAB.DETAILS}
-            disabled={hasGroupBeenReprocessedAndHasntEvent}
+            disabled={disabledTabs.includes(TAB.DETAILS)}
           >
             {t('Details')}
           </ListLink>
           <StyledListLink
             to={`${baseUrl}activity/${location.search}`}
             isActive={() => currentTab === TAB.ACTIVITY}
-            disabled={isGroupBeingReprocessing}
+            disabled={disabledTabs.includes(TAB.ACTIVITY)}
           >
             {t('Activity')} <TabCount>{group.numComments}</TabCount>
             <IconChat
@@ -270,7 +307,7 @@ class GroupHeader extends React.Component<Props, State> {
           <StyledListLink
             to={`${baseUrl}feedback/${location.search}`}
             isActive={() => currentTab === TAB.USER_FEEDBACK}
-            disabled={isGroupBeingReprocessing}
+            disabled={disabledTabs.includes(TAB.USER_FEEDBACK)}
           >
             {t('User Feedback')} <TabCount>{group.userReportCount}</TabCount>
           </StyledListLink>
@@ -278,7 +315,7 @@ class GroupHeader extends React.Component<Props, State> {
             <ListLink
               to={`${baseUrl}attachments/${location.search}`}
               isActive={() => currentTab === TAB.ATTACHMENTS}
-              disabled={isGroupBeingReprocessing || hasGroupBeenReprocessedAndHasntEvent}
+              disabled={disabledTabs.includes(TAB.ATTACHMENTS)}
             >
               {t('Attachments')}
             </ListLink>
@@ -286,21 +323,21 @@ class GroupHeader extends React.Component<Props, State> {
           <ListLink
             to={`${baseUrl}tags/${location.search}`}
             isActive={() => currentTab === TAB.TAGS}
-            disabled={isGroupBeingReprocessing || hasGroupBeenReprocessedAndHasntEvent}
+            disabled={disabledTabs.includes(TAB.TAGS)}
           >
             {t('Tags')}
           </ListLink>
           <ListLink
             to={eventRouteToObject}
-            isActive={() => currentTab === 'events'}
-            disabled={isGroupBeingReprocessing || hasGroupBeenReprocessedAndHasntEvent}
+            isActive={() => currentTab === TAB.EVENTS}
+            disabled={disabledTabs.includes(TAB.EVENTS)}
           >
             {t('Events')}
           </ListLink>
           <ListLink
             to={`${baseUrl}merged/${location.search}`}
             isActive={() => currentTab === TAB.MERGED}
-            disabled={isGroupBeingReprocessing || hasGroupBeenReprocessedAndHasntEvent}
+            disabled={disabledTabs.includes(TAB.MERGED)}
           >
             {t('Merged Issues')}
           </ListLink>
@@ -308,7 +345,7 @@ class GroupHeader extends React.Component<Props, State> {
             <ListLink
               to={`${baseUrl}similar/${location.search}`}
               isActive={() => currentTab === TAB.SIMILAR_ISSUES}
-              disabled={isGroupBeingReprocessing || hasGroupBeenReprocessedAndHasntEvent}
+              disabled={disabledTabs.includes(TAB.SIMILAR_ISSUES)}
             >
               {t('Similar Issues')}
             </ListLink>


### PR DESCRIPTION
if an error occurs when fetching the event and if the group's reprocessing status is `REPROCESSED_AND_HAS_EVENT`, the user will be redirected to the Activity tabs and all other tabs and actions will be disabled.

closes https://app.asana.com/0/1158284503473033/1200073409986435