### PR TITLE
feat(ui): Improve project details for legacy plans

### DIFF
--- a/src/sentry/api/endpoints/organization_projects.py
+++ b/src/sentry/api/endpoints/organization_projects.py
@@ -26,7 +26,7 @@ class OrganizationProjectsEndpoint(OrganizationEndpoint, EnvironmentMixin):
         """
         stats_period = request.GET.get("statsPeriod")
         collapse = request.GET.getlist("collapse", [])
-        if stats_period not in (None, "", "24h", "14d", "30d"):
+        if stats_period not in (None, "", "1h", "24h", "7d", "14d", "30d"):
             return Response(
                 {"error": {"params": {"stats_period": {"message": ERR_INVALID_STATS_PERIOD}}}},
                 status=400,

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -45,7 +45,9 @@ STATUS_LABELS = {
 STATS_PERIOD_CHOICES = {
     "30d": StatsPeriod(30, timedelta(hours=24)),
     "14d": StatsPeriod(14, timedelta(hours=24)),
+    "7d": StatsPeriod(7, timedelta(hours=24)),
     "24h": StatsPeriod(24, timedelta(hours=1)),
+    "1h": StatsPeriod(60, timedelta(minutes=1)),
 }
 
 _PROJECT_SCOPE_PREFIX = "projects:"

--- a/src/sentry/static/sentry/app/stores/hookStore.tsx
+++ b/src/sentry/static/sentry/app/stores/hookStore.tsx
@@ -35,6 +35,7 @@ const validHookNames = new Set<HookName>([
   'feature-disabled:performance-new-project',
   'feature-disabled:performance-page',
   'feature-disabled:performance-sidebar-item',
+  'feature-disabled:project-performance-score-card',
   'feature-disabled:project-selector-checkbox',
   'feature-disabled:rate-limits',
   'feature-disabled:sso-basic',

--- a/src/sentry/static/sentry/app/types/hooks.tsx
+++ b/src/sentry/static/sentry/app/types/hooks.tsx
@@ -107,6 +107,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:performance-new-project': FeatureDisabledHook;
   'feature-disabled:performance-page': FeatureDisabledHook;
   'feature-disabled:performance-sidebar-item': FeatureDisabledHook;
+  'feature-disabled:project-performance-score-card': FeatureDisabledHook;
   'feature-disabled:project-selector-checkbox': FeatureDisabledHook;
   'feature-disabled:rate-limits': FeatureDisabledHook;
   'feature-disabled:sso-basic': FeatureDisabledHook;

--- a/src/sentry/static/sentry/app/views/issueList/noGroupsHandler/index.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/noGroupsHandler/index.tsx
@@ -16,6 +16,7 @@ type Props = {
   query: string;
   selectedProjectIds?: number[];
   groupIds: string[];
+  emptyMessage?: React.ReactNode;
 };
 
 type State = {
@@ -132,9 +133,10 @@ class NoGroupsHandler extends React.Component<Props, State> {
   }
 
   renderEmpty() {
+    const {emptyMessage} = this.props;
     return (
       <EmptyStateWarning>
-        <p>{t('Sorry, no issues match your filters.')}</p>
+        <p>{emptyMessage ?? t('Sorry, no issues match your filters.')}</p>
       </EmptyStateWarning>
     );
   }

--- a/src/sentry/static/sentry/app/views/projectDetail/charts/projectErrorsBasicChart.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/charts/projectErrorsBasicChart.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import {browserHistory} from 'react-router';
+import {withTheme} from 'emotion-theming';
+import {Location} from 'history';
+
+import AsyncComponent from 'app/components/asyncComponent';
+import BaseChart from 'app/components/charts/baseChart';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
+import TransitionChart from 'app/components/charts/transitionChart';
+import TransparentLoadingMask from 'app/components/charts/transparentLoadingMask';
+import {DEFAULT_STATS_PERIOD} from 'app/constants';
+import {t} from 'app/locale';
+import {Organization, Project} from 'app/types';
+import {Theme} from 'app/utils/theme';
+
+const ALLOWED_TIME_PERIODS = ['1h', '24h', '7d', '14d', '30d'];
+
+type Props = AsyncComponent['props'] & {
+  organization: Organization;
+  location: Location;
+  theme: Theme;
+  onTotalValuesChange: (value: number | null) => void;
+  projectId?: string;
+};
+
+type State = AsyncComponent['state'] & {
+  projects: Project[] | null;
+};
+
+class ProjectErrorsBasicChart extends AsyncComponent<Props, State> {
+  getDefaultState() {
+    return {
+      ...super.getDefaultState(),
+      projects: null,
+    };
+  }
+
+  getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
+    const {organization, projectId} = this.props;
+
+    if (!projectId) {
+      return [];
+    }
+
+    return [
+      [
+        'projects',
+        `/organizations/${organization.slug}/projects/`,
+        {
+          query: {
+            statsPeriod: this.getStatsPeriod(),
+            query: `id:${projectId}`,
+          },
+        },
+      ],
+    ];
+  }
+
+  componentDidMount() {
+    const {location} = this.props;
+    if (!ALLOWED_TIME_PERIODS.includes(location.query.statsPeriod)) {
+      browserHistory.replace({
+        pathname: location.pathname,
+        query: {
+          ...location.query,
+          statsPeriod: this.getStatsPeriod(),
+          start: undefined,
+          end: undefined,
+        },
+      });
+    }
+  }
+
+  onLoadAllEndpointsSuccess() {
+    this.props.onTotalValuesChange(
+      this.state.projects?.[0]?.stats?.reduce((acc, [, value]) => acc + value, 0) ?? null
+    );
+  }
+
+  getStatsPeriod() {
+    const {location} = this.props;
+    const statsPeriod = location.query.statsPeriod;
+
+    if (ALLOWED_TIME_PERIODS.includes(statsPeriod)) {
+      return statsPeriod;
+    }
+
+    return DEFAULT_STATS_PERIOD;
+  }
+
+  getSeries() {
+    const {projects} = this.state;
+
+    return [
+      {
+        cursor: 'normal' as const,
+        name: t('Errors'),
+        type: 'bar',
+        data:
+          projects?.[0]?.stats?.map(([timestamp, value]) => [timestamp * 1000, value]) ??
+          [],
+      },
+    ];
+  }
+
+  renderLoading() {
+    return this.renderBody();
+  }
+
+  renderBody() {
+    const {theme} = this.props;
+    const {loading, reloading} = this.state;
+
+    return (
+      <TransitionChart loading={loading} reloading={reloading}>
+        <TransparentLoadingMask visible={reloading} />
+
+        <HeaderTitleLegend>{t('Daily Errors')}</HeaderTitleLegend>
+
+        <BaseChart
+          series={this.getSeries()}
+          isGroupedByDate
+          showTimeInTooltip
+          colors={[theme.purple300, theme.purple200]}
+          grid={{left: '10px', right: '10px', top: '40px', bottom: '0px'}}
+        />
+      </TransitionChart>
+    );
+  }
+}
+
+export default withTheme(ProjectErrorsBasicChart);

--- a/src/sentry/static/sentry/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/missingFeatureButtons/missingPerformanceButtons.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 
+import Feature from 'app/components/acl/feature';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import FeatureTourModal from 'app/components/modals/featureTourModal';
@@ -37,25 +38,31 @@ function MissingPerformanceButtons({organization}: Props) {
   }
 
   return (
-    <StyledButtonBar gap={1}>
-      <Button size="small" priority="primary" external href={DOCS_URL}>
-        {t('Start Setup')}
-      </Button>
+    <Feature
+      hookName="feature-disabled:project-performance-score-card"
+      features={['performance-view']}
+      organization={organization}
+    >
+      <StyledButtonBar gap={1}>
+        <Button size="small" priority="primary" external href={DOCS_URL}>
+          {t('Start Setup')}
+        </Button>
 
-      <FeatureTourModal
-        steps={PERFORMANCE_TOUR_STEPS}
-        onAdvance={handleTourAdvance}
-        onCloseModal={handleClose}
-        doneText={t('Start Setup')}
-        doneUrl={DOCS_URL}
-      >
-        {({showModal}) => (
-          <Button size="small" onClick={showModal}>
-            {t('Get a tour')}
-          </Button>
-        )}
-      </FeatureTourModal>
-    </StyledButtonBar>
+        <FeatureTourModal
+          steps={PERFORMANCE_TOUR_STEPS}
+          onAdvance={handleTourAdvance}
+          onCloseModal={handleClose}
+          doneText={t('Start Setup')}
+          doneUrl={DOCS_URL}
+        >
+          {({showModal}) => (
+            <Button size="small" onClick={showModal}>
+              {t('Get a tour')}
+            </Button>
+          )}
+        </FeatureTourModal>
+      </StyledButtonBar>
+    </Feature>
   );
 }
 

--- a/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
@@ -222,7 +222,12 @@ class ProjectDetail extends AsyncView<Props, State> {
                         index={id}
                       />
                     ))}
-                    <ProjectIssues organization={organization} location={location} />
+                    <ProjectIssues
+                      organization={organization}
+                      location={location}
+                      projectId={selection.projects[0]}
+                      api={this.api}
+                    />
                   </React.Fragment>
                 )}
               </Layout.Main>

--- a/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectDetail.tsx
@@ -131,7 +131,13 @@ class ProjectDetail extends AsyncView<Props, State> {
       selection,
     } = this.props;
     const project = this.project;
+    const hasPerformance = organization.features.includes('performance-view');
     const isProjectStabilized = this.isProjectStabilized();
+    const displayedChartIds = [0];
+
+    if (hasPerformance) {
+      displayedChartIds.push(1);
+    }
 
     if (!loadingProjects && !project) {
       return this.renderProjectNotFound();
@@ -213,13 +219,14 @@ class ProjectDetail extends AsyncView<Props, State> {
                 />
                 {isProjectStabilized && (
                   <React.Fragment>
-                    {[0, 1].map(id => (
+                    {displayedChartIds.map(id => (
                       <ProjectCharts
                         location={location}
                         organization={organization}
                         router={router}
                         key={`project-charts-${id}`}
                         index={id}
+                        projectId={project?.id}
                       />
                     ))}
                     <ProjectIssues

--- a/src/sentry/static/sentry/app/views/projectDetail/projectIssues.tsx
+++ b/src/sentry/static/sentry/app/views/projectDetail/projectIssues.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 import pick from 'lodash/pick';
 
+import {Client} from 'app/api';
 import Button from 'app/components/button';
 import {SectionHeading} from 'app/components/charts/styles';
-import EmptyStateWarning from 'app/components/emptyStateWarning';
 import GroupList from 'app/components/issues/groupList';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel, PanelBody} from 'app/components/panels';
@@ -17,12 +17,16 @@ import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {decodeScalar} from 'app/utils/queryString';
 
+import NoGroupsHandler from '../issueList/noGroupsHandler';
+
 type Props = {
   organization: Organization;
   location: Location;
+  projectId: number;
+  api: Client;
 };
 
-function ProjectIssues({organization, location}: Props) {
+function ProjectIssues({organization, location, projectId, api}: Props) {
   function handleOpenClick() {
     trackAnalyticsEvent({
       eventKey: 'project_detail.open_issues',
@@ -30,6 +34,20 @@ function ProjectIssues({organization, location}: Props) {
       organization_id: parseInt(organization.id, 10),
     });
   }
+
+  const endpointPath = `/organizations/${organization.slug}/issues/`;
+  const issueQuery = 'is:unresolved error.unhandled:true';
+  const queryParams = {
+    limit: 5,
+    ...getParams(pick(location.query, [...Object.values(URL_PARAM), 'cursor'])),
+    query: issueQuery,
+    sort: 'freq',
+  };
+
+  const issueSearch = {
+    pathname: endpointPath,
+    query: queryParams,
+  };
 
   function renderEmptyMessage() {
     const selectedTimePeriod = location.query.start
@@ -44,30 +62,20 @@ function ProjectIssues({organization, location}: Props) {
     return (
       <Panel>
         <PanelBody>
-          <EmptyStateWarning>
-            <p>
-              {tct('No issues for the [timePeriod].', {
-                timePeriod: displayedPeriod,
-              })}
-            </p>
-          </EmptyStateWarning>
+          <NoGroupsHandler
+            api={api}
+            organization={organization}
+            query={issueQuery}
+            selectedProjectIds={[projectId]}
+            groupIds={[]}
+            emptyMessage={tct('No issues for the [timePeriod].', {
+              timePeriod: displayedPeriod,
+            })}
+          />
         </PanelBody>
       </Panel>
     );
   }
-
-  const endpointPath = `/organizations/${organization.slug}/issues/`;
-  const queryParams = {
-    limit: 5,
-    ...getParams(pick(location.query, [...Object.values(URL_PARAM), 'cursor'])),
-    query: 'is:unresolved error.unhandled:true',
-    sort: 'freq',
-  };
-
-  const issueSearch = {
-    pathname: endpointPath,
-    query: queryParams,
-  };
 
   return (
     <React.Fragment>


### PR DESCRIPTION
This PR is making the project details experience on lower/legacy plans a bit nicer.

- show only one chart instead of two (one of which would be empty)
- add waiting for the first event robot to the frequent unhandled issues section
- on free mm2 (legacy) plans without discover and without performance, show daily errors chart
- show "migrate plan" button in the apdex score card on legacy plans

getsentry part: https://github.com/getsentry/getsentry/pull/5378