### PR TITLE
fix(ts): Remove TODO on EChart lineStyle

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/areaChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/areaChart.tsx
@@ -8,10 +8,7 @@ import BaseChart from './baseChart';
 
 type ChartProps = React.ComponentProps<typeof BaseChart>;
 
-export type AreaChartSeries = Series &
-  Omit<EChartOption.SeriesLine, 'data' | 'name' | 'lineStyle'> & {
-    lineStyle?: any; // TODO(ts): Fix when echarts type is updated so that EchartOption.LineStyle matches SeriesLine['lineStyle']
-  };
+export type AreaChartSeries = Series & Omit<EChartOption.SeriesLine, 'data' | 'name'>;
 
 type Props = Omit<ChartProps, 'series'> & {
   stacked?: boolean;

--- a/src/sentry/static/sentry/app/components/charts/lineChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/lineChart.tsx
@@ -9,9 +9,8 @@ import BaseChart from './baseChart';
 type ChartProps = React.ComponentProps<typeof BaseChart>;
 
 export type LineChartSeries = Series &
-  Omit<EChartOption.SeriesLine, 'data' | 'name' | 'lineStyle'> & {
+  Omit<EChartOption.SeriesLine, 'data' | 'name'> & {
     dataArray?: EChartOption.SeriesLine['data'];
-    lineStyle?: any; // TODO(ts): Fix when echarts type is updated so that EchartOption.LineStyle matches SeriesLine['lineStyle']
   };
 
 type Props = Omit<ChartProps, 'series'> & {


### PR DESCRIPTION
The `@types/echarts` package was updated in #24112 which included the necessary
fixes for `lineStyle`. This workaround can now be removed.