### PR TITLE
feat(search): Handle IN search in snuba

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -49,6 +49,7 @@ NEGATION_MAP = {
     "IN": "NOT IN",
 }
 equality_operators = frozenset(["=", "IN"])
+inequality_operators = frozenset(["!=", "NOT IN"])
 
 RESULT_TYPES = {"duration", "string", "number", "integer", "percentage", "date"}
 

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -941,6 +941,9 @@ def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
         return [name, operator, like_value]
     elif name in ARRAY_FIELDS and search_filter.is_in_filter:
         operator = "=" if search_filter.operator == "IN" else "!="
+        # XXX: This `arrayConcat` usage is unnecessary, but we need it in place to
+        # trick the legacy Snuba language into not treating `name` as a
+        # function. Once we switch over to snql it can be removed.
         return [
             ["hasAny", [["arrayConcat", [name]], ["array", [f"'{v}'" for v in value]]]],
             operator,
@@ -961,13 +964,20 @@ def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
         return [name, search_filter.operator, internal_value]
     elif name == "issue.id":
         # Handle "has" queries
-        if search_filter.value.raw_value == "":
+        if (
+            search_filter.value.raw_value == ""
+            or search_filter.is_in_filter
+            and [v for v in value if not v]
+        ):
             # The state of having no issues is represented differently on transactions vs
             # other events. On the transactions table, it is represented by 0 whereas it is
             # represented by NULL everywhere else. We use coalesce here so we can treat this
             # consistently
             name = ["coalesce", [name, 0]]
-            value = 0
+            if search_filter.is_in_filter:
+                value = [v if v else 0 for v in value]
+            else:
+                value = 0
 
         # Skip isNull check on group_id value as we want to
         # allow snuba's prewhere optimizer to find this condition.
@@ -1059,7 +1069,11 @@ def convert_search_filter_to_snuba_query(search_filter, key=None, params=None):
 
         is_null_condition = None
         # TODO(wmak): Skip this for all non-nullable keys not just event.type
-        if search_filter.operator == "!=" and not search_filter.key.is_tag and name != "event.type":
+        if (
+            search_filter.operator in ("!=", "NOT IN")
+            and not search_filter.key.is_tag
+            and name != "event.type"
+        ):
             # Handle null columns on inequality comparisons. Any comparison
             # between a value and a null will result to null, so we need to
             # explicitly check for whether the condition is null, and OR it
@@ -1090,7 +1104,7 @@ def to_list(value):
 
 
 def format_search_filter(term, params):
-    project_to_filter = None  # Used to avoid doing multiple conditions on project ID
+    projects_to_filter = []  # Used to avoid doing multiple conditions on project ID
     conditions = []
     group_ids = None
     name = term.key.name
@@ -1098,55 +1112,76 @@ def format_search_filter(term, params):
     if name in (PROJECT_ALIAS, PROJECT_NAME_ALIAS):
         if term.operator == "=" and value == "":
             raise InvalidSearchQuery("Invalid query for 'has' search: 'project' cannot be empty.")
-        project = None
-        try:
-            project = Project.objects.get(id__in=params.get("project_id", []), slug=value)
-        except Exception as e:
-            if not isinstance(e, Project.DoesNotExist) or term.operator != "!=":
-                raise InvalidSearchQuery(
-                    f"Invalid query. Project {value} does not exist or is not an actively selected project."
-                )
-        else:
+        slugs = to_list(value)
+        projects = {
+            p.slug: p.id
+            for p in Project.objects.filter(id__in=params.get("project_id", []), slug__in=slugs)
+        }
+        missing = [slug for slug in slugs if slug not in projects]
+        if missing and term.operator not in ("!=", "NOT IN"):
+            raise InvalidSearchQuery(
+                f"Invalid query. Projects {missing} do not exist or are not actively selected."
+            )
+        project_ids = list(sorted(projects.values()))
+        if project_ids:
             # Create a new search filter with the correct values
-            term = SearchFilter(SearchKey("project_id"), term.operator, SearchValue(project.id))
+            term = SearchFilter(
+                SearchKey("project_id"),
+                term.operator,
+                SearchValue(project_ids if term.is_in_filter else project_ids[0]),
+            )
             converted_filter = convert_search_filter_to_snuba_query(term)
             if converted_filter:
-                if term.operator == "=":
-                    project_to_filter = project.id
-
+                if term.operator in equality_operators:
+                    projects_to_filter = project_ids
                 conditions.append(converted_filter)
     elif name == ISSUE_ID_ALIAS and value != "":
         # A blank term value means that this is a has filter
         group_ids = to_list(value)
     elif name == ISSUE_ALIAS:
         operator = term.operator
-        if value == "unknown":
-            # `unknown` is a special value for when there is no issue associated with the event
-            operator = "=" if term.operator == "=" else "!="
-            value = ""
-        elif value != "" and params and "organization_id" in params:
+        value = to_list(value)
+        group_short_ids = [v for v in value if v and v != "unknown"]
+        value = ["" for v in value if not v or v == "unknown"]
+
+        if group_short_ids and params and "organization_id" in params:
             try:
-                group = Group.objects.by_qualified_short_id(params["organization_id"], value)
+                groups = Group.objects.by_qualified_short_id_bulk(
+                    params["organization_id"],
+                    group_short_ids,
+                )
             except Exception:
-                raise InvalidSearchQuery(f"Invalid value '{value}' for 'issue:' filter")
+                raise InvalidSearchQuery(f"Invalid value '{group_short_ids}' for 'issue:' filter")
             else:
-                value = group.id
-        term = SearchFilter(SearchKey("issue.id"), operator, SearchValue(value))
+                value.extend([g.id for g in groups])
+
+        term = SearchFilter(
+            SearchKey("issue.id"),
+            operator,
+            SearchValue(value if term.is_in_filter else value[0]),
+        )
         converted_filter = convert_search_filter_to_snuba_query(term)
         conditions.append(converted_filter)
-    elif name == RELEASE_ALIAS and params and value == "latest":
+    elif (
+        name == RELEASE_ALIAS
+        and params
+        and (value == "latest" or term.is_in_filter and any(v for v in value if v == "latest"))
+    ):
+        value = [
+            parse_release(
+                v,
+                params["project_id"],
+                params.get("environment_objects"),
+                params.get("organization_id"),
+            )
+            for v in to_list(value)
+        ]
+
         converted_filter = convert_search_filter_to_snuba_query(
             SearchFilter(
                 term.key,
                 term.operator,
-                SearchValue(
-                    parse_release(
-                        value,
-                        params["project_id"],
-                        params.get("environment_objects"),
-                        params.get("organization_id"),
-                    )
-                ),
+                SearchValue(value if term.is_in_filter else value[0]),
             )
         )
         if converted_filter:
@@ -1156,7 +1191,7 @@ def format_search_filter(term, params):
         if converted_filter:
             conditions.append(converted_filter)
 
-    return conditions, project_to_filter, group_ids
+    return conditions, projects_to_filter, group_ids
 
 
 def convert_condition_to_function(cond):
@@ -1216,8 +1251,7 @@ def convert_snuba_condition_to_function(term, params=None):
     group_ids = []
     projects_to_filter = []
     if isinstance(term, SearchFilter):
-        conditions, project_to_filter, group_ids = format_search_filter(term, params)
-        projects_to_filter = [project_to_filter] if project_to_filter else []
+        conditions, projects_to_filter, group_ids = format_search_filter(term, params)
         group_ids = group_ids if group_ids else []
         if conditions:
             conditions_to_and = []
@@ -1385,13 +1419,14 @@ def get_filter(query=None, params=None):
         if group_ids is not None:
             kwargs["group_ids"].extend(list(set(group_ids)))
     else:
+        projects_to_filter = set()
         for term in parsed_terms:
             if isinstance(term, SearchFilter):
-                conditions, found_project_to_filter, group_ids = format_search_filter(term, params)
+                conditions, found_projects_to_filter, group_ids = format_search_filter(term, params)
                 if len(conditions) > 0:
                     kwargs["conditions"].extend(conditions)
-                if found_project_to_filter:
-                    projects_to_filter = [found_project_to_filter]
+                if found_projects_to_filter:
+                    projects_to_filter.update(found_projects_to_filter)
                 if group_ids is not None:
                     kwargs["group_ids"].extend(group_ids)
             elif isinstance(term, AggregateFilter):
@@ -1399,6 +1434,7 @@ def get_filter(query=None, params=None):
                 kwargs["condition_aggregates"].append(term.key.name)
                 if converted_filter:
                     kwargs["having"].append(converted_filter)
+        projects_to_filter = list(projects_to_filter)
 
     # Keys included as url params take precedent if same key is included in search
     # They are also considered safe and to have had access rules applied unlike conditions

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1166,7 +1166,7 @@ def format_search_filter(term, params):
     elif (
         name == RELEASE_ALIAS
         and params
-        and (value == "latest" or term.is_in_filter and any(v for v in value if v == "latest"))
+        and (value == "latest" or term.is_in_filter and any(v == "latest" for v in value))
     ):
         value = [
             parse_release(

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1121,7 +1121,7 @@ def format_search_filter(term, params):
         missing = [slug for slug in slugs if slug not in projects]
         if missing and term.operator not in ("!=", "NOT IN"):
             raise InvalidSearchQuery(
-                f"Invalid query. Projects {missing} do not exist or are not actively selected."
+                f"Invalid query. Project(s) {', '.join(missing)} do not exist or are not actively selected."
             )
         project_ids = list(sorted(projects.values()))
         if project_ids:

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1142,8 +1142,9 @@ def format_search_filter(term, params):
     elif name == ISSUE_ALIAS:
         operator = term.operator
         value = to_list(value)
+        # `unknown` is a special value for when there is no issue associated with the event
         group_short_ids = [v for v in value if v and v != "unknown"]
-        value = ["" for v in value if not v or v == "unknown"]
+        filter_values = ["" for v in value if not v or v == "unknown"]
 
         if group_short_ids and params and "organization_id" in params:
             try:
@@ -1154,12 +1155,12 @@ def format_search_filter(term, params):
             except Exception:
                 raise InvalidSearchQuery(f"Invalid value '{group_short_ids}' for 'issue:' filter")
             else:
-                value.extend([g.id for g in groups])
+                filter_values.extend([g.id for g in groups])
 
         term = SearchFilter(
             SearchKey("issue.id"),
             operator,
-            SearchValue(value if term.is_in_filter else value[0]),
+            SearchValue(filter_values if term.is_in_filter else filter_values[0]),
         )
         converted_filter = convert_search_filter_to_snuba_query(term)
         conditions.append(converted_filter)

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -1119,7 +1119,7 @@ def format_search_filter(term, params):
             for p in Project.objects.filter(id__in=params.get("project_id", []), slug__in=slugs)
         }
         missing = [slug for slug in slugs if slug not in projects]
-        if missing and term.operator not in ("!=", "NOT IN"):
+        if missing and term.operator in equality_operators:
             raise InvalidSearchQuery(
                 f"Invalid query. Project(s) {', '.join(missing)} do not exist or are not actively selected."
             )

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -2,11 +2,15 @@ import logging
 import math
 import re
 import warnings
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 from datetime import timedelta
 from enum import Enum
+from functools import reduce
+from operator import or_
+from typing import List, Set
 
 from django.db import models
+from django.db.models import Q
 from django.utils import timezone
 from django.utils.http import urlencode, urlquote
 from django.utils.translation import ugettext_lazy as _
@@ -188,21 +192,40 @@ def get_oldest_or_latest_event_for_environments(
 class GroupManager(BaseManager):
     use_for_related_fields = True
 
-    def by_qualified_short_id(self, organization_id, short_id):
-        short_id = parse_short_id(short_id)
-        if not short_id:
+    def by_qualified_short_id(self, organization_id: int, short_id: str):
+        return self.by_qualified_short_id_bulk(organization_id, [short_id])[0]
+
+    def by_qualified_short_id_bulk(self, organization_id: int, short_ids: List[str]):
+        short_ids = [parse_short_id(short_id) for short_id in short_ids]
+        if not short_ids or any(short_id for short_id in short_ids if short_id is None):
             raise Group.DoesNotExist()
-        return Group.objects.exclude(
-            status__in=[
-                GroupStatus.PENDING_DELETION,
-                GroupStatus.DELETION_IN_PROGRESS,
-                GroupStatus.PENDING_MERGE,
-            ]
-        ).get(
-            project__organization=organization_id,
-            project__slug=short_id.project_slug,
-            short_id=short_id.short_id,
+
+        project_short_id_lookup = defaultdict(list)
+        for short_id in short_ids:
+            project_short_id_lookup[short_id.project_slug].append(short_id.short_id)
+
+        short_id_lookup = reduce(
+            or_,
+            [
+                Q(project__slug=slug, short_id__in=short_ids)
+                for slug, short_ids in project_short_id_lookup.items()
+            ],
         )
+
+        groups: List[Group] = list(
+            Group.objects.exclude(
+                status__in=[
+                    GroupStatus.PENDING_DELETION,
+                    GroupStatus.DELETION_IN_PROGRESS,
+                    GroupStatus.PENDING_MERGE,
+                ]
+            ).filter(short_id_lookup, project__organization=organization_id)
+        )
+        group_lookup: Set[int] = {group.short_id for group in groups}
+        for short_id in short_ids:
+            if short_id.short_id not in group_lookup:
+                raise Group.DoesNotExist()
+        return groups
 
     def from_kwargs(self, project, **kwargs):
         from sentry.event_manager import EventManager, HashDiscarded

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1093,7 +1093,6 @@ def resolve_condition(cond, column_resolver):
     column_resolver (Function[string]) Function to resolve column names for the
                                        current dataset.
     """
-    # import pdb; pdb.set_trace()
     index = get_function_index(cond)
     # IN/NOT IN conditions are detected as a function but aren't really.
     if index is not None and cond[index] not in ("IN", "NOT IN"):

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -51,6 +51,7 @@ MAX_HASHES = 5000
 # in a single query to lessen the load on snuba
 MAX_FIELDS = 20
 
+SAFE_FUNCTIONS = frozenset(["NOT IN"])
 SAFE_FUNCTION_RE = re.compile(r"-?[a-zA-Z_][a-zA-Z0-9_]*$")
 # Match any text surrounded by quotes, can't use `.*` here since it
 # doesn't include new lines,
@@ -384,7 +385,9 @@ def get_function_index(column_expr, depth=0):
             # The assumption here is that a list that follows a string means
             # the string is a function name
             if isinstance(column_expr[i], str) and isinstance(column_expr[i + 1], (tuple, list)):
-                assert SAFE_FUNCTION_RE.match(column_expr[i])
+                assert column_expr[i] in SAFE_FUNCTIONS or SAFE_FUNCTION_RE.match(
+                    column_expr[i]
+                ), column_expr[i]
                 index = i
                 break
             else:
@@ -1090,13 +1093,11 @@ def resolve_condition(cond, column_resolver):
     column_resolver (Function[string]) Function to resolve column names for the
                                        current dataset.
     """
+    # import pdb; pdb.set_trace()
     index = get_function_index(cond)
-    if index is not None:
-        # IN conditions are detected as a function but aren't really.
-        if cond[index] == "IN":
-            cond[0] = column_resolver(cond[0])
-            return cond
-        elif cond[index] in FUNCTION_TO_OPERATOR:
+    # IN/NOT IN conditions are detected as a function but aren't really.
+    if index is not None and cond[index] not in ("IN", "NOT IN"):
+        if cond[index] in FUNCTION_TO_OPERATOR:
             func_args = cond[index + 1]
             for i, arg in enumerate(func_args):
                 if i == 0:
@@ -1120,6 +1121,8 @@ def resolve_condition(cond, column_resolver):
             # Nested function
             if isinstance(arg, (list, tuple)):
                 func_args[i] = resolve_condition(arg, column_resolver)
+            if isinstance(arg, set):
+                func_args[i] = arg
             else:
                 func_args[i] = column_resolver(arg)
         cond[index + 1] = func_args

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1121,8 +1121,6 @@ def resolve_condition(cond, column_resolver):
             # Nested function
             if isinstance(arg, (list, tuple)):
                 func_args[i] = resolve_condition(arg, column_resolver)
-            if isinstance(arg, set):
-                func_args[i] = arg
             else:
                 func_args[i] = column_resolver(arg)
         cond[index + 1] = func_args

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -2100,6 +2100,23 @@ class GetSnubaQueryArgsTest(TestCase):
             [["ifNull", ["tags[project_id]", "''"]], "=", "123"]
         ]
 
+    def test_in_syntax(self):
+        # TODO: Need to go over format_search_filter in detail and make sure we cover all
+        # cases
+        # _filter = get_filter("random_field:[123, 456]")
+        assert get_filter("environment:[prod, dev]").conditions == [
+            [["environment", "IN", {"prod", "dev"}]]
+        ]
+        assert get_filter("random_tag:[what, hi]").conditions == [
+            [["ifNull", ["random_tag", "''"]], "IN", ["what", "hi"]]
+        ]
+        # assert _filter.filter_keys == {}
+        # _filter = get_filter("random_field:[123, 456]")
+        # assert _filter.conditions == [
+        #     [[["isNull", ["user.email"]], "=", 1], ["random_field", "IN", ""]]
+        # ]
+        # assert _filter.filter_keys == {}
+
     def test_no_search(self):
         _filter = get_filter(
             params={

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1948,7 +1948,9 @@ class ParseBooleanSearchQueryTest(TestCase):
         project3 = self.create_project()
         with self.assertRaisesRegexp(
             InvalidSearchQuery,
-            f"Invalid query. Projects {re.escape(str([project3.slug]))} do not exist or are not actively selected.",
+            re.escape(
+                f"Invalid query. Project(s) {str(project3.slug)} do not exist or are not actively selected."
+            ),
         ):
             get_filter(
                 f"project:{project1.slug} OR project:{project3.slug}",
@@ -2435,7 +2437,7 @@ class GetSnubaQueryArgsTest(TestCase):
         exc = exc_info.value
         exc_str = f"{exc}"
         assert (
-            f"Invalid query. Projects {[p1.slug]} do not exist or are not actively selected."
+            f"Invalid query. Project(s) {p1.slug} do not exist or are not actively selected."
             in exc_str
         )
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -1,5 +1,4 @@
 import datetime
-import pytest
 import re
 import unittest
 from datetime import timedelta

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -2441,6 +2441,160 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert data[0]["issue.id"] == event.group_id
         assert data[0]["count_id"] == 2
 
+    def test_in_query_events(self):
+        project_1 = self.create_project()
+        data = load_data(
+            "python",
+            timestamp=before_now(minutes=1),
+            start_timestamp=before_now(minutes=1, seconds=5),
+        )
+        test_event = self.store_event(
+            data=data,
+            project_id=project_1.id,
+        )
+
+        event_1 = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": self.min_ago,
+                "fingerprint": ["group_1"],
+                "message": "group1",
+                "user": {"email": "hello@example.com"},
+                "environment": "prod",
+                "tags": {"random": "123"},
+                "stacktrace": {
+                    "frames": [{"filename": "src/app/group1.py", "abs_path": "src/app/group1.py"}]
+                },
+            },
+            project_id=project_1.id,
+        )
+        project_2 = self.create_project()
+        event_2 = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "timestamp": self.min_ago,
+                "fingerprint": ["group_2"],
+                "message": "group2",
+                "user": {"email": "bar@example.com"},
+                "environment": "staging",
+                "tags": {"random": "456"},
+                "stacktrace": {"frames": [{"filename": "src/app/group2.py"}]},
+            },
+            project_id=project_2.id,
+        )
+        project_3 = self.create_project()
+        event_3 = self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "timestamp": self.min_ago,
+                "fingerprint": ["group_3"],
+                "message": "group3",
+                "user": {"email": "foo@example.com"},
+                "environment": "canary",
+                "tags": {"random": "789"},
+            },
+            project_id=project_3.id,
+        )
+
+        def run_test_in_query(query, expected_events, expected_negative_events=None):
+            params = {
+                "field": ["id"],
+                "query": query,
+                "orderby": "id",
+            }
+            response = self.do_request(
+                params, {"organizations:discover-basic": True, "organizations:global-views": True}
+            )
+            assert response.status_code == 200, response.content
+            assert [row["id"] for row in response.data["data"]] == [
+                e.event_id for e in expected_events
+            ]
+
+            if expected_negative_events is not None:
+                params["query"] = f"!{query}"
+                response = self.do_request(
+                    params,
+                    {"organizations:discover-basic": True, "organizations:global-views": True},
+                )
+                assert response.status_code == 200, response.content
+                assert [row["id"] for row in response.data["data"]] == [
+                    e.event_id for e in expected_negative_events
+                ]
+
+        run_test_in_query("environment:[prod, staging]", [event_1, event_2], [event_3])
+        run_test_in_query("environment:[staging]", [event_2], [event_1, event_3])
+        run_test_in_query(
+            "user.email:[foo@example.com, hello@example.com]", [event_1, event_3], [event_2]
+        )
+        run_test_in_query("user.email:[foo@example.com]", [event_3], [event_1, event_2])
+        run_test_in_query(
+            "user.display:[foo@example.com, hello@example.com]", [event_1, event_3], [event_2]
+        )
+        run_test_in_query("message:[group2, group1]", [event_1, event_2], [event_3])
+        run_test_in_query("stack.filename:*.py", [test_event])
+        run_test_in_query("stack.filename:*.py", [event_1], [event_2, event_3])
+
+        # TODO: Make sure this is properly validated for perms
+        # run_test_in_query(f"issue.id:[{event_1.group_id},{event_2.group_id}]", [event_1, event_2], [event_3])
+        # TODO: Make sure this is properly validated for perms
+        # run_test_in_query(f"project_id:[{project_3.id},{project_2.id}]", [event_2, event_3], [event_1])
+        run_test_in_query("random:[789,456]", [event_2, event_3], [event_1])
+        # run_test_in_query("tags[random]:[789,456]", [event_2, event_3], [event_1])
+        # TODO: Test stack. and error. (with wildcards? or disallow?)
+        # TODO: Negations
+        assert False
+
+    def test_in_query_transactions(self):
+        project = self.create_project()
+        data = load_data(
+            "transaction",
+            timestamp=before_now(minutes=1),
+            start_timestamp=before_now(minutes=1, seconds=5),
+        )
+        data["event_id"] = "a" * 32
+        data["contexts"]["trace"]["status"] = "ok"
+        transaction_1 = self.store_event(data, project_id=project.id)
+
+        data = load_data(
+            "transaction",
+            timestamp=before_now(minutes=1),
+            start_timestamp=before_now(minutes=1, seconds=5),
+        )
+        data["event_id"] = "b" * 32
+        data["contexts"]["trace"]["status"] = "aborted"
+        transaction_2 = self.store_event(data, project_id=project.id)
+
+        data = load_data(
+            "transaction",
+            timestamp=before_now(minutes=1),
+            start_timestamp=before_now(minutes=1, seconds=5),
+        )
+        data["event_id"] = "c" * 32
+        data["contexts"]["trace"]["status"] = "already_exists"
+        transaction_3 = self.store_event(data, project_id=project.id)
+
+        def run_test_in_query(query, expected_events):
+            params = {
+                "field": ["id"],
+                "query": query,
+                "orderby": "id",
+            }
+            response = self.do_request(
+                params, {"organizations:discover-basic": True, "organizations:global-views": True}
+            )
+            assert response.status_code == 200, response.content
+            print(response.content)
+            assert [row["id"] for row in response.data["data"]] == [
+                e.event_id for e in expected_events
+            ]
+
+        run_test_in_query(
+            "transaction.status:[aborted, already_exists]", [transaction_2, transaction_3]
+        )
+        run_test_in_query("!transaction.status:[aborted, already_exists]", [transaction_1])
+
+        assert False
+
     def test_messed_up_function_values(self):
         # TODO (evanh): It would be nice if this surfaced an error to the user.
         # The problem: The && causes the parser to treat that term not as a bad

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -265,11 +265,10 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         }
         response = self.do_request(query)
         assert response.status_code == 400, response.content
-        assert response.data[
-            "detail"
-        ] == "Invalid query. Projects %s do not exist or are not actively selected." % [
-            project.slug
-        ]
+        assert (
+            response.data["detail"]
+            == f"Invalid query. Project(s) {project.slug} do not exist or are not actively selected."
+        )
 
     def test_project_in_query_does_not_exist(self):
         project = self.create_project()
@@ -284,7 +283,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 400, response.content
         assert (
             response.data["detail"]
-            == "Invalid query. Projects ['morty'] do not exist or are not actively selected."
+            == "Invalid query. Project(s) morty do not exist or are not actively selected."
         )
 
     def test_not_project_in_query_but_in_header(self):


### PR DESCRIPTION
This builds on the grammar work done in https://github.com/getsentry/sentry/pull/24692

In this pr put in search capabilities into the the converters that take `SearchFilters` generated by the parser and convert them 
into snuba queries. This should enable `IN` search to work in discover.

I'll follow this up with a final pr to make `IN` search also work in issue search.