### PR TITLE
build(relay): Upgrade sentry-relay to 0.8.5

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -48,7 +48,7 @@ requests[security]==2.20.1
 rfc3339-validator==0.1.2
 rfc3986-validator==0.1.1
 # [end] jsonschema format validators
-sentry-relay==0.8.4
+sentry-relay==0.8.5
 sentry-sdk>=1.0.0,<1.2.0
 snuba-sdk>=0.0.8,<1.0.0
 simplejson==3.17.2


### PR DESCRIPTION
Needed for upcoming span op breakdown changes that will be added to Sentry.

Ref: https://pypi.org/project/sentry-relay/0.8.5/