### PR TITLE
fix(images-loaded): Fix action not being displayed for internal sources

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/actions.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/actions.tsx
@@ -32,7 +32,7 @@ function Actions({
 }: Props) {
   const {download, location: debugFileId} = candidate;
 
-  if (!debugFileId || isInternalSource) {
+  if (!debugFileId || !isInternalSource) {
     return <NotAvailable />;
   }
 

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidates.tsx
@@ -307,7 +307,7 @@ class Candidates extends React.Component<Props, State> {
                 'These are the Debug Information Files (DIFs) corresponding to this image which have been looked up on [docLink:symbol servers] during the processing of the stacktrace.',
                 {
                   docLink: (
-                    <ExternalLink href="https://docs.sentry.io/platforms/native/data-management/debug-files/#symbol-servers" />
+                    <ExternalLink href="https://docs.sentry.io/platforms/native/data-management/debug-files/symbol-servers/" />
                   ),
                 }
               )}

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -168,7 +168,7 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
         download: {
           status: CandidateDownloadStatus.UNAPPLIED,
         },
-        location: `${INTERNAL_SOURCE_LOCATION}${debugFile.id}`,
+        location: debugFile.id,
         source: INTERNAL_SOURCE,
         source_name: t('Sentry'),
       })) as ImageCandidates;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29228205/112800584-210a6b80-9070-11eb-9296-c3694e83988c.png)

In Debug Images Details Modal, the actions of a candidate should be displayed if the candidate's source is internal - only.