### PR TITLE
ref(tests): Clean Organization Endpoint Tests

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1012,6 +1012,7 @@ urlpatterns = [
                 url(
                     r"^(?P<organization_slug>[^\/]+)/monitors/$",
                     OrganizationMonitorsEndpoint.as_view(),
+                    name="sentry-api-0-organization-monitors",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/pinned-searches/$",

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -393,7 +393,7 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
         """
         status_code = params.pop("status_code", None)
 
-        if status_code >= 400:
+        if status_code and status_code >= 400:
             raise Exception("status_code must be < 400")
 
         response = self.get_response(*args, **params)
@@ -417,7 +417,7 @@ class APITestCase(BaseTestCase, BaseAPITestCase):
         """
         status_code = params.pop("status_code", None)
 
-        if status_code < 400:
+        if status_code and status_code < 400:
             raise Exception("status_code must be >= 400 (an error status code)")
 
         response = self.get_response(*args, **params)
@@ -465,7 +465,7 @@ class TwoFactorAPITestCase(APITestCase):
             assert err_msg.encode("utf-8") in response.content
         organization = Organization.objects.get(id=organization.id)
 
-        if status_code >= 200 and status_code < 300:
+        if 200 <= status_code < 300:
             assert organization.flags.require_2fa
         else:
             assert not organization.flags.require_2fa

--- a/tests/sentry/api/endpoints/test_index.py
+++ b/tests/sentry/api/endpoints/test_index.py
@@ -6,19 +6,17 @@ from sentry.testutils import APITestCase
 
 
 class ApiIndexTest(APITestCase):
+    endpoint = "sentry-api-index"
+
     def test_anonymous(self):
-        url = reverse("sentry-api-index")
-        response = self.client.get(url)
-        assert response.status_code == 200
+        response = self.get_success_response()
         assert response.data["version"] == "0"
         assert not response.data["user"]
         assert not response.data["auth"]
 
     def test_session_auth(self):
         self.login_as(user=self.user)
-        url = reverse("sentry-api-index")
-        response = self.client.get(url)
-        assert response.status_code == 200
+        response = self.get_success_response()
         assert response.data["version"] == "0"
         assert response.data["user"]["id"] == str(self.user.id)
         assert not response.data["auth"]

--- a/tests/sentry/api/endpoints/test_onboarding.py
+++ b/tests/sentry/api/endpoints/test_onboarding.py
@@ -1,26 +1,21 @@
-from django.core.urlresolvers import reverse
-
 from sentry.models import OrganizationOnboardingTask, OnboardingTask, OnboardingTaskStatus
 from sentry.testutils import APITestCase
 
 
 class SkipOnboardingTaskTest(APITestCase):
+    endpoint = "sentry-api-0-organization-onboardingtasks"
+    method = "post"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
     def test_update_onboarding_task(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
-        url = reverse(
-            "sentry-api-0-organization-onboardingtasks",
-            kwargs={"organization_slug": organization.slug},
-        )
-
-        resp = self.client.post(
-            url, data={"task": "setup_issue_tracker", "status": "skipped"}, format="json"
-        )
-        assert resp.status_code == 204
+        data = {"task": "setup_issue_tracker", "status": "skipped"}
+        self.get_success_response(self.organization.slug, status_code=204, **data)
 
         oot = OrganizationOnboardingTask.objects.get(
-            organization=organization,
+            organization=self.organization,
             task=OnboardingTask.ISSUE_TRACKER,
             status=OnboardingTaskStatus.SKIPPED,
         )

--- a/tests/sentry/api/endpoints/test_organization_activity.py
+++ b/tests/sentry/api/endpoints/test_organization_activity.py
@@ -3,6 +3,12 @@ from sentry.testutils import APITestCase
 
 
 class OrganizationActivityTest(APITestCase):
+    endpoint = "sentry-api-0-organization-activity"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
     def test_simple(self):
         group = self.group
         org = group.organization
@@ -15,28 +21,23 @@ class OrganizationActivityTest(APITestCase):
             data={"text": "hello world"},
         )
 
-        self.login_as(user=self.user)
-
-        url = f"/api/0/organizations/{org.slug}/activity/"
-        response = self.client.get(url, format="json")
-        assert response.status_code == 200, response.content
+        response = self.get_success_response(org.slug)
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(activity.id)
 
     def test_inbox(self):
         group = self.group
         org = group.organization
+
         Activity.objects.create(
             group=group,
             project=group.project,
             type=Activity.MARK_REVIEWED,
             user=self.user,
         )
-        self.login_as(user=self.user)
-        url = f"/api/0/organizations/{org.slug}/activity/"
-        response = self.client.get(url, format="json")
+        response = self.get_success_response(org.slug)
         assert len(response.data) == 0
 
         with self.feature("organizations:inbox"):
-            response = self.client.get(url, format="json")
+            response = self.get_success_response(org.slug)
             assert len(response.data) == 1

--- a/tests/sentry/api/endpoints/test_organization_api_key_details.py
+++ b/tests/sentry/api/endpoints/test_organization_api_key_details.py
@@ -17,8 +17,7 @@ class OrganizationApiKeyDetailsBase(APITestCase):
 
 class OrganizationApiKeyDetails(OrganizationApiKeyDetailsBase):
     def test_api_key_no_exist(self):
-        invalid_key = self.api_key.id + 10
-        self.get_error_response(self.organization.slug, invalid_key, status_code=404)
+        self.get_error_response(self.organization.slug, 123456, status_code=404)
 
     def test_get_api_details(self):
         response = self.get_success_response(self.organization.slug, self.api_key.id)

--- a/tests/sentry/api/endpoints/test_organization_api_key_details.py
+++ b/tests/sentry/api/endpoints/test_organization_api_key_details.py
@@ -1,70 +1,50 @@
-from django.core.urlresolvers import reverse
-
 from sentry.models import ApiKey
 from sentry.testutils import APITestCase
 
 DEFAULT_SCOPES = ["project:read", "event:read", "team:read", "org:read", "member:read"]
 
 
-class OrganizationApiKeyDetails(APITestCase):
+class OrganizationApiKeyDetailsBase(APITestCase):
+    endpoint = "sentry-api-0-organization-api-key-details"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+        self.api_key = ApiKey.objects.create(
+            organization=self.organization, scope_list=DEFAULT_SCOPES
+        )
+
+
+class OrganizationApiKeyDetails(OrganizationApiKeyDetailsBase):
     def test_api_key_no_exist(self):
-        self.login_as(user=self.user)
-        organization = self.create_organization(name="foo", owner=self.user)
-
-        path = reverse("sentry-api-0-organization-api-key-details", args=[organization.slug, 2])
-
-        resp = self.client.get(path)
-
-        assert resp.status_code == 404
+        invalid_key = self.api_key.id + 10
+        self.get_error_response(self.organization.slug, invalid_key, status_code=404)
 
     def test_get_api_details(self):
-        self.login_as(user=self.user)
-        organization = self.create_organization(name="foo", owner=self.user)
+        response = self.get_success_response(self.organization.slug, self.api_key.id)
+        assert response.data.get("id") == str(self.api_key.id)
 
-        api_key = ApiKey.objects.create(organization=organization, scope_list=DEFAULT_SCOPES)
 
-        path = reverse(
-            "sentry-api-0-organization-api-key-details", args=[organization.slug, api_key.id]
-        )
-
-        resp = self.client.get(path)
-
-        assert resp.status_code == 200
-        assert resp.data.get("id") == str(api_key.id)
+class OrganizationApiKeyDetailsPut(OrganizationApiKeyDetailsBase):
+    method = "put"
 
     def test_update_api_key_details(self):
-        self.login_as(user=self.user)
-        organization = self.create_organization(name="foo", owner=self.user)
+        data = {"label": "New Label", "allowed_origins": "sentry.io"}
+        self.get_success_response(self.organization.slug, self.api_key.id, **data)
 
-        api_key = ApiKey.objects.create(organization=organization, scope_list=DEFAULT_SCOPES)
-
-        path = reverse(
-            "sentry-api-0-organization-api-key-details", args=[organization.slug, api_key.id]
-        )
-
-        resp = self.client.put(path, data={"label": "New Label", "allowed_origins": "sentry.io"})
-
-        assert resp.status_code == 200
-
-        api_key = ApiKey.objects.get(id=api_key.id, organization_id=organization.id)
+        api_key = ApiKey.objects.get(id=self.api_key.id, organization_id=self.organization.id)
 
         assert api_key.label == "New Label"
         assert api_key.allowed_origins == "sentry.io"
 
+
+class OrganizationApiKeyDetailsDelete(OrganizationApiKeyDetailsBase):
+    method = "delete"
+
     def test_can_delete_api_key(self):
-        self.login_as(user=self.user)
-        organization = self.create_organization(name="foo", owner=self.user)
-
-        api_key = ApiKey.objects.create(organization=organization, scope_list=DEFAULT_SCOPES)
-
-        path = reverse(
-            "sentry-api-0-organization-api-key-details", args=[organization.slug, api_key.id]
-        )
-
-        resp = self.client.delete(path)
-
-        assert resp.status_code == 204
+        self.get_success_response(self.organization.slug, self.api_key.id)
 
         # check to make sure it's deleted
-        resp = self.client.get(path)
-        assert resp.status_code == 404
+        self.get_error_response(
+            self.organization.slug, self.api_key.id, method="get", status_code=404
+        )

--- a/tests/sentry/api/endpoints/test_organization_auditlogs.py
+++ b/tests/sentry/api/endpoints/test_organization_auditlogs.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from django.core.urlresolvers import reverse
 from django.utils import timezone
 
 from sentry.models import AuditLogEntry, AuditLogEntryEvent
@@ -7,10 +6,14 @@ from sentry.testutils import APITestCase
 
 
 class OrganizationAuditLogsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-audit-logs"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
     def test_simple(self):
         now = timezone.now()
-
-        self.login_as(user=self.user)
 
         org = self.create_organization(owner=self.user, name="baz")
         org2 = self.create_organization(owner=self.user, name="baz")
@@ -28,10 +31,7 @@ class OrganizationAuditLogsTest(APITestCase):
             organization=org2, event=AuditLogEntryEvent.ORG_EDIT, actor=self.user, datetime=now
         )
 
-        url = reverse("sentry-api-0-organization-audit-logs", args=[org.slug])
-        response = self.client.get(url, format="json")
-
-        assert response.status_code == 200, response.content
+        response = self.get_success_response(org.slug)
         assert len(response.data) == 2
         assert response.data[0]["id"] == str(entry2.id)
         assert response.data[1]["id"] == str(entry1.id)

--- a/tests/sentry/api/endpoints/test_organization_auth_providers.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_providers.py
@@ -20,15 +20,13 @@ class OrganizationAuthProvidersPermissionTest(PermissionTestCase):
 
 
 class OrganizationAuthProviders(APITestCase):
-    def test_get_list_of_auth_providers(self):
-        organization = self.create_organization(name="foo", owner=self.user)
+    endpoint = "sentry-api-0-organization-auth-providers"
 
-        path = reverse("sentry-api-0-organization-auth-providers", args=[organization.slug])
-
+    def setUp(self):
+        super().setUp()
         self.login_as(self.user)
 
+    def test_get_list_of_auth_providers(self):
         with self.feature("organizations:sso-basic"):
-            resp = self.client.get(path)
-
-        assert resp.status_code == 200
-        assert any(d["key"] == "dummy" for d in resp.data)
+            response = self.get_success_response(self.organization.slug)
+        assert any(d["key"] == "dummy" for d in response.data)

--- a/tests/sentry/api/endpoints/test_organization_config_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_config_integrations.py
@@ -1,20 +1,17 @@
-from django.core.urlresolvers import reverse
-
 from sentry.testutils import APITestCase
 from sentry.features import OrganizationFeature
 from sentry import features
 
 
 class OrganizationConfigIntegrationsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-config-integrations"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
     def test_simple(self):
-        self.login_as(user=self.user)
-
-        org = self.create_organization(owner=self.user, name="baz")
-
-        url = reverse("sentry-api-0-organization-config-integrations", args=[org.slug])
-        response = self.client.get(url)
-
-        assert response.status_code == 200, response.content
+        response = self.get_success_response(self.organization.slug)
         assert len(response.data["providers"]) > 0
         provider = [r for r in response.data["providers"] if r["key"] == "example"]
         assert len(provider) == 1
@@ -23,32 +20,21 @@ class OrganizationConfigIntegrationsTest(APITestCase):
         assert provider["setupDialog"]["url"]
 
     def test_provider_key(self):
-        self.login_as(user=self.user)
-        org = self.create_organization(owner=self.user, name="baz")
-        path = f"/api/0/organizations/{org.slug}/config/integrations/?provider_key=example_server"
-        response = self.client.get(path, format="json")
-
-        assert response.status_code == 200, response.content
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"provider_key": "example_server"}
+        )
         assert len(response.data["providers"]) == 1
         assert response.data["providers"][0]["name"] == "Example Server"
 
     def test_feature_flag_integration(self):
         features.add("organizations:integrations-feature_flag_integration", OrganizationFeature)
-        self.login_as(user=self.user)
 
-        org = self.create_organization(owner=self.user, name="baz")
-
-        url = reverse("sentry-api-0-organization-config-integrations", args=[org.slug])
-        response = self.client.get(url)
-
-        assert response.status_code == 200, response.content
+        response = self.get_success_response(self.organization.slug)
         provider = [r for r in response.data["providers"] if r["key"] == "feature_flag_integration"]
         assert len(provider) == 0
 
         with self.feature("organizations:integrations-feature_flag_integration"):
-            response = self.client.get(url)
-
-            assert response.status_code == 200, response.content
+            response = self.get_success_response(self.organization.slug)
             provider = [
                 r for r in response.data["providers"] if r["key"] == "feature_flag_integration"
             ]

--- a/tests/sentry/api/endpoints/test_organization_details.py
+++ b/tests/sentry/api/endpoints/test_organization_details.py
@@ -1,18 +1,13 @@
+import dateutil
 from datetime import datetime
 
-import dateutil
-from pytz import UTC
 from base64 import b64encode
-from exam import fixture
-from pprint import pprint
-
-from django.core.urlresolvers import reverse
 from django.core import mail
+from pprint import pprint
+from pytz import UTC
 
-from sentry.utils import json
-from sentry.utils.compat.mock import patch
-from sentry.auth.authenticators import TotpInterface
 from sentry.api.endpoints.organization_details import ERR_NO_2FA, ERR_SSO_ENABLED
+from sentry.auth.authenticators import TotpInterface
 from sentry.constants import APDEX_THRESHOLD_DEFAULT, RESERVED_ORGANIZATION_SLUGS
 from sentry.models import (
     AuditLogEntry,
@@ -27,6 +22,8 @@ from sentry.models import (
 )
 from sentry.signals import project_created
 from sentry.testutils import APITestCase, TwoFactorAPITestCase, pytest
+from sentry.utils import json
+from sentry.utils.compat.mock import patch
 
 # some relay keys
 _VALID_RELAY_KEYS = [
@@ -37,53 +34,65 @@ _VALID_RELAY_KEYS = [
 ]
 
 
-class OrganizationDetailsTest(APITestCase):
-    def test_simple(self):
-        user = self.create_user("owner@example.org")
-        org = self.create_organization(owner=user)
+def get_trusted_relay_value(organization):
+    return list(
+        OrganizationOption.objects.filter(
+            organization=organization,
+            key="sentry:trusted-relays",
+        )
+    )[0].value
 
-        self.login_as(user=user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.get(url, format="json")
+
+class OrganizationDetailsTestBase(APITestCase):
+    endpoint = "sentry-api-0-organization-details"
+
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+
+class OrganizationDetailsTest(OrganizationDetailsTestBase):
+    def test_simple(self):
+        response = self.get_success_response(self.organization.slug)
+
         assert response.data["onboardingTasks"] == []
-        assert response.status_code == 200, response.content
-        assert response.data["id"] == str(org.id)
+        assert response.data["id"] == str(self.organization.id)
         assert response.data["role"] == "owner"
         assert len(response.data["teams"]) == 0
         assert len(response.data["projects"]) == 0
 
     def test_with_projects(self):
-        user = self.create_user("owner@example.org")
-        org = self.create_organization(owner=user)
-        team = self.create_team(name="appy", organization=org, members=[user])
         # Create non-member team to test response shape
-        self.create_team(name="no-member", organization=org)
+        self.create_team(name="no-member", organization=self.organization)
 
         # Ensure deleted teams don't come back.
         self.create_team(
-            name="deleted", organization=org, members=[user], status=ObjectStatus.PENDING_DELETION
+            name="deleted",
+            organization=self.organization,
+            members=[self.user],
+            status=ObjectStatus.PENDING_DELETION,
         )
 
         # Some projects with membership and some without.
         for i in range(2):
-            self.create_project(organization=org, teams=[team])
+            self.create_project(organization=self.organization, teams=[self.team])
         for i in range(2):
-            self.create_project(organization=org)
+            self.create_project(organization=self.organization)
 
         # Should not show up.
         self.create_project(
-            slug="deleted", organization=org, teams=[team], status=ObjectStatus.PENDING_DELETION
+            slug="deleted",
+            organization=self.organization,
+            teams=[self.team],
+            status=ObjectStatus.PENDING_DELETION,
         )
-
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        self.login_as(user=user)
 
         # TODO(dcramer): we need to pare this down -- lots of duplicate queries
         # for membership data
         with self.assertNumQueries(36, using="default"):
             from django.db import connections
 
-            response = self.client.get(url, format="json")
+            response = self.get_success_response(self.organization.slug)
             pprint(connections["default"].queries)
 
         project_slugs = [p["slug"] for p in response.data["projects"]]
@@ -95,19 +104,13 @@ class OrganizationDetailsTest(APITestCase):
         assert "deleted" not in team_slugs
 
     def test_details_no_projects_or_teams(self):
-        user = self.create_user("owner@example.org")
-        org = self.create_organization(owner=user)
-        team = self.create_team(name="appy", organization=org, members=[user])
         # Create non-member team to test response shape
-        self.create_team(name="no-member", organization=org)
+        self.create_team(name="no-member", organization=self.organization)
 
         for i in range(2):
-            self.create_project(organization=org, teams=[team])
+            self.create_project(organization=self.organization, teams=[self.team])
 
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        self.login_as(user=user)
-
-        response = self.client.get(f"{url}?detailed=0", format="json")
+        response = self.get_success_response(self.organization.slug, qs_params={"detailed": 0})
 
         assert "projects" not in response.data
         assert "teams" not in response.data
@@ -121,41 +124,29 @@ class OrganizationDetailsTest(APITestCase):
         for i in range(5):
             self.create_project(organization=org, teams=[team])
 
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.get(url, format="json")
+        response = self.get_success_response(org.slug)
         assert len(response.data["projects"]) == 5
         assert len(response.data["teams"]) == 1
 
     def test_onboarding_tasks(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.get(url, format="json")
+        response = self.get_success_response(self.organization.slug)
         assert response.data["onboardingTasks"] == []
-        assert response.status_code == 200, response.content
-        assert response.data["id"] == str(org.id)
+        assert response.data["id"] == str(self.organization.id)
 
-        project = self.create_project(organization=org)
+        project = self.create_project(organization=self.organization)
         project_created.send(project=project, user=self.user, sender=type(project))
 
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.get(url, format="json")
+        response = self.get_success_response(self.organization.slug)
         assert len(response.data["onboardingTasks"]) == 1
         assert response.data["onboardingTasks"][0]["task"] == "create_project"
 
     def test_apdex_threshold_default(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.get(url, format="json")
+        response = self.get_success_response(self.organization.slug)
 
         assert response.data["apdexThreshold"] == APDEX_THRESHOLD_DEFAULT
 
     def test_trusted_relays_info(self):
-        org = self.create_organization(owner=self.user)
-        AuditLogEntry.objects.filter(organization=org).delete()
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
+        AuditLogEntry.objects.filter(organization=self.organization).delete()
 
         trusted_relays = [
             {
@@ -174,11 +165,9 @@ class OrganizationDetailsTest(APITestCase):
 
         with self.feature("organizations:relay"):
             start_time = datetime.utcnow().replace(tzinfo=UTC)
-            response = self.client.put(url, data=data)
+            self.get_success_response(self.organization.slug, method="put", **data)
             end_time = datetime.utcnow().replace(tzinfo=UTC)
-            assert response.status_code == 200
-            response = self.client.get(url)
-            assert response.status_code == 200
+            response = self.get_success_response(self.organization.slug)
 
         response_data = response.data.get("trustedRelays")
 
@@ -197,61 +186,39 @@ class OrganizationDetailsTest(APITestCase):
             assert start_time < created < end_time
 
 
-class OrganizationUpdateTest(APITestCase):
+class OrganizationUpdateTest(OrganizationDetailsTestBase):
+    method = "put"
+
     def test_simple(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(url, data={"name": "hello world", "slug": "foobar"})
-        assert response.status_code == 200, response.content
-        org = Organization.objects.get(id=org.id)
+        self.get_success_response(self.organization.slug, name="hello world", slug="foobar")
+
+        org = Organization.objects.get(id=self.organization.id)
         assert org.name == "hello world"
         assert org.slug == "foobar"
 
     def test_dupe_slug(self):
-        org = self.create_organization(owner=self.user)
-        org2 = self.create_organization(owner=self.user, slug="baz")
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(url, data={"slug": org2.slug})
-        assert response.status_code == 400, response.content
+        org = self.create_organization(owner=self.user, slug="duplicate")
+
+        self.get_error_response(self.organization.slug, slug=org.slug, status_code=400)
 
     def test_short_slug(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(url, data={"slug": "a"})
-        assert response.status_code == 400, response.content
+        self.get_error_response(self.organization.slug, slug="a", status_code=400)
 
     def test_reserved_slug(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(url, data={"slug": list(RESERVED_ORGANIZATION_SLUGS)[0]})
-        assert response.status_code == 400, response.content
+        illegal_slug = list(RESERVED_ORGANIZATION_SLUGS)[0]
+        self.get_error_response(self.organization.slug, slug=illegal_slug, status_code=400)
 
     def test_upload_avatar(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(
-            url,
-            data={"avatarType": "upload", "avatar": b64encode(self.load_fixture("avatar.jpg"))},
-            format="json",
-        )
+        data = {"avatarType": "upload", "avatar": b64encode(self.load_fixture("avatar.jpg"))}
+        self.get_success_response(self.organization.slug, **data)
 
-        avatar = OrganizationAvatar.objects.get(organization=org)
-        assert response.status_code == 200, response.content
+        avatar = OrganizationAvatar.objects.get(organization=self.organization)
         assert avatar.get_avatar_type_display() == "upload"
         assert avatar.file
 
     def test_various_options(self):
-        org = self.create_organization(owner=self.user)
-        initial = org.get_audit_log_data()
-        AuditLogEntry.objects.filter(organization=org).delete()
-
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
+        initial = self.organization.get_audit_log_data()
+        AuditLogEntry.objects.filter(organization=self.organization).delete()
 
         data = {
             "openMembership": False,
@@ -278,10 +245,9 @@ class OrganizationUpdateTest(APITestCase):
         interface.enroll(self.user)
         assert Authenticator.objects.user_has_2fa(self.user)
 
-        response = self.client.put(url, data=data)
-        assert response.status_code == 200, response.content
+        self.get_success_response(self.organization.slug, **data)
 
-        org = Organization.objects.get(id=org.id)
+        org = Organization.objects.get(id=self.organization.id)
         assert initial != org.get_audit_log_data()
 
         assert org.flags.early_adopter
@@ -328,10 +294,6 @@ class OrganizationUpdateTest(APITestCase):
         assert "to {}".format(data["apdexThreshold"]) in log.data["apdexThreshold"]
 
     def test_setting_trusted_relays_forbidden(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-
         data = {
             "trustedRelays": [
                 {"publicKey": _VALID_RELAY_KEYS[0], "name": "name1"},
@@ -340,9 +302,8 @@ class OrganizationUpdateTest(APITestCase):
         }
 
         with self.feature({"organizations:relay": False}):
-            response = self.client.put(url, data=data)
+            response = self.get_error_response(self.organization.slug, status_code=400, **data)
 
-        assert response.status_code == 400
         assert b"feature" in response.content
 
     def test_setting_duplicate_trusted_keys(self):
@@ -351,10 +312,7 @@ class OrganizationUpdateTest(APITestCase):
 
         Try to put the same key twice and check we get an error
         """
-        org = self.create_organization(owner=self.user)
-        AuditLogEntry.objects.filter(organization=org).delete()
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
+        AuditLogEntry.objects.filter(organization=self.organization).delete()
 
         trusted_relays = [
             {
@@ -377,9 +335,8 @@ class OrganizationUpdateTest(APITestCase):
         data = {"trustedRelays": trusted_relays}
 
         with self.feature("organizations:relay"):
-            response = self.client.put(url, data=data)
+            response = self.get_error_response(self.organization.slug, status_code=400, **data)
 
-        assert response.status_code == 400
         response_data = response.data.get("trustedRelays")
         assert response_data is not None
         resp_str = json.dumps(response_data)
@@ -387,10 +344,7 @@ class OrganizationUpdateTest(APITestCase):
         assert resp_str.find(_VALID_RELAY_KEYS[0]) >= 0
 
     def test_creating_trusted_relays(self):
-        org = self.create_organization(owner=self.user)
-        AuditLogEntry.objects.filter(organization=org).delete()
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
+        AuditLogEntry.objects.filter(organization=self.organization).delete()
 
         trusted_relays = [
             {
@@ -409,16 +363,11 @@ class OrganizationUpdateTest(APITestCase):
 
         with self.feature("organizations:relay"):
             start_time = datetime.utcnow().replace(tzinfo=UTC)
-            response = self.client.put(url, data=data)
+            response = self.get_success_response(self.organization.slug, **data)
             end_time = datetime.utcnow().replace(tzinfo=UTC)
-
-            assert response.status_code == 200
             response_data = response.data.get("trustedRelays")
 
-        (option,) = OrganizationOption.objects.filter(organization=org, key="sentry:trusted-relays")
-
-        actual = option.value
-
+        actual = get_trusted_relay_value(self.organization)
         assert len(actual) == len(trusted_relays)
         assert len(response_data) == len(trusted_relays)
 
@@ -438,7 +387,7 @@ class OrganizationUpdateTest(APITestCase):
             assert start_time < created < end_time
             assert response_data[i]["created"] == actual[i]["created"]
 
-        log = AuditLogEntry.objects.get(organization=org)
+        log = AuditLogEntry.objects.get(organization=self.organization)
         trusted_relay_log = log.data["trustedRelays"]
 
         assert trusted_relay_log is not None
@@ -449,10 +398,7 @@ class OrganizationUpdateTest(APITestCase):
         assert trusted_relays[1]["publicKey"] in trusted_relay_log
 
     def test_modifying_trusted_relays(self):
-        org = self.create_organization(owner=self.user)
-        AuditLogEntry.objects.filter(organization=org).delete()
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
+        AuditLogEntry.objects.filter(organization=self.organization).delete()
 
         initial_trusted_relays = [
             {
@@ -499,17 +445,12 @@ class OrganizationUpdateTest(APITestCase):
 
         with self.feature("organizations:relay"):
             start_time = datetime.utcnow().replace(tzinfo=UTC)
-            self.client.put(url, data=initial_settings)
+            self.get_success_response(self.organization.slug, **initial_settings)
             after_initial = datetime.utcnow().replace(tzinfo=UTC)
-            response = self.client.put(url, data=changed_settings)
+            self.get_success_response(self.organization.slug, **changed_settings)
             after_final = datetime.utcnow().replace(tzinfo=UTC)
 
-            assert response.status_code == 200
-
-        (option,) = OrganizationOption.objects.filter(organization=org, key="sentry:trusted-relays")
-
-        actual = option.value
-
+        actual = get_trusted_relay_value(self.organization)
         assert len(actual) == len(modified_trusted_relays)
 
         for i in range(len(actual)):
@@ -535,7 +476,7 @@ class OrganizationUpdateTest(APITestCase):
                 assert after_initial < last_modified < after_final
 
         # we should have 2 log messages from the two calls
-        (first_log, second_log) = AuditLogEntry.objects.filter(organization=org)
+        (first_log, second_log) = AuditLogEntry.objects.filter(organization=self.organization)
         log_str_1 = first_log.data["trustedRelays"]
         log_str_2 = second_log.data["trustedRelays"]
 
@@ -553,10 +494,7 @@ class OrganizationUpdateTest(APITestCase):
             assert modified_trusted_relays[i]["publicKey"] in modif_log
 
     def test_deleting_trusted_relays(self):
-        org = self.create_organization(owner=self.user)
-        AuditLogEntry.objects.filter(organization=org).delete()
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
+        AuditLogEntry.objects.filter(organization=self.organization).delete()
 
         initial_trusted_relays = [
             {
@@ -567,49 +505,47 @@ class OrganizationUpdateTest(APITestCase):
         ]
 
         initial_settings = {"trustedRelays": initial_trusted_relays}
+        changed_settings = {"trustedRelays": []}
 
         with self.feature("organizations:relay"):
-            self.client.put(url, data=initial_settings)
-            response = self.client.put(url, data={"trustedRelays": []})
+            self.get_success_response(self.organization.slug, **initial_settings)
+            response = self.get_success_response(self.organization.slug, **changed_settings)
 
-            assert response.status_code == 200
-            response_data = response.data.get("trustedRelays")
+        response_data = response.data.get("trustedRelays")
 
-        (option,) = OrganizationOption.objects.filter(organization=org, key="sentry:trusted-relays")
-        actual = option.value
-
+        actual = get_trusted_relay_value(self.organization)
         assert len(actual) == 0
         assert len(response_data) == 0
 
     def test_setting_legacy_rate_limits(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(url, data={"accountRateLimit": 1000})
-        assert response.status_code == 400, response.content
+        data = {"accountRateLimit": 1000}
+        self.get_error_response(self.organization.slug, status_code=400, **data)
 
-        response = self.client.put(url, data={"projectRateLimit": 1000})
-        assert response.status_code == 400, response.content
+        data = {"projectRateLimit": 1000}
+        self.get_error_response(self.organization.slug, status_code=400, **data)
 
-        OrganizationOption.objects.set_value(org, "sentry:project-rate-limit", 1)
+        OrganizationOption.objects.set_value(self.organization, "sentry:project-rate-limit", 1)
 
-        response = self.client.put(url, data={"projectRateLimit": 100})
-        assert response.status_code == 200, response.content
+        data = {"projectRateLimit": 100}
+        self.get_success_response(self.organization.slug, **data)
 
-        assert OrganizationOption.objects.get_value(org, "sentry:project-rate-limit") == 100
+        assert (
+            OrganizationOption.objects.get_value(self.organization, "sentry:project-rate-limit")
+            == 100
+        )
 
-        response = self.client.put(url, data={"accountRateLimit": 50})
-        assert response.status_code == 200, response.content
+        data = {"accountRateLimit": 50}
+        self.get_success_response(self.organization.slug, **data)
 
-        assert OrganizationOption.objects.get_value(org, "sentry:account-rate-limit") == 50
+        assert (
+            OrganizationOption.objects.get_value(self.organization, "sentry:account-rate-limit")
+            == 50
+        )
 
     def test_safe_fields_as_string_regression(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(url, data={"safeFields": "email"})
-        assert response.status_code == 400, (response.status_code, response.content)
-        org = Organization.objects.get(id=org.id)
+        data = {"safeFields": "email"}
+        self.get_error_response(self.organization.slug, status_code=400, **data)
+        org = Organization.objects.get(id=self.organization.id)
 
         options = {o.key: o.value for o in OrganizationOption.objects.filter(organization=org)}
 
@@ -620,46 +556,41 @@ class OrganizationUpdateTest(APITestCase):
         user = self.create_user("baz@example.com")
         self.create_member(organization=org, user=user, role="manager")
         self.login_as(user=user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(url, data={"defaultRole": "owner"})
-        assert response.status_code == 200, response.content
+
+        self.get_success_response(org.slug, **{"defaultRole": "owner"})
         org = Organization.objects.get(id=org.id)
 
         assert org.default_role == "member"
 
     def test_empty_string_in_array_safe_fields(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(url, data={"safeFields": [""]})
-        assert response.status_code == 400, (response.status_code, response.content)
-        org = Organization.objects.get(id=org.id)
+        self.get_error_response(self.organization.slug, status_code=400, **{"safeFields": [""]})
+        org = Organization.objects.get(id=self.organization.id)
 
         options = {o.key: o.value for o in OrganizationOption.objects.filter(organization=org)}
 
         assert not options.get("sentry:safe_fields")
 
     def test_empty_string_in_array_sensitive_fields(self):
-        org = self.create_organization(owner=self.user)
-        OrganizationOption.objects.set_value(org, "sentry:sensitive_fields", ["foobar"])
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(url, data={"sensitiveFields": [""]})
-        assert response.status_code == 400, (response.status_code, response.content)
-        org = Organization.objects.get(id=org.id)
+        OrganizationOption.objects.set_value(
+            self.organization, "sentry:sensitive_fields", ["foobar"]
+        )
+
+        self.get_error_response(
+            self.organization.slug, status_code=400, **{"sensitiveFields": [""]}
+        )
+        org = Organization.objects.get(id=self.organization.id)
 
         options = {o.key: o.value for o in OrganizationOption.objects.filter(organization=org)}
 
         assert options.get("sentry:sensitive_fields") == ["foobar"]
 
     def test_empty_sensitive_fields(self):
-        org = self.create_organization(owner=self.user)
-        OrganizationOption.objects.set_value(org, "sentry:sensitive_fields", ["foobar"])
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(url, data={"sensitiveFields": []})
-        assert response.status_code == 200, (response.status_code, response.content)
-        org = Organization.objects.get(id=org.id)
+        OrganizationOption.objects.set_value(
+            self.organization, "sentry:sensitive_fields", ["foobar"]
+        )
+
+        self.get_success_response(self.organization.slug, **{"sensitiveFields": []})
+        org = Organization.objects.get(id=self.organization.id)
 
         options = {o.key: o.value for o in OrganizationOption.objects.filter(organization=org)}
 
@@ -667,60 +598,43 @@ class OrganizationUpdateTest(APITestCase):
 
     def test_cancel_delete(self):
         org = self.create_organization(owner=self.user, status=OrganizationStatus.PENDING_DELETION)
-        self.login_as(user=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.put(url, data={"cancelDeletion": True})
-        assert response.status_code == 200, (response.status_code, response.content)
+
+        self.get_success_response(org.slug, **{"cancelDeletion": True})
+
         org = Organization.objects.get(id=org.id)
         assert org.status == OrganizationStatus.VISIBLE
 
     def test_relay_pii_config(self):
-        org = self.create_organization(owner=self.user)
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        self.login_as(user=self.user)
-
         value = '{"applications": {"freeform": []}}'
-        resp = self.client.put(url, data={"relayPiiConfig": value})
-        assert resp.status_code == 200, resp.content
-        assert org.get_option("sentry:relay_pii_config") == value
-        assert resp.data["relayPiiConfig"] == value
+        response = self.get_success_response(self.organization.slug, **{"relayPiiConfig": value})
+
+        assert self.organization.get_option("sentry:relay_pii_config") == value
+        assert response.data["relayPiiConfig"] == value
 
 
-class OrganizationDeleteTest(APITestCase):
+class OrganizationDeleteTest(OrganizationDetailsTestBase):
+    method = "delete"
+
     @patch("sentry.api.endpoints.organization_details.uuid4")
     @patch("sentry.api.endpoints.organization_details.delete_organization")
     def test_can_remove_as_owner(self, mock_delete_organization, mock_uuid4):
         mock_uuid4.return_value = self.get_mock_uuid()
 
-        org = self.create_organization()
-
-        user = self.create_user(email="foo@example.com", is_superuser=False)
-
-        self.create_member(organization=org, user=user, role="owner")
-
-        self.login_as(user)
-
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-
-        owners = org.get_owners()
+        owners = self.organization.get_owners()
         assert len(owners) > 0
 
         with self.tasks():
-            response = self.client.delete(url)
+            self.get_success_response(self.organization.slug, status_code=202)
 
-        org = Organization.objects.get(id=org.id)
-
-        assert response.status_code == 202, response.data
+        org = Organization.objects.get(id=self.organization.id)
 
         assert org.status == OrganizationStatus.PENDING_DELETION
 
         deleted_org = DeletedOrganization.objects.get(slug=org.slug)
         self.assert_valid_deleted_log(deleted_org, org)
 
-        mock_delete_organization.apply_async.assert_called_once_with(
-            kwargs={"object_id": org.id, "transaction_id": "abc123", "actor_id": user.id},
-            countdown=86400,
-        )
+        data = {"object_id": org.id, "transaction_id": "abc123", "actor_id": self.user.id}
+        mock_delete_organization.apply_async.assert_called_once_with(kwargs=data, countdown=86400)
 
         # Make sure we've emailed all owners
         assert len(mail.outbox) == len(owners)
@@ -734,34 +648,24 @@ class OrganizationDeleteTest(APITestCase):
 
     def test_cannot_remove_as_admin(self):
         org = self.create_organization(owner=self.user)
-
         user = self.create_user(email="foo@example.com", is_superuser=False)
-
         self.create_member(organization=org, user=user, role="admin")
 
-        self.login_as(user=user)
+        self.login_as(user)
 
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-        response = self.client.delete(url)
-
-        assert response.status_code == 403
+        self.get_error_response(org.slug, status_code=403)
 
     def test_cannot_remove_default(self):
         Organization.objects.all().delete()
-
         org = self.create_organization(owner=self.user)
 
-        self.login_as(self.user)
-
-        url = reverse("sentry-api-0-organization-details", kwargs={"organization_slug": org.slug})
-
         with self.settings(SENTRY_SINGLE_ORGANIZATION=True):
-            response = self.client.delete(url)
-
-        assert response.status_code == 400, response.data
+            self.get_error_response(org.slug, status_code=400)
 
 
 class OrganizationSettings2FATest(TwoFactorAPITestCase):
+    endpoint = "sentry-api-0-organization-details"
+
     def setUp(self):
         # 2FA enforced org
         self.org_2fa = self.create_organization(owner=self.create_user())
@@ -783,23 +687,15 @@ class OrganizationSettings2FATest(TwoFactorAPITestCase):
         self.create_member(organization=self.organization, user=self.has_2fa, role="manager")
         assert Authenticator.objects.user_has_2fa(self.has_2fa)
 
-    @fixture
-    def path(self):
-        return reverse(
-            "sentry-api-0-organization-details", kwargs={"organization_slug": self.org_2fa.slug}
-        )
-
     def assert_2fa_email_equal(self, outbox, expected):
         assert len(outbox) == len(expected)
         assert sorted([email.to[0] for email in outbox]) == sorted(expected)
 
-    def assert_can_access_org_details(self, url):
-        response = self.client.get(url)
-        assert response.status_code == 200
+    def assert_can_access_org_details(self):
+        self.get_success_response(self.org_2fa.slug)
 
-    def assert_cannot_access_org_details(self, url):
-        response = self.client.get(url)
-        assert response.status_code == 401
+    def assert_cannot_access_org_details(self):
+        self.get_error_response(self.org_2fa.slug, status_code=401)
 
     def test_cannot_enforce_2fa_without_2fa_enabled(self):
         assert not Authenticator.objects.user_has_2fa(self.owner)
@@ -866,33 +762,33 @@ class OrganizationSettings2FATest(TwoFactorAPITestCase):
 
     def test_preexisting_members_must_enable_2fa(self):
         self.login_as(self.no_2fa_user)
-        self.assert_cannot_access_org_details(self.path)
+        self.assert_cannot_access_org_details()
 
         TotpInterface().enroll(self.no_2fa_user)
-        self.assert_can_access_org_details(self.path)
+        self.assert_can_access_org_details()
 
     def test_new_member_must_enable_2fa(self):
         new_user = self.create_user()
         self.create_member(organization=self.org_2fa, user=new_user, role="member")
         self.login_as(new_user)
-        self.assert_cannot_access_org_details(self.path)
+        self.assert_cannot_access_org_details()
 
         TotpInterface().enroll(new_user)
-        self.assert_can_access_org_details(self.path)
+        self.assert_can_access_org_details()
 
     def test_member_disable_all_2fa_blocked(self):
         TotpInterface().enroll(self.no_2fa_user)
         self.login_as(self.no_2fa_user)
 
-        self.assert_can_access_org_details(self.path)
+        self.assert_can_access_org_details()
 
         Authenticator.objects.get(user=self.no_2fa_user).delete()
-        self.assert_cannot_access_org_details(self.path)
+        self.assert_cannot_access_org_details()
 
     def test_superuser_can_access_org_details(self):
         user = self.create_user(is_superuser=True)
         self.login_as(user, superuser=True)
-        self.assert_can_access_org_details(self.path)
+        self.assert_can_access_org_details()
 
 
 from sentry.api.endpoints.organization_details import TrustedRelaySerializer

--- a/tests/sentry/api/endpoints/test_organization_index.py
+++ b/tests/sentry/api/endpoints/test_organization_index.py
@@ -1,6 +1,3 @@
-from django.core.urlresolvers import reverse
-from exam import fixture
-
 from sentry.auth.authenticators import TotpInterface
 from sentry.models import (
     Authenticator,
@@ -11,46 +8,46 @@ from sentry.models import (
 from sentry.testutils import APITestCase, TwoFactorAPITestCase
 
 
-class OrganizationsListTest(APITestCase):
-    path = "/api/0/organizations/"
+class OrganizationIndexTest(APITestCase):
+    endpoint = "sentry-api-0-organizations"
 
+    def setUp(self):
+        super().setUp()
+        self.login_as(self.user)
+
+
+class OrganizationsListTest(OrganizationIndexTest):
     def test_membership(self):
-        org = self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
-        response = self.client.get(f"{self.path}")
-        assert response.status_code == 200
+        org = self.organization  # force creation
+        response = self.get_success_response()
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(org.id)
 
     def test_show_all_with_superuser(self):
-        org = self.organization
-        self.login_as(user=self.create_user(is_superuser=True), superuser=True)
-        response = self.client.get(f"{self.path}?show=all")
-        assert response.status_code == 200
+        org = self.organization  # force creation
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+
+        response = self.get_success_response(qs_params={"show": "all"})
         assert len(response.data) == 2
         assert response.data[0]["id"] == str(org.id)
 
     def test_show_all_without_superuser(self):
-        self.create_organization(owner=self.user)
-        self.login_as(user=self.create_user(is_superuser=False))
-        response = self.client.get(f"{self.path}?show=all")
-        assert response.status_code == 200
+        response = self.get_success_response(qs_params={"show": "all"})
         assert len(response.data) == 0
 
     def test_ownership(self):
         org = self.create_organization(name="A", owner=self.user)
-        user2 = self.create_user(email="user2@example.com")
         org2 = self.create_organization(name="B", owner=self.user)
+
+        user2 = self.create_user(email="user2@example.com")
         org3 = self.create_organization(name="C", owner=user2)
         self.create_organization(name="D", owner=user2)
 
         self.create_member(user=user2, organization=org2, role="owner")
-
         self.create_member(user=self.user, organization=org3, role="owner")
 
-        self.login_as(user=self.user)
-        response = self.client.get(f"{self.path}?owner=1")
-        assert response.status_code == 200
+        response = self.get_success_response(qs_params={"owner": 1})
         assert len(response.data) == 3
         assert response.data[0]["organization"]["id"] == str(org.id)
         assert response.data[0]["singleOwner"] is True
@@ -61,85 +58,74 @@ class OrganizationsListTest(APITestCase):
 
     def test_status_query(self):
         org = self.create_organization(owner=self.user, status=OrganizationStatus.PENDING_DELETION)
-        self.login_as(user=self.user)
-        response = self.client.get(f"{self.path}?query=status:pending_deletion")
-        assert response.status_code == 200
+
+        response = self.get_success_response(qs_params={"query": "status:pending_deletion"})
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(org.id)
-        response = self.client.get(f"{self.path}?query=status:deletion_in_progress")
-        assert response.status_code == 200
+
+        response = self.get_success_response(qs_params={"query": "status:deletion_in_progress"})
         assert len(response.data) == 0
-        response = self.client.get(f"{self.path}?query=status:invalid_status")
-        assert response.status_code == 200
+
+        response = self.get_success_response(qs_params={"query": "status:invalid_status"})
         assert len(response.data) == 0
 
     def test_member_id_query(self):
-        org = self.create_organization(owner=self.user)
+        org = self.organization  # force creation
         self.create_organization(owner=self.user)
-        self.login_as(user=self.user)
 
-        response = self.client.get(f"{self.path}?member=1")
-        assert response.status_code == 200
+        response = self.get_success_response(qs_params={"member": 1})
         assert len(response.data) == 2
 
         om = OrganizationMember.objects.get(organization=org, user=self.user)
-        response = self.client.get(f"{self.path}?query=member_id:{om.id}")
-        assert response.status_code == 200
+        response = self.get_success_response(qs_params={"query": f"member_id:{om.id}"})
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(org.id)
 
-        response = self.client.get(f"{self.path}?query=member_id:{om.id + 10}")
-        assert response.status_code == 200
+        response = self.get_success_response(qs_params={"query": f"member_id:{om.id + 10}"})
         assert len(response.data) == 0
 
 
-class OrganizationsCreateTest(APITestCase):
-    path = "/api/0/organizations/"
+class OrganizationsCreateTest(OrganizationIndexTest):
+    method = "post"
 
     def test_missing_params(self):
-        self.login_as(user=self.user)
-        resp = self.client.post(self.path)
-        assert resp.status_code == 400
+        self.get_error_response(status_code=400)
 
     def test_valid_params(self):
-        self.login_as(user=self.user)
+        data = {"name": "hello world", "slug": "foobar"}
+        response = self.get_success_response(**data)
 
-        resp = self.client.post(self.path, data={"name": "hello world", "slug": "foobar"})
-        assert resp.status_code == 201, resp.content
-        org = Organization.objects.get(id=resp.data["id"])
+        organization_id = response.data["id"]
+        org = Organization.objects.get(id=organization_id)
         assert org.name == "hello world"
         assert org.slug == "foobar"
 
-        resp = self.client.post(self.path, data={"name": "hello world", "slug": "foobar"})
-        assert resp.status_code == 409, resp.content
+        self.get_error_response(status_code=409, **data)
 
     def test_without_slug(self):
-        self.login_as(user=self.user)
+        data = {"name": "hello world"}
+        response = self.get_success_response(**data)
 
-        resp = self.client.post(self.path, data={"name": "hello world"})
-        assert resp.status_code == 201, resp.content
-        org = Organization.objects.get(id=resp.data["id"])
+        organization_id = response.data["id"]
+        org = Organization.objects.get(id=organization_id)
         assert org.slug == "hello-world"
 
     def test_required_terms_with_terms_url(self):
-        self.login_as(user=self.user)
-
+        data = {"name": "hello world"}
         with self.settings(PRIVACY_URL=None, TERMS_URL="https://example.com/terms"):
-            resp = self.client.post(self.path, data={"name": "hello world"})
-            assert resp.status_code == 201, resp.content
+            self.get_success_response(**data)
 
         with self.settings(TERMS_URL=None, PRIVACY_URL="https://example.com/privacy"):
-            resp = self.client.post(self.path, data={"name": "hello world"})
-            assert resp.status_code == 201, resp.content
+            self.get_success_response(**data)
 
         with self.settings(
             TERMS_URL="https://example.com/terms", PRIVACY_URL="https://example.com/privacy"
         ):
-            resp = self.client.post(self.path, data={"name": "hello world", "agreeTerms": False})
-            assert resp.status_code == 400, resp.content
+            data = {"name": "hello world", "agreeTerms": False}
+            self.get_error_response(status_code=400, **data)
 
-            resp = self.client.post(self.path, data={"name": "hello world", "agreeTerms": True})
-            assert resp.status_code == 201, resp.content
+            data = {"name": "hello world", "agreeTerms": True}
+            self.get_success_response(**data)
 
 
 class OrganizationIndex2faTest(TwoFactorAPITestCase):
@@ -151,15 +137,8 @@ class OrganizationIndex2faTest(TwoFactorAPITestCase):
         self.no_2fa_user = self.create_user()
         self.create_member(organization=self.org_2fa, user=self.no_2fa_user, role="member")
 
-    @fixture
-    def path(self):
-        return reverse("sentry-organization-home", kwargs={"organization_slug": self.org_2fa.slug})
-
-    def assert_can_access_org_home(self):
-        self.get_valid_response(self.org_2fa.slug)
-
     def assert_redirected_to_2fa(self):
-        response = self.get_valid_response(self.org_2fa.slug, status_code=302)
+        response = self.get_success_response(self.org_2fa.slug, status_code=302)
         assert self.path_2fa in response.url
 
     def test_preexisting_members_must_enable_2fa(self):
@@ -167,7 +146,7 @@ class OrganizationIndex2faTest(TwoFactorAPITestCase):
         self.assert_redirected_to_2fa()
 
         TotpInterface().enroll(self.no_2fa_user)
-        self.assert_can_access_org_home()
+        self.get_success_response(self.org_2fa.slug)
 
     def test_new_member_must_enable_2fa(self):
         new_user = self.create_user()
@@ -177,12 +156,12 @@ class OrganizationIndex2faTest(TwoFactorAPITestCase):
         self.assert_redirected_to_2fa()
 
         TotpInterface().enroll(new_user)
-        self.assert_can_access_org_home()
+        self.get_success_response(self.org_2fa.slug)
 
     def test_member_disable_all_2fa_blocked(self):
         TotpInterface().enroll(self.no_2fa_user)
         self.login_as(self.no_2fa_user)
-        self.assert_can_access_org_home()
+        self.get_success_response(self.org_2fa.slug)
 
         Authenticator.objects.get(user=self.no_2fa_user).delete()
         self.assert_redirected_to_2fa()
@@ -190,4 +169,4 @@ class OrganizationIndex2faTest(TwoFactorAPITestCase):
     def test_superuser_can_access_org_home(self):
         user = self.create_user(is_superuser=True)
         self.login_as(user, superuser=True)
-        self.assert_can_access_org_home()
+        self.get_success_response(self.org_2fa.slug)

--- a/tests/sentry/api/endpoints/test_organization_join_request.py
+++ b/tests/sentry/api/endpoints/test_organization_join_request.py
@@ -2,7 +2,12 @@ from exam import fixture
 from sentry.utils.compat.mock import patch
 from django.core import mail
 
-from sentry.models import AuthProvider, InviteStatus, OrganizationOption, OrganizationMember
+from sentry.models import (
+    AuthProvider,
+    InviteStatus,
+    OrganizationOption,
+    OrganizationMember,
+)
 from sentry.testutils import APITestCase
 
 
@@ -13,59 +18,55 @@ class OrganizationJoinRequestTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.email = "test@example.com"
-        self.org = self.create_organization(owner=self.user)
 
     @fixture
     def owner(self):
-        return OrganizationMember.objects.get(user=self.user, organization=self.org)
+        return OrganizationMember.objects.get(user=self.user, organization=self.organization)
 
     def test_invalid_org_slug(self):
-        resp = self.get_response("invalid-slug", email=self.email)
-        assert resp.status_code == 404
+        self.get_error_response("invalid-slug", email=self.email, status_code=404)
 
     def test_email_required(self):
-        resp = self.get_response(self.org.slug)
-        assert resp.status_code == 400
-        assert resp.data["email"][0] == "This field is required."
+        response = self.get_error_response(self.organization.slug, status_code=400)
+        assert response.data["email"][0] == "This field is required."
 
     def test_invalid_email(self):
-        resp = self.get_response(self.org.slug, email="invalid-email")
-        assert resp.status_code == 400
-        assert resp.data["email"][0] == "Enter a valid email address."
+        response = self.get_error_response(
+            self.organization.slug, email="invalid-email", status_code=400
+        )
+        assert response.data["email"][0] == "Enter a valid email address."
 
     def test_organization_setting_disabled(self):
         OrganizationOption.objects.create(
-            organization_id=self.org.id, key="sentry:join_requests", value=False
+            organization_id=self.organization.id, key="sentry:join_requests", value=False
         )
 
-        resp = self.get_response(self.org.slug)
-        assert resp.status_code == 403
+        self.get_error_response(self.organization.slug, status_code=403)
 
     @patch(
         "sentry.api.endpoints.organization_join_request.ratelimiter.is_limited", return_value=True
     )
     def test_ratelimit(self, is_limited):
-        resp = self.get_response(self.org.slug, email=self.email)
-        assert resp.status_code == 429
-        assert resp.data["detail"] == "Rate limit exceeded."
+        response = self.get_error_response(
+            self.organization.slug, email=self.email, status_code=429
+        )
+        assert response.data["detail"] == "Rate limit exceeded."
 
     @patch("sentry.api.endpoints.organization_join_request.logger")
     def test_org_sso_enabled(self, mock_log):
-        AuthProvider.objects.create(organization=self.org, provider="google")
+        AuthProvider.objects.create(organization=self.organization, provider="google")
 
-        resp = self.get_response(self.org.slug, email=self.email)
-        assert resp.status_code == 403
+        self.get_error_response(self.organization.slug, email=self.email, status_code=403)
 
-        member = OrganizationMember.objects.get(organization=self.org)
+        member = OrganizationMember.objects.get(organization=self.organization)
         assert member == self.owner
         assert not mock_log.info.called
 
     @patch("sentry.api.endpoints.organization_join_request.logger")
     def test_user_already_exists(self, mock_log):
-        resp = self.get_response(self.org.slug, email=self.user.email)
-        assert resp.status_code == 204
+        self.get_success_response(self.organization.slug, email=self.user.email, status_code=204)
 
-        member = OrganizationMember.objects.get(organization=self.org)
+        member = OrganizationMember.objects.get(organization=self.organization)
         assert member == self.owner
         assert not mock_log.info.called
 
@@ -73,13 +74,12 @@ class OrganizationJoinRequestTest(APITestCase):
     def test_pending_member_already_exists(self, mock_log):
         pending_email = "pending@example.com"
         original_pending = self.create_member(
-            email=pending_email, organization=self.org, role="admin"
+            email=pending_email, organization=self.organization, role="admin"
         )
 
-        resp = self.get_response(self.org.slug, email=pending_email)
-        assert resp.status_code == 204
+        self.get_success_response(self.organization.slug, email=pending_email, status_code=204)
 
-        members = OrganizationMember.objects.filter(organization=self.org)
+        members = OrganizationMember.objects.filter(organization=self.organization)
         assert members.count() == 2
         pending = members.get(email=pending_email)
         assert pending == original_pending
@@ -91,15 +91,14 @@ class OrganizationJoinRequestTest(APITestCase):
         join_request_email = "join-request@example.com"
         original_join_request = self.create_member(
             email=join_request_email,
-            organization=self.org,
+            organization=self.organization,
             role="member",
             invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
         )
 
-        resp = self.get_response(self.org.slug, email=join_request_email)
-        assert resp.status_code == 204
+        self.get_success_response(self.organization.slug, email=join_request_email, status_code=204)
 
-        members = OrganizationMember.objects.filter(organization=self.org)
+        members = OrganizationMember.objects.filter(organization=self.organization)
         assert members.count() == 2
         join_request = members.get(email=join_request_email)
         assert join_request == original_join_request
@@ -110,11 +109,9 @@ class OrganizationJoinRequestTest(APITestCase):
     @patch("sentry.analytics.record")
     def test_request_to_join(self, mock_record):
         with self.tasks():
-            resp = self.get_response(self.org.slug, email=self.email)
+            self.get_success_response(self.organization.slug, email=self.email, status_code=204)
 
-        assert resp.status_code == 204
-
-        members = OrganizationMember.objects.filter(organization=self.org)
+        members = OrganizationMember.objects.filter(organization=self.organization)
         assert members.count() == 2
         join_request = members.get(email=self.email)
         assert join_request.user is None
@@ -122,7 +119,7 @@ class OrganizationJoinRequestTest(APITestCase):
         assert not join_request.invite_approved
 
         mock_record.assert_called_with(
-            "join_request.created", member_id=join_request.id, organization_id=self.org.id
+            "join_request.created", member_id=join_request.id, organization_id=self.organization.id
         )
 
         assert len(mail.outbox) == 1

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -19,41 +19,105 @@ from sentry.testutils import APITestCase
 from sentry.utils.compat import map
 
 
-class UpdateOrganizationMemberTest(APITestCase):
-    def test_invalid_id(self):
-        self.login_as(user=self.user)
+class OrganizationMemberTestBase(APITestCase):
+    endpoint = "sentry-api-0-organization-member-details"
 
-        organization = self.create_organization(name="foo", owner=self.user)
-        member = self.create_user("bar@example.com")
-        self.create_member(organization=organization, user=member, role="member")
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, "trash"]
-        )
+    def setUp(self):
+        super().setUp()
         self.login_as(self.user)
 
-        resp = self.client.put(path, data={"reinvite": 1})
 
-        assert resp.status_code == 404
+class GetOrganizationMemberTest(OrganizationMemberTestBase):
+    def test_me(self):
+        response = self.get_success_response(self.organization.slug, "me")
+
+        assert response.data["role"] == "owner"
+        assert response.data["user"]["id"] == str(self.user.id)
+        assert response.data["email"] == self.user.email
+
+    def test_get_by_id(self):
+        user = self.create_user("dummy@example.com")
+        member = OrganizationMember.objects.create(
+            organization=self.organization, user=user, role="member"
+        )
+        self.login_as(user)
+
+        response = self.get_success_response(self.organization.slug, member.id)
+        assert response.data["role"] == "member"
+        assert response.data["id"] == str(member.id)
+
+    def test_get_by_garbage(self):
+        self.get_error_response(self.organization.slug, "trash", status_code=404)
+
+    def test_cannot_get_unapproved_invite(self):
+        join_request = self.create_member(
+            organization=self.organization,
+            email="test@gmail.com",
+            invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
+        )
+
+        invite_request = self.create_member(
+            organization=self.organization,
+            email="test2@gmail.com",
+            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+        )
+
+        self.get_error_response(self.organization.slug, join_request.id, status_code=404)
+        self.get_error_response(self.organization.slug, invite_request.id, status_code=404)
+
+    def test_admin_can_get_invite_link(self):
+        pending_om = self.create_member(
+            user=None,
+            email="bar@example.com",
+            organization=self.organization,
+            role="member",
+            teams=[],
+        )
+
+        response = self.get_success_response(self.organization.slug, pending_om.id)
+        assert response.data["invite_link"] == pending_om.get_invite_link()
+
+    def test_member_cannot_get_invite_link(self):
+        pending_om = self.create_member(
+            user=None,
+            email="bar@example.com",
+            organization=self.organization,
+            role="member",
+            teams=[],
+        )
+
+        member = self.create_user("baz@example.com")
+        self.create_member(organization=self.organization, user=member, role="member")
+        self.login_as(member)
+
+        response = self.get_success_response(self.organization.slug, pending_om.id)
+        assert "invite_link" not in response.data
+
+    def test_get_member_list_teams(self):
+        team = self.create_team(organization=self.organization, name="Team")
+
+        member = self.create_user("baz@example.com")
+        member_om = self.create_member(
+            organization=self.organization, user=member, role="member", teams=[team]
+        )
+
+        response = self.get_success_response(self.organization.slug, member_om.id)
+        assert team.slug in response.data["teams"]
+
+
+class UpdateOrganizationMemberTest(OrganizationMemberTestBase):
+    method = "put"
+
+    def test_invalid_id(self):
+        self.get_error_response(self.organization.slug, "trash", reinvite=1, status_code=404)
 
     @patch("sentry.models.OrganizationMember.send_invite_email")
     def test_reinvite_pending_member(self, mock_send_invite_email):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
         member_om = self.create_member(
-            organization=organization, email="foo@example.com", role="member"
+            organization=self.organization, email="foo@example.com", role="member"
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
-        )
-
-        self.login_as(self.user)
-
-        resp = self.client.put(path, data={"reinvite": 1})
-
-        assert resp.status_code == 200
+        self.get_success_response(self.organization.slug, member_om.id, reinvite=1)
         mock_send_invite_email.assert_called_once_with()
 
     @patch("sentry.utils.ratelimits.for_organization_member_invite")
@@ -61,90 +125,57 @@ class UpdateOrganizationMemberTest(APITestCase):
     def test_rate_limited(self, mock_send_invite_email, mock_rate_limit):
         mock_rate_limit.return_value = True
 
-        organization = self.create_organization(name="foo", owner=self.user)
         member_om = self.create_member(
-            organization=organization, email="foo@example.com", role="member"
+            organization=self.organization, email="foo@example.com", role="member"
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
-        )
+        self.get_error_response(self.organization.slug, member_om.id, reinvite=1, status_code=429)
 
-        self.login_as(self.user)
-
-        resp = self.client.put(path, data={"reinvite": 1})
-        assert resp.status_code == 429
         assert not mock_send_invite_email.mock_calls
 
     @patch("sentry.models.OrganizationMember.send_invite_email")
     def test_member_cannot_regenerate_pending_invite(self, mock_send_invite_email):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
         member_om = self.create_member(
-            organization=organization, email="foo@example.com", role="member"
+            organization=self.organization, email="foo@example.com", role="member"
         )
         old_invite = member_om.get_invite_link()
 
         member = self.create_user("baz@example.com")
-        self.create_member(organization=organization, user=member, role="member")
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
-        )
-
+        self.create_member(organization=self.organization, user=member, role="member")
         self.login_as(member)
 
-        resp = self.client.put(path, data={"reinvite": 1, "regenerate": 1})
-
-        assert resp.status_code == 403
+        self.get_error_response(
+            self.organization.slug, member_om.id, reinvite=1, regenerate=1, status_code=403
+        )
         member_om = OrganizationMember.objects.get(id=member_om.id)
         assert old_invite == member_om.get_invite_link()
         assert not mock_send_invite_email.mock_calls
 
     @patch("sentry.models.OrganizationMember.send_invite_email")
     def test_admin_can_regenerate_pending_invite(self, mock_send_invite_email):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
         member_om = self.create_member(
-            organization=organization, email="foo@example.com", role="member"
+            organization=self.organization, email="foo@example.com", role="member"
         )
         old_invite = member_om.get_invite_link()
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
+        response = self.get_success_response(
+            self.organization.slug, member_om.id, reinvite=1, regenerate=1
         )
-
-        self.login_as(self.user)
-
-        resp = self.client.put(path, data={"reinvite": 1, "regenerate": 1})
-
-        assert resp.status_code == 200
         member_om = OrganizationMember.objects.get(id=member_om.id)
         assert old_invite != member_om.get_invite_link()
         mock_send_invite_email.assert_called_once_with()
-        assert resp.data["invite_link"] == member_om.get_invite_link()
+        assert response.data["invite_link"] == member_om.get_invite_link()
 
     @patch("sentry.models.OrganizationMember.send_invite_email")
     def test_reinvite_invite_expired_member(self, mock_send_invite_email):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
         member = self.create_member(
-            organization=organization,
+            organization=self.organization,
             email="foo@example.com",
             role="member",
             token_expires_at="2018-10-20 00:00:00",
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member.id]
-        )
-        self.login_as(self.user)
-        resp = self.client.put(path, data={"reinvite": 1})
-
-        assert resp.status_code == 400
+        self.get_error_response(self.organization.slug, member.id, reinvite=1, status_code=400)
         assert mock_send_invite_email.called is False
 
         member = OrganizationMember.objects.get(pk=member.id)
@@ -152,23 +183,15 @@ class UpdateOrganizationMemberTest(APITestCase):
 
     @patch("sentry.models.OrganizationMember.send_invite_email")
     def test_regenerate_invite_expired_member(self, mock_send_invite_email):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
         member = self.create_member(
-            organization=organization,
+            organization=self.organization,
             email="foo@example.com",
             role="member",
             token_expires_at="2018-10-20 00:00:00",
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member.id]
-        )
-        self.login_as(self.user)
-        resp = self.client.put(path, data={"reinvite": 1, "regenerate": 1})
+        self.get_success_response(self.organization.slug, member.id, reinvite=1, regenerate=1)
 
-        assert resp.status_code == 200
         mock_send_invite_email.assert_called_once_with()
 
         member = OrganizationMember.objects.get(pk=member.id)
@@ -176,187 +199,68 @@ class UpdateOrganizationMemberTest(APITestCase):
 
     @patch("sentry.models.OrganizationMember.send_invite_email")
     def test_cannot_reinvite_unapproved_invite(self, mock_send_invite_email):
-        self.login_as(self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
         member = self.create_member(
-            organization=organization,
+            organization=self.organization,
             email="foo@example.com",
             role="member",
             invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member.id]
-        )
-
-        resp = self.client.put(path, data={"reinvite": 1})
-        assert resp.status_code == 404
+        self.get_error_response(self.organization.slug, member.id, reinvite=1, status_code=404)
 
     @patch("sentry.models.OrganizationMember.send_invite_email")
     def test_cannot_regenerate_unapproved_invite(self, mock_send_invite_email):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
         member = self.create_member(
-            organization=organization,
+            organization=self.organization,
             email="foo@example.com",
             role="member",
             invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member.id]
+        self.get_error_response(
+            self.organization.slug, member.id, reinvite=1, regenerate=1, status_code=404
         )
-
-        resp = self.client.put(path, data={"reinvite": 1, "regenerate": 1})
-        assert resp.status_code == 404
 
     def test_reinvite_sso_link(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
         member = self.create_user("bar@example.com")
-        member_om = self.create_member(organization=organization, user=member, role="member")
-        AuthProvider.objects.create(organization=organization, provider="dummy", flags=1)
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
-        )
-
-        self.login_as(self.user)
+        member_om = self.create_member(organization=self.organization, user=member, role="member")
+        AuthProvider.objects.create(organization=self.organization, provider="dummy", flags=1)
 
         with self.tasks():
-            resp = self.client.put(path, data={"reinvite": 1})
+            self.get_success_response(self.organization.slug, member_om.id, reinvite=1)
 
-        assert resp.status_code == 200
         assert len(mail.outbox) == 1
 
-    def test_admin_can_get_invite_link(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
-
-        pending_om = self.create_member(
-            user=None, email="bar@example.com", organization=organization, role="member", teams=[]
-        )
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, pending_om.id]
-        )
-
-        self.login_as(self.user)
-
-        resp = self.client.get(path)
-
-        assert resp.status_code == 200
-        assert resp.data["invite_link"] == pending_om.get_invite_link()
-
-    def test_member_cannot_get_invite_link(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
-
-        pending_om = self.create_member(
-            user=None, email="bar@example.com", organization=organization, role="member", teams=[]
-        )
-
-        member = self.create_user("baz@example.com")
-        self.create_member(organization=organization, user=member, role="member")
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, pending_om.id]
-        )
-
-        self.login_as(member)
-
-        resp = self.client.get(path)
-
-        assert resp.status_code == 200
-        assert "invite_link" not in resp.data
-
-    def test_get_member_list_teams(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
-        team = self.create_team(organization=organization, name="Team")
-
-        member = self.create_user("baz@example.com")
-        member_om = self.create_member(
-            organization=organization, user=member, role="member", teams=[team]
-        )
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
-        )
-
-        self.login_as(self.user)
-
-        resp = self.client.get(path)
-
-        assert resp.status_code == 200
-        assert team.slug in resp.data["teams"]
-
     def test_can_update_member_membership(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
-
         member = self.create_user("baz@example.com")
         member_om = self.create_member(
-            organization=organization, user=member, role="member", teams=[]
+            organization=self.organization, user=member, role="member", teams=[]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
-        )
-
-        self.login_as(self.user)
-
-        resp = self.client.put(path, data={"role": "admin"})
-        assert resp.status_code == 200
-
+        self.get_success_response(self.organization.slug, member_om.id, role="admin")
         member_om = OrganizationMember.objects.get(id=member_om.id)
         assert member_om.role == "admin"
 
-    def test_can_not_update_own_membership(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
-
-        member_om = OrganizationMember.objects.get(user_id=self.user.id)
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
+    def test_cannot_update_own_membership(self):
+        member_om = OrganizationMember.objects.get(
+            organization=self.organization, user_id=self.user.id
         )
 
-        self.login_as(self.user)
-
-        resp = self.client.put(path, data={"role": "admin"})
-        assert resp.status_code == 400
+        self.get_error_response(self.organization.slug, member_om.id, role="admin", status_code=400)
 
         member_om = OrganizationMember.objects.get(user_id=self.user.id)
         assert member_om.role == "owner"
 
     def test_can_update_teams(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
-        foo = self.create_team(organization=organization, name="Team Foo")
-        bar = self.create_team(organization=organization, name="Team Bar")
+        foo = self.create_team(organization=self.organization, name="Team Foo")
+        bar = self.create_team(organization=self.organization, name="Team Bar")
 
         member = self.create_user("baz@example.com")
         member_om = self.create_member(
-            organization=organization, user=member, role="member", teams=[]
+            organization=self.organization, user=member, role="member", teams=[]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
-        )
-
-        self.login_as(self.user)
-
-        resp = self.client.put(path, data={"teams": [foo.slug, bar.slug]})
-        assert resp.status_code == 200
+        self.get_success_response(self.organization.slug, member_om.id, teams=[foo.slug, bar.slug])
 
         member_teams = OrganizationMemberTeam.objects.filter(organizationmember=member_om)
         team_ids = map(lambda x: x.team_id, member_teams)
@@ -369,106 +273,150 @@ class UpdateOrganizationMemberTest(APITestCase):
         assert foo.slug in teams
         assert bar.slug in teams
 
-    def test_can_not_update_with_invalid_team(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
-
+    def test_cannot_update_with_invalid_team(self):
         member = self.create_user("baz@example.com")
         member_om = self.create_member(
-            organization=organization, user=member, role="member", teams=[]
+            organization=self.organization, user=member, role="member", teams=[]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
+        self.get_error_response(
+            self.organization.slug, member_om.id, teams=["invalid"], status_code=400
         )
-
-        self.login_as(self.user)
-
-        resp = self.client.put(path, data={"teams": ["invalid-team"]})
-        assert resp.status_code == 400
 
         member_om = OrganizationMember.objects.get(id=member_om.id)
         teams = map(lambda team: team.slug, member_om.teams.all())
         assert len(teams) == 0
 
     def test_can_update_role(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
         member = self.create_user("baz@example.com")
         member_om = self.create_member(
-            organization=organization, user=member, role="member", teams=[]
+            organization=self.organization, user=member, role="member", teams=[]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
-        )
+        self.get_success_response(self.organization.slug, member_om.id, role="admin")
 
-        self.login_as(self.user)
-
-        resp = self.client.put(path, data={"role": "admin"})
-        assert resp.status_code == 200
-
-        member_om = OrganizationMember.objects.get(organization=organization, user=member)
+        member_om = OrganizationMember.objects.get(organization=self.organization, user=member)
         assert member_om.role == "admin"
 
-    def test_can_not_update_with_invalid_role(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
+    def test_cannot_update_with_invalid_role(self):
         member = self.create_user("baz@example.com")
         member_om = self.create_member(
-            organization=organization, user=member, role="member", teams=[]
+            organization=self.organization, user=member, role="member", teams=[]
         )
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
+        self.get_error_response(
+            self.organization.slug, member_om.id, role="invalid", status_code=400
         )
 
-        self.login_as(self.user)
-
-        resp = self.client.put(path, data={"role": "invalid-role"})
-        assert resp.status_code == 400
-        member_om = OrganizationMember.objects.get(organization=organization, user=member)
+        member_om = OrganizationMember.objects.get(organization=self.organization, user=member)
         assert member_om.role == "member"
 
     @patch("sentry.models.OrganizationMember.send_sso_link_email")
     def test_cannot_reinvite_normal_member(self, mock_send_sso_link_email):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
         member = self.create_user("bar@example.com")
-        member_om = self.create_member(organization=organization, user=member, role="member")
+        member_om = self.create_member(organization=self.organization, user=member, role="member")
 
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
-        )
-
-        self.login_as(self.user)
-
-        resp = self.client.put(path, data={"reinvite": 1})
-
-        assert resp.status_code == 400
+        self.get_error_response(self.organization.slug, member_om.id, reinvite=1, status_code=400)
 
     def test_cannot_lower_superior_role(self):
-        organization = self.create_organization(name="foo", owner=self.user)
         owner = self.create_user("baz@example.com")
-        owner_om = self.create_member(organization=organization, user=owner, role="owner", teams=[])
-
-        manager = self.create_user("foo@example.com")
-        self.create_member(organization=organization, user=manager, role="manager", teams=[])
-        self.login_as(manager)
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, owner_om.id]
+        owner_om = self.create_member(
+            organization=self.organization, user=owner, role="owner", teams=[]
         )
 
-        resp = self.client.put(path, data={"role": "member"})
-        assert resp.status_code == 403
+        manager = self.create_user("foo@example.com")
+        self.create_member(organization=self.organization, user=manager, role="manager", teams=[])
+        self.login_as(manager)
 
-        owner_om = OrganizationMember.objects.get(organization=organization, user=owner)
+        self.get_error_response(self.organization.slug, owner_om.id, role="member", status_code=403)
+
+        owner_om = OrganizationMember.objects.get(organization=self.organization, user=owner)
         assert owner_om.role == "owner"
+
+
+class DeleteOrganizationMemberTest(OrganizationMemberTestBase):
+    method = "delete"
+
+    def test_simple(self):
+        member = self.create_user("bar@example.com")
+        member_om = self.create_member(organization=self.organization, user=member, role="member")
+
+        self.get_success_response(self.organization.slug, member_om.id)
+
+        assert not OrganizationMember.objects.filter(id=member_om.id).exists()
+
+    def test_invalid_id(self):
+        member = self.create_user("bar@example.com")
+        self.create_member(organization=self.organization, user=member, role="member")
+
+        self.get_error_response(self.organization.slug, "trash", status_code=404)
+
+    def test_cannot_delete_member_with_higher_access(self):
+        other_user = self.create_user("bar@example.com")
+
+        self.create_member(organization=self.organization, role="manager", user=other_user)
+
+        owner_om = OrganizationMember.objects.get(organization=self.organization, user=self.user)
+
+        assert owner_om.role == "owner"
+
+        self.login_as(other_user)
+        self.get_error_response(self.organization.slug, owner_om.id, status_code=400)
+
+        assert OrganizationMember.objects.filter(id=owner_om.id).exists()
+
+    def test_cannot_delete_only_owner(self):
+        # create a pending member, which shouldn't be counted in the checks
+        self.create_member(organization=self.organization, role="owner", email="bar@example.com")
+
+        owner_om = OrganizationMember.objects.get(organization=self.organization, user=self.user)
+
+        assert owner_om.role == "owner"
+
+        self.get_error_response(self.organization.slug, owner_om.id, status_code=403)
+
+        assert OrganizationMember.objects.filter(id=owner_om.id).exists()
+
+    def test_can_delete_self(self):
+        other_user = self.create_user("bar@example.com")
+        self.create_member(organization=self.organization, role="member", user=other_user)
+
+        self.login_as(other_user)
+        self.get_success_response(self.organization.slug, "me")
+
+        assert not OrganizationMember.objects.filter(
+            user=other_user, organization=self.organization
+        ).exists()
+
+    def test_missing_scope(self):
+        admin_user = self.create_user("bar@example.com")
+        self.create_member(organization=self.organization, role="admin", user=admin_user)
+
+        member_user = self.create_user("baz@example.com")
+        member_om = self.create_member(
+            organization=self.organization, role="member", user=member_user
+        )
+
+        self.login_as(admin_user)
+        self.get_error_response(self.organization.slug, member_om.id, status_code=400)
+
+        assert OrganizationMember.objects.filter(id=member_om.id).exists()
+
+    def test_cannot_delete_unapproved_invite(self):
+        join_request = self.create_member(
+            organization=self.organization,
+            email="test@gmail.com",
+            invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
+        )
+
+        invite_request = self.create_member(
+            organization=self.organization,
+            email="test2@gmail.com",
+            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
+        )
+
+        self.get_error_response(self.organization.slug, join_request.id, status_code=404)
+        self.get_error_response(self.organization.slug, invite_request.id, status_code=404)
 
 
 class ResetOrganizationMember2faTest(APITestCase):
@@ -612,224 +560,3 @@ class ResetOrganizationMember2faTest(APITestCase):
         )
         resp = self.client.put(path)
         assert resp.status_code == 403
-
-
-class DeleteOrganizationMemberTest(APITestCase):
-    def test_simple(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
-        member = self.create_user("bar@example.com")
-
-        member_om = self.create_member(organization=organization, user=member, role="member")
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
-        )
-
-        self.login_as(self.user)
-
-        resp = self.client.delete(path)
-
-        assert resp.status_code == 204
-        assert not OrganizationMember.objects.filter(id=member_om.id).exists()
-
-    def test_invalid_id(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
-        member = self.create_user("bar@example.com")
-        self.create_member(organization=organization, user=member, role="member")
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, "trash"]
-        )
-        self.login_as(self.user)
-
-        resp = self.client.delete(path)
-
-        assert resp.status_code == 404
-
-    def test_cannot_delete_member_with_higher_access(self):
-        organization = self.create_organization(name="foo", owner=self.user)
-
-        other_user = self.create_user("bar@example.com")
-
-        self.create_member(organization=organization, role="manager", user=other_user)
-
-        owner_om = OrganizationMember.objects.get(organization=organization, user=self.user)
-
-        assert owner_om.role == "owner"
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, owner_om.id]
-        )
-
-        self.login_as(other_user)
-
-        resp = self.client.delete(path)
-
-        assert resp.status_code == 400
-        assert OrganizationMember.objects.filter(id=owner_om.id).exists()
-
-    def test_cannot_delete_only_owner(self):
-        self.login_as(user=self.user)
-
-        organization = self.create_organization(name="foo", owner=self.user)
-
-        # create a pending member, which shouldn't be counted in the checks
-        self.create_member(organization=organization, role="owner", email="bar@example.com")
-
-        owner_om = OrganizationMember.objects.get(organization=organization, user=self.user)
-
-        assert owner_om.role == "owner"
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, owner_om.id]
-        )
-
-        self.login_as(self.user)
-
-        resp = self.client.delete(path)
-
-        assert resp.status_code == 403
-        assert OrganizationMember.objects.filter(id=owner_om.id).exists()
-
-    def test_can_delete_self(self):
-        organization = self.create_organization(name="foo", owner=self.user)
-
-        other_user = self.create_user("bar@example.com")
-
-        self.create_member(organization=organization, role="member", user=other_user)
-
-        path = reverse("sentry-api-0-organization-member-details", args=[organization.slug, "me"])
-
-        self.login_as(other_user)
-
-        resp = self.client.delete(path)
-
-        assert resp.status_code == 204
-        assert not OrganizationMember.objects.filter(
-            user=other_user, organization=organization
-        ).exists()
-
-    def test_missing_scope(self):
-        organization = self.create_organization(name="foo", owner=self.user)
-
-        admin_user = self.create_user("bar@example.com")
-
-        self.create_member(organization=organization, role="admin", user=admin_user)
-
-        member_user = self.create_user("baz@example.com")
-
-        member_om = self.create_member(organization=organization, role="member", user=member_user)
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member_om.id]
-        )
-
-        self.login_as(admin_user)
-
-        resp = self.client.delete(path)
-
-        assert resp.status_code == 400
-
-        assert OrganizationMember.objects.filter(id=member_om.id).exists()
-
-    def test_cannot_delete_unapproved_invite(self):
-        organization = self.create_organization(name="test", owner=self.user)
-        self.login_as(self.user)
-
-        join_request = self.create_member(
-            organization=organization,
-            email="test@gmail.com",
-            invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
-        )
-
-        invite_request = self.create_member(
-            organization=organization,
-            email="test2@gmail.com",
-            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
-        )
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, join_request.id]
-        )
-        resp = self.client.delete(path)
-        assert resp.status_code == 404
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, invite_request.id]
-        )
-        resp = self.client.delete(path)
-        assert resp.status_code == 404
-
-
-class GetOrganizationMemberTest(APITestCase):
-    def test_me(self):
-        user = self.create_user("dummy@example.com")
-        organization = self.create_organization(name="test", owner=user)
-        self.create_team(name="first", organization=organization, members=[user])
-
-        path = reverse("sentry-api-0-organization-member-details", args=[organization.slug, "me"])
-        self.login_as(user)
-        resp = self.client.get(path)
-        assert resp.status_code == 200
-        assert resp.data["role"] == "owner"
-        assert resp.data["user"]["id"] == str(user.id)
-        assert resp.data["email"] == user.email
-
-    def test_get_by_id(self):
-        user = self.create_user("dummy@example.com")
-        organization = self.create_organization(name="test")
-        team = self.create_team(name="first", organization=organization, members=[user])
-        member = team.member_set.first()
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, member.id]
-        )
-        self.login_as(user)
-        resp = self.client.get(path)
-        assert resp.status_code == 200
-        assert resp.data["role"] == "member"
-        assert resp.data["id"] == str(member.id)
-
-    def test_get_by_garbage(self):
-        user = self.create_user("dummy@example.com")
-        organization = self.create_organization(name="test")
-        self.create_team(name="first", organization=organization, members=[user])
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, "trash"]
-        )
-        self.login_as(user)
-        resp = self.client.get(path)
-        assert resp.status_code == 404
-
-    def test_cannot_get_unapproved_invite(self):
-        organization = self.create_organization(name="test", owner=self.user)
-        self.login_as(self.user)
-
-        join_request = self.create_member(
-            organization=organization,
-            email="test@gmail.com",
-            invite_status=InviteStatus.REQUESTED_TO_JOIN.value,
-        )
-
-        invite_request = self.create_member(
-            organization=organization,
-            email="test2@gmail.com",
-            invite_status=InviteStatus.REQUESTED_TO_BE_INVITED.value,
-        )
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, join_request.id]
-        )
-        resp = self.client.get(path)
-        assert resp.status_code == 404
-
-        path = reverse(
-            "sentry-api-0-organization-member-details", args=[organization.slug, invite_request.id]
-        )
-        resp = self.client.get(path)
-        assert resp.status_code == 404


### PR DESCRIPTION
Cleaning up endpoint test files with the following techniques:
- move repeated code like setting up user, team, and organization to `setUp`
- inlining `reverse`, `self.client`, and `assert` code with `self.get_success_response` calls
- moving repeated assertions to helpers