### PR TITLE
fix(images-loaded): Fix SearchBar inconsistency

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -578,12 +578,6 @@ export default withRouter(DebugMeta);
 const StyledEventDataSection = styled(EventDataSection)`
   padding-bottom: ${space(4)};
 
-  > * :nth-child(1) {
-    > *:nth-child(2) {
-      min-width: calc(100% - 45%);
-    }
-  }
-
   /* to increase specificity */
   @media (min-width: ${p => p.theme.breakpoints[0]}) {
     padding-bottom: ${space(2)};
@@ -639,7 +633,6 @@ const StyledList = styled(List)<{height: number}>`
   outline: none;
 `;
 
-// Search
 const Search = styled('div')`
   display: grid;
   grid-gap: ${space(2)};
@@ -649,8 +642,19 @@ const Search = styled('div')`
   @media (min-width: ${props => props.theme.breakpoints[0]}) {
     margin-top: 0;
     grid-gap: 0;
-    grid-template-columns: max-content 1fr;
+    grid-template-columns: ${p =>
+      p.children && React.Children.toArray(p.children).length === 1
+        ? '1fr'
+        : 'max-content 1fr'};
     justify-content: flex-end;
+  }
+
+  @media (min-width: ${props => props.theme.breakpoints[1]}) {
+    width: 400px;
+  }
+
+  @media (min-width: ${props => props.theme.breakpoints[3]}) {
+    width: 600px;
   }
 `;
 


### PR DESCRIPTION
When there is only one option to be displayed in the filter, the UI doesn't display the filter. 

with the changes pushed in the PR https://github.com/getsentry/sentry/pull/24699, the search bar is no longer displayed entirely on the right, looking odd:

![image](https://user-images.githubusercontent.com/29228205/112620776-4194b480-8e29-11eb-9e7f-48ff7b100522.png)


This PR fixes this issue:

![image](https://user-images.githubusercontent.com/29228205/112620726-33469880-8e29-11eb-9d01-92bfcbb8672e.png)


