### PR TITLE
fix(ui): moved time interval out of alert details chart

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -18,6 +18,7 @@ import * as Layout from 'app/components/layouts/thirds';
 import {Panel, PanelBody} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
 import TimeSince from 'app/components/timeSince';
+import Tooltip from 'app/components/tooltip';
 import {IconCheckmark, IconFire, IconInfo, IconUser, IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
@@ -52,6 +53,7 @@ type Props = {
     label: string;
     custom?: boolean;
   };
+  project: Project;
   organization: Organization;
   location: Location;
   handleTimePeriodChange: (value: string) => void;
@@ -65,10 +67,23 @@ export default class DetailsBody extends React.Component<Props> {
       return '';
     }
 
-    const {aggregate, timeWindow} = rule;
+    const {aggregate} = rule;
 
-    return tct(' [metric] over [window]', {
+    return tct('[metric]', {
       metric: aggregate,
+    });
+  }
+
+  getTimeWindow(): React.ReactNode {
+    const {rule} = this.props;
+
+    if (!rule) {
+      return '';
+    }
+
+    const {timeWindow} = rule;
+
+    return tct('[window]', {
       window: <Duration seconds={timeWindow * 60} />,
     });
   }
@@ -283,26 +298,42 @@ export default class DetailsBody extends React.Component<Props> {
                 )}
               </Alert>
               <Layout.Main>
-                <ChartControls>
-                  <DropdownControl label={timePeriod.label}>
-                    {TIME_OPTIONS.map(({label, value}) => (
-                      <DropdownItem
-                        key={value}
-                        eventKey={value}
-                        onSelect={this.props.handleTimePeriodChange}
-                      >
-                        {label}
-                      </DropdownItem>
-                    ))}
-                  </DropdownControl>
-                  {timePeriod.custom && (
-                    <StyledTimeRange>
-                      <DateTime date={moment.utc(timePeriod.start)} timeAndDate />
-                      {' — '}
-                      <DateTime date={moment.utc(timePeriod.end)} timeAndDate />
-                    </StyledTimeRange>
-                  )}
-                </ChartControls>
+                <HeaderContainer>
+                  <div>
+                    <SidebarHeading noMargin>{t('Display')}</SidebarHeading>
+                    <ChartControls>
+                      <DropdownControl label={timePeriod.label}>
+                        {TIME_OPTIONS.map(({label, value}) => (
+                          <DropdownItem
+                            key={value}
+                            eventKey={value}
+                            onSelect={this.props.handleTimePeriodChange}
+                          >
+                            {label}
+                          </DropdownItem>
+                        ))}
+                      </DropdownControl>
+                      {timePeriod.custom && (
+                        <StyledTimeRange>
+                          <DateTime date={moment.utc(timePeriod.start)} timeAndDate />
+                          {' — '}
+                          <DateTime date={moment.utc(timePeriod.end)} timeAndDate />
+                        </StyledTimeRange>
+                      )}
+                    </ChartControls>
+                  </div>
+                  <div>
+                    <SidebarHeading noMargin>
+                      {t('Time Interval')}
+                      <Tooltip title="This is the time period which the metric is evaluated by.">
+                        <IconInfo size="xs" />
+                      </Tooltip>
+                    </SidebarHeading>
+
+                    <RuleText>{this.getTimeWindow()}</RuleText>
+                  </div>
+                </HeaderContainer>
+
                 <MetricChart
                   api={api}
                   rule={rule}
@@ -367,6 +398,11 @@ const DetailWrapper = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints[0]}) {
     flex-direction: column-reverse;
   }
+`;
+
+const HeaderContainer = styled('div')`
+  display: flex;
+  gap: ${space(4)};
 `;
 
 const ActivityWrapper = styled('div')`

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -53,7 +53,6 @@ type Props = {
     label: string;
     custom?: boolean;
   };
-  project: Project;
   organization: Organization;
   location: Location;
   handleTimePeriodChange: (value: string) => void;


### PR DESCRIPTION
Made a new section at the top of the page for the Time Interval

## Before
<img width="913" alt="CleanShot 2021-03-25 at 06 35 05@2x" src="https://user-images.githubusercontent.com/1900676/112481478-46c40780-8d34-11eb-8fe3-4ae96f778594.png">


## After
<img width="920" alt="CleanShot 2021-03-25 at 06 32 50@2x" src="https://user-images.githubusercontent.com/1900676/112481394-3449ce00-8d34-11eb-9c76-85df4ecfd4f8.png">
