### PR TITLE
chore(deps): Bump python SDK version

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -49,7 +49,7 @@ rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
 sentry-relay==0.8.4
-sentry-sdk>=0.20.0,<0.21.0
+sentry-sdk>=1.0.0,<1.2.0
 simplejson==3.17.2
 statsd==3.1
 structlog==17.1.0


### PR DESCRIPTION
This supports https://github.com/getsentry/getsentry/pull/5335, which rebases the dynamic sampling changes we're dogfooding on top of the new `1.0.0` Python SDK.