### PR TITLE
chore(group): Add stats to Group.get_first_release to see if the call to`tagstore.get_first_release` ever returns a result

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -23,6 +23,7 @@ from sentry.db.models import (
     Model,
     sane_repr,
 )
+from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
 from sentry.utils.numbers import base32_decode, base32_encode
 from sentry.utils.strings import strip, truncatechars
@@ -448,7 +449,10 @@ class Group(Model):
 
     def get_first_release(self):
         if self.first_release_id is None:
-            return tagstore.get_first_release(self.project_id, self.id)
+            first_release = tagstore.get_first_release(self.project_id, self.id)
+            found = "hit" if first_release is not None else "miss"
+            metrics.incr(f"group.get_first_release.tagstore.{found}")
+            return first_release
 
         return self.first_release.version
 


### PR DESCRIPTION
In a small number of groups I checked, when they had no `first_release_id`, the call to
`tagstore.get_first_release` also returned no release, and we had no releases for that group's
organization at all. Adding metrics here to validate that this call to `tagstore.get_first_release`
is unnecessary.

Ideally we want to remove this call so that we can stop hitting snuba as part of calculating suspect
owners in `post_process_group`. If it's unnecessary then this is an easy fix.