### PR TITLE
fix(migrations): Rename migration

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -10,7 +10,7 @@ auth: 0008_alter_user_username_max_length
 contenttypes: 0002_remove_content_type_name
 jira_ac: 0001_initial
 nodestore: 0002_nodestore_no_dictfield
-sentry: 0183_make_codemapping_unique_on_projectcodeowners
+sentry: 0184_copy_useroptions_to_notificationsettings_2
 sessions: 0001_initial
 sites: 0002_alter_domain_unique
 social_auth: 0001_initial

--- a/src/sentry/migrations/0184_copy_useroptions_to_notificationsettings_2.py
+++ b/src/sentry/migrations/0184_copy_useroptions_to_notificationsettings_2.py
@@ -94,7 +94,7 @@ class Migration(migrations.Migration):
     # transaction.
     atomic = False
     dependencies = [
-        ("sentry", "0182_update_user_misery_on_saved_queries"),
+        ("sentry", "0183_make_codemapping_unique_on_projectcodeowners"),
     ]
     operations = [
         migrations.RunPython(


### PR DESCRIPTION
We accidentally merged two migrations with the same ID at the same time (https://github.com/getsentry/sentry/pull/24749 and https://github.com/getsentry/sentry/pull/24762.) This PR renames the migration that landed second.