### PR TITLE
test: Fix a Discover transactions test

### DIFF
--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -2731,7 +2731,6 @@ class GetPerformanceFacetsTest(SnubaTestCase, TestCase):
             }
         ):
             result = discover.get_performance_facets("", params)
-            self.wait_for_event_count(self.project.id, 2)
 
             assert len(result) == 12
             for r in result:


### PR DESCRIPTION
We cannot wait_for_event_count() on transaction events since the
eventstore.get_events() function that it calls does not return
transactions, only errors. It works temporarily while transactions
are being dual written to the events storage in addition to their own
storage but is not expected to in the future.