### PR TITLE
feat(trace-view): Add project icon to trace view

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {SpanBarTitle} from 'app/components/events/interfaces/spans/spanBar';
 import {Panel} from 'app/components/panels';
 import SearchBar from 'app/components/searchBar';
 import {IconChevron} from 'app/icons';
@@ -12,7 +13,6 @@ export {
   DurationPill,
   OperationName,
   SpanBarRectangle as TransactionBarRectangle,
-  SpanBarTitle as TransactionBarTitle,
   SpanBarTitleContainer as TransactionBarTitleContainer,
   SpanRowCell as TransactionRowCell,
   SpanRowCellContainer as TransactionRowCellContainer,
@@ -74,8 +74,11 @@ export const StyledIconChevron = styled(IconChevron)`
   margin-left: ${space(0.25)};
 `;
 
-export const TransactionBarTitleContent = styled('span')`
+export const TransactionBarTitle = styled(SpanBarTitle)`
   display: flex;
   align-items: center;
-  gap: ${space(0.75)};
+`;
+
+export const TransactionBarTitleContent = styled('span')`
+  margin-left: ${space(0.75)};
 `;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
@@ -73,3 +73,9 @@ export const StyledIconChevron = styled(IconChevron)`
   width: 7px;
   margin-left: ${space(0.25)};
 `;
+
+export const TransactionBarTitleContent = styled('span')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.75)};
+`;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
@@ -4,8 +4,10 @@ import {Location} from 'history';
 
 import Count from 'app/components/count';
 import * as DividerHandlerManager from 'app/components/events/interfaces/spans/dividerHandlerManager';
+import ProjectBadge from 'app/components/idBadge/projectBadge';
 import {Organization} from 'app/types';
 import {TraceFull} from 'app/utils/performance/quickTrace/types';
+import Projects from 'app/utils/projects';
 import {Theme} from 'app/utils/theme';
 
 import {
@@ -19,6 +21,7 @@ import {
   TransactionBarRectangle,
   TransactionBarTitle,
   TransactionBarTitleContainer,
+  TransactionBarTitleContent,
   TransactionRow,
   TransactionRowCell,
   TransactionRowCellContainer,
@@ -171,7 +174,7 @@ class TransactionBar extends React.Component<Props, State> {
   }
 
   renderTitle() {
-    const {transaction} = this.props;
+    const {organization, transaction} = this.props;
     const left = this.getCurrentOffset();
 
     return (
@@ -183,15 +186,29 @@ class TransactionBar extends React.Component<Props, State> {
             width: '100%',
           }}
         >
-          <span>
-            <strong>
-              <OperationName spanErrors={transaction.errors}>
-                {transaction['transaction.op']}
-              </OperationName>
-              {' \u2014 '}
-            </strong>
-            {transaction.transaction}
-          </span>
+          <TransactionBarTitleContent>
+            <Projects orgId={organization.slug} slugs={[transaction.project_slug]}>
+              {({projects}) => {
+                const project = projects.find(p => p.slug === transaction.project_slug);
+                return (
+                  <ProjectBadge
+                    project={project ? project : {slug: transaction.project_slug}}
+                    avatarSize={16}
+                    hideName
+                  />
+                );
+              }}
+            </Projects>
+            <span>
+              <strong>
+                <OperationName spanErrors={transaction.errors}>
+                  {transaction['transaction.op']}
+                </OperationName>
+                {' \u2014 '}
+              </strong>
+              {transaction.transaction}
+            </span>
+          </TransactionBarTitleContent>
         </TransactionBarTitle>
       </TransactionBarTitleContainer>
     );

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
@@ -186,28 +186,26 @@ class TransactionBar extends React.Component<Props, State> {
             width: '100%',
           }}
         >
+          <Projects orgId={organization.slug} slugs={[transaction.project_slug]}>
+            {({projects}) => {
+              const project = projects.find(p => p.slug === transaction.project_slug);
+              return (
+                <ProjectBadge
+                  project={project ? project : {slug: transaction.project_slug}}
+                  avatarSize={16}
+                  hideName
+                />
+              );
+            }}
+          </Projects>
           <TransactionBarTitleContent>
-            <Projects orgId={organization.slug} slugs={[transaction.project_slug]}>
-              {({projects}) => {
-                const project = projects.find(p => p.slug === transaction.project_slug);
-                return (
-                  <ProjectBadge
-                    project={project ? project : {slug: transaction.project_slug}}
-                    avatarSize={16}
-                    hideName
-                  />
-                );
-              }}
-            </Projects>
-            <span>
-              <strong>
-                <OperationName spanErrors={transaction.errors}>
-                  {transaction['transaction.op']}
-                </OperationName>
-                {' \u2014 '}
-              </strong>
-              {transaction.transaction}
-            </span>
+            <strong>
+              <OperationName spanErrors={transaction.errors}>
+                {transaction['transaction.op']}
+              </OperationName>
+              {' \u2014 '}
+            </strong>
+            {transaction.transaction}
           </TransactionBarTitleContent>
         </TransactionBarTitle>
       </TransactionBarTitleContainer>


### PR DESCRIPTION
This change adds a project icon to each transaction row to indicate the project
they belong to.

# Screenshot

![image](https://user-images.githubusercontent.com/10239353/112168852-08a9d500-8bc8-11eb-8ac0-9f8df5619225.png)
