### PR TITLE
feat(alert): Have chart show alert wizard data

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -16,6 +16,7 @@ import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup'
 
 import {
   AlertType,
+  AlertWizardAlertNames,
   AlertWizardDescriptions,
   AlertWizardOptions,
   AlertWizardRuleTemplates,
@@ -94,7 +95,10 @@ class AlertWizard extends React.Component<Props, State> {
                   <OptionsWrapper key={categoryHeading}>
                     <Heading>{categoryHeading}</Heading>
                     <RadioGroup
-                      choices={options}
+                      choices={options.map(alertType => [
+                        alertType,
+                        AlertWizardAlertNames[alertType],
+                      ])}
                       onChange={this.handleChangeAlertOption}
                       value={alertOption}
                       label="alert-option"

--- a/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/options.tsx
@@ -9,25 +9,26 @@ export type AlertType =
   | 'trans_duration'
   | 'lcp';
 
+export const AlertWizardAlertNames: Record<AlertType, string> = {
+  issues: t('Issues'),
+  num_errors: t('Number of Errors'),
+  users_experiencing_errors: t('Users Experiencing Errors'),
+  throughput: t('Throughput'),
+  trans_duration: t('Transaction Duration'),
+  lcp: t('Longest Contentful Paint'),
+};
+
 export const AlertWizardOptions: {
   categoryHeading: string;
-  options: [AlertType, string][];
+  options: AlertType[];
 }[] = [
   {
     categoryHeading: t('Errors'),
-    options: [
-      ['issues', t('Issues')],
-      ['num_errors', t('Number of Errors')],
-      ['users_experiencing_errors', t('Users Experiencing Errors')],
-    ],
+    options: ['issues', 'num_errors', 'users_experiencing_errors'],
   },
   {
     categoryHeading: t('Performance'),
-    options: [
-      ['throughput', t('Throughput')],
-      ['trans_duration', t('Transaction Duration')],
-      ['lcp', t('Longest Contentful Paint')],
-    ],
+    options: ['throughput', 'trans_duration', 'lcp'],
   },
 ];
 

--- a/src/sentry/static/sentry/app/views/alerts/wizard/utils.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/utils.tsx
@@ -2,6 +2,7 @@ import {Dataset} from 'app/views/settings/incidentRules/types';
 
 import {AlertType, WizardRuleTemplate} from './options';
 
+// A set of unique identifiers to be able to tie aggregate and dataset back to a wizard alert type
 const alertTypeIdentifiers: Record<Dataset, Partial<Record<AlertType, string>>> = {
   [Dataset.ERRORS]: {
     num_errors: 'count()',
@@ -14,6 +15,11 @@ const alertTypeIdentifiers: Record<Dataset, Partial<Record<AlertType, string>>> 
   },
 };
 
+/**
+ * Given an aggregate and dataset object, will return the corresponding wizard alert type
+ * e.g. {aggregate: 'count()', dataset: 'events'} will yield 'num_errors'
+ * @param template
+ */
 export function getAlertTypeFromAggregateDataset({
   aggregate,
   dataset,

--- a/src/sentry/static/sentry/app/views/alerts/wizard/utils.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/utils.tsx
@@ -1,0 +1,27 @@
+import {Dataset} from 'app/views/settings/incidentRules/types';
+
+import {AlertType, WizardRuleTemplate} from './options';
+
+const alertTypeIdentifiers: Record<Dataset, Partial<Record<AlertType, string>>> = {
+  [Dataset.ERRORS]: {
+    num_errors: 'count()',
+    users_experiencing_errors: 'count_unique(tags[sentry:user])',
+  },
+  [Dataset.TRANSACTIONS]: {
+    throughput: 'count()',
+    trans_duration: 'transaction.duration',
+    lcp: 'measurements.lcp',
+  },
+};
+
+export function getAlertTypeFromAggregateDataset({
+  aggregate,
+  dataset,
+}: Pick<WizardRuleTemplate, 'aggregate' | 'dataset'>): AlertType {
+  const identifiersForDataset = alertTypeIdentifiers[dataset];
+  const matchingAlertTypeEntry = Object.entries(identifiersForDataset).find(
+    ([_alertType, identifier]) => identifier && aggregate.includes(identifier)
+  );
+  const alertType = matchingAlertTypeEntry && (matchingAlertTypeEntry[0] as AlertType);
+  return alertType ? alertType : 'num_errors';
+}

--- a/src/sentry/static/sentry/app/views/alerts/wizard/utils.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/utils.tsx
@@ -24,8 +24,8 @@ export function getAlertTypeFromAggregateDataset({
   aggregate,
   dataset,
 }: Pick<WizardRuleTemplate, 'aggregate' | 'dataset'>): AlertType {
-  const identifiersForDataset = alertTypeIdentifiers[dataset];
-  const matchingAlertTypeEntry = Object.entries(identifiersForDataset).find(
+  const identifierForDataset = alertTypeIdentifiers[dataset];
+  const matchingAlertTypeEntry = Object.entries(identifierForDataset).find(
     ([_alertType, identifier]) => identifier && aggregate.includes(identifier)
   );
   const alertType = matchingAlertTypeEntry && (matchingAlertTypeEntry[0] as AlertType);

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
@@ -42,7 +42,7 @@ type Props = {
   organization: Organization;
   projectSlug: string;
   disabled: boolean;
-  thresholdChart: React.ReactElement;
+  thresholdChart: (props: {footer: React.ReactNode}) => React.ReactElement;
   onFilterSearch: (query: string) => void;
 };
 
@@ -142,7 +142,50 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
     return (
       <React.Fragment>
         <Panel>
-          <StyledPanelBody>{this.props.thresholdChart}</StyledPanelBody>
+          <StyledPanelBody>
+            {this.props.thresholdChart({
+              footer: (
+                <ChartFooter>
+                  <MetricField
+                    name="aggregate"
+                    help={null}
+                    organization={organization}
+                    disabled={disabled}
+                    style={{
+                      ...formElemBaseStyle,
+                    }}
+                    inline={false}
+                    flexibleControlStateSize
+                    columnWidth={250}
+                    inFieldLabels
+                    required
+                  />
+                  <FormRowText>{t('over a')}</FormRowText>
+                  <Tooltip
+                    title={t(
+                      'Triggers are evaluated every minute regardless of this value.'
+                    )}
+                  >
+                    <SelectField
+                      name="timeWindow"
+                      style={{
+                        ...formElemBaseStyle,
+                        flex: 1,
+                        minWidth: 180,
+                      }}
+                      choices={Object.entries(TIME_WINDOW_MAP)}
+                      required
+                      isDisabled={disabled}
+                      getValue={value => Number(value)}
+                      setValue={value => `${value}`}
+                      inline={false}
+                      flexibleControlStateSize
+                    />
+                  </Tooltip>
+                </ChartFooter>
+              ),
+            })}
+          </StyledPanelBody>
         </Panel>
         <StyledListItem>{t('Select events')}</StyledListItem>
         <FormRow>
@@ -269,49 +312,12 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
             )}
           </FormField>
         </FormRow>
-        <FormRow>
-          <MetricField
-            name="aggregate"
-            help={null}
-            organization={organization}
-            disabled={disabled}
-            style={{
-              ...formElemBaseStyle,
-            }}
-            inline={false}
-            flexibleControlStateSize
-            columnWidth={250}
-            inFieldLabels
-            required
-          />
-          <FormRowText>{t('over a')}</FormRowText>
-          <Tooltip
-            title={t('Triggers are evaluated every minute regardless of this value.')}
-          >
-            <SelectField
-              name="timeWindow"
-              style={{
-                ...formElemBaseStyle,
-                flex: 1,
-                minWidth: 180,
-              }}
-              choices={Object.entries(TIME_WINDOW_MAP)}
-              required
-              isDisabled={disabled}
-              getValue={value => Number(value)}
-              setValue={value => `${value}`}
-              inline={false}
-              flexibleControlStateSize
-            />
-          </Tooltip>
-        </FormRow>
       </React.Fragment>
     );
   }
 }
 
 const StyledPanelBody = styled(PanelBody)`
-  padding-top: ${space(1)};
   ol,
   h4 {
     margin-bottom: ${space(1)};
@@ -336,6 +342,10 @@ const FormRow = styled('div')`
   align-items: flex-end;
   flex-wrap: wrap;
   margin-bottom: ${space(2)};
+`;
+
+const ChartFooter = styled(FormRow)`
+  margin: 0;
 `;
 
 const FormRowText = styled('div')`

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -23,6 +23,8 @@ import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import {defined} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
+import {AlertWizardAlertNames} from 'app/views/alerts/wizard/options';
+import {getAlertTypeFromAggregateDataset} from 'app/views/alerts/wizard/utils';
 import Form from 'app/views/settings/components/forms/form';
 import FormModel from 'app/views/settings/components/forms/model';
 import RuleNameOwnerForm from 'app/views/settings/incidentRules/ruleNameOwnerForm';
@@ -38,6 +40,7 @@ import RuleConditionsFormForWizard from '../ruleConditionsFormForWizard';
 import {
   AlertRuleThresholdType,
   Dataset,
+  EventTypes,
   IncidentRule,
   MetricActionTemplate,
   Trigger,
@@ -82,6 +85,7 @@ type State = {
   timeWindow: number;
   environment: string | null;
   uuid?: string;
+  eventTypes?: EventTypes[];
 } & AsyncComponent['state'];
 
 const isEmpty = (str: unknown): boolean => str === '' || !defined(str);
@@ -576,24 +580,40 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       thresholdType,
       resolveThreshold,
       loading,
+      eventTypes,
+      dataset,
     } = this.state;
 
-    const eventTypeFilter = getEventTypeFilter(this.state.dataset, this.state.eventTypes);
+    const eventTypeFilter = getEventTypeFilter(this.state.dataset, eventTypes);
     const queryWithTypeFilter = `${query} ${eventTypeFilter}`.trim();
 
-    const chart = (
+    const chartProps = {
+      organization,
+      projects: this.state.projects,
+      triggers,
+      query: queryWithTypeFilter,
+      aggregate,
+      timeWindow,
+      environment,
+      resolveThreshold,
+      thresholdType,
+    };
+    const alertType = getAlertTypeFromAggregateDataset({aggregate, dataset});
+    const wizardBuilderChart = ({footer}) => (
       <TriggersChart
-        organization={organization}
-        projects={this.state.projects}
-        triggers={triggers}
-        query={queryWithTypeFilter}
-        aggregate={aggregate}
-        timeWindow={timeWindow}
-        environment={environment}
-        resolveThreshold={resolveThreshold}
-        thresholdType={thresholdType}
+        {...chartProps}
+        header={
+          <ChartHeader>
+            <AlertName>{AlertWizardAlertNames[alertType]}</AlertName>
+            <AlertInfo>
+              {aggregate} | event.type:{eventTypes?.join(',')}
+            </AlertInfo>
+          </ChartHeader>
+        }
+        footer={footer}
       />
     );
+    const chart = <TriggersChart {...chartProps} />;
 
     const ownerId = rule.owner?.split(':')[1];
     const canEdit = ownerId ? userTeamIds.has(ownerId) : true;
@@ -676,7 +696,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                       projectSlug={params.projectId}
                       organization={organization}
                       disabled={!hasAccess || !canEdit}
-                      thresholdChart={chart}
+                      thresholdChart={wizardBuilderChart}
                       onFilterSearch={this.handleFilterUpdate}
                     />
                     <StyledListItem>
@@ -711,6 +731,23 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 
 const StyledListItem = styled(ListItem)`
   margin-bottom: ${space(1)};
+`;
+
+const ChartHeader = styled('div')`
+  padding: ${space(3)} ${space(3)} 0 ${space(3)};
+`;
+
+const AlertName = styled('div')`
+  font-size: ${p => p.theme.fontSizeExtraLarge};
+  font-weight: normal;
+  color: ${p => p.theme.textColor};
+`;
+
+const AlertInfo = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  font-family: ${p => p.theme.text.familyMono};
+  font-weight: normal;
+  color: ${p => p.theme.subText};
 `;
 
 export {RuleFormContainer};

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -38,6 +38,8 @@ type Props = {
   triggers: Trigger[];
   resolveThreshold: IncidentRule['resolveThreshold'];
   thresholdType: IncidentRule['thresholdType'];
+  header?: React.ReactNode;
+  footer?: React.ReactNode;
 };
 
 const TIME_PERIOD_MAP: Record<TimePeriod, string> = {
@@ -192,6 +194,8 @@ class TriggersChart extends React.PureComponent<Props, State> {
       resolveThreshold,
       thresholdType,
       environment,
+      header,
+      footer,
     } = this.props;
     const {statsPeriod, totalEvents} = this.state;
 
@@ -258,6 +262,7 @@ class TriggersChart extends React.PureComponent<Props, State> {
                       <ChartPlaceholder />
                     ) : (
                       <React.Fragment>
+                        {header}
                         <TransparentLoadingMask visible={reloading} />
                         <ThresholdsChart
                           period={statsPeriod}
@@ -271,11 +276,17 @@ class TriggersChart extends React.PureComponent<Props, State> {
                     )}
                     <ChartControls>
                       <InlineContainer>
-                        <SectionHeading>{t('Total Events')}</SectionHeading>
-                        {totalEvents !== null ? (
-                          <SectionValue>{totalEvents.toLocaleString()}</SectionValue>
+                        {footer ? (
+                          footer
                         ) : (
-                          <SectionValue>&mdash;</SectionValue>
+                          <React.Fragment>
+                            <SectionHeading>{t('Total Events')}</SectionHeading>
+                            {totalEvents !== null ? (
+                              <SectionValue>{totalEvents.toLocaleString()}</SectionValue>
+                            ) : (
+                              <SectionValue>&mdash;</SectionValue>
+                            )}
+                          </React.Fragment>
                         )}
                       </InlineContainer>
                       <InlineContainer>

--- a/tests/js/spec/views/alerts/wizard/utils.spec.jsx
+++ b/tests/js/spec/views/alerts/wizard/utils.spec.jsx
@@ -1,0 +1,82 @@
+import {getAlertTypeFromAggregateDataset} from 'app/views/alerts/wizard/utils';
+import {Dataset} from 'app/views/settings/incidentRules/types';
+
+describe('Wizard utils', function () {
+  it('extracts lcp alert', function () {
+    expect(
+      getAlertTypeFromAggregateDataset({
+        aggregate: 'p95(measurements.lcp)',
+        dataset: Dataset.TRANSACTIONS,
+      })
+    ).toEqual('lcp');
+    expect(
+      getAlertTypeFromAggregateDataset({
+        aggregate: 'percentile(measurements.lcp,0.7)',
+        dataset: Dataset.TRANSACTIONS,
+      })
+    ).toEqual('lcp');
+    expect(
+      getAlertTypeFromAggregateDataset({
+        aggregate: 'avg(measurements.lcp)',
+        dataset: Dataset.TRANSACTIONS,
+      })
+    ).toEqual('lcp');
+  });
+
+  it('extracts duration alert', function () {
+    expect(
+      getAlertTypeFromAggregateDataset({
+        aggregate: 'p95(transaction.duration)',
+        dataset: Dataset.TRANSACTIONS,
+      })
+    ).toEqual('trans_duration');
+    expect(
+      getAlertTypeFromAggregateDataset({
+        aggregate: 'percentile(transaction.duration,0.3)',
+        dataset: Dataset.TRANSACTIONS,
+      })
+    ).toEqual('trans_duration');
+    expect(
+      getAlertTypeFromAggregateDataset({
+        aggregate: 'avg(transaction.duration)',
+        dataset: Dataset.TRANSACTIONS,
+      })
+    ).toEqual('trans_duration');
+  });
+
+  it('extracts throughput alert', function () {
+    expect(
+      getAlertTypeFromAggregateDataset({
+        aggregate: 'count()',
+        dataset: Dataset.TRANSACTIONS,
+      })
+    ).toEqual('throughput');
+  });
+
+  it('extracts user error alert', function () {
+    expect(
+      getAlertTypeFromAggregateDataset({
+        aggregate: 'count_unique(tags[sentry:user])',
+        dataset: Dataset.ERRORS,
+      })
+    ).toEqual('users_experiencing_errors');
+  });
+
+  it('extracts error count alert', function () {
+    expect(
+      getAlertTypeFromAggregateDataset({
+        aggregate: 'count()',
+        dataset: Dataset.ERRORS,
+      })
+    ).toEqual('num_errors');
+  });
+
+  it('defaults to num_errors', function () {
+    expect(
+      getAlertTypeFromAggregateDataset({
+        aggregate: 'count_unique(tags[sentry:user])',
+        dataset: Dataset.TRANSACTIONS,
+      })
+    ).toEqual('num_errors');
+  });
+});


### PR DESCRIPTION
mocks: https://www.figma.com/file/uG4rQ7ZYMIigVaPLcqVHAZ/Handover%3A-Alerts-Wizard?node-id=21%3A1
**Before:**
<img width="1192" alt="Screen Shot 2021-03-30 at 2 58 55 PM" src="https://user-images.githubusercontent.com/9372512/113042552-5646b480-9169-11eb-9bd3-c793c575c08b.png">

**After:**
<img width="1189" alt="Screen Shot 2021-03-30 at 3 10 28 PM" src="https://user-images.githubusercontent.com/9372512/113043193-16340180-916a-11eb-9f1f-4f87649265b0.png">

This PR:
- Creates a header and footer to the triggers chart
    - **Header:** The wizard alert name (`Throughput`, `Longest Contentful Paint`, etc...) which has to be derived from dataset and aggregate until we decide to have the backend store this info
    - **Footer:** Now includes the `MetricField` component per the mocks
-  Adds a new map in `options.tsx` which goes from `AlertType` to name so that other areas of the metric alert builder can use this 'nicer' alert name such as in the chart header.
