### PR TITLE
feat(alert): Connect wizard options to alert rule builder

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -14,7 +14,12 @@ import {Organization, Project} from 'app/types';
 import BuilderBreadCrumbs from 'app/views/alerts/builder/builderBreadCrumbs';
 import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
 
-import {AlertType, AlertWizardDescriptions, AlertWizardOptions} from './options';
+import {
+  AlertType,
+  AlertWizardDescriptions,
+  AlertWizardEventViewInfo,
+  AlertWizardOptions,
+} from './options';
 
 type RouteParams = {
   orgId: string;
@@ -37,6 +42,27 @@ class AlertWizard extends React.Component<Props, State> {
 
   handleChangeAlertOption = (alertOption: AlertType) => {
     this.setState({alertOption});
+  };
+
+  renderCreateAlertButton = () => {
+    const {organization, project} = this.props;
+    const {alertOption} = this.state;
+    const metricRuleTemplate = AlertWizardEventViewInfo[alertOption];
+    const to = {
+      pathname: `/organizations/${organization.slug}/alerts/${project.slug}/new/`,
+      query: {
+        ...(metricRuleTemplate && metricRuleTemplate),
+        createFromWizard: true,
+      },
+    };
+    return (
+      <CreateAlertButton
+        organization={organization}
+        projectSlug={project.slug}
+        priority="primary"
+        to={to}
+      />
+    );
   };
 
   render() {
@@ -77,13 +103,7 @@ class AlertWizard extends React.Component<Props, State> {
               </WizardOptions>
               <WizardPanel>
                 <WizardPanelBody>{AlertWizardDescriptions[alertOption]}</WizardPanelBody>
-                <CreateAlertButton
-                  organization={organization}
-                  priority="primary"
-                  projectSlug={projectId}
-                >
-                  {t('Create Alert')}
-                </CreateAlertButton>
+                {this.renderCreateAlertButton()}
               </WizardPanel>
             </WizardBody>
           </Feature>

--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -17,8 +17,8 @@ import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup'
 import {
   AlertType,
   AlertWizardDescriptions,
-  AlertWizardEventViewInfo,
   AlertWizardOptions,
+  AlertWizardRuleTemplates,
 } from './options';
 
 type RouteParams = {
@@ -47,7 +47,7 @@ class AlertWizard extends React.Component<Props, State> {
   renderCreateAlertButton = () => {
     const {organization, project} = this.props;
     const {alertOption} = this.state;
-    const metricRuleTemplate = AlertWizardEventViewInfo[alertOption];
+    const metricRuleTemplate = AlertWizardRuleTemplates[alertOption];
     const to = {
       pathname: `/organizations/${organization.slug}/alerts/${project.slug}/new/`,
       query: {

--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -44,8 +44,8 @@ class AlertWizard extends React.Component<Props, State> {
     this.setState({alertOption});
   };
 
-  renderCreateAlertButton = () => {
-    const {organization, project} = this.props;
+  renderCreateAlertButton() {
+    const {organization, project, location} = this.props;
     const {alertOption} = this.state;
     const metricRuleTemplate = AlertWizardRuleTemplates[alertOption];
     const to = {
@@ -53,6 +53,7 @@ class AlertWizard extends React.Component<Props, State> {
       query: {
         ...(metricRuleTemplate && metricRuleTemplate),
         createFromWizard: true,
+        referrer: location?.query?.referrer,
       },
     };
     return (
@@ -63,7 +64,7 @@ class AlertWizard extends React.Component<Props, State> {
         to={to}
       />
     );
-  };
+  }
 
   render() {
     const {

--- a/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
@@ -47,7 +47,10 @@ export type WizardRuleTemplate = {
   eventTypes: EventTypes;
 };
 
-export const AlertWizardRuleTemplates: Partial<Record<AlertType, WizardRuleTemplate>> = {
+export const AlertWizardRuleTemplates: Record<
+  Exclude<AlertType, 'issues'>,
+  WizardRuleTemplate
+> = {
   num_errors: {
     aggregate: 'count()',
     dataset: Dataset.ERRORS,

--- a/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
@@ -1,4 +1,5 @@
 import {t} from 'app/locale';
+import {Dataset, EventTypes} from 'app/views/settings/incidentRules/types';
 
 export type AlertType =
   | 'issues'
@@ -38,4 +39,38 @@ export const AlertWizardDescriptions: Record<AlertType, string> = {
   throughput: t('Alert on the number of transactions happening in your application'),
   trans_duration: t('Alert on the duration of transactions'),
   lcp: t('Alert on longest contentful paint'),
+};
+
+export type WizardRuleTemplate = {
+  aggregate: string;
+  dataset: Dataset;
+  eventTypes: EventTypes;
+};
+
+export const AlertWizardEventViewInfo: Partial<Record<AlertType, WizardRuleTemplate>> = {
+  num_errors: {
+    aggregate: 'count()',
+    dataset: Dataset.ERRORS,
+    eventTypes: EventTypes.ERROR,
+  },
+  users_experiencing_errors: {
+    aggregate: 'count_unique(tags[sentry:user])',
+    dataset: Dataset.ERRORS,
+    eventTypes: EventTypes.ERROR,
+  },
+  throughput: {
+    aggregate: 'count()',
+    dataset: Dataset.TRANSACTIONS,
+    eventTypes: EventTypes.TRANSACTION,
+  },
+  trans_duration: {
+    aggregate: 'p95(transaction.duration)',
+    dataset: Dataset.TRANSACTIONS,
+    eventTypes: EventTypes.TRANSACTION,
+  },
+  lcp: {
+    aggregate: 'p95(measurements.lcp)',
+    dataset: Dataset.TRANSACTIONS,
+    eventTypes: EventTypes.TRANSACTION,
+  },
 };

--- a/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
@@ -47,7 +47,7 @@ export type WizardRuleTemplate = {
   eventTypes: EventTypes;
 };
 
-export const AlertWizardEventViewInfo: Partial<Record<AlertType, WizardRuleTemplate>> = {
+export const AlertWizardRuleTemplates: Partial<Record<AlertType, WizardRuleTemplate>> = {
   num_errors: {
     aggregate: 'count()',
     dataset: Dataset.ERRORS,

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/constants.tsx
@@ -5,6 +5,7 @@ import {
   DATA_SOURCE_TO_SET_AND_EVENT_TYPES,
   getQueryDatasource,
 } from 'app/views/alerts/utils';
+import {WizardRuleTemplate} from 'app/views/alerts/wizard/options';
 import {
   AlertRuleThresholdType,
   Dataset,
@@ -104,5 +105,16 @@ export function createRuleFromEventView(eventView: EventView): UnsavedIncidentRu
         ? 'p95(transaction.duration)'
         : eventView.getYAxis(),
     environment: eventView.environment.length ? eventView.environment[0] : null,
+  };
+}
+
+export function createRuleFromWizardTemplate(
+  wizardTemplate: WizardRuleTemplate
+): UnsavedIncidentRule {
+  const {eventTypes, ...aggregateDataset} = wizardTemplate;
+  return {
+    ...createDefaultRule(),
+    eventTypes: [eventTypes],
+    ...aggregateDataset,
   };
 }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/create.tsx
@@ -4,9 +4,11 @@ import {RouteComponentProps} from 'react-router';
 import {Organization, Project, Team} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
 import withTeams from 'app/utils/withTeams';
+import {WizardRuleTemplate} from 'app/views/alerts/wizard/options';
 import {
   createDefaultRule,
   createRuleFromEventView,
+  createRuleFromWizardTemplate,
 } from 'app/views/settings/incidentRules/constants';
 
 import RuleForm from './ruleForm';
@@ -21,6 +23,7 @@ type Props = {
   organization: Organization;
   project: Project;
   eventView: EventView | undefined;
+  wizardTemplate?: WizardRuleTemplate;
   sessionId?: string;
   teams: Team[];
 } & RouteComponentProps<RouteParams, {}>;
@@ -37,9 +40,11 @@ class IncidentRulesCreate extends React.Component<Props> {
   };
 
   render() {
-    const {project, eventView, sessionId, teams, ...props} = this.props;
+    const {project, eventView, wizardTemplate, sessionId, teams, ...props} = this.props;
     const defaultRule = eventView
       ? createRuleFromEventView(eventView)
+      : wizardTemplate
+      ? createRuleFromWizardTemplate(wizardTemplate)
       : createDefaultRule();
 
     const userTeamIdArr = teams.filter(({isMember}) => isMember).map(({id}) => id);

--- a/src/sentry/static/sentry/app/views/settings/projectAlerts/create.tsx
+++ b/src/sentry/static/sentry/app/views/settings/projectAlerts/create.tsx
@@ -12,6 +12,7 @@ import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
 import {uniqueId} from 'app/utils/guid';
 import BuilderBreadCrumbs from 'app/views/alerts/builder/builderBreadCrumbs';
+import {WizardRuleTemplate} from 'app/views/alerts/wizard/options';
 import IncidentRulesCreate from 'app/views/settings/incidentRules/create';
 import IssueRuleEditor from 'app/views/settings/projectAlerts/issueRuleEditor';
 
@@ -33,6 +34,7 @@ type AlertType = 'metric' | 'issue' | null;
 type State = {
   alertType: AlertType;
   eventView: EventView | undefined;
+  wizardTemplate?: WizardRuleTemplate;
 };
 
 class Create extends React.Component<Props, State> {
@@ -56,10 +58,28 @@ class Create extends React.Component<Props, State> {
       session_id: this.sessionId,
     });
 
-    if (location?.query?.createFromDiscover) {
-      const eventView = EventView.fromLocation(location);
-      // eslint-disable-next-line react/no-did-mount-set-state
-      this.setState({alertType: 'metric', eventView});
+    if (location?.query) {
+      const {query} = location;
+      const {createFromDiscover, createFromWizard} = query;
+      if (createFromDiscover) {
+        const eventView = EventView.fromLocation(location);
+        // eslint-disable-next-line react/no-did-mount-set-state
+        this.setState({alertType: 'metric', eventView});
+      } else if (createFromWizard) {
+        const {aggregate, dataset, eventTypes} = query;
+        if (aggregate && dataset && eventTypes) {
+          // eslint-disable-next-line react/no-did-mount-set-state
+          this.setState({
+            alertType: 'metric',
+            wizardTemplate: {aggregate, dataset, eventTypes},
+          });
+        } else {
+          // eslint-disable-next-line react/no-did-mount-set-state
+          this.setState({
+            alertType: 'issue',
+          });
+        }
+      }
     }
   }
 
@@ -78,7 +98,7 @@ class Create extends React.Component<Props, State> {
       project,
       params: {projectId},
     } = this.props;
-    const {alertType, eventView} = this.state;
+    const {alertType, eventView, wizardTemplate} = this.state;
 
     const shouldShowAlertTypeChooser = hasMetricAlerts;
     const title = t('New Alert Rule');
@@ -111,6 +131,7 @@ class Create extends React.Component<Props, State> {
             <IncidentRulesCreate
               {...this.props}
               eventView={eventView}
+              wizardTemplate={wizardTemplate}
               sessionId={this.sessionId}
               project={project}
             />


### PR DESCRIPTION
Using a similar pattern to `createFromDiscover` I have predefined alert types defined for each alert wizard option which will populate three query args:
- `aggregate`
- `datasource`
- `eventTypes`

these three fields are used to pre-fill the unsaved metric rule. 

Selecting `Issue Alert` on the wizard will set `createFromWizard=true`, but will not provide any of the above three fields, and the builder will just show the user the blank issue alert builder.

![Kapture 2021-03-23 at 18 17 36](https://user-images.githubusercontent.com/9372512/112226094-1c732c80-8c04-11eb-82c8-61c503bf5306.gif)
