### PR TITLE
fix(workflow): Pass slug to group row actions, rename ids

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/resolve.tsx
+++ b/src/sentry/static/sentry/app/components/actions/resolve.tsx
@@ -30,9 +30,9 @@ const defaultProps = {
 type Props = {
   hasRelease: boolean;
   onUpdate: (data: UpdateResolutionStatus) => void;
-  orgId: string;
+  orgSlug: string;
   latestRelease?: Release;
-  projectId?: string;
+  projectSlug?: string;
   shouldConfirm?: boolean;
   confirmMessage?: React.ReactNode;
   disabled?: boolean;
@@ -77,7 +77,7 @@ class ResolveActions extends React.Component<Props> {
 
   renderDropdownMenu() {
     const {
-      projectId,
+      projectSlug,
       isResolved,
       hasRelease,
       latestRelease,
@@ -111,7 +111,7 @@ class ResolveActions extends React.Component<Props> {
           !hasInbox && (
             <ActionButton
               label={t('More resolve options')}
-              disabled={!projectId ? disabled : disableDropdown}
+              disabled={!projectSlug ? disabled : disableDropdown}
               icon={<IconChevron direction="down" size="xs" />}
             />
           )
@@ -119,7 +119,7 @@ class ResolveActions extends React.Component<Props> {
         caret={false}
         title={hasInbox && t('Resolve In\u2026')}
         alwaysRenderMenu
-        disabled={!projectId ? disabled : disableDropdown}
+        disabled={!projectSlug ? disabled : disableDropdown}
         anchorRight={hasInbox}
         isNestedDropdown={hasInbox}
       >
@@ -178,7 +178,7 @@ class ResolveActions extends React.Component<Props> {
   }
 
   openCustomReleaseModal() {
-    const {orgId, projectId} = this.props;
+    const {orgSlug, projectSlug} = this.props;
 
     openModal(deps => (
       <CustomResolutionModal
@@ -186,8 +186,8 @@ class ResolveActions extends React.Component<Props> {
         onSelected={(statusDetails: ResolutionStatusDetails) =>
           this.onCustomResolution(statusDetails)
         }
-        orgId={orgId}
-        projectId={projectId}
+        orgSlug={orgSlug}
+        projectSlug={projectSlug}
       />
     ));
   }

--- a/src/sentry/static/sentry/app/components/customResolutionModal.tsx
+++ b/src/sentry/static/sentry/app/components/customResolutionModal.tsx
@@ -12,8 +12,8 @@ import {Release} from 'app/types';
 
 type Props = ModalRenderProps & {
   onSelected: ({inRelease: string}) => void;
-  orgId: string;
-  projectId?: string;
+  orgSlug: string;
+  projectSlug?: string;
 };
 
 type State = {
@@ -55,10 +55,18 @@ class CustomResolutionModal extends React.Component<Props, State> {
     }));
 
   render() {
-    const {orgId, projectId, closeModal, onSelected, Header, Body, Footer} = this.props;
-    const url = projectId
-      ? `/projects/${orgId}/${projectId}/releases/`
-      : `/organizations/${orgId}/releases/`;
+    const {
+      orgSlug,
+      projectSlug,
+      closeModal,
+      onSelected,
+      Header,
+      Body,
+      Footer,
+    } = this.props;
+    const url = projectSlug
+      ? `/projects/${orgSlug}/${projectSlug}/releases/`
+      : `/organizations/${orgSlug}/releases/`;
 
     const onSubmit = (e: React.FormEvent) => {
       e.preventDefault();

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -548,7 +548,7 @@ class StreamGroup extends React.Component<Props, State> {
               <ActionsWrapper>
                 <GroupRowActions
                   group={data}
-                  orgId={organization.slug}
+                  orgSlug={organization.slug}
                   selection={selection}
                   onMarkReviewed={onMarkReviewed}
                   query={query}

--- a/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
@@ -19,7 +19,7 @@ import MenuItemActionLink from '../actions/menuItemActionLink';
 
 type Props = {
   api: Client;
-  orgId: string;
+  orgSlug: string;
   group: Group;
   selection: GlobalSelection;
   query?: string;
@@ -29,7 +29,7 @@ type Props = {
 class GroupRowActions extends React.Component<Props> {
   handleUpdate = (data?: any, event?: React.MouseEvent) => {
     event?.stopPropagation();
-    const {api, group, orgId, query, selection, onMarkReviewed} = this.props;
+    const {api, group, orgSlug, query, selection, onMarkReviewed} = this.props;
 
     addLoadingMessage(t('Saving changes\u2026'));
 
@@ -40,7 +40,7 @@ class GroupRowActions extends React.Component<Props> {
     bulkUpdate(
       api,
       {
-        orgId,
+        orgId: orgSlug,
         itemIds: [group.id],
         data,
         query,
@@ -57,14 +57,14 @@ class GroupRowActions extends React.Component<Props> {
   };
 
   handleDelete = () => {
-    const {api, group, orgId, query, selection} = this.props;
+    const {api, group, orgSlug, query, selection} = this.props;
 
     addLoadingMessage(t('Removing events\u2026'));
 
     bulkDelete(
       api,
       {
-        orgId,
+        orgId: orgSlug,
         itemIds: [group.id],
         query,
         project: selection.projects,
@@ -80,7 +80,7 @@ class GroupRowActions extends React.Component<Props> {
   };
 
   render() {
-    const {orgId, group} = this.props;
+    const {orgSlug, group} = this.props;
 
     return (
       <Wrapper>
@@ -112,7 +112,7 @@ class GroupRowActions extends React.Component<Props> {
           </MenuItemActionLink>
 
           <StyledMenuItem noAnchor>
-            <Projects orgId={orgId} slugs={[group.project.slug]}>
+            <Projects orgId={orgSlug} slugs={[group.project.slug]}>
               {({projects, initiallyLoaded, fetchError}) => {
                 const project = projects[0];
                 return (
@@ -127,8 +127,8 @@ class GroupRowActions extends React.Component<Props> {
                         ? ((project as Project).latestRelease as Release)
                         : undefined
                     }
-                    orgId={orgId}
-                    projectId={group.project.id}
+                    orgSlug={orgSlug}
+                    projectSlug={group.project.slug}
                     onUpdate={this.handleUpdate}
                     shouldConfirm={false}
                     hasInbox

--- a/src/sentry/static/sentry/app/views/issueList/actions/resolveActions.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/resolveActions.tsx
@@ -41,8 +41,8 @@ function ResolveActionsContainer({
     <ResolveActions
       hasRelease={hasReleases}
       latestRelease={latestRelease}
-      orgId={orgSlug}
-      projectId={projectId}
+      orgSlug={orgSlug}
+      projectSlug={projectId}
       onUpdate={onUpdate}
       shouldConfirm={onShouldConfirm(ConfirmAction.RESOLVE)}
       confirmMessage={confirm('resolve', true)}

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/actions/index.tsx
@@ -242,8 +242,8 @@ class Actions extends React.Component<Props, State> {
             hasRelease={hasRelease}
             latestRelease={project.latestRelease}
             onUpdate={this.onUpdate}
-            orgId={organization.slug}
-            projectId={project.slug}
+            orgSlug={organization.slug}
+            projectSlug={project.slug}
             isResolved={isResolved}
             isAutoResolved={
               group.status === 'resolved' ? group.statusDetails.autoResolved : undefined

--- a/tests/js/spec/components/actions/resolve.spec.jsx
+++ b/tests/js/spec/components/actions/resolve.spec.jsx
@@ -17,8 +17,8 @@ describe('ResolveActions', function () {
           onUpdate={spy}
           disabled
           hasRelease={false}
-          orgId="org-1"
-          projectId="proj-1"
+          orgSlug="org-1"
+          projectSlug="proj-1"
         />,
         TestStubs.routerContext()
       );
@@ -45,8 +45,8 @@ describe('ResolveActions', function () {
           onUpdate={spy}
           disableDropdown
           hasRelease={false}
-          orgId="org-1"
-          projectId="proj-1"
+          orgSlug="org-1"
+          projectSlug="proj-1"
         />,
         TestStubs.routerContext()
       );
@@ -78,8 +78,8 @@ describe('ResolveActions', function () {
           onUpdate={spy}
           disabled
           hasRelease={false}
-          orgId="org-1"
-          projectId="proj-1"
+          orgSlug="org-1"
+          projectSlug="proj-1"
           isResolved
         />,
         TestStubs.routerContext()
@@ -106,8 +106,8 @@ describe('ResolveActions', function () {
           onUpdate={spy}
           disabled
           hasRelease={false}
-          orgId="org-1"
-          projectId="proj-1"
+          orgSlug="org-1"
+          projectSlug="proj-1"
           isResolved
           isAutoResolved
         />,
@@ -127,8 +127,8 @@ describe('ResolveActions', function () {
         <ResolveActions
           onUpdate={spy}
           hasRelease={false}
-          orgId="org-1"
-          projectId="proj-1"
+          orgSlug="org-1"
+          projectSlug="proj-1"
         />,
         TestStubs.routerContext()
       );
@@ -157,8 +157,8 @@ describe('ResolveActions', function () {
           <ResolveActions
             onUpdate={spy}
             hasRelease={false}
-            orgId="org-1"
-            projectId="proj-1"
+            orgSlug="org-1"
+            projectSlug="proj-1"
             shouldConfirm
             confirmMessage="Are you sure???"
           />
@@ -198,8 +198,8 @@ describe('ResolveActions', function () {
         <GlobalModal />
         <ResolveActions
           hasRelease
-          orgId="org-slug"
-          projectId="project-slug"
+          orgSlug="org-slug"
+          projectSlug="project-slug"
           onUpdate={onUpdate}
         />
       </React.Fragment>,

--- a/tests/js/spec/components/customResolutionModal.spec.jsx
+++ b/tests/js/spec/components/customResolutionModal.spec.jsx
@@ -21,8 +21,8 @@ describe('CustomResolutionModal', function () {
         Header={p => p.children}
         Body={p => p.children}
         Footer={p => p.children}
-        orgId="org-slug"
-        projectId="project-slug"
+        orgSlug="org-slug"
+        projectSlug="project-slug"
         onSelected={onSelected}
         closeModal={jest.fn()}
       />,


### PR DESCRIPTION
Group row actions were being passed the id but it needs the slug. This is confusing because it was named projectId but should be projectSlug