### PR TITLE
fix(trace-view): Handle errors when storing tags

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -124,9 +124,9 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
             if len(result["data"]) == 0:
                 return Response(status=404)
             len_transactions = len(result["data"])
-            sentry_sdk.set_tag("trace-view.num_transactions", len_transactions)
+            sentry_sdk.set_tag("trace_view.num_transactions", len_transactions)
             sentry_sdk.set_tag(
-                "trace-view.num_transactions.grouped",
+                "trace_view.num_transactions.grouped",
                 "<10" if len_transactions < 10 else "<100" if len_transactions < 100 else ">100",
             )
 

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -124,9 +124,9 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
             if len(result["data"]) == 0:
                 return Response(status=404)
             len_transactions = len(result["data"])
-            sentry_sdk.set_tag("discover.trace-view.num_transactions", len_transactions)
+            sentry_sdk.set_tag("trace-view.num_transactions", len_transactions)
             sentry_sdk.set_tag(
-                "discover.trace-view.num_transactions.grouped",
+                "trace-view.num_transactions.grouped",
                 "<10" if len_transactions < 10 else "<100" if len_transactions < 100 else ">100",
             )
 

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 
 from sentry import features, eventstore
 from sentry.api.bases import OrganizationEventsV2EndpointBase, NoProjects
+from sentry.api.serializers.models.event import get_tags_with_meta
 from sentry.snuba import discover
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 
@@ -336,21 +337,16 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
         )
         return result
 
-    def update_nodestore_extra(self, event, nodestore_data, detailed=False):
+    def update_nodestore_extra(self, event, nodestore_event, detailed=False):
         """ Add extra data that we get from Nodestore """
-        event.update({event_key: nodestore_data.get(event_key) for event_key in NODESTORE_KEYS})
+        event.update(
+            {event_key: nodestore_event.data.get(event_key) for event_key in NODESTORE_KEYS}
+        )
         if detailed:
-            if "measurements" in nodestore_data:
-                event["measurements"] = nodestore_data.get("measurements")
-            event["tags"] = [
-                {
-                    "key": tag_key.split("sentry:", 1)[-1],
-                    "value": tag_value,
-                }
-                for [tag_key, tag_value] in sorted(
-                    nodestore_data.get("tags"), key=lambda tag: tag[0]
-                )
-            ]
+            if "measurements" in nodestore_event.data:
+                event["measurements"] = nodestore_event.data.get("measurements")
+            event["_meta"] = {}
+            event["tags"], event["_meta"]["tags"] = get_tags_with_meta(nodestore_event)
 
     def update_generations(self, event):
         parents = [event]
@@ -417,7 +413,7 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
                         current_event["project.id"], current_event["id"]
                     )
 
-                self.update_nodestore_extra(previous_event, nodestore_event.data, detailed)
+                self.update_nodestore_extra(previous_event, nodestore_event, detailed)
 
                 spans = nodestore_event.data.get("spans", [])
                 # Need to include the transaction as a span as well

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -26,9 +26,11 @@ class OrganizationEventsTraceEndpointBase(APITestCase, SnubaTestCase):
         spans,
         parent_span_id,
         project_id,
+        tags=None,
         duration=4000,
         span_id=None,
         measurements=None,
+        **kwargs,
     ):
         start, end = self.get_start_end(duration)
         data = load_data(
@@ -45,7 +47,9 @@ class OrganizationEventsTraceEndpointBase(APITestCase, SnubaTestCase):
         if measurements:
             for key, value in measurements.items():
                 data["measurements"][key]["value"] = value
-        return self.store_event(data, project_id=project_id)
+        if tags is not None:
+            data["tags"] = tags
+        return self.store_event(data, project_id=project_id, **kwargs)
 
     def setUp(self):
         """
@@ -567,6 +571,37 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
                 assert root_tags[key[7:]] == value, f"tags - {key}"
         assert root["measurements"]["lcp"]["value"] == 1000
         assert root["measurements"]["fcp"]["value"] == 750
+
+    def test_detailed_trace_with_bad_tags(self):
+        """ Basically test that we're actually using the event serializer's method for tags """
+        trace = uuid4().hex
+        self.create_event(
+            trace=trace,
+            transaction="bad-tags",
+            parent_span_id=None,
+            spans=[],
+            project_id=self.project.id,
+            tags=[["somethinglong" * 250, "somethinglong" * 250]],
+            duration=3000,
+            assert_no_errors=False,
+        )
+
+        url = reverse(
+            self.url_name,
+            kwargs={"organization_slug": self.project.organization.slug, "trace_id": trace},
+        )
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                url,
+                data={"project": -1, "detailed": 1},
+                format="json",
+            )
+
+        assert response.status_code == 200, response.content
+        root = response.data[0]
+        assert root["transaction.status"] == "ok"
+        assert {"key": None, "value": None} in root["tags"]
 
     def test_bad_span_loop(self):
         """Maliciously create a loop in the span structure


### PR DESCRIPTION
- Also stop trying to store tags that cause errors
- Reusing the event tag serializer since we basically want the same
  functionality
Fixes SENTRY-PAF