### PR TITLE
fix(inbox): Fix inbox counter on delete

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -78,6 +78,7 @@ type Props = {
   hasGuideAnchor?: boolean;
   memberList?: User[];
   onMarkReviewed?: (itemIds: string[]) => void;
+  onDelete?: () => void;
   showInboxTime?: boolean;
   index?: number;
   // TODO(ts): higher order functions break defaultprops export types
@@ -346,6 +347,7 @@ class StreamGroup extends React.Component<Props, State> {
       showInboxTime,
       onMarkReviewed,
       useFilteredStats,
+      onDelete,
     } = this.props;
 
     const {period, start, end} = selection.datetime || {};
@@ -561,6 +563,7 @@ class StreamGroup extends React.Component<Props, State> {
                   group={data}
                   orgSlug={organization.slug}
                   selection={selection}
+                  onDelete={onDelete}
                   onMarkReviewed={onMarkReviewed}
                   query={query}
                 />

--- a/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
+++ b/src/sentry/static/sentry/app/components/stream/groupRowActions.tsx
@@ -24,6 +24,7 @@ type Props = {
   selection: GlobalSelection;
   query?: string;
   onMarkReviewed?: (itemIds: string[]) => void;
+  onDelete?: () => void;
 };
 
 class GroupRowActions extends React.Component<Props> {
@@ -57,7 +58,7 @@ class GroupRowActions extends React.Component<Props> {
   };
 
   handleDelete = () => {
-    const {api, group, orgSlug, query, selection} = this.props;
+    const {api, group, orgSlug, query, selection, onDelete} = this.props;
 
     addLoadingMessage(t('Removing events\u2026'));
 
@@ -74,6 +75,7 @@ class GroupRowActions extends React.Component<Props> {
       {
         complete: () => {
           clearIndicators();
+          onDelete?.();
         },
       }
     );

--- a/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/index.tsx
@@ -25,6 +25,7 @@ type Props = {
   organization: Organization;
   selection: GlobalSelection;
   groupIds: string[];
+  onDelete: () => void;
   onRealtimeChange: (realtime: boolean) => void;
   onSelectStatsPeriod: (period: string) => void;
   realtimeActive: boolean;
@@ -180,7 +181,7 @@ class IssueListActions extends React.Component<Props, State> {
   };
 
   handleDelete = () => {
-    const {selection, api, organization, query} = this.props;
+    const {selection, api, organization, query, onDelete} = this.props;
     const orgId = organization.slug;
 
     addLoadingMessage(t('Removing events\u2026'));
@@ -199,6 +200,7 @@ class IssueListActions extends React.Component<Props, State> {
         {
           complete: () => {
             clearIndicators();
+            onDelete();
           },
         }
       );

--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -141,16 +141,16 @@ type StatEndpointParams = Omit<EndpointParams, 'cursor' | 'page'> & {
 };
 
 class IssueListOverview extends React.Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
+  state: State = this.getInitialState();
 
+  getInitialState() {
     const realtimeActiveCookie = Cookies.get('realtimeActive');
     const realtimeActive =
       typeof realtimeActiveCookie === 'undefined'
         ? false
         : realtimeActiveCookie === 'true';
 
-    this.state = {
+    return {
       groupIds: [],
       selectAllActive: false,
       realtimeActive,
@@ -519,7 +519,7 @@ class IssueListOverview extends React.Component<Props, State> {
     this.setState({queryCounts});
   };
 
-  fetchData = (selectionChanged?: boolean) => {
+  fetchData = (fetchAllCounts = false) => {
     GroupStore.loadInitialData([]);
     this._streamManager.reset();
     const transaction = getCurrentSentryReactTransaction();
@@ -566,9 +566,6 @@ class IssueListOverview extends React.Component<Props, State> {
     }
 
     this._poller.disable();
-
-    const fetchAllCounts =
-      this.props.organization.features.includes('inbox') && !!selectionChanged;
 
     this._lastRequest = this.props.api.request(this.getGroupListEndpoint(), {
       method: 'GET',
@@ -678,9 +675,7 @@ class IssueListOverview extends React.Component<Props, State> {
 
   onRealtimeChange = (realtime: boolean) => {
     Cookies.set('realtimeActive', realtime.toString());
-    this.setState({
-      realtimeActive: realtime,
-    });
+    this.setState({realtimeActive: realtime});
   };
 
   onSelectStatsPeriod = (period: string) => {
@@ -861,6 +856,7 @@ class IssueListOverview extends React.Component<Props, State> {
           memberList={members}
           displayReprocessingLayout={displayReprocessingLayout}
           onMarkReviewed={this.onMarkReviewed}
+          onDelete={this.onDelete}
           useFilteredStats
           showInboxTime={showInboxTime}
         />
@@ -931,8 +927,13 @@ class IssueListOverview extends React.Component<Props, State> {
     });
   };
 
+  onDelete = () => {
+    this.fetchData(true);
+  };
+
   onMarkReviewed = (itemIds: string[]) => {
     const query = this.getQuery();
+
     if (!isForReviewQuery(query)) {
       return;
     }
@@ -1094,6 +1095,7 @@ class IssueListOverview extends React.Component<Props, State> {
                     onSelectStatsPeriod={this.onSelectStatsPeriod}
                     onRealtimeChange={this.onRealtimeChange}
                     onMarkReviewed={this.onMarkReviewed}
+                    onDelete={this.onDelete}
                     realtimeActive={realtimeActive}
                     statsPeriod={this.getGroupStatsPeriod()}
                     groupIds={groupIds}


### PR DESCRIPTION
Now that this PR has been merged https://github.com/getsentry/sentry/pull/24621, an update in the frontend was needed in order to update the counters on deleting an issue. 

This PR brings the `onDelete` method, which fetches the data again to obtain the updated X-Hits and thus update the tab counters.