### PR TITLE
feat(alert): Disable event type selector for transaction alerts

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -13,6 +13,7 @@ import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import BuilderBreadCrumbs from 'app/views/alerts/builder/builderBreadCrumbs';
 import RadioGroup from 'app/views/settings/components/forms/controls/radioGroup';
+import {Dataset} from 'app/views/settings/incidentRules/types';
 
 import {
   AlertType,
@@ -49,6 +50,10 @@ class AlertWizard extends React.Component<Props, State> {
     const {organization, project, location} = this.props;
     const {alertOption} = this.state;
     const metricRuleTemplate = AlertWizardRuleTemplates[alertOption];
+    const disabled =
+      !organization.features.includes('performance-view') &&
+      metricRuleTemplate?.dataset === Dataset.TRANSACTIONS;
+
     const to = {
       pathname: `/organizations/${organization.slug}/alerts/${project.slug}/new/`,
       query: {
@@ -63,6 +68,7 @@ class AlertWizard extends React.Component<Props, State> {
         projectSlug={project.slug}
         priority="primary"
         to={to}
+        disabled={disabled}
       />
     );
   }

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -698,6 +698,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                       disabled={!hasAccess || !canEdit}
                       thresholdChart={wizardBuilderChart}
                       onFilterSearch={this.handleFilterUpdate}
+                      allowChangeEventTypes={dataset === Dataset.ERRORS}
                     />
                     <StyledListItem>
                       {t('Set actions for when a threshold is met')}


### PR DESCRIPTION
With the new alert wizard, we only need to show this event type selector for `error` alerts. Also moved the permissions check to the alert wizard to prevent users from creating transaction alerts without the `performance-view` feature. Eventually we can add a tooltip to the button to let users know.

**Before:**
![image](https://user-images.githubusercontent.com/9372512/113176792-df69f400-921a-11eb-8fe2-bf1dfce9ba1e.png)

**After:**
![image](https://user-images.githubusercontent.com/9372512/113176834-e7299880-921a-11eb-989d-15becfd60335.png)
