### PR TITLE
ref(analytics): Fix integrations.upgrade_plan_modal_opened

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceLinkModal.tsx
@@ -176,10 +176,9 @@ class StacktraceLinkModal extends React.Component<Props, State> {
         </Body>
         <Footer>
           <Alert type="info" icon={<IconInfo />}>
-            {tct(
-              'Stack trace linking is in Beta. Got feedback? Email [email:ecosystem-feedback@sentry.io].',
-              {email: <a href="mailto:ecosystem-feedback@sentry.io" />}
-            )}
+            {tct('Got feedback? Email [email:ecosystem-feedback@sentry.io].', {
+              email: <a href="mailto:ecosystem-feedback@sentry.io" />,
+            })}
           </Alert>
         </Footer>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/utils/integrationEvents.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationEvents.tsx
@@ -58,6 +58,7 @@ type IntegrationInstalltionInputValueChangeEventParams = {
 
 //define the event key to payload mappings
 export type IntegrationEventParameters = {
+  'integrations.upgrade_plan_modal_opened': SingleIntegrationEventParams;
   'integrations.install_modal_opened': SingleIntegrationEventParams;
   'integrations.integration_viewed': SingleIntegrationEventParams;
   'integrations.installation_start': SingleIntegrationEventParams;
@@ -95,6 +96,7 @@ export type IntegrationAnalyticsKey = keyof IntegrationEventParameters;
 
 //define the event key to event name mappings
 export const integrationEventMap: Record<IntegrationAnalyticsKey, string> = {
+  'integrations.upgrade_plan_modal_opened': 'Integrations: Upgrade Plan Modal Opened',
   'integrations.install_modal_opened': 'Integrations: Install Modal Opened',
   'integrations.integration_viewed': 'Integrations: Integration Viewed',
   'integrations.installation_start': 'Integrations: Installation Start',

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -16,6 +16,7 @@ import {
   DocumentIntegration,
   IntegrationFeature,
   IntegrationInstallationStatus,
+  IntegrationType,
   Organization,
   PluginWithProjectList,
   SentryApp,
@@ -153,7 +154,9 @@ export function isDocumentIntegration(
   return integration.hasOwnProperty('docUrl');
 }
 
-export const getIntegrationType = (integration: AppOrProviderOrPlugin): string => {
+export const getIntegrationType = (
+  integration: AppOrProviderOrPlugin
+): IntegrationType => {
   if (isSentryApp(integration)) {
     return 'sentry_app';
   }

--- a/src/sentry/static/sentry/app/utils/integrationUtil.tsx
+++ b/src/sentry/static/sentry/app/utils/integrationUtil.tsx
@@ -153,6 +153,19 @@ export function isDocumentIntegration(
   return integration.hasOwnProperty('docUrl');
 }
 
+export const getIntegrationType = (integration: AppOrProviderOrPlugin): string => {
+  if (isSentryApp(integration)) {
+    return 'sentry_app';
+  }
+  if (isPlugin(integration)) {
+    return 'plugin';
+  }
+  if (isDocumentIntegration(integration)) {
+    return 'document';
+  }
+  return 'first_party';
+};
+
 export const convertIntegrationTypeToSnakeCase = (
   type: 'plugin' | 'firstParty' | 'sentryApp' | 'documentIntegration'
 ) => {

--- a/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
+++ b/src/sentry/static/sentry/app/views/organizationIntegrations/integrationCodeMappings.tsx
@@ -181,10 +181,9 @@ class IntegrationCodeMappings extends AsyncComponent<Props, State> {
     return (
       <React.Fragment>
         <Alert type="info" icon={<IconInfo />}>
-          {tct(
-            'Stack trace linking is in Beta. Got feedback? Email [email:ecosystem-feedback@sentry.io].',
-            {email: <a href="mailto:ecosystem-feedback@sentry.io" />}
-          )}
+          {tct('Got feedback? Email [email:ecosystem-feedback@sentry.io].', {
+            email: <a href="mailto:ecosystem-feedback@sentry.io" />,
+          })}
         </Alert>
         <TextBlock>
           {tct(


### PR DESCRIPTION
We refactored the integration analytic events to be simpler in https://github.com/getsentry/sentry/pull/23668, but we forgot about updating `getsentry`. 

The fun thing was that because we hadn't updated the `IntegrationFeatures` file yet to typescript, we didn't get an error, we just stopped tracking events.

PR to update getsentry and covert to TS: https://github.com/getsentry/getsentry/pull/5341