### PR TITLE
feat(breakdowns): Add ability to query span op breakdowns

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1688,16 +1688,20 @@ class NumericColumn(FunctionArg):
 
 
 class NumericColumnNoLookup(NumericColumn):
-    def __init__(self, name, allow_measurements_value=False):
+    def __init__(self, name, allow_array_value=False):
         super().__init__(name)
-        self.allow_measurements_value = allow_measurements_value
+        self.allow_array_value = allow_array_value
 
     def normalize(self, value, params):
-        # `measurement_value` is actually an array of Float64s. But when used
-        # in this context, we always want to expand it using `arrayJoin`. The
-        # resulting column will be a numeric column of type Float64.
-        if self.allow_measurements_value and value == "measurements_value":
-            return ["arrayJoin", ["measurements_value"]]
+        # `measurement_value` and `span_op_breakdowns_value` are actually an
+        # array of Float64s. But when used in this context, we always want to
+        # expand it using `arrayJoin`. The resulting column will be a numeric
+        # column of type Float64.
+        if self.allow_array_value:
+            if value == "measurements_value":
+                return ["arrayJoin", ["measurements_value"]]
+            if value == "span_op_breakdowns_value":
+                return ["arrayJoin", ["span_op_breakdowns_value"]]
 
         super().normalize(value, params)
         return value
@@ -2133,7 +2137,7 @@ FUNCTIONS = {
         Function(
             "histogram",
             required_args=[
-                NumericColumnNoLookup("column", allow_measurements_value=True),
+                NumericColumnNoLookup("column", allow_array_value=True),
                 # the bucket_size and start_offset should already be adjusted
                 # using the multiplier before it is passed here
                 NumberRange("bucket_size", 0, None),

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -36,6 +36,7 @@ from sentry.utils.snuba import (
     get_json_type,
     is_duration_measurement,
     is_measurement,
+    is_span_op_breakdown,
 )
 
 WILDCARD_CHARS = re.compile(r"[\*]")
@@ -268,11 +269,16 @@ class SearchKey(namedtuple("SearchKey", "name")):
             self.name not in SEARCH_MAP
             and self.name not in FIELD_ALIASES
             and not self.is_measurement
+            and not self.is_span_op_breakdown
         )
 
     @cached_property
     def is_measurement(self):
         return is_measurement(self.name) and self.name not in SEARCH_MAP
+
+    @cached_property
+    def is_span_op_breakdown(self):
+        return is_span_op_breakdown(self.name) and self.name not in SEARCH_MAP
 
 
 class AggregateFilter(namedtuple("AggregateFilter", "key operator value")):
@@ -382,7 +388,9 @@ class SearchVisitor(NodeVisitor):
         return key in self.numeric_keys or is_measurement(key)
 
     def is_duration_key(self, key):
-        return key in self.duration_keys or is_duration_measurement(key)
+        return (
+            key in self.duration_keys or is_duration_measurement(key) or is_span_op_breakdown(key)
+        )
 
     def is_percentage_key(self, key):
         return key in self.percentage_keys
@@ -1458,7 +1466,11 @@ def get_json_meta_type(field_alias, snuba_type, function=None):
                 if result_type is not None:
                     return result_type
 
-    if "duration" in field_alias or is_duration_measurement(field_alias):
+    if (
+        "duration" in field_alias
+        or is_duration_measurement(field_alias)
+        or is_span_op_breakdown(field_alias)
+    ):
         return "duration"
     if is_measurement(field_alias):
         return "number"
@@ -1560,7 +1572,7 @@ class FieldColumn(CountColumn):
     """ Allow any field column, of any type """
 
     def get_type(self, value):
-        if is_duration_measurement(value):
+        if is_duration_measurement(value) or is_span_op_breakdown(value):
             return "duration"
         elif value == "transaction.duration":
             return "duration"
@@ -1653,6 +1665,8 @@ class NumericColumn(FunctionArg):
         snuba_column = SEARCH_MAP.get(value)
         if not snuba_column and is_measurement(value):
             return value
+        if not snuba_column and is_span_op_breakdown(value):
+            return value
         if not snuba_column:
             raise InvalidFunctionArgument(f"{value} is not a valid column")
         elif snuba_column not in ["time", "timestamp", "duration"]:
@@ -1664,7 +1678,7 @@ class NumericColumn(FunctionArg):
 
     def get_type(self, value):
         snuba_column = self._normalize(value)
-        if is_duration_measurement(snuba_column):
+        if is_duration_measurement(snuba_column) or is_span_op_breakdown(snuba_column):
             return "duration"
         elif snuba_column == "duration":
             return "duration"
@@ -1693,6 +1707,8 @@ class DurationColumn(FunctionArg):
     def normalize(self, value, params):
         snuba_column = SEARCH_MAP.get(value)
         if not snuba_column and is_duration_measurement(value):
+            return value
+        if not snuba_column and is_span_op_breakdown(value):
             return value
         if not snuba_column:
             raise InvalidFunctionArgument(f"{value} is not a valid column")

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1725,7 +1725,7 @@ class DurationColumnNoLookup(DurationColumn):
 
 class StringArrayColumn(FunctionArg):
     def normalize(self, value, params):
-        if value in ["tags.key", "tags.value", "measurements_key"]:
+        if value in ["tags.key", "tags.value", "measurements_key", "span_op_breakdowns_key"]:
             return value
         raise InvalidFunctionArgument(f"{value} is not a valid string array column")
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1698,10 +1698,8 @@ class NumericColumnNoLookup(NumericColumn):
         # expand it using `arrayJoin`. The resulting column will be a numeric
         # column of type Float64.
         if self.allow_array_value:
-            if value == "measurements_value":
-                return ["arrayJoin", ["measurements_value"]]
-            if value == "span_op_breakdowns_value":
-                return ["arrayJoin", ["span_op_breakdowns_value"]]
+            if value in {"measurements_value", "span_op_breakdowns_value"}:
+                return ["arrayJoin", [value]]
 
         super().normalize(value, params)
         return value

--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -285,6 +285,7 @@ class EventSerializer(Serializer):
             "startTimestamp": obj.data.get("start_timestamp"),
             "endTimestamp": obj.data.get("timestamp"),
             "measurements": obj.data.get("measurements"),
+            "breakdowns": obj.data.get("breakdowns"),
         }
 
     def __serialize_error_attrs(self, attrs, obj):

--- a/src/sentry/data/samples/transaction.json
+++ b/src/sentry/data/samples/transaction.json
@@ -175,5 +175,24 @@
       "cls": {
          "value": 0.0382
       }
+   },
+   "breakdowns": {
+      "span_ops": {
+         "ops.http": {
+            "value": 2039.16049
+         },
+         "ops.db": {
+            "value": 91.876
+         },
+         "ops.resource": {
+            "value": 2024.234772
+         },
+         "ops.browser": {
+            "value": 633.474827
+         },
+         "total.time": {
+            "value": 2875.570536
+         }
+      }
    }
 }

--- a/src/sentry/snuba/events.py
+++ b/src/sentry/snuba/events.py
@@ -283,6 +283,20 @@ class Columns(Enum):
         "measurements.value",
         "measurements_value",
     )
+    SPAN_OP_BREAKDOWNS_KEYS = Column(
+        None,
+        None,
+        "span_op_breakdowns.key",
+        "span_op_breakdowns.key",
+        "span_op_breakdowns_key",
+    )
+    SPAN_OP_BREAKDOWNS_VALUES = Column(
+        None,
+        None,
+        "span_op_breakdowns.value",
+        "span_op_breakdowns.value",
+        "span_op_breakdowns_value",
+    )
     # Tracing context fields.
     TRACE_ID = Column(
         "events.contexts[trace.trace_id]",

--- a/tests/sentry/api/serializers/test_event.py
+++ b/tests/sentry/api/serializers/test_event.py
@@ -203,6 +203,8 @@ class EventSerializerTest(TestCase):
         assert "fingerprints" not in result
         assert "measurements" in result
         assert result["measurements"] == event_data["measurements"]
+        assert "breakdowns" in result
+        assert result["breakdowns"] == event_data["breakdowns"]
 
     def test_transaction_event_empty_spans(self):
         event_data = load_data("transaction")


### PR DESCRIPTION
Expose `span_op_breakdowns` fields to Sentry from Snuba added in https://github.com/getsentry/snuba/pull/1763

The query is `span_op_breakdowns.<key>` where `<key>` can be any non-empty string. For example `span_op_breakdowns.ops.browser`.

Another pull request will add span op breakdowns support for histograms. This pull-request contains some preliminary histogram support.