### PR TITLE
fix(metric_alerts): Fix Slack timestamp footer

### DIFF
--- a/src/sentry/integrations/slack/utils.py
+++ b/src/sentry/integrations/slack/utils.py
@@ -326,6 +326,12 @@ def build_incident_attachment(action, incident, metric_value=None, method=None):
         "Critical": LEVEL_TO_COLOR["fatal"],
     }
 
+    incident_footer_ts = (
+        "<!date^{:.0f}^Sentry Incident - Started {} at {} | Sentry Incident>".format(
+            to_timestamp(data["ts"]), "{date_pretty}", "{time}"
+        )
+    )
+
     return {
         "fallback": data["title"],
         "title": data["title"],
@@ -334,8 +340,7 @@ def build_incident_attachment(action, incident, metric_value=None, method=None):
         "fields": [],
         "mrkdwn_in": ["text"],
         "footer_icon": data["logo_url"],
-        "footer": "Sentry Incident",
-        "ts": to_timestamp(data["ts"]),
+        "footer": incident_footer_ts,
         "color": colors[data["status"]],
         "actions": [],
     }

--- a/tests/sentry/integrations/slack/test_utils.py
+++ b/tests/sentry/integrations/slack/test_utils.py
@@ -104,6 +104,11 @@ class BuildIncidentAttachmentTest(TestCase):
             alert_rule_trigger=trigger, triggered_for_incident=incident
         )
         title = f"Resolved: {alert_rule.name}"
+        incident_footer_ts = (
+            "<!date^{:.0f}^Sentry Incident - Started {} at {} | Sentry Incident>".format(
+                to_timestamp(incident.date_started), "{date_pretty}", "{time}"
+            )
+        )
         assert build_incident_attachment(action, incident) == {
             "fallback": title,
             "title": title,
@@ -120,8 +125,7 @@ class BuildIncidentAttachmentTest(TestCase):
             "fields": [],
             "mrkdwn_in": ["text"],
             "footer_icon": logo_url,
-            "footer": "Sentry Incident",
-            "ts": to_timestamp(incident.date_started),
+            "footer": incident_footer_ts,
             "color": RESOLVED_COLOR,
             "actions": [],
         }
@@ -135,6 +139,11 @@ class BuildIncidentAttachmentTest(TestCase):
         trigger = self.create_alert_rule_trigger(alert_rule, CRITICAL_TRIGGER_LABEL, 100)
         action = self.create_alert_rule_trigger_action(
             alert_rule_trigger=trigger, triggered_for_incident=incident
+        )
+        incident_footer_ts = (
+            "<!date^{:.0f}^Sentry Incident - Started {} at {} | Sentry Incident>".format(
+                to_timestamp(incident.date_started), "{date_pretty}", "{time}"
+            )
         )
         # This should fail because it pulls status from `action` instead of `incident`
         assert build_incident_attachment(
@@ -155,8 +164,7 @@ class BuildIncidentAttachmentTest(TestCase):
             "fields": [],
             "mrkdwn_in": ["text"],
             "footer_icon": logo_url,
-            "footer": "Sentry Incident",
-            "ts": to_timestamp(incident.date_started),
+            "footer": incident_footer_ts,
             "color": LEVEL_TO_COLOR["fatal"],
             "actions": [],
         }


### PR DESCRIPTION
Fix Slack timestamp footer to include 'started' to avoid confusion.

FIXES [WOR-396](https://getsentry.atlassian.net/browse/WOR-396)

### Before
<img width="314" alt="Screen Shot 2021-03-26 at 3 26 02 AM" src="https://user-images.githubusercontent.com/20312973/112620560-f1483300-8de5-11eb-9893-3fcc7df3b440.png">

### After
<img width="352" alt="Screen Shot 2021-03-26 at 3 37 16 AM" src="https://user-images.githubusercontent.com/20312973/112620598-fdcc8b80-8de5-11eb-8f0c-3914a7bdea0b.png">