### PR TITLE
fix(ui): Fix circular import in `<SettingsSearch>`

### DIFF
--- a/src/sentry/static/sentry/app/components/search/searchResult.tsx
+++ b/src/sentry/static/sentry/app/components/search/searchResult.tsx
@@ -7,7 +7,7 @@ import {IconInput, IconLink, IconSettings} from 'app/icons';
 import PluginIcon from 'app/plugins/components/pluginIcon';
 import space from 'app/styles/space';
 import highlightFuseMatches from 'app/utils/highlightFuseMatches';
-import SettingsSearch from 'app/views/settings/components/settingsSearch';
+import {StyledSettingsSearch} from 'app/views/settings/components/settingsSearch';
 
 import {Result} from './sources/types';
 
@@ -143,7 +143,7 @@ const Content = styled('div')`
 `;
 
 const IconWrapper = styled('div')`
-  ${/* sc-selector*/ SettingsSearch} & {
+  ${/* sc-selector*/ StyledSettingsSearch} & {
     color: inherit;
   }
 `;

--- a/src/sentry/static/sentry/app/views/settings/components/settingsSearch/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/settingsSearch/index.tsx
@@ -54,7 +54,7 @@ class SettingsSearch extends React.Component<Props> {
 const StyledSettingsSearch = styled(SettingsSearch)``;
 
 export default StyledSettingsSearch;
-export {SettingsSearch};
+export {SettingsSearch, StyledSettingsSearch};
 
 const SearchInputWrapper = styled('div')`
   position: relative;


### PR DESCRIPTION
This fixes a circular import in `<SettingsSearch>` that breaks with `webpack@5`.