### PR TITLE
fix(discover): Top events with project field with no results

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -467,7 +467,7 @@ def top_events_timeseries(
 
         for field in selected_columns:
             # If we have a project field, we need to limit results by project so we dont hit the result limit
-            if field in ["project", "project.id"]:
+            if field in ["project", "project.id"] and top_events["data"]:
                 snuba_filter.project_ids = [event["project.id"] for event in top_events["data"]]
                 continue
             if field in FIELD_ALIASES:

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -744,6 +744,31 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             kwargs={"organization_slug": self.project.organization.slug},
         )
 
+    def test_no_top_events_with_project_field(self):
+        project = self.create_project()
+        with self.feature(self.enabled_features):
+            response = self.client.get(
+                self.url,
+                data={
+                    # make sure to query the project with 0 events
+                    "project": project.id,
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=2)),
+                    "interval": "1h",
+                    "yAxis": "count()",
+                    "orderby": ["-count()"],
+                    "field": ["count()", "project"],
+                    "topEvents": 5,
+                },
+                format="json",
+            )
+
+        assert response.status_code == 200, response.content
+        # When there are no top events, we do not return an empty dict.
+        # Instead, we return a single zero-filled series for an empty graph.
+        data = response.data["data"]
+        assert [attrs for time, attrs in data] == [[{"count": 0}], [{"count": 0}]]
+
     def test_no_top_events(self):
         project = self.create_project()
         with self.feature(self.enabled_features):


### PR DESCRIPTION
When making a top events query with the project field when there are no results,
all project ids are stripped from the snuba filter resulting in a 400 error. This
change ensures that the snuba filter has non empty project ids.