### PR TITLE
ref(processing): Use `KVStorage` interface instead of `BaseCache` for event processing store

### DIFF
--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -24,8 +24,8 @@ class BaseEventProcessingStore:
     implementations.
     """
 
-    def __init__(self, store: KVStorage[str, Event], timeout: int = DEFAULT_TIMEOUT):
-        self.store = store
+    def __init__(self, inner: KVStorage[str, Event], timeout: int = DEFAULT_TIMEOUT):
+        self.inner = inner
         self.timeout = timedelta(seconds=timeout)
 
     def __get_unprocessed_key(self, key: str) -> str:
@@ -35,17 +35,17 @@ class BaseEventProcessingStore:
         key = cache_key_for_event(event)
         if unprocessed:
             key = self.__get_unprocessed_key(key)
-        self.store.set(key, event, self.timeout)
+        self.inner.set(key, event, self.timeout)
         return key
 
     def get(self, key: str, unprocessed: bool = False) -> Optional[Event]:
         if unprocessed:
             key = self.__get_unprocessed_key(key)
-        return self.store.get(key)
+        return self.inner.get(key)
 
     def delete_by_key(self, key: str) -> None:
-        self.store.delete(key)
-        self.store.delete(self.__get_unprocessed_key(key))
+        self.inner.delete(key)
+        self.inner.delete(self.__get_unprocessed_key(key))
 
     def delete(self, event: Event) -> None:
         key = cache_key_for_event(event)

--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -1,10 +1,12 @@
+from typing import Any, Optional
+
 from sentry.utils.cache import cache_key_for_event
+
 
 DEFAULT_TIMEOUT = 60 * 60 * 24
 
 
-def _get_unprocessed_key(key):
-    return key + ":u"
+Event = Any
 
 
 class BaseEventProcessingStore:
@@ -20,26 +22,29 @@ class BaseEventProcessingStore:
     implementations.
     """
 
-    def __init__(self, inner, timeout=DEFAULT_TIMEOUT):
+    def __init__(self, inner, timeout: int = DEFAULT_TIMEOUT):
         self.inner = inner
         self.timeout = timeout
 
-    def store(self, event, unprocessed=False):
+    def __get_unprocessed_key(self, key: str) -> str:
+        return key + ":u"
+
+    def store(self, event: Event, unprocessed: bool = False) -> str:
         key = cache_key_for_event(event)
         if unprocessed:
-            key = _get_unprocessed_key(key)
+            key = self.__get_unprocessed_key(key)
         self.inner.set(key, event, self.timeout)
         return key
 
-    def get(self, key, unprocessed=False):
+    def get(self, key: str, unprocessed: bool = False) -> Optional[Event]:
         if unprocessed:
-            key = _get_unprocessed_key(key)
+            key = self.__get_unprocessed_key(key)
         return self.inner.get(key)
 
-    def delete_by_key(self, key):
+    def delete_by_key(self, key: str) -> None:
         self.inner.delete(key)
-        self.inner.delete(_get_unprocessed_key(key))
+        self.inner.delete(self.__get_unprocessed_key(key))
 
-    def delete(self, event):
+    def delete(self, event: Event) -> None:
         key = cache_key_for_event(event)
         self.delete_by_key(key)

--- a/src/sentry/eventstore/processing/default.py
+++ b/src/sentry/eventstore/processing/default.py
@@ -1,4 +1,5 @@
 from sentry.cache import default_cache
+from sentry.utils.kvstore.cache import CacheKVStorage
 
 from .base import BaseEventProcessingStore
 
@@ -9,5 +10,5 @@ class DefaultEventProcessingStore(BaseEventProcessingStore):
     as backend.
     """
 
-    def __init__(self, **options):
-        super().__init__(inner=default_cache, **options)
+    def __init__(self, **options) -> None:
+        super().__init__(store=CacheKVStorage(default_cache), **options)

--- a/src/sentry/eventstore/processing/default.py
+++ b/src/sentry/eventstore/processing/default.py
@@ -11,4 +11,4 @@ class DefaultEventProcessingStore(BaseEventProcessingStore):
     """
 
     def __init__(self, **options) -> None:
-        super().__init__(store=CacheKVStorage(default_cache), **options)
+        super().__init__(inner=CacheKVStorage(default_cache), **options)

--- a/src/sentry/eventstore/processing/redis.py
+++ b/src/sentry/eventstore/processing/redis.py
@@ -10,4 +10,4 @@ class RedisClusterEventProcessingStore(BaseEventProcessingStore):
     """
 
     def __init__(self, **options) -> None:
-        super().__init__(store=CacheKVStorage(RedisClusterCache(**options)))
+        super().__init__(inner=CacheKVStorage(RedisClusterCache(**options)))

--- a/src/sentry/eventstore/processing/redis.py
+++ b/src/sentry/eventstore/processing/redis.py
@@ -1,9 +1,7 @@
-import logging
+from sentry.cache.redis import RedisClusterCache
+from sentry.utils.kvstore.cache import CacheKVStorage
 
 from .base import BaseEventProcessingStore
-from sentry.cache.redis import RedisClusterCache
-
-logger = logging.getLogger(__name__)
 
 
 class RedisClusterEventProcessingStore(BaseEventProcessingStore):
@@ -11,5 +9,5 @@ class RedisClusterEventProcessingStore(BaseEventProcessingStore):
     Processing store implementation using the redis cluster cache as a backend.
     """
 
-    def __init__(self, **options):
-        super().__init__(inner=RedisClusterCache(**options))
+    def __init__(self, **options) -> None:
+        super().__init__(store=CacheKVStorage(RedisClusterCache(**options)))

--- a/src/sentry/utils/cache.py
+++ b/src/sentry/utils/cache.py
@@ -72,5 +72,5 @@ class cached_for_request(memoize):
         return functools.partial(self.__call__, obj)
 
 
-def cache_key_for_event(data):
+def cache_key_for_event(data) -> str:
     return "e:{1}:{0}".format(data["project"], data["event_id"])


### PR DESCRIPTION
Another piece of the endless march towards Bigtable as started in #24644. This builds on top of #24809 to use the `KVStorage` interface for event processing store so that the `BigtableKVStorage` can be used as a backend in a future change.