### PR TITLE
fix(metric_alerts): Make warning and resolve threshold not a dropdown

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/thresholdControl.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/thresholdControl.tsx
@@ -108,6 +108,18 @@ class ThresholdControl extends React.Component<Props, State> {
             {value: AlertRuleThresholdType.BELOW, label: t('Below')},
             {value: AlertRuleThresholdType.ABOVE, label: t('Above')},
           ]}
+          components={disableThresholdType ? {DropdownIndicator: null} : null}
+          styles={
+            disableThresholdType
+              ? {
+                  control: provided => ({
+                    ...provided,
+                    cursor: 'not-allowed',
+                    pointerEvents: 'auto',
+                  }),
+                }
+              : null
+          }
           onChange={this.handleTypeChange}
         />
         <StyledInput


### PR DESCRIPTION
Make warning and resolve threshold directions not a dropdown. User was confused why they can't select the warning/resolve directions.

cc @robinrendle @adhiraj for design feedback

FIXES [WOR-232](https://getsentry.atlassian.net/browse/WOR-232)

### Before
<img width="1186" alt="disabled-threshold-og" src="https://user-images.githubusercontent.com/20312973/112703406-05c31480-8e54-11eb-9a45-4b84d191f4ef.png">

### After

_Includes disabled mouse cursor_
<img width="1182" alt="disabled-threshold" src="https://user-images.githubusercontent.com/20312973/112703426-1d020200-8e54-11eb-9907-d9e47b8e05f0.png">
