### PR TITLE
feat(alert): No wizard selection by default

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -39,11 +39,11 @@ type Props = RouteComponentProps<RouteParams, {}> & {
 };
 
 type State = {
-  alertOption: AlertType;
+  alertOption: AlertType | null;
 };
 class AlertWizard extends React.Component<Props, State> {
   state: State = {
-    alertOption: 'issues',
+    alertOption: null,
   };
 
   handleChangeAlertOption = (alertOption: AlertType) => {
@@ -53,7 +53,7 @@ class AlertWizard extends React.Component<Props, State> {
   renderCreateAlertButton() {
     const {organization, project, location} = this.props;
     const {alertOption} = this.state;
-    const metricRuleTemplate = AlertWizardRuleTemplates[alertOption];
+    const metricRuleTemplate = alertOption && AlertWizardRuleTemplates[alertOption];
     const disabled =
       !organization.features.includes('performance-view') &&
       metricRuleTemplate?.dataset === Dataset.TRANSACTIONS;
@@ -85,7 +85,7 @@ class AlertWizard extends React.Component<Props, State> {
     } = this.props;
     const {alertOption} = this.state;
     const title = t('Alert Creation Wizard');
-    const {description, examples, docsLink} = AlertWizardPanelContent[alertOption];
+    const panelContent = alertOption && AlertWizardPanelContent[alertOption];
     return (
       <React.Fragment>
         <SentryDocumentTitle title={title} projectSlug={projectId} />
@@ -116,25 +116,29 @@ class AlertWizard extends React.Component<Props, State> {
                   </OptionsWrapper>
                 ))}
               </WizardOptions>
-              <WizardPanel>
-                <WizardPanelBody>
-                  <PageHeading>{AlertWizardAlertNames[alertOption]}</PageHeading>
-                  <PanelDescription>
-                    {description}{' '}
-                    {docsLink && (
-                      <ExternalLink href={docsLink}>{t('Learn more')}</ExternalLink>
-                    )}
-                  </PanelDescription>
-                  <Placeholder height="250px" />
-                  <ExampleHeader>{t('Examples')}</ExampleHeader>
-                  <List symbol="bullet">
-                    {examples.map((example, i) => (
-                      <ExampleItem key={i}>{example}</ExampleItem>
-                    ))}
-                  </List>
-                </WizardPanelBody>
-                {this.renderCreateAlertButton()}
-              </WizardPanel>
+              {panelContent && alertOption && (
+                <WizardPanel>
+                  <WizardPanelBody>
+                    <PageHeading>{AlertWizardAlertNames[alertOption]}</PageHeading>
+                    <PanelDescription>
+                      {panelContent.description}{' '}
+                      {panelContent.docsLink && (
+                        <ExternalLink href={panelContent.docsLink}>
+                          {t('Learn more')}
+                        </ExternalLink>
+                      )}
+                    </PanelDescription>
+                    <Placeholder height="250px" />
+                    <ExampleHeader>{t('Examples')}</ExampleHeader>
+                    <List symbol="bullet">
+                      {panelContent.examples.map((example, i) => (
+                        <ExampleItem key={i}>{example}</ExampleItem>
+                      ))}
+                    </List>
+                  </WizardPanelBody>
+                  {this.renderCreateAlertButton()}
+                </WizardPanel>
+              )}
             </WizardBody>
           </Feature>
         </PageContent>


### PR DESCRIPTION
When initially loading the wizard page, don't have a default selection

This matches the behavior of the mocks

**No selection example:**
![image](https://user-images.githubusercontent.com/9372512/113191846-0b41a580-922c-11eb-8d59-4211bd23a42d.png)
