### PR TITLE
rfc: Use `django-manifest-loader` for static assets

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -59,11 +59,15 @@ jobs:
           name: jest-html
           path: .artifacts/visual-snapshots/jest
 
+      - name: Get CSS filename
+        id: css-manifest
+        run: echo "::set-output name=sentrycss::$(jq '.[\"sentry.css\"]' static/dist/manifest.json)"
+
       - name: Create Images from HTML
         uses: getsentry/action-html-to-image@main
         with:
           base-path: .artifacts/visual-snapshots/jest
-          css-path: src/sentry/static/sentry/dist/sentry.css
+          css-path: src/sentry/static/sentry/dist/${{ steps.css-manifest.outputs.sentrycss }}
 
       - name: Save snapshots
         if: always()

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Get CSS filename
         id: css-manifest
-        run: echo "::set-output name=sentrycss::$(jq '.[\"sentry.css\"]' static/dist/manifest.json)"
+        run: echo "::set-output name=sentrycss::$(jq '.["sentry.css"]' static/dist/manifest.json)"
 
       - name: Create Images from HTML
         uses: getsentry/action-html-to-image@main

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Get CSS filename
         id: css-manifest
-        run: echo "::set-output name=sentrycss::$(jq '.["sentry.css"]' static/dist/manifest.json)"
+        run: echo "::set-output name=sentrycss::$(jq -r '.["sentry.css"]' static/dist/manifest.json)"
 
       - name: Create Images from HTML
         uses: getsentry/action-html-to-image@main

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,10 @@
 import os
 import sys
 
+dist_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "src", "sentry", "static", "sentry", "dist")
+)
+manifest_path = os.path.join(dist_path, "manifest.json")
 pytest_plugins = ["sentry.utils.pytest"]
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
@@ -12,3 +16,19 @@ def pytest_configure(config):
     # XXX(dcramer): Kombu throws a warning due to transaction.commit_manually
     # being used
     warnings.filterwarnings("error", "", Warning, r"^(?!(|kombu|raven|sentry))")
+
+    # Create an empty webpack manifest file - otherwise tests will crash if it does not exist
+    os.makedirs(dist_path, exist_ok=True)
+
+    # Only create manifest if it doesn't exist
+    # (e.g. acceptance tests will have an actual manifest from webpack)
+    if os.path.exists(manifest_path):
+        return
+
+    with open(manifest_path, "w+") as fp:
+        fp.write("{}")
+
+
+def pytest_unconfigure():
+    # Clean up manifest file
+    os.remove(manifest_path)

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "webpack": "5.27.2",
     "webpack-cli": "4.5.0",
     "webpack-remove-empty-scripts": "^0.7.1",
+    "webpack-manifest-plugin": "^3.1.0",
     "wink-jaro-distance": "^2.0.0",
     "zxcvbn": "^4.4.2"
   },

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -8,6 +8,7 @@ confluent-kafka==1.6.0; python_version == '3.9'
 croniter==0.3.34
 datadog==0.29.3
 django-crispy-forms==1.7.2
+django-manifest-loader==1.0.0
 django-picklefield==1.0.0
 django-sudo==3.1.0
 Django==1.11.29

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -330,6 +330,7 @@ INSTALLED_APPS = (
     "django.contrib.sites",
     "crispy_forms",
     "rest_framework",
+    "manifest_loader",
     "sentry",
     "sentry.analytics",
     "sentry.incidents.apps.Config",
@@ -366,7 +367,16 @@ SILENCED_SYSTEM_CHECKS = (
 )
 
 STATIC_ROOT = os.path.realpath(os.path.join(PROJECT_ROOT, "static"))
-STATIC_URL = "/_static/{version}/"
+STATIC_URL = "/_static/"
+
+
+# The webpack output directory, used by django-manifest-loader
+STATICFILES_DIRS = [
+    os.path.join(STATIC_ROOT, "sentry", "dist"),
+]
+
+# django-manifest-loader settings
+MANIFEST_LOADER = {"cache": True}
 
 # various middleware will use this to identify resources which should not access
 # cookies

--- a/src/sentry/static/sentry/app/utils/statics-setup.tsx
+++ b/src/sentry/static/sentry/app/utils/statics-setup.tsx
@@ -4,9 +4,14 @@
 declare var __webpack_public_path__: string;
 
 /**
- * Set the webpack public path at runtime. This is necessary so that imports can be resolved properly
+ * Set the webpack public path at runtime. This is necessary so that imports
+ * can be resolved properly
  *
  * NOTE: This MUST be loaded before any other app modules in the entrypoint.
+ *
+ * This may not be as necessary without versioned asset URLs. (Rather, instead of a version directory
+ * that is generated on backend, frontend assets will be "versioned" by webpack with a content hash in
+ * its filename). This means that the public path does not need to be piped from the backend.
  *
  * XXX(epurkhiser): Currently we only boot with hydration in experimental SPA
  * mode, where assets are *currently not versioned*. We hardcode `/_assets/` here

--- a/src/sentry/templates/sentry/base-react.html
+++ b/src/sentry/templates/sentry/base-react.html
@@ -9,7 +9,7 @@
       <div class="loading-mask"></div>
 
       <div class="loading-indicator">
-        <img src="{% asset_url 'sentry' 'images/sentry-loader.svg' %}" />
+        <img src="{% manifest_asset_url 'sentry' 'images/sentry-loader.svg' %}" />
       </div>
 
       <div class="loading-message">

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -4,6 +4,7 @@
 {% load sentry_features %}
 {% load sentry_helpers %}
 {% load sentry_react %}
+{% load manifest %}
 
 {% load sentry_status %}
 {% get_sentry_version %}
@@ -25,7 +26,7 @@
 
   <link rel="mask-icon" sizes="any" href="{% absolute_asset_url "sentry" "images/logos/logo-sentry.svg" %}" color="#FB4226">
 
-  <link href="{% asset_url "sentry" "dist/sentry.css" %}" rel="stylesheet"/>
+  <link href="{% manifest_asset_url "sentry" "sentry.css" %}" rel="stylesheet"/>
 
   {% block css %}{% endblock %}
 
@@ -45,11 +46,14 @@
 
   {% block scripts %}
   {% locale_js_include %}
-  {% asset_url "sentry" "dist/vendor.js" as asset_url %}
+  {% manifest_asset_url "sentry" "runtime.js" as asset_url %}
+  {% script src=asset_url %}{% endscript %}
+
+  {% manifest_asset_url "sentry" "vendor.js" as asset_url %}
   {% script src=asset_url %}{% endscript %}
 
   {% block scripts_main_entrypoint %}
-    {% asset_url "sentry" "dist/app.js" as asset_url %}
+    {% manifest_asset_url "sentry" "app.js" as asset_url %}
     {% script src=asset_url data-entry="true" %}{% endscript %}
   {% endblock %}
 

--- a/src/sentry/templatetags/sentry_assets.py
+++ b/src/sentry/templatetags/sentry_assets.py
@@ -6,12 +6,13 @@ from django.template.base import token_kwargs
 from django.utils.safestring import mark_safe
 
 from sentry import options
-from sentry.utils.assets import get_asset_url
+from sentry.utils.assets import get_asset_url, get_manifest_url
 from sentry.utils.http import absolute_uri
 
 register = template.Library()
 
 register.simple_tag(get_asset_url, name="asset_url")
+register.simple_tag(get_manifest_url, name="manifest_asset_url")
 
 
 @register.simple_tag
@@ -61,7 +62,7 @@ def locale_js_include(context):
     if hasattr(request, "csp_nonce"):
         nonce = f' nonce="{request.csp_nonce}"'
 
-    href = get_asset_url("sentry", "dist/locale/" + lang_code + ".js")
+    href = get_manifest_url("sentry", "locale/" + lang_code + ".js")
     return mark_safe(f'<script src="{href}"{crossorigin()}{nonce}></script>')
 
 

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -108,6 +108,38 @@ class BaseTestCase(Fixtures, Exam):
 
     @classmethod
     @contextmanager
+    def static_asset_manifest(cls, manifest_data):
+        dist_path = "src/sentry/static/sentry/dist"
+        manifest_path = f"{dist_path}/manifest.json"
+
+        with open(manifest_path, "w") as manifest_fp:
+            manifest_fp.truncate(0)
+            json.dump(manifest_data, manifest_fp)
+
+        files = []
+        for file_path in manifest_data.values():
+            full_path = f"{dist_path}/{file_path}"
+            # make directories in case they don't exist
+            # (e.g. dist path should exist, but subdirs won't)
+            os.makedirs(os.path.dirname(full_path), exist_ok=True)
+            open(full_path, "a").close()
+            files.append(full_path)
+
+        try:
+            yield {"manifest": manifest_data, "files": files}
+        finally:
+            with open(manifest_path, "w") as manifest_fp:
+                # Instead of unlinking, preserve an empty manifest file so that other tests that
+                # may or may not load static assets, do not fail
+                manifest_fp.truncate(0)
+                manifest_fp.write("{}")
+
+            # Remove any files created from the test manifest
+            for filepath in files:
+                os.unlink(filepath)
+
+    @classmethod
+    @contextmanager
     def capture_on_commit_callbacks(cls, using=DEFAULT_DB_ALIAS, execute=False):
         """
         Context manager to capture transaction.on_commit() callbacks.

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-
 from manifest_loader.utils import _get_manifest, _load_from_manifest
 
 

--- a/src/sentry/utils/assets.py
+++ b/src/sentry/utils/assets.py
@@ -1,5 +1,31 @@
 from django.conf import settings
 
+from manifest_loader.utils import _get_manifest, _load_from_manifest
+
+
+def get_manifest_obj():
+    """
+    Returns the webpack asset manifest as a dict of <file key, hashed file name>
+
+    The `manifest_loader` library caches this (if `cache` settings is set)
+    """
+    return _get_manifest()
+
+
+def get_manifest_url(module, key):
+    """
+    Returns an asset URL that is produced by webpack. Uses webpack's manifest to map
+    `key` to the asset produced by webpack. Required if using file contents based hashing for filenames.
+
+    Example:
+      {% manifest_asset_url 'sentry' 'sentry.css' %}
+      =>  "/_static/sentry/dist/sentry.filehash123.css"
+    """
+    manifest_obj = get_manifest_obj()
+    manifest_value = _load_from_manifest(manifest_obj, key=key)
+
+    return "{}/{}/dist/{}".format(settings.STATIC_URL.rstrip("/"), module, manifest_value)
+
 
 def get_asset_url(module, path):
     """

--- a/src/sentry/web/frontend/generic.py
+++ b/src/sentry/web/frontend/generic.py
@@ -33,13 +33,29 @@ def resolve(path):
     return os.path.split(absolute_path)
 
 
+def static_media_with_manifest(request, **kwargs):
+    """
+    Serve static files that are generated with webpack.
+
+    Only these assets should have a long TTL as its filename has a hash based on file contents
+    """
+    path = kwargs.get("path", "")
+
+    kwargs["path"] = f"dist/{path}"
+    response = static_media(request, **kwargs)
+
+    if not settings.DEBUG:
+        response["Cache-Control"] = FOREVER_CACHE
+
+    return response
+
+
 def static_media(request, **kwargs):
     """
     Serve static files below a given point in the directory structure.
     """
     module = kwargs.get("module")
     path = kwargs.get("path", "")
-    version = kwargs.get("version")
 
     if module:
         path = f"{module}/{path}"
@@ -77,11 +93,7 @@ def static_media(request, **kwargs):
     if path.endswith((".js", ".ttf", ".ttc", ".otf", ".eot", ".woff", ".woff2")):
         response["Access-Control-Allow-Origin"] = "*"
 
-    # If we have a version and not DEBUG, we can cache it FOREVER
-    if version is not None and not settings.DEBUG:
-        response["Cache-Control"] = FOREVER_CACHE
-    else:
-        # Otherwise, we explicitly don't want to cache at all
-        response["Cache-Control"] = NEVER_CACHE
+    # These assets should never be cached because they do not have a versioned filename
+    response["Cache-Control"] = NEVER_CACHE
 
     return response

--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -91,9 +91,13 @@ urlpatterns += [
     ),
     # Frontend client config
     url(r"^api/client-config/?$", api.ClientConfigView.as_view(), name="sentry-api-client-config"),
-    # The static version is either a 10 digit timestamp, a sha1, or md5 hash
     url(
-        r"^_static/(?:(?P<version>\d{10}|[a-f0-9]{32,40})/)?(?P<module>[^/]+)/(?P<path>.*)$",
+        r"^_static/(?P<module>[^/]+)/dist/(?P<path>.*)$",
+        generic.static_media_with_manifest,
+        name="sentry-webpack-media",
+    ),
+    url(
+        r"^_static/(?P<module>[^/]+)/(?P<path>.*)$",
         generic.static_media,
         name="sentry-media",
     ),

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -138,7 +138,7 @@ class BuildIncidentAttachmentTest(TestCase):
             + "/?referrer=slack",
             "callback_id": '{"issue":' + str(group.id) + "}",
             "fallback": f"[{self.project.slug}] {group.title}",
-            "footer_icon": "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
+            "footer_icon": "http://testserver/_static/sentry/images/sentry-email-avatar.png",
         }
         event = self.store_event(data={}, project_id=self.project.id)
         ts = event.datetime
@@ -185,7 +185,7 @@ class BuildIncidentAttachmentTest(TestCase):
             + "/?referrer=slack",
             "callback_id": '{"issue":' + str(group.id) + "}",
             "fallback": f"[{self.project.slug}] {event.title}",
-            "footer_icon": "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
+            "footer_icon": "http://testserver/_static/sentry/images/sentry-email-avatar.png",
         }
 
         assert build_group_attachment(group, event, link_to_event=True) == {
@@ -230,7 +230,7 @@ class BuildIncidentAttachmentTest(TestCase):
             + "?referrer=slack",
             "callback_id": '{"issue":' + str(group.id) + "}",
             "fallback": f"[{self.project.slug}] {event.title}",
-            "footer_icon": "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
+            "footer_icon": "http://testserver/_static/sentry/images/sentry-email-avatar.png",
         }
 
     def test_build_group_attachment_color_no_event_error_fallback(self):

--- a/tests/sentry/integrations/test_metric_alerts.py
+++ b/tests/sentry/integrations/test_metric_alerts.py
@@ -30,10 +30,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert data["text"] == "123 events in the last 10 minutes\nFilter: level:error"
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
-        assert (
-            data["logo_url"]
-            == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"
-        )
+        assert data["logo_url"] == "http://testserver/_static/sentry/images/sentry-email-avatar.png"
 
     def test_with_incident_trigger(self):
         alert_rule = self.create_alert_rule()
@@ -74,10 +71,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert data["text"] == "4 events in the last 10 minutes\nFilter: level:error"
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
-        assert (
-            data["logo_url"]
-            == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"
-        )
+        assert data["logo_url"] == "http://testserver/_static/sentry/images/sentry-email-avatar.png"
 
         # Test the trigger "resolving"
         data = incident_attachment_info(incident, action=action, method="resolve")
@@ -86,10 +80,7 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert data["text"] == "4 events in the last 10 minutes\nFilter: level:error"
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
-        assert (
-            data["logo_url"]
-            == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"
-        )
+        assert data["logo_url"] == "http://testserver/_static/sentry/images/sentry-email-avatar.png"
 
         # No trigger passed, uses incident as fallback
         data = incident_attachment_info(incident, action=action)
@@ -98,7 +89,4 @@ class IncidentAttachmentInfoTest(TestCase, BaseIncidentsTest):
         assert data["text"] == "4 events in the last 10 minutes\nFilter: level:error"
         assert data["ts"] == date_started
         assert data["title_link"] == "http://testserver/organizations/baz/alerts/1/"
-        assert (
-            data["logo_url"]
-            == "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png"
-        )
+        assert data["logo_url"] == "http://testserver/_static/sentry/images/sentry-email-avatar.png"

--- a/tests/sentry/templatetags/test_sentry_assets.py
+++ b/tests/sentry/templatetags/test_sentry_assets.py
@@ -12,24 +12,36 @@ class AssetsTest(TestCase):
         {% locale_js_include %}
     """
     )
+    DIST_PATH = "src/sentry/static/sentry/dist"
+    MANIFEST_PATH = f"{DIST_PATH}/manifest.json"
 
     def test_supported_foreign_lang(self):
-        request = RequestFactory().get("/")
-        request.LANGUAGE_CODE = "fr"  # French, in locale/catalogs.json
-        result = self.TEMPLATE.render(request=request)
+        # Locale files are generated from webpack, so we need to have a manifest file,
+        # otherwise this will 404
+        locale_manifest = {
+            "locale/fr.js": "locale/fr.f00f00.js",
+        }
+        with self.static_asset_manifest(locale_manifest):
+            request = RequestFactory().get("/")
+            request.LANGUAGE_CODE = "fr"  # French, in locale/catalogs.json
+            result = self.TEMPLATE.render(request=request)
 
-        assert '<script src="/_static/{version}/sentry/dist/locale/fr.js"></script>' in result
+            assert '<script src="/_static/sentry/dist/locale/fr.f00f00.js"></script>' in result
 
     def test_supported_foreign_lang_csp_nonce(self):
-        request = RequestFactory().get("/")
-        request.LANGUAGE_CODE = "fr"  # French, in locale/catalogs.json
-        request.csp_nonce = "r@nD0m"
-        result = self.TEMPLATE.render(request=request)
+        locale_manifest = {
+            "locale/fr.js": "locale/fr.f00f00.js",
+        }
+        with self.static_asset_manifest(locale_manifest):
+            request = RequestFactory().get("/")
+            request.LANGUAGE_CODE = "fr"  # French, in locale/catalogs.json
+            request.csp_nonce = "r@nD0m"
+            result = self.TEMPLATE.render(request=request)
 
-        assert (
-            '<script src="/_static/{version}/sentry/dist/locale/fr.js" nonce="r@nD0m"></script>'
-            in result
-        )
+            assert (
+                '<script src="/_static/sentry/dist/locale/fr.f00f00.js" nonce="r@nD0m"></script>'
+                in result
+            )
 
     def test_unsupported_foreign_lang(self):
         request = RequestFactory().get("/")

--- a/tests/sentry/web/frontend/generic/test_static_media.py
+++ b/tests/sentry/web/frontend/generic/test_static_media.py
@@ -3,6 +3,7 @@ import os
 from django.test.utils import override_settings
 
 from sentry.testutils import TestCase
+from sentry.utils.assets import get_manifest_url
 from sentry.web.frontend.generic import FOREVER_CACHE, NEVER_CACHE
 
 
@@ -18,29 +19,36 @@ class StaticMediaTest(TestCase):
         "Content-Encoding" not in response
 
     @override_settings(DEBUG=False)
-    def test_versioned(self):
-        url = "/_static/1234567890/sentry/js/ads.js"
-        response = self.client.get(url)
-        assert response.status_code == 200, response
-        assert response["Cache-Control"] == FOREVER_CACHE
-        assert response["Vary"] == "Accept-Encoding"
-        assert response["Access-Control-Allow-Origin"] == "*"
-        "Content-Encoding" not in response
+    def test_from_manifest(self):
+        """
+        manifest here refers to the webpack manifest for frontend assets
+        """
 
-        url = "/_static/a43db3b08ddd4918972f80739f15344b/sentry/js/ads.js"
-        response = self.client.get(url)
-        assert response.status_code == 200, response
-        assert response["Cache-Control"] == FOREVER_CACHE
-        assert response["Vary"] == "Accept-Encoding"
-        assert response["Access-Control-Allow-Origin"] == "*"
-        "Content-Encoding" not in response
+        app_manifest = {
+            "app.js": "app.f00f00.js",
+        }
 
-        with override_settings(DEBUG=True):
+        with self.static_asset_manifest(app_manifest):
+            # `get_manifest_url()` should return the mapped filename
+            url = get_manifest_url("sentry", "app.js")
+
             response = self.client.get(url)
             assert response.status_code == 200, response
-            assert response["Cache-Control"] == NEVER_CACHE
+            assert response["Cache-Control"] == FOREVER_CACHE
             assert response["Vary"] == "Accept-Encoding"
             assert response["Access-Control-Allow-Origin"] == "*"
+            "Content-Encoding" not in response
+
+            # non-existant dist file
+            response = self.client.get("/_static/sentry/dist/invalid.js")
+            assert response.status_code == 404, response
+
+            with override_settings(DEBUG=True):
+                response = self.client.get(url)
+                assert response.status_code == 200, response
+                assert response["Cache-Control"] == NEVER_CACHE
+                assert response["Vary"] == "Accept-Encoding"
+                assert response["Access-Control-Allow-Origin"] == "*"
 
     @override_settings(DEBUG=False)
     def test_no_cors(self):

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const {CleanWebpackPlugin} = require('clean-webpack-plugin'); // installed via npm
+const {WebpackManifestPlugin} = require('webpack-manifest-plugin');
 const webpack = require('webpack');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -304,6 +305,8 @@ let appConfig = {
   plugins: [
     new CleanWebpackPlugin(),
 
+    new WebpackManifestPlugin({}),
+
     /**
      * jQuery must be provided in the global scope specifically and only for
      * bootstrap, as it will not import jQuery itself.
@@ -319,7 +322,9 @@ let appConfig = {
     /**
      * Extract CSS into separate files.
      */
-    new MiniCssExtractPlugin(),
+    new MiniCssExtractPlugin({
+      filename: '[name].[contenthash:6].css',
+    }),
 
     /**
      * Defines environment specific flags.
@@ -398,12 +403,18 @@ let appConfig = {
   },
   output: {
     path: distPath,
-    filename: '[name].js',
+    filename: '[name].[hash].js',
+    chunkFilename: '[name].[contenthash].js',
+
+    // Rename global that is used to async load chunks
+    // Avoids 3rd party js from overwriting the default name (webpackJsonp)
+    jsonpFunction: 'sntryWpJsonp',
     sourceMapFilename: '[name].js.map',
   },
   optimization: {
     chunkIds: 'named',
     moduleIds: 'named',
+    runtimeChunk: {name: 'runtime'},
     splitChunks: {
       // Only affect async chunks, otherwise webpack could potentially split our initial chunks
       // Which means the app will not load because we'd need these additional chunks to be loaded in our
@@ -477,7 +488,7 @@ if (
 
     appConfig.devServer = {
       ...appConfig.devServer,
-      publicPath: '/_webpack',
+      publicPath: '/_static/sentry/dist',
       // syntax for matching is using https://www.npmjs.com/package/micromatch
       proxy: {
         '/api/store/**': relayAddress,
@@ -485,11 +496,9 @@ if (
         '/api/0/relays/outcomes/': relayAddress,
         '!/_webpack': backendAddress,
       },
-      before: app =>
-        app.use((req, _res, next) => {
-          req.url = req.url.replace(/^\/_static\/[^\/]+\/sentry\/dist/, '/_webpack');
-          next();
-        }),
+      writeToDisk: filePath => {
+        return /manifest\.json/.test(filePath);
+      },
     };
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -288,7 +288,7 @@ let appConfig = {
             options: {
               // This needs to be `false` because of platformicons package
               esModule: false,
-              name: '[folder]/[name].[hash:6].[ext]',
+              name: '[folder]/[name].[contenthash:6].[ext]',
             },
           },
         ],
@@ -305,7 +305,7 @@ let appConfig = {
   plugins: [
     new CleanWebpackPlugin(),
 
-    new WebpackManifestPlugin({}),
+    new WebpackManifestPlugin(),
 
     /**
      * jQuery must be provided in the global scope specifically and only for
@@ -403,7 +403,8 @@ let appConfig = {
   },
   output: {
     path: distPath,
-    filename: '[name].[hash].js',
+    publicPath: '',
+    filename: '[name].[contenthash].js',
     chunkFilename: '[name].[contenthash].js',
     sourceMapFilename: '[name].js.map',
   },
@@ -490,7 +491,7 @@ if (
         '/api/store/**': relayAddress,
         '/api/{1..9}*({0..9})/**': relayAddress,
         '/api/0/relays/outcomes/': relayAddress,
-        '!/_webpack': backendAddress,
+        '!/_static/sentry/dist/**': backendAddress,
       },
       writeToDisk: filePath => {
         return /manifest\.json/.test(filePath);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -405,10 +405,6 @@ let appConfig = {
     path: distPath,
     filename: '[name].[hash].js',
     chunkFilename: '[name].[contenthash].js',
-
-    // Rename global that is used to async load chunks
-    // Avoids 3rd party js from overwriting the default name (webpackJsonp)
-    jsonpFunction: 'sntryWpJsonp',
     sourceMapFilename: '[name].js.map',
   },
   optimization: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15518,6 +15518,14 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
+webpack-manifest-plugin@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-3.1.0.tgz#9030b8839bed093d93930a9d1d3a7ab00f7ac4f7"
+  integrity sha512-7jgB8Kb0MRWXq3YaDfe+0smv5c7MLMfze8YvG6eBEXZmy6fhwMe/eT47A0KEIF30c0DDEYKbbYTXzaMQETaZ0Q==
+  dependencies:
+    tapable "^2.0.0"
+    webpack-sources "^2.2.0"
+
 webpack-merge@^5.7.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.7.3.tgz#2a0754e1877a25a8bbab3d2475ca70a052708213"
@@ -15539,7 +15547,7 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.3:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack-sources@^2.1.1:
+webpack-sources@^2.1.1, webpack-sources@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
   integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==


### PR DESCRIPTION
This changes the way we handle static assets. Previously, the assets were versioned by either a `version` file (commit sha?) or a timestamp. This changes it so that the `version` is removed from the path and instead change webpack to include a hash (based on file contents) in the filename. Webpack also produces a manifest.json file that maps a key -> hashed filename which `django-manifest-loader` uses to load static assets.

Old:

```
/_static/{version}/sentry/dist/app.js
```

New:
```
/_static/sentry/dist/app.{appHash}.js
```

* [x] Check CDN (fastly) settings to make sure that non-webpack assets are not cached long term

~After thinking about this some more, I don't think we'll need this long-term as we will be aiming to have a webpack runtime chunk/bootloader handle loading all webpack assets (so remove loading webpack assets from django views), but this may be a good intermediate step if we wanted to evaluate CDN caching.~

~We will need to refactor `sentry.css` so that it is split into CSS that's needed during initial rendering state and application level css which is imported via js application (vs being included in server template).~

