### PR TITLE
test(discover): Skip invalid test

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -411,13 +411,6 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(response.data["data"]) == 1
         assert response.data["data"][0]["issue"] == event.group.qualified_short_id
 
-        # # should only show 1 event of type transaction since they dont have issues
-        # query = {"field": ["project", "issue"], "query": "!has:issue", "statsPeriod": "14d"}
-        # response = self.do_request(query, features=features)
-        # assert response.status_code == 200, response.content
-        # assert len(response.data["data"]) == 1
-        # assert response.data["data"][0]["issue"] == "unknown"
-
         # should only show 1 event of type default
         query = {
             "field": ["project", "issue"],

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1,4 +1,5 @@
 from pytz import utc
+import pytest
 
 from django.core.urlresolvers import reverse
 
@@ -459,6 +460,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(response.data["data"]) == 1
         assert response.data["data"][0]["issue"] == "unknown"
 
+    @pytest.mark.skip("Cannot look up group_id of transaction events")
     def test_unknown_issue(self):
         project = self.create_project()
         event = self.store_event(

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -410,12 +410,12 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(response.data["data"]) == 1
         assert response.data["data"][0]["issue"] == event.group.qualified_short_id
 
-        # should only show 1 event of type transaction since they dont have issues
-        query = {"field": ["project", "issue"], "query": "!has:issue", "statsPeriod": "14d"}
-        response = self.do_request(query, features=features)
-        assert response.status_code == 200, response.content
-        assert len(response.data["data"]) == 1
-        assert response.data["data"][0]["issue"] == "unknown"
+        # # should only show 1 event of type transaction since they dont have issues
+        # query = {"field": ["project", "issue"], "query": "!has:issue", "statsPeriod": "14d"}
+        # response = self.do_request(query, features=features)
+        # assert response.status_code == 200, response.content
+        # assert len(response.data["data"]) == 1
+        # assert response.data["data"][0]["issue"] == "unknown"
 
         # should only show 1 event of type default
         query = {


### PR DESCRIPTION
This test isn't valid because it generates a query that attempts to
look at the group_id column in the Discover table. This table is not
present in the Discover table since it is not relevant for transactions.

It's likely the underlying implementation of has:issue needs to be fixed
though that is not tackled here.

has:issue or issue:unknown seems equivalent to type != transaction since all
non transaction events have issues, and no transaction ever has an issue.

These queries just happened to pass previously because events and transactions
were temporarily colocated in the same table, but that will no longer be the
case going forward.