### PR TITLE
feat(trace-view): More consistent hover text

### DIFF
--- a/src/sentry/static/sentry/app/components/quickTrace/index.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/index.tsx
@@ -240,7 +240,7 @@ type EventNodeSelectorProps = {
   extrasTarget?: LocationDescriptor;
   numEvents?: number;
   anchor: 'left' | 'right';
-  nodeKey: 'root' | 'ancestors' | 'parent' | 'current' | 'children' | 'descendants';
+  nodeKey: keyof typeof TOOLTIP_PREFIX;
   errorDest: ErrorDestination;
   transactionDest: TransactionDestination;
 };


### PR DESCRIPTION
- This uses the nodeKey to figure out hovertext instead, unfortunately I
  didn't really consider this use case when originally adding nodeKeys
  for analytics. So added a map between node keys and what we want to
  prefix in the tooltip

# Previews
Switches between errors and transactions now depending on what's in the dropdown:
<img width="344" alt="image" src="https://user-images.githubusercontent.com/4205004/112706463-a75d5c80-8e7a-11eb-89dc-9f6760a078de.png">

Changed the text a bit since `View all Ancestor Events for this Event` would be a bit strange
<img width="526" alt="image" src="https://user-images.githubusercontent.com/4205004/112706457-a1677b80-8e7a-11eb-8303-e3c42cf973be.png">

Individual events
<img width="408" alt="image" src="https://user-images.githubusercontent.com/4205004/112706466-afb59780-8e7a-11eb-9b5f-e1bfd117ebcc.png">
<img width="401" alt="image" src="https://user-images.githubusercontent.com/4205004/112706468-b5ab7880-8e7a-11eb-849a-adeb3169b012.png">


