### PR TITLE
feat(guides): adds markOthersAsSeeen option for guides

### DIFF
--- a/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/getGuidesContent.tsx
@@ -221,6 +221,7 @@ function getDemoModeGuides(): GuidesContent {
       guide: 'sidebar',
       requiredTargets: ['projects', 'issues'],
       priority: 1, //lower number means higher priority
+      markOthersAsSeen: true,
       steps: [
         {
           title: t('Projects'),

--- a/src/sentry/static/sentry/app/components/assistant/types.tsx
+++ b/src/sentry/static/sentry/app/components/assistant/types.tsx
@@ -28,6 +28,12 @@ type BaseGuide = {
    * level takes precedent.
    */
   priority?: number;
+  /**
+   * When dismissing a guide on the same page, all subsequent guides
+   * will be marked as seen.
+   * Note that on a page refresh, the subseqeuent guides will be visible still.
+   */
+  markOthersAsSeen?: boolean;
 };
 
 export type Guide = BaseGuide & {

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -132,7 +132,7 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
 
   onCloseGuide() {
     const {currentGuide, guides} = this.state;
-    //update the current guide to true or all guides if markOthersAsSeen is true
+    //update the current guide seen to true or all guides if markOthersAsSeen is true
     guides
       .filter(
         guide => guide.guide === currentGuide?.guide || currentGuide?.markOthersAsSeen

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -131,12 +131,13 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
   },
 
   onCloseGuide() {
-    const {currentGuide} = this.state;
-    this.state.guides.map(guide => {
-      if (guide.guide === currentGuide?.guide) {
-        guide.seen = true;
-      }
-    });
+    const {currentGuide, guides} = this.state;
+    //update the current guide to true or all guides if markOthersAsSeen is true
+    guides
+      .filter(
+        guide => guide.guide === currentGuide?.guide || currentGuide?.markOthersAsSeen
+      )
+      .forEach(guide => (guide.seen = true));
     this.state.forceShow = false;
     this.updateCurrentGuide();
   },


### PR DESCRIPTION
This PR adds a new `markOthersAsSeen` option for guides. When someone dismisses a guide where `markOthersAsSeen=true`, all other guides that are on the page are marked as seen. This is a better experience when there are multiple guides on a page. Note that when the page is refreshed, the guide the user didn't see becomes visible again (which I think is the preferred behavior).