### PR TITLE
fix(dashboardsv2): adjust for breakpoints

### DIFF
--- a/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/dashboard.tsx
@@ -164,20 +164,20 @@ export default withApi(withGlobalSelection(Dashboard));
 
 const WidgetContainer = styled('div')`
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   grid-auto-flow: row dense;
   grid-gap: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   @media (min-width: ${p => p.theme.breakpoints[3]}) {
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: repeat(6, minmax(0, 1fr));
   }
 
   @media (min-width: ${p => p.theme.breakpoints[4]}) {
-    grid-template-columns: repeat(8, 1fr);
+    grid-template-columns: repeat(8, minmax(0, 1fr));
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetWrapper.tsx
@@ -5,8 +5,6 @@ import {Widget} from './types';
 
 const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
   position: relative;
-  /* Min-width prevents grid items from stretching the grid */
-  min-width: 200px;
   touch-action: manipulation;
 
   ${p => {
@@ -14,16 +12,16 @@ const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
       case 'big_number':
         return `
           /* 2 cols */
-          grid-area: span 1 / span 2;
+          grid-area: span 1 / span 1;
 
           @media (min-width: ${p.theme.breakpoints[1]}) {
             /* 4 cols */
-            grid-area: span 1 / span 2;
+            grid-area: span 1 / span 1;
           }
 
           @media (min-width: ${p.theme.breakpoints[3]}) {
             /* 6 cols */
-            grid-area: span 1 / span 3;
+            grid-area: span 1 / span 2;
           }
 
           @media (min-width: ${p.theme.breakpoints[4]}) {
@@ -34,16 +32,16 @@ const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
       default:
         return `
           /* 2 cols */
-          grid-area: span 2 / span 2;
+          grid-area: span 1 / span 2;
 
           @media (min-width: ${p.theme.breakpoints[1]}) {
             /* 4 cols */
-            grid-area: span 2 / span 4;
+            grid-area: span 2 / span 2;
           }
 
           @media (min-width: ${p.theme.breakpoints[3]}) {
             /* 6 cols */
-            grid-area: span 2 / span 3;
+            grid-area: span 2 / span 2;
           }
 
           @media (min-width: ${p.theme.breakpoints[4]}) {

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetWrapper.tsx
@@ -21,13 +21,8 @@ const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
         `;
       default:
         return `
-          /* 2 cols */
-          grid-area: span 1 / span 2;
-
-          @media (min-width: ${p.theme.breakpoints[1]}) {
-            /* 4, 6 and 8 cols */
-            grid-area: span 2 / span 2;
-          }
+          /* 2, 4, 6 and 8 cols */
+          grid-area: span 2 / span 2;
         `;
     }
   }};

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetWrapper.tsx
@@ -11,8 +11,13 @@ const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
     switch (p.displayType) {
       case 'big_number':
         return `
-          /* 2 and 4 cols */
-          grid-area: span 1 / span 1;
+          /* 2 cols */
+          grid-area: span 1 / span 2;
+
+          @media (min-width: ${p.theme.breakpoints[0]}) {
+            /* 4 cols */
+            grid-area: span 1 / span 1;
+          }
 
           @media (min-width: ${p.theme.breakpoints[3]}) {
             /* 6 and 8 cols */

--- a/src/sentry/static/sentry/app/views/dashboardsV2/widgetWrapper.tsx
+++ b/src/sentry/static/sentry/app/views/dashboardsV2/widgetWrapper.tsx
@@ -11,21 +11,11 @@ const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
     switch (p.displayType) {
       case 'big_number':
         return `
-          /* 2 cols */
+          /* 2 and 4 cols */
           grid-area: span 1 / span 1;
 
-          @media (min-width: ${p.theme.breakpoints[1]}) {
-            /* 4 cols */
-            grid-area: span 1 / span 1;
-          }
-
           @media (min-width: ${p.theme.breakpoints[3]}) {
-            /* 6 cols */
-            grid-area: span 1 / span 2;
-          }
-
-          @media (min-width: ${p.theme.breakpoints[4]}) {
-            /* 8 cols */
+            /* 6 and 8 cols */
             grid-area: span 1 / span 2;
           }
         `;
@@ -35,17 +25,7 @@ const WidgetWrapper = styled(motion.div)<{displayType: Widget['displayType']}>`
           grid-area: span 1 / span 2;
 
           @media (min-width: ${p.theme.breakpoints[1]}) {
-            /* 4 cols */
-            grid-area: span 2 / span 2;
-          }
-
-          @media (min-width: ${p.theme.breakpoints[3]}) {
-            /* 6 cols */
-            grid-area: span 2 / span 2;
-          }
-
-          @media (min-width: ${p.theme.breakpoints[4]}) {
-            /* 8 cols */
+            /* 4, 6 and 8 cols */
             grid-area: span 2 / span 2;
           }
         `;


### PR DESCRIPTION
- Added minmax(0,1fr) to prevent grid items from stretching the grid (cancels out need for min-width: 200px)
- BigNumber is smaller until the 6 column breakpoint and becomes as wide as the graphs after that

**Before & After:**
![Screen Shot 2021-03-30 at 10 10 51 AM](https://user-images.githubusercontent.com/4830259/113028759-83cb3800-9140-11eb-925a-f6a7aeb8c519.png)
![Screen Shot 2021-03-30 at 10 19 57 AM](https://user-images.githubusercontent.com/4830259/113029667-8aa67a80-9141-11eb-9ab4-ff63ba970afb.png)
![Screen Shot 2021-03-30 at 10 21 14 AM](https://user-images.githubusercontent.com/4830259/113029786-b45fa180-9141-11eb-822e-12f62be87b0c.png)
![Screen Shot 2021-03-30 at 10 20 48 AM](https://user-images.githubusercontent.com/4830259/113029793-b6c1fb80-9141-11eb-9ec1-c65e516d5411.png)
![Screen Shot 2021-03-30 at 10 11 18 AM](https://user-images.githubusercontent.com/4830259/113028786-8c237300-9140-11eb-9393-cee59f5ebde4.png)
![Screen Shot 2021-03-30 at 10 11 10 AM](https://user-images.githubusercontent.com/4830259/113028797-8d54a000-9140-11eb-8c37-68a762877e19.png)
![Screen Shot 2021-03-30 at 10 11 35 AM](https://user-images.githubusercontent.com/4830259/113028811-93e31780-9140-11eb-922d-0498dda93ca2.png)
![Screen Shot 2021-03-30 at 10 11 29 AM](https://user-images.githubusercontent.com/4830259/113028816-95acdb00-9140-11eb-9c7d-6cc1ea442ce7.png)
![Screen Shot 2021-03-30 at 10 11 58 AM](https://user-images.githubusercontent.com/4830259/113028863-a2c9ca00-9140-11eb-8cd2-a60e1ef60891.png)
![Screen Shot 2021-03-30 at 10 11 51 AM](https://user-images.githubusercontent.com/4830259/113028878-a5c4ba80-9140-11eb-808a-fea7e78a96d9.png)