### PR TITLE
feat: use __class__ to properly serialize LazyObjects

### DIFF
--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -20,7 +20,8 @@ def serialize(objects, user=None, serializer=None, **kwargs):
         # find the first object that is in the registry
         for o in objects:
             try:
-                serializer = registry[type(o)]
+                # use __class__ instead of type(o) to properly serialize django LazyObject(User)
+                serializer = registry[o.__class__]
                 break
             except KeyError:
                 pass


### PR DESCRIPTION
This is required for Dashboards Management page, but I'm posting this as a separate PR in order to get more review.

`o.__class__` is slightly slower than `type(o)` but I think it makes more sense than special-casing LazyObject.