### PR TITLE
ref: remove fieldrenderer location

### DIFF
--- a/src/sentry/static/sentry/app/components/charts/simpleTableChart.tsx
+++ b/src/sentry/static/sentry/app/components/charts/simpleTableChart.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 
 import PanelTable, {PanelTableHeader} from 'app/components/panels/panelTable';
 import {Organization} from 'app/types';
@@ -12,7 +11,6 @@ import {decodeColumnOrder} from 'app/views/eventsV2/utils';
 
 type Props = {
   organization: Organization;
-  location: Location;
   loading: boolean;
   fields: string[];
   title: string;
@@ -28,11 +26,11 @@ class SimpleTableChart extends React.Component<Props> {
     tableMeta: NonNullable<TableData['meta']>,
     columns: ReturnType<typeof decodeColumnOrder>
   ) {
-    const {location, organization} = this.props;
+    const {organization} = this.props;
 
     return columns.map(column => {
       const fieldRenderer = getFieldRenderer(column.name, tableMeta);
-      const rendered = fieldRenderer(row, {organization, location});
+      const rendered = fieldRenderer(row, {organization});
       return <div key={`${index}:${column.name}`}>{rendered}</div>;
     });
   }

--- a/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
+++ b/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
@@ -456,7 +456,7 @@ class TransactionsTable extends React.PureComponent<TableProps> {
       const fieldType = tableMeta[fieldName];
 
       const fieldRenderer = getFieldRenderer(field, tableMeta);
-      let rendered = fieldRenderer(row, {organization, location});
+      let rendered = fieldRenderer(row, {organization});
 
       const target = generateLink?.[field]?.(organization, row, location.query);
 

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import {Location} from 'history';
 import partial from 'lodash/partial';
 
 import Count from 'app/components/count';
@@ -37,7 +36,6 @@ import {
  */
 type RenderFunctionBaggage = {
   organization: Organization;
-  location: Location;
 };
 
 type FieldFormatterRenderFunction = (field: string, data: EventData) => React.ReactNode;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedTransactions.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedTransactions.tsx
@@ -56,7 +56,7 @@ class Table extends React.Component<TableProps, TableState> {
     column: TableColumn<keyof TableDataRow>,
     dataRow: TableDataRow
   ): React.ReactNode {
-    const {eventView, organization, projects, location, summaryConditions} = this.props;
+    const {eventView, organization, projects, summaryConditions} = this.props;
 
     if (!tableData || !tableData.meta) {
       return dataRow[column.key];
@@ -65,7 +65,7 @@ class Table extends React.Component<TableProps, TableState> {
 
     const field = String(column.key);
     const fieldRenderer = getFieldRenderer(field, tableMeta);
-    const rendered = fieldRenderer(dataRow, {organization, location});
+    const rendered = fieldRenderer(dataRow, {organization});
 
     if (field === 'transaction') {
       const projectID = getProjectID(dataRow, projects);

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetCardChart.tsx
@@ -73,7 +73,7 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
     errorMessage,
     tableResults,
   }: TableResultProps): React.ReactNode {
-    const {location, widget, organization} = this.props;
+    const {widget, organization} = this.props;
     if (errorMessage) {
       return (
         <ErrorPanel>
@@ -92,7 +92,6 @@ class WidgetCardChart extends React.Component<WidgetCardChartProps> {
       return (
         <StyledSimpleTableChart
           key={`table:${result.title}`}
-          location={location}
           fields={fields}
           title={tableResults.length > 1 ? result.title : ''}
           loading={loading}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -148,7 +148,7 @@ class TableView extends React.Component<TableViewProps> {
 
       if (tableData && tableData.meta) {
         const fieldRenderer = getFieldRenderer('id', tableData.meta);
-        value = fieldRenderer(dataRow, {organization, location});
+        value = fieldRenderer(dataRow, {organization});
       }
 
       const eventSlug = generateEventSlug(dataRow);
@@ -225,7 +225,7 @@ class TableView extends React.Component<TableViewProps> {
 
     const count = Math.min(tableData?.data?.length ?? TOP_N, TOP_N);
 
-    let cell = fieldRenderer(dataRow, {organization, location});
+    let cell = fieldRenderer(dataRow, {organization});
 
     if (columnKey === 'id') {
       const eventSlug = generateEventSlug(dataRow);

--- a/src/sentry/static/sentry/app/views/performance/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/table.tsx
@@ -92,7 +92,7 @@ class Table extends React.Component<Props, State> {
     column: TableColumn<keyof TableDataRow>,
     dataRow: TableDataRow
   ): React.ReactNode {
-    const {eventView, organization, projects, location, summaryConditions} = this.props;
+    const {eventView, organization, projects, summaryConditions} = this.props;
 
     if (!tableData || !tableData.meta) {
       return dataRow[column.key];
@@ -101,7 +101,7 @@ class Table extends React.Component<Props, State> {
 
     const field = String(column.key);
     const fieldRenderer = getFieldRenderer(field, tableMeta);
-    const rendered = fieldRenderer(dataRow, {organization, location});
+    const rendered = fieldRenderer(dataRow, {organization});
 
     const allowActions = [
       Actions.ADD,

--- a/src/sentry/static/sentry/app/views/performance/vitalDetail/table.tsx
+++ b/src/sentry/static/sentry/app/views/performance/vitalDetail/table.tsx
@@ -128,7 +128,7 @@ class Table extends React.Component<Props, State> {
     dataRow: TableDataRow,
     vitalName: WebVital
   ): React.ReactNode {
-    const {eventView, organization, projects, location, summaryConditions} = this.props;
+    const {eventView, organization, projects, summaryConditions} = this.props;
 
     if (!tableData || !tableData.meta) {
       return dataRow[column.key];
@@ -162,7 +162,7 @@ class Table extends React.Component<Props, State> {
     }
 
     const fieldRenderer = getFieldRenderer(field, tableMeta);
-    const rendered = fieldRenderer(dataRow, {organization, location});
+    const rendered = fieldRenderer(dataRow, {organization});
 
     const allowActions = [
       Actions.ADD,

--- a/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
+++ b/tests/js/spec/utils/discover/fieldRenderer.spec.jsx
@@ -5,7 +5,7 @@ import ProjectsStore from 'app/stores/projectsStore';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 
 describe('getFieldRenderer', function () {
-  let location, context, project, organization, data, user;
+  let context, project, organization, data, user;
   beforeEach(function () {
     context = initializeOrg({
       project: TestStubs.Project(),
@@ -15,10 +15,6 @@ describe('getFieldRenderer', function () {
     ProjectsStore.loadInitialData([project]);
     user = 'email:text@example.com';
 
-    location = {
-      pathname: '/events',
-      query: {},
-    };
     data = {
       key_transaction: 1,
       title: 'ValueError: something bad',
@@ -50,21 +46,21 @@ describe('getFieldRenderer', function () {
 
   it('can render string fields', function () {
     const renderer = getFieldRenderer('url', {url: 'string'});
-    const wrapper = mountWithTheme(renderer(data, {location, organization}));
+    const wrapper = mountWithTheme(renderer(data, {organization}));
     const text = wrapper.find('Container');
     expect(text.text()).toEqual(data.url);
   });
 
   it('can render boolean fields', function () {
     const renderer = getFieldRenderer('boolValue', {boolValue: 'boolean'});
-    const wrapper = mountWithTheme(renderer(data, {location, organization}));
+    const wrapper = mountWithTheme(renderer(data, {organization}));
     const text = wrapper.find('Container');
     expect(text.text()).toEqual('true');
   });
 
   it('can render integer fields', function () {
     const renderer = getFieldRenderer('numeric', {numeric: 'integer'});
-    const wrapper = mountWithTheme(renderer(data, {location, organization}));
+    const wrapper = mountWithTheme(renderer(data, {organization}));
 
     const value = wrapper.find('Count');
     expect(value).toHaveLength(1);
@@ -74,7 +70,7 @@ describe('getFieldRenderer', function () {
   it('can render date fields', function () {
     const renderer = getFieldRenderer('createdAt', {createdAt: 'date'});
     expect(renderer).toBeInstanceOf(Function);
-    const wrapper = mountWithTheme(renderer(data, {location, organization}));
+    const wrapper = mountWithTheme(renderer(data, {organization}));
 
     const value = wrapper.find('StyledDateTime');
     expect(value).toHaveLength(1);
@@ -83,7 +79,7 @@ describe('getFieldRenderer', function () {
 
   it('can render null date fields', function () {
     const renderer = getFieldRenderer('nope', {nope: 'date'});
-    const wrapper = mountWithTheme(renderer(data, {location, organization}));
+    const wrapper = mountWithTheme(renderer(data, {organization}));
 
     const value = wrapper.find('StyledDateTime');
     expect(value).toHaveLength(0);
@@ -94,35 +90,29 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('error.handled', {'error.handled': 'boolean'});
 
     // Should render the last value.
-    let wrapper = mountWithTheme(
-      renderer({'error.handled': [0, 1]}, {location, organization})
-    );
+    let wrapper = mountWithTheme(renderer({'error.handled': [0, 1]}, {organization}));
     expect(wrapper.text()).toEqual('true');
 
-    wrapper = mountWithTheme(
-      renderer({'error.handled': [0, 0]}, {location, organization})
-    );
+    wrapper = mountWithTheme(renderer({'error.handled': [0, 0]}, {organization}));
     expect(wrapper.text()).toEqual('false');
 
     // null = true for error.handled data.
-    wrapper = mountWithTheme(
-      renderer({'error.handled': [null]}, {location, organization})
-    );
+    wrapper = mountWithTheme(renderer({'error.handled': [null]}, {organization}));
     expect(wrapper.text()).toEqual('true');
 
     // Default events won't have error.handled and will return an empty list.
-    wrapper = mountWithTheme(renderer({'error.handled': []}, {location, organization}));
+    wrapper = mountWithTheme(renderer({'error.handled': []}, {organization}));
     expect(wrapper.text()).toEqual('n/a');
 
     // Transactions will have null for error.handled as the 'tag' won't be set.
-    wrapper = mountWithTheme(renderer({'error.handled': null}, {location, organization}));
+    wrapper = mountWithTheme(renderer({'error.handled': null}, {organization}));
     expect(wrapper.text()).toEqual('n/a');
   });
 
   it('can render user fields with aliased user', function () {
     const renderer = getFieldRenderer('user', {user: 'string'});
 
-    const wrapper = mountWithTheme(renderer(data, {location, organization}));
+    const wrapper = mountWithTheme(renderer(data, {organization}));
 
     const badge = wrapper.find('UserBadge');
     expect(badge).toHaveLength(1);
@@ -136,7 +126,7 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('user', {user: 'string'});
 
     delete data.user;
-    const wrapper = mountWithTheme(renderer(data, {location, organization}));
+    const wrapper = mountWithTheme(renderer(data, {organization}));
 
     const badge = wrapper.find('UserBadge');
     expect(badge).toHaveLength(0);
@@ -150,7 +140,7 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('release', {release: 'string'});
 
     delete data.release;
-    const wrapper = mountWithTheme(renderer(data, {location, organization}));
+    const wrapper = mountWithTheme(renderer(data, {organization}));
 
     const value = wrapper.find('EmptyValueContainer');
     expect(value).toHaveLength(1);
@@ -160,10 +150,7 @@ describe('getFieldRenderer', function () {
   it('can render project as an avatar', function () {
     const renderer = getFieldRenderer('project', {project: 'string'});
 
-    const wrapper = mountWithTheme(
-      renderer(data, {location, organization}),
-      context.routerContext
-    );
+    const wrapper = mountWithTheme(renderer(data, {organization}), context.routerContext);
 
     const value = wrapper.find('ProjectBadge');
     expect(value).toHaveLength(1);
@@ -174,10 +161,7 @@ describe('getFieldRenderer', function () {
     const renderer = getFieldRenderer('key_transaction', {key_transaction: 'boolean'});
     delete data.project;
 
-    const wrapper = mountWithTheme(
-      renderer(data, {location, organization}),
-      context.routerContext
-    );
+    const wrapper = mountWithTheme(renderer(data, {organization}), context.routerContext);
 
     const value = wrapper.find('StyledKey');
     expect(value).toHaveLength(1);
@@ -190,10 +174,7 @@ describe('getFieldRenderer', function () {
   it('can render key transaction as a clickable star', async function () {
     const renderer = getFieldRenderer('key_transaction', {key_transaction: 'boolean'});
 
-    const wrapper = mountWithTheme(
-      renderer(data, {location, organization}),
-      context.routerContext
-    );
+    const wrapper = mountWithTheme(renderer(data, {organization}), context.routerContext);
     await tick();
     wrapper.update();
 


### PR DESCRIPTION
In #16648, the use of location in fieldrenderers was removed. I don't think it
will be coming back, and considering the broader use of fieldrenderers now,
it's not even applicable in many uses. Remove the boilerplate to make things a
little faster and a little easier for future devs.