### PR TITLE
fix(dashboards): Ensure only legal function options can be graphed

### DIFF
--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -6,8 +6,10 @@ import {IconAdd, IconDelete} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {
+  aggregateFunctionOutputType,
   explodeField,
   generateFieldAsString,
+  isLegalYAxisType,
   QueryFieldValue,
 } from 'app/utils/discover/fields';
 import {Widget} from 'app/views/dashboardsV2/types';
@@ -117,7 +119,26 @@ function WidgetQueryFields({
             fieldOptions={fieldOptions}
             onChange={value => handleChangeField(value, i)}
             filterPrimaryOptions={option => {
+              if (option.value.kind === FieldValueKind.FUNCTION) {
+                const primaryOutput = aggregateFunctionOutputType(
+                  option.value.meta.name,
+                  undefined
+                );
+                if (primaryOutput) {
+                  // If a function returns a specific type, then validate it.
+                  return isLegalYAxisType(primaryOutput);
+                }
+              }
+
               return option.value.kind === FieldValueKind.FUNCTION;
+            }}
+            filterAggregateParameters={option => {
+              if (option.value.kind === FieldValueKind.FUNCTION) {
+                // Functions are not legal options as an aggregate/function parameter.
+                return false;
+              }
+
+              return isLegalYAxisType(option.value.meta.dataType);
             }}
           />
           {fields.length > 1 && (

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -28,6 +28,7 @@ import {
   generateFieldAsString,
   getAggregateAlias,
   isAggregateField,
+  isLegalYAxisType,
   Sort,
 } from './fields';
 import {
@@ -1023,11 +1024,7 @@ class EventView {
     return uniqBy(
       this.getAggregateFields()
         // Only include aggregates that make sense to be graphable (eg. not string or date)
-        .filter((field: Field) =>
-          ['number', 'integer', 'duration', 'percentage'].includes(
-            aggregateOutputType(field.field)
-          )
-        )
+        .filter((field: Field) => isLegalYAxisType(aggregateOutputType(field.field)))
         .map((field: Field) => ({label: field.field, value: field.field}))
         .concat(CHART_AXIS_OPTIONS),
       'value'

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -809,3 +809,10 @@ export function fieldAlignment(
   }
   return align;
 }
+
+/**
+ * Match on types that are legal to show on a timeseries chart.
+ */
+export function isLegalYAxisType(match: ColumnType) {
+  return ['number', 'integer', 'duration', 'percentage'].includes(match);
+}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -58,6 +58,10 @@ type Props = {
    */
   filterPrimaryOptions?: (option: FieldValueOption) => boolean;
   /**
+   * Function to filter the options that are used as parameters for function/aggregate.
+   */
+  filterAggregateParameters?: (option: FieldValueOption) => boolean;
+  /**
    * Whether or not to add labels inside of the input fields, currently only
    * used for the metric alert builder.
    */
@@ -299,15 +303,19 @@ class QueryField extends React.Component<Props> {
   }
 
   renderParameterInputs(parameters: ParameterDescription[]): React.ReactNode[] {
-    const {disabled, inFieldLabels} = this.props;
+    const {disabled, inFieldLabels, filterAggregateParameters} = this.props;
     const inputs = parameters.map((descriptor: ParameterDescription, index: number) => {
       if (descriptor.kind === 'column' && descriptor.options.length > 0) {
+        const aggregateParameters = filterAggregateParameters
+          ? descriptor.options.filter(filterAggregateParameters)
+          : descriptor.options;
+
         return (
           <SelectControl
             key="select"
             name="parameter"
             placeholder={t('Select value')}
-            options={descriptor.options}
+            options={aggregateParameters}
             value={descriptor.value}
             required={descriptor.required}
             onChange={this.handleFieldParameterChange}


### PR DESCRIPTION
Certain combinations of functions and their parameters may not be legal to graph on a timeseries chart. 

Some examples:
- `any(timestamp)`
- `last_seen()`

This PR doesn't discriminate any usage of functions that may not make sense to chart. We shouldn't stop customers from choosing to graph them if it doesn't bork the event stats endpoint.