### PR TITLE
fix(trace-view): Fixing tags on the detailed trace view

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -342,10 +342,15 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
         if detailed:
             if "measurements" in nodestore_data:
                 event["measurements"] = nodestore_data.get("measurements")
-            event["tags"] = OrderedDict()
-            for [tag_key, tag_value] in sorted(nodestore_data.get("tags"), key=lambda tag: tag[0]):
-                cleaned_tag_key = tag_key.split("sentry:", 1)[-1]
-                event["tags"][cleaned_tag_key] = tag_value
+            event["tags"] = [
+                {
+                    "key": tag_key.split("sentry:", 1)[-1],
+                    "value": tag_value,
+                }
+                for [tag_key, tag_value] in sorted(
+                    nodestore_data.get("tags"), key=lambda tag: tag[0]
+                )
+            ]
 
     def update_generations(self, event):
         parents = [event]

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -15,7 +15,6 @@ from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 logger = logging.getLogger(__name__)
 MAX_TRACE_SIZE = 100
 NODESTORE_KEYS = ["timestamp", "start_timestamp"]
-DETAILED_NODESTORE_KEYS = ["environment", "release"]
 ERROR_COLUMNS = [
     "id",
     "project",
@@ -341,14 +340,12 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
         """ Add extra data that we get from Nodestore """
         event.update({event_key: nodestore_data.get(event_key) for event_key in NODESTORE_KEYS})
         if detailed:
-            event.update(
-                {event_key: nodestore_data.get(event_key) for event_key in DETAILED_NODESTORE_KEYS}
-            )
             if "measurements" in nodestore_data:
                 event["measurements"] = nodestore_data.get("measurements")
-            event["tags"] = {}
-            for [tag_key, tag_value] in nodestore_data.get("tags"):
-                event["tags"][tag_key] = tag_value
+            event["tags"] = OrderedDict()
+            for [tag_key, tag_value] in sorted(nodestore_data.get("tags"), key=lambda tag: tag[0]):
+                cleaned_tag_key = tag_key.split("sentry:", 1)[-1]
+                event["tags"][cleaned_tag_key] = tag_value
 
     def update_generations(self, event):
         parents = [event]

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -560,7 +560,10 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         root = response.data[0]
         assert root["transaction.status"] == "ok"
         for [key, value] in self.root_event.tags:
-            assert root["tags"][key] == value, f"tags - {key}"
+            if not key.startswith("sentry:"):
+                assert root["tags"][key] == value, f"tags - {key}"
+            else:
+                assert root["tags"][key[7:]] == value, f"tags - {key}"
         assert root["measurements"]["lcp"]["value"] == 1000
         assert root["measurements"]["fcp"]["value"] == 750
 

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -559,11 +559,12 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         self.assert_trace_data(response.data[0])
         root = response.data[0]
         assert root["transaction.status"] == "ok"
+        root_tags = {tag["key"]: tag["value"] for tag in root["tags"]}
         for [key, value] in self.root_event.tags:
             if not key.startswith("sentry:"):
-                assert root["tags"][key] == value, f"tags - {key}"
+                assert root_tags[key] == value, f"tags - {key}"
             else:
-                assert root["tags"][key[7:]] == value, f"tags - {key}"
+                assert root_tags[key[7:]] == value, f"tags - {key}"
         assert root["measurements"]["lcp"]["value"] == 1000
         assert root["measurements"]["fcp"]["value"] == 750
 


### PR DESCRIPTION
- We have `sentry:environment` and `sentry:release` as tags already, so
  getting those from tags instead of using DETAILED_NODESTORE_KEYS
- Sorting the tags so we're more consistent