### PR TITLE
fix(trace-view): Use UTC time for trace date range

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/utils.tsx
@@ -323,9 +323,14 @@ export function getTraceDateTimeRange(input: {
   const start = moment
     .unix(input.start)
     .subtract(12, 'hours')
+    .utc()
     .format('YYYY-MM-DDTHH:mm:ss.SSS');
 
-  const end = moment.unix(input.end).add(12, 'hours').format('YYYY-MM-DDTHH:mm:ss.SSS');
+  const end = moment
+    .unix(input.end)
+    .add(12, 'hours')
+    .utc()
+    .format('YYYY-MM-DDTHH:mm:ss.SSS');
 
   return {
     start,


### PR DESCRIPTION
The `getTraceDateTimeRange` returns the timestamps in the user's preferred
timezone. However, `eventView` assumes UTC time as it generates the appropriate
payload.