### PR TITLE
feat(discover): Introduce a count_miserable aggregation to replace user misery

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -317,6 +317,7 @@ class SearchVisitor(NodeVisitor):
         "p95",
         "p99",
         "failure_rate",
+        "count_miserable",
         "user_misery",
         "user_misery_prototype",
     }
@@ -2054,6 +2055,17 @@ FUNCTIONS = {
             "apdex",
             required_args=[NumberRange("satisfaction", 0, None)],
             transform="apdex(duration, {satisfaction:g})",
+            default_result_type="number",
+        ),
+        Function(
+            "count_miserable",
+            required_args=[CountColumn("column"), NumberRange("satisfaction", 0, None)],
+            calculated_args=[{"name": "tolerated", "fn": lambda args: args["satisfaction"] * 4.0}],
+            aggregate=[
+                "uniqIf",
+                [ArgValue("column"), ["greater", ["transaction.duration", ArgValue("tolerated")]]],
+                None,
+            ],
             default_result_type="number",
         ),
         Function(

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -25,14 +25,13 @@ export type ColumnType =
 export type ColumnValueType = ColumnType | 'never'; // Matches to nothing
 
 type ValidateColumnValueFunction = ({name: string, dataType: ColumnType}) => boolean;
-type ValidateColumnFunction = ({name: string}) => boolean;
 
 export type ValidateColumnTypes = ColumnType[] | ValidateColumnValueFunction;
 
 export type AggregateParameter =
   | {
       kind: 'column';
-      columnTypes: Readonly<ValidateColumnTypes | ValidateColumnFunction>;
+      columnTypes: Readonly<ValidateColumnTypes>;
       defaultValue?: string;
       required: boolean;
     }
@@ -784,8 +783,8 @@ function validateForNumericAggregate(
   };
 }
 
-function validateAllowedColumns(validColumns: string[]): ValidateColumnFunction {
-  return function ({name}: {name: string}): boolean {
+function validateAllowedColumns(validColumns: string[]): ValidateColumnValueFunction {
+  return function ({name}): boolean {
     return validColumns.includes(name);
   };
 }

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2300,6 +2300,7 @@ class ResolveFieldListTest(unittest.TestCase):
             "latest_event()",
             "last_seen()",
             "apdex(300)",
+            "count_miserable(user, 300)",
             "user_misery(300)",
             "user_misery_prototype(300)",
             "percentile(transaction.duration, 0.75)",
@@ -2318,6 +2319,11 @@ class ResolveFieldListTest(unittest.TestCase):
             ["argMax", ["id", "timestamp"], "latest_event"],
             ["max", "timestamp", "last_seen"],
             ["apdex(duration, 300)", None, "apdex_300"],
+            [
+                "uniqIf",
+                ["user", ["greater", ["transaction.duration", 1200.0]]],
+                "count_miserable_user_300",
+            ],
             ["uniqIf(user, greater(duration, 1200))", None, "user_misery_300"],
             [
                 "ifNull(divide(plus(uniqIf(user, greater(duration, 1200)), 5.8875), plus(uniq(user), 117.75)), 0)",

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1974,6 +1974,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "p100()",
                 "percentile(transaction.duration, 0.99)",
                 "apdex(300)",
+                "count_miserable(user, 300)",
                 "user_misery(300)",
                 "user_misery_prototype(300)",
                 "failure_rate()",
@@ -2118,6 +2119,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             "field": [
                 "event.type",
                 "apdex(300)",
+                "count_miserable(user, 300)",
                 "user_misery(300)",
                 "user_misery_prototype(300)",
                 "failure_rate()",


### PR DESCRIPTION
Introducing a count_miserable aggregate function that takes two inputs:
a column name (currently only supporting user) and threshold and returns
the number of unique aggregates (user in this case) that have experienced
a transaction duration > 4x the threshold.