### PR TITLE
feat(trace-view): Add additional details from detailed trace

### DIFF
--- a/src/sentry/static/sentry/app/components/quickTrace/utils.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/utils.tsx
@@ -74,6 +74,7 @@ export function generateTraceTarget(
   const dateSelection = getParams(getTraceTimeRangeFromEvent(event));
 
   if (organization.features.includes('trace-view-summary')) {
+    // TODO(txiao): Should this persist the current query when going to trace view?
     return getTraceDetailsUrl(organization, traceId, dateSelection, {});
   }
 

--- a/src/sentry/static/sentry/app/types/event.tsx
+++ b/src/sentry/static/sentry/app/types/event.tsx
@@ -152,7 +152,7 @@ type EventContexts = {
   client_os?: OSContext;
 };
 
-type Measurement = {value: number};
+export type Measurement = {value: number};
 
 export type EventTag = {key: string; value: string};
 

--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/types.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/types.tsx
@@ -1,3 +1,4 @@
+import {EventTag, Measurement} from 'app/types/event';
 import {
   DiscoverQueryProps,
   GenericChildrenProps,
@@ -55,6 +56,10 @@ export type TraceFull = Omit<QuickTraceEvent, 'generation' | 'errors'> & {
  */
 export type TraceFullDetailed = Omit<TraceFull, 'children'> & {
   children: TraceFullDetailed[];
+  environment: string;
+  measurements?: Record<string, Measurement>;
+  tags?: EventTag[];
+  release: string;
   start_timestamp: number;
   timestamp: number;
   'transaction.op': string;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
@@ -1,10 +1,19 @@
+import React from 'react';
 import styled from '@emotion/styled';
+import {Location} from 'history';
 
+import EventTagsPill from 'app/components/events/eventTags/eventTagsPill';
 import {SpanBarTitle} from 'app/components/events/interfaces/spans/spanBar';
 import {Panel} from 'app/components/panels';
+import Pills from 'app/components/pills';
 import SearchBar from 'app/components/searchBar';
 import {IconChevron} from 'app/icons';
 import space from 'app/styles/space';
+import {Organization} from 'app/types';
+import {defined} from 'app/utils';
+import {TraceFullDetailed} from 'app/utils/performance/quickTrace/types';
+import {appendTagCondition} from 'app/utils/queryString';
+import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
 
 export {
   ConnectorBar,
@@ -82,3 +91,61 @@ export const TransactionBarTitle = styled(SpanBarTitle)`
 export const TransactionBarTitleContent = styled('span')`
   margin-left: ${space(0.75)};
 `;
+
+const StyledPills = styled(Pills)`
+  padding: ${space(1)};
+`;
+
+export function Tags({
+  location,
+  organization,
+  transaction,
+}: {
+  location: Location;
+  organization: Organization;
+  transaction: TraceFullDetailed;
+}) {
+  const {tags} = transaction;
+
+  if (!tags || tags.length <= 0) {
+    return null;
+  }
+
+  const orgSlug = organization.slug;
+  const releasesPath = `/organizations/${orgSlug}/releases/`;
+
+  return (
+    <tr>
+      <td className="key">Tags</td>
+      <td className="value">
+        <StyledPills>
+          {tags.map((tag, index) => {
+            const {pathname: streamPath, query} = transactionSummaryRouteWithQuery({
+              orgSlug,
+              transaction: transaction.transaction,
+              projectID: String(transaction.project_id),
+              query: {
+                ...location.query,
+                query: appendTagCondition(location.query.query, tag.key, tag.value),
+              },
+            });
+
+            return (
+              <EventTagsPill
+                key={!defined(tag.key) ? `tag-pill-${index}` : tag.key}
+                tag={tag}
+                projectId={transaction.project_slug}
+                organization={organization}
+                location={location}
+                query={query}
+                streamPath={streamPath}
+                releasesPath={releasesPath}
+                hasQueryFeature={false}
+              />
+            );
+          })}
+        </StyledPills>
+      </td>
+    </tr>
+  );
+}


### PR DESCRIPTION
The detailed parameter will return back additional information about the
transactions in the trace. This change ensures to render these additional
details in the expanded transaction.

# Screenshot

![image](https://user-images.githubusercontent.com/10239353/112499311-bac6d580-8d5d-11eb-9e55-0d5a7484a432.png)
