### PR TITLE
feat: Support passing a to/from timestamp when tombstoning an event

### DIFF
--- a/src/sentry/eventstream/base.py
+++ b/src/sentry/eventstream/base.py
@@ -96,7 +96,9 @@ class EventStream(Service):
     def end_delete_tag(self, state):
         pass
 
-    def tombstone_events_unsafe(self, project_id, event_ids, old_primary_hash=False):
+    def tombstone_events_unsafe(
+        self, project_id, event_ids, old_primary_hash=False, from_timestamp=None, to_timestamp=None
+    ):
         pass
 
     def replace_group_unsafe(self, project_id, event_ids, new_group_id):

--- a/src/sentry/eventstream/snuba.py
+++ b/src/sentry/eventstream/snuba.py
@@ -212,7 +212,9 @@ class SnubaProtocolEventStream(EventStream):
         state["datetime"] = datetime.now(tz=pytz.utc)
         self._send(state["project_id"], "end_delete_tag", extra_data=(state,), asynchronous=False)
 
-    def tombstone_events_unsafe(self, project_id, event_ids, old_primary_hash=False):
+    def tombstone_events_unsafe(
+        self, project_id, event_ids, old_primary_hash=False, from_timestamp=None, to_timestamp=None
+    ):
         """
         Tell Snuba to eventually delete these events.
 
@@ -239,6 +241,8 @@ class SnubaProtocolEventStream(EventStream):
             "project_id": project_id,
             "event_ids": event_ids,
             "old_primary_hash": old_primary_hash,
+            "from_timestamp": from_timestamp,
+            "to_timestamp": to_timestamp,
         }
         self._send(project_id, "tombstone_events", extra_data=(state,), asynchronous=False)
 


### PR DESCRIPTION
This is cherry picked from https://github.com/getsentry/sentry/pull/24667.
It doesn't actually send the timestamps for reprocessed events yet.