### PR TITLE
fix(ui): Fix projects page for superusers with no projects

### DIFF
--- a/src/sentry/static/sentry/app/components/noProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/noProjectMessage.tsx
@@ -16,7 +16,7 @@ type Props = {
   organization: LightWeightOrganization | Organization;
   projects?: Project[];
   loadingProjects?: boolean;
-  superusersNeedToBeProjectMembers?: boolean;
+  superuserNeedsToBeProjectMember?: boolean;
 };
 
 export default class NoProjectMessage extends React.Component<Props> {
@@ -26,7 +26,7 @@ export default class NoProjectMessage extends React.Component<Props> {
       organization,
       projects,
       loadingProjects,
-      superusersNeedToBeProjectMembers,
+      superuserNeedsToBeProjectMember,
     } = this.props;
     const orgId = organization.slug;
     const canCreateProject = organization.access.includes('project:write');
@@ -40,7 +40,7 @@ export default class NoProjectMessage extends React.Component<Props> {
 
       orgHasProjects = organization.projects.length > 0;
       hasProjectAccess =
-        isSuperuser && !superusersNeedToBeProjectMembers
+        isSuperuser && !superuserNeedsToBeProjectMember
           ? organization.projects.some(p => p.hasAccess)
           : organization.projects.some(p => p.isMember && p.hasAccess);
     } else {

--- a/src/sentry/static/sentry/app/components/noProjectMessage.tsx
+++ b/src/sentry/static/sentry/app/components/noProjectMessage.tsx
@@ -16,11 +16,18 @@ type Props = {
   organization: LightWeightOrganization | Organization;
   projects?: Project[];
   loadingProjects?: boolean;
+  superusersNeedToBeProjectMembers?: boolean;
 };
 
 export default class NoProjectMessage extends React.Component<Props> {
   render() {
-    const {children, organization, projects, loadingProjects} = this.props;
+    const {
+      children,
+      organization,
+      projects,
+      loadingProjects,
+      superusersNeedToBeProjectMembers,
+    } = this.props;
     const orgId = organization.slug;
     const canCreateProject = organization.access.includes('project:write');
     const canJoinTeam = organization.access.includes('team:read');
@@ -32,9 +39,10 @@ export default class NoProjectMessage extends React.Component<Props> {
       const {isSuperuser} = ConfigStore.get('user');
 
       orgHasProjects = organization.projects.length > 0;
-      hasProjectAccess = isSuperuser
-        ? organization.projects.some(p => p.hasAccess)
-        : organization.projects.some(p => p.isMember && p.hasAccess);
+      hasProjectAccess =
+        isSuperuser && !superusersNeedToBeProjectMembers
+          ? organization.projects.some(p => p.hasAccess)
+          : organization.projects.some(p => p.isMember && p.hasAccess);
     } else {
       hasProjectAccess = projects ? projects.length > 0 : false;
       orgHasProjects = hasProjectAccess;

--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.tsx
@@ -69,7 +69,7 @@ class Dashboard extends React.Component<Props> {
         <NoProjectMessage
           organization={organization}
           projects={projects}
-          superusersNeedToBeProjectMembers
+          superuserNeedsToBeProjectMember
         >
           {null}
         </NoProjectMessage>

--- a/src/sentry/static/sentry/app/views/projectsDashboard/index.tsx
+++ b/src/sentry/static/sentry/app/views/projectsDashboard/index.tsx
@@ -66,7 +66,11 @@ class Dashboard extends React.Component<Props> {
 
     if (showEmptyMessage) {
       return (
-        <NoProjectMessage organization={organization} projects={projects}>
+        <NoProjectMessage
+          organization={organization}
+          projects={projects}
+          superusersNeedToBeProjectMembers
+        >
           {null}
         </NoProjectMessage>
       );

--- a/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {mountWithTheme} from 'sentry-test/enzyme';
 
 import NoProjectMessage from 'app/components/noProjectMessage';
+import ConfigStore from 'app/stores/configStore';
 
 describe('NoProjectMessage', function () {
   const org = TestStubs.Organization();
@@ -87,5 +88,22 @@ describe('NoProjectMessage', function () {
     );
     // ensure loading projects causes children to render
     expect(wrapper.find('div')).toHaveLength(1);
+  });
+
+  it('shows empty message to superusers that are not members', function () {
+    ConfigStore.config.user = {isSuperuser: true};
+    const wrapper = mountWithTheme(
+      <NoProjectMessage
+        organization={{
+          ...org,
+          projects: [TestStubs.Project({hasAccess: true, isMember: false})],
+        }}
+        superusersNeedToBeProjectMembers
+      >
+        {null}
+      </NoProjectMessage>,
+      TestStubs.routerContext()
+    );
+    expect(wrapper.find('HelpMessage')).toHaveLength(1);
   });
 });

--- a/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
+++ b/tests/js/spec/views/projectsDashboard/noProjectMessage.spec.jsx
@@ -98,7 +98,7 @@ describe('NoProjectMessage', function () {
           ...org,
           projects: [TestStubs.Project({hasAccess: true, isMember: false})],
         }}
-        superusersNeedToBeProjectMembers
+        superuserNeedsToBeProjectMember
       >
         {null}
       </NoProjectMessage>,


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/9060071/112305661-3f065380-8c9f-11eb-8430-a4f1e2ef5bf5.png)

## After
![image](https://user-images.githubusercontent.com/9060071/112305594-2dbd4700-8c9f-11eb-973c-e965a24a08a5.png)

Normally we don't need superusers to be a member of a team/project to access content on a page. 
The Projects page, however, does not make sense without being a member of any of the projects/teams so we show the empty message.