### PR TITLE
fix(discover): Include projects in top events filter

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -466,9 +466,9 @@ def top_events_timeseries(
         )
 
         for field in selected_columns:
-            # project is handled by filter_keys already
+            # If we have a project field, we need to limit results by project so we dont hit the result limit
             if field in ["project", "project.id"]:
-                continue
+                snuba_filter.project_ids = [event["project.id"] for event in top_events["data"]]
             if field in FIELD_ALIASES:
                 field = FIELD_ALIASES[field].alias
             # Note that because orderby shouldn't be an array field its not included in the values


### PR DESCRIPTION
- Because we weren't adjusting the projects filter, if the top events
  were grouped by project we would hit the 10,000 item result limit
  since we included stats results for all the filtered projects instead
- I believe this wasn't noticed before because we weren't ordering by
  the group by so we just lucked out with random results making the
  chart look full https://github.com/getsentry/sentry/blob/73dd774bca7a7969593b54f1ca23d4c1a4744a25/src/sentry/snuba/discover.py#L506
- Side effect is that top events by project is now faster too