### PR TITLE
feat(discover): Add tooltip to display options

### DIFF
--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -11,6 +11,7 @@ import {EventQuery} from 'app/actionCreators/events';
 import {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {DEFAULT_PER_PAGE} from 'app/constants';
+import {t} from 'app/locale';
 import {GlobalSelection, NewQuery, SavedQuery, SelectValue, User} from 'app/types';
 import {decodeList, decodeScalar} from 'app/utils/queryString';
 import {TableColumn, TableColumnSort} from 'app/views/eventsV2/table/types';
@@ -1066,13 +1067,21 @@ class EventView {
 
       if (item.value === DisplayModes.TOP5 || item.value === DisplayModes.DAILYTOP5) {
         if (this.getAggregateFields().length === 0) {
-          return {...item, disabled: true};
+          return {
+            ...item,
+            disabled: true,
+            tooltip: t('At least one aggregate function is required to use this view.'),
+          };
         }
       }
 
       if (item.value === DisplayModes.DAILY || item.value === DisplayModes.DAILYTOP5) {
         if (this.getDays() < 1) {
-          return {...item, disabled: true};
+          return {
+            ...item,
+            disabled: true,
+            tooltip: t('Date range must be at least 1 day to use this view.'),
+          };
         }
       }
 

--- a/src/sentry/static/sentry/app/utils/discover/eventView.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/eventView.tsx
@@ -1070,7 +1070,7 @@ class EventView {
           return {
             ...item,
             disabled: true,
-            tooltip: t('At least one aggregate function is required to use this view.'),
+            tooltip: t('Add a function that groups events to use this view.'),
           };
         }
       }
@@ -1080,7 +1080,7 @@ class EventView {
           return {
             ...item,
             disabled: true,
-            tooltip: t('Date range must be at least 1 day to use this view.'),
+            tooltip: t('Change the date rage to at least 1 day to use this view.'),
           };
         }
       }


### PR DESCRIPTION
Discover display options can be disabled in some cases. This adds a tooltip for
when they are disabled to explain why.

# Screenshots

![Screen Shot 2021-03-30 at 5 38 24 PM](https://user-images.githubusercontent.com/10239353/113060509-bdbb2f00-917e-11eb-8298-018ccf0e0485.png)
![Screen Shot 2021-03-30 at 5 38 52 PM](https://user-images.githubusercontent.com/10239353/113060558-cf043b80-917e-11eb-9d39-510533eb87fc.png)
![Screen Shot 2021-03-30 at 5 39 12 PM](https://user-images.githubusercontent.com/10239353/113060582-d9bed080-917e-11eb-88df-ac40be4d523f.png)

