### PR TITLE
fix(ui): Fix preloading data for create org URL

### DIFF
--- a/src/sentry/templates/sentry/partial/preload-data.html
+++ b/src/sentry/templates/sentry/partial/preload-data.html
@@ -28,11 +28,16 @@
       return '/api/0/organizations/' + slug + suffix;
     }
 
-    var preloadPromises = { orgSlug: slug };
-    window.__sentry_preload = preloadPromises;
 
-    preloadPromises.organization = promiseRequest(makeUrl('/?detailed=0'));
-    preloadPromises.projects =  promiseRequest(makeUrl('/projects/?all_projects=1&collapse=latestDeploys'));
-    preloadPromises.teams = promiseRequest(makeUrl('/teams/'));
+    // There are probably more, but this is at least one case where
+    // this should not be treated as a slug
+    if (slug !== 'new') {
+      var preloadPromises = { orgSlug: slug };
+      window.__sentry_preload = preloadPromises;
+
+      preloadPromises.organization = promiseRequest(makeUrl('/?detailed=0'));
+      preloadPromises.projects =  promiseRequest(makeUrl('/projects/?all_projects=1&collapse=latestDeploys'));
+      preloadPromises.teams = promiseRequest(makeUrl('/teams/'));
+    }
   } catch(_) {}
 </script>


### PR DESCRIPTION
This fixes the preloading data for the creating a new organization view. (`/organizations/new/`).