### PR TITLE
feat(codeowners): Collect codeowners assignment/updated metrics

### DIFF
--- a/src/sentry/analytics/events/codeowners_assignment.py
+++ b/src/sentry/analytics/events/codeowners_assignment.py
@@ -1,0 +1,14 @@
+from sentry import analytics
+
+
+class CodeownersAssignment(analytics.Event):
+    type = "codeowners.assignment"
+
+    attributes = (
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_ids"),
+        analytics.Attribute("group_id"),
+    )
+
+
+analytics.register(CodeownersAssignment)

--- a/src/sentry/analytics/events/codeowners_assignment.py
+++ b/src/sentry/analytics/events/codeowners_assignment.py
@@ -6,7 +6,7 @@ class CodeownersAssignment(analytics.Event):
 
     attributes = (
         analytics.Attribute("organization_id"),
-        analytics.Attribute("project_ids"),
+        analytics.Attribute("project_id"),
         analytics.Attribute("group_id"),
     )
 

--- a/src/sentry/analytics/events/codeowners_created.py
+++ b/src/sentry/analytics/events/codeowners_created.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class CodeownersCreated(analytics.Event):
+    type = "codeowners.created"
+
+    attributes = (
+        analytics.Attribute("user_id", required=False),
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_id"),
+        analytics.Attribute("codeowners_id"),
+    )
+
+
+analytics.register(CodeownersCreated)

--- a/src/sentry/analytics/events/codeowners_updated.py
+++ b/src/sentry/analytics/events/codeowners_updated.py
@@ -1,0 +1,15 @@
+from sentry import analytics
+
+
+class CodeownersUpdated(analytics.Event):
+    type = "codeowners.updated"
+
+    attributes = (
+        analytics.Attribute("user_id", required=False),
+        analytics.Attribute("organization_id"),
+        analytics.Attribute("project_ids"),
+        analytics.Attribute("codeowners_id"),
+    )
+
+
+analytics.register(CodeownersUpdated)

--- a/src/sentry/analytics/events/codeowners_updated.py
+++ b/src/sentry/analytics/events/codeowners_updated.py
@@ -7,7 +7,7 @@ class CodeownersUpdated(analytics.Event):
     attributes = (
         analytics.Attribute("user_id", required=False),
         analytics.Attribute("organization_id"),
-        analytics.Attribute("project_ids"),
+        analytics.Attribute("project_id"),
         analytics.Attribute("codeowners_id"),
     )
 

--- a/src/sentry/api/endpoints/project_codeowners_details.py
+++ b/src/sentry/api/endpoints/project_codeowners_details.py
@@ -48,6 +48,7 @@ class ProjectCodeOwnersDetailsEndpoint(
         :auth: required
         """
         if not self.has_feature(request, project):
+            self.track_response_code("update", PermissionDenied.status_code)
             raise PermissionDenied
 
         serializer = ProjectCodeOwnerSerializer(
@@ -66,9 +67,10 @@ class ProjectCodeOwnersDetailsEndpoint(
                 project_id=project.id,
                 codeowners_id=updated_codeowners.id,
             )
-
+            self.track_response_code("update", status.HTTP_200_OK)
             return Response(serialize(updated_codeowners, request.user), status=status.HTTP_200_OK)
 
+        self.track_response_code("update", status.HTTP_400_BAD_REQUEST)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def delete(self, request, project, codeowners):

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -42,22 +42,6 @@ class ProjectOwnership(Model):
         return f"projectownership_project_id:1:{project_id}"
 
     @classmethod
-    def get_combined_schema(self, ownership, codeowners):
-        if codeowners and codeowners.schema:
-            ownership.schema = (
-                codeowners.schema
-                if not ownership.schema
-                else {
-                    **ownership.schema,
-                    "rules": [
-                        *codeowners.schema["rules"],
-                        *ownership.schema["rules"],
-                    ],
-                }
-            )
-        return ownership.schema
-
-    @classmethod
     def get_ownership_cached(cls, project_id):
         """
         Cached read access to projectownership.
@@ -117,50 +101,70 @@ class ProjectOwnership(Model):
         return ordered_actors, rules
 
     @classmethod
+    def _find_owners(cls, project_id, rules, limit):
+        """
+        Get the last matching rule to take the most precedence.
+        """
+        owners = [owner for rule in rules for owner in rule.owners]
+        owners.reverse()
+        actors = {
+            key: val
+            for key, val in resolve_actors({owner for owner in owners}, project_id).items()
+            if val
+        }
+        actors = [actors[owner] for owner in owners if owner in actors][:limit]
+        return actors
+
+    @classmethod
     def get_autoassign_owners(cls, project_id, data, limit=2):
         """
         Get the auto-assign owner for a project if there are any.
 
         We combine the schemas from IssueOwners and CodeOwners.
 
-        Returns a tuple of (auto_assignment_enabled, list_of_owners).
+        Returns a tuple of (auto_assignment_enabled, list_of_owners, assigned_by_codeowners: boolean).
         """
         from sentry.models import ProjectCodeOwners
 
         with metrics.timer("projectownership.get_autoassign_owners"):
             ownership = cls.get_ownership_cached(project_id)
             codeowners = ProjectCodeOwners.get_codeowners_cached(project_id)
-
+            assigned_by_codeowners = False
             if not (ownership or codeowners):
-                return False, []
+                return False, [], assigned_by_codeowners
 
             if not ownership:
                 ownership = cls(project_id=project_id)
 
-            ownership.schema = cls.get_combined_schema(ownership, codeowners)
+            ownership_rules = cls._matching_ownership_rules(ownership, project_id, data)
+            codeowners_rules = (
+                cls._matching_ownership_rules(codeowners, project_id, data) if codeowners else []
+            )
 
-            rules = cls._matching_ownership_rules(ownership, project_id, data)
-            if not rules:
-                return ownership.auto_assignment, []
+            if not (codeowners_rules or ownership_rules):
+                return ownership.auto_assignment, [], assigned_by_codeowners
 
-            # We want the last matching rule to take the most precedence.
-            owners = [owner for rule in rules for owner in rule.owners]
-            owners.reverse()
-            actors = {
-                key: val
-                for key, val in resolve_actors({owner for owner in owners}, project_id).items()
-                if val
-            }
-            actors = [actors[owner] for owner in owners if owner in actors][:limit]
+            ownership_actors = cls._find_owners(project_id, ownership_rules, limit)
+            codeowners_actors = cls._find_owners(project_id, codeowners_rules, limit)
 
             # Can happen if the ownership rule references a user/team that no longer
             # is assigned to the project or has been removed from the org.
-            if not actors:
-                return ownership.auto_assignment, []
+            if not (ownership_actors or codeowners_actors):
+                return ownership.auto_assignment, [], assigned_by_codeowners
+
+            # Ownership rules take precedence over codeowner rules.
+            actors = [*ownership_actors]
+            if len(actors) < limit and codeowners_actors:
+                actors = [*ownership_actors, *codeowners_actors][:limit]
+                assigned_by_codeowners = True
 
             from sentry.models import ActorTuple
 
-            return ownership.auto_assignment, ActorTuple.resolve_many(actors)
+            return (
+                ownership.auto_assignment,
+                ActorTuple.resolve_many(actors),
+                assigned_by_codeowners,
+            )
 
     @classmethod
     def _matching_ownership_rules(cls, ownership, project_id, data):

--- a/src/sentry/models/projectownership.py
+++ b/src/sentry/models/projectownership.py
@@ -169,9 +169,11 @@ class ProjectOwnership(Model):
                 return ownership.auto_assignment, [], assigned_by_codeowners
 
             # Ownership rules take precedence over codeowner rules.
-            actors = [*ownership_actors]
-            if len(actors) < limit and codeowners_actors:
-                actors = [*ownership_actors, *codeowners_actors][:limit]
+            actors = [*ownership_actors, *codeowners_actors][:limit]
+
+            # Only the first item in the list is used for assignment, the rest are just used to suggest suspect owners.
+            # So if ownership_actors is empty, it will be assigned by codeowners_actors
+            if len(ownership_actors) == 0:
                 assigned_by_codeowners = True
 
             from sentry.models import ActorTuple

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -137,10 +137,7 @@ class ProjectOwnershipTestCase(TestCase):
         )
 
     def test_get_autoassign_owners_no_codeowners_or_issueowners(self):
-        assert ProjectOwnership.get_autoassign_owners(self.project.id, {}) == (
-            False,
-            [],
-        )
+        assert ProjectOwnership.get_autoassign_owners(self.project.id, {}) == (False, [], False)
 
     def test_get_autoassign_owners_only_issueowners_exists(self):
         rule_a = Rule(Matcher("path", "*.py"), [Owner("team", self.team.slug)])
@@ -152,12 +149,12 @@ class ProjectOwnershipTestCase(TestCase):
         )
 
         # No data matches
-        assert ProjectOwnership.get_autoassign_owners(self.project.id, {}) == (False, [])
+        assert ProjectOwnership.get_autoassign_owners(self.project.id, {}) == (False, [], False)
 
         # No autoassignment on match
         assert ProjectOwnership.get_autoassign_owners(
             self.project.id, {"stacktrace": {"frames": [{"filename": "foo.py"}]}}
-        ) == (False, [self.team])
+        ) == (False, [self.team], False)
 
         # autoassignment is True
         owner = ProjectOwnership.objects.get(project_id=self.project.id)
@@ -166,7 +163,7 @@ class ProjectOwnershipTestCase(TestCase):
 
         assert ProjectOwnership.get_autoassign_owners(
             self.project.id, {"stacktrace": {"frames": [{"filename": "foo.py"}]}}
-        ) == (True, [self.team])
+        ) == (True, [self.team], False)
 
     def test_get_autoassign_owners_only_codeowners_exists(self):
         # This case will never exist bc we create a ProjectOwnership record if none exists when creating a ProjectCodeOwner record.
@@ -185,12 +182,12 @@ class ProjectOwnershipTestCase(TestCase):
             schema=dump_schema([rule_a]),
         )
         # No data matches
-        assert ProjectOwnership.get_autoassign_owners(self.project.id, {}) == (False, [])
+        assert ProjectOwnership.get_autoassign_owners(self.project.id, {}) == (False, [], False)
 
         # No autoassignment on match
         assert ProjectOwnership.get_autoassign_owners(
             self.project.id, {"stacktrace": {"frames": [{"filename": "foo.js"}]}}
-        ) == (False, [self.team])
+        ) == (False, [self.team], True)
 
     def test_get_autoassign_owners_when_codeowners_and_issueowners_exists(self):
         self.team = self.create_team(
@@ -219,10 +216,7 @@ class ProjectOwnershipTestCase(TestCase):
         # No autoassignment on match
         assert ProjectOwnership.get_autoassign_owners(
             self.project.id, {"stacktrace": {"frames": [{"filename": "api/foo.py"}]}}
-        ) == (
-            False,
-            [self.team, self.team2],
-        )
+        ) == (False, [self.team, self.team2], True)
 
         # autoassignment is True
         owner = ProjectOwnership.objects.get(project_id=self.project.id)
@@ -231,18 +225,12 @@ class ProjectOwnershipTestCase(TestCase):
 
         assert ProjectOwnership.get_autoassign_owners(
             self.project.id, {"stacktrace": {"frames": [{"filename": "api/foo.py"}]}}
-        ) == (
-            True,
-            [self.team, self.team2],
-        )
+        ) == (True, [self.team, self.team2], True)
 
         # more than 2 matches
         assert ProjectOwnership.get_autoassign_owners(
             self.project.id, {"stacktrace": {"frames": [{"filename": "src/foo.py"}]}}
-        ) == (
-            True,
-            [self.user, self.team],
-        )
+        ) == (True, [self.user, self.team], False)
 
 
 class ResolveActorsTestCase(TestCase):

--- a/tests/sentry/models/test_projectownership.py
+++ b/tests/sentry/models/test_projectownership.py
@@ -216,8 +216,7 @@ class ProjectOwnershipTestCase(TestCase):
         # No autoassignment on match
         assert ProjectOwnership.get_autoassign_owners(
             self.project.id, {"stacktrace": {"frames": [{"filename": "api/foo.py"}]}}
-        ) == (False, [self.team, self.team2], True)
-
+        ) == (False, [self.team, self.team2], False)
         # autoassignment is True
         owner = ProjectOwnership.objects.get(project_id=self.project.id)
         owner.auto_assignment = True
@@ -225,9 +224,9 @@ class ProjectOwnershipTestCase(TestCase):
 
         assert ProjectOwnership.get_autoassign_owners(
             self.project.id, {"stacktrace": {"frames": [{"filename": "api/foo.py"}]}}
-        ) == (True, [self.team, self.team2], True)
+        ) == (True, [self.team, self.team2], False)
 
-        # more than 2 matches
+        # # more than 2 matches
         assert ProjectOwnership.get_autoassign_owners(
             self.project.id, {"stacktrace": {"frames": [{"filename": "src/foo.py"}]}}
         ) == (True, [self.user, self.team], False)


### PR DESCRIPTION
## Objective:
We want to collect adoption metrics of the CodeOwners feature. We will be storing the metrics in Big Query.
We want to know "how often users are updating the CodeOwners file" and "how many issues were assigned because of CodeOwners"

We also want to track how often people fail to upload/update. This info will be stored in datadog.