### PR TITLE
fix(ui): Fix stack trace previews analytics

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
@@ -20,6 +20,8 @@ const defaultProps = {
   expandFirstFrame: true,
 };
 
+type DefaultProps = typeof defaultProps;
+
 type Props = {
   data: StacktraceType;
   platform: PlatformType;
@@ -28,7 +30,7 @@ type Props = {
   className?: string;
   isHoverPreviewed?: boolean;
   organization?: Organization;
-} & typeof defaultProps;
+} & Partial<DefaultProps>;
 
 type State = {
   showingAbsoluteAddresses: boolean;
@@ -36,7 +38,7 @@ type State = {
 };
 
 class StacktraceContent extends React.Component<Props, State> {
-  static defaultProps = {
+  static defaultProps: DefaultProps = {
     includeSystemFrames: true,
     expandFirstFrame: true,
   };

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
@@ -9,9 +9,11 @@ import {
   stackTracePlatformIcon,
 } from 'app/components/events/interfaces/utils';
 import {t} from 'app/locale';
-import {Frame, PlatformType} from 'app/types';
+import {Frame, Organization, PlatformType} from 'app/types';
 import {Event} from 'app/types/event';
 import {StacktraceType} from 'app/types/stacktrace';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
+import withOrganization from 'app/utils/withOrganization';
 
 const defaultProps = {
   includeSystemFrames: true,
@@ -25,6 +27,7 @@ type Props = {
   newestFirst?: boolean;
   className?: string;
   isHoverPreviewed?: boolean;
+  organization?: Organization;
 } & typeof defaultProps;
 
 type State = {
@@ -32,7 +35,7 @@ type State = {
   showCompleteFunctionName: boolean;
 };
 
-export default class StacktraceContent extends React.Component<Props, State> {
+class StacktraceContent extends React.Component<Props, State> {
   static defaultProps = {
     includeSystemFrames: true,
     expandFirstFrame: true,
@@ -42,6 +45,19 @@ export default class StacktraceContent extends React.Component<Props, State> {
     showingAbsoluteAddresses: false,
     showCompleteFunctionName: false,
   };
+
+  componentDidMount() {
+    const {isHoverPreviewed, organization, event} = this.props;
+
+    if (isHoverPreviewed) {
+      trackAnalyticsEvent({
+        eventKey: 'stacktrace.preview.open',
+        eventName: 'Stack Trace Preview: Open',
+        organization_id: organization?.id ? parseInt(organization.id, 10) : '',
+        issue_id: event.groupID,
+      });
+    }
+  }
 
   renderOmittedFrames = (firstFrameOmitted, lastFrameOmitted) => {
     const props = {
@@ -263,6 +279,8 @@ export default class StacktraceContent extends React.Component<Props, State> {
     );
   }
 }
+
+export default withOrganization(StacktraceContent);
 
 const Wrapper = styled('div')`
   position: relative;

--- a/src/sentry/static/sentry/app/components/stacktracePreview.tsx
+++ b/src/sentry/static/sentry/app/components/stacktracePreview.tsx
@@ -12,7 +12,6 @@ import {Organization, PlatformType} from 'app/types';
 import {EntryType, Event} from 'app/types/event';
 import {StacktraceType} from 'app/types/stacktrace';
 import {defined} from 'app/utils';
-import {trackAnalyticsEvent} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
 
 import findBestThread from './events/interfaces/threads/threadSelector/findBestThread';
@@ -128,13 +127,6 @@ class StacktracePreview extends React.Component<Props, State> {
     }
 
     if (event) {
-      trackAnalyticsEvent({
-        eventKey: 'stacktrace.preview.open',
-        eventName: 'Stack Trace Preview: Open',
-        organization_id: parseInt(this.props.organization.id, 10),
-        issue_id: this.props.issueId,
-      });
-
       return (
         <div onClick={this.handleStacktracePreviewClick}>
           <StacktraceContent


### PR DESCRIPTION
This event has been firing on hover even before the hovercard preview was opened.