### PR TITLE
fix(ui): Allow pointer-events to pass through ClipFade

### DIFF
--- a/src/sentry/static/sentry/app/components/clippedBox.tsx
+++ b/src/sentry/static/sentry/app/components/clippedBox.tsx
@@ -179,4 +179,12 @@ const ClipFade = styled('div')`
   );
   text-align: center;
   border-bottom: ${space(1.5)} solid ${p => p.theme.background};
+
+  // Let pointer-events pass through ClipFade to visible elements underneath it
+  pointer-events: none;
+
+  // Ensure pointer-events trigger event listeners on ClipFade's child elements
+  > * {
+    pointer-events: auto;
+  }
 `;

--- a/src/sentry/static/sentry/app/components/clippedBox.tsx
+++ b/src/sentry/static/sentry/app/components/clippedBox.tsx
@@ -180,10 +180,10 @@ const ClipFade = styled('div')`
   text-align: center;
   border-bottom: ${space(1.5)} solid ${p => p.theme.background};
 
-  // Let pointer-events pass through ClipFade to visible elements underneath it
+  /* Let pointer-events pass through ClipFade to visible elements underneath it */
   pointer-events: none;
 
-  // Ensure pointer-events trigger event listeners on ClipFade's child elements
+  /* Ensure pointer-events trigger event listeners on "Expand" button */
   > * {
     pointer-events: auto;
   }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1748388/112906337-dd7c2580-90a0-11eb-8d2d-61bb9d7e2e79.png)

I can see the "copy" button but I cannot interact with it, which was frustrating. 

(Link to page in [dev.getsentry.net]( http://dev.getsentry.net:8000/settings/sentry/projects/internal/keys/))