### PR TITLE
build(ci): Clean up webpack tasks for acceptance tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -141,7 +141,7 @@ jobs:
           # this is fine to not have for forks, it shouldn't fail
           SENTRY_WEBPACK_WEBHOOK_SECRET: ${{ secrets.SENTRY_WEBPACK_WEBHOOK_SECRET }}
         run: |
-          yarn webpack --display errors-only
+          yarn build-acceptance
 
       - name: Run acceptance tests (#${{ steps.setup.outputs.matrix-instance-number }} of ${{ strategy.job-total }})
         if: always()

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "watch-api-docs": "sane 'yarn build-derefed-docs' api-docs",
     "build-css": "NODE_ENV=production yarn webpack --config=config/webpack.css.config.js",
     "build-chartcuterie-config": "NODE_ENV=production yarn webpack --config=config/webpack.chartcuterie.config.js",
-    "build-acceptance": "yarn build-production",
+    "build-acceptance": "IS_ACCEPTANCE_TEST=1 yarn build-production",
     "build-production": "NODE_ENV=production yarn webpack --mode production --display errors-only",
     "build": "yarn build-production --output-path=public",
     "validate-api-examples": "yarn install-api-docs && cd api-docs && yarn openapi-examples-validator ./openapi.json --no-additional-properties"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,13 @@ const IS_STORYBOOK = env.STORYBOOK_BUILD === '1';
 // We want it in the case where we are running tests and it is in CI,
 // this should not happen in local
 const IS_CI = !!env.CI;
-const IS_ACCEPTANCE_TEST = IS_CI && !!env.VISUAL_SNAPSHOT_ENABLE;
+// We intentionally build in production mode for acceptance tests, so we explicitly use an env var to
+// say that the bundle will be used in acceptance tests. This affects webpack plugins and components
+// with dynamic data that render differently statically in tests.
+//
+// Note, cannot assume it is an acceptance test if `IS_CI` is true, as our image builds has the
+// `CI` env var set.
+const IS_ACCEPTANCE_TEST = !!env.IS_ACCEPTANCE_TEST;
 const IS_DEPLOY_PREVIEW = !!env.NOW_GITHUB_DEPLOYMENT;
 const IS_UI_DEV_ONLY = !!env.SENTRY_UI_DEV_ONLY;
 const DEV_MODE = !(IS_PRODUCTION || IS_CI);
@@ -401,7 +407,7 @@ if (IS_TEST || IS_ACCEPTANCE_TEST || IS_STORYBOOK) {
   appConfig.resolve.alias['integration-docs-platforms'] = plugin.modulePath;
 }
 
-if (!IS_PRODUCTION) {
+if (IS_ACCEPTANCE_TEST) {
   appConfig.plugins.push(new LastBuiltPlugin({basePath: __dirname}));
 }
 


### PR DESCRIPTION
Build webpack bundle with explicit `IS_ACCEPTANCE_TEST` env var. We prefer to run acceptance tests with webpack building in "production" mode, but at the same time we need a way to tell the application that we are running acceptance tests due to some components that render dynamic data which negatively affects our snapshots. See https://github.com/getsentry/sentry/pull/21415 for some more historical context.