### PR TITLE
feat(demo): add preconfigured alerts

### DIFF
--- a/src/sentry/demo/data_population.py
+++ b/src/sentry/demo/data_population.py
@@ -842,5 +842,5 @@ def handle_react_python_scenario(react_project: Project, python_project: Project
     generate_releases([react_project, python_project], quick=quick)
     generate_alerts(python_project)
     populate_connected_event_scenario_1(react_project, python_project, quick=quick)
-    # populate_connected_event_scenario_2(react_project, python_project, quick=quick)
-    # populate_connected_event_scenario_3(python_project, quick=quick)
+    populate_connected_event_scenario_2(react_project, python_project, quick=quick)
+    populate_connected_event_scenario_3(python_project, quick=quick)


### PR DESCRIPTION
This PR adds pre-generated metric alerts and issue alerts for demo organizations.

The only real question/concern is the best way to generate the alerts. I decided to not to use the API and instead use internal methods.