### PR TITLE
test: Fix organization event stats test

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -865,6 +865,7 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
                     "orderby": ["-count()"],
                     "field": ["count()", "message", "issue"],
                     "topEvents": 5,
+                    "query": "!event.type:transaction",
                 },
                 format="json",
             )
@@ -874,8 +875,8 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
         assert len(data) == 5
 
-        for index, event in enumerate(self.events[:5]):
-            message = event.message or event.transaction
+        for index, event in enumerate(self.events[:4]):
+            message = event.message
             # Because we deleted the group for event 0
             if index == 0 or event.group is None:
                 issue = "unknown"


### PR DESCRIPTION
Ensure that transactions are excluded from the top_event_with_issue test.
This query is ambiguous because the `issue` field is not relevant to transactions.
We should ensure these are excluded from the query.

This change ensures that the query returns consistent results regardless of
whether we are using the legacy combined errors/transaction storage or the new
separated versions. Once we are on the new storage, the presence of
`!event.type:transaction` here will not have any effect.