### PR TITLE
feat(alerts): Add an alert banner to the new alert details page

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -278,7 +278,7 @@ export default class DetailsBody extends React.Component<Props> {
           return initiallyLoaded ? (
             <Layout.Body>
               <Alert type="info" icon={<IconInfo size="md" />}>
-                {t("You’re viewing the new alert details page. To view the old experience, select an alert below.")}
+                {t('You’re viewing the new alert details page. To view the old experience, select an alert below.')}
               </Alert>
               <Layout.Main>
                 <ChartControls>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -278,7 +278,9 @@ export default class DetailsBody extends React.Component<Props> {
           return initiallyLoaded ? (
             <Layout.Body>
               <Alert type="info" icon={<IconInfo size="md" />}>
-                {t('You’re viewing the new alert details page. To view the old experience, select an alert below.')}
+                {t(
+                  'You’re viewing the new alert details page. To view the old experience, select an alert below.'
+                )}
               </Alert>
               <Layout.Main>
                 <ChartControls>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -6,6 +6,7 @@ import moment from 'moment';
 
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
+import Alert from 'app/components/alert';
 import ActorAvatar from 'app/components/avatar/actorAvatar';
 import {SectionHeading} from 'app/components/charts/styles';
 import {getInterval} from 'app/components/charts/utils';
@@ -17,7 +18,7 @@ import * as Layout from 'app/components/layouts/thirds';
 import {Panel, PanelBody} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
 import TimeSince from 'app/components/timeSince';
-import {IconCheckmark, IconFire, IconUser, IconWarning} from 'app/icons';
+import {IconCheckmark, IconFire, IconInfo, IconUser, IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -276,6 +277,9 @@ export default class DetailsBody extends React.Component<Props> {
         {({initiallyLoaded, projects}) => {
           return initiallyLoaded ? (
             <Layout.Body>
+              <Alert type="info" icon={<IconInfo size="md" />}>
+                {t("You’re viewing the new alert details page. To view the old experience, select an alert below.")}
+              </Alert>
               <Layout.Main>
                 <ChartControls>
                   <DropdownControl label={timePeriod.label}>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
@@ -7,6 +7,7 @@ import {SectionHeading} from 'app/components/charts/styles';
 import DateTime from 'app/components/dateTime';
 import Duration from 'app/components/duration';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
+import Link from 'app/components/links/link';
 import {Panel, PanelBody} from 'app/components/panels';
 import SeenByList from 'app/components/seenByList';
 import TimeSince from 'app/components/timeSince';
@@ -134,11 +135,13 @@ class TimelineIncident extends React.Component<IncidentProps> {
   }
 
   render() {
-    const {incident} = this.props;
+    const {incident, orgId} = this.props;
     return (
       <IncidentSection key={incident.identifier}>
         <IncidentHeader>
-          {tct('Alert #[id]', {id: incident.identifier})}
+          <Link to={`/organizations/${orgId}/alerts/${incident.identifier}/?redirect=false`}>
+            {tct('Alert #[id]', {id: incident.identifier})}
+          </Link>
           <SeenByTab>
             {incident && (
               <StyledSeenByList

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/timeline.tsx
@@ -139,7 +139,9 @@ class TimelineIncident extends React.Component<IncidentProps> {
     return (
       <IncidentSection key={incident.identifier}>
         <IncidentHeader>
-          <Link to={`/organizations/${orgId}/alerts/${incident.identifier}/?redirect=false`}>
+          <Link
+            to={`/organizations/${orgId}/alerts/${incident.identifier}/?redirect=false`}
+          >
             {tct('Alert #[id]', {id: incident.identifier})}
           </Link>
           <SeenByTab>


### PR DESCRIPTION
This adds an alert banner to inform users of the changes to the alert details page. Adds links to the old alert page on incident titles.
![Screen Shot 2021-03-26 at 2 52 05 PM](https://user-images.githubusercontent.com/15015880/112696324-d7890900-8e42-11eb-8e1c-fd97f0c30fc8.png)
