### PR TITLE
fix(sdk): Disable smart trimming experiment

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1739,7 +1739,6 @@ SENTRY_SDK_CONFIG = {
     "release": sentry.__build__,
     "environment": ENVIRONMENT,
     "in_app_include": ["sentry", "sentry_plugins"],
-    "_experiments": {"smart_transaction_trimming": True},
     "debug": True,
     "send_default_pii": True,
     "auto_enabling_integrations": False,


### PR DESCRIPTION
In some cases we trim span descriptions too eagerly. 
Example:
![image](https://user-images.githubusercontent.com/1120468/112473922-3ed58900-8d6f-11eb-8ec9-3513f94daa5e.png)


There's a chance that the smart trimming feature is the culprit here, so let's disable it for now.