### PR TITLE
test(eventstore): Fix eventstore test

### DIFF
--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -69,7 +69,9 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
         events = self.eventstore.get_events(
             filter=Filter(
                 project_ids=[self.project1.id, self.project2.id],
-                conditions=[["type", "!=", "transaction"]],
+                conditions=[
+                    ["type", "!=", "transaction"]
+                ],  # TODO: Remove once errors storage rolled out
             )
         )
         assert len(events) == 3

--- a/tests/sentry/eventstore/snuba/test_backend.py
+++ b/tests/sentry/eventstore/snuba/test_backend.py
@@ -67,15 +67,16 @@ class SnubaEventStorageTest(TestCase, SnubaTestCase):
 
     def test_get_events(self):
         events = self.eventstore.get_events(
-            filter=Filter(project_ids=[self.project1.id, self.project2.id])
+            filter=Filter(
+                project_ids=[self.project1.id, self.project2.id],
+                conditions=[["type", "!=", "transaction"]],
+            )
         )
-        assert len(events) == 5
+        assert len(events) == 3
         # Default sort is timestamp desc, event_id desc
-        assert events[0].event_id == "e" * 32
-        assert events[1].event_id == "d" * 32
-        assert events[2].event_id == "c" * 32
-        assert events[3].event_id == "b" * 32
-        assert events[4].event_id == "a" * 32
+        assert events[0].event_id == "c" * 32
+        assert events[1].event_id == "b" * 32
+        assert events[2].event_id == "a" * 32
 
         # No events found
         project = self.create_project()


### PR DESCRIPTION
The `eventstore.get_events()` method can only be used to return
non transaction events. This test happens to pass since transactions
are currently stored in the same table other error types, but it will not
be the case when the storages are split.