### PR TITLE
feat(kvstore): Add cache-backed implementation for interoperability and migration purposes

### DIFF
--- a/src/sentry/utils/kvstore/cache.py
+++ b/src/sentry/utils/kvstore/cache.py
@@ -1,0 +1,51 @@
+from datetime import timedelta
+from typing import Any, Optional
+
+from sentry.cache.base import BaseCache
+from sentry.utils.kvstore.abstract import KVStorage
+
+
+class CacheKVStorage(KVStorage[Any, Any]):
+    """
+    This class implements a compatibility layer for code that was previously
+    storing key/value data one of the various cache backends.
+
+    This class is only intended to aid in the migration of existing code and
+    data, new functionality that doesn't require interopability with or
+    migration from existing implementations should use a more well-formed
+    backend specific to their purposes.
+    """
+
+    # NOTE: Several untyped calls to ``BaseCache`` are ignored in this class
+    # because the existing cache implementations have extremely flexible
+    # parameter types to begin with (e.g. anything that can be formatted to a
+    # string can be considered a valid key) and different backends have various
+    # value encoding strategies that are not always compatible (generally
+    # pickle and JSON.)
+
+    def __init__(self, backend: BaseCache) -> None:
+        self.backend = backend
+
+    def get(self, key: Any) -> Optional[Any]:
+        return self.backend.get(key)  # type: ignore
+
+    def set(self, key: Any, value: Any, ttl: Optional[timedelta] = None) -> None:
+        self.backend.set(key, value, timeout=int(ttl.total_seconds()) if ttl is not None else None)  # type: ignore
+
+    def delete(self, key: Any) -> None:
+        self.backend.delete(key)  # type: ignore
+
+    def bootstrap(self) -> None:
+        # Nothing to do in this method: the backend is expected to either not
+        # require any explicit setup action (memcached, Redis) or that setup is
+        # assumed to be managed elsewhere (e.g. the Django database cache is
+        # managed by the migration framework) in both deployment and testing
+        # environments.
+        pass
+
+    def destroy(self) -> None:
+        # Nothing to do in this method: this backend is expected to be torn
+        # down in tests by the test runner machinery. Hopefully you're not
+        # running this against a real deployment (it could be helpful to
+        # destroy a development environment, though.)
+        pass

--- a/tests/sentry/utils/kvstore/test_common.py
+++ b/tests/sentry/utils/kvstore/test_common.py
@@ -1,0 +1,67 @@
+import itertools
+import pytest
+from dataclasses import dataclass
+from typing import Iterator, Tuple
+
+from sentry.utils.kvstore import K, KVStorage, V
+
+
+@dataclass
+class TestProperties:
+    store: KVStorage[K, V]
+    keys: Iterator[K]
+    values: Iterator[V]
+
+    @property
+    def items(self) -> Iterator[Tuple[K, V]]:
+        return zip(self.keys, self.values)
+
+
+@pytest.fixture
+def properties(request) -> TestProperties:
+    raise NotImplementedError
+
+
+def test_single_key_operations(properties: TestProperties) -> None:
+    store = properties.store
+    key, value = next(properties.keys), next(properties.values)
+
+    # Test setting a key with no prior value.
+    store.set(key, value)
+    assert store.get(key) == value
+
+    # Test overwriting a key with a prior value.
+    new_value = next(properties.values)
+    store.set(key, new_value)
+    assert store.get(key) == new_value
+
+    # Test deleting an existing key.
+    store.delete(key)
+    assert store.get(key) is None
+
+    # Test reading a missing key.
+    missing_key = next(properties.keys)
+    assert store.get(missing_key) is None
+
+    # Test deleting a missing key.
+    store.delete(missing_key)
+
+
+def test_multiple_key_operations(properties: TestProperties) -> None:
+    store = properties.store
+
+    items = dict(itertools.islice(properties.items, 10))
+    for key, value in items.items():
+        store.set(key, value)
+
+    missing_keys = set(itertools.islice(properties.keys, 5))
+
+    all_keys = list(items.keys() | missing_keys)
+
+    # Test reading a combination of present and missing keys.
+    assert dict(store.get_many(all_keys)) == items
+
+    # Test deleting a combination of present and missing keys.
+    store.delete_many(all_keys)
+
+    assert dict(store.get_many(all_keys)) == {}


### PR DESCRIPTION
Continuing the lineage of #24644, this adds a cache-backed `KVStorage` implementation to support migrating from cache-backed storage to a different a key/value storage backend.

This also generalizes the tests as discussed here: https://github.com/getsentry/sentry/pull/24748#discussion_r602581123