### PR TITLE
chore(trace-view): Remove the errors flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -864,8 +864,6 @@ SENTRY_FEATURES = {
     "organizations:performance-view": False,
     # Enable the quick trace view on event details
     "organizations:trace-view-quick": False,
-    # Enable the errors in the quick trace
-    "organizations:trace-view-errors": False,
     # Enable the trace view summary
     "organizations:trace-view-summary": False,
     # Enable multi project selection

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -121,7 +121,6 @@ default_manager.add("organizations:sso-saml2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:stacktrace-hover-preview", OrganizationFeature)  # NOQA
 default_manager.add("organizations:symbol-sources", OrganizationFeature)  # NOQA
 default_manager.add("organizations:team-alerts-ownership", OrganizationFeature)  # NOQA
-default_manager.add("organizations:trace-view-errors", OrganizationFeature)  # NOQA
 default_manager.add("organizations:trace-view-quick", OrganizationFeature)  # NOQA
 default_manager.add("organizations:trace-view-summary", OrganizationFeature)  # NOQA
 default_manager.add("organizations:transaction-comparison", OrganizationFeature)  # NOQA

--- a/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/eventDetails/content.tsx
@@ -272,9 +272,7 @@ class EventDetailsContent extends AsyncComponent<Props, State> {
     );
 
     const hasQuickTraceView =
-      (event.type === 'transaction' &&
-        organization.features.includes('trace-view-quick')) ||
-      organization.features.includes('trace-view-errors') ||
+      organization.features.includes('trace-view-quick') ||
       organization.features.includes('trace-view-summary');
 
     if (hasQuickTraceView) {

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -145,7 +145,7 @@ class GroupEventToolbar extends React.Component<Props> {
       Math.abs(+moment(evt.dateReceived) - +moment(evt.dateCreated)) > latencyThreshold;
     const hasQuickTraceView =
       (organization.features.includes('trace-view-summary') ||
-        organization.features.includes('trace-view-errors')) &&
+        organization.features.includes('trace-view-quick')) &&
       evt.contexts?.trace?.trace_id;
 
     return (

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -12,7 +12,6 @@ from sentry.testutils.helpers.datetime import before_now, iso_format
 class OrganizationEventsTraceEndpointBase(APITestCase, SnubaTestCase):
     FEATURES = [
         "organizations:trace-view-quick",
-        "organizations:trace-view-errors",
         "organizations:trace-view-summary",
         "organizations:global-views",
     ]


### PR DESCRIPTION
- errors is now equivalent with the trace-view-quick flag in SAAS,
  remove it and just use trace-view-quick instead.