### PR TITLE
build(webpack): Perserve folder for files from `file-loader`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -273,7 +273,7 @@ let appConfig = {
             options: {
               // This needs to be `false` because of platformicons package
               esModule: false,
-              name: '[name].[hash:6].[ext]',
+              name: '[folder]/[name].[hash:6].[ext]',
             },
           },
         ],


### PR DESCRIPTION
This change preserves parent folders for files processed from `file-loader`. This silences some webpack warnings where it complains about processing files with the same name. The main culprit here is https://github.com/getsentry/platformicons where the file names in `svg` and `svg_80x80` are the same. The filenames contain a hash so that the correct files are currently correctly loading.