### PR TITLE
feat: Make Radio buttons be small via props

### DIFF
--- a/src/sentry/static/sentry/app/components/radio.tsx
+++ b/src/sentry/static/sentry/app/components/radio.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import {css} from '@emotion/core';
-import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
 import {growIn} from 'app/styles/animations';
 import {Theme} from 'app/utils/theme';
 
+type Props = {radioSize?: 'small'};
+
 type CheckedProps = React.HTMLProps<HTMLInputElement> & {
   theme: Theme;
-  radioSize?: 'small';
-};
+} & Props;
 
 const checkedCss = (p: CheckedProps) => css`
   display: block;
@@ -21,9 +21,7 @@ const checkedCss = (p: CheckedProps) => css`
   opacity: ${p.disabled ? 0.4 : null};
 `;
 
-const shouldForwardProp = p => p !== 'radioSize' && isPropValid(p);
-
-const Radio = styled('input', {shouldForwardProp})<{radioSize?: 'small'}>`
+const Radio = styled('input')<{radioSize?: 'small'}>`
   display: flex;
   padding: 0;
   width: ${p => (p.radioSize === 'small' ? '16px' : '1.5em')};

--- a/src/sentry/static/sentry/app/components/radio.tsx
+++ b/src/sentry/static/sentry/app/components/radio.tsx
@@ -1,27 +1,33 @@
 import React from 'react';
 import {css} from '@emotion/core';
+import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 
 import {growIn} from 'app/styles/animations';
 import {Theme} from 'app/utils/theme';
 
-type CheckedProps = React.HTMLProps<HTMLInputElement> & {theme: Theme};
+type CheckedProps = React.HTMLProps<HTMLInputElement> & {
+  theme: Theme;
+  radioSize?: 'small';
+};
 
 const checkedCss = (p: CheckedProps) => css`
   display: block;
-  width: 1rem;
-  height: 1rem;
+  width: ${p.radioSize === 'small' ? '8px' : '1rem'};
+  height: ${p.radioSize === 'small' ? '8px' : '1rem'};
   border-radius: 50%;
   background-color: ${p.theme.active};
   animation: 0.2s ${growIn} ease;
   opacity: ${p.disabled ? 0.4 : null};
 `;
 
-const Radio = styled('input')`
+const shouldForwardProp = p => p !== 'radioSize' && isPropValid(p);
+
+const Radio = styled('input', {shouldForwardProp})<{radioSize?: 'small'}>`
   display: flex;
   padding: 0;
-  width: 1.5em;
-  height: 1.5em;
+  width: ${p => (p.radioSize === 'small' ? '16px' : '1.5em')};
+  height: ${p => (p.radioSize === 'small' ? '16px' : '1.5em')};
   position: relative;
   border-radius: 50%;
   align-items: center;


### PR DESCRIPTION
For the span op breakdowns product feature, the radio button will need to be rendered in a smaller size.

Example of where it will be used:

<img width="267" alt="Screen Shot 2021-03-31 at 8 56 45 PM" src="https://user-images.githubusercontent.com/139499/113229495-1a911500-9265-11eb-8b7c-c969a7230cd9.png">
