### PR TITLE
fix(ui): Fix alert details page chart summary percentages and gray area

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -293,7 +293,7 @@ export default class DetailsBody extends React.Component<Props> {
             <Layout.Body>
               <Alert type="info" icon={<IconInfo size="md" />}>
                 {t(
-                  'You’re viewing the new alert details page. To view the old experience, select an alert below.'
+                  'You’re viewing the new alert details page. To view the old experience, select an alert on the chart or in the history.'
                 )}
               </Alert>
               <Layout.Main>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -432,7 +432,9 @@ class MetricChart extends React.PureComponent<Props, State> {
                 const timeWindowMs = rule.timeWindow * 60 * 1000;
 
                 const incidentStartDate = moment(incident.dateStarted).valueOf();
-                const incidentStartValue = dataArr.find(point => point.name >= incidentStartDate);
+                const incidentStartValue = dataArr.find(
+                  point => point.name >= incidentStartDate
+                );
                 series.push(
                   createIncidentSeries(
                     router,
@@ -450,11 +452,17 @@ class MetricChart extends React.PureComponent<Props, State> {
                     series[0].seriesName
                   )
                 );
-                const areaEnd = Math.min(statusChanges?.length && statusChanges[0].dateCreated
+                const areaEnd = Math.min(
+                  statusChanges?.length && statusChanges[0].dateCreated
                     ? moment(statusChanges[0].dateCreated).valueOf() - timeWindowMs
-                    : moment(incidentEnd).valueOf(), lastPoint);
+                    : moment(incidentEnd).valueOf(),
+                  lastPoint
+                );
                 const areaColor = warningTrigger ? theme.yellow300 : theme.red300;
-                const areaStart = Math.max(moment(incident.dateStarted).valueOf(), firstPoint);
+                const areaStart = Math.max(
+                  moment(incident.dateStarted).valueOf(),
+                  firstPoint
+                );
                 series.push(
                   createStatusAreaSeries(
                     areaColor,
@@ -471,7 +479,10 @@ class MetricChart extends React.PureComponent<Props, State> {
                 }
 
                 statusChanges?.forEach((activity, idx) => {
-                  const statusAreaStart = Math.max(moment(activity.dateCreated).valueOf() - timeWindowMs, firstPoint);
+                  const statusAreaStart = Math.max(
+                    moment(activity.dateCreated).valueOf() - timeWindowMs,
+                    firstPoint
+                  );
                   const statusAreaColor =
                     activity.value === `${IncidentStatus.CRITICAL}`
                       ? theme.red300
@@ -480,7 +491,9 @@ class MetricChart extends React.PureComponent<Props, State> {
                     idx === statusChanges.length - 1
                       ? moment(incidentEnd).valueOf()
                       : moment(statusChanges[idx + 1].dateCreated).valueOf() -
-                        timeWindowMs, lastPoint);
+                          timeWindowMs,
+                    lastPoint
+                  );
                   series.push(
                     createStatusAreaSeries(
                       statusAreaColor,

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -70,8 +70,6 @@ function createStatusAreaSeries(
   lineColor: string,
   startTime: number,
   endTime: number,
-  startLimit?: number,
-  endLimit?: number
 ): LineChartSeries {
   return {
     seriesName: 'Status Area',
@@ -81,8 +79,8 @@ function createStatusAreaSeries(
       lineStyle: {color: lineColor, type: 'solid', width: 4},
       data: [
         [
-          {coord: [startLimit ? Math.max(startTime, startLimit) : startTime, 0]},
-          {coord: [endLimit ? Math.min(endLimit, endTime) : endTime, 0]},
+          {coord: [startTime, 0]},
+          {coord: [endTime, 0]},
         ] as any,
       ],
     }),
@@ -452,6 +450,7 @@ class MetricChart extends React.PureComponent<Props, State> {
                     series[0].seriesName
                   )
                 );
+                const areaStart = Math.max(moment(incident.dateStarted).valueOf(), firstPoint);
                 const areaEnd = Math.min(
                   statusChanges?.length && statusChanges[0].dateCreated
                     ? moment(statusChanges[0].dateCreated).valueOf() - timeWindowMs
@@ -459,19 +458,7 @@ class MetricChart extends React.PureComponent<Props, State> {
                   lastPoint
                 );
                 const areaColor = warningTrigger ? theme.yellow300 : theme.red300;
-                const areaStart = Math.max(
-                  moment(incident.dateStarted).valueOf(),
-                  firstPoint
-                );
-                series.push(
-                  createStatusAreaSeries(
-                    areaColor,
-                    areaStart,
-                    areaEnd,
-                    firstPoint,
-                    lastPoint
-                  )
-                );
+                series.push(createStatusAreaSeries(areaColor, areaStart, areaEnd));
                 if (areaColor === theme.yellow300) {
                   warningDuration += areaEnd - areaStart;
                 } else {
@@ -483,10 +470,6 @@ class MetricChart extends React.PureComponent<Props, State> {
                     moment(activity.dateCreated).valueOf() - timeWindowMs,
                     firstPoint
                   );
-                  const statusAreaColor =
-                    activity.value === `${IncidentStatus.CRITICAL}`
-                      ? theme.red300
-                      : theme.yellow300;
                   const statusAreaEnd = Math.min(
                     idx === statusChanges.length - 1
                       ? moment(incidentEnd).valueOf()
@@ -494,15 +477,11 @@ class MetricChart extends React.PureComponent<Props, State> {
                           timeWindowMs,
                     lastPoint
                   );
-                  series.push(
-                    createStatusAreaSeries(
-                      statusAreaColor,
-                      statusAreaStart,
-                      statusAreaEnd,
-                      firstPoint,
-                      lastPoint
-                    )
-                  );
+                  const statusAreaColor =
+                    activity.value === `${IncidentStatus.CRITICAL}`
+                      ? theme.red300
+                      : theme.yellow300;
+                  series.push(createStatusAreaSeries(statusAreaColor, statusAreaStart, statusAreaEnd));
                   if (statusAreaColor === theme.yellow300) {
                     warningDuration += statusAreaEnd - statusAreaStart;
                   } else {

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -431,8 +431,8 @@ class MetricChart extends React.PureComponent<Props, State> {
 
                 const timeWindowMs = rule.timeWindow * 60 * 1000;
 
-                const areaStart = moment(incident.dateStarted).valueOf();
-                const incidentStartValue = dataArr.find(point => point.name >= areaStart);
+                const incidentStartDate = moment(incident.dateStarted).valueOf();
+                const incidentStartValue = dataArr.find(point => point.name >= incidentStartDate);
                 series.push(
                   createIncidentSeries(
                     router,
@@ -444,17 +444,17 @@ class MetricChart extends React.PureComponent<Props, State> {
                       )
                       ? theme.yellow300
                       : theme.red300,
-                    areaStart,
+                    incidentStartDate,
                     incident.identifier,
                     incidentStartValue,
                     series[0].seriesName
                   )
                 );
-                const areaEnd =
-                  statusChanges?.length && statusChanges[0].dateCreated
+                const areaEnd = Math.min(statusChanges?.length && statusChanges[0].dateCreated
                     ? moment(statusChanges[0].dateCreated).valueOf() - timeWindowMs
-                    : moment(incidentEnd).valueOf();
+                    : moment(incidentEnd).valueOf(), lastPoint);
                 const areaColor = warningTrigger ? theme.yellow300 : theme.red300;
+                const areaStart = Math.max(moment(incident.dateStarted).valueOf(), firstPoint);
                 series.push(
                   createStatusAreaSeries(
                     areaColor,
@@ -471,21 +471,20 @@ class MetricChart extends React.PureComponent<Props, State> {
                 }
 
                 statusChanges?.forEach((activity, idx) => {
-                  const statusAreaStart =
-                    moment(activity.dateCreated).valueOf() - timeWindowMs;
+                  const statusAreaStart = Math.max(moment(activity.dateCreated).valueOf() - timeWindowMs, firstPoint);
                   const statusAreaColor =
                     activity.value === `${IncidentStatus.CRITICAL}`
                       ? theme.red300
                       : theme.yellow300;
-                  const statusAreaEnd =
+                  const statusAreaEnd = Math.min(
                     idx === statusChanges.length - 1
                       ? moment(incidentEnd).valueOf()
                       : moment(statusChanges[idx + 1].dateCreated).valueOf() -
-                        timeWindowMs;
+                        timeWindowMs, lastPoint);
                   series.push(
                     createStatusAreaSeries(
                       statusAreaColor,
-                      areaStart,
+                      statusAreaStart,
                       statusAreaEnd,
                       firstPoint,
                       lastPoint

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -27,7 +27,7 @@ import {IncidentRule} from 'app/views/settings/incidentRules/types';
 import {Incident, IncidentActivityType, IncidentStatus} from '../../types';
 import {getIncidentRuleMetricPreset} from '../../utils';
 
-const X_AXIS_BOUNDARY_GAP = 15;
+const X_AXIS_BOUNDARY_GAP = 20;
 const VERTICAL_PADDING = 22;
 
 type Props = WithRouterProps & {

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -69,7 +69,7 @@ function createThresholdSeries(lineColor: string, threshold: number): LineChartS
 function createStatusAreaSeries(
   lineColor: string,
   startTime: number,
-  endTime: number,
+  endTime: number
 ): LineChartSeries {
   return {
     seriesName: 'Status Area',
@@ -77,12 +77,7 @@ function createStatusAreaSeries(
     markLine: MarkLine({
       silent: true,
       lineStyle: {color: lineColor, type: 'solid', width: 4},
-      data: [
-        [
-          {coord: [startTime, 0]},
-          {coord: [endTime, 0]},
-        ] as any,
-      ],
+      data: [[{coord: [startTime, 0]}, {coord: [endTime, 0]}] as any],
     }),
     data: [],
   };
@@ -450,7 +445,10 @@ class MetricChart extends React.PureComponent<Props, State> {
                     series[0].seriesName
                   )
                 );
-                const areaStart = Math.max(moment(incident.dateStarted).valueOf(), firstPoint);
+                const areaStart = Math.max(
+                  moment(incident.dateStarted).valueOf(),
+                  firstPoint
+                );
                 const areaEnd = Math.min(
                   statusChanges?.length && statusChanges[0].dateCreated
                     ? moment(statusChanges[0].dateCreated).valueOf() - timeWindowMs
@@ -481,7 +479,13 @@ class MetricChart extends React.PureComponent<Props, State> {
                     activity.value === `${IncidentStatus.CRITICAL}`
                       ? theme.red300
                       : theme.yellow300;
-                  series.push(createStatusAreaSeries(statusAreaColor, statusAreaStart, statusAreaEnd));
+                  series.push(
+                    createStatusAreaSeries(
+                      statusAreaColor,
+                      statusAreaStart,
+                      statusAreaEnd
+                    )
+                  );
                   if (statusAreaColor === theme.yellow300) {
                     warningDuration += statusAreaEnd - statusAreaStart;
                   } else {


### PR DESCRIPTION
This fixes the summary percentage calculation in the alert details summary, fixes the gray area overlaying the y axis in the chart and corrects the alert copy.

OLD:
![Screen Shot 2021-03-29 at 4 52 19 PM](https://user-images.githubusercontent.com/15015880/112913828-669a5900-90af-11eb-8f77-d3703f38b323.png)

NEW:
![Screen Shot 2021-03-29 at 4 52 31 PM](https://user-images.githubusercontent.com/15015880/112913837-6dc16700-90af-11eb-9174-208d4caa8da3.png)

OLD:
![Screen Shot 2021-03-29 at 4 53 19 PM](https://user-images.githubusercontent.com/15015880/112913846-74e87500-90af-11eb-9398-1028cb33bdd5.png)

NEW:
![Screen Shot 2021-03-29 at 4 53 01 PM](https://user-images.githubusercontent.com/15015880/112913851-7ade5600-90af-11eb-84ac-0f73d2f25742.png)
