### PR TITLE
fix(quick-trace): Error event timestamps are in milliseconds

### DIFF
--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/utils.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/utils.tsx
@@ -276,7 +276,7 @@ export function reduceTrace<T>(
 export function getTraceTimeRangeFromEvent(event: Event): {start: string; end: string} {
   const start = isTransaction(event)
     ? event.startTimestamp
-    : new Date(event.dateCreated).getTime();
+    : new Date(event.dateCreated).getTime() / 1000;
   const end = isTransaction(event) ? event.endTimestamp : start;
   return getTraceDateTimeRange({start, end});
 }


### PR DESCRIPTION
The error event created timestamp is in milliseconds so the quick trace queries
were failing to parse the correct start/end timestamps and using the 14d default
instead. This means that on error events, anything older than 14d will result in
a 404.