### PR TITLE
ref(feature-flag): removing pass/fail vital feature flag

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -262,6 +262,7 @@ class SummaryContent extends React.Component<Props, State> {
               organization={organization}
               location={location}
               isLoading={isLoading}
+              hasWebVitals={hasWebVitals}
               error={error}
               totals={totalValues}
               transactionName={transactionName}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
-import Feature from 'app/components/acl/feature';
 import {SectionHeading} from 'app/components/charts/styles';
 import Link from 'app/components/links/link';
 import Placeholder from 'app/components/placeholder';
@@ -10,18 +9,12 @@ import QuestionTooltip from 'app/components/questionTooltip';
 import UserMisery from 'app/components/userMisery';
 import {IconOpen} from 'app/icons';
 import {t} from 'app/locale';
-import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
-import {getAggregateAlias, WebVital} from 'app/utils/discover/fields';
-import {WEB_VITAL_DETAILS} from 'app/utils/performance/vitals/constants';
+import {WebVital} from 'app/utils/discover/fields';
 import {decodeScalar} from 'app/utils/queryString';
 import {getTermHelp, PERFORMANCE_TERM} from 'app/views/performance/data';
 import {SidebarSpacer} from 'app/views/performance/transactionSummary/utils';
-import {
-  PERCENTILE as VITAL_PERCENTILE,
-  VITAL_GROUPS,
-} from 'app/views/performance/transactionVitals/constants';
 import {vitalsRouteWithQuery} from 'app/views/performance/transactionVitals/utils';
 
 import VitalInfo from '../vitalDetail/vitalInfo';
@@ -47,7 +40,6 @@ function UserStats({
 }: Props) {
   let userMisery = error !== null ? <div>{'\u2014'}</div> : <Placeholder height="34px" />;
   const threshold = organization.apdexThreshold;
-  let vitalsPassRate: React.ReactNode = null;
 
   if (!isLoading && error === null && totals) {
     const miserableUsers = totals[`count_miserable_user_${threshold}`];
@@ -63,25 +55,6 @@ function UserStats({
         miserableUsers={miserableUsers}
       />
     );
-
-    const [vitalsPassed, vitalsTotal] = VITAL_GROUPS.map(({vitals: vs}) => vs).reduce(
-      ([passed, total], vs) => {
-        vs.forEach(vital => {
-          const alias = getAggregateAlias(`percentile(${vital}, ${VITAL_PERCENTILE})`);
-          if (Number.isFinite(totals[alias])) {
-            total += 1;
-            if (totals[alias] < WEB_VITAL_DETAILS[vital].poorThreshold) {
-              passed += 1;
-            }
-          }
-        });
-        return [passed, total];
-      },
-      [0, 0]
-    );
-    if (vitalsTotal > 0) {
-      vitalsPassRate = <StatNumber>{`${vitalsPassed}/${vitalsTotal}`}</StatNumber>;
-    }
   }
 
   const webVitalsTarget = vitalsRouteWithQuery({
@@ -93,64 +66,30 @@ function UserStats({
 
   return (
     <React.Fragment>
-      <Feature features={['organizations:performance-vitals-overview']}>
-        {({hasFeature}) => {
-          if (vitalsPassRate !== null && hasFeature) {
-            return (
-              <React.Fragment>
-                <VitalsHeading>
-                  <SectionHeading>
-                    {t('Web Vitals')}
-                    <QuestionTooltip
-                      position="top"
-                      title={t(
-                        'Web Vitals with p75 better than the "poor" threshold, as defined by Google Web Vitals.'
-                      )}
-                      size="sm"
-                    />
-                  </SectionHeading>
-                  <Link to={webVitalsTarget}>
-                    <IconOpen />
-                  </Link>
-                </VitalsHeading>
-                <VitalInfo
-                  eventView={eventView}
-                  organization={organization}
-                  location={location}
-                  vital={[WebVital.FCP, WebVital.LCP, WebVital.FID, WebVital.CLS]}
-                  hideVitalPercentNames
-                  hideDurationDetail
-                />
-
-                <SidebarSpacer />
-              </React.Fragment>
-            );
-          } else {
-            return (
-              vitalsPassRate !== null && (
-                <React.Fragment>
-                  <SectionHeading>
-                    {t('Web Vitals')}
-                    <QuestionTooltip
-                      position="top"
-                      title={t(
-                        'Web Vitals with p75 better than the "poor" threshold, as defined by Google Web Vitals.'
-                      )}
-                      size="sm"
-                    />
-                  </SectionHeading>
-                  <StatNumber>{vitalsPassRate}</StatNumber>
-                  <Link to={webVitalsTarget}>
-                    <SectionValue>{t('Passed')}</SectionValue>
-                  </Link>
-
-                  <SidebarSpacer />
-                </React.Fragment>
-              )
-            );
-          }
-        }}
-      </Feature>
+      <VitalsHeading>
+        <SectionHeading>
+          {t('Web Vitals')}
+          <QuestionTooltip
+            position="top"
+            title={t(
+              'Web Vitals with p75 better than the "poor" threshold, as defined by Google Web Vitals.'
+            )}
+            size="sm"
+          />
+        </SectionHeading>
+        <Link to={webVitalsTarget}>
+          <IconOpen />
+        </Link>
+      </VitalsHeading>
+      <VitalInfo
+        eventView={eventView}
+        organization={organization}
+        location={location}
+        vital={[WebVital.FCP, WebVital.LCP, WebVital.FID, WebVital.CLS]}
+        hideVitalPercentNames
+        hideDurationDetail
+      />
+      <SidebarSpacer />
       <SectionHeading>
         {t('User Misery')}
         <QuestionTooltip
@@ -169,20 +108,6 @@ const VitalsHeading = styled('div')`
   display: flex;
   justify-content: space-between;
   align-items: center;
-`;
-
-const StatNumber = styled('div')`
-  font-size: 32px;
-  margin-bottom: ${space(0.5)};
-  color: ${p => p.theme.textColor};
-
-  > div {
-    text-align: left;
-  }
-`;
-
-const SectionValue = styled('span')`
-  font-size: ${p => p.theme.fontSizeMedium};
 `;
 
 export default UserStats;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/userStats.tsx
@@ -22,6 +22,7 @@ import VitalInfo from '../vitalDetail/vitalInfo';
 type Props = {
   eventView: EventView;
   isLoading: boolean;
+  hasWebVitals: boolean;
   error: string | null;
   totals: Record<string, number> | null;
   location: Location;
@@ -32,6 +33,7 @@ type Props = {
 function UserStats({
   eventView,
   isLoading,
+  hasWebVitals,
   error,
   totals,
   location,
@@ -66,30 +68,34 @@ function UserStats({
 
   return (
     <React.Fragment>
-      <VitalsHeading>
-        <SectionHeading>
-          {t('Web Vitals')}
-          <QuestionTooltip
-            position="top"
-            title={t(
-              'Web Vitals with p75 better than the "poor" threshold, as defined by Google Web Vitals.'
-            )}
-            size="sm"
+      {hasWebVitals && (
+        <React.Fragment>
+          <VitalsHeading>
+            <SectionHeading>
+              {t('Web Vitals')}
+              <QuestionTooltip
+                position="top"
+                title={t(
+                  'Web Vitals with p75 better than the "poor" threshold, as defined by Google Web Vitals.'
+                )}
+                size="sm"
+              />
+            </SectionHeading>
+            <Link to={webVitalsTarget}>
+              <IconOpen />
+            </Link>
+          </VitalsHeading>
+          <VitalInfo
+            eventView={eventView}
+            organization={organization}
+            location={location}
+            vital={[WebVital.FCP, WebVital.LCP, WebVital.FID, WebVital.CLS]}
+            hideVitalPercentNames
+            hideDurationDetail
           />
-        </SectionHeading>
-        <Link to={webVitalsTarget}>
-          <IconOpen />
-        </Link>
-      </VitalsHeading>
-      <VitalInfo
-        eventView={eventView}
-        organization={organization}
-        location={location}
-        vital={[WebVital.FCP, WebVital.LCP, WebVital.FID, WebVital.CLS]}
-        hideVitalPercentNames
-        hideDurationDetail
-      />
-      <SidebarSpacer />
+          <SidebarSpacer />
+        </React.Fragment>
+      )}
       <SectionHeading>
         {t('User Misery')}
         <QuestionTooltip

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -194,6 +194,39 @@ describe('Performance > TransactionSummary', function () {
         },
       ],
     });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-vitals/',
+      body: {
+        'measurements.fcp': {
+          poor: 3,
+          meh: 100,
+          good: 47,
+          total: 150,
+          p75: 1500,
+        },
+        'measurements.lcp': {
+          poor: 2,
+          meh: 38,
+          good: 40,
+          total: 80,
+          p75: 2750,
+        },
+        'measurements.fid': {
+          poor: 2,
+          meh: 53,
+          good: 5,
+          total: 60,
+          p75: 1000,
+        },
+        'measurements.cls': {
+          poor: 3,
+          meh: 10,
+          good: 4,
+          total: 17,
+          p75: 0.2,
+        },
+      },
+    });
   });
 
   afterEach(function () {

--- a/tests/js/spec/views/performance/transactionVitals.spec.jsx
+++ b/tests/js/spec/views/performance/transactionVitals.spec.jsx
@@ -39,31 +39,26 @@ const vitals = [
   {
     slug: 'fp',
     heading: 'First Paint (FP)',
-    state: 'Fail',
     baseline: '4.57s',
   },
   {
     slug: 'fcp',
     heading: 'First Contentful Paint (FCP)',
-    state: 'Pass',
     baseline: '1.46s',
   },
   {
     slug: 'lcp',
     heading: 'Largest Contentful Paint (LCP)',
-    state: 'Pass',
     baseline: '1.34s',
   },
   {
     slug: 'fid',
     heading: 'First Input Delay (FID)',
-    state: 'Fail',
     baseline: '987.00ms',
   },
   {
     slug: 'cls',
     heading: 'Cumulative Layout Shift (CLS)',
-    state: 'Pass',
     baseline: '0.02',
   },
 ];
@@ -186,7 +181,6 @@ describe('Performance > Web Vitals', function () {
       expect(vitalCard.find('CardSectionHeading').text()).toEqual(
         expect.stringContaining(vitals[i].heading)
       );
-      expect(vitalCard.find('Tag').text()).toEqual(vitals[i].state);
       expect(vitalCard.find('StatNumber').text()).toEqual(vitals[i].baseline);
     });
     expect(vitalCards.find('BarChart')).toHaveLength(5);


### PR DESCRIPTION
- Removing web vitals passing/failing on summary overview
- Removing fail box and indicators on summary web vitals page
- Fixing tests to remove pass/fail state

**Unresolved:**
- [x] Need to conditionalize web vitals appearing on Frontend only
- [x] Fixing transactionSummary.spec.jsx

**Screenshots to confirm non-breakage:**
![Screen Shot 2021-03-31 at 3 54 21 PM](https://user-images.githubusercontent.com/4830259/113221198-6d54d780-9239-11eb-95f2-dcf62df2ff2f.png)
![Screen Shot 2021-03-31 at 3 54 12 PM](https://user-images.githubusercontent.com/4830259/113221199-6ded6e00-9239-11eb-841e-8e0169e66802.png)

**To be resolved in another PR:**
- Remove the flag organizations:performance-vitals-overview from sentry and getsentry