### PR TITLE
fix(darkmode): sidepanel, breakdown and empty state gradient

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/breakdownBars.tsx
+++ b/src/sentry/static/sentry/app/components/charts/breakdownBars.tsx
@@ -63,7 +63,7 @@ const Label = styled('span')`
 
 const Bar = styled('div')`
   border-radius: 2px;
-  background-color: ${p => p.theme.gray100};
+  background-color: ${p => p.theme.border};
   position: absolute;
   top: 0;
   left: 0;

--- a/src/sentry/static/sentry/app/components/errorRobot.tsx
+++ b/src/sentry/static/sentry/app/components/errorRobot.tsx
@@ -150,12 +150,6 @@ const ErrorRobotWrapper = styled('div')<{gradient: boolean}>`
   border-radius: 0 0 3px 3px;
   padding: 40px ${space(3)} ${space(3)};
   min-height: 260px;
-  ${p =>
-    p.gradient
-      ? `
-          background-image: linear-gradient(to bottom, ${p.theme.backgroundSecondary}, ${p.theme.background});
-         `
-      : ''};
 
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     flex-direction: column;

--- a/src/sentry/static/sentry/app/components/onboardingWizard/sidebar.tsx
+++ b/src/sentry/static/sentry/app/components/onboardingWizard/sidebar.tsx
@@ -218,6 +218,7 @@ const TopRight = styled('img')`
   position: absolute;
   top: 0;
   right: 0;
+  width: 60%;
 `;
 
 export default withApi(withOrganization(OnboardingWizardSidebar));

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarPanel.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarPanel.tsx
@@ -103,7 +103,7 @@ const PanelContainer = styled('div')`
   display: flex;
   flex-direction: column;
   z-index: ${p => p.theme.zIndex.sidebarPanel};
-  background: ${p => p.theme.white};
+  background: ${p => p.theme.background};
   color: ${p => p.theme.textColor};
   border-right: 1px solid ${p => p.theme.border};
   box-shadow: 1px 0 2px rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
**Before:**
![Screen Shot 2021-03-24 at 5 21 04 PM](https://user-images.githubusercontent.com/4830259/112401217-4a6d7500-8cc7-11eb-95a7-fe2d87fed078.png)
![Screen Shot 2021-03-24 at 5 32 46 PM](https://user-images.githubusercontent.com/4830259/112401243-56f1cd80-8cc7-11eb-90a5-707badaa2c6a.png)
![Screen Shot 2021-03-24 at 5 34 22 PM](https://user-images.githubusercontent.com/4830259/112401268-63762600-8cc7-11eb-9cd4-a8dd9a6c09f8.png)

**After:**
![Screen Shot 2021-03-24 at 5 20 55 PM](https://user-images.githubusercontent.com/4830259/112401227-4e999280-8cc7-11eb-9fc6-378924481e80.png)
![Screen Shot 2021-03-24 at 5 32 11 PM](https://user-images.githubusercontent.com/4830259/112401254-5bb68180-8cc7-11eb-923c-15621f5e43f0.png)
![Screen Shot 2021-03-24 at 5 34 13 PM](https://user-images.githubusercontent.com/4830259/112401278-66711680-8cc7-11eb-9a43-bbe750563758.png)