### PR TITLE
feat(trace-view): Add transaction details on expand

### DIFF
--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/types.ts
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/types.ts
@@ -25,6 +25,7 @@ export type TraceError = {
   event_id: string;
   span: string;
   transaction: string;
+  project_id: number;
   project_slug: string;
 };
 

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
@@ -205,6 +205,8 @@ class TraceDetailsContent extends React.Component<Props, State> {
       traceInfo: TraceInfo;
     }
   ) {
+    const {location, organization} = this.props;
+
     const isVisible = this.isTransactionVisible(transaction);
 
     const accumulated: AccType = transaction.children.reduce(
@@ -246,6 +248,8 @@ class TraceDetailsContent extends React.Component<Props, State> {
             numberOfHiddenTransactionsAbove,
           })}
           <TransactionGroup
+            location={location}
+            organization={organization}
             traceInfo={traceInfo}
             transaction={transaction}
             continuingDepths={continuingDepths}

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
@@ -20,6 +20,13 @@ export {
   SpanTreeToggler as TransactionTreeToggle,
   SpanTreeTogglerContainer as TransactionTreeToggleContainer,
 } from 'app/components/events/interfaces/spans/spanBar';
+
+export {
+  Row,
+  SpanDetails as TransactionDetails,
+  SpanDetailContainer as TransactionDetailsContainer,
+} from 'app/components/events/interfaces/spans/spanDetail';
+
 export {
   SPAN_ROW_HEIGHT as TRANSACTION_ROW_HEIGHT,
   SPAN_ROW_PADDING as TRANSACTION_ROW_PADDING,

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/transactionDetail.tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import Alert from 'app/components/alert';
+import Button from 'app/components/button';
+import DateTime from 'app/components/dateTime';
+import {getTraceDateTimeRange} from 'app/components/events/interfaces/spans/utils';
+import Link from 'app/components/links/link';
+import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
+import {IconWarning} from 'app/icons';
+import {t, tct} from 'app/locale';
+import space from 'app/styles/space';
+import {Organization} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+import {eventDetailsRoute, generateEventSlug} from 'app/utils/discover/urls';
+import getDynamicText from 'app/utils/getDynamicText';
+import {TraceError, TraceFull} from 'app/utils/performance/quickTrace/types';
+import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {getTransactionDetailsUrl} from 'app/views/performance/utils';
+
+import {Row, TransactionDetails, TransactionDetailsContainer} from './styles';
+
+type Props = {
+  location: Location;
+  organization: Organization;
+  transaction: TraceFull;
+};
+
+class TransactionDetail extends React.Component<Props> {
+  renderSingleErrorMessage(error: TraceError) {
+    const {organization} = this.props;
+
+    const eventSlug = generateEventSlug({
+      id: error.event_id,
+      project: error.project_slug,
+    });
+
+    const target = {
+      pathname: eventDetailsRoute({
+        orgSlug: organization.slug,
+        eventSlug,
+      }),
+    };
+
+    return (
+      <Link to={target}>
+        <span>{t('An error event occurred in this transaction.')}</span>
+      </Link>
+    );
+  }
+
+  renderMultiErrorMessage(errors: TraceError[]) {
+    const {organization, transaction} = this.props;
+
+    const {start, end} = getTraceDateTimeRange({
+      start: transaction.start_timestamp,
+      end: transaction.timestamp,
+    });
+
+    const queryResults = new QueryResults([]);
+    const eventIds = errors.map(child => child.event_id);
+    for (let i = 0; i < eventIds.length; i++) {
+      queryResults.addOp(i === 0 ? '(' : 'OR');
+      queryResults.addQuery(`id:${eventIds[i]}`);
+      if (i === eventIds.length - 1) {
+        queryResults.addOp(')');
+      }
+    }
+
+    const eventView = EventView.fromSavedQuery({
+      id: undefined,
+      name: `Errors events associated with transaction ${transaction.event_id}`,
+      fields: [
+        'transaction',
+        'project',
+        'trace.span',
+        'transaction.duration',
+        'timestamp',
+      ],
+      orderby: '-timestamp',
+      query: stringifyQueryObject(queryResults),
+      projects: organization.features.includes('global-views')
+        ? [ALL_ACCESS_PROJECTS]
+        : [...new Set(errors.map(error => error.project_id))],
+      version: 2,
+      start,
+      end,
+    });
+
+    const target = eventView.getResultsViewUrlTarget(organization.slug);
+
+    return (
+      <div>
+        {tct('[link] occured in this transaction.', {
+          link: (
+            <Link to={target}>
+              <span>{t('%d error events', errors.length)}</span>
+            </Link>
+          ),
+        })}
+      </div>
+    );
+  }
+
+  renderTransactionErrors() {
+    const {transaction} = this.props;
+    const {errors} = transaction;
+
+    if (errors.length === 0) {
+      return null;
+    }
+
+    const message =
+      errors.length === 1
+        ? this.renderSingleErrorMessage(errors[0])
+        : this.renderMultiErrorMessage(errors);
+
+    return (
+      <Alert system type="error" icon={<IconWarning size="md" />}>
+        {message}
+      </Alert>
+    );
+  }
+
+  renderGoToTransactionButton() {
+    const {location, organization, transaction} = this.props;
+
+    const eventSlug = generateEventSlug({
+      id: transaction.event_id,
+      project: transaction.project_slug,
+    });
+
+    const target = getTransactionDetailsUrl(
+      organization,
+      eventSlug,
+      transaction.transaction,
+      location.query
+    );
+
+    return (
+      <StyledButton size="xsmall" to={target}>
+        {t('View Transaction')}
+      </StyledButton>
+    );
+  }
+
+  renderGoToSummaryButton() {
+    return null;
+  }
+
+  renderTransactionDetail() {
+    const {transaction} = this.props;
+    const startTimestamp = Math.min(transaction.start_timestamp, transaction.timestamp);
+    const endTimestamp = Math.max(transaction.start_timestamp, transaction.timestamp);
+    const duration = (endTimestamp - startTimestamp) * 1000;
+    const durationString = `${Number(duration.toFixed(3)).toLocaleString()}ms`;
+
+    return (
+      <TransactionDetails>
+        <table className="table key-value">
+          <tbody>
+            <Row title="Transaction ID" extra={this.renderGoToTransactionButton()}>
+              {transaction.event_id}
+            </Row>
+            <Row title="Transaction" extra={this.renderGoToSummaryButton()}>
+              {transaction.transaction}
+            </Row>
+            <Row title="Start Date">
+              {getDynamicText({
+                fixed: 'Mar 19, 2021 11:06:27 AM UTC',
+                value: (
+                  <React.Fragment>
+                    <DateTime date={startTimestamp * 1000} />
+                    {` (${startTimestamp})`}
+                  </React.Fragment>
+                ),
+              })}
+            </Row>
+            <Row title="End Date">
+              {getDynamicText({
+                fixed: 'Mar 19, 2021 11:06:28 AM UTC',
+                value: (
+                  <React.Fragment>
+                    <DateTime date={endTimestamp * 1000} />
+                    {` (${endTimestamp})`}
+                  </React.Fragment>
+                ),
+              })}
+            </Row>
+            <Row title="Duration">{durationString}</Row>
+            <Row title="Operation">{transaction['transaction.op'] || ''}</Row>
+          </tbody>
+        </table>
+      </TransactionDetails>
+    );
+  }
+
+  render() {
+    return (
+      <TransactionDetailsContainer
+        onClick={event => {
+          // prevent toggling the transaction detail
+          event.stopPropagation();
+        }}
+      >
+        {this.renderTransactionErrors()}
+        {this.renderTransactionDetail()}
+      </TransactionDetailsContainer>
+    );
+  }
+}
+
+const StyledButton = styled(Button)`
+  position: absolute;
+  top: ${space(0.75)};
+  right: ${space(0.5)};
+`;
+
+export default TransactionDetail;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/transactionGroup.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/transactionGroup.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
+import {Location} from 'history';
 
+import {Organization} from 'app/types';
 import {TraceFull} from 'app/utils/performance/quickTrace/types';
 
 import TransactionBar from './transactionBar';
 import {TraceInfo} from './types';
 
 type Props = {
+  location: Location;
+  organization: Organization;
   transaction: TraceFull;
   traceInfo: TraceInfo;
   continuingDepths: Array<number>;
@@ -30,6 +34,8 @@ class TransactionGroup extends React.Component<Props, State> {
 
   render() {
     const {
+      location,
+      organization,
       transaction,
       traceInfo,
       continuingDepths,
@@ -43,6 +49,8 @@ class TransactionGroup extends React.Component<Props, State> {
     return (
       <React.Fragment>
         <TransactionBar
+          location={location}
+          organization={organization}
           index={index}
           transaction={transaction}
           traceInfo={traceInfo}


### PR DESCRIPTION
When clicking on a transaction in the trace view, it should expand to show
details about the transaction. This includes

1. any errors that happened in the transaction
2. the transaction id + view transaction button
3. the transaction name
4. the transaction start date
5. the transaction end date
6. the transaction duration
7. the transaction operation

# Screenshot

![image](https://user-images.githubusercontent.com/10239353/112019257-a4bed800-8b05-11eb-8494-119ea180cdb2.png)
