### PR TITLE
fix(ui): added dropdown UI for editing/deleting rules

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -6,14 +6,16 @@ import moment from 'moment';
 
 import Access from 'app/components/acl/access';
 import Feature from 'app/components/acl/feature';
+import MenuItemActionLink from 'app/components/actions/menuItemActionLink';
 import ActorAvatar from 'app/components/avatar/actorAvatar';
 import Button from 'app/components/button';
 import ButtonBar from 'app/components/buttonBar';
 import Confirm from 'app/components/confirm';
+import DropdownLink from 'app/components/dropdownLink';
 import ErrorBoundary from 'app/components/errorBoundary';
 import IdBadge from 'app/components/idBadge';
 import Link from 'app/components/links/link';
-import {IconDelete, IconSettings, IconUser} from 'app/icons';
+import {IconEllipsis, IconUser} from 'app/icons';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -95,33 +97,42 @@ class RuleListRow extends React.Component<Props, State> {
           <Access access={['alerts:write']}>
             {({hasAccess}) => (
               <ButtonBar gap={1}>
-                <Confirm
-                  disabled={!hasAccess || !canEdit}
-                  message={tct(
-                    "Are you sure you want to delete [name]? You won't be able to view the history of this alert once it's deleted.",
-                    {
-                      name: rule.name,
-                    }
-                  )}
-                  header={t('Delete Alert Rule?')}
-                  priority="danger"
-                  confirmText={t('Delete Rule')}
-                  onConfirm={() => onDelete(slug, rule)}
+                <DropdownLink
+                  anchorRight
+                  caret={false}
+                  title={
+                    <Button
+                      tooltipProps={{
+                        containerDisplayMode: 'flex',
+                      }}
+                      size="small"
+                      type="button"
+                      aria-label={t('Show more')}
+                      icon={<IconEllipsis size="xs" />}
+                    />
+                  }
                 >
-                  <Button
-                    type="button"
-                    icon={<IconDelete />}
-                    size="small"
-                    title={t('Delete')}
-                  />
-                </Confirm>
-                <Button
-                  size="small"
-                  type="button"
-                  icon={<IconSettings />}
-                  title={t('Edit')}
-                  to={editLink}
-                />
+                  <MenuItemActionLink href={editLink} title={t('Edit')}>
+                    {t('Edit')}
+                  </MenuItemActionLink>
+                  <Confirm
+                    disabled={!hasAccess || !canEdit}
+                    message={tct(
+                      "Are you sure you want to delete [name]? You won't be able to view the history of this alert once it's deleted.",
+                      {
+                        name: rule.name,
+                      }
+                    )}
+                    header={t('Delete Alert Rule?')}
+                    priority="danger"
+                    confirmText={t('Delete Rule')}
+                    onConfirm={() => onDelete(slug, rule)}
+                  >
+                    <MenuItemActionLink title={t('Delete')}>
+                      {t('Delete')}
+                    </MenuItemActionLink>
+                  </Confirm>
+                </DropdownLink>
               </ButtonBar>
             )}
           </Access>


### PR DESCRIPTION
In the Alert Rules list I’ve moved actions into a dropdown UI so it's less distracting 

### Before

<img width="1256" alt="CleanShot 2021-03-31 at 09 59 59@2x" src="https://user-images.githubusercontent.com/1900676/113182620-f3f0c100-9207-11eb-8564-35c2fb916166.png">

### After

<img width="1269" alt="CleanShot 2021-03-31 at 09 59 06@2x" src="https://user-images.githubusercontent.com/1900676/113182633-f9e6a200-9207-11eb-981f-7d6e1ac3aad5.png">
