### PR TITLE
ref(perf): Add experimental UI for tag explorer

### DIFF
--- a/src/sentry/static/sentry/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import {EventQuery} from 'app/actionCreators/events';
+import {LocationQuery} from 'app/utils/discover/eventView';
+import GenericDiscoverQuery, {
+  DiscoverQueryProps,
+  GenericChildrenProps,
+} from 'app/utils/discover/genericDiscoverQuery';
+import withApi from 'app/utils/withApi';
+
+/**
+ * An individual row in a Segment explorer result
+ */
+export type TableDataRow = {
+  id: string;
+  key: string;
+  [key: string]: string | number | TopValue[];
+};
+
+export type TopValue = {
+  name: string;
+  value: string;
+  aggregate: number;
+  count: number;
+};
+
+/**
+ * A Segment Explorer result including rows and metadata.
+ */
+export type TableData = TableDataRow[];
+
+type ChildrenProps = Omit<GenericChildrenProps<TableData>, 'tableData'> & {
+  tableData: TableData | null;
+};
+
+type QueryProps = DiscoverQueryProps & {
+  tagOrder: string;
+  aggregateColumn: string;
+  children: (props: ChildrenProps) => React.ReactNode;
+};
+
+type FacetQuery = LocationQuery &
+  EventQuery & {
+    order?: string;
+    aggregateColumn?: string;
+  };
+
+export function getRequestFunction(_props: QueryProps) {
+  const {tagOrder, aggregateColumn} = _props;
+  function getTagExplorerRequestPayload(props: DiscoverQueryProps) {
+    const {eventView} = props;
+    const apiPayload: FacetQuery = eventView?.getEventsAPIPayload(props.location);
+    apiPayload.order = tagOrder;
+    apiPayload.aggregateColumn = aggregateColumn;
+    return apiPayload;
+  }
+  return getTagExplorerRequestPayload;
+}
+
+function shouldRefetchData(prevProps: QueryProps, nextProps: QueryProps) {
+  return (
+    prevProps.tagOrder !== nextProps.tagOrder ||
+    prevProps.aggregateColumn !== nextProps.aggregateColumn
+  );
+}
+
+function SegmentExplorerQuery(props: QueryProps) {
+  return (
+    <GenericDiscoverQuery<TableData, QueryProps>
+      route="events-facets-performance"
+      getRequestPayload={getRequestFunction(props)}
+      shouldRefetchData={shouldRefetchData}
+      {...props}
+    />
+  );
+}
+
+export default withApi(SegmentExplorerQuery);

--- a/src/sentry/static/sentry/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
@@ -49,7 +49,7 @@ export function getRequestFunction(_props: QueryProps) {
   const {tagOrder, aggregateColumn} = _props;
   function getTagExplorerRequestPayload(props: DiscoverQueryProps) {
     const {eventView} = props;
-    const apiPayload: FacetQuery = eventView?.getEventsAPIPayload(props.location);
+    const apiPayload: FacetQuery = eventView.getEventsAPIPayload(props.location);
     apiPayload.order = tagOrder;
     apiPayload.aggregateColumn = aggregateColumn;
     return apiPayload;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import {Location, LocationDescriptor, Query} from 'history';
 import omit from 'lodash/omit';
 
+import Feature from 'app/components/acl/feature';
 import {CreateAlertFromViewButton} from 'app/components/createAlertButton';
 import TransactionsList, {DropdownOption} from 'app/components/discover/transactionsList';
 import SearchBar from 'app/components/events/searchBar';
@@ -39,6 +40,7 @@ import TransactionHeader, {Tab} from './header';
 import RelatedIssues from './relatedIssues';
 import SidebarCharts from './sidebarCharts';
 import StatusBreakdown from './statusBreakdown';
+import {TagExplorer} from './tagExplorer';
 import UserStats from './userStats';
 import {SidebarSpacer, TransactionFilterOptions} from './utils';
 
@@ -231,6 +233,15 @@ class SummaryContent extends React.Component<Props, State> {
               })}
               forceLoading={isLoading}
             />
+            <Feature features={['performance-tag-explorer']}>
+              <TagExplorer
+                eventView={eventView}
+                organization={organization}
+                location={location}
+                projects={projects}
+                transactionName={transactionName}
+              />
+            </Feature>
             <RelatedIssues
               organization={organization}
               location={location}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -22,6 +22,7 @@ import {decodeScalar} from 'app/utils/queryString';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
 import CellAction from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
+import {PerformanceDuration} from '../utils';
 
 const COLUMN_ORDER = [
   {
@@ -95,29 +96,24 @@ const renderBodyCell = (
   if (Array.isArray(value)) {
     return (
       // TODO(Kevan): Remove ts any
-      <CellAction column={column} dataRow={dataRow as any} handleCellAction={() => {}}>
-        <TagValueContainer>
-          {value.map(v => {
-            return (
-              <TagInner key={v.value}>
-                <Link
-                  to=""
-                  onClick={() => handleTagValueClick(location, dataRow.key, v.value)}
-                >
-                  <TagValue value={v} />
-                </Link>
-                <DurationCountSplit>
-                  <Duration
-                    seconds={v.aggregate / 1000}
-                    fixedDigits={v.aggregate > 1000 ? 2 : 0}
-                  />
-                  <div>{formatAbbreviatedNumber(v.count)}</div>
-                </DurationCountSplit>
-              </TagInner>
-            );
-          })}
-        </TagValueContainer>
-      </CellAction>
+      <TagValueContainer>
+        {value.map(v => {
+          return (
+            <TagInner key={v.value}>
+              <Link
+                to=""
+                onClick={() => handleTagValueClick(location, dataRow.key, v.value)}
+              >
+                <TagValue value={v} />
+              </Link>
+              <DurationCountSplit>
+                <PerformanceDuration milliseconds={v.aggregate} />
+                <div>{formatAbbreviatedNumber(v.count)}</div>
+              </DurationCountSplit>
+            </TagInner>
+          );
+        })}
+      </TagValueContainer>
     );
   }
   return value;
@@ -198,46 +194,44 @@ class _TagExplorer extends React.Component<Props, State> {
       columnDropdownOptions[0];
 
     return (
-      <React.Fragment>
-        <SegmentExplorerQuery
-          eventView={eventView}
-          orgSlug={organization.slug}
-          location={location}
-          tagOrder={tagOrder}
-          aggregateColumn={aggregateColumn}
-          limit={5}
-        >
-          {({isLoading, tableData, pageLinks}) => {
-            return (
-              <React.Fragment>
-                <TagsHeader
-                  selectedSort={selectedSort}
-                  sortOptions={sortDropdownOptions}
-                  selectedColumn={selectedColumn}
-                  columnOptions={columnDropdownOptions}
-                  handleSortDropdownChange={(v: string) => this.setTagOrder(v)}
-                  handleColumnDropdownChange={(v: string) => this.setAggregateColumn(v)}
-                />
-                <GridEditable
-                  isLoading={isLoading}
-                  data={tableData ? tableData : []}
-                  columnOrder={COLUMN_ORDER}
-                  columnSortBy={[]}
-                  grid={{
-                    renderBodyCell: renderBodyCellWithData(this.props) as any,
-                  }}
-                  location={location}
-                />
-                <StyledPagination
-                  pageLinks={pageLinks}
-                  onCursor={handleCursor}
-                  size="small"
-                />
-              </React.Fragment>
-            );
-          }}
-        </SegmentExplorerQuery>
-      </React.Fragment>
+      <SegmentExplorerQuery
+        eventView={eventView}
+        orgSlug={organization.slug}
+        location={location}
+        tagOrder={tagOrder}
+        aggregateColumn={aggregateColumn}
+        limit={5}
+      >
+        {({isLoading, tableData, pageLinks}) => {
+          return (
+            <React.Fragment>
+              <TagsHeader
+                selectedSort={selectedSort}
+                sortOptions={sortDropdownOptions}
+                selectedColumn={selectedColumn}
+                columnOptions={columnDropdownOptions}
+                handleSortDropdownChange={(v: string) => this.setTagOrder(v)}
+                handleColumnDropdownChange={(v: string) => this.setAggregateColumn(v)}
+              />
+              <GridEditable
+                isLoading={isLoading}
+                data={tableData ? tableData : []}
+                columnOrder={COLUMN_ORDER}
+                columnSortBy={[]}
+                grid={{
+                  renderBodyCell: renderBodyCellWithData(this.props) as any,
+                }}
+                location={location}
+              />
+              <StyledPagination
+                pageLinks={pageLinks}
+                onCursor={handleCursor}
+                size="small"
+              />
+            </React.Fragment>
+          );
+        }}
+      </SegmentExplorerQuery>
     );
   }
 }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -5,7 +5,6 @@ import {Location} from 'history';
 
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
-import Duration from 'app/components/duration';
 import GridEditable from 'app/components/gridEditable';
 import Link from 'app/components/links/link';
 import Pagination from 'app/components/pagination';
@@ -20,8 +19,8 @@ import SegmentExplorerQuery, {
 } from 'app/utils/performance/segmentExplorer/segmentExplorerQuery';
 import {decodeScalar} from 'app/utils/queryString';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
-import CellAction from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
+
 import {PerformanceDuration} from '../utils';
 
 const COLUMN_ORDER = [

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -1,0 +1,337 @@
+import React from 'react';
+import {browserHistory} from 'react-router';
+import styled from '@emotion/styled';
+import {Location} from 'history';
+
+import DropdownButton from 'app/components/dropdownButton';
+import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
+import Duration from 'app/components/duration';
+import GridEditable from 'app/components/gridEditable';
+import Link from 'app/components/links/link';
+import Pagination from 'app/components/pagination';
+import {t} from 'app/locale';
+import space from 'app/styles/space';
+import {Organization, Project} from 'app/types';
+import EventView from 'app/utils/discover/eventView';
+import {formatAbbreviatedNumber} from 'app/utils/formatters';
+import SegmentExplorerQuery, {
+  TableDataRow,
+  TopValue,
+} from 'app/utils/performance/segmentExplorer/segmentExplorerQuery';
+import {decodeScalar} from 'app/utils/queryString';
+import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
+import CellAction from 'app/views/eventsV2/table/cellAction';
+import {TableColumn} from 'app/views/eventsV2/table/types';
+
+const COLUMN_ORDER = [
+  {
+    key: 'key',
+    name: 'Key',
+    width: -1,
+    column: {
+      kind: 'field',
+    },
+  },
+  {
+    key: 'topValues',
+    name: 'Values',
+    width: -1,
+    column: {
+      kind: 'field',
+    },
+  },
+];
+
+const HEADER_OPTIONS: DropdownOption[] = [
+  {
+    label: 'Slowest Tag Values',
+    value: '-aggregate',
+  },
+  {
+    label: 'Fastest Tag Values',
+    value: 'aggregate',
+  },
+  {
+    label: 'Most Frequent Tag Values',
+    value: '-count',
+  },
+];
+
+const DURATION_OPTIONS: DropdownOption[] = [
+  {
+    label: 'transaction.duration',
+    value: 'duration',
+  },
+  {
+    label: 'measurements.lcp',
+    value: 'measurements[lcp]',
+  },
+];
+
+const handleTagValueClick = (location: Location, tagKey: string, tagValue: string) => {
+  const queryString = decodeScalar(location.query.query);
+  const conditions = tokenizeSearch(queryString || '');
+
+  conditions.addTagValues(tagKey, [tagValue]);
+
+  const query = stringifyQueryObject(conditions);
+  browserHistory.push({
+    pathname: location.pathname,
+    query: {
+      ...location.query,
+      query: String(query).trim(),
+    },
+  });
+};
+
+const renderBodyCell = (
+  parentProps: Props,
+  column: TableColumn<keyof TableDataRow>,
+  dataRow: TableDataRow
+): React.ReactNode => {
+  const value = dataRow[column.key];
+  const {location} = parentProps;
+
+  if (Array.isArray(value)) {
+    return (
+      // TODO(Kevan): Remove ts any
+      <CellAction column={column} dataRow={dataRow as any} handleCellAction={() => {}}>
+        <TagValueContainer>
+          {value.map(v => {
+            return (
+              <TagInner key={v.value}>
+                <Link
+                  to=""
+                  onClick={() => handleTagValueClick(location, dataRow.key, v.value)}
+                >
+                  <TagValue value={v} />
+                </Link>
+                <DurationCountSplit>
+                  <Duration
+                    seconds={v.aggregate / 1000}
+                    fixedDigits={v.aggregate > 1000 ? 2 : 0}
+                  />
+                  <div>{formatAbbreviatedNumber(v.count)}</div>
+                </DurationCountSplit>
+              </TagInner>
+            );
+          })}
+        </TagValueContainer>
+      </CellAction>
+    );
+  }
+  return value;
+};
+
+const renderBodyCellWithData = (parentProps: Props) => {
+  return (
+    column: TableColumn<keyof TableDataRow>,
+    dataRow: TableDataRow
+  ): React.ReactNode => renderBodyCell(parentProps, column, dataRow);
+};
+
+const TagValueContainer = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-gap: ${space(1)};
+`;
+const TagInner = styled('div')`
+  display: grid;
+`;
+const DurationCountSplit = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+`;
+
+type TagValueProps = {
+  value: TopValue;
+};
+
+function TagValue(props: TagValueProps) {
+  const {value} = props;
+  return <div>{value.name}</div>;
+}
+
+type Props = {
+  eventView: EventView;
+  organization: Organization;
+  location: Location;
+  projects: Project[];
+  transactionName: string;
+};
+
+type State = {
+  tagOrder: string;
+  aggregateColumn: string;
+};
+
+class _TagExplorer extends React.Component<Props, State> {
+  state: State = {
+    tagOrder: HEADER_OPTIONS[0].value,
+    aggregateColumn: DURATION_OPTIONS[0].value,
+  };
+
+  setTagOrder(value: string) {
+    this.setState({
+      tagOrder: value,
+    });
+  }
+
+  setAggregateColumn(value: string) {
+    this.setState({
+      aggregateColumn: value,
+    });
+  }
+
+  render() {
+    const {eventView, organization, location} = this.props;
+    const {tagOrder, aggregateColumn} = this.state;
+    const handleCursor = () => {};
+
+    const sortDropdownOptions = HEADER_OPTIONS;
+    const columnDropdownOptions = DURATION_OPTIONS;
+
+    const selectedSort =
+      sortDropdownOptions.find(o => o.value === tagOrder) || sortDropdownOptions[0];
+    const selectedColumn =
+      columnDropdownOptions.find(o => o.value === aggregateColumn) ||
+      columnDropdownOptions[0];
+
+    return (
+      <React.Fragment>
+        <SegmentExplorerQuery
+          eventView={eventView}
+          orgSlug={organization.slug}
+          location={location}
+          tagOrder={tagOrder}
+          aggregateColumn={aggregateColumn}
+          limit={5}
+        >
+          {({isLoading, tableData, pageLinks}) => {
+            return (
+              <React.Fragment>
+                <TagsHeader
+                  selectedSort={selectedSort}
+                  sortOptions={sortDropdownOptions}
+                  selectedColumn={selectedColumn}
+                  columnOptions={columnDropdownOptions}
+                  handleSortDropdownChange={(v: string) => this.setTagOrder(v)}
+                  handleColumnDropdownChange={(v: string) => this.setAggregateColumn(v)}
+                />
+                <GridEditable
+                  isLoading={isLoading}
+                  data={tableData ? tableData : []}
+                  columnOrder={COLUMN_ORDER}
+                  columnSortBy={[]}
+                  grid={{
+                    renderBodyCell: renderBodyCellWithData(this.props) as any,
+                  }}
+                  location={location}
+                />
+                <StyledPagination
+                  pageLinks={pageLinks}
+                  onCursor={handleCursor}
+                  size="small"
+                />
+              </React.Fragment>
+            );
+          }}
+        </SegmentExplorerQuery>
+      </React.Fragment>
+    );
+  }
+}
+
+type DropdownOption = {
+  label: string;
+  value: string;
+};
+
+type HeaderProps = {
+  selectedSort: DropdownOption;
+  sortOptions: DropdownOption[];
+  selectedColumn: DropdownOption;
+  columnOptions: DropdownOption[];
+  handleSortDropdownChange: (k: string) => void;
+  handleColumnDropdownChange: (k: string) => void;
+};
+function TagsHeader(props: HeaderProps) {
+  const {
+    selectedSort,
+    sortOptions,
+    selectedColumn,
+    columnOptions,
+    handleSortDropdownChange,
+    handleColumnDropdownChange,
+  } = props;
+  return (
+    <Header>
+      <DropdownControl
+        data-test-id="sort-tag-values"
+        button={({isOpen, getActorProps}) => (
+          <StyledDropdownButton
+            {...getActorProps()}
+            isOpen={isOpen}
+            prefix={t('Sort')}
+            size="small"
+          >
+            {selectedSort.label}
+          </StyledDropdownButton>
+        )}
+      >
+        {sortOptions.map(({value, label}) => (
+          <DropdownItem
+            data-test-id={`option-${value}`}
+            key={value}
+            onSelect={handleSortDropdownChange}
+            eventKey={value}
+            isActive={value === selectedSort.value}
+          >
+            {label}
+          </DropdownItem>
+        ))}
+      </DropdownControl>
+      <DropdownControl
+        data-test-id="tag-column-performance"
+        button={({isOpen, getActorProps}) => (
+          <StyledDropdownButton
+            {...getActorProps()}
+            isOpen={isOpen}
+            prefix={t('Column')}
+            size="small"
+          >
+            {selectedColumn.label}
+          </StyledDropdownButton>
+        )}
+      >
+        {columnOptions.map(({value, label}) => (
+          <DropdownItem
+            data-test-id={`option-${value}`}
+            key={value}
+            onSelect={handleColumnDropdownChange}
+            eventKey={value}
+            isActive={value === selectedColumn.value}
+          >
+            {label}
+          </DropdownItem>
+        ))}
+      </DropdownControl>
+    </Header>
+  );
+}
+
+const Header = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin: 0 0 ${space(1)} 0;
+`;
+const StyledDropdownButton = styled(DropdownButton)`
+  min-width: 145px;
+`;
+
+const StyledPagination = styled(Pagination)`
+  margin: 0 0 ${space(3)} 0;
+`;
+
+export const TagExplorer = _TagExplorer;

--- a/src/sentry/static/sentry/app/views/performance/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/utils.tsx
@@ -1,6 +1,9 @@
+import React from 'react';
 import {Location, LocationDescriptor, Query} from 'history';
 
+import Duration from 'app/components/duration';
 import {GlobalSelection, OrganizationSummary} from 'app/types';
+import {defined} from 'app/utils';
 import {statsPeriodToDays} from 'app/utils/dates';
 import getCurrentSentryReactTransaction from 'app/utils/getCurrentSentryReactTransaction';
 import {decodeScalar} from 'app/utils/queryString';
@@ -83,4 +86,21 @@ export function getTransactionName(location: Location): string | undefined {
   const {transaction} = location.query;
 
   return decodeScalar(transaction);
+}
+
+type SecondsProps = {seconds: number};
+type MillisecondsProps = {milliseconds: number};
+type PerformanceDurationProps = SecondsProps | MillisecondsProps;
+const hasMilliseconds = (props: PerformanceDurationProps): props is MillisecondsProps => {
+  return defined((props as MillisecondsProps).milliseconds);
+};
+export function PerformanceDuration(props: SecondsProps);
+export function PerformanceDuration(props: MillisecondsProps);
+export function PerformanceDuration(props: PerformanceDurationProps) {
+  const normalizedSeconds = hasMilliseconds(props)
+    ? props.milliseconds / 1000
+    : props.seconds;
+  return (
+    <Duration seconds={normalizedSeconds} fixedDigits={normalizedSeconds > 1 ? 2 : 0} />
+  );
 }


### PR DESCRIPTION
### Summary
This will add a simple table showing the results from the experimental tag explorer endpoint. It has a couple dropdowns which can be used to control the tag value order (by frequency or by time) as well as which column the performance facets are operating against (duration or measurements.lcp).

This is temporary/experimental and is flagged just for visibility team use as we confirm the performance.


### Screenshots
![Screen Shot 2021-03-26 at 10 42 39 AM](https://user-images.githubusercontent.com/6111995/112671889-0346c780-8e20-11eb-8185-5d98068cd501.png)
