### PR TITLE
fix(demo): bug when org member doesn't exist

### DIFF
--- a/src/sentry/demo/middleware.py
+++ b/src/sentry/demo/middleware.py
@@ -34,11 +34,10 @@ class DemoMiddleware:
                 return
 
         # find a member in the target org
-        try:
-            member = OrganizationMember.objects.filter(
-                organization__slug=org_slug, role="member"
-            ).first()
-            auth.login(request, member.user)
-        except OrganizationMember.DoesNotExist:
-            # TODO: render landing pagee
-            pass
+        member = OrganizationMember.objects.filter(
+            organization__slug=org_slug, role="member"
+        ).first()
+        # if no member, can't login
+        if not member:
+            return
+        auth.login(request, member.user)


### PR DESCRIPTION
This fixes a bug when we try to find an org member for an organization route and it fails. Since we are using `first`, it will return `None` if no org member is found rather than raising a `OrganizationMember.DoesNotExist` which is what I was checking before.