### PR TITLE
fix(notifications): Fix Dual Write

### DIFF
--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -79,8 +79,8 @@ class UserNotificationDetailsEndpoint(UserEndpoint):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            if key in [UserOptionsSettingsKey.DEPLOY, UserOptionsSettingsKey.WORKFLOW]:
-                type = get_type_from_user_option_settings_key(key)
+            type = get_type_from_user_option_settings_key(key)
+            if type:
                 NotificationSetting.objects.update_settings(
                     ExternalProviders.EMAIL,
                     type,

--- a/src/sentry/notifications/legacy_mappings.py
+++ b/src/sentry/notifications/legacy_mappings.py
@@ -150,6 +150,7 @@ def get_type_from_user_option_settings_key(key: UserOptionsSettingsKey) -> Notif
     return {
         UserOptionsSettingsKey.DEPLOY: NotificationSettingTypes.DEPLOY,
         UserOptionsSettingsKey.WORKFLOW: NotificationSettingTypes.WORKFLOW,
+        UserOptionsSettingsKey.SUBSCRIBE_BY_DEFAULT: NotificationSettingTypes.ISSUE_ALERTS,
     }.get(key)
 
 


### PR DESCRIPTION
The `PUT` method of the `UserNotificationDetailsEndpoint` serializes a JSON blob of user preferences and saves them to the DB. Our previous implementation assumed that only "deploy" and "workflow" needed to be copied to both tables. We also need to copy "subscribeByDefault" settings to `NotificationSettings` as a "issue alert" row.