### PR TITLE
fix(discover): Fix os_rooted column

### DIFF
--- a/src/sentry/static/sentry/app/views/discover/data.tsx
+++ b/src/sentry/static/sentry/app/views/discover/data.tsx
@@ -25,10 +25,6 @@ export const PROMOTED_TAGS = [
   'os.rooted',
 ];
 
-// All tags are assumed to be strings, except the following
-export const SPECIAL_TAGS: any = {
-  os_rooted: TYPES.DATETIME,
-};
 // Hide the following tags if they are returned from Snuba since these are
 // already mapped to user and release attributes
 export const HIDDEN_TAGS = ['sentry:user', 'sentry:release'];

--- a/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
+++ b/src/sentry/static/sentry/app/views/discover/queryBuilder.tsx
@@ -12,7 +12,7 @@ import ConfigStore from 'app/stores/configStore';
 import {Organization, Project} from 'app/types';
 
 import {isValidAggregation} from './aggregations/utils';
-import {COLUMNS, HIDDEN_TAGS, PROMOTED_TAGS, SPECIAL_TAGS} from './data';
+import {COLUMNS, HIDDEN_TAGS, PROMOTED_TAGS} from './data';
 import MissingProjectWarningModal from './missingProjectWarningModal';
 import {Aggregation, Column, Query, SnubaResult} from './types';
 
@@ -122,14 +122,12 @@ export default function createQueryBuilder(
         tags = res.data
           .filter((tag: TagData) => !HIDDEN_TAGS.includes(tag.tags_key))
           .map((tag: TagData) => {
-            const type = SPECIAL_TAGS[tag.tags_key] || 'string';
-            return {name: tag.tags_key, type, isTag: true};
+            return {name: tag.tags_key, type: 'string', isTag: true};
           });
       })
       .catch(() => {
         tags = PROMOTED_TAGS.map((tag: string) => {
-          const type = SPECIAL_TAGS[tag] || 'string';
-          return {name: tag, type, isTag: true};
+          return {name: tag, type: 'string', isTag: true};
         });
       });
   }


### PR DESCRIPTION
os_rooted is no longer handled any differently from other tags,
and should be a string like the rest.

This was the only mention of the column I could find in the Sentry codebase,
so I assume the invalid query was generated based on this data.

Fixes SENTRY-NXF