### PR TITLE
ref(trace-view): Make root optional for traces

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -242,6 +242,7 @@ class OrganizationEventsTraceLightEndpoint(OrganizationEventsTraceEndpointBase):
         parent_map = self.construct_span_map(transactions, "trace.parent_span")
         error_map = self.construct_span_map(errors, "trace.span")
         trace_results = []
+        current_generation = None
 
         with sentry_sdk.start_span(op="building.trace", description="light trace"):
             # We might not be necessarily connected to the root if we're on an orphan event
@@ -269,8 +270,6 @@ class OrganizationEventsTraceLightEndpoint(OrganizationEventsTraceEndpointBase):
                 is_root_child = False
                 if root is not None and root["id"] == snuba_event["id"]:
                     current_generation = 0
-                else:
-                    current_generation = None
 
             current_event = self.serialize_event(
                 snuba_event, root["id"] if is_root_child else None, current_generation

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -264,13 +264,16 @@ class OrganizationEventsTraceLightEndpoint(OrganizationEventsTraceEndpointBase):
                             0,
                         )
                     )
+                    current_generation = 1
             else:
-                is_root_child = None
+                is_root_child = False
+                if root is not None and root["id"] == snuba_event["id"]:
+                    current_generation = 0
+                else:
+                    current_generation = None
 
             current_event = self.serialize_event(
-                snuba_event,
-                root["id"] if is_root_child else None,
-                1 if is_root_child else 0 if root and root["id"] == snuba_event["id"] else None,
+                snuba_event, root["id"] if is_root_child else None, current_generation
             )
             trace_results.append(current_event)
 


### PR DESCRIPTION
- Now that we have orphan traces included in the response, its
  possible that for a trace id we only have orphan traces. Which
  means that we were 204ing in a case where we could've returned a
  valid response
- This also means that we had to remove root always being returned in
  the light trace response, this is because with orphan traces we can no
  longer guarantee that the root is connected to the current
  transaction. This means that the (root)-(this event) link could
  potentially be incorrect during the full trace loading state
- **Note** that in the case of a trace with no root, the full trace may fail to return the current event in the 1st element of the `trace_results`
    - We currently 204 in these cases so still an improvement
    - And we'll be consuming the orphan traces before GA so this will no longer be a problem once we do that.

tldr; root transactions are iffy in traces so only return when we're absolutely sure.