### PR TITLE
test: Make Discover test deterministic

### DIFF
--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -540,16 +540,16 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
         results = discover.query(
             selected_columns=["count()", "any(transaction)", "any(user.id)"],
-            query="",
+            query="event.type:transaction",
             params={"project_id": [self.project.id]},
             use_aggregate_conditions=True,
         )
 
         data = results["data"]
         assert len(data) == 1
-        assert data[0]["any_transaction"] in ["", "a" * 32]
-        assert data[0]["any_user_id"] in [None, "99"]
-        assert data[0]["count"] == 2
+        assert data[0]["any_transaction"] == "a" * 32
+        assert data[0]["any_user_id"] is None
+        assert data[0]["count"] == 1
 
 
 class QueryTransformTest(TestCase):

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -547,8 +547,8 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
         data = results["data"]
         assert len(data) == 1
-        assert data[0]["any_transaction"] == "a" * 32
-        assert data[0]["any_user_id"] == "99"
+        assert data[0]["any_transaction"] in ["", "a" * 32]
+        assert data[0]["any_user_id"] in [None, "99"]
         assert data[0]["count"] == 2
 
 


### PR DESCRIPTION
This test is flaky because the transaction is stored as a nullable string in
events and a non nullable string in transactions. Specifically, it happens
because `"a" > ""` but `"a" < NULL`.

Unfortunately we cannot fix this by rewriting `transaction` into `nullIf(transaction, '')` 
in Snuba since some tests in
https://github.com/getsentry/sentry/blob/master/tests/snuba/api/endpoints/test_organization_events_v2.py
will fail with that change and depend on the existing behaviour.
This is a workaround that avoids that issue by simply ensuring the same
`min()` is returned from both storages.