### PR TITLE
fix(inbox): Fix problem where counts in inbox look wrong when using inbox sort and delete groups.

### DIFF
--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -343,6 +343,8 @@ def _delete_groups(request, project, group_list, delete_type):
     transaction_id = uuid4().hex
 
     GroupHash.objects.filter(project_id=project.id, group__id__in=group_ids).delete()
+    # We remove `GroupInbox` rows here so that they don't end up influencing queries for
+    # `Group` instances that are pending deletion
     GroupInbox.objects.filter(project_id=project.id, group__id__in=group_ids).delete()
 
     delete_groups_task.apply_async(

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -47,7 +47,7 @@ from sentry.models import (
     User,
     UserOption,
 )
-from sentry.models.groupinbox import add_group_to_inbox, GroupInboxRemoveAction
+from sentry.models.groupinbox import add_group_to_inbox, GroupInbox, GroupInboxRemoveAction
 from sentry.models.group import looks_like_short_id, STATUS_UPDATE_CHOICES
 from sentry.api.issue_search import convert_query_values, InvalidSearchQuery, parse_search_query
 from sentry.signals import (
@@ -343,6 +343,7 @@ def _delete_groups(request, project, group_list, delete_type):
     transaction_id = uuid4().hex
 
     GroupHash.objects.filter(project_id=project.id, group__id__in=group_ids).delete()
+    GroupInbox.objects.filter(project_id=project.id, group__id__in=group_ids).delete()
 
     delete_groups_task.apply_async(
         kwargs={

--- a/src/sentry/group_deletion.py
+++ b/src/sentry/group_deletion.py
@@ -22,6 +22,8 @@ def delete_group(group):
     transaction_id = uuid4().hex
 
     GroupHash.objects.filter(project_id=group.project_id, group__id=group.id).delete()
+    # We remove `GroupInbox` rows here so that they don't end up influencing queries for
+    # `Group` instances that are pending deletion
     GroupInbox.objects.filter(project_id=group.project.id, group__id__in=group.id).delete()
 
     delete_groups.apply_async(

--- a/src/sentry/group_deletion.py
+++ b/src/sentry/group_deletion.py
@@ -24,7 +24,7 @@ def delete_group(group):
     GroupHash.objects.filter(project_id=group.project_id, group__id=group.id).delete()
     # We remove `GroupInbox` rows here so that they don't end up influencing queries for
     # `Group` instances that are pending deletion
-    GroupInbox.objects.filter(project_id=group.project.id, group__id__in=group.id).delete()
+    GroupInbox.objects.filter(project_id=group.project.id, group__id=group.id).delete()
 
     delete_groups.apply_async(
         kwargs={

--- a/src/sentry/group_deletion.py
+++ b/src/sentry/group_deletion.py
@@ -4,6 +4,7 @@ from sentry import eventstream
 
 from sentry.models.group import Group, GroupStatus
 from sentry.models.grouphash import GroupHash
+from sentry.models.groupinbox import GroupInbox
 from sentry.tasks.deletion import delete_groups
 
 
@@ -21,6 +22,7 @@ def delete_group(group):
     transaction_id = uuid4().hex
 
     GroupHash.objects.filter(project_id=group.project_id, group__id=group.id).delete()
+    GroupInbox.objects.filter(project_id=group.project.id, group__id__in=group.id).delete()
 
     delete_groups.apply_async(
         kwargs={

--- a/src/sentry/reprocessing2.py
+++ b/src/sentry/reprocessing2.py
@@ -102,6 +102,11 @@ _REDIS_SYNC_TTL = 3600 * 24
 # Note: Event attachments and group reports are migrated in save_event.
 GROUP_MODELS_TO_MIGRATE = DIRECT_GROUP_RELATED_MODELS + (models.Activity,)
 
+# If we were to move groupinbox to the new, empty group, inbox would show the
+# empty, unactionable group while it is reprocessing. Let post-process take
+# care of assigning GroupInbox like normally.
+GROUP_MODELS_TO_MIGRATE = tuple(x for x in GROUP_MODELS_TO_MIGRATE if x != models.GroupInbox)
+
 
 def _generate_unprocessed_event_node_id(project_id, event_id):
     return hashlib.md5(f"{project_id}:{event_id}:unprocessed".encode("utf-8")).hexdigest()


### PR DESCRIPTION
This fixes a discrepency between the counts in inbox and the number of rows. In cases where a group
is pending deletion but has not already been removed, we return the number of `GroupInbox` rows in
`hits`, which does not match the number of active groups.

To fix this, we just make sure we remove the `GroupInbox` rows when marking a group as pending
deletion.

Fixes WOR-755