### PR TITLE
fix(notifications): Notification Settings as Strings

### DIFF
--- a/src/sentry/api/serializers/models/user_notifications.py
+++ b/src/sentry/api/serializers/models/user_notifications.py
@@ -45,9 +45,9 @@ class UserNotificationsSerializer(Serializer):
                 # that should not receive reports
                 # This UserOption should have both project + organization = None
                 for org_id in uo.value:
-                    data[org_id] = 0
+                    data[org_id] = "0"
             elif uo.project is not None:
-                data[uo.project.id] = uo.value
+                data[uo.project.id] = str(uo.value)
             elif uo.organization is not None:
-                data[uo.organization.id] = uo.value
+                data[uo.organization.id] = str(uo.value)
         return data

--- a/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -9,90 +9,16 @@ import {t} from 'app/locale';
 import {Organization, Project, UserEmail} from 'app/types';
 import withOrganizations from 'app/utils/withOrganizations';
 import AsyncView from 'app/views/asyncView';
+import {
+  ACCOUNT_NOTIFICATION_FIELDS,
+  FineTuneField,
+} from 'app/views/settings/account/notifications/fields';
 import EmptyMessage from 'app/views/settings/components/emptyMessage';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import SelectField from 'app/views/settings/components/forms/selectField';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import TextBlock from 'app/views/settings/components/text/textBlock';
-
-type FineTuneField = {
-  title: string;
-  description: string;
-  type: 'select';
-  choices?: any;
-  defaultValue?: number;
-  defaultFieldName?: string;
-};
-
-const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
-  alerts: {
-    title: 'Project Alerts',
-    description: t('Control alerts that you receive per project.'),
-    type: 'select',
-    choices: [
-      [-1, t('Default')],
-      [1, t('On')],
-      [0, t('Off')],
-    ],
-    defaultValue: -1,
-    defaultFieldName: 'subscribeByDefault',
-  },
-  workflow: {
-    title: 'Workflow Notifications',
-    description: t(
-      'Control workflow notifications, e.g. changes in issue assignment, resolution status, and comments.'
-    ),
-    type: 'select',
-    choices: [
-      [-1, t('Default')],
-      [0, t('Always')],
-      [1, t('Only on issues I subscribe to')],
-      [2, t('Never')],
-    ],
-    defaultValue: -1,
-    defaultFieldName: 'workflowNotifications',
-  },
-  deploy: {
-    title: t('Deploy Notifications'),
-    description: t(
-      'Control deploy notifications that include release, environment, and commit overviews.'
-    ),
-    type: 'select',
-    choices: [
-      [-1, t('Default')],
-      [2, t('Always')],
-      [3, t('Only on deploys with my commits')],
-      [4, t('Never')],
-    ],
-    defaultValue: -1,
-    defaultFieldName: 'deployNotifications',
-  },
-  reports: {
-    title: t('Weekly Reports'),
-    description: t(
-      "Reports contain a summary of what's happened within the organization."
-    ),
-    type: 'select',
-    // API only saves organizations that have this disabled, so we should default to "On"
-    defaultValue: 1,
-    choices: [
-      [1, t('On')],
-      [0, t('Off')],
-    ],
-    defaultFieldName: 'weeklyReports',
-  },
-
-  email: {
-    title: t('Email Routing'),
-    description: t(
-      'On a per project basis, route emails to an alternative email address.'
-    ),
-    type: 'select',
-    // No choices here because it's going to have dynamic content
-    // Component will create choices
-  },
-};
 
 const PanelBodyLineItem = styled(PanelBody)`
   font-size: 1.4rem;

--- a/src/sentry/static/sentry/app/views/settings/account/notifications/fields.tsx
+++ b/src/sentry/static/sentry/app/views/settings/account/notifications/fields.tsx
@@ -1,0 +1,79 @@
+import {t} from 'app/locale';
+
+export type FineTuneField = {
+  title: string;
+  description: string;
+  type: 'select';
+  choices?: string[][];
+  defaultValue?: string;
+  defaultFieldName?: string;
+};
+
+export const ACCOUNT_NOTIFICATION_FIELDS: Record<string, FineTuneField> = {
+  alerts: {
+    title: 'Project Alerts',
+    description: t('Control alerts that you receive per project.'),
+    type: 'select',
+    choices: [
+      ['-1', t('Default')],
+      ['1', t('On')],
+      ['0', t('Off')],
+    ],
+    defaultValue: '-1',
+    defaultFieldName: 'subscribeByDefault',
+  },
+  workflow: {
+    title: 'Workflow Notifications',
+    description: t(
+      'Control workflow notifications, e.g. changes in issue assignment, resolution status, and comments.'
+    ),
+    type: 'select',
+    choices: [
+      ['-1', t('Default')],
+      ['0', t('Always')],
+      ['1', t('Only on issues I subscribe to')],
+      ['2', t('Never')],
+    ],
+    defaultValue: '-1',
+    defaultFieldName: 'workflowNotifications',
+  },
+  deploy: {
+    title: t('Deploy Notifications'),
+    description: t(
+      'Control deploy notifications that include release, environment, and commit overviews.'
+    ),
+    type: 'select',
+    choices: [
+      ['-1', t('Default')],
+      ['2', t('Always')],
+      ['3', t('Only on deploys with my commits')],
+      ['4', t('Never')],
+    ],
+    defaultValue: '-1',
+    defaultFieldName: 'deployNotifications',
+  },
+  reports: {
+    title: t('Weekly Reports'),
+    description: t(
+      "Reports contain a summary of what's happened within the organization."
+    ),
+    type: 'select',
+    // API only saves organizations that have this disabled, so we should default to "On"
+    defaultValue: '1',
+    choices: [
+      ['1', t('On')],
+      ['0', t('Off')],
+    ],
+    defaultFieldName: 'weeklyReports',
+  },
+
+  email: {
+    title: t('Email Routing'),
+    description: t(
+      'On a per project basis, route emails to an alternative email address.'
+    ),
+    type: 'select',
+    // No choices here because it's going to have dynamic content
+    // Component will create choices
+  },
+};

--- a/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
+++ b/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
@@ -34,7 +34,7 @@ class UserNotificationFineTuningTest(APITestCase):
             project=self.project,
         )
         response = self.get_valid_response("me", "alerts")
-        assert response.data.get(self.project.id) == 1
+        assert response.data.get(self.project.id) == "1"
 
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
@@ -53,7 +53,7 @@ class UserNotificationFineTuningTest(APITestCase):
             value=[self.org.id],
         )
         response = self.get_valid_response("me", "reports")
-        assert response.data.get(self.org.id) == 0
+        assert response.data.get(self.org.id) == "0"
 
     def test_invalid_notification_type(self):
         self.get_valid_response("me", "invalid", status_code=404)


### PR DESCRIPTION
The Notification Settings Fine Tuning frontend expects the API to send values as `int`s. Deploy and Workflow settings are stored as strings and Issue Alert settings are stored as integers. 
This PR casts the values to strings in the serializer and updates to UI to handle strings.