### PR TITLE
test: Fix Snuba util test

### DIFF
--- a/tests/snuba/test_util.py
+++ b/tests/snuba/test_util.py
@@ -10,7 +10,7 @@ class SnubaUtilTest(TestCase, SnubaTestCase):
         snuba.raw_query(
             start=datetime.now(),
             end=datetime.now(),
-            filter_keys={"project_id": {1}, "logger": {"asdf"}},
+            filter_keys={"project_id": {1}, "culprit": {"asdf"}},
             aggregations=[["count()", "", "count"]],
         )
 


### PR DESCRIPTION
Replace the reference to `logger` column in the test as it is no longer a field in Snuba.