### PR TITLE
ref(dynamic-sampling): Update rule category options

### DIFF
--- a/src/sentry/static/sentry/app/types/dynamicSampling.tsx
+++ b/src/sentry/static/sentry/app/types/dynamicSampling.tsx
@@ -47,10 +47,12 @@ export enum DynamicSamplingInnerOperator {
 export enum DynamicSamplingInnerName {
   TRACE_RELEASE = 'trace.release',
   TRACE_ENVIRONMENT = 'trace.environment',
-  TRACE_USER = 'trace.user',
+  TRACE_USER_ID = 'trace.user.id',
+  TRACE_USER_SEGMENT = 'trace.user.segment',
   EVENT_RELEASE = 'event.release',
   EVENT_ENVIRONMENT = 'event.environment',
-  EVENT_USER = 'event.user',
+  EVENT_USER_ID = 'event.user.id',
+  EVENT_USER_SEGMENT = 'event.user.segment',
   EVENT_LOCALHOST = 'event.is_local_ip',
   EVENT_WEB_CRAWLERS = 'event.web_crawlers',
   EVENT_BROWSER_EXTENSIONS = 'event.has_bad_browser_extensions',
@@ -79,8 +81,10 @@ type DynamicSamplingConditionLogicalInnerEq = {
   name:
     | DynamicSamplingInnerName.EVENT_ENVIRONMENT
     | DynamicSamplingInnerName.TRACE_ENVIRONMENT
-    | DynamicSamplingInnerName.EVENT_USER
-    | DynamicSamplingInnerName.TRACE_USER;
+    | DynamicSamplingInnerName.EVENT_USER_ID
+    | DynamicSamplingInnerName.TRACE_USER_ID
+    | DynamicSamplingInnerName.EVENT_USER_SEGMENT
+    | DynamicSamplingInnerName.TRACE_USER_SEGMENT;
   value: Array<string>;
   options: {
     ignoreCase: boolean;

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/errorRuleModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/errorRuleModal.tsx
@@ -43,7 +43,8 @@ class ErrorRuleModal extends Form<Props, State> {
     return [
       [DynamicSamplingInnerName.EVENT_RELEASE, t('Releases')],
       [DynamicSamplingInnerName.EVENT_ENVIRONMENT, t('Environments')],
-      [DynamicSamplingInnerName.EVENT_USER, t('Users')],
+      [DynamicSamplingInnerName.EVENT_USER_ID, t('User Id')],
+      [DynamicSamplingInnerName.EVENT_USER_SEGMENT, t('User Segment')],
       [DynamicSamplingInnerName.EVENT_BROWSER_EXTENSIONS, t('Browser Extensions')],
       [DynamicSamplingInnerName.EVENT_LOCALHOST, t('Localhost')],
       [DynamicSamplingInnerName.EVENT_LEGACY_BROWSER, t('Legacy Browsers')],

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/form.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/form.tsx
@@ -147,6 +147,21 @@ class Form<P extends Props = Props, S extends State = State> extends React.Compo
     }
 
     // DynamicSamplingConditionLogicalInnerEq
+    if (
+      condition.category === DynamicSamplingInnerName.TRACE_USER_ID ||
+      condition.category === DynamicSamplingInnerName.EVENT_USER_ID
+    ) {
+      return {
+        op: DynamicSamplingInnerOperator.EQUAL,
+        name: condition.category,
+        value: newValue,
+        options: {
+          ignoreCase: false,
+        },
+      };
+    }
+
+    // DynamicSamplingConditionLogicalInnerEq
     return {
       op: DynamicSamplingInnerOperator.EQUAL,
       name: condition.category,

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/utils.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/modals/utils.tsx
@@ -101,9 +101,12 @@ export function getMatchFieldPlaceholder(category: DynamicSamplingInnerName) {
       return t('Match all localhosts');
     case DynamicSamplingInnerName.EVENT_WEB_CRAWLERS:
       return t('Match all web crawlers');
-    case DynamicSamplingInnerName.EVENT_USER:
-    case DynamicSamplingInnerName.TRACE_USER:
-      return t('Match by user id, ex. 4711 (Multiline)');
+    case DynamicSamplingInnerName.EVENT_USER_ID:
+    case DynamicSamplingInnerName.TRACE_USER_ID:
+      return t('ex. 4711 (Multiline)');
+    case DynamicSamplingInnerName.EVENT_USER_SEGMENT:
+    case DynamicSamplingInnerName.TRACE_USER_SEGMENT:
+      return t('ex. paid, common (Multiline)');
     case DynamicSamplingInnerName.TRACE_ENVIRONMENT:
     case DynamicSamplingInnerName.EVENT_ENVIRONMENT:
       return t('ex. prod or dev (Multiline)');

--- a/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/rule/utils.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/filtersAndSampling/rules/rule/utils.tsx
@@ -11,9 +11,12 @@ export function getInnerNameLabel(name: DynamicSamplingInnerName) {
     case DynamicSamplingInnerName.TRACE_RELEASE:
     case DynamicSamplingInnerName.EVENT_RELEASE:
       return t('Release');
-    case DynamicSamplingInnerName.EVENT_USER:
-    case DynamicSamplingInnerName.TRACE_USER:
-      return t('User');
+    case DynamicSamplingInnerName.EVENT_USER_ID:
+    case DynamicSamplingInnerName.TRACE_USER_ID:
+      return t('User Id');
+    case DynamicSamplingInnerName.EVENT_USER_SEGMENT:
+    case DynamicSamplingInnerName.TRACE_USER_SEGMENT:
+      return t('User Segment');
     case DynamicSamplingInnerName.EVENT_BROWSER_EXTENSIONS:
       return t('Browser Extensions');
     case DynamicSamplingInnerName.EVENT_LOCALHOST:


### PR DESCRIPTION
Remove rule categories:

TRACE_USER - t(Users)
EVENT_USER - t(Users)

Add rule categories:
TRACE_USER_ID - t(User Id)
TRACE_USER_SEGMENT - t(User Segment)
EVENT_USER_ID - t(User Id)
EVENT_USER_SEGMENT - t(User Segment)

**Before:**

![image](https://user-images.githubusercontent.com/29228205/112315420-6c0c3380-8caa-11eb-8dfc-b3a0bff1d91e.png)


**After:**

![image](https://user-images.githubusercontent.com/29228205/112315319-50a12880-8caa-11eb-80f0-5718f71c3c31.png)
