### PR TITLE
fix(ui): mark reviewed button now always the default style

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/actionSet.tsx
@@ -15,8 +15,6 @@ import space from 'app/styles/space';
 import {Organization, Project, ResolutionStatus} from 'app/types';
 import Projects from 'app/utils/projects';
 
-import {isForReviewQuery} from '../utils';
-
 import ResolveActions from './resolveActions';
 import ReviewAction from './reviewAction';
 import {ConfirmAction, getConfirm, getLabel} from './utils';
@@ -77,11 +75,7 @@ function ActionSet({
           position="bottom"
         >
           <div className="hidden-sm hidden-xs">
-            <ReviewAction
-              primary={isForReviewQuery(query)}
-              disabled={!anySelected}
-              onUpdate={onUpdate}
-            />
+            <ReviewAction disabled={!anySelected} onUpdate={onUpdate} />
           </div>
         </GuideAnchor>
       )}

--- a/src/sentry/static/sentry/app/views/issueList/actions/reviewAction.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/reviewAction.tsx
@@ -6,15 +6,14 @@ import {t} from 'app/locale';
 
 type Props = {
   onUpdate: (data?: any) => void;
-  primary?: boolean;
   disabled?: boolean;
 };
 
-function ReviewAction({disabled, primary, onUpdate}: Props) {
+function ReviewAction({disabled, onUpdate}: Props) {
   return (
     <ActionLink
       type="button"
-      priority={primary ? 'primary' : 'default'}
+      priority="default"
       disabled={disabled}
       onAction={() => onUpdate({inbox: false})}
       title={t('Mark Reviewed')}


### PR DESCRIPTION
On the Review List the Mark Reviewed button is purple but it looks like the state of a button – similar to the Issue Details page. So I’m making it consistent with other UI labels.

<img width="311" alt="CleanShot 2021-03-31 at 14 05 19@2x" src="https://user-images.githubusercontent.com/1900676/113211584-85712a80-922a-11eb-83c6-2ab5ae8e2a07.png">
