### PR TITLE
ref(kvstore): Remove `nodestore` associated default arguments

### DIFF
--- a/src/sentry/utils/kvstore/bigtable.py
+++ b/src/sentry/utils/kvstore/bigtable.py
@@ -74,9 +74,9 @@ class BigtableKVStorage(KVStorage[str, bytes]):
 
     def __init__(
         self,
+        instance: str,
+        table_name: str,
         project: Optional[str] = None,
-        instance: str = "sentry",
-        table_name: str = "nodestore",
         client_options: Optional[Mapping[Any, Any]] = None,
         default_ttl: Optional[timedelta] = None,
         compression: Optional[str] = None,

--- a/tests/sentry/utils/kvstore/test_bigtable.py
+++ b/tests/sentry/utils/kvstore/test_bigtable.py
@@ -28,6 +28,8 @@ def create_store(
 ) -> BigtableKVStorage:
     store = BigtableKVStorage(
         project="test",
+        instance="test",
+        table_name="test",
         compression=compression,
         client_options={"credentials": credentials},
     )


### PR DESCRIPTION
These values shouldn't be shared across different storage instances (i.e. you wouldn't use the same table for both nodestore and event processing store.) They are already [used as defaults in nodestore](https://github.com/getsentry/sentry/blob/cbce746e391bee59dbc610ca816d8a8ef1c03367/src/sentry/nodestore/bigtable/backend.py#L35-L36) so this ensures they are only set at the appropriate abstraction level.