### PR TITLE
Implement grammar for IN search in event/issue query parser

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -158,7 +158,7 @@ tag_filter           = negation? "tags[" search_key "]" sep search_value
 aggregate_key        = key open_paren function_arg* closed_paren
 search_key           = key / quoted_key
 search_value         = quoted_value / value
-value                = ~r"[^()\s]*[^\]\s]" / ~r"[^()\s]*"
+value                = ~r"[^()\s]*[^\]\s)]" / ~r"[^()\s]*"
 numeric_value        = ~r"([-]?[0-9\.]+)([kmb])?(?=\s|\)|$|,|])"
 boolean_value        = ~r"(true|1|false|0)(?=\s|\)|$)"i
 quoted_value         = ~r"\"((?:[^\"]|(?<=\\)[\"])*)?\""s
@@ -502,6 +502,8 @@ class SearchVisitor(NodeVisitor):
         else:
             if operator != "IN":
                 search_value = search_value.text
+            else:
+                search_value = [v.text for v in search_value]
             search_value = SearchValue(
                 operator + search_value if operator not in ("=", "IN") else search_value
             )

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -184,7 +184,7 @@ operator             = ">=" / "<=" / ">" / "<" / "=" / "!="
 open_paren           = "("
 closed_paren         = ")"
 open_bracket         = "["
-closed_bracket       = "]"
+closed_bracket       = ~r"\](?=\s|$)"
 sep                  = ":"
 space                = " "
 negation             = "!"
@@ -686,7 +686,9 @@ class SearchVisitor(NodeVisitor):
                 self.process_list(search_value[1], [(_, _, val) for _, _, val in search_value[2]])
             )
         else:
-            if not search_value:
+            # XXX: We check whether the text in the node itself is actually empty, so
+            # we can tell the difference between an empty quoted string and no string
+            if not search_value.raw_value and not node.children[3].text:
                 raise InvalidSearchQuery(f"Empty string after '{search_key.name}:'")
 
         operator = self.handle_negation(negation, operator)

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -46,6 +46,7 @@ NEGATION_MAP = {
     "<=": ">",
     ">": "<=",
     ">=": "<",
+    "IN": "NOT IN",
 }
 
 RESULT_TYPES = {"duration", "string", "number", "integer", "percentage", "date"}
@@ -130,8 +131,8 @@ raw_search           = (!key_val_term ~r"\ *(?!(?i)OR(?![^\s]))(?!(?i)AND(?![^\s
 quoted_raw_search    = spaces quoted_value spaces
 
 # standard key:val filter
-basic_filter         = negation? search_key sep search_value
-quoted_basic_filter  = negation? search_key sep quoted_value
+basic_filter         = negation? search_key sep ((open_bracket value (comma value)* closed_bracket) / value)
+quoted_basic_filter  = negation? search_key sep (quoted_value / (open_bracket quoted_value (comma quoted_value)* closed_bracket))
 # filter for dates
 time_filter          = search_key sep? operator (date_format / alt_date_format)
 # filter for relative dates
@@ -141,7 +142,7 @@ duration_filter      = search_key sep operator? duration_format
 # exact time filter for dates
 specific_time_filter = search_key sep (date_format / alt_date_format)
 # Numeric comparison filter
-numeric_filter       = search_key sep operator? numeric_value
+numeric_filter       = search_key sep ((operator? numeric_value) / (open_bracket numeric_value (comma numeric_value)* closed_bracket))
 # Boolean comparison filter
 boolean_filter       = negation? search_key sep boolean_value
 # Aggregate numeric filter
@@ -157,8 +158,8 @@ tag_filter           = negation? "tags[" search_key "]" sep search_value
 aggregate_key        = key open_paren function_arg* closed_paren
 search_key           = key / quoted_key
 search_value         = quoted_value / value
-value                = ~r"[^()\s]*"
-numeric_value        = ~r"([-]?[0-9\.]+)([k|m|b])?(?=\s|\)|$)"
+value                = ~r"[^()\s]*[^\]\s]" / ~r"[^()\s]*"
+numeric_value        = ~r"([-]?[0-9\.]+)([kmb])?(?=\s|\)|$|,|])"
 boolean_value        = ~r"(true|1|false|0)(?=\s|\)|$)"i
 quoted_value         = ~r"\"((?:[^\"]|(?<=\\)[\"])*)?\""s
 key                  = ~r"[a-zA-Z0-9_\.-]+"
@@ -180,6 +181,8 @@ and_operator         = ~r"AND(?![^\s])"i
 operator             = ">=" / "<=" / ">" / "<" / "=" / "!="
 open_paren           = "("
 closed_paren         = ")"
+open_bracket         = "["
+closed_bracket       = "]"
 sep                  = ":"
 space                = " "
 negation             = "!"
@@ -434,7 +437,19 @@ class SearchVisitor(NodeVisitor):
 
         # Numeric and boolean filters overlap on 1 and 0 values.
         if self.is_numeric_key(search_key.name):
-            return self.visit_numeric_filter(node, (search_key, sep, "=", search_value))
+            return self.visit_numeric_filter(
+                node,
+                (
+                    search_key,
+                    sep,
+                    (
+                        (
+                            "=",
+                            search_value,
+                        ),
+                    ),
+                ),
+            )
 
         if search_key.name in self.boolean_keys:
             if search_value.text.lower() in ("true", "1"):
@@ -450,24 +465,54 @@ class SearchVisitor(NodeVisitor):
                 search_key, "=" if not is_negated else "!=", search_value
             )
 
+    def process_list(self, first, remaining):
+        return [
+            first,
+            *[item[1] for item in remaining],
+        ]
+
     def visit_numeric_filter(self, node, children):
-        (search_key, _, operator, search_value) = children
-        operator = operator[0] if not isinstance(operator, Node) else "="
+        (search_key, _, (value,)) = children
+        operator = value[0]
+        # import pdb; pdb.set_trace()
+        if isinstance(operator, Node):
+            if isinstance(operator.expr, Optional):
+                operator = "="
+            else:
+                operator = operator.text
+        else:
+            operator = operator[0]
+
+        if operator == "[":
+            operator = "IN"
+            search_value = self.process_list(value[1], value[2])
+        else:
+            search_value = value[1]
 
         if self.is_numeric_key(search_key.name):
             try:
-                search_value = SearchValue(parse_numeric_value(*search_value.match.groups()))
+                search_value = SearchValue(
+                    [parse_numeric_value(*val.match.groups()) for val in search_value]
+                    if operator == "IN"
+                    else parse_numeric_value(*search_value.match.groups())
+                )
             except InvalidQuery as exc:
                 raise InvalidSearchQuery(str(exc))
             return SearchFilter(search_key, operator, search_value)
         else:
+            if operator != "IN":
+                search_value = search_value.text
             search_value = SearchValue(
-                operator + search_value.text if operator != "=" else search_value.text
+                operator + search_value if operator not in ("=", "IN") else search_value
             )
-            return self._handle_basic_filter(search_key, "=", search_value)
+            operator = "=" if operator not in ("=", "IN") else operator
+            return self._handle_basic_filter(search_key, operator, search_value)
 
     def handle_negation(self, negation, operator):
-        operator = operator[0] if not isinstance(operator, Node) else "="
+        if isinstance(operator, Node):
+            operator = "="
+        elif not isinstance(operator, str):
+            operator = operator[0]
         if self.is_negated(negation):
             return NEGATION_MAP.get(operator, "!=")
         return operator
@@ -564,7 +609,7 @@ class SearchVisitor(NodeVisitor):
                 raise InvalidSearchQuery(str(exc))
             return SearchFilter(search_key, operator, SearchValue(search_value))
         elif self.is_numeric_key(search_key.name):
-            return self.visit_numeric_filter(node, (search_key, sep, operator, search_value))
+            return self.visit_numeric_filter(node, (search_key, sep, ((operator, search_value),)))
         else:
             search_value = operator + search_value.text if operator != "=" else search_value.text
             return self._handle_basic_filter(search_key, "=", SearchValue(search_value))
@@ -630,18 +675,36 @@ class SearchVisitor(NodeVisitor):
         return node.text == "!"
 
     def visit_quoted_basic_filter(self, node, children):
-        (negation, search_key, _, search_value) = children
-        operator = "!=" if self.is_negated(negation) else "="
+        (negation, search_key, _, (search_value,)) = children
+        operator = "="
+        # import pdb
+        #
+        # pdb.set_trace()
+        if isinstance(search_value, list):
+            operator = "IN"
+            search_value = self.process_list(search_value[1], search_value[2])
+
         search_value = SearchValue(search_value)
+        operator = self.handle_negation(negation, operator)
+
         return self._handle_basic_filter(search_key, operator, search_value)
 
     def visit_basic_filter(self, node, children):
-        (negation, search_key, _, search_value) = children
-        operator = "!=" if self.is_negated(negation) else "="
-        if not search_value.raw_value:
-            raise InvalidSearchQuery(f"Empty string after '{search_key.name}:'")
+        (negation, search_key, _, (search_value,)) = children
+        operator = "="
+        # import pdb
+        #
+        # pdb.set_trace()
+        if isinstance(search_value, list):
+            operator = "IN"
+            search_value = self.process_list(search_value[1], search_value[2])
+        else:
+            if not search_value:
+                raise InvalidSearchQuery(f"Empty string after '{search_key.name}:'")
 
-        return self._handle_basic_filter(search_key, operator, search_value)
+        operator = self.handle_negation(negation, operator)
+
+        return self._handle_basic_filter(search_key, operator, SearchValue(search_value))
 
     def _handle_basic_filter(self, search_key, operator, search_value):
         # If a date or numeric key gets down to the basic filter, then it means
@@ -675,6 +738,9 @@ class SearchVisitor(NodeVisitor):
         return SearchFilter(search_key, operator, SearchValue(""))
 
     def visit_tag_filter(self, node, children):
+        # import pdb
+        #
+        # pdb.set_trace()
         (negation, _, search_key, _, sep, search_value) = children
         operator = "!=" if self.is_negated(negation) else "="
         return SearchFilter(SearchKey(f"tags[{search_key.name}]"), operator, search_value)

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -525,39 +525,39 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
     def test_quoted_val(self):
-        # assert parse_search_query('release:"a release"') == [
-        #     SearchFilter(
-        #         key=SearchKey(name="release"),
-        #         operator="=",
-        #         value=SearchValue(raw_value="a release"),
-        #     )
-        # ]
-        # assert parse_search_query('!release:"a release"') == [
-        #     SearchFilter(
-        #         key=SearchKey(name="release"), operator="!=", value=SearchValue("a release")
-        #     )
-        # ]
-        # assert parse_search_query('release:["a release"]') == [
-        #     SearchFilter(
-        #         key=SearchKey(name="release"),
-        #         operator="IN",
-        #         value=SearchValue(raw_value=["a release"]),
-        #     )
-        # ]
-        # assert parse_search_query('release:["a release","b release"]') == [
-        #     SearchFilter(
-        #         key=SearchKey(name="release"),
-        #         operator="IN",
-        #         value=SearchValue(raw_value=["a release", "b release"]),
-        #     )
-        # ]
-        # assert parse_search_query('!release:["a release","b release"]') == [
-        #     SearchFilter(
-        #         key=SearchKey(name="release"),
-        #         operator="NOT IN",
-        #         value=SearchValue(raw_value=["a release", "b release"]),
-        #     )
-        # ]
+        assert parse_search_query('release:"a release"') == [
+            SearchFilter(
+                key=SearchKey(name="release"),
+                operator="=",
+                value=SearchValue(raw_value="a release"),
+            )
+        ]
+        assert parse_search_query('!release:"a release"') == [
+            SearchFilter(
+                key=SearchKey(name="release"), operator="!=", value=SearchValue("a release")
+            )
+        ]
+        assert parse_search_query('release:["a release"]') == [
+            SearchFilter(
+                key=SearchKey(name="release"),
+                operator="IN",
+                value=SearchValue(raw_value=["a release"]),
+            )
+        ]
+        assert parse_search_query('release:["a release","b release"]') == [
+            SearchFilter(
+                key=SearchKey(name="release"),
+                operator="IN",
+                value=SearchValue(raw_value=["a release", "b release"]),
+            )
+        ]
+        assert parse_search_query('!release:["a release","b release"]') == [
+            SearchFilter(
+                key=SearchKey(name="release"),
+                operator="NOT IN",
+                value=SearchValue(raw_value=["a release", "b release"]),
+            )
+        ]
         assert parse_search_query('release:["a release"] hello:["123"]') == [
             SearchFilter(
                 key=SearchKey(name="release"),
@@ -840,13 +840,13 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
     def test_numeric_in_filter(self):
-        # assert parse_search_query("project_id:[500,501,502]") == [
-        #     SearchFilter(
-        #         key=SearchKey(name="project_id"),
-        #         operator="IN",
-        #         value=SearchValue(raw_value=[500, 501, 502]),
-        #     )
-        # ]
+        assert parse_search_query("project_id:[500,501,502]") == [
+            SearchFilter(
+                key=SearchKey(name="project_id"),
+                operator="IN",
+                value=SearchValue(raw_value=[500, 501, 502]),
+            )
+        ]
         assert parse_search_query("project_id:[500,501,502] issue.id:[100]") == [
             SearchFilter(
                 key=SearchKey(name="project_id"),
@@ -861,13 +861,18 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
         # Numeric format should still return a string if field isn't
         # allowed
-        # assert parse_search_query("random_field:[500,501,502]") == [
-        #     SearchFilter(
-        #         key=SearchKey(name="random_field"),
-        #         operator="IN",
-        #         value=SearchValue(raw_value=["500", "501", "502"]),
-        #     )
-        # ]
+        assert parse_search_query("project_id:[500,501,502] random_field:[500,501,502]") == [
+            SearchFilter(
+                key=SearchKey(name="project_id"),
+                operator="IN",
+                value=SearchValue(raw_value=[500, 501, 502]),
+            ),
+            SearchFilter(
+                key=SearchKey(name="random_field"),
+                operator="IN",
+                value=SearchValue(raw_value=["500", "501", "502"]),
+            ),
+        ]
 
     def test_numeric_filter_with_decimals(self):
         assert parse_search_query("transaction.duration:>3.1415") == [

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -275,13 +275,11 @@ class ParseSearchQueryTest(unittest.TestCase):
                 value=SearchValue(raw_value="[h[e]llo"),
             ),
         ]
-
-    def test_simple_in_fails(self):
-        assert parse_search_query('user.email:[test@test.com, 1, "hi"]') == [
+        assert parse_search_query('user.email:[test@test.com, "hi", 1]') == [
             SearchFilter(
                 key=SearchKey(name="user.email"),
                 operator="IN",
-                value=SearchValue(raw_value=["test@test.com", "1", "hi"]),
+                value=SearchValue(raw_value=["test@test.com", "hi", "1"]),
             )
         ]
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -275,12 +275,67 @@ class ParseSearchQueryTest(unittest.TestCase):
                 value=SearchValue(raw_value="[h[e]llo"),
             ),
         ]
+        assert parse_search_query('test:"[h]"') == [
+            SearchFilter(
+                key=SearchKey(name="test"),
+                operator="=",
+                value=SearchValue(raw_value="[h]"),
+            ),
+        ]
+        assert parse_search_query("test:[h]*") == [
+            SearchFilter(
+                key=SearchKey(name="test"),
+                operator="=",
+                value=SearchValue(raw_value="[h]*"),
+            ),
+        ]
+        assert parse_search_query("test:[h e]") == [
+            SearchFilter(
+                key=SearchKey(name="test"),
+                operator="=",
+                value=SearchValue(raw_value="[h"),
+            ),
+            SearchFilter(
+                key=SearchKey(name="message"),
+                operator="=",
+                value=SearchValue(raw_value="e]"),
+            ),
+        ]
+        assert parse_search_query("test:[[h]]") == [
+            SearchFilter(
+                key=SearchKey(name="test"),
+                operator="=",
+                value=SearchValue(raw_value="[[h]]"),
+            ),
+        ]
+        assert parse_search_query("test:[]") == [
+            SearchFilter(
+                key=SearchKey(name="test"),
+                operator="=",
+                value=SearchValue(raw_value="[]"),
+            ),
+        ]
         assert parse_search_query('user.email:[test@test.com, "hi", 1]') == [
             SearchFilter(
                 key=SearchKey(name="user.email"),
                 operator="IN",
                 value=SearchValue(raw_value=["test@test.com", "hi", "1"]),
             )
+        ]
+        assert parse_search_query('user.email:[test@test.com, "hi", 1.0]') == [
+            SearchFilter(
+                key=SearchKey(name="user.email"),
+                operator="IN",
+                value=SearchValue(raw_value=["test@test.com", "hi", "1.0"]),
+            )
+        ]
+
+        assert parse_search_query("user.email:[test@test.com]user.email:hello@hello.com") == [
+            SearchFilter(
+                key=SearchKey(name="user.email"),
+                operator="=",
+                value=SearchValue(raw_value="[test@test.com]user.email:hello@hello.com"),
+            ),
         ]
 
     def test_raw_search_anywhere(self):

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -276,6 +276,15 @@ class ParseSearchQueryTest(unittest.TestCase):
             ),
         ]
 
+    def test_simple_in_fails(self):
+        assert parse_search_query('user.email:[test@test.com, 1, "hi"]') == [
+            SearchFilter(
+                key=SearchKey(name="user.email"),
+                operator="IN",
+                value=SearchValue(raw_value=["test@test.com", "1", "hi"]),
+            )
+        ]
+
     def test_raw_search_anywhere(self):
         assert parse_search_query(
             "hello what user.email:foo@example.com where release:1.2.1 when"
@@ -780,6 +789,22 @@ class ParseSearchQueryTest(unittest.TestCase):
                 key=SearchKey(name="tags[project_id]"),
                 operator="=",
                 value=SearchValue(raw_value="123"),
+            ),
+        ]
+
+    def test_explicit_tags_in_filter(self):
+        assert parse_search_query("tags[fruit]:[apple, pear]") == [
+            SearchFilter(
+                key=SearchKey(name="tags[fruit]"),
+                operator="IN",
+                value=SearchValue(raw_value=["apple", "pear"]),
+            ),
+        ]
+        assert parse_search_query('tags[fruit]:["apple wow", "pear"]') == [
+            SearchFilter(
+                key=SearchKey(name="tags[fruit]"),
+                operator="IN",
+                value=SearchValue(raw_value=["apple wow", "pear"]),
             ),
         ]
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -392,7 +392,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.issue_rule = self.create_issue_alert_rule(
             data={
                 "project": self.project,
-                "name": "issue Rule Test",
+                "name": "Issue Rule Test",
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -392,7 +392,7 @@ class OrganizationCombinedRuleIndexEndpointTest(BaseAlertRuleSerializerTest, API
         self.issue_rule = self.create_issue_alert_rule(
             data={
                 "project": self.project,
-                "name": "Issue Rule Test",
+                "name": "issue Rule Test",
                 "conditions": [],
                 "actions": [],
                 "actionMatch": "all",


### PR DESCRIPTION
This implements grammar for IN search for events and issues. Our query backends don't understand how to use this yet,
and I'll follow up with separate prs to handle that. The plan is to not merge this until the backends are ready, so that we
don't error if someone tries an IN search.

Grammar looks like `myfield:[123, 456,789]`. There can be 0 to many spaces after each comma, and we support this 
on basic searches, quoted string searches and numeric searches. We also support negation via `!myfield:[123, 456, 789]`. 

Internally, we translate these to `IN` and `NOT IN` operators. Open to any feedback if we want to change that.