### PR TITLE
feat(trace-view): Adding issue urls to the response

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -346,12 +346,15 @@ class Group(Model):
         )
         super().save(*args, **kwargs)
 
-    def get_absolute_url(self, params=None, event_id=None):
+    def get_absolute_url(self, params=None, event_id=None, organization_slug=None):
         # Built manually in preference to django.core.urlresolvers.reverse,
         # because reverse has a measured performance impact.
         event_path = f"events/{event_id}/" if event_id else ""
         url = "organizations/{org}/issues/{id}/{event_path}{params}".format(
-            org=urlquote(self.organization.slug),
+            # Pass organization_slug if this needs to be called multiple times to avoid n+1 queries
+            org=urlquote(
+                self.organization.slug if organization_slug is None else organization_slug
+            ),
             id=self.id,
             event_path=event_path,
             params="?" + urlencode(params) if params else "",


### PR DESCRIPTION
- We need these urls to link back and forth between performance and
  issues
- Also added an organization_slug param to get_absolute_url to avoid a
  n+1 query