### PR TITLE
ref(trace-view): Don't check global views

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -85,7 +85,8 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
             return Response(status=404)
 
         try:
-            params = self.get_snuba_params(request, organization)
+            # The trace view isn't useful without global views, so skipping the check here
+            params = self.get_snuba_params(request, organization, check_global_views=False)
         except NoProjects:
             return Response(status=404)
 

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -14,7 +14,6 @@ class OrganizationEventsTraceEndpointBase(APITestCase, SnubaTestCase):
         "organizations:trace-view-quick",
         "organizations:trace-view-errors",
         "organizations:trace-view-summary",
-        "organizations:global-views",
     ]
 
     def get_start_end(self, duration):


### PR DESCRIPTION
- We want team and free plans to be able to use the quick trace (for EA at least)