### PR TITLE
fix: allow passwords to be set using Django admin

### DIFF
--- a/src/sentry/admin.py
+++ b/src/sentry/admin.py
@@ -265,7 +265,7 @@ class UserAdmin(admin.ModelAdmin):
     def user_change_password(self, request, id, form_url=""):
         if not self.has_change_permission(request):
             raise PermissionDenied
-        user = get_object_or_404(self.queryset(request), pk=id)
+        user = get_object_or_404(self.get_queryset(request), pk=id)
         if request.method == "POST":
             form = self.change_password_form(user, request.POST)
             if form.is_valid():
@@ -299,7 +299,6 @@ class UserAdmin(admin.ModelAdmin):
             request,
             self.change_user_password_template or "admin/auth/user/change_password.html",
             context,
-            current_app=self.admin_site.name,
         )
 
     def response_add(self, request, obj, post_url_continue=None):

--- a/src/sentry/admin.py
+++ b/src/sentry/admin.py
@@ -217,7 +217,10 @@ class UserAdmin(admin.ModelAdmin):
         defaults = {}
         if obj is None:
             defaults.update(
-                {"form": self.add_form, "fields": admin.util.flatten_fieldsets(self.add_fieldsets)}
+                {
+                    "form": self.add_form,
+                    "fields": admin.options.flatten_fieldsets(self.add_fieldsets),
+                }
             )
         defaults.update(kwargs)
         return super().get_form(request, obj, **defaults)


### PR DESCRIPTION
Requires #24674 to be useful.

I'm not sure if self.queryset was ever correct, I think it was supposed to be
self.get_queryset but wasn't noticed because nobody sets password with Django
admin?

current_app was removed in https://code.djangoproject.com/ticket/24126.