### PR TITLE
fix(ui): use correct font on incident marker

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -115,6 +115,7 @@ function createIncidentSeries(
         formatter: identifier || '-',
         color: lineColor,
         fontSize: 10,
+        fontFamily: 'Rubik',
       } as any,
     }),
     data: [],


### PR DESCRIPTION
Use Rubik for incident markers on the Alert Details page

### Before

<img width="890" alt="CleanShot 2021-03-31 at 14 46 54@2x" src="https://user-images.githubusercontent.com/1900676/113215612-f6671100-922f-11eb-9b54-54fc621eb0a8.png">


### After
<img width="876" alt="CleanShot 2021-03-31 at 14 46 33@2x" src="https://user-images.githubusercontent.com/1900676/113215617-f8c96b00-922f-11eb-8a1a-11ef2aedb0b5.png">
