### PR TITLE
fix: react-router.d.ts: remove nested declare

### DIFF
--- a/src/sentry/static/sentry/app/types/react-router.d.ts
+++ b/src/sentry/static/sentry/app/types/react-router.d.ts
@@ -23,12 +23,12 @@ declare module 'react-router' {
     | StatelessComponent<P>
     | ComponentType<P>;
 
-  declare function withRouter<P extends WithRouterProps>(
+  function withRouter<P extends WithRouterProps>(
     component: ComponentConstructor<P>,
     options?: Options
   ): ComponentClass<Omit<P, keyof WithRouterProps>>;
 
-  declare function withRouter<P extends WithRouterProps, S>(
+  function withRouter<P extends WithRouterProps, S>(
     component: ComponentConstructor<P> & S,
     options?: Options
   ): ComponentClass<Omit<P, keyof WithRouterProps>> & S;


### PR DESCRIPTION
I'm not fully familiar with TypeScript but I'm pretty sure this is not strictly
valid. I'm not 100% sure why it doesn't error but swc doesn't like it so let's
get rid of it.