### PR TITLE
ui(quick-trace): Placeholder should be smaller

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -74,7 +74,7 @@ class GroupEventToolbar extends React.Component<Props> {
           <QuickTraceQuery event={event} location={location} orgSlug={organization.slug}>
             {results =>
               results.isLoading ? (
-                <Placeholder height="27px" />
+                <Placeholder height="24px" />
               ) : results.error || results.trace === null ? (
                 '\u2014'
               ) : (

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -46,7 +46,7 @@ export default function QuickTraceMeta({
   const traceTarget = generateTraceTarget(event, organization);
 
   const body = isLoading ? (
-    <Placeholder height="27px" />
+    <Placeholder height="24px" />
   ) : error || trace === null ? (
     '\u2014'
   ) : (


### PR DESCRIPTION
Quick trace only takes up 24px vertically now that the alignment has been fixed.
This adjusts the placeholder to the appropriate size to remove layout shifts
once quick trace loads.