### PR TITLE
feat(ui): Adjust stack trace preview empty/loading states

### DIFF
--- a/src/sentry/static/sentry/app/components/hovercard.tsx
+++ b/src/sentry/static/sentry/app/components/hovercard.tsx
@@ -54,6 +54,10 @@ type Props = DefaultProps & {
    */
   tipColor?: string;
   /**
+   * Color of the arrow tip border
+   */
+  tipBorderColor?: string;
+  /**
    * Offset for the arrow
    */
   offset?: string;
@@ -129,6 +133,7 @@ class Hovercard extends React.Component<Props, State> {
       position,
       show,
       tipColor,
+      tipBorderColor,
       offset,
       modifiers,
     } = this.props;
@@ -191,6 +196,7 @@ class Hovercard extends React.Component<Props, State> {
                       style={arrowProps.style}
                       placement={placement as Direction}
                       tipColor={tipColor}
+                      tipBorderColor={tipBorderColor}
                     />
                   </StyledHovercard>
                 );
@@ -277,7 +283,11 @@ const Body = styled('div')`
   min-height: 30px;
 `;
 
-type HovercardArrowProps = {placement: Direction; tipColor?: string};
+type HovercardArrowProps = {
+  placement: Direction;
+  tipColor?: string;
+  tipBorderColor?: string;
+};
 
 const HovercardArrow = styled('span')<HovercardArrowProps>`
   position: absolute;
@@ -306,7 +316,8 @@ const HovercardArrow = styled('span')<HovercardArrowProps>`
   &::before {
     top: 1px;
     border: 10px solid transparent;
-    border-${getTipDirection}-color: ${p => p.tipColor || p.theme.border};
+    border-${getTipDirection}-color: ${p =>
+  p.tipBorderColor || p.tipColor || p.theme.border};
 
     ${p => (p.placement === 'bottom' ? 'top: -1px' : '')};
     ${p => (p.placement === 'left' ? 'top: 0; left: 1px;' : '')};

--- a/src/sentry/static/sentry/app/components/stacktracePreview.tsx
+++ b/src/sentry/static/sentry/app/components/stacktracePreview.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import {withTheme} from 'emotion-theming';
 
 import {Client} from 'app/api';
 import {isStacktraceNewestFirst} from 'app/components/events/interfaces/stacktrace';
@@ -12,17 +13,20 @@ import {Organization, PlatformType} from 'app/types';
 import {EntryType, Event} from 'app/types/event';
 import {StacktraceType} from 'app/types/stacktrace';
 import {defined} from 'app/utils';
+import {Theme} from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 
 import findBestThread from './events/interfaces/threads/threadSelector/findBestThread';
 import getThreadStacktrace from './events/interfaces/threads/threadSelector/getThreadStacktrace';
 
+const HOVERCARD_DELAY = 500;
 export const STACKTRACE_PREVIEW_TOOLTIP_DELAY = 1000;
 
 type Props = {
   issueId: string;
   organization: Organization;
   api: Client;
+  theme: Theme;
   disablePreview?: boolean;
 };
 
@@ -47,7 +51,7 @@ class StacktracePreview extends React.Component<Props, State> {
 
     this.loaderTimeout = window.setTimeout(() => {
       this.setState({loadingVisible: true});
-    }, 1000);
+    }, HOVERCARD_DELAY);
 
     const {api, issueId} = this.props;
     try {
@@ -102,14 +106,13 @@ class StacktracePreview extends React.Component<Props, State> {
     return undefined;
   }
 
-  renderHovercardBody() {
+  renderHovercardBody(stacktrace: StacktraceType | undefined) {
     const {event, loading, loadingVisible} = this.state;
-    const stacktrace = this.getStacktrace();
 
     if (loading && loadingVisible) {
       return (
         <NoStackTraceWrapper>
-          <LoadingIndicator hideMessage size={48} />
+          <LoadingIndicator hideMessage size={32} />
         </NoStackTraceWrapper>
       );
     }
@@ -146,7 +149,10 @@ class StacktracePreview extends React.Component<Props, State> {
   }
 
   render() {
-    const {children, organization, disablePreview} = this.props;
+    const {children, organization, disablePreview, theme} = this.props;
+
+    const {loading, loadingVisible} = this.state;
+    const stacktrace = this.getStacktrace();
 
     if (!organization.features.includes('stacktrace-hover-preview') || disablePreview) {
       return children;
@@ -155,7 +161,7 @@ class StacktracePreview extends React.Component<Props, State> {
     return (
       <span onMouseEnter={this.fetchData}>
         <StyledHovercard
-          body={this.renderHovercardBody()}
+          body={this.renderHovercardBody(stacktrace)}
           position="right"
           modifiers={{
             flip: {
@@ -167,6 +173,9 @@ class StacktracePreview extends React.Component<Props, State> {
               boundariesElement: 'viewport',
             },
           }}
+          state={loading && loadingVisible ? 'loading' : !stacktrace ? 'empty' : 'done'}
+          tipBorderColor={theme.border}
+          tipColor={theme.background}
         >
           {children}
         </StyledHovercard>
@@ -175,8 +184,16 @@ class StacktracePreview extends React.Component<Props, State> {
   }
 }
 
-const StyledHovercard = styled(Hovercard)`
-  width: 700px;
+const StyledHovercard = styled(Hovercard)<{state: 'loading' | 'empty' | 'done'}>`
+  width: ${p => {
+    if (p.state === 'loading') {
+      return 'auto';
+    }
+    if (p.state === 'empty') {
+      return '340px';
+    }
+    return '700px';
+  }};
 
   ${Body} {
     padding: 0;
@@ -192,12 +209,15 @@ const StyledHovercard = styled(Hovercard)`
     box-shadow: none;
   }
 
-  .loading .loading-indicator {
-    /**
-   * Overriding the .less file - for default 64px loader we have the width of border set to 6px
-   * For 48px we therefore need 4.5px to keep the same thickness ratio
-   */
-    border-width: 4.5px;
+  .loading {
+    margin: 0 auto;
+    .loading-indicator {
+      /**
+      * Overriding the .less file - for default 64px loader we have the width of border set to 6px
+      * For 32px we therefore need 3px to keep the same thickness ratio
+      */
+      border-width: 3px;
+    }
   }
 
   @media (max-width: ${p => p.theme.breakpoints[2]}) {
@@ -206,12 +226,13 @@ const StyledHovercard = styled(Hovercard)`
 `;
 
 const NoStackTraceWrapper = styled('div')`
-  color: ${p => p.theme.gray400};
+  color: ${p => p.theme.subText};
   padding: ${space(1.5)};
+  font-size: ${p => p.theme.fontSizeMedium};
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 80px;
+  min-height: 56px;
 `;
 
-export default withApi(StacktracePreview);
+export default withApi(withTheme(StacktracePreview));


### PR DESCRIPTION
## Before
![image](https://user-images.githubusercontent.com/9060071/112321842-b09acd80-8cb0-11eb-9076-836f3c8f285c.png)
![image](https://user-images.githubusercontent.com/9060071/112321914-be505300-8cb0-11eb-9ceb-c5275427e854.png)

## After
![image](https://user-images.githubusercontent.com/9060071/112321990-cf995f80-8cb0-11eb-9b5d-5fca355ae686.png)
![image](https://user-images.githubusercontent.com/9060071/112322064-e0e26c00-8cb0-11eb-89e9-9e0ab48e35bc.png)
