### PR TITLE
fix: timestamp.to_{hour,day} topn

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -482,7 +482,7 @@ def top_events_timeseries(
             )
             if values:
                 # timestamp needs special handling, creating a big OR instead
-                if field == "timestamp":
+                if field in ["timestamp", "timestamp.to_hour", "timestamp.to_day"]:
                     snuba_filter.conditions.append([["timestamp", "=", value] for value in values])
                 elif None in values:
                     non_none_values = [value for value in values if value is not None]


### PR DESCRIPTION
Tests not included because:

1. I'm not sure topn actually makes sense for timestamp.to_hour
2. I think the special case will be removed with SnQL migration
3. It seems hard

IMO it's good enough to just have it not crashing right now.