### PR TITLE
feat(demo): adds task to delete orphaned organizations

### DIFF
--- a/src/sentry/demo/settings.py
+++ b/src/sentry/demo/settings.py
@@ -19,6 +19,11 @@ CELERYBEAT_SCHEDULE["demo_delete_users_orgs"] = {
     "schedule": timedelta(hours=1),
     "options": {"expires": 3600, "queue": "cleanup"},
 }
+CELERYBEAT_SCHEDULE["demo_delete_initializing_orgs"] = {
+    "task": "sentry.demo.tasks.delete_initializing_orgs",
+    "schedule": timedelta(hours=1),
+    "options": {"expires": 3600, "queue": "cleanup"},
+}
 MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + ("sentry.demo.middleware.DemoMiddleware",)
 INSTALLED_APPS = INSTALLED_APPS + ("sentry.demo.apps.Config",)
 ROOT_URLCONF = "sentry.demo.urls"
@@ -37,6 +42,7 @@ DEMO_DATA_GEN_PARAMS = {
     "DURATION_SIGMA": 600,  # the variability in durations
     "BASE_FRONTEND_DURATION": 2000,  # the average front end duration discounting the day impact
     "MIN_FRONTEND_DURATION": 600,  # absolute minimum duration of a FE transaction
+    "MAX_INITIALIZATION_TIME": 60,  # number of minutes to give an organization to initialize
 }
 
 # parameters for an org when quickly generating them synchronously

--- a/src/sentry/demo/tasks.py
+++ b/src/sentry/demo/tasks.py
@@ -1,3 +1,5 @@
+import logging
+
 from datetime import timedelta
 from django.conf import settings
 from django.utils import timezone
@@ -14,6 +16,9 @@ from .models import DemoOrgStatus, DemoOrganization
 from .demo_org_manager import create_demo_org
 
 
+logger = logging.getLogger(__name__)
+
+
 @instrumented_task(
     name="sentry.demo.tasks.delete_users_orgs",
 )
@@ -21,6 +26,7 @@ def delete_users_orgs(**kwargs):
     if not settings.DEMO_MODE:
         return
 
+    logger.info("delete_users_orgs.start")
     # delete everything older than a day
     cutoff_time = timezone.now() - timedelta(days=1)
 
@@ -43,6 +49,39 @@ def delete_users_orgs(**kwargs):
     # now finally delete the orgs
     for org in org_list:
         # apply async so if so we continue if one org aborts
+        logger.info("delete_initializing_orgs.delete", extra={"organization_slug": org.slug})
+        delete_organization.apply_async(kwargs={"object_id": org.id})
+
+
+@instrumented_task(
+    name="sentry.demo.tasks.delete_initializing_orgs",
+)
+def delete_initializing_orgs(**kwargs):
+    """
+    Deletes orgs that are still in the initializing state.
+    This happens if Sentry is killed while an organization is being created.
+    """
+    if not settings.DEMO_MODE:
+        return
+
+    logger.info("delete_initializing_orgs.start")
+    # delete everything older than MAX_INITIALIZATION_TIME
+    max_init_time = settings.DEMO_DATA_GEN_PARAMS["MAX_INITIALIZATION_TIME"]
+    cutoff_time = timezone.now() - timedelta(minutes=max_init_time)
+
+    # note this only runs in demo mode (not SaaS) so the underlying tables here are small
+    org_list = Organization.objects.filter(
+        demoorganization__date_added__lte=cutoff_time,
+        demoorganization__status=DemoOrgStatus.INITIALIZING,
+    )
+
+    # first mark orgs for deletion
+    org_list.update(status=OrganizationStatus.PENDING_DELETION)
+
+    # now finally delete the orgs
+    for org in org_list:
+        # apply async so if so we continue if one org aborts
+        logger.info("delete_initializing_orgs.delete", extra={"organization_slug": org.slug})
         delete_organization.apply_async(kwargs={"object_id": org.id})
 
 
@@ -53,6 +92,7 @@ def build_up_org_buffer():
     if not settings.DEMO_MODE:
         return
 
+    logger.info("build_up_org_buffer.start")
     ORG_BUFFER_SIZE = settings.DEMO_DATA_GEN_PARAMS["ORG_BUFFER_SIZE"]
 
     # find how many orgs we have waiting assignment or being initialized
@@ -60,6 +100,7 @@ def build_up_org_buffer():
         status__in=[DemoOrgStatus.PENDING, DemoOrgStatus.INITIALIZING]
     ).count()
     num_to_populate = ORG_BUFFER_SIZE - num_orgs
+    logger.info("build_up_org_buffer.check", extra={"num_to_populate": num_to_populate})
 
     # synchronnously build up our org buffer if under sized
     if num_to_populate > 0:

--- a/tests/sentry/demo/test_tasks.py
+++ b/tests/sentry/demo/test_tasks.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.test import override_settings
 
-from sentry.demo.tasks import delete_users_orgs, build_up_org_buffer
+from sentry.demo.tasks import delete_users_orgs, build_up_org_buffer, delete_initializing_orgs
 from sentry.demo.models import DemoOrganization, DemoUser, DemoOrgStatus
 from sentry.models import Organization, User
 from sentry.testutils import TestCase
@@ -11,8 +11,10 @@ from sentry.utils.compat import mock
 
 # fix buffer size at 3
 ORG_BUFFER_SIZE = 3
+MAX_INITIALIZATION_TIME = 60
 DEMO_DATA_GEN_PARAMS = settings.DEMO_DATA_GEN_PARAMS.copy()
 DEMO_DATA_GEN_PARAMS["ORG_BUFFER_SIZE"] = ORG_BUFFER_SIZE
+DEMO_DATA_GEN_PARAMS["MAX_INITIALIZATION_TIME"] = MAX_INITIALIZATION_TIME
 
 
 @override_settings(DEMO_MODE=True, DEMO_DATA_GEN_PARAMS=DEMO_DATA_GEN_PARAMS)
@@ -131,3 +133,20 @@ class BuildUpOrgBufferTest(DemoTaskBaseClass):
             build_up_org_buffer()
 
         assert mock_create_demo_org.call_count == 0
+
+
+class DeleteInitializingOrgTest(DemoTaskBaseClass):
+    def test_basic(self):
+        before_cutoff = before_now(minutes=MAX_INITIALIZATION_TIME + 5)
+        after_cutoff = before_now(minutes=MAX_INITIALIZATION_TIME - 5)
+
+        org1 = self.create_demo_org(date_added=before_cutoff, status=DemoOrgStatus.INITIALIZING)
+        org2 = self.create_demo_org(date_added=after_cutoff, status=DemoOrgStatus.INITIALIZING)
+        org3 = self.create_demo_org(date_added=before_cutoff, status=DemoOrgStatus.ACTIVE)
+
+        with self.tasks():
+            delete_initializing_orgs()
+
+        assert not Organization.objects.filter(id=org1.id).exists()
+        assert Organization.objects.filter(id=org2.id).exists()
+        assert Organization.objects.filter(id=org3.id).exists()


### PR DESCRIPTION
This PR fixes the edge case where an organization starts to initialize but doesn't finish because the server stops. This can happen whenever we need to stop Docker for the Sentry demo/sandbox so it's something we have to handle. The logic is basically to delete organizations older than an hour if they are still in the initialization state. Since orgs should take far less than an hour to populate, this shouldn't impact orgs being initialized.