### PR TITLE
feat(notifications): Add Reads to NotificationSettingsManager

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 python_version = 3.6
-files = src/sentry/snuba/query_subscription_consumer.py,
+files = src/sentry/notifications/*.py,
+        src/sentry/snuba/query_subscription_consumer.py,
         src/sentry/utils/kvstore
 
 ; Enable all options used with --strict

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -26,11 +26,11 @@ class UserNotificationsSerializer(Serializer):
             ).select_related("user")
         )
 
-        actor_mapping = {user.actor: user for user in item_list}
+        actor_mapping = {user.actor_id: user for user in item_list}
         notification_settings = NotificationSetting.objects._filter(
             ExternalProviders.EMAIL,
             scope_type=NotificationScopeType.USER,
-            targets=actor_mapping.keys(),
+            target_ids=actor_mapping.keys(),
         )
         data += map_notification_settings_to_legacy(notification_settings, actor_mapping)
 

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -13,8 +13,9 @@ from sentry.notifications.legacy_mappings import (
     USER_OPTION_SETTINGS,
     get_option_value_from_int,
     get_type_from_user_option_settings_key,
+    map_notification_settings_to_legacy,
 )
-from sentry.notifications.types import UserOptionsSettingsKey
+from sentry.notifications.types import NotificationScopeType, UserOptionsSettingsKey
 
 
 class UserNotificationsSerializer(Serializer):
@@ -25,11 +26,17 @@ class UserNotificationsSerializer(Serializer):
             ).select_related("user")
         )
 
-        results = defaultdict(list)
+        actor_mapping = {user.actor: user for user in item_list}
+        notification_settings = NotificationSetting.objects._filter(
+            ExternalProviders.EMAIL,
+            scope_type=NotificationScopeType.USER,
+            targets=actor_mapping.keys(),
+        )
+        data += map_notification_settings_to_legacy(notification_settings, actor_mapping)
 
+        results = defaultdict(list)
         for uo in data:
             results[uo.user].append(uo)
-
         return results
 
     def serialize(self, obj, attrs, user, *args, **kwargs):

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -32,13 +32,14 @@ class UserNotificationFineTuningEndpoint(UserEndpoint):
             )
 
         notifications = UserNotificationsSerializer()
-        serialized = serialize(
-            user,
-            request.user,
-            notifications,
-            notification_type=notification_type,
+        return Response(
+            serialize(
+                user,
+                request.user,
+                notifications,
+                notification_type=notification_type,
+            )
         )
-        return Response(serialized)
 
     def put(self, request, user, notification_type):
         """

--- a/src/sentry/api/serializers/models/user_notifications.py
+++ b/src/sentry/api/serializers/models/user_notifications.py
@@ -34,11 +34,11 @@ class UserNotificationsSerializer(Serializer):
         if not type:
             data = handle_legacy(notification_type, item_list)
         else:
-            actor_mapping = {user.actor: user for user in item_list}
+            actor_mapping = {user.actor_id: user for user in item_list}
             notifications_settings = NotificationSetting.objects._filter(
                 ExternalProviders.EMAIL,
                 get_type_from_fine_tuning_key(notification_type),
-                targets=actor_mapping.keys(),
+                target_ids=actor_mapping.keys(),
             ).exclude(scope_type=NotificationScopeType.USER.value)
             data = map_notification_settings_to_legacy(notifications_settings, actor_mapping)
 

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -2,7 +2,7 @@ from django.conf import settings
 from django.db import IntegrityError, models, transaction
 from django.db.models import Q
 from django.utils import timezone
-from typing import Mapping
+from typing import Any, Mapping
 
 from sentry.db.models import (
     BaseManager,
@@ -124,7 +124,7 @@ class GroupSubscriptionManager(BaseManager):
                     raise e
 
     @staticmethod
-    def get_participants(group) -> Mapping[any, GroupSubscriptionReason]:
+    def get_participants(group) -> Mapping[Any, GroupSubscriptionReason]:
         """
         Identify all users who are participating with a given issue.
         :param group: Group object

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -73,10 +73,10 @@ def transform_to_notification_settings_by_user(
     Given a unorganized list of notification settings, create a mapping of
     users to a map of notification scopes to setting values.
     """
-    actor_mapping = {user.actor: user for user in users}
+    actor_mapping = {user.actor_id: user for user in users}
     notification_settings_by_user = defaultdict(dict)
     for notification_setting in notification_settings:
-        user = actor_mapping.get(notification_setting.target)
+        user = actor_mapping.get(notification_setting.target_id)
         notification_settings_by_user[user][
             NotificationScopeType(notification_setting.scope_type)
         ] = NotificationSettingOptionValues(notification_setting.value)
@@ -142,9 +142,9 @@ def get_scope(
     raise Exception("scope must be either user, organization, or project")
 
 
-def get_target(user: Optional = None, team: Optional = None):
+def get_target_id(user: Optional = None, team: Optional = None) -> int:
     """ :returns the Actor object from a User or Team. """
     try:
-        return getattr((user or team), "actor")
+        return getattr((user or team), "actor_id")
     except AttributeError:
         raise Exception("target must be either a user or a team")

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -1,0 +1,154 @@
+from collections import defaultdict
+from typing import List, Mapping, Optional
+
+from sentry.models import (
+    Actor,
+    NotificationSetting,
+    Organization,
+    Project,
+    Team,
+    User,
+)
+from sentry.notifications.legacy_mappings import get_legacy_value
+from sentry.notifications.types import (
+    NotificationScopeType,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+)
+
+
+def should_user_be_notified(
+    notification_settings_by_user: Mapping[
+        User, Mapping[NotificationScopeType, NotificationSettingOptionValues]
+    ],
+    user: User,
+) -> bool:
+    """
+    Given a mapping of default and specific notification settings by user,
+    determine if a user should receive an ISSUE_ALERT notification.
+    """
+    specific_scope = get_scope_type(NotificationSettingTypes.ISSUE_ALERTS)
+    notification_setting_option = (
+        notification_settings_by_user.get(user)[specific_scope]
+        or notification_settings_by_user.get(user)[NotificationScopeType.USER]
+    )
+    value = getattr(
+        notification_setting_option,
+        "value",
+        NotificationSettingOptionValues.ALWAYS,
+    )
+
+    return value == NotificationSettingOptionValues.ALWAYS.value
+
+
+def should_be_participating(
+    user: User,
+    subscriptions_by_user_id: Mapping[int, any],
+    notification_settings_by_user: Mapping[
+        User, Mapping[NotificationScopeType, NotificationSettingOptionValues]
+    ],
+) -> bool:
+    """
+    Given a mapping of users to subscriptions and a mapping of default and
+    specific notification settings by user, determine if a user should receive
+    a WORKFLOW notification.
+    """
+    specific_scope = get_scope_type(NotificationSettingTypes.WORKFLOW)
+    notification_setting_option = (
+        notification_settings_by_user.get(user)[specific_scope]
+        or notification_settings_by_user.get(user)[NotificationScopeType.USER]
+    )
+    value = getattr(
+        notification_setting_option,
+        "value",
+        NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+    )
+    if value == NotificationSettingOptionValues.NEVER.value:
+        return False
+
+    if value == NotificationSettingOptionValues.ALWAYS.value:
+        return True
+
+    subscription = subscriptions_by_user_id.get(user.id)
+    return subscription and subscription.is_active
+
+
+def transform_to_notification_settings_by_user(
+    notification_settings: List[NotificationSetting],
+    users: List[User],
+) -> Mapping[User, Mapping[NotificationScopeType, NotificationSettingOptionValues]]:
+    """
+    Given a unorganized list of notification settings, create a mapping of
+    users to a map of notification scopes to setting values.
+    """
+    actor_mapping = {user.actor: user for user in users}
+    notification_settings_by_user = defaultdict(dict)
+    for notification_setting in notification_settings:
+        user = actor_mapping.get(notification_setting.target)
+        notification_settings_by_user.get(user)[
+            notification_setting.scope_type
+        ] = notification_setting.value
+    return notification_settings_by_user
+
+
+def transform_to_notification_settings_by_parent_id(
+    notification_settings: List[NotificationSetting],
+) -> (Mapping[int, NotificationSettingOptionValues], Optional[NotificationSettingOptionValues]):
+    """
+    Given a unorganized list of notification settings, create a mapping of
+    parents (projects or organizations) to setting values. Return this mapping
+    as a tuple with the user's parent-independent notification preference.
+    """
+    notification_settings_by_parent_id = defaultdict(dict)
+    notification_setting_user_default = None
+    for notification_setting in notification_settings:
+        if notification_setting.scope_type == NotificationScopeType.USER:
+            notification_setting_user_default = notification_setting.value
+        else:
+            key = notification_setting.scope_identifier
+            notification_settings_by_parent_id[key] = notification_setting.value
+    return notification_settings_by_parent_id, notification_setting_user_default
+
+
+def validate(type: NotificationSettingTypes, value: NotificationSettingOptionValues) -> bool:
+    """ :returns boolean. True if the "value" is valid for the "type". """
+    return get_legacy_value(type, value) is not None
+
+
+def get_scope_type(type: NotificationSettingTypes) -> NotificationScopeType:
+    """ In which scope (proj or org) can a user set more specific settings?"""
+    if type in [NotificationSettingTypes.DEPLOY]:
+        return NotificationScopeType.ORGANIZATION
+
+    if type in [NotificationSettingTypes.WORKFLOW, NotificationSettingTypes.ISSUE_ALERTS]:
+        return NotificationScopeType.PROJECT
+
+    raise Exception("type must be issue_alert, deploy, or workflow")
+
+
+def get_scope(
+    user_id: int, project: Optional[Project] = None, organization: Optional[Organization] = None
+) -> (NotificationScopeType, int):
+    """
+    Figure out the scope from parameters and return it as a tuple.
+    TODO(mgaeta): Make sure user_id is in the project or organization.
+    """
+
+    if project:
+        return NotificationScopeType.PROJECT, project.id
+
+    if organization:
+        return NotificationScopeType.ORGANIZATION, organization.id
+
+    if user_id:
+        return NotificationScopeType.USER, user_id
+
+    raise Exception("scope must be either user, organization, or project")
+
+
+def get_target(user: Optional[User] = None, team: Optional[Team] = None) -> Actor:
+    """ Get the actor from a User or Team. """
+    try:
+        return getattr((user or team), "actor")
+    except AttributeError:
+        raise Exception("target must be either a user or a team")

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Iterable, Mapping, Optional
+from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
 
 from sentry.notifications.legacy_mappings import get_legacy_value
 from sentry.notifications.types import (
@@ -9,35 +9,51 @@ from sentry.notifications.types import (
 )
 
 
+def _get_setting_value_from_mapping(
+    notification_settings_by_user: Mapping[
+        Any, Mapping[NotificationScopeType, NotificationSettingOptionValues]
+    ],
+    user: Any,
+    type: NotificationSettingTypes,
+    default: NotificationSettingOptionValues,
+) -> NotificationSettingOptionValues:
+    specific_scope = get_scope_type(type)
+    notification_settings_option = notification_settings_by_user.get(user)
+    if notification_settings_option:
+        notification_setting_option = notification_settings_option.get(
+            specific_scope
+        ) or notification_settings_option.get(NotificationScopeType.USER)
+        if notification_setting_option:
+            return notification_setting_option
+    return default
+
+
 def should_user_be_notified(
     notification_settings_by_user: Mapping[
-        any, Mapping[NotificationScopeType, NotificationSettingOptionValues]
+        Any, Mapping[NotificationScopeType, NotificationSettingOptionValues]
     ],
-    user,
+    user: Any,
 ) -> bool:
     """
     Given a mapping of default and specific notification settings by user,
     determine if a user should receive an ISSUE_ALERT notification.
     """
-    specific_scope = get_scope_type(NotificationSettingTypes.ISSUE_ALERTS)
-    notification_settings_option = notification_settings_by_user.get(user, {})
-    notification_setting_option = notification_settings_option.get(
-        specific_scope
-    ) or notification_settings_option.get(NotificationScopeType.USER)
-    value = getattr(
-        notification_setting_option,
-        "value",
-        NotificationSettingOptionValues.ALWAYS,
+    return (
+        _get_setting_value_from_mapping(
+            notification_settings_by_user,
+            user,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.ALWAYS,
+        )
+        == NotificationSettingOptionValues.ALWAYS
     )
-
-    return value == NotificationSettingOptionValues.ALWAYS
 
 
 def should_be_participating(
-    user,
-    subscriptions_by_user_id: Mapping[int, any],
+    user: Any,
+    subscriptions_by_user_id: Mapping[int, Any],
     notification_settings_by_user: Mapping[
-        any, Mapping[NotificationScopeType, NotificationSettingOptionValues]
+        Any, Mapping[NotificationScopeType, NotificationSettingOptionValues]
     ],
 ) -> bool:
     """
@@ -45,36 +61,35 @@ def should_be_participating(
     specific notification settings by user, determine if a user should receive
     a WORKFLOW notification.
     """
-    specific_scope = get_scope_type(NotificationSettingTypes.WORKFLOW)
-    notification_setting_option = (
-        notification_settings_by_user.get(user)[specific_scope]
-        or notification_settings_by_user.get(user)[NotificationScopeType.USER]
-    )
-    value = getattr(
-        notification_setting_option,
-        "value",
+    value = _get_setting_value_from_mapping(
+        notification_settings_by_user,
+        user,
+        NotificationSettingTypes.WORKFLOW,
         NotificationSettingOptionValues.SUBSCRIBE_ONLY,
     )
-    if value == NotificationSettingOptionValues.NEVER.value:
+
+    if value == NotificationSettingOptionValues.NEVER:
         return False
 
-    if value == NotificationSettingOptionValues.ALWAYS.value:
+    if value == NotificationSettingOptionValues.ALWAYS:
         return True
 
     subscription = subscriptions_by_user_id.get(user.id)
-    return subscription and subscription.is_active
+    return bool(subscription and subscription.is_active)
 
 
 def transform_to_notification_settings_by_user(
-    notification_settings: Iterable,
-    users: Iterable,
-) -> Mapping[any, Mapping[NotificationScopeType, NotificationSettingOptionValues]]:
+    notification_settings: Iterable[Any],
+    users: Iterable[Any],
+) -> Mapping[Any, Mapping[NotificationScopeType, NotificationSettingOptionValues]]:
     """
     Given a unorganized list of notification settings, create a mapping of
     users to a map of notification scopes to setting values.
     """
     actor_mapping = {user.actor_id: user for user in users}
-    notification_settings_by_user = defaultdict(dict)
+    notification_settings_by_user: Dict[
+        Any, Dict[NotificationScopeType, NotificationSettingOptionValues]
+    ] = defaultdict(dict)
     for notification_setting in notification_settings:
         user = actor_mapping.get(notification_setting.target_id)
         notification_settings_by_user[user][
@@ -84,22 +99,24 @@ def transform_to_notification_settings_by_user(
 
 
 def transform_to_notification_settings_by_parent_id(
-    notification_settings: Iterable,
-) -> (Mapping[int, NotificationSettingOptionValues], Optional[NotificationSettingOptionValues]):
+    notification_settings: Iterable[Any],
+) -> Tuple[
+    Mapping[int, NotificationSettingOptionValues], Optional[NotificationSettingOptionValues]
+]:
     """
     Given a unorganized list of notification settings, create a mapping of
     parents (projects or organizations) to setting values. Return this mapping
     as a tuple with the user's parent-independent notification preference.
     """
-    notification_settings_by_parent_id = defaultdict(dict)
+    notification_settings_by_parent_id = {}
     notification_setting_user_default = None
     for notification_setting in notification_settings:
-        if notification_setting.scope_type == NotificationScopeType.USER:
+        if notification_setting.scope_type == NotificationScopeType.USER.value:
             notification_setting_user_default = NotificationSettingOptionValues(
                 notification_setting.value
             )
         else:
-            key = notification_setting.scope_identifier
+            key = int(notification_setting.scope_identifier)
             notification_settings_by_parent_id[key] = NotificationSettingOptionValues(
                 notification_setting.value
             )
@@ -123,8 +140,8 @@ def get_scope_type(type: NotificationSettingTypes) -> NotificationScopeType:
 
 
 def get_scope(
-    user_id: int, project: Optional = None, organization: Optional = None
-) -> (NotificationScopeType, int):
+    user_id: int, project: Optional[Any] = None, organization: Optional[Any] = None
+) -> Tuple[NotificationScopeType, int]:
     """
     Figure out the scope from parameters and return it as a tuple.
     TODO(mgaeta): Make sure user_id is in the project or organization.
@@ -142,9 +159,11 @@ def get_scope(
     raise Exception("scope must be either user, organization, or project")
 
 
-def get_target_id(user: Optional = None, team: Optional = None) -> int:
-    """ :returns the Actor object from a User or Team. """
-    try:
-        return getattr((user or team), "actor_id")
-    except AttributeError:
-        raise Exception("target must be either a user or a team")
+def get_target_id(user: Optional[Any] = None, team: Optional[Any] = None) -> int:
+    """ :returns the actor ID from a User or Team. """
+    if user:
+        return int(user.actor_id)
+    if team:
+        return int(team.actor_id)
+
+    raise Exception("target must be either a user or a team")

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -1,14 +1,6 @@
 from collections import defaultdict
 from typing import List, Mapping, Optional
 
-from sentry.models import (
-    Actor,
-    NotificationSetting,
-    Organization,
-    Project,
-    Team,
-    User,
-)
 from sentry.notifications.legacy_mappings import get_legacy_value
 from sentry.notifications.types import (
     NotificationScopeType,
@@ -19,9 +11,9 @@ from sentry.notifications.types import (
 
 def should_user_be_notified(
     notification_settings_by_user: Mapping[
-        User, Mapping[NotificationScopeType, NotificationSettingOptionValues]
+        any, Mapping[NotificationScopeType, NotificationSettingOptionValues]
     ],
-    user: User,
+    user,
 ) -> bool:
     """
     Given a mapping of default and specific notification settings by user,
@@ -42,10 +34,10 @@ def should_user_be_notified(
 
 
 def should_be_participating(
-    user: User,
+    user,
     subscriptions_by_user_id: Mapping[int, any],
     notification_settings_by_user: Mapping[
-        User, Mapping[NotificationScopeType, NotificationSettingOptionValues]
+        any, Mapping[NotificationScopeType, NotificationSettingOptionValues]
     ],
 ) -> bool:
     """
@@ -74,9 +66,9 @@ def should_be_participating(
 
 
 def transform_to_notification_settings_by_user(
-    notification_settings: List[NotificationSetting],
-    users: List[User],
-) -> Mapping[User, Mapping[NotificationScopeType, NotificationSettingOptionValues]]:
+    notification_settings: List,
+    users: List,
+) -> Mapping[any, Mapping[NotificationScopeType, NotificationSettingOptionValues]]:
     """
     Given a unorganized list of notification settings, create a mapping of
     users to a map of notification scopes to setting values.
@@ -92,7 +84,7 @@ def transform_to_notification_settings_by_user(
 
 
 def transform_to_notification_settings_by_parent_id(
-    notification_settings: List[NotificationSetting],
+    notification_settings: List,
 ) -> (Mapping[int, NotificationSettingOptionValues], Optional[NotificationSettingOptionValues]):
     """
     Given a unorganized list of notification settings, create a mapping of
@@ -127,7 +119,7 @@ def get_scope_type(type: NotificationSettingTypes) -> NotificationScopeType:
 
 
 def get_scope(
-    user_id: int, project: Optional[Project] = None, organization: Optional[Organization] = None
+    user_id: int, project: Optional = None, organization: Optional = None
 ) -> (NotificationScopeType, int):
     """
     Figure out the scope from parameters and return it as a tuple.
@@ -146,8 +138,8 @@ def get_scope(
     raise Exception("scope must be either user, organization, or project")
 
 
-def get_target(user: Optional[User] = None, team: Optional[Team] = None) -> Actor:
-    """ Get the actor from a User or Team. """
+def get_target(user: Optional = None, team: Optional = None):
+    """ :returns the Actor object from a User or Team. """
     try:
         return getattr((user or team), "actor")
     except AttributeError:

--- a/src/sentry/notifications/legacy_mappings.py
+++ b/src/sentry/notifications/legacy_mappings.py
@@ -236,8 +236,8 @@ def get_parent_mappings(
         if notification_setting.scope_type == NotificationScopeType.ORGANIZATION.value:
             organization_ids.append(notification_setting.scope_identifier)
 
-    projects = Project.objects.get(id__in=project_ids)
-    organizations = Organization.objects.get(id__in=organization_ids)
+    projects = Project.objects.filter(id__in=project_ids)
+    organizations = Organization.objects.filter(id__in=organization_ids)
 
     project_mapping = {project.id: project for project in projects}
     organization_mapping = {organization.id: organization for organization in organizations}

--- a/src/sentry/notifications/legacy_mappings.py
+++ b/src/sentry/notifications/legacy_mappings.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from typing import Iterable, List, Mapping
+from typing import Any, Iterable, List, Mapping
 from sentry.notifications.types import (
     FineTuningAPIKey,
     NotificationScopeType,
@@ -186,7 +186,9 @@ def get_key_value_from_legacy(
     return type, option_value
 
 
-def get_legacy_from_notification_settings(notification_setting, actor_mapping: Mapping):
+def get_legacy_from_notification_settings(
+    notification_setting, actor_mapping: Mapping[int, Any]
+) -> LegacyUserOptionClone:
     """
     TODO(mgaeta): If getting projects and organizations is a bottleneck,
      prefetch them and pass them as a Mapping.
@@ -198,7 +200,7 @@ def get_legacy_from_notification_settings(notification_setting, actor_mapping: M
     data = {
         "key": key,
         "value": get_legacy_value(type, value),
-        "user": actor_mapping.get(notification_setting.target),
+        "user": actor_mapping.get(notification_setting.target_id),
         "project": None,
         "organization": None,
     }
@@ -216,7 +218,7 @@ def get_legacy_from_notification_settings(notification_setting, actor_mapping: M
 
 
 def map_notification_settings_to_legacy(
-    notification_settings: Iterable, actor_mapping: Mapping
+    notification_settings: Iterable, actor_mapping: Mapping[int, Any]
 ) -> List:
     """ A hack for legacy serializers. Pretend a list of NotificationSettings is a list of UserOptions. """
     return [

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -229,7 +229,7 @@ class NotificationsManager(BaseManager):
         type: Optional[NotificationSettingTypes] = None,
         scope_type: Optional[NotificationScopeType] = None,
         scope_identifier: Optional[int] = None,
-        targets: Optional[Iterable] = None,
+        targets: Optional[Iterable[any]] = None,
     ) -> QuerySet:
         """ Wrapper for .filter that translates types to actual attributes to column types. """
         filters = {}
@@ -258,17 +258,19 @@ class NotificationsManager(BaseManager):
             kwargs["key__in"] = KEYS_TO_LEGACY_KEYS.values()
         return kwargs
 
-    def remove_for_user(self, user, type: Optional[NotificationSettingTypes] = None) -> None:
+    def remove_for_user(self, user: any, type: Optional[NotificationSettingTypes] = None) -> None:
         """ Bulk delete all Notification Settings for a USER, optionally by type. """
         # We don't need a transaction because this is only used in tests.
         UserOption.objects.filter(**self._get_legacy_filters(type, user=user)).delete()
         self._filter(targets=[user.actor], type=type).delete()
 
-    def remove_for_team(self, team, type: Optional[NotificationSettingTypes] = None) -> None:
+    def remove_for_team(self, team: any, type: Optional[NotificationSettingTypes] = None) -> None:
         """ Bulk delete all Notification Settings for a TEAM, optionally by type. """
         self._filter(targets=[team.actor], type=type).delete()
 
-    def remove_for_project(self, project, type: Optional[NotificationSettingTypes] = None) -> None:
+    def remove_for_project(
+        self, project: any, type: Optional[NotificationSettingTypes] = None
+    ) -> None:
         """ Bulk delete all Notification Settings for a PROJECT, optionally by type. """
         UserOption.objects.filter(**self._get_legacy_filters(type, project=project)).delete()
         self._filter(
@@ -278,7 +280,7 @@ class NotificationsManager(BaseManager):
         ).delete()
 
     def remove_for_organization(
-        self, organization, type: Optional[NotificationSettingTypes] = None
+        self, organization: any, type: Optional[NotificationSettingTypes] = None
     ) -> None:
         """ Bulk delete all Notification Settings for an ENTIRE ORGANIZATION, optionally by type. """
         UserOption.objects.filter(

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -41,11 +41,11 @@ class NotificationsManager(BaseManager):
         self,
         provider: ExternalProviders,
         type: NotificationSettingTypes,
-        user=None,
-        team=None,
-        project=None,
-        organization=None,
-    ):
+        user: Optional[User] = None,
+        team: Optional[Team] = None,
+        project: Optional[Project] = None,
+        organization: Optional[Organization] = None,
+    ) -> NotificationSettingOptionValues:
         """
         In this temporary implementation, always read EMAIL settings from
         UserOptions. One and only one of (user, team, project, or organization)
@@ -69,11 +69,11 @@ class NotificationsManager(BaseManager):
         provider: ExternalProviders,
         type: NotificationSettingTypes,
         value: NotificationSettingOptionValues,
-        user=None,
-        team=None,
-        project=None,
-        organization=None,
-    ):
+        user: Optional[User] = None,
+        team: Optional[Team] = None,
+        project: Optional[Project] = None,
+        organization: Optional[Organization] = None,
+    ) -> None:
         """
         Save a target's notification preferences.
         Examples:
@@ -131,11 +131,11 @@ class NotificationsManager(BaseManager):
         self,
         provider: ExternalProviders,
         type: NotificationSettingTypes,
-        user=None,
-        team=None,
-        project=None,
-        organization=None,
-    ):
+        user: Optional[User] = None,
+        team: Optional[Team] = None,
+        project: Optional[Project] = None,
+        organization: Optional[Organization] = None,
+    ) -> None:
         """
         We don't anticipate this function will be used by the API but is useful
         for tests. This can also be called by `update_settings` when attempting

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -229,7 +229,7 @@ class NotificationsManager(BaseManager):
         type: Optional[NotificationSettingTypes] = None,
         scope_type: Optional[NotificationScopeType] = None,
         scope_identifier: Optional[int] = None,
-        targets: Optional[Iterable[any]] = None,
+        targets: Optional[Iterable] = None,
     ) -> QuerySet:
         """ Wrapper for .filter that translates types to actual attributes to column types. """
         filters = {}
@@ -258,19 +258,17 @@ class NotificationsManager(BaseManager):
             kwargs["key__in"] = KEYS_TO_LEGACY_KEYS.values()
         return kwargs
 
-    def remove_for_user(self, user: any, type: Optional[NotificationSettingTypes] = None) -> None:
+    def remove_for_user(self, user, type: Optional[NotificationSettingTypes] = None) -> None:
         """ Bulk delete all Notification Settings for a USER, optionally by type. """
         # We don't need a transaction because this is only used in tests.
         UserOption.objects.filter(**self._get_legacy_filters(type, user=user)).delete()
         self._filter(targets=[user.actor], type=type).delete()
 
-    def remove_for_team(self, team: any, type: Optional[NotificationSettingTypes] = None) -> None:
+    def remove_for_team(self, team, type: Optional[NotificationSettingTypes] = None) -> None:
         """ Bulk delete all Notification Settings for a TEAM, optionally by type. """
         self._filter(targets=[team.actor], type=type).delete()
 
-    def remove_for_project(
-        self, project: any, type: Optional[NotificationSettingTypes] = None
-    ) -> None:
+    def remove_for_project(self, project, type: Optional[NotificationSettingTypes] = None) -> None:
         """ Bulk delete all Notification Settings for a PROJECT, optionally by type. """
         UserOption.objects.filter(**self._get_legacy_filters(type, project=project)).delete()
         self._filter(
@@ -280,7 +278,7 @@ class NotificationsManager(BaseManager):
         ).delete()
 
     def remove_for_organization(
-        self, organization: any, type: Optional[NotificationSettingTypes] = None
+        self, organization, type: Optional[NotificationSettingTypes] = None
     ) -> None:
         """ Bulk delete all Notification Settings for an ENTIRE ORGANIZATION, optionally by type. """
         UserOption.objects.filter(

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -3,7 +3,6 @@ from django.db.models import Q, QuerySet
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 from sentry.db.models import BaseManager
-from sentry.models.actor import ACTOR_TYPES
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.helpers import (
     get_scope,

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -10,6 +10,7 @@ from sentry.notifications.helpers import (
     get_scope_type,
     get_target,
     should_user_be_notified,
+    transform_to_notification_settings_by_user,
     validate,
 )
 from sentry.notifications.types import (
@@ -44,7 +45,7 @@ class NotificationsManager(BaseManager):
         must not be null. This function automatically translates a missing DB
         row to NotificationSettingOptionValues.DEFAULT.
         """
-        from sentry.model import UserOption
+        from sentry.models import UserOption
 
         setting_option = self.find_settings(
             provider, type, user, team, project, organization
@@ -75,7 +76,7 @@ class NotificationsManager(BaseManager):
           * Updating a user's per-project preferences
           * Updating a user's per-organization preferences
         """
-        from sentry.model import UserOption
+        from sentry.models import UserOption
 
         # A missing DB row is equivalent to DEFAULT.
         if value == NotificationSettingOptionValues.DEFAULT:
@@ -137,7 +138,7 @@ class NotificationsManager(BaseManager):
         for tests. This can also be called by `update_settings` when attempting
         to set a notification preference to DEFAULT.
         """
-        from sentry.model import UserOption
+        from sentry.models import UserOption
 
         with transaction.atomic():
             self.find_settings(provider, type, user, team, project, organization).delete()
@@ -172,7 +173,7 @@ class NotificationsManager(BaseManager):
 
     @staticmethod
     def remove_legacy_option(type: Optional[NotificationSettingTypes] = None, **kwargs) -> None:
-        from sentry.model import UserOption
+        from sentry.models import UserOption
 
         if type:
             kwargs["key"] = get_legacy_key(type)
@@ -226,7 +227,7 @@ class NotificationsManager(BaseManager):
             user_id_option, project=project, organization=organization
         )
         target = get_target(user, team)
-        return self._filter(provider, type, scope_type, scope_identifier, target)
+        return self._filter(provider, type, scope_type, scope_identifier, [target])
 
     def get_for_user_by_projects(
         self,
@@ -272,12 +273,12 @@ class NotificationsManager(BaseManager):
                 scope_identifier=parent.id,
             )
             | Q(
-                scope_type=NotificationScopeType.USER,
+                scope_type=NotificationScopeType.USER.value,
                 scope_identifier__in=[user.id for user in users],
             ),
             provider=provider.value,
             type=type.value,
-            target__in=[user.actor for user in users],
+            target__in=[user.actor.id for user in users],
         )
 
     def filter_to_subscribed_users(
@@ -293,7 +294,7 @@ class NotificationsManager(BaseManager):
         notification_settings = self.get_for_users_by_parent(
             provider, NotificationSettingTypes.ISSUE_ALERTS, parent=project, users=users
         )
-        notification_settings_by_user = self.transform_to_notification_settings_by_user(
+        notification_settings_by_user = transform_to_notification_settings_by_user(
             notification_settings, users
         )
         return [
@@ -308,5 +309,8 @@ class NotificationsManager(BaseManager):
         dictionary. Finally, we traverse the set of users and return the ones
         that should get a notification.
         """
-        users = project.member_set.values_list("user", flat=True)
+        from sentry.models import User
+
+        user_ids = project.member_set.values_list("user", flat=True)
+        users = User.objects.filter(id__in=user_ids)
         return self.filter_to_subscribed_users(provider, project, users)

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -47,12 +47,13 @@ class NotificationsManager(BaseManager):
         """
         from sentry.models.useroption import UserOption
 
-        setting_option = self.find_settings(
-            provider, type, user, team, project, organization
-        ).first()
+        # The `unique_together` constraint should guarantee 0 or 1 rows, but
+        # using `list()` rather than `.first()` to prevent Django from adding an
+        # ordering that could make the query slow.
+        settings = list(self.find_settings(provider, type, user, team, project, organization))[:1]
         value = (
-            NotificationSettingOptionValues(setting_option.value)
-            if setting_option
+            NotificationSettingOptionValues(settings[0].value)
+            if settings
             else NotificationSettingOptionValues.DEFAULT
         )
 

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -2,7 +2,7 @@ from django.db import transaction
 from django.db.models import Q, QuerySet
 from typing import Any, Dict, Iterable, List, Optional, Union
 
-from sentry.db.models import BaseManager
+from sentry.db.models.manager import BaseManager
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.helpers import (
     get_scope,

--- a/src/sentry/notifications/notify.py
+++ b/src/sentry/notifications/notify.py
@@ -1,19 +1,15 @@
-from typing import Optional
+from typing import Any, Optional
 
 from sentry.models.integration import ExternalProviders
-from sentry.models import (
-    Team,
-    User,
-)
 from sentry.notifications.types import NotificationSettingTypes
 
 
 def notify(
     provider: ExternalProviders,
     type: NotificationSettingTypes,
-    user: Optional[User] = None,
-    team: Optional[Team] = None,
-    data: Optional[object] = None,
+    user: Optional[Any] = None,
+    team: Optional[Any] = None,
+    data: Optional[Any] = None,
 ) -> bool:
     """
     Something noteworthy has happened. Let the targets know about what

--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -7,47 +7,40 @@ from sentry.notifications.types import (
 from sentry.testutils import APITestCase
 
 
-class UserNotificationDetailsTest(APITestCase):
+class UserNotificationDetailsTestBase(APITestCase):
     endpoint = "sentry-api-0-user-notifications"
 
+    def setUp(self):
+        self.login_as(self.user)
+
+
+class UserNotificationDetailsGetTest(UserNotificationDetailsTestBase):
     def test_lookup_self(self):
-        user = self.create_user(email="a@example.com")
-
-        self.login_as(user=user)
-
         self.get_valid_response("me")
 
     def test_lookup_other_user(self):
-        user_a = self.create_user(email="a@example.com")
         user_b = self.create_user(email="b@example.com")
-
-        self.login_as(user=user_b)
-
-        self.get_valid_response(user_a.id, status_code=403)
+        self.get_valid_response(user_b.id, status_code=403)
 
     def test_superuser(self):
-        user = self.create_user(email="a@example.com")
         superuser = self.create_user(email="b@example.com", is_superuser=True)
 
         self.login_as(user=superuser, superuser=True)
 
-        self.get_valid_response(user.id)
+        self.get_valid_response(self.user.id)
 
     def test_returns_correct_defaults(self):
         """
         In this test we add existing per-project and per-organization
         Notification settings in order to test that defaults are correct.
         """
-        user = self.create_user(email="a@example.com")
-        org = self.create_organization(name="Org Name", owner=user)
-
         # default is 3
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
             NotificationSettingTypes.DEPLOY,
             NotificationSettingOptionValues.NEVER,
-            user=user,
-            organization=org,
+            user=self.user,
+            organization=self.organization,
         )
 
         # default is NotificationSettingOptionValues.COMMITTED_ONLY
@@ -55,11 +48,9 @@ class UserNotificationDetailsTest(APITestCase):
             ExternalProviders.EMAIL,
             NotificationSettingTypes.WORKFLOW,
             NotificationSettingOptionValues.ALWAYS,
-            user=user,
-            organization=org,
+            user=self.user,
+            organization=self.organization,
         )
-
-        self.login_as(user=user)
 
         response = self.get_valid_response("me")
 
@@ -69,16 +60,17 @@ class UserNotificationDetailsTest(APITestCase):
         assert response.data.get("subscribeByDefault") is True
         assert response.data.get("workflowNotifications") == 1
 
-    def test_saves_and_returns_values(self):
-        user = self.create_user(email="a@example.com")
-        self.login_as(user=user)
 
+class UserNotificationDetailsPutTest(UserNotificationDetailsTestBase):
+    method = "put"
+
+    def test_saves_and_returns_values(self):
         data = {
             "deployNotifications": 2,
             "personalActivityNotifications": True,
             "selfAssignOnResolve": True,
         }
-        response = self.get_valid_response("me", method="put", **data)
+        response = self.get_valid_response("me", **data)
 
         assert response.data.get("deployNotifications") == 2
         assert response.data.get("personalActivityNotifications") is True
@@ -86,50 +78,39 @@ class UserNotificationDetailsTest(APITestCase):
         assert response.data.get("subscribeByDefault") is True
         assert response.data.get("workflowNotifications") == 1
 
-        assert (
-            NotificationSetting.objects.get_settings(
-                ExternalProviders.EMAIL,
-                NotificationSettingTypes.DEPLOY,
-                user=user,
-            )
-            == "2"
+        value = NotificationSetting.objects.get_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.DEPLOY,
+            user=self.user,
         )
+        assert value == NotificationSettingOptionValues.ALWAYS
 
     def test_saves_and_returns_values_when_defaults_present(self):
-        user = self.create_user(email="a@example.com")
-        org = self.create_organization(name="Org Name", owner=user)
-        self.login_as(user=user)
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
             NotificationSettingTypes.DEPLOY,
             NotificationSettingOptionValues.NEVER,
-            user=user,
-            organization=org,
+            user=self.user,
+            organization=self.organization,
         )
 
-        response = self.get_valid_response("me", method="put", **{"deployNotifications": 2})
-
+        response = self.get_valid_response("me", **{"deployNotifications": 2})
         assert response.data.get("deployNotifications") == 2
-        assert (
-            NotificationSetting.objects.get_settings(
-                ExternalProviders.EMAIL,
-                NotificationSettingTypes.DEPLOY,
-                user=user,
-                organization=org,
-            )
-            == "4"
+
+        value1 = NotificationSetting.objects.get_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.DEPLOY,
+            user=self.user,
+            organization=self.organization,
         )
-        assert (
-            NotificationSetting.objects.get_settings(
-                ExternalProviders.EMAIL,
-                NotificationSettingTypes.DEPLOY,
-                user=user,
-            )
-            == "2"
+        value2 = NotificationSetting.objects.get_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.DEPLOY,
+            user=self.user,
         )
+
+        assert value1 == NotificationSettingOptionValues.NEVER
+        assert value2 == NotificationSettingOptionValues.ALWAYS
 
     def test_reject_invalid_values(self):
-        user = self.create_user(email="a@example.com")
-        self.login_as(user=user)
-
-        self.get_valid_response("me", method="put", status_code=400, **{"deployNotifications": 6})
+        self.get_valid_response("me", status_code=400, **{"deployNotifications": 6})

--- a/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
+++ b/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
@@ -11,24 +11,23 @@ from sentry.notifications.types import (
 from sentry.testutils import APITestCase
 
 
-class UserNotificationFineTuningTest(APITestCase):
+class UserNotificationFineTuningTestBase(APITestCase):
     endpoint = "sentry-api-0-user-notifications-fine-tuning"
 
     def setUp(self):
-        self.user = self.create_user(email="a@example.com")
-        self.org = self.create_organization(name="Org Name", owner=self.user)
-        self.org2 = self.create_organization(name="Another Org", owner=self.user)
-        self.team = self.create_team(name="Team Name", organization=self.org, members=[self.user])
-        self.project = self.create_project(
-            organization=self.org, teams=[self.team], name="Project Name"
-        )
-
+        self.organization2 = self.create_organization(name="Another Org", owner=self.user)
         self.project2 = self.create_project(
-            organization=self.org, teams=[self.team], name="Another Name"
+            organization=self.organization, teams=[self.team], name="Another Name"
         )
 
         self.login_as(user=self.user)
 
+    def test_invalid_notification_type(self):
+        """ This is run twice because of inheritance. """
+        self.get_valid_response("me", "invalid", status_code=404)
+
+
+class UserNotificationFineTuningGetTest(UserNotificationFineTuningTestBase):
     def test_returns_correct_defaults(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -45,249 +44,200 @@ class UserNotificationFineTuningTest(APITestCase):
             NotificationSettingTypes.DEPLOY,
             NotificationSettingOptionValues.ALWAYS,
             user=self.user,
-            organization=self.org,
+            organization=self.organization,
         )
         response = self.get_valid_response("me", "deploy")
-        assert response.data.get(self.org.id) == "2"
+        assert response.data.get(self.organization.id) == "2"
 
         UserOption.objects.create(
             user=self.user,
             organization=None,
             key="reports:disabled-organizations",
-            value=[self.org.id],
+            value=[self.organization.id],
         )
         response = self.get_valid_response("me", "reports")
-        assert response.data.get(self.org.id) == "0"
+        assert response.data.get(self.organization.id) == "0"
 
-    def test_invalid_notification_type(self):
-        self.get_valid_response("me", "invalid", status_code=404)
-        self.get_valid_response("me", "invalid", method="put", status_code=404)
+
+class UserNotificationFineTuningTest(UserNotificationFineTuningTestBase):
+    method = "put"
 
     def test_update_invalid_project(self):
-        self.get_valid_response("me", "alerts", method="put", status_code=403, **{"123": 1})
+        self.get_valid_response("me", "alerts", status_code=403, **{"123": 1})
 
     def test_invalid_id_value(self):
-        self.get_valid_response("me", "alerts", method="put", status_code=400, **{"nope": 1})
+        self.get_valid_response("me", "alerts", status_code=400, **{"nope": 1})
 
     def test_saves_and_returns_alerts(self):
-        self.get_valid_response(
-            "me",
-            "alerts",
-            method="put",
-            status_code=204,
-            **{str(self.project.id): 1, str(self.project2.id): 0},
+        data = {str(self.project.id): 1, str(self.project2.id): 0}
+        self.get_valid_response("me", "alerts", status_code=204, **data)
+
+        value1 = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.ISSUE_ALERTS,
+            user=self.user,
+            project=self.project,
         )
 
-        assert (
-            NotificationSetting.objects.get_settings(
-                provider=ExternalProviders.EMAIL,
-                type=NotificationSettingTypes.ISSUE_ALERTS,
-                user=self.user,
-                project=self.project,
-            )
-            == 1
+        value2 = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.ISSUE_ALERTS,
+            user=self.user,
+            project=self.project2,
         )
 
-        assert (
-            NotificationSetting.objects.get_settings(
-                provider=ExternalProviders.EMAIL,
-                type=NotificationSettingTypes.ISSUE_ALERTS,
-                user=self.user,
-                project=self.project2,
-            )
-            == 0
-        )
+        assert value1 == NotificationSettingOptionValues.ALWAYS
+        assert value2 == NotificationSettingOptionValues.NEVER
 
         # Can return to default
-        self.get_valid_response(
-            "me", "alerts", method="put", status_code=204, **{str(self.project.id): -1}
+        data = {str(self.project.id): -1}
+        self.get_valid_response("me", "alerts", status_code=204, **data)
+
+        value1 = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.ISSUE_ALERTS,
+            user=self.user,
+            project=self.project,
+        )
+        value2 = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.ISSUE_ALERTS,
+            user=self.user,
+            project=self.project2,
         )
 
-        assert (
-            NotificationSetting.objects.get_settings(
-                provider=ExternalProviders.EMAIL,
-                type=NotificationSettingTypes.ISSUE_ALERTS,
-                user=self.user,
-                project=self.project,
-            )
-            is None
-        )
-
-        assert (
-            NotificationSetting.objects.get_settings(
-                provider=ExternalProviders.EMAIL,
-                type=NotificationSettingTypes.ISSUE_ALERTS,
-                user=self.user,
-                project=self.project2,
-            )
-            == 0
-        )
+        assert value1 == NotificationSettingOptionValues.DEFAULT
+        assert value2 == NotificationSettingOptionValues.NEVER
 
     def test_saves_and_returns_workflow(self):
-        self.get_valid_response(
-            "me",
-            "workflow",
-            method="put",
-            status_code=204,
-            **{str(self.project.id): 1, str(self.project2.id): 2},
+        data = {str(self.project.id): 1, str(self.project2.id): 2}
+        self.get_valid_response("me", "workflow", status_code=204, **data)
+
+        value = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.WORKFLOW,
+            user=self.user,
+            project=self.project,
+        )
+        value2 = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.WORKFLOW,
+            user=self.user,
+            project=self.project2,
         )
 
-        assert (
-            NotificationSetting.objects.get_settings(
-                provider=ExternalProviders.EMAIL,
-                type=NotificationSettingTypes.WORKFLOW,
-                user=self.user,
-                project=self.project,
-            )
-            == "1"
-        )
-
-        assert (
-            NotificationSetting.objects.get_settings(
-                provider=ExternalProviders.EMAIL,
-                type=NotificationSettingTypes.WORKFLOW,
-                user=self.user,
-                project=self.project2,
-            )
-            == "2"
-        )
+        assert value == NotificationSettingOptionValues.SUBSCRIBE_ONLY
+        assert value2 == NotificationSettingOptionValues.NEVER
 
         # Can return to default
-        self.get_valid_response(
-            "me", "workflow", method="put", status_code=204, **{str(self.project.id): -1}
+        data = {str(self.project.id): -1}
+        self.get_valid_response("me", "workflow", status_code=204, **data)
+
+        value1 = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.WORKFLOW,
+            user=self.user,
+            project=self.project,
+        )
+        value2 = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.WORKFLOW,
+            user=self.user,
+            project=self.project2,
         )
 
-        assert (
-            NotificationSetting.objects.get_settings(
-                provider=ExternalProviders.EMAIL,
-                type=NotificationSettingTypes.WORKFLOW,
-                user=self.user,
-                project=self.project,
-            )
-            is None
-        )
-
-        assert (
-            NotificationSetting.objects.get_settings(
-                provider=ExternalProviders.EMAIL,
-                type=NotificationSettingTypes.WORKFLOW,
-                user=self.user,
-                project=self.project2,
-            )
-            == "2"
-        )
+        assert value1 == NotificationSettingOptionValues.DEFAULT
+        assert value2 == NotificationSettingOptionValues.NEVER
 
     def test_saves_and_returns_email_routing(self):
         UserEmail.objects.create(user=self.user, email="alias@example.com", is_verified=True).save()
+        email = self.user.email
 
-        data = {str(self.project.id): "a@example.com", str(self.project2.id): "alias@example.com"}
-        self.get_valid_response("me", "email", method="put", status_code=204, **data)
+        data = {str(self.project.id): email, str(self.project2.id): "alias@example.com"}
+        self.get_valid_response("me", "email", status_code=204, **data)
 
-        assert (
-            UserOption.objects.get(user=self.user, project=self.project, key="mail:email").value
-            == "a@example.com"
-        )
+        value1 = UserOption.objects.get(
+            user=self.user, project=self.project, key="mail:email"
+        ).value
+        value2 = UserOption.objects.get(
+            user=self.user, project=self.project2, key="mail:email"
+        ).value
 
-        assert (
-            UserOption.objects.get(user=self.user, project=self.project2, key="mail:email").value
-            == "alias@example.com"
-        )
+        assert value1 == email
+        assert value2 == "alias@example.com"
 
     def test_email_routing_emails_must_be_verified(self):
         UserEmail.objects.create(
             user=self.user, email="alias@example.com", is_verified=False
         ).save()
 
-        self.get_valid_response(
-            "me",
-            "email",
-            method="put",
-            status_code=400,
-            **{str(self.project.id): "alias@example.com"},
-        )
+        data = {str(self.project.id): "alias@example.com"}
+        self.get_valid_response("me", "email", status_code=400, **data)
 
     def test_email_routing_emails_must_be_valid(self):
         new_user = self.create_user(email="b@example.com")
         UserEmail.objects.create(user=new_user, email="alias2@example.com", is_verified=True).save()
 
-        self.get_valid_response(
-            "me",
-            "email",
-            method="put",
-            status_code=400,
-            **{str(self.project2.id): "alias2@example.com"},
-        )
+        data = {str(self.project2.id): "alias2@example.com"}
+        self.get_valid_response("me", "email", status_code=400, **data)
 
     def test_saves_and_returns_deploy(self):
-        self.get_valid_response(
-            "me", "deploy", method="put", status_code=204, **{str(self.org.id): 4}
-        )
+        data = {str(self.organization.id): 4}
+        self.get_valid_response("me", "deploy", status_code=204, **data)
 
-        assert (
-            NotificationSetting.objects.get_settings(
-                provider=ExternalProviders.EMAIL,
-                type=NotificationSettingTypes.DEPLOY,
-                user=self.user,
-                organization=self.org,
-            )
-            == "4"
+        value = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.DEPLOY,
+            user=self.user,
+            organization=self.organization,
         )
+        assert value == NotificationSettingOptionValues.NEVER
 
-        self.get_valid_response(
-            "me", "deploy", method="put", status_code=204, **{str(self.org.id): 2}
-        )
-        assert (
-            NotificationSetting.objects.get_settings(
-                provider=ExternalProviders.EMAIL,
-                type=NotificationSettingTypes.DEPLOY,
-                user=self.user,
-                organization=self.org,
-            )
-            == "2"
-        )
+        data = {str(self.organization.id): 2}
+        self.get_valid_response("me", "deploy", status_code=204, **data)
 
-        self.get_valid_response(
-            "me", "deploy", method="put", status_code=204, **{str(self.org.id): -1}
+        value = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.DEPLOY,
+            user=self.user,
+            organization=self.organization,
         )
-        assert not UserOption.objects.filter(
-            user=self.user, organization=self.org, key="deploy-emails"
-        ).exists()
+        assert value == NotificationSettingOptionValues.ALWAYS
+
+        data = {str(self.organization.id): -1}
+        self.get_valid_response("me", "deploy", status_code=204, **data)
+
+        value = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.DEPLOY,
+            user=self.user,
+            organization=self.organization,
+        )
+        assert value == NotificationSettingOptionValues.DEFAULT
 
     def test_saves_and_returns_weekly_reports(self):
-        self.get_valid_response(
-            "me",
-            "reports",
-            method="put",
-            status_code=204,
-            **{str(self.org.id): 0, str(self.org2.id): "0"},
-        )
+        data = {str(self.organization.id): 0, str(self.organization2.id): "0"}
+        self.get_valid_response("me", "reports", status_code=204, **data)
 
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
-        ) == {self.org.id, self.org2.id}
+        ) == {self.organization.id, self.organization2.id}
 
-        self.get_valid_response(
-            "me", "reports", method="put", status_code=204, **{str(self.org.id): 1}
-        )
+        data = {str(self.organization.id): 1}
+        self.get_valid_response("me", "reports", status_code=204, **data)
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
-        ) == {self.org2.id}
+        ) == {self.organization2.id}
 
-        self.get_valid_response(
-            "me", "reports", method="put", status_code=204, **{str(self.org.id): 0}
-        )
+        data = {str(self.organization.id): 0}
+        self.get_valid_response("me", "reports", status_code=204, **data)
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
-        ) == {self.org.id, self.org2.id}
+        ) == {self.organization.id, self.organization2.id}
 
     def test_enable_weekly_reports_from_default_setting(self):
-        self.get_valid_response(
-            "me",
-            "reports",
-            method="put",
-            status_code=204,
-            **{str(self.org.id): 1, str(self.org2.id): "1"},
-        )
+        data = {str(self.organization.id): 1, str(self.organization2.id): "1"}
+        self.get_valid_response("me", "reports", status_code=204, **data)
 
         assert (
             set(UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value)
@@ -295,17 +245,15 @@ class UserNotificationFineTuningTest(APITestCase):
         )
 
         # can disable
-        self.get_valid_response(
-            "me", "reports", method="put", status_code=204, **{str(self.org.id): 0}
-        )
+        data = {str(self.organization.id): 0}
+        self.get_valid_response("me", "reports", status_code=204, **data)
         assert set(
             UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value
-        ) == {self.org.id}
+        ) == {self.organization.id}
 
         # re-enable
-        self.get_valid_response(
-            "me", "reports", method="put", status_code=204, **{str(self.org.id): 1}
-        )
+        data = {str(self.organization.id): 1}
+        self.get_valid_response("me", "reports", status_code=204, **data)
         assert (
             set(UserOption.objects.get(user=self.user, key="reports:disabled-organizations").value)
             == set()
@@ -319,24 +267,20 @@ class UserNotificationFineTuningTest(APITestCase):
             organization=new_org, teams=[new_team], name="New Project"
         )
 
-        self.get_valid_response(
-            "me", "reports", method="put", status_code=403, **{str(new_org.id): 0}
-        )
+        data = {str(new_org.id): 0}
+        self.get_valid_response("me", "reports", status_code=403, **data)
 
         assert not UserOption.objects.filter(
             user=self.user, organization=new_org, key="reports"
         ).exists()
 
-        self.get_valid_response(
-            "me", "alerts", method="put", status_code=403, **{str(new_project.id): 1}
-        )
+        data = {str(new_project.id): 1}
+        self.get_valid_response("me", "alerts", status_code=403, **data)
 
-        assert (
-            NotificationSetting.objects.get_settings(
-                ExternalProviders.EMAIL,
-                NotificationSettingTypes.ISSUE_ALERTS,
-                user=self.user,
-                project=new_project,
-            )
-            is None
+        value = NotificationSetting.objects.get_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            user=self.user,
+            project=new_project,
         )
+        assert value == NotificationSettingOptionValues.DEFAULT

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -13,10 +13,6 @@ from sentry.notifications.types import (
 from sentry.testutils import TestCase
 
 
-def clear_workflow_options(user):
-    NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
-
-
 class SubscribeTest(TestCase):
     def test_simple(self):
         group = self.create_group()
@@ -180,7 +176,7 @@ class GetParticipantsTest(TestCase):
                 project=project,
             )
 
-        clear_workflow_options(user)
+        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
 
         # Implicit subscription, ensure the project setting overrides the
         # explicit global option.
@@ -203,7 +199,7 @@ class GetParticipantsTest(TestCase):
                 project=project,
             )
 
-        clear_workflow_options(user)
+        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
 
         # Explicit subscription, overridden by the global option.
 
@@ -225,7 +221,7 @@ class GetParticipantsTest(TestCase):
                 user=user,
             )
 
-        clear_workflow_options(user)
+        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
 
         # Explicit subscription, overridden by the project option.
 
@@ -247,7 +243,7 @@ class GetParticipantsTest(TestCase):
                 project=project,
             )
 
-        clear_workflow_options(user)
+        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
 
         # Explicit subscription, overridden by the project option which also
         # overrides the default option.
@@ -293,7 +289,7 @@ class GetParticipantsTest(TestCase):
                 project=project,
             )
 
-        clear_workflow_options(user)
+        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
 
         # Implicit subscription, ensure the project setting overrides the
         # explicit global option.
@@ -316,7 +312,7 @@ class GetParticipantsTest(TestCase):
                 project=project,
             )
 
-        clear_workflow_options(user)
+        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
 
         # Ensure the global default is applied.
 
@@ -339,7 +335,7 @@ class GetParticipantsTest(TestCase):
             )
 
         subscription.delete()
-        clear_workflow_options(user)
+        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
 
         # Ensure the project setting overrides the global default.
 
@@ -363,7 +359,7 @@ class GetParticipantsTest(TestCase):
             )
 
         subscription.delete()
-        clear_workflow_options(user)
+        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
 
         # Ensure the project setting overrides the global setting.
 
@@ -394,7 +390,7 @@ class GetParticipantsTest(TestCase):
             )
 
         subscription.delete()
-        clear_workflow_options(user)
+        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
 
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -1,17 +1,16 @@
 import pytest
 import zipfile
-from sentry.utils.compat.mock import patch
-
-from io import BytesIO
 
 from django.core.urlresolvers import reverse
 from django.core.files.uploadedfile import SimpleUploadedFile
+from io import BytesIO
 
 from sentry import eventstore
+from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
+from sentry.models import EventAttachment, File
+from sentry.utils.compat.mock import patch
 from sentry.testutils import TransactionTestCase, RelayStoreHelper
 from sentry.testutils.helpers.task_runner import BurstTaskRunner
-from sentry.models import EventAttachment, File
-from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 
 from tests.symbolicator import get_fixture_path, insta_snapshot_stacktrace_data
 


### PR DESCRIPTION
This PR adds new functions for reading values from the new NotificationSetting table. Until now the NotificationsSettings manager only implemented methods to write and delete values.

These new functions make it easier to query for lists of NotificationSettings:
- `get_settings`
- `get_for_user_by_projects`
- `get_for_users_by_parent`

These functions interpret the DB to get a list of users that have opted into getting notifications:
- `filter_to_subscribed_users`
- `get_notification_recipients`

And these functions manipulate lists of NotificationsSettings to answers questions about user preferences:
- `should_be_participating`
- `should_user_be_notified`
- `transform_to_notification_settings_by_parent_id`
- `transform_to_notification_settings_by_user`

