### PR TITLE
ref(context-summary): Add legacy edge context logo className

### DIFF
--- a/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryGeneric.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/contextSummaryGeneric.tsx
@@ -31,7 +31,7 @@ const ContextSummaryGeneric = ({data, unknownTitle}: Props) => {
     return <AnnotatedText value={data[key]} meta={meta} />;
   };
 
-  const className = generateClassName(data.name);
+  const className = generateClassName(data.name, data.version);
 
   return (
     <Item className={className} icon={<span className="context-item-icon" />}>

--- a/src/sentry/static/sentry/app/components/events/contextSummary/generateClassName.tsx
+++ b/src/sentry/static/sentry/app/components/events/contextSummary/generateClassName.tsx
@@ -1,33 +1,46 @@
 import {defined} from 'app/utils';
 
-function generateClassname(name?: string): string {
+function generateClassname(name?: string, version?: string): string {
   if (!defined(name)) {
     return '';
   }
 
+  const lowerCaseName = name.toLowerCase();
+
   // amazon fire tv device id changes with version: AFTT, AFTN, AFTS, AFTA, AFTVA (alexa), ...
-  if (name.toLowerCase().startsWith('aft')) {
+  if (lowerCaseName.startsWith('aft')) {
     return 'amazon';
   }
 
-  if (name.toLowerCase().startsWith('sm-') || name.toLowerCase().startsWith('st-')) {
+  if (lowerCaseName.startsWith('sm-') || lowerCaseName.startsWith('st-')) {
     return 'samsung';
   }
 
-  if (name.toLowerCase().startsWith('moto')) {
+  if (lowerCaseName.startsWith('moto')) {
     return 'motorola';
   }
 
-  if (name.toLowerCase().startsWith('pixel')) {
+  if (lowerCaseName.startsWith('pixel')) {
     return 'google';
   }
 
-  return name
+  const formattedName = name
     .split(/\d/)[0]
     .toLowerCase()
     .replace(/[^a-z0-9\-]+/g, '-')
     .replace(/\-+$/, '')
     .replace(/^\-+/, '');
+
+  if (formattedName === 'edge' && version) {
+    const majorVersion = version.split('.')[0];
+    const isLegacyEdge = majorVersion >= '12' && majorVersion <= '18';
+
+    if (isLegacyEdge) {
+      return 'legacy-edge';
+    }
+  }
+
+  return formattedName;
 }
 
 export default generateClassname;

--- a/src/sentry/static/sentry/less/group-detail.less
+++ b/src/sentry/static/sentry/less/group-detail.less
@@ -325,6 +325,10 @@
       background-image: url(../images/logos/logo-edge-new.svg);
     }
 
+    &.legacy-edge .context-item-icon {
+      background-image: url(../images/logos/logo-edge-old.svg);
+    }
+
     &.internet-explorer .context-item-icon {
       background-image: url(../images/logos/logo-ie.svg);
     }


### PR DESCRIPTION
Add a condition to display the correct version of Internet Explorer Edge that are currently: 

`12 - 18` -> Legacy Edge
`>= 79` -> New Edge

closes: https://github.com/getsentry/sentry/issues/21247