### PR TITLE
fix(notifications): Handle alert notifications when disabled

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -251,17 +251,19 @@ class Project(Model, PendingDeletionMixin):
         """
         from sentry.models import UserOption, User
 
-        member_alert_disabled = {}
-        for user in User.objects.get_from_projects(self.organization.id, [self]):
-            is_disabled = {
-                o.user_id: int(o.value)
-                for o in UserOption.objects.filter(user=user)
-                if str(o.value) == "0"
-            }
+        alert_settings = {}
+        users = [user for user in User.objects.get_from_projects(self.organization.id, [self])]
 
-            member_alert_disabled.update(is_disabled)
+        for u in users:
+            alert_settings.update(
+                {
+                    o.user_id: int(o.value)
+                    for o in UserOption.objects.filter(user=u)
+                    if str(o.value) == "0"
+                }
+            )
 
-        return member_alert_disabled
+        return alert_settings
 
     def get_notification_recipients(self, user_option):
         from sentry.models import UserOption

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -23,6 +23,7 @@ from sentry.models import (
     Repository,
     Rule,
     User,
+    UserOption,
     UserReport,
 )
 from sentry.models.integration import ExternalProviders
@@ -686,9 +687,13 @@ class MailAdapterGetSendToOwnersTest(BaseMailAdapterTest, TestCase):
         event_all_users = self.store_event(
             data=self.make_event_data("foo.cbl"), project_id=self.project.id
         )
+        alert_disabled = UserOption.objects.get(user=self.user2)
         assert self.adapter.get_send_to_owners(event_all_users, self.project) == {
             self.user.id,
             self.user3.id,
+        }
+        assert self.project.get_member_alert_settings(self.project) == {
+            alert_disabled.user_id: alert_disabled.value
         }
 
 


### PR DESCRIPTION
This fixes a bug when users _disabled_ alerts for all projects in their [user settings](https://sentry.io/settings/account/notifications/) (before fine-tuning it per project). If "Default" or "On" was selected for the project in fine-tuning, alert notifications would still be sent to Issue Owners and/or Teams that user was part of.

FIXES [WOR-140](https://getsentry.atlassian.net/browse/WOR-140)