### PR TITLE
fix(trace-view): Link multi errors to correct discover query

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/transactionDetail.tsx
@@ -71,13 +71,7 @@ class TransactionDetail extends React.Component<Props> {
     const eventView = EventView.fromSavedQuery({
       id: undefined,
       name: `Errors events associated with transaction ${transaction.event_id}`,
-      fields: [
-        'transaction',
-        'project',
-        'trace.span',
-        'transaction.duration',
-        'timestamp',
-      ],
+      fields: ['title', 'project', 'issue', 'timestamp'],
       orderby: '-timestamp',
       query: stringifyQueryObject(queryResults),
       projects: organization.features.includes('global-views')


### PR DESCRIPTION
When there are multiple errors on a single transaction, the target discover
query should show all of the errors.