### PR TITLE
fix(alerts): Reset page and cursor on search (WOR-779)

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/index.tsx
@@ -92,10 +92,11 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
 
   handleChangeFilter = (activeFilters: Set<string>) => {
     const {router, location} = this.props;
+    const {cursor: _cursor, page: _page, ...currentQuery} = location.query;
     router.push({
       pathname: location.pathname,
       query: {
-        ...location.query,
+        ...currentQuery,
         team: [...activeFilters],
       },
     });
@@ -103,10 +104,11 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
 
   handleChangeSearch = (name: string) => {
     const {router, location} = this.props;
+    const {cursor: _cursor, page: _page, ...currentQuery} = location.query;
     router.push({
       pathname: location.pathname,
       query: {
-        ...location.query,
+        ...currentQuery,
         name,
       },
     });


### PR DESCRIPTION
when changing a filter, remove cursor and page query params if it exists