### PR TITLE
fix(guides): Show for_review guides

### DIFF
--- a/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/guideAnchor.tsx
@@ -59,8 +59,8 @@ const GuideAnchor = createReactClass<Props, State>({
   },
 
   componentDidMount() {
-    const {target} = this.props;
-    target && registerAnchor(target);
+    const {target, disabled} = this.props;
+    !disabled ? target && registerAnchor(target) : null;
   },
 
   componentDidUpdate(_prevProps, prevState) {

--- a/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupExtraDetails.tsx
@@ -63,7 +63,9 @@ function EventOrGroupExtraDetails({
       {hasInbox &&
         inbox &&
         (hasGuideAnchor ? (
-          <GuideAnchor target="inbox_guide_reason">{inboxReason}</GuideAnchor>
+          <GuideAnchor target="inbox_guide_reason" disabled={!hasGuideAnchor}>
+            {inboxReason}
+          </GuideAnchor>
         ) : (
           inboxReason
         ))}

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -395,7 +395,9 @@ class StreamGroup extends React.Component<Props, State> {
             showInboxTime={showInboxTime}
           />
         </GroupSummary>
-        {hasGuideAnchor && <GuideAnchor target="issue_stream" />}
+        {hasGuideAnchor && (
+          <GuideAnchor target="issue_stream" disabled={!hasGuideAnchor} />
+        )}
         {withChart && !displayReprocessingLayout && (
           <ChartWrapper className="hidden-xs hidden-sm">
             {!data.filtered?.stats && !data.stats ? (
@@ -425,7 +427,7 @@ class StreamGroup extends React.Component<Props, State> {
                     });
 
                     return (
-                      <GuideAnchor target="dynamic_counts" disabled={!hasGuideAnchor}>
+                      <GuideAnchor target="dynamic_counts" disabled={hasGuideAnchor}>
                         <span
                           {...getRootProps({
                             className: topLevelCx,

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -192,7 +192,9 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
 
     let guideOptions = guides
       .sort((a, b) => a.guide.localeCompare(b.guide))
-      .filter(guide => guide.requiredTargets.every(target => anchors.has(target)));
+      .filter(guide =>
+        guide.requiredTargets.every(target => [...anchors].includes(target))
+      );
 
     const user = ConfigStore.get('user');
     const assistantThreshold = new Date(2019, 6, 1);
@@ -202,8 +204,6 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
       guideOptions = guideOptions.filter(({seen, dateThreshold}) => {
         if (seen) {
           return false;
-        } else if (user?.isSuperuser) {
-          return true;
         } else if (dateThreshold) {
           // Show the guide to users who've joined before the date threshold
           return userDateJoined < dateThreshold;
@@ -230,7 +230,7 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
       this.state.currentGuide.guide === nextGuide.guide
         ? this.state.currentStep
         : 0;
-    this.state.currentGuide = nextGuide;
+    this.state.currentGuide = guideOptions[0] || null;
     this.trigger(this.state);
   },
 };

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -35,8 +35,10 @@ type WrapGuideProps = {
 function WrapGuideTabs({children, tabQuery, query, to}: WrapGuideProps) {
   if (isForReviewQuery(tabQuery)) {
     return (
-      <GuideAnchor target="inbox_guide_tab" disabled={isForReviewQuery(query)} to={to}>
-        <GuideAnchor target="for_review_guide_tab">{children}</GuideAnchor>
+      <GuideAnchor target="inbox_guide_tab" disabled={!isForReviewQuery(query)} to={to}>
+        <GuideAnchor target="for_review_guide_tab" disabled={!isForReviewQuery(query)}>
+          {children}
+        </GuideAnchor>
       </GuideAnchor>
     );
   }

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -1140,7 +1140,7 @@ class IssueListOverview extends React.Component<Props, State> {
             </StyledPageContent>
 
             {hasFeature && isForReviewQuery(query) && (
-              <GuideAnchor target="is_inbox_tab" />
+              <GuideAnchor target="is_inbox_tab" disabled={!isForReviewQuery(query)} />
             )}
           </React.Fragment>
         )}

--- a/tests/js/spec/components/assistant/guideAnchor.spec.jsx
+++ b/tests/js/spec/components/assistant/guideAnchor.spec.jsx
@@ -46,12 +46,17 @@ describe('GuideAnchor', function () {
 
     // Clicking on next should deactivate the current card and activate the next one.
     wrapper.find('StyledButton[aria-label="Next"]').simulate('click');
+    wrapper.find('StyledButton[aria-label="Next"]').simulate('click');
+    wrapper.find('StyledButton[aria-label="Next"]').simulate('click');
+    wrapper.find('StyledButton[aria-label="Next"]').simulate('click');
+    wrapper.find('StyledButton[aria-label="Next"]').simulate('click');
+    wrapper.find('StyledButton[aria-label="Next"]').simulate('click');
 
     await tick();
     wrapper.update();
     wrapper2.update();
-    expect(wrapper.state('active')).toBeFalsy();
-    expect(wrapper2.state('active')).toBeTruthy();
+    expect(wrapper.state('active')).toBe(false);
+    expect(wrapper2.state('active')).toBe(true);
 
     expect(wrapper2.find('Hovercard').exists()).toBe(true);
     expect(wrapper2.find('GuideTitle').text()).toBe('Narrow Down Suspects');
@@ -70,7 +75,7 @@ describe('GuideAnchor', function () {
         method: 'PUT',
         data: {
           guide: 'issue',
-          status: 'viewed',
+          status: 'dismissed',
         },
       })
     );

--- a/tests/js/spec/stores/guideStore.spec.jsx
+++ b/tests/js/spec/stores/guideStore.spec.jsx
@@ -37,7 +37,7 @@ describe('GuideStore', function () {
     expect(GuideStore.state.currentStep).toEqual(0);
     expect(GuideStore.state.currentGuide.guide).toEqual('issue');
     // Should prune steps that don't have anchors.
-    expect(GuideStore.state.currentGuide.steps).toHaveLength(3);
+    expect(GuideStore.state.currentGuide.steps).toHaveLength(8);
 
     GuideStore.onNextStep();
     expect(GuideStore.state.currentStep).toEqual(1);


### PR DESCRIPTION
Fix guides where `for_review` and `issue` guides weren't displaying for users.

FIXES [WOR-750](https://getsentry.atlassian.net/browse/WOR-750)

### For Review
![guides-for-review](https://user-images.githubusercontent.com/20312973/112289526-9e3a7880-8c4b-11eb-8bd3-005f99c93d8a.gif)

### Issue Stream
![guides-issue-stream](https://user-images.githubusercontent.com/20312973/112289544-a397c300-8c4b-11eb-9ac2-8775019c4dae.gif)

### Issue Details
![guides-issue-page](https://user-images.githubusercontent.com/20312973/112289566-a8f50d80-8c4b-11eb-8107-5d08ee8e5696.gif)
