### PR TITLE
feat(codeowners): Minimum CodeOwners list view for validation

### DIFF
--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -21,6 +21,7 @@ from sentry.ownership.grammar import (
 )
 
 from sentry.api.endpoints.project_ownership import ProjectOwnershipSerializer, ProjectOwnershipMixin
+from sentry.api.serializers.models import projectcodeowners as projectcodeowners_serializers
 
 logger = logging.getLogger(__name__)
 
@@ -162,9 +163,17 @@ class ProjectCodeOwnersEndpoint(ProjectEndpoint, ProjectOwnershipMixin, ProjectC
         if not self.has_feature(request, project):
             raise PermissionDenied
 
+        expand = request.GET.getlist("expand", [])
         codeowners = list(ProjectCodeOwners.objects.filter(project=project))
 
-        return Response(serialize(codeowners, request.user), status.HTTP_200_OK)
+        return Response(
+            serialize(
+                codeowners,
+                request.user,
+                serializer=projectcodeowners_serializers.ProjectCodeOwnersSerializer(expand=expand),
+            ),
+            status.HTTP_200_OK,
+        )
 
     def post(self, request, project):
         """

--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -48,6 +48,5 @@ class ProjectCodeOwnersSerializer(Serializer):
             data["codeMapping"] = serialize(
                 config, user=user, serializer=RepositoryProjectPathConfigSerializer()
             )
-            data.pop("codeMappingId", None)
 
         return data

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -67,7 +67,6 @@ class CodeOwners extends AsyncComponent<Props, State> {
             ).fromNow()}`}</InnerPanelHeader>
             <InnerPanelBody>
               <StyledTextArea
-                // disabled={true}
                 value={raw}
                 spellCheck="false"
                 autoComplete="off"
@@ -157,6 +156,8 @@ const InnerPanel = styled(Panel)`
 
 const InnerPanelHeader = styled(PanelHeader)`
   text-transform: none;
+  font-size 16px;
+  font-weight 400;
 `;
 const InnerPanelBody = styled(PanelBody)`
   height: auto;
@@ -177,6 +178,7 @@ const StyledTextArea = styled(TextareaAutosize)`
   border: none;
   box-shadow: none;
   padding: ${space(2)};
+  color: #9386a0;
 
   &:hover,
   &:focus,

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -1,0 +1,187 @@
+import React from 'react';
+import TextareaAutosize from 'react-autosize-textarea';
+import styled from '@emotion/styled';
+import {withTheme} from 'emotion-theming';
+import moment from 'moment';
+
+import AsyncComponent from 'app/components/asyncComponent';
+import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import Tag from 'app/components/tag';
+import {IconGithub, IconGitlab} from 'app/icons';
+import {inputStyles} from 'app/styles/input';
+import space from 'app/styles/space';
+import {Organization, Project} from 'app/types';
+import {Theme} from 'app/utils/theme';
+
+type Props = AsyncComponent['props'] & {
+  theme: Theme;
+  organization: Organization;
+  project: Project;
+};
+
+type State = {} & AsyncComponent['state'];
+
+class CodeOwners extends AsyncComponent<Props, State> {
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const {organization, project} = this.props;
+    return [
+      [
+        'codeowners',
+        `/projects/${organization.slug}/${project.slug}/codeowners/?expand=codeMapping`,
+      ],
+    ];
+  }
+  renderIcon(provider) {
+    switch (provider) {
+      case 'github':
+        return <IconGithub size="md" />;
+      case 'gitlab':
+        return <IconGitlab size="md" />;
+      default:
+        return null;
+    }
+  }
+  renderView(data) {
+    const {theme} = this.props;
+    const {
+      raw,
+      dateUpdated,
+      provider,
+      codeMapping: {repoName},
+    } = data;
+    return (
+      <Container>
+        <RulesHeader>
+          <TitleContainer>
+            {this.renderIcon(provider)}
+            <Title>CODEOWNERS</Title>
+          </TitleContainer>
+          <ReadOnlyTag type="default">{'Read Only'}</ReadOnlyTag>
+          <Repository>{repoName}</Repository>
+          <Detail />
+        </RulesHeader>
+        <RulesView>
+          <InnerPanel>
+            <InnerPanelHeader>{`Last synced ${moment(
+              dateUpdated
+            ).fromNow()}`}</InnerPanelHeader>
+            <InnerPanelBody>
+              <StyledTextArea
+                // disabled={true}
+                value={raw}
+                spellCheck="false"
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                theme={theme}
+              />
+            </InnerPanelBody>
+          </InnerPanel>
+        </RulesView>
+      </Container>
+    );
+  }
+
+  renderBody() {
+    const {codeowners} = this.state;
+    return codeowners.map(codeowner => (
+      <React.Fragment key={codeowner.id}>{this.renderView(codeowner)}</React.Fragment>
+    ));
+  }
+}
+
+export default withTheme(CodeOwners);
+
+const Container = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  grid-template-areas: 'rules-header rules-view';
+  height: 400px;
+  margin-bottom: ${space(3)};
+`;
+
+const RulesHeader = styled('div')`
+  grid-area: rules-header;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: 45px 1fr 1fr 1fr 1fr;
+  grid-template-areas: 'title tag' 'repository repository' '. .' '. .' 'detail detail';
+  border: 1px solid #c6becf;
+  border-radius: 4px 0 0 4px;
+  border-right: none;
+  box-shadow: 0 2px 0 rgb(37 11 54 / 4%);
+  background-color: #ffffff;
+`;
+const TitleContainer = styled('div')`
+  grid-area: title;
+  align-self: center;
+  padding-left: ${space(2)};
+  display: flex;
+  * {
+    padding-right: ${space(0.5)};
+  }
+`;
+const Title = styled('div')`
+  align-self: center;
+`;
+const ReadOnlyTag = styled(Tag)`
+  grid-area: tag;
+  align-self: center;
+  justify-self: end;
+  padding-right: ${space(1)};
+`;
+const Repository = styled('div')`
+  grid-area: repository;
+  padding-left: calc(${space(2)} + ${space(3)});
+  color: #9386a0;
+  font-size: 14px;
+`;
+const Detail = styled('div')`
+  grid-area: detail;
+  align-self: end;
+  padding: 0 0 ${space(2)} ${space(2)};
+  color: #9386a0;
+  font-size: 14px;
+`;
+
+const RulesView = styled('div')`
+  grid-area: rules-view;
+`;
+
+const InnerPanel = styled(Panel)`
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0px;
+  margin: 0px;
+  height: 100%;
+`;
+
+const InnerPanelHeader = styled(PanelHeader)`
+  text-transform: none;
+`;
+const InnerPanelBody = styled(PanelBody)`
+  height: auto;
+`;
+
+const StyledTextArea = styled(TextareaAutosize)`
+  ${inputStyles};
+  height: calc(400px - ${space(2)} - ${space(1)} - ${space(3)}) !important;
+  overflow: auto;
+  outline: 0;
+  width: 100%;
+  resize: none;
+  margin: 0;
+  font-family: ${p => p.theme.text.familyMono};
+  word-break: break-all;
+  white-space: pre-wrap;
+  line-height: ${space(3)};
+  border: none;
+  box-shadow: none;
+  padding: ${space(2)};
+
+  &:hover,
+  &:focus,
+  &:active {
+    border: none;
+    box-shadow: none;
+  }
+`;

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -155,9 +155,10 @@ const InnerPanel = styled(Panel)`
 
 const InnerPanelHeader = styled(PanelHeader)`
   text-transform: none;
-  font-size 16px;
-  font-weight 400;
+  font-size: 16px;
+  font-weight: 400;
 `;
+
 const InnerPanelBody = styled(PanelBody)`
   height: auto;
 `;

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -95,7 +95,6 @@ const Container = styled('div')`
   display: grid;
   grid-template-columns: 1fr 2fr;
   grid-template-areas: 'rules-header rules-view';
-  height: 400px;
   margin-bottom: ${space(3)};
 `;
 

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 
+import Feature from 'app/components/acl/feature';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
@@ -14,6 +15,7 @@ import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
 import PermissionAlert from 'app/views/settings/project/permissionAlert';
+import CodeOwners from 'app/views/settings/project/projectOwnership/codeowners';
 import OwnerInput from 'app/views/settings/project/projectOwnership/ownerInput';
 
 type Props = {
@@ -107,7 +109,9 @@ class ProjectOwnership extends AsyncView<Props, State> {
             />
           </PanelBody>
         </Panel>
-
+        <Feature features={['import-codeowners']}>
+          <CodeOwners {...this.props} />
+        </Feature>
         <Form
           apiEndpoint={`/projects/${organization.slug}/${project.slug}/ownership/`}
           apiMethod="PUT"

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -88,6 +88,19 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         assert resp_data["codeMappingId"] == str(self.code_mapping_with_integration.id)
         assert resp_data["provider"] == self.integration.provider
 
+    def test_get_expanded_codeowners_with_integration(self):
+        self._create_codeowner_with_integration()
+        with self.feature({"organizations:import-codeowners": True}):
+            resp = self.client.get(f"{self.url}?expand=codeMapping")
+        assert resp.status_code == 200
+        resp_data = resp.data[0]
+        assert resp_data["raw"] == self.code_owner.raw
+        assert resp_data["dateCreated"] == self.code_owner.date_added
+        assert resp_data["dateUpdated"] == self.code_owner.date_updated
+        assert resp_data["codeMappingId"] == str(self.code_mapping_with_integration.id)
+        assert resp_data["provider"] == self.integration.provider
+        assert resp_data["codeMapping"]["id"] == str(self.code_mapping_with_integration.id)
+
     def test_basic_post(self):
         with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, self.data)


### PR DESCRIPTION
## Objective:
Prior to releasing Phase 1, we want to have a UI for users to visually validate their API requests. This required adding an `expand` query param to the `GET codeowners` API.

This UI is gated with the `import-codeowners` feature flag.

## UI
Design:
<img width="930" alt="Screen Shot 2021-03-24 at 6 26 13 PM" src="https://user-images.githubusercontent.com/10491193/112404889-6de7ee00-8cce-11eb-8a0e-64fd6fa801e1.png">

Implementation:
![Screen Shot 2021-03-25 at 2 05 42 PM](https://user-images.githubusercontent.com/10491193/112543600-38e1a700-8d73-11eb-91d9-05a9bcd91419.png)
