### PR TITLE
ref(azure): Fix SENTRY-NT8

### DIFF
--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -53,6 +53,7 @@ class WorkItemWebhook(Endpoint):
                     "vsts.integration-in-webhook-payload-does-not-exist",
                     extra={"external_id": external_id, "event_type": event_type},
                 )
+                return self.respond(status=400)
 
             try:
                 self.check_webhook_secret(request, integration)

--- a/src/sentry/integrations/vsts/webhooks.py
+++ b/src/sentry/integrations/vsts/webhooks.py
@@ -53,7 +53,7 @@ class WorkItemWebhook(Endpoint):
                     "vsts.integration-in-webhook-payload-does-not-exist",
                     extra={"external_id": external_id, "event_type": event_type},
                 )
-                return self.respond(status=400)
+                return self.respond({"detail": "Integration does not exist."}, status=400)
 
             try:
                 self.check_webhook_secret(request, integration)


### PR DESCRIPTION
If we don't have the integration, we can just return early, since it probably means they uninstalled on our end. 

Fixes SENTRY-NT8