### PR TITLE
fix(demo): bug with login path middleware

### DIFF
--- a/src/sentry/demo/middleware.py
+++ b/src/sentry/demo/middleware.py
@@ -42,11 +42,10 @@ class DemoMiddleware:
             return
 
         # don't want people to see the login page in demo mode
-        if (
-            path == reverse("sentry-auth-organization", kwargs=view_kwargs)
-            and disable_login
-            and method == "GET"
-        ):
+        org_login_path = reverse(
+            "sentry-auth-organization", args=[view_kwargs["organization_slug"]]
+        )
+        if path == org_login_path and disable_login and method == "GET":
             return HttpResponseRedirect(login_redirect_route)
 
         # automatically log in logged out users when they land


### PR DESCRIPTION
This PR fixes errors like this in demo mode:
```
Reverse for 'sentry-auth-organization' with keyword arguments '{'organization_slug': 'prime-wasp', 'group_id': '161'}' not found. 1 pattern(s) tried: ['auth/login/(?P<organization_slug>[^/]+)/$']
```
The problem is that we were passing in too many args for reverse. The fix is to only pass in the `organization_slug`.

Fixes: SENTRY-DEMO-5