### PR TITLE
fix(ui): Fix incorrect `console.error` in bootstrap

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -115,13 +115,13 @@ const render = (Component: React.ComponentType) => {
   try {
     ReactDOM.render(<Component />, rootEl);
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.error(
-      new Error(
-        'An unencoded "%" has appeared, it is super effective! (See https://github.com/ReactTraining/history/issues/505)'
-      )
-    );
     if (err.message === 'URI malformed') {
+      // eslint-disable-next-line no-console
+      console.error(
+        new Error(
+          'An unencoded "%" has appeared, it is super effective! (See https://github.com/ReactTraining/history/issues/505)'
+        )
+      );
       window.location.assign(window.location.pathname);
     }
   }


### PR DESCRIPTION
This `console.error` should only pop up in the case of the "URI malformed" exception. Introduced in https://github.com/getsentry/sentry/pull/13306 (oops)