### PR TITLE
fix(transaction-label): update from total to event duration

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/eventMetas.tsx
@@ -67,9 +67,9 @@ function EventMetas({
       />
       {isTransaction(event) ? (
         <MetaData
-          headingText={t('Total Duration')}
+          headingText={t('Event Duration')}
           tooltipText={t(
-            'The total time elapsed between the start and end of this transaction.'
+            'The time elapsed between the start and end of this transaction.'
           )}
           bodyText={getDuration(event.endTimestamp - event.startTimestamp, 2, true)}
           subtext={timestamp}


### PR DESCRIPTION
- Saving the label 'Total Duration' for the trace view 

**Before:**
![Screen Shot 2021-03-30 at 3 08 58 PM](https://user-images.githubusercontent.com/4830259/113063284-ea188080-9169-11eb-860c-013f1dcbbc99.png)

**After:**
![Screen Shot 2021-03-30 at 3 08 24 PM](https://user-images.githubusercontent.com/4830259/113063292-edac0780-9169-11eb-9b30-cf5a9f06335b.png)