### PR TITLE
feat(trace-view): Add link to trace view to discover

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -27,6 +27,7 @@ import {DisplayModes, TOP_N} from 'app/utils/discover/types';
 import {eventDetailsRouteWithEventView, generateEventSlug} from 'app/utils/discover/urls';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withProjects from 'app/utils/withProjects';
+import {getTraceDetailsUrl} from 'app/views/performance/traceDetails/utils';
 import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
 
 import {getExpandedResults, pushEventViewToLocation} from '../utils';
@@ -242,6 +243,24 @@ class TableView extends React.Component<TableViewProps> {
           </StyledLink>
         </Tooltip>
       );
+    } else if (columnKey === 'trace') {
+      const dateSelection = eventView.normalizeDateSelection(location);
+      if (dataRow.trace) {
+        const target = getTraceDetailsUrl(
+          organization,
+          String(dataRow.trace),
+          dateSelection,
+          {}
+        );
+
+        cell = (
+          <Tooltip title={t('View Trace')}>
+            <StyledLink data-test-id="view-trace" to={target}>
+              {cell}
+            </StyledLink>
+          </Tooltip>
+        );
+      }
     }
 
     return (


### PR DESCRIPTION
When trace is added as a column in discover, it should link to the trace view
when possible.