### PR TITLE
fix(workflow): Use badge component on activity tab

### DIFF
--- a/src/sentry/static/sentry/app/components/badge.tsx
+++ b/src/sentry/static/sentry/app/components/badge.tsx
@@ -4,11 +4,14 @@ import styled from '@emotion/styled';
 import space from 'app/styles/space';
 
 type Props = React.HTMLProps<HTMLSpanElement> & {
+  children?: React.ReactNode;
   text?: string | number | null;
   className?: string;
 };
 
-const Badge = styled(({text, ...props}: Props) => <span {...props}>{text}</span>)<Props>`
+const Badge = styled(({text, children, ...props}: Props) => (
+  <span {...props}>{text ?? children}</span>
+))<Props>`
   display: inline-block;
   height: 20px;
   min-width: 20px;

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
@@ -22,7 +22,6 @@ import ListLink from 'app/components/links/listLink';
 import NavTabs from 'app/components/navTabs';
 import SeenByList from 'app/components/seenByList';
 import ShortId from 'app/components/shortId';
-import Tag from 'app/components/tag';
 import Tooltip from 'app/components/tooltip';
 import {IconChat} from 'app/icons';
 import {t} from 'app/locale';
@@ -293,10 +292,10 @@ class GroupHeader extends React.Component<Props, State> {
             disabled={disabledTabs.includes(TAB.ACTIVITY)}
           >
             {t('Activity')}
-            <StyledTag>
+            <Badge>
               <TabCount>{group.numComments}</TabCount>
               <IconChat size="xs" color="white" />
-            </StyledTag>
+            </Badge>
           </StyledListLink>
           <StyledListLink
             to={`${baseUrl}feedback/${location.search}`}
@@ -381,13 +380,6 @@ const StyledListLink = styled(ListLink)`
     margin-bottom: ${space(0.25)};
     vertical-align: middle;
   }
-`;
-
-const StyledTag = styled(Tag)`
-  div {
-    background-color: ${p => p.theme.badge.default.background};
-  }
-  margin-left: ${space(0.75)};
 `;
 
 const TabCount = styled('span')`

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/header.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 import omit from 'lodash/omit';
 import PropTypes from 'prop-types';
@@ -292,7 +293,12 @@ class GroupHeader extends React.Component<Props, State> {
             disabled={disabledTabs.includes(TAB.ACTIVITY)}
           >
             {t('Activity')}
-            <Badge>
+
+            <Badge
+              css={css`
+                padding: 0 ${space(1)};
+              `}
+            >
               <TabCount>{group.numComments}</TabCount>
               <IconChat size="xs" color="white" />
             </Badge>


### PR DESCRIPTION
switch to using the badge component

before 
<img width="338" alt="Screen Shot 2021-03-31 at 4 33 37 PM" src="https://user-images.githubusercontent.com/1400464/113225488-9e85d580-9242-11eb-9359-02c6f849bfb7.png">

after
<img width="344" alt="Screen Shot 2021-03-31 at 5 00 17 PM" src="https://user-images.githubusercontent.com/1400464/113225520-b2313c00-9242-11eb-9602-aca2f48d45ee.png">

