### PR TITLE
fix(ui): replaced icon for ignore actions

### DIFF
--- a/src/sentry/static/sentry/app/components/actions/ignore.tsx
+++ b/src/sentry/static/sentry/app/components/actions/ignore.tsx
@@ -10,7 +10,7 @@ import CustomIgnoreDurationModal from 'app/components/customIgnoreDurationModal'
 import DropdownLink from 'app/components/dropdownLink';
 import Duration from 'app/components/duration';
 import Tooltip from 'app/components/tooltip';
-import {IconChevron, IconMute, IconNot} from 'app/icons';
+import {IconChevron, IconMute} from 'app/icons';
 import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
 import {
@@ -75,7 +75,7 @@ const IgnoreActions = ({
           priority="primary"
           onClick={() => onUpdate({status: ResolutionStatus.UNRESOLVED})}
           label={t('Unignore')}
-          icon={<IconNot size="xs" />}
+          icon={<IconMute size="xs" />}
         />
       </Tooltip>
     );
@@ -123,7 +123,7 @@ const IgnoreActions = ({
           type="button"
           title={t('Ignore')}
           onAction={() => onUpdate({status: ResolutionStatus.IGNORED})}
-          icon={<IconNot size="xs" />}
+          icon={<IconMute size="xs" />}
         >
           {t('Ignore')}
         </ActionLink>


### PR DESCRIPTION
Making ignored icon consistent with everywhere else in Issues.


## Before 

<img width="536" alt="CleanShot 2021-03-31 at 13 22 55@2x" src="https://user-images.githubusercontent.com/1900676/113206352-37592880-9224-11eb-8b7f-164324be6eba.png">


## After

<img width="629" alt="CleanShot 2021-03-31 at 13 22 24@2x" src="https://user-images.githubusercontent.com/1900676/113206298-26a8b280-9224-11eb-957a-e1d907937eb2.png">
