### PR TITLE
ref(codeowners): Do not create dummy issue owner record

### DIFF
--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -1,7 +1,5 @@
 import logging
 
-from django.utils import timezone
-
 from rest_framework import serializers, status
 from rest_framework.response import Response
 from rest_framework.exceptions import PermissionDenied
@@ -125,14 +123,6 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
             raise serializers.ValidationError("This code mapping does not exist.")
 
     def create(self, validated_data):
-        # Create a project_ownership record with default values if none exists.
-        ownership = self.context["ownership"]
-        if ownership.id is None:
-            now = timezone.now()
-            ownership.date_created = now
-            ownership.last_updated = now
-            ownership.save()
-
         # Save projectcodeowners record
         repository_project_path_config = validated_data.pop("code_mapping_id", None)
         project = self.context["project"]

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -1,7 +1,7 @@
 from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase
-from sentry.models import Integration, ProjectCodeOwners, ProjectOwnership
+from sentry.models import Integration, ProjectCodeOwners
 
 
 class ProjectCodeOwnersEndpointTestCase(APITestCase):
@@ -168,13 +168,6 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             response = self.client.post(self.url, self.data)
         assert response.status_code == 400
         assert response.data == {"codeMappingId": ["This code mapping does not exist."]}
-
-    def test_default_project_ownership_record_created(self):
-        assert ProjectOwnership.objects.filter(project=self.project).exists() is False
-        with self.feature({"organizations:import-codeowners": True}):
-            response = self.client.post(self.url, self.data)
-        assert response.status_code == 201, response.content
-        assert ProjectOwnership.objects.filter(project=self.project).exists() is True
 
     def test_schema_is_correct(self):
         with self.feature({"organizations:import-codeowners": True}):


### PR DESCRIPTION
**Context:**
This PR comes out the discussion around https://github.com/getsentry/sentry/pull/24409#discussion_r597201043. 

Originally we were creating a dummy issue owner (aka `ProjectOwnership`) record in the db so that we use the `fallthrough` and `auto_assignment` from that record in order to determine what to use for code owners. 

However, we can just use the defaults by creating an instance when we evaluate the ownership rules, which is what we do already here:
https://github.com/getsentry/sentry/blob/631937e93352bba3ca692e49e5d3b1d1542c61f5/src/sentry/models/projectownership.py#L138

