### PR TITLE
fix(alerts): Fix incident fetch on alert details change

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -35,6 +35,23 @@ type State = {
 class AlertRuleDetails extends React.Component<Props, State> {
   state: State = {isLoading: false, hasError: false};
 
+  componentDidMount() {
+    const {api, params} = this.props;
+
+    fetchOrgMembers(api, params.orgId);
+    this.fetchData();
+  }
+
+  componentDidUpdate(prevProps: Props) {
+    if (
+      prevProps.location.search !== this.props.location.search ||
+      prevProps.params.orgId !== this.props.params.orgId ||
+      prevProps.params.ruleId !== this.props.params.ruleId
+    ) {
+      this.fetchData();
+    }
+  }
+
   getTimePeriod() {
     const {location} = this.props;
 
@@ -60,23 +77,6 @@ class AlertRuleDetails extends React.Component<Props, State> {
       end,
       label: timeOption.label as string,
     };
-  }
-
-  componentDidMount() {
-    const {api, params} = this.props;
-
-    fetchOrgMembers(api, params.orgId);
-    this.fetchData();
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (
-      prevProps.location.search !== this.props.location.search ||
-      prevProps.params.orgId !== this.props.params.orgId ||
-      prevProps.params.ruleId !== this.props.params.ruleId
-    ) {
-      this.fetchData();
-    }
   }
 
   fetchData = async () => {

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -71,9 +71,9 @@ class AlertRuleDetails extends React.Component<Props, State> {
 
   componentDidUpdate(prevProps: Props) {
     if (
-      prevProps.location.search !== this.props.location.search
-      || prevProps.params.orgId !== this.props.params.orgId
-      || prevProps.params.ruleId !== this.props.params.ruleId
+      prevProps.location.search !== this.props.location.search ||
+      prevProps.params.orgId !== this.props.params.orgId ||
+      prevProps.params.ruleId !== this.props.params.ruleId
     ) {
       this.fetchData();
     }

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -69,6 +69,16 @@ class AlertRuleDetails extends React.Component<Props, State> {
     this.fetchData();
   }
 
+  componentDidUpdate(prevProps: Props) {
+    if (
+      prevProps.location.search !== this.props.location.search
+      || prevProps.params.orgId !== this.props.params.orgId
+      || prevProps.params.ruleId !== this.props.params.ruleId
+    ) {
+      this.fetchData();
+    }
+  }
+
   fetchData = async () => {
     this.setState({isLoading: true, hasError: false});
     const {
@@ -103,8 +113,6 @@ class AlertRuleDetails extends React.Component<Props, State> {
         period: value,
       },
     });
-
-    await this.fetchData();
   };
 
   render() {


### PR DESCRIPTION
This fixes an issue where incidents on the alert rule details weren't fetched on navigation changes. Just putting the fetch function in the selector function works for most cases but when browser navigates the data gets lost. We check on component update whether the query changed to fetch the data.

Might be a little over-exhaustive to add params changes but it doesn't hurt.

[WOR-730](https://getsentry.atlassian.net/browse/WOR-730)