### PR TITLE
feat(demo): disable org creation

### DIFF
--- a/src/sentry/demo/middleware.py
+++ b/src/sentry/demo/middleware.py
@@ -45,6 +45,6 @@ class DemoMiddleware:
             organization__slug=org_slug, role="member"
         ).first()
         # if no member, can't login
-        if not member:
+        if not member or not member.user:
             return
         auth.login(request, member.user)

--- a/src/sentry/demo/middleware.py
+++ b/src/sentry/demo/middleware.py
@@ -6,6 +6,7 @@ from sentry.models import OrganizationMember
 from sentry.utils import auth
 
 prompt_route = reverse("sentry-api-0-prompts-activity")
+org_creation_route = reverse("sentry-api-0-organizations")
 
 
 class DemoMiddleware:
@@ -16,6 +17,12 @@ class DemoMiddleware:
         # always return dismissed if we are in demo mode
         if request.path == prompt_route:
             return JsonResponse({"data": {"dismissed_ts": 1}}, status=200)
+
+        # disable org creation
+        if request.path == org_creation_route and request.method == "POST":
+            return JsonResponse(
+                {"detail": "Organization creation disabled in demo mode"}, status=400
+            )
 
         # only handling org views
         if "organization_slug" not in view_kwargs:

--- a/tests/sentry/demo/test_middleware.py
+++ b/tests/sentry/demo/test_middleware.py
@@ -55,3 +55,9 @@ class DemoMiddlewareTest(APITestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         assert response.content == b'{"data": {"dismissed_ts": 1}}'
+
+    def test_org_creation(self):
+        url = reverse("sentry-api-0-organizations")
+        response = self.client.post(url)
+        assert response.status_code == 400
+        assert response.content == b'{"detail": "Organization creation disabled in demo mode"}'


### PR DESCRIPTION
This PR disables org creation in demo mode. This is needed to prevent people from creating non-demo mode orgs that don't get deleted after 24 hours.