### PR TITLE
feat(demo): adds more guides for demo mode

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -34,4 +34,9 @@ if settings.DEMO_MODE:
         "sidebar": {"id": 20, "required_targets": ["projects"]},
         "issue_stream_v2": {"id": 21, "required_targets": ["issue_title"]},
         "issue_v2": {"id": 22, "required_targets": ["issue_details"]},
+        "releases": {"id": 23, "required_targets": ["release_version"]},
+        "release_details": {"id": 24, "required_targets": ["release_chart"]},
+        "discover_landing": {"id": 25, "required_targets": ["discover_landing_header"]},
+        "discover_event_view": {"id": 26, "required_targets": ["create_alert_from_discover"]},
+        "transaction_details": {"id": 27, "required_targets": ["span_tree"]},
     }

--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -310,5 +310,97 @@ function getDemoModeGuides(): GuidesContent {
         },
       ],
     },
+    {
+      guide: 'releases',
+      requiredTargets: ['release_version'],
+      steps: [
+        {
+          title: t('Release'),
+          target: 'release_version',
+          description: t(`See the details of your release and how it's performing.`),
+        },
+        {
+          title: t('View'),
+          target: 'view_release',
+          description: t(`You can also get release details by clicking here.`),
+        },
+      ],
+    },
+    {
+      guide: 'release_details',
+      requiredTargets: ['release_chart'],
+      steps: [
+        {
+          title: t('Chart'),
+          target: 'release_chart',
+          description: t(
+            `Click and drag to zoom in on a specific section of the histogram.`
+          ),
+        },
+        {
+          title: t('Discover'),
+          target: 'release_issues_open_in_discover',
+          description: t(
+            `Click here to analyze new errors by URL, geography, device, browser, etc.`
+          ),
+        },
+        {
+          title: t('Discover'),
+          target: 'release_transactions_open_in_discover',
+          description: t(
+            `Click here to analyze new performance issues by URL, geography, device, browser, etc.`
+          ),
+        },
+      ],
+    },
+    {
+      guide: 'discover_landing',
+      requiredTargets: ['discover_landing_header'],
+      steps: [
+        {
+          title: t('Discover'),
+          target: 'discover_landing_header',
+          description: t(
+            `Click into any of the queries below to analyze trends in event data.`
+          ),
+        },
+      ],
+    },
+    {
+      guide: 'discover_event_view',
+      requiredTargets: ['create_alert_from_discover'],
+      steps: [
+        {
+          title: t('Create Alert'),
+          target: 'create_alert_from_discover',
+          description: t(
+            `Create an alert based on this query to get notified when an event exceeds user-defined thresholds.`
+          ),
+        },
+        {
+          title: t('Columns'),
+          target: 'columns_header_button',
+          description: t(`View all query conditions.`),
+        },
+      ],
+    },
+    {
+      guide: 'transaction_details',
+      requiredTargets: ['span_tree'],
+      steps: [
+        {
+          title: t('Span Tree'),
+          target: 'span_tree',
+          description: t(`Click to expand the spans and see dependencies.`),
+        },
+        {
+          title: t('Breadcrumbs'),
+          target: 'breadcrumbs',
+          description: t(
+            `Check out the play by play of what your user experienced till they encountered the performance issue.`
+          ),
+        },
+      ],
+    },
   ];
 }

--- a/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
+++ b/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
@@ -3,6 +3,7 @@ import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location, LocationDescriptor, Query} from 'history';
 
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import DiscoverButton from 'app/components/discoverButton';
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
@@ -180,16 +181,18 @@ class TransactionsList extends React.Component<Props> {
         </DropdownControl>
         {!this.isTrend() && (
           <HeaderButtonContainer>
-            <DiscoverButton
-              onClick={handleOpenInDiscoverClick}
-              to={eventView
-                .withSorts([selected.sort])
-                .getResultsViewUrlTarget(organization.slug)}
-              size="small"
-              data-test-id="discover-open"
-            >
-              {t('Open in Discover')}
-            </DiscoverButton>
+            <GuideAnchor target="release_transactions_open_in_discover">
+              <DiscoverButton
+                onClick={handleOpenInDiscoverClick}
+                to={eventView
+                  .withSorts([selected.sort])
+                  .getResultsViewUrlTarget(organization.slug)}
+                size="small"
+                data-test-id="discover-open"
+              >
+                {t('Open in Discover')}
+              </DiscoverButton>
+            </GuideAnchor>
           </HeaderButtonContainer>
         )}
       </Header>

--- a/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/breadcrumbs/index.tsx
@@ -347,7 +347,7 @@ class Breadcrumbs extends React.Component<Props, State> {
       <StyledEventDataSection
         type={type}
         title={
-          <GuideAnchor target="breadcrumbs" position="bottom">
+          <GuideAnchor target="breadcrumbs" position="right">
             <h3>{t('Breadcrumbs')}</h3>
           </GuideAnchor>
         }

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import {t, tct} from 'app/locale';
 import {Organization} from 'app/types';
 import {EventTransaction} from 'app/types/event';
@@ -430,6 +431,9 @@ class SpanTree extends React.Component<PropType> {
     return (
       <TraceViewContainer ref={this.props.traceViewRef}>
         {spanTree}
+        <GuideAnchorWrapper>
+          <GuideAnchor target="span_tree" position="bottom" />
+        </GuideAnchorWrapper>
         {infoMessage}
         {limitExceededMessage}
       </TraceViewContainer>
@@ -441,6 +445,12 @@ const TraceViewContainer = styled('div')`
   overflow-x: hidden;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
+`;
+
+const GuideAnchorWrapper = styled('div')`
+  height: 0;
+  width: 50%;
+  float: right;
 `;
 
 /**

--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanTree.tsx
@@ -449,8 +449,8 @@ const TraceViewContainer = styled('div')`
 
 const GuideAnchorWrapper = styled('div')`
   height: 0;
-  width: 50%;
-  float: right;
+  width: 0;
+  margin-left: 50%;
 `;
 
 /**

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarItem.tsx
@@ -86,15 +86,16 @@ const SidebarItem = ({
   ...props
 }: Props) => {
   // label might be wrapped in a guideAnchor
+  let labelString = label;
   if (React.isValidElement(label)) {
-    label = label?.props?.children ?? label;
+    labelString = label?.props?.children ?? label;
   }
   // If there is no active panel open and if path is active according to react-router
   const isActiveRouter =
     (!hasPanel && router && to && location.pathname.startsWith(to)) ||
-    (label === 'Discover' && location.pathname.includes('/discover/')) ||
+    (labelString === 'Discover' && location.pathname.includes('/discover/')) ||
     // TODO: this won't be necessary once we remove settingsHome
-    (label === 'Settings' && location.pathname.startsWith('/settings/'));
+    (labelString === 'Settings' && location.pathname.startsWith('/settings/'));
 
   const isActive = active || isActiveRouter;
   const isTop = orientation === 'top';

--- a/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/landing.tsx
@@ -9,6 +9,7 @@ import {stringify} from 'query-string';
 
 import Feature from 'app/components/acl/feature';
 import Alert from 'app/components/alert';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import AsyncComponent from 'app/components/asyncComponent';
 import Button from 'app/components/button';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
@@ -350,7 +351,9 @@ class DiscoverLanding extends AsyncComponent<Props, State> {
             <LightWeightNoProjectMessage organization={organization}>
               <PageContent>
                 <StyledPageHeader>
-                  {t('Discover')}
+                  <GuideAnchor target="discover_landing_header">
+                    {t('Discover')}
+                  </GuideAnchor>
                   <StyledButton
                     data-test-id="build-new-query"
                     to={to}

--- a/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/savedQuery/index.tsx
@@ -6,6 +6,7 @@ import {Location} from 'history';
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import {CreateAlertFromViewButton} from 'app/components/createAlertButton';
@@ -301,15 +302,17 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
     const {eventView, organization, projects, onIncompatibleAlertQuery} = this.props;
 
     return (
-      <CreateAlertFromViewButton
-        eventView={eventView}
-        organization={organization}
-        projects={projects}
-        onIncompatibleQuery={onIncompatibleAlertQuery}
-        onSuccess={this.handleCreateAlertSuccess}
-        referrer="discover"
-        data-test-id="discover2-create-from-discover"
-      />
+      <GuideAnchor target="create_alert_from_discover">
+        <CreateAlertFromViewButton
+          eventView={eventView}
+          organization={organization}
+          projects={projects}
+          onIncompatibleQuery={onIncompatibleAlertQuery}
+          onSuccess={this.handleCreateAlertSuccess}
+          referrer="discover"
+          data-test-id="discover2-create-from-discover"
+        />
+      </GuideAnchor>
     );
   }
 

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
@@ -3,6 +3,7 @@ import {Location} from 'history';
 
 import Feature from 'app/components/acl/feature';
 import FeatureDisabled from 'app/components/acl/featureDisabled';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import Button from 'app/components/button';
 import DataExport, {ExportQueryType} from 'app/components/dataExport';
 import Hovercard from 'app/components/hovercard';
@@ -87,15 +88,17 @@ function renderAsyncExportButton(canEdit: boolean, props: Props) {
 function renderEditButton(canEdit: boolean, props: Props) {
   const onClick = canEdit ? props.onEdit : undefined;
   return (
-    <Button
-      size="small"
-      disabled={!canEdit}
-      onClick={onClick}
-      data-test-id="grid-edit-enable"
-      icon={<IconStack size="xs" />}
-    >
-      {t('Columns')}
-    </Button>
+    <GuideAnchor target="columns_header_button">
+      <Button
+        size="small"
+        disabled={!canEdit}
+        onClick={onClick}
+        data-test-id="grid-edit-enable"
+        icon={<IconStack size="xs" />}
+      >
+        {t('Columns')}
+      </Button>
+    </GuideAnchor>
   );
 }
 // Placate eslint proptype checking

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import * as ReactRouter from 'react-router';
+import styled from '@emotion/styled';
 import {withTheme} from 'emotion-theming';
 import {Location} from 'history';
 
 import {Client} from 'app/api';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import EventsChart from 'app/components/charts/eventsChart';
 import {ChartContainer, HeaderTitleLegend} from 'app/components/charts/styles';
 import {Panel} from 'app/components/panels';
@@ -297,6 +299,11 @@ class ReleaseChartContainer extends React.Component<Props> {
                 ? this.renderStackedChart()
                 : this.renderHealthChart(loading, reloading, errored, chartData)}
             </ChartContainer>
+            <AnchorWrapper>
+              <GuideAnchor target="release_chart" position="bottom" offset="-80px">
+                <React.Fragment />
+              </GuideAnchor>
+            </AnchorWrapper>
             <ReleaseChartControls
               summary={chartSummary}
               yAxis={yAxis}
@@ -318,3 +325,9 @@ class ReleaseChartContainer extends React.Component<Props> {
 }
 
 export default withTheme(ReleaseChartContainer);
+
+const AnchorWrapper = styled('div')`
+  height: 0px;
+  width: 50%;
+  float: right;
+`;

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/chart/index.tsx
@@ -327,7 +327,7 @@ class ReleaseChartContainer extends React.Component<Props> {
 export default withTheme(ReleaseChartContainer);
 
 const AnchorWrapper = styled('div')`
-  height: 0px;
-  width: 50%;
-  float: right;
+  height: 0;
+  width: 0;
+  margin-left: 50%;
 `;

--- a/src/sentry/static/sentry/app/views/releases/detail/overview/issues.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/overview/issues.tsx
@@ -4,6 +4,7 @@ import {Location} from 'history';
 import pick from 'lodash/pick';
 
 import Feature from 'app/components/acl/feature';
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import DiscoverButton from 'app/components/discoverButton';
@@ -217,13 +218,15 @@ class Issues extends React.Component<Props, State> {
             </Button>
 
             <Feature features={['discover-basic']}>
-              <DiscoverButton
-                to={this.getDiscoverUrl()}
-                size="small"
-                data-test-id="discover-button"
-              >
-                {t('Open in Discover')}
-              </DiscoverButton>
+              <GuideAnchor target="release_issues_open_in_discover">
+                <DiscoverButton
+                  to={this.getDiscoverUrl()}
+                  size="small"
+                  data-test-id="discover-button"
+                >
+                  {t('Open in Discover')}
+                </DiscoverButton>
+              </GuideAnchor>
             </Feature>
           </OpenInButtonBar>
         </ControlsWrapper>

--- a/src/sentry/static/sentry/app/views/releases/list/releaseCard.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
+import GuideAnchor from 'app/components/assistant/guideAnchor';
 import GlobalSelectionLink from 'app/components/globalSelectionLink';
 import {Panel} from 'app/components/panels';
 import ReleaseStats from 'app/components/releaseStats';
@@ -72,9 +73,11 @@ const ReleaseCard = ({
               query: {project: getReleaseProjectId(release, selection)},
             }}
           >
-            <VersionWrapper>
-              <StyledVersion version={version} tooltipRawVersion anchor={false} />
-            </VersionWrapper>
+            <GuideAnchor disabled={!isTopRelease} target="release_version">
+              <VersionWrapper>
+                <StyledVersion version={version} tooltipRawVersion anchor={false} />
+              </VersionWrapper>
+            </GuideAnchor>
           </GlobalSelectionLink>
           {commitCount > 0 && <ReleaseStats release={release} withHeading={false} />}
         </ReleaseInfoHeader>

--- a/src/sentry/static/sentry/app/views/releases/list/releaseHealth/content.tsx
+++ b/src/sentry/static/sentry/app/views/releases/list/releaseHealth/content.tsx
@@ -94,7 +94,7 @@ const Content = ({
             </CollapseButtonWrapper>
           )}
         >
-          {projects.map(project => {
+          {projects.map((project, index) => {
             const {id, slug, newGroups} = project;
 
             const crashCount = getHealthData.getCrashCount(
@@ -213,12 +213,17 @@ const Content = ({
                   </NewIssuesColumn>
 
                   <ViewColumn>
-                    <ProjectLink
-                      orgSlug={organization.slug}
-                      project={project}
-                      releaseVersion={releaseVersion}
-                      location={location}
-                    />
+                    <GuideAnchor
+                      disabled={!isTopRelease || index !== 0}
+                      target="view_release"
+                    >
+                      <ProjectLink
+                        orgSlug={organization.slug}
+                        project={project}
+                        releaseVersion={releaseVersion}
+                        location={location}
+                      />
+                    </GuideAnchor>
                   </ViewColumn>
                 </Layout>
               </ProjectRow>


### PR DESCRIPTION
This PR adds more guides to demo mode and fixes a bug with guides that were added earlier (https://github.com/getsentry/sentry/pull/24649). The following guides have been added:

1. Releases
2. Release Details
3. Discover landing page
4. Discover event view
5. Transaction details