### PR TITLE
direnv(feat): Support GNU and BSD mktemp

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -237,4 +237,4 @@ EOF
 fi
 
 # Since we can't use an EXIT routine we need to guarantee we delete the file here
-test -f "${_SENTRY_LOG_FILE}" && rm "$_SENTRY_LOG_FILE"
+rm -f "$_SENTRY_LOG_FILE"

--- a/.envrc
+++ b/.envrc
@@ -6,12 +6,6 @@
 
 set -e
 
-# Since direnv traps the EXIT signal we place the temp file under /tmp for the odd time
-# the script will use the EXIT path
-_SENTRY_LOG_FILE=$(mktemp /tmp/sentry.envrc.$$.out)
-exec > >(tee "$_SENTRY_LOG_FILE")
-exec 2>&1
-
 bold="$(tput bold)"
 red="$(tput setaf 1)"
 green="$(tput setaf 2)"
@@ -137,6 +131,11 @@ fi
 if [ -n "${SENTRY_DEVENV_NO_REPORT+x}" ]; then
     info "No development environment errors will be reported (since you've defined SENTRY_DEVENV_NO_REPORT)."
 else
+    # Since direnv traps the EXIT signal we place the temp file under /tmp for the odd time
+    # the script will use the EXIT path
+    _SENTRY_LOG_FILE=$(mktemp /tmp/sentry.envrc.$$.out || mktemp /tmp/sentry.envrc.XXXXXXXX.out)
+    exec > >(tee "$_SENTRY_LOG_FILE")
+    exec 2>&1
     info "Development errors will be reported to Sentry.io."$'\n'"        If you wish to opt-out, set SENTRY_DEVENV_NO_REPORT as an env variable."
     export SENTRY_DEVENV_DSN=https://23670f54c6254bfd9b7de106637808e9@o1.ingest.sentry.io/1492057
 fi
@@ -238,4 +237,4 @@ EOF
 fi
 
 # Since we can't use an EXIT routine we need to guarantee we delete the file here
-rm "$_SENTRY_LOG_FILE"
+test -f "${_SENTRY_LOG_FILE}" && rm "$_SENTRY_LOG_FILE"


### PR DESCRIPTION
It seems that folks on Mac can install GNU Coreutils. GNU's mktemp behaves differently than
Mac's BSD version.

This also moves the initialization code behind the SENTRY_DEVENV_NO_REPORT flag.

This has the side effect of potentially missing `dotenv` loading not reporting.