### PR TITLE
feat(dashboards): Add widget builder - metrics - Part 1

### DIFF
--- a/src/sentry/static/sentry/app/routes.tsx
+++ b/src/sentry/static/sentry/app/routes.tsx
@@ -1184,6 +1184,15 @@ function routes() {
               }
               component={errorHandler(LazyLoad)}
             />
+            <Route
+              path="widgetBuilder"
+              componentPromise={() =>
+                import(
+                  /* webpackChunkName: "WidgetBuilder" */ 'app/views/dashboardsV2/widgetBuilder'
+                )
+              }
+              component={errorHandler(LazyLoad)}
+            />
           </Route>
 
           <Route

--- a/src/sentry/static/sentry/app/views/dashboardsV2/addWidget.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/addWidget.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 import {useSortable} from '@dnd-kit/sortable';
 import styled from '@emotion/styled';
 
+import Button from 'app/components/button';
+import ButtonBar from 'app/components/buttonBar';
 import {IconAdd} from 'app/icons';
+import {t} from 'app/locale';
+import {Organization} from 'app/types';
 
 import WidgetWrapper from './widgetWrapper';
 
@@ -15,9 +19,13 @@ const initialStyles = {
   scaleY: 1,
 };
 
-function AddWidget(props: {onClick: () => void}) {
-  const {onClick} = props;
+type Props = {
+  onClick: () => void;
+  orgFeatures: Organization['features'];
+  orgSlug: Organization['slug'];
+};
 
+function AddWidget({onClick, orgFeatures, orgSlug}: Props) {
   const {setNodeRef, transform} = useSortable({
     disabled: true,
     id: ADD_WIDGET_BUTTON_DRAG_ID,
@@ -45,14 +53,42 @@ function AddWidget(props: {onClick: () => void}) {
         duration: 0.25,
       }}
     >
-      <AddWidgetWrapper key="add" data-test-id="widget-add" onClick={onClick}>
-        <IconAdd size="lg" isCircled color="inactive" />
-      </AddWidgetWrapper>
+      {orgFeatures.includes('metrics') ? (
+        <InnerWrapper>
+          <ButtonBar gap={1}>
+            <Button to={`/organizations/${orgSlug}/dashboards/widgetBuilder/`}>
+              {t('Add metrics widget')}
+            </Button>
+            <Button onClick={onClick}>{t('Add events widget')}</Button>
+          </ButtonBar>
+        </InnerWrapper>
+      ) : (
+        <InnerWrapper onClick={onClick}>
+          <AddButton
+            data-test-id="widget-add"
+            onClick={onClick}
+            icon={<IconAdd size="lg" isCircled color="inactive" />}
+          />
+        </InnerWrapper>
+      )}
     </WidgetWrapper>
   );
 }
 
-const AddWidgetWrapper = styled('a')`
+export default AddWidget;
+
+const AddButton = styled(Button)`
+  border: none;
+  &,
+  &:focus,
+  &:active,
+  &:hover {
+    background: transparent;
+    box-shadow: none;
+  }
+`;
+
+const InnerWrapper = styled('div')<{onClick?: () => void}>`
   width: 100%;
   height: 110px;
   border: 2px dashed ${p => p.theme.border};
@@ -60,6 +96,5 @@ const AddWidgetWrapper = styled('a')`
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: ${p => (p.onClick ? 'pointer' : '')};
 `;
-
-export default AddWidget;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -121,6 +121,7 @@ class Dashboard extends React.Component<Props> {
       isEditing,
       onUpdate,
       dashboard: {widgets},
+      organization,
     } = this.props;
 
     const items = this.getWidgetIds();
@@ -145,7 +146,13 @@ class Dashboard extends React.Component<Props> {
         <WidgetContainer>
           <SortableContext items={items} strategy={rectSortingStrategy}>
             {widgets.map((widget, index) => this.renderWidget(widget, index))}
-            {isEditing && <AddWidget onClick={this.handleStartAdd} />}
+            {isEditing && (
+              <AddWidget
+                orgSlug={organization.slug}
+                orgFeatures={organization.features}
+                onClick={this.handleStartAdd}
+              />
+            )}
           </SortableContext>
         </WidgetContainer>
       </DndContext>

--- a/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/detail.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {browserHistory, PlainRoute, WithRouterProps} from 'react-router';
 import styled from '@emotion/styled';
+import {Location} from 'history';
 import isEqual from 'lodash/isEqual';
 
 import {
@@ -61,23 +62,34 @@ class DashboardDetail extends React.Component<Props, State> {
     if (!dashboard) {
       return;
     }
+
     trackAnalyticsEvent({
       eventKey: 'dashboards2.edit.start',
       eventName: 'Dashboards2: Edit start',
       organization_id: parseInt(this.props.organization.id, 10),
     });
+
     this.setState({
       dashboardState: 'edit',
       modifiedDashboard: cloneDashboard(dashboard),
     });
   };
 
-  onRouteLeave = (): string | undefined => {
+  onRouteLeave = (nextLocation?: Location) => {
+    const {organization} = this.props;
+
+    if (
+      nextLocation?.pathname ===
+      `/organizations/${organization.slug}/dashboards/widgetBuilder/`
+    ) {
+      return undefined;
+    }
+
     if (!['view', 'pending_delete'].includes(this.state.dashboardState)) {
       return UNSAVED_MESSAGE;
     }
-    // eslint-disable-next-line consistent-return
-    return;
+
+    return undefined;
   };
 
   onUnload = (event: BeforeUnloadEvent) => {

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetBuilder/buildStep.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetBuilder/buildStep.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import ListItem from 'app/components/list/listItem';
+import space from 'app/styles/space';
+
+type Props = {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+};
+
+function BuildStep({title, description, children}: Props) {
+  return (
+    <StyledListItem>
+      <Header>
+        <Description>{title}</Description>
+        <SubDescription>{description}</SubDescription>
+      </Header>
+      <Content>{children}</Content>
+    </StyledListItem>
+  );
+}
+
+export default BuildStep;
+
+const StyledListItem = styled(ListItem)`
+  display: grid;
+  grid-gap: ${space(2)};
+`;
+
+const Description = styled('h4')`
+  font-weight: 400;
+  margin-bottom: 0;
+`;
+
+const SubDescription = styled('div')`
+  color: ${p => p.theme.gray300};
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const Header = styled('div')`
+  display: grid;
+  grid-gap: ${space(0.5)};
+`;
+
+const Content = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr max-content;
+`;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetBuilder/chart.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetBuilder/chart.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {Panel} from 'app/components/panels';
+
+function Chart() {
+  return <StyledPanel>Chart</StyledPanel>;
+}
+
+export default Chart;
+
+const StyledPanel = styled(Panel)`
+  height: 100%;
+  min-height: 96px;
+`;

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetBuilder/index.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetBuilder/index.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import {RouteComponentProps} from 'react-router';
+
+import Feature from 'app/components/acl/feature';
+import Alert from 'app/components/alert';
+import {t} from 'app/locale';
+import {PageContent} from 'app/styles/organization';
+import {Organization} from 'app/types';
+import withOrganization from 'app/utils/withOrganization';
+
+import WidgetBuilder from './widgetBuilder';
+
+type RouteParams = {
+  orgId: string;
+};
+
+type Props = RouteComponentProps<RouteParams, {}> & {
+  organization: Organization;
+  children: React.ReactNode;
+};
+
+function WidgetBuilderContainer({organization, ...props}: Props) {
+  return (
+    <Feature
+      features={['metrics']}
+      organization={organization}
+      renderDisabled={() => (
+        <PageContent>
+          <Alert type="warning">{t("You don't have access to this feature")}</Alert>
+        </PageContent>
+      )}
+    >
+      <WidgetBuilder {...props} />
+    </Feature>
+  );
+}
+
+export default withOrganization(WidgetBuilderContainer);

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetBuilder/utils.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetBuilder/utils.tsx
@@ -1,0 +1,13 @@
+import {t} from 'app/locale';
+
+export const visualizationColors = [{label: t('Default Color'), value: 'purple'}];
+
+export const metricMockOptions = [
+  'sentry.response',
+  'sentry.events.failed',
+  'sentry.events.processed',
+  'sentry.events.processed.javascript',
+  'sentry.events.processed.java',
+  'sentry.events.processed.node',
+  'symbolicator.healthcheck',
+];

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetBuilder/widgetBuilder.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import {RouteComponentProps} from 'react-router';
+import {components, OptionProps} from 'react-select';
+import styled from '@emotion/styled';
+
+import Breadcrumbs from 'app/components/breadcrumbs';
+import Button from 'app/components/button';
+import ButtonBar from 'app/components/buttonBar';
+import SelectControl from 'app/components/forms/selectControl';
+import Highlight from 'app/components/highlight';
+import * as Layout from 'app/components/layouts/thirds';
+import List from 'app/components/list';
+import {t} from 'app/locale';
+import {PageContent} from 'app/styles/organization';
+import space from 'app/styles/space';
+import routeTitleGen from 'app/utils/routeTitle';
+import AsyncView from 'app/views/asyncView';
+
+import {DISPLAY_TYPE_CHOICES} from '../data';
+
+import BuildStep from './buildStep';
+import Chart from './chart';
+import {metricMockOptions, visualizationColors} from './utils';
+
+type SelectControlOption = {
+  label: string;
+  value: string;
+};
+
+type RouteParams = {
+  orgId: string;
+};
+
+type Props = AsyncView['props'] & RouteComponentProps<RouteParams, {}> & {};
+
+type State = AsyncView['state'] & {
+  metrics: Array<string>;
+  visualization: {
+    type: string;
+    color: string;
+  };
+};
+
+class WidgetBuilder extends AsyncView<Props, State> {
+  getDefaultState() {
+    return {
+      ...super.getDefaultState(),
+      visualization: {
+        type: 'line',
+        color: 'purple',
+      },
+    };
+  }
+
+  getTitle() {
+    const {params} = this.props;
+    return routeTitleGen(t('Dashboards - Widget Builder'), params.orgId, false);
+  }
+
+  handleFieldChange<F extends keyof State>(field: F, value: State[F]) {
+    this.setState(state => ({...state, [field]: value}));
+  }
+
+  render() {
+    const {params} = this.props;
+    const {visualization, metrics} = this.state;
+
+    return (
+      <StyledPageContent>
+        <Layout.Header>
+          <Layout.HeaderContent>
+            <Breadcrumbs
+              crumbs={[
+                {
+                  to: `/organizations/${params.orgId}/dashboards/`,
+                  label: t('Dashboards'),
+                },
+                {label: t('Widget Builder')},
+              ]}
+            />
+            <Layout.Title>{t('Custom Metrics Widget')}</Layout.Title>
+          </Layout.HeaderContent>
+
+          <Layout.HeaderActions>
+            <ButtonBar gap={1}>
+              <Button
+                title={t(
+                  "You’re seeing the metrics project because you have the feature flag 'organizations:metrics' enabled. Send us feedback via email."
+                )}
+                href="mailto:metrics-feedback@sentry.io?subject=Metrics Feedback"
+              >
+                {t('Give Feedback')}
+              </Button>
+              <Button priority="primary">{t('Save Widget')}</Button>
+            </ButtonBar>
+          </Layout.HeaderActions>
+        </Layout.Header>
+
+        <Layout.Body>
+          <BuildSteps symbol="colored-numeric">
+            <BuildStep
+              title={t('Graph your data')}
+              description={t(
+                'Choose the metric to graph by searching or selecting it from the dropdown.'
+              )}
+            >
+              <SelectControl
+                name="metrics"
+                placeholder={t('Select a metric')}
+                options={metricMockOptions.map(metricMockOption => ({
+                  label: metricMockOption,
+                  value: metricMockOption,
+                }))}
+                value={metrics}
+                onChange={(options: Array<SelectControlOption>) => {
+                  this.handleFieldChange(
+                    'metrics',
+                    options.map(option => option.value)
+                  );
+                }}
+                components={{
+                  Option: (option: OptionProps<SelectControlOption>) => {
+                    const {label, selectProps} = option;
+                    const {inputValue = ''} = selectProps;
+                    return (
+                      <components.Option {...option}>
+                        <Highlight text={inputValue}>{label}</Highlight>
+                      </components.Option>
+                    );
+                  },
+                }}
+                multiple
+              />
+            </BuildStep>
+            <BuildStep
+              title={t('Choose your visualization')}
+              description={t(
+                'This is a preview of how your widget will appear in the dashboard.'
+              )}
+            >
+              <VisualizationWrapper>
+                <VisualizationFields>
+                  <SelectControl
+                    name="visualizationDisplay"
+                    options={DISPLAY_TYPE_CHOICES.slice()}
+                    value={visualization.type}
+                    onChange={(option: SelectControlOption) => {
+                      this.handleFieldChange('visualization', {
+                        ...visualization,
+                        type: option.value,
+                      });
+                    }}
+                  />
+                  <SelectControl
+                    name="visualizationColor"
+                    options={visualizationColors.slice()}
+                    value={visualization.color}
+                    onChange={(option: SelectControlOption) => {
+                      this.handleFieldChange('visualization', {
+                        ...visualization,
+                        color: option.value,
+                      });
+                    }}
+                  />
+                </VisualizationFields>
+                <Chart />
+              </VisualizationWrapper>
+            </BuildStep>
+          </BuildSteps>
+        </Layout.Body>
+      </StyledPageContent>
+    );
+  }
+}
+
+export default WidgetBuilder;
+
+const StyledPageContent = styled(PageContent)`
+  padding: 0;
+`;
+
+const BuildSteps = styled(List)`
+  display: grid;
+  grid-gap: ${space(3)};
+  max-width: calc(100% - 40%);
+`;
+
+const VisualizationFields = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr minmax(200px, auto);
+  grid-gap: ${space(1.5)};
+`;
+
+const VisualizationWrapper = styled('div')`
+  display: grid;
+  grid-gap: ${space(1.5)};
+`;


### PR DESCRIPTION
This is a prototype and it's under the feature flag `organizations:metrics`

. Add router `app/views/dashboardsV2/widgetBuilder`
. Add the buttons "Add event widget" and "Add metric widget" on the dashboard page (it's under feature flag)
. Add the work in progress view "WidgetBuilder"

Preview: 

![image](https://user-images.githubusercontent.com/29228205/112466577-4f353600-8d66-11eb-9fd1-4b375f389ab8.png)


![image](https://user-images.githubusercontent.com/29228205/112471356-16985b00-8d6c-11eb-9428-eda74ee82290.png)
