### PR TITLE
fix: calendar dark mode using style-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -258,7 +258,21 @@ let appConfig = {
       },
       {
         test: /\.css/,
-        use: ['style-loader', 'css-loader'],
+        use: [
+          {
+            loader: 'style-loader',
+            options: {
+              // allow emotion to override style-loader.
+              // note that it must be injected after sentry.css, otherwise
+              // it breaks onboarding prism styling.
+              insert: function (element) {
+                // insertBefore(element, null) appends the element
+                document.head.insertBefore(element, document.head.querySelector('style'));
+              },
+            },
+          },
+          'css-loader',
+        ],
       },
       {
         test: /\.less$/,


### PR DESCRIPTION
After #23240, react-date-range is now lazy-loaded. Unfortunately, this causes
its CSS to non-deterministically override GlobalStyles. Adjust the injection so
that it happens before emotion's injected styles.