### PR TITLE
feat(kvstore): Support transparent value encoding/decoding using codecs

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 python_version = 3.6
 files = src/sentry/snuba/query_subscription_consumer.py,
+        src/sentry/utils/codecs.py,
         src/sentry/utils/kvstore
 
 ; Enable all options used with --strict

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -11,6 +11,11 @@ TEncoded = TypeVar("TEncoded")
 
 
 class Codec(ABC, Generic[TDecoded, TEncoded]):
+    """
+    Codes provides bidirectional encoding/decoding (mapping) from one type
+    to another.
+    """
+
     @abstractmethod
     def encode(self, value: TDecoded) -> TEncoded:
         raise NotImplementedError
@@ -20,6 +25,13 @@ class Codec(ABC, Generic[TDecoded, TEncoded]):
         raise NotImplementedError
 
     def __or__(self, codec: "Codec[TEncoded, T]") -> "Codec[TDecoded, T]":
+        """
+        Create a new codec by pipelining it with another codec.
+
+        When encoding, the output of this codec is provided as the input to
+        the provided codec. When decoding, the output of the provided codec
+        is used as the input to this codec.
+        """
         return ChainedCodec(self, codec)
 
 
@@ -36,6 +48,11 @@ class ChainedCodec(Codec[TDecoded, TEncoded]):
 
 
 class BytesCodec(Codec[str, bytes]):
+    """
+    Encode/decode strings to/from bytes using the encoding provided to the
+    constructor.
+    """
+
     def __init__(self, encoding: str = "utf8"):
         self.encoding = encoding
 
@@ -47,6 +64,10 @@ class BytesCodec(Codec[str, bytes]):
 
 
 class JSONCodec(Codec[JSONData, str]):
+    """
+    Encode/decode Python data structures to/from JSON-encoded strings.
+    """
+
     def encode(self, value: JSONData) -> str:
         return json.dumps(value)
 

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+from typing import Generic, TypeVar
+
+
+TDecoded = TypeVar("TDecoded")
+TEncoded = TypeVar("TEncoded")
+
+
+class Codec(ABC, Generic[TDecoded, TEncoded]):
+    @abstractmethod
+    def encode(self, value: TDecoded) -> TEncoded:
+        raise NotImplementedError
+
+    @abstractmethod
+    def decode(self, value: TEncoded) -> TDecoded:
+        raise NotImplementedError

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -4,6 +4,7 @@ from typing import Generic, TypeVar
 from sentry.utils import json
 from sentry.utils.json import JSONData
 
+T = TypeVar("T")
 
 TDecoded = TypeVar("TDecoded")
 TEncoded = TypeVar("TEncoded")
@@ -17,6 +18,21 @@ class Codec(ABC, Generic[TDecoded, TEncoded]):
     @abstractmethod
     def decode(self, value: TEncoded) -> TDecoded:
         raise NotImplementedError
+
+    def __or__(self, codec: "Codec[TEncoded, T]") -> "Codec[TDecoded, T]":
+        return ChainedCodec(self, codec)
+
+
+class ChainedCodec(Codec[TDecoded, TEncoded]):
+    def __init__(self, outer: Codec[TDecoded, T], inner: Codec[T, TEncoded]) -> None:
+        self.outer = outer
+        self.inner = inner
+
+    def encode(self, value: TDecoded) -> TEncoded:
+        return self.inner.encode(self.outer.encode(value))
+
+    def decode(self, value: TEncoded) -> TDecoded:
+        return self.outer.decode(self.inner.decode(value))
 
 
 class BytesCodec(Codec[str, bytes]):

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -1,8 +1,11 @@
+import zlib
 from abc import ABC, abstractmethod
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, cast
 
+import zstandard
 from sentry.utils import json
 from sentry.utils.json import JSONData
+
 
 T = TypeVar("T")
 
@@ -73,3 +76,19 @@ class JSONCodec(Codec[JSONData, str]):
 
     def decode(self, value: str) -> JSONData:
         return json.loads(value)
+
+
+class ZlibCodec(Codec[bytes, bytes]):
+    def encode(self, value: bytes) -> bytes:
+        return zlib.compress(value)
+
+    def decode(self, value: bytes) -> bytes:
+        return zlib.decompress(value)
+
+
+class ZstdCodec(Codec[bytes, bytes]):
+    def encode(self, value: bytes) -> bytes:
+        return cast(bytes, zstandard.ZstdCompressor().compress(value))
+
+    def decode(self, value: bytes) -> bytes:
+        return cast(bytes, zstandard.ZstdDecompressor().decompress(value))

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -19,6 +19,17 @@ class Codec(ABC, Generic[TDecoded, TEncoded]):
         raise NotImplementedError
 
 
+class BytesCodec(Codec[str, bytes]):
+    def __init__(self, encoding: str = "utf8"):
+        self.encoding = encoding
+
+    def encode(self, value: str) -> bytes:
+        return value.encode(self.encoding)
+
+    def decode(self, value: bytes) -> str:
+        return value.decode(self.encoding)
+
+
 class JSONCodec(Codec[JSONData, str]):
     def encode(self, value: JSONData) -> str:
         return json.dumps(value)

--- a/src/sentry/utils/codecs.py
+++ b/src/sentry/utils/codecs.py
@@ -1,6 +1,9 @@
 from abc import ABC, abstractmethod
 from typing import Generic, TypeVar
 
+from sentry.utils import json
+from sentry.utils.json import JSONData
+
 
 TDecoded = TypeVar("TDecoded")
 TEncoded = TypeVar("TEncoded")
@@ -14,3 +17,11 @@ class Codec(ABC, Generic[TDecoded, TEncoded]):
     @abstractmethod
     def decode(self, value: TEncoded) -> TDecoded:
         raise NotImplementedError
+
+
+class JSONCodec(Codec[JSONData, str]):
+    def encode(self, value: JSONData) -> str:
+        return json.dumps(value)
+
+    def decode(self, value: str) -> JSONData:
+        return json.loads(value)

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -84,23 +84,26 @@ _default_escaped_encoder = JSONEncoderForHTML(
 )
 
 
-def dump(value, fp, **kwargs):
+JSONData = Any  # https://github.com/python/typing/issues/182
+
+
+def dump(value: JSONData, fp, **kwargs):
     for chunk in _default_encoder.iterencode(value):
         fp.write(chunk)
 
 
-def dumps(value, escape=False, **kwargs):
+def dumps(value: JSONData, escape: bool = False, **kwargs) -> str:
     # Legacy use. Do not use. Use dumps_htmlsafe
     if escape:
         return _default_escaped_encoder.encode(value)
     return _default_encoder.encode(value)
 
 
-def load(fp, **kwargs):
+def load(fp, **kwargs) -> str:
     return loads(fp.read())
 
 
-def loads(value: str, **kwargs) -> Any:
+def loads(value: str, **kwargs) -> JSONData:
     return _default_decoder.decode(value)
 
 

--- a/src/sentry/utils/kvstore/bigtable.py
+++ b/src/sentry/utils/kvstore/bigtable.py
@@ -1,27 +1,21 @@
 import enum
 import logging
 import struct
-import zlib
 from datetime import timedelta
 from threading import Lock
-from typing import Any, Callable, Iterator, Mapping, NamedTuple, Optional, Sequence, Tuple, cast
+from typing import Any, Iterator, Mapping, Optional, Sequence, Tuple, cast
 
-import zstandard
 from django.utils import timezone
 from google.api_core import exceptions, retry
 from google.cloud import bigtable
 from google.cloud.bigtable.row_data import PartialRowData
 from google.cloud.bigtable.row_set import RowSet
 from google.cloud.bigtable.table import Table
+from sentry.utils.codecs import Codec, ZlibCodec, ZstdCodec
 from sentry.utils.kvstore.abstract import KVStorage
 
 
 logger = logging.getLogger(__name__)
-
-
-class CompressionStrategy(NamedTuple):
-    compress: Callable[[bytes], bytes]
-    decompress: Callable[[bytes], bytes]
 
 
 class BigtableError(Exception):
@@ -58,18 +52,9 @@ class BigtableKVStorage(KVStorage[str, bytes]):
         COMPRESSED_ZLIB = 1 << 0
         COMPRESSED_ZSTD = 1 << 1
 
-    compression_strategies: Mapping[str, Tuple[Flags, CompressionStrategy]] = {
-        "zlib": (
-            Flags.COMPRESSED_ZLIB,
-            CompressionStrategy(compress=zlib.compress, decompress=zlib.decompress),
-        ),
-        "zstd": (
-            Flags.COMPRESSED_ZSTD,
-            CompressionStrategy(
-                compress=lambda x: cast(bytes, zstandard.ZstdCompressor().compress(x)),
-                decompress=lambda x: cast(bytes, zstandard.ZstdDecompressor().decompress(x)),
-            ),
-        ),
+    compression_strategies: Mapping[str, Tuple[Flags, Codec[bytes, bytes]]] = {
+        "zlib": (Flags.COMPRESSED_ZLIB, ZlibCodec()),
+        "zstd": (Flags.COMPRESSED_ZSTD, ZstdCodec()),
     }
 
     def __init__(
@@ -177,7 +162,7 @@ class BigtableKVStorage(KVStorage[str, bytes]):
             # after the first one matches. Good luck!
             for compression_flag, strategy in self.compression_strategies.values():
                 if compression_flag in flags:
-                    value = strategy.decompress(value)
+                    value = strategy.decode(value)
                     break
 
         return value
@@ -227,7 +212,7 @@ class BigtableKVStorage(KVStorage[str, bytes]):
         if self.compression:
             compression_flag, strategy = self.compression_strategies[self.compression]
             flags |= compression_flag
-            value = strategy.compress(value)
+            value = strategy.encode(value)
 
         # Only need to write the column at all if any flags are enabled. And if
         # so, pack it into a single byte.

--- a/src/sentry/utils/kvstore/encoding.py
+++ b/src/sentry/utils/kvstore/encoding.py
@@ -6,6 +6,14 @@ from sentry.utils.kvstore.abstract import K, KVStorage
 
 
 class CodecWrapper(KVStorage[K, TDecoded]):
+    """
+    This class provides a wrapper that can be used to transparently
+    encode/decode values in the provided key/value storage to another type on
+    reading and writing by using the provided codec. This allows key/value
+    storages that have different value types to be used interchangably by
+    wrapping one or both storages so that they expect a common type.
+    """
+
     def __init__(
         self, store: KVStorage[K, TEncoded], value_codec: Codec[TDecoded, TEncoded]
     ) -> None:

--- a/src/sentry/utils/kvstore/encoding.py
+++ b/src/sentry/utils/kvstore/encoding.py
@@ -1,0 +1,39 @@
+from datetime import timedelta
+from typing import Iterator, Optional, Sequence, Tuple
+
+from sentry.utils.codecs import Codec, TDecoded, TEncoded
+from sentry.utils.kvstore.abstract import K, KVStorage
+
+
+class KVStorageCodecWrapper(KVStorage[K, TDecoded]):
+    def __init__(
+        self, store: KVStorage[K, TEncoded], value_codec: Codec[TDecoded, TEncoded]
+    ) -> None:
+        self.store = store
+        self.value_codec = value_codec
+
+    def get(self, key: K) -> Optional[TDecoded]:
+        value = self.store.get(key)
+        if value is None:
+            return None
+
+        return self.value_codec.decode(value)
+
+    def get_many(self, keys: Sequence[K]) -> Iterator[Tuple[K, TDecoded]]:
+        for key, value in self.store.get_many(keys):
+            yield key, self.value_codec.decode(value)
+
+    def set(self, key: K, value: TDecoded, ttl: Optional[timedelta] = None) -> None:
+        return self.store.set(key, self.value_codec.encode(value), ttl)
+
+    def delete(self, key: K) -> None:
+        return self.store.delete(key)
+
+    def delete_many(self, keys: Sequence[K]) -> None:
+        return self.store.delete_many(keys)
+
+    def bootstrap(self) -> None:
+        return self.store.bootstrap()
+
+    def destroy(self) -> None:
+        return self.store.destroy()

--- a/src/sentry/utils/kvstore/encoding.py
+++ b/src/sentry/utils/kvstore/encoding.py
@@ -5,7 +5,7 @@ from sentry.utils.codecs import Codec, TDecoded, TEncoded
 from sentry.utils.kvstore.abstract import K, KVStorage
 
 
-class CodecWrapper(KVStorage[K, TDecoded]):
+class KVStorageCodecWrapper(KVStorage[K, TDecoded]):
     """
     This class provides a wrapper that can be used to transparently
     encode/decode values in the provided key/value storage to another type on

--- a/src/sentry/utils/kvstore/encoding.py
+++ b/src/sentry/utils/kvstore/encoding.py
@@ -5,7 +5,7 @@ from sentry.utils.codecs import Codec, TDecoded, TEncoded
 from sentry.utils.kvstore.abstract import K, KVStorage
 
 
-class KVStorageCodecWrapper(KVStorage[K, TDecoded]):
+class CodecWrapper(KVStorage[K, TDecoded]):
     def __init__(
         self, store: KVStorage[K, TEncoded], value_codec: Codec[TDecoded, TEncoded]
     ) -> None:

--- a/src/sentry/utils/kvstore/memory.py
+++ b/src/sentry/utils/kvstore/memory.py
@@ -12,6 +12,11 @@ class Record(Generic[V]):
 
 
 class MemoryKVStorage(KVStorage[K, V]):
+    """
+    This class provides an in-memory key/value store. It is intended for use
+    in testing as a lightweight substitute for other backends.
+    """
+
     def __init__(self) -> None:
         self.__records: MutableMapping[K, Record[V]] = {}
 

--- a/src/sentry/utils/kvstore/memory.py
+++ b/src/sentry/utils/kvstore/memory.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Generic, MutableMapping, Optional
+
+from sentry.utils.kvstore.abstract import K, KVStorage, V
+
+
+@dataclass
+class Record(Generic[V]):
+    value: V
+    expires_at: Optional[datetime] = None
+
+
+class MemoryKVStorage(KVStorage[K, V]):
+    def __init__(self) -> None:
+        self.__records: MutableMapping[K, Record[V]] = {}
+
+    def get(self, key: K) -> Optional[V]:
+        try:
+            record = self.__records[key]
+        except KeyError:
+            return None
+
+        if record.expires_at is not None and datetime.now() > record.expires_at:
+            del self.__records[key]
+            return None
+
+        return record.value
+
+    def set(self, key: K, value: V, ttl: Optional[timedelta] = None) -> None:
+        self.__records[key] = Record(value, datetime.now() + ttl if ttl is not None else None)
+
+    def delete(self, key: K) -> None:
+        try:
+            del self.__records[key]
+        except KeyError:
+            pass
+
+    def bootstrap(self) -> None:
+        pass
+
+    def destroy(self) -> None:
+        self.__records.clear()

--- a/tests/sentry/utils/kvstore/test_common.py
+++ b/tests/sentry/utils/kvstore/test_common.py
@@ -17,7 +17,7 @@ class Properties:
         return zip(self.keys, self.values)
 
 
-@pytest.fixture(params=["bigtable", "cache/default"])
+@pytest.fixture(params=["bigtable", "cache/default", "memory"])
 def properties(request) -> Properties:
     if request.param == "bigtable":
         from tests.sentry.utils.kvstore.test_bigtable import create_store, get_credentials
@@ -42,6 +42,14 @@ def properties(request) -> Properties:
         return Properties(
             CacheKVStorage(cache),
             keys=(f"kvstore/{i}" for i in itertools.count()),
+            values=itertools.count(),
+        )
+    elif request.param == "memory":
+        from sentry.utils.kvstore.memory import MemoryKVStorage
+
+        return Properties(
+            MemoryKVStorage(),
+            keys=itertools.count(),
             values=itertools.count(),
         )
     else:

--- a/tests/sentry/utils/kvstore/test_encoding.py
+++ b/tests/sentry/utils/kvstore/test_encoding.py
@@ -3,7 +3,7 @@ from typing import Iterator
 import pytest
 from sentry.utils.codecs import BytesCodec, JSONCodec
 from sentry.utils.kvstore.abstract import KVStorage
-from sentry.utils.kvstore.encoding import CodecWrapper
+from sentry.utils.kvstore.encoding import KVStorageCodecWrapper
 from sentry.utils.kvstore.memory import MemoryKVStorage
 
 
@@ -14,8 +14,8 @@ def store() -> Iterator[KVStorage[str, bytes]]:
     store.destroy()
 
 
-def test_encoding(store: KVStorage[str, bytes]) -> None:
-    wrapper = CodecWrapper(store, JSONCodec() | BytesCodec())
+def test_encoding_wrapper(store: KVStorage[str, bytes]) -> None:
+    wrapper = KVStorageCodecWrapper(store, JSONCodec() | BytesCodec())
 
     wrapper.set("key", [1, 2, 3])
     assert store.get("key") == b"[1,2,3]"

--- a/tests/sentry/utils/kvstore/test_encoding.py
+++ b/tests/sentry/utils/kvstore/test_encoding.py
@@ -1,0 +1,24 @@
+from typing import Iterator
+
+import pytest
+from sentry.utils.codecs import BytesCodec, JSONCodec
+from sentry.utils.kvstore.abstract import KVStorage
+from sentry.utils.kvstore.encoding import CodecWrapper
+from sentry.utils.kvstore.memory import MemoryKVStorage
+
+
+@pytest.fixture
+def store() -> Iterator[KVStorage[str, bytes]]:
+    store: KVStorage[str, bytes] = MemoryKVStorage()
+    yield store
+    store.destroy()
+
+
+def test_encoding(store: KVStorage[str, bytes]) -> None:
+    wrapper = CodecWrapper(store, JSONCodec() | BytesCodec())
+
+    wrapper.set("key", [1, 2, 3])
+    assert store.get("key") == b"[1,2,3]"
+
+    assert wrapper.get("key") == [1, 2, 3]
+    assert [*wrapper.get_many(["key", "missing"])] == [("key", [1, 2, 3])]

--- a/tests/sentry/utils/test_codecs.py
+++ b/tests/sentry/utils/test_codecs.py
@@ -1,0 +1,8 @@
+from sentry.utils.codecs import BytesCodec, JSONCodec
+
+
+def test_codec_chaining() -> None:
+    codec = JSONCodec() | BytesCodec()
+
+    assert codec.encode([1, 2, 3]) == b"[1,2,3]"
+    assert codec.decode(b"[1,2,3]") == [1, 2, 3]

--- a/tests/sentry/utils/test_codecs.py
+++ b/tests/sentry/utils/test_codecs.py
@@ -1,4 +1,19 @@
-from sentry.utils.codecs import BytesCodec, JSONCodec
+import pytest
+from sentry.utils.codecs import BytesCodec, JSONCodec, ZlibCodec, ZstdCodec
+
+
+@pytest.mark.parametrize(
+    "codec, decoded, encoded",
+    [
+        (JSONCodec(), {"foo": "bar"}, '{"foo":"bar"}'),
+        (BytesCodec("utf8"), "\N{SNOWMAN}", b"\xe2\x98\x83"),
+        (ZlibCodec(), b"hello", b"x\x9c\xcbH\xcd\xc9\xc9\x07\x00\x06,\x02\x15"),
+        (ZstdCodec(), b"hello", b"(\xb5/\xfd \x05)\x00\x00hello"),
+    ],
+)
+def test_codec(codec, encoded, decoded):
+    assert codec.encode(decoded) == encoded
+    assert codec.decode(encoded) == decoded
 
 
 def test_codec_chaining() -> None:


### PR DESCRIPTION
Yet another change in the process started by #24644. This will allow the `BigtableKVStorage` to be used interchangeably with the `CacheKVStorage` in `EventProcesingStore` (which expects `KVStorage[str, Event]` as of #24827) by using a `JSONCodec() | ByteCodec()` codec pipeline to map the value type from `Event`/`Any` to `bytes`. This will allow us to start the dual writing/reading process safely.