### PR TITLE
ref(migrations): Handle non-expected values

### DIFF
--- a/src/sentry/migrations/0181_copy_useroptions_to_notificationsettings.py
+++ b/src/sentry/migrations/0181_copy_useroptions_to_notificationsettings.py
@@ -79,17 +79,25 @@ def copy_useroption_to_notificationsetting(apps, schema_editor):
                 scope_identifier = user_option.user.id
                 scope_type = NotificationScopeType.USER.value
             type = NotificationSettingTypes.ISSUE_ALERTS.value
-            if int(user_option.value) == 0:
+            try:
+                int_value = int(user_option.value)
+            except (ValueError, TypeError):
+                continue
+            if int_value == 0:
                 value = NotificationSettingOptionValues.NEVER.value
-            if int(user_option.value) == 1:
+            if int_value == 1:
                 value = NotificationSettingOptionValues.ALWAYS.value
         elif user_option.key == "subscribe_by_default":  # top level project alerts on/off
             scope_identifier = user_option.user.id
             scope_type = NotificationScopeType.USER.value
             type = NotificationSettingTypes.ISSUE_ALERTS.value
-            if int(user_option.value) == 1:
+            try:
+                int_value = int(user_option.value)
+            except (ValueError, TypeError):
+                continue
+            if int_value == 1:
                 value = NotificationSettingOptionValues.ALWAYS.value
-            if int(user_option.value) == 0:
+            if int_value == 0:
                 value = NotificationSettingOptionValues.NEVER.value
         elif user_option.key == "deploy-emails":
             # if you have fine tuning for an org, organization_id will have a value (rather than None)

--- a/src/sentry/migrations/0181_copy_useroptions_to_notificationsettings.py
+++ b/src/sentry/migrations/0181_copy_useroptions_to_notificationsettings.py
@@ -82,6 +82,8 @@ def copy_useroption_to_notificationsetting(apps, schema_editor):
             try:
                 int_value = int(user_option.value)
             except (ValueError, TypeError):
+                # if for some reason this isn't an int or a stringified int, it's garbage and we'll skip
+                # because an empty value is meaningless
                 continue
             if int_value == 0:
                 value = NotificationSettingOptionValues.NEVER.value


### PR DESCRIPTION
Update the [copy migration](https://github.com/getsentry/sentry/pull/24449) to handle unexpected user option values like an empty string or a string of characters, basically anything that isn't the stringified int I thought it'd be. 