### PR TITLE
fix(ui): Wait even longer for sample event

### DIFF
--- a/src/sentry/static/sentry/app/views/onboarding/createSampleEventButton.tsx
+++ b/src/sentry/static/sentry/app/views/onboarding/createSampleEventButton.tsx
@@ -26,7 +26,7 @@ type State = {
   creating: boolean;
 };
 
-const EVENT_POLL_RETRIES = 10;
+const EVENT_POLL_RETRIES = 15;
 const EVENT_POLL_INTERVAL = 1000;
 
 async function latestEventAvailable(


### PR DESCRIPTION
in #24186 I increased the time to wait for the sample event. It wasn't quite enough and some are still failing