### PR TITLE
fix(quick-trace): Check subtraces for quick trace results

### DIFF
--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/quickTraceQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/quickTraceQuery.tsx
@@ -49,18 +49,17 @@ export default function QuickTraceQuery({children, event, ...props}: QueryProps)
               traceFullResults.error === null &&
               traceFullResults.traces !== null
             ) {
-              try {
-                // TODO: consume the entire array for quick trace
-                const trace = flattenRelevantPaths(
-                  event,
-                  traceFullResults.traces?.[0] ?? null
-                );
-                return children({
-                  ...traceFullResults,
-                  trace,
-                });
-              } catch {
-                // let this fall through and use the lite results
+              for (const subtrace of traceFullResults.traces) {
+                try {
+                  const trace = flattenRelevantPaths(event, subtrace);
+                  return children({
+                    ...traceFullResults,
+                    trace,
+                  });
+                } catch {
+                  // let this fall through and check the next subtrace
+                  // or use the trace lite results
+                }
               }
             }
 


### PR DESCRIPTION
The current event may be disconnected from the room meaning that in the full
trace, it may be in one of the orphaned subtraces. This change ensures that
quick trace consumes the entire full trace result and searches for the subtrace
that contains the current event.