### PR TITLE
fix: Refactor stringifyQueryList() to support multiple query string key values

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/utils.tsx
@@ -77,12 +77,16 @@ export function stringifyQueryList(query: string | [key: string, value: string][
     return query;
   }
 
-  const queryObj: Record<string, string> = {};
+  const queryObj: Record<string, string[]> = {};
   for (const kv of query) {
     if (kv !== null && kv.length === 2) {
-      const [k, v] = kv;
-      if (v !== null) {
-        queryObj[k] = v;
+      const [key, value] = kv;
+      if (value !== null) {
+        if (Array.isArray(queryObj[key])) {
+          queryObj[key].push(value);
+        } else {
+          queryObj[key] = [value];
+        }
       }
     }
   }

--- a/tests/js/spec/components/events/interfaces/utils.spec.jsx
+++ b/tests/js/spec/components/events/interfaces/utils.spec.jsx
@@ -2,6 +2,7 @@ import {
   getCurlCommand,
   objectToSortedTupleArray,
   removeFilterMaskedEntries,
+  stringifyQueryList,
 } from 'app/components/events/interfaces/utils';
 import {MetaProxy, withMeta} from 'app/components/events/meta/metaProxy';
 import {FILTER_MASK} from 'app/constants';
@@ -197,6 +198,24 @@ describe('components/interfaces/utils', function () {
       expect(result.id).toEqual('26');
       expect(result).toHaveProperty('username');
       expect(result.username).toEqual('maiseythedog');
+    });
+  });
+
+  describe('stringifyQueryList()', function () {
+    it('should return query if it is a string', function () {
+      const query = stringifyQueryList('query');
+      expect(query).toEqual('query');
+    });
+    it('should parse query tuples', function () {
+      const query = stringifyQueryList([
+        ['field', 'ops.http'],
+        ['field', 'ops.db'],
+        ['field', 'total.time'],
+        ['numBuckets', '100'],
+      ]);
+      expect(query).toEqual(
+        'field=ops.http&field=ops.db&field=total.time&numBuckets=100'
+      );
     });
   });
 });


### PR DESCRIPTION



Generated URLS with query strings with multiple values with the same key are not produced correctly. For example:

<img width="1326" alt="Screen Shot 2021-03-25 at 12 51 55 PM" src="https://user-images.githubusercontent.com/139499/112513261-86a5e180-8d6a-11eb-8d4a-0501eb79ddfc.png">

Only the last value of the query string key values are used for generating the URL.

See: https://github.com/sindresorhus/query-string/tree/v6.6.0#arrayformat-1