### PR TITLE
fix(dashboards): Do not validate y-axis options for non-timeseries widgets

### DIFF
--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -101,6 +101,11 @@ function WidgetQueryFields({
     (['line', 'area', 'stacked_area', 'bar'].includes(displayType) &&
       fields.length === 3);
 
+  // Any column choice for World Map and Big Number widgets is legal since the
+  // data source is from an endpoint that is not timeseries-based.
+  // Column builder for Table widget is already handled above.
+  const doNotValidateYAxis = ['world_map', 'big_number'].includes(displayType);
+
   return (
     <Field
       data-test-id="y-axis"
@@ -119,7 +124,8 @@ function WidgetQueryFields({
             fieldOptions={fieldOptions}
             onChange={value => handleChangeField(value, i)}
             filterPrimaryOptions={option => {
-              if (option.value.kind === FieldValueKind.FUNCTION) {
+              // Only validate functions for timeseries widgets.
+              if (!doNotValidateYAxis && option.value.kind === FieldValueKind.FUNCTION) {
                 const primaryOutput = aggregateFunctionOutputType(
                   option.value.meta.name,
                   undefined
@@ -133,6 +139,11 @@ function WidgetQueryFields({
               return option.value.kind === FieldValueKind.FUNCTION;
             }}
             filterAggregateParameters={option => {
+              // Only validate function parameters for timeseries widgets.
+              if (doNotValidateYAxis) {
+                return true;
+              }
+
               if (option.value.kind === FieldValueKind.FUNCTION) {
                 // Functions are not legal options as an aggregate/function parameter.
                 return false;

--- a/tests/js/sentry-test/select-new.js
+++ b/tests/js/sentry-test/select-new.js
@@ -37,6 +37,11 @@ export function selectByLabel(wrapper, label, options = {}) {
   findOption(wrapper, {label}, options).at(0).simulate('click');
 }
 
+export function getOptionByLabel(wrapper, label, options = {}) {
+  openMenu(wrapper, options);
+  return findOption(wrapper, {label}, options).at(0);
+}
+
 export function selectByValue(wrapper, value, options = {}) {
   openMenu(wrapper, options);
   findOption(wrapper, {value}, options).at(0).simulate('click');

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {selectByLabel} from 'sentry-test/select-new';
+import {getOptionByLabel, selectByLabel} from 'sentry-test/select-new';
 
 import AddDashboardWidgetModal from 'app/components/modals/addDashboardWidgetModal';
 import TagStore from 'app/stores/tagStore';
@@ -67,6 +67,10 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/eventsv2/',
       body: {data: [{'event.type': 'error'}], meta: {'event.type': 'string'}},
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-geo/',
+      body: {data: [], meta: {}},
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/recent-searches/',
@@ -417,5 +421,109 @@ describe('Modals -> AddDashboardWidgetModal', function () {
 
     expect(widget.queries).toHaveLength(1);
     expect(widget.queries[0].fields).toEqual(['p95(transaction.duration)']);
+  });
+
+  it('should filter non-legal y-axis choices for timeseries widget charts', async function () {
+    let widget = undefined;
+    const wrapper = mountModal({
+      initialData,
+      onAddWidget: data => (widget = data),
+    });
+    // No delete button as there is only one field.
+    expect(wrapper.find('IconDelete')).toHaveLength(0);
+
+    selectByLabel(wrapper, 'any(\u2026)', {
+      name: 'field',
+      at: 0,
+      control: true,
+    });
+
+    // Expect user.display to not be an available parameter option for any()
+    // for line (timeseries) widget charts
+    const option = getOptionByLabel(wrapper, 'user.display', {
+      name: 'parameter',
+      at: 0,
+      control: true,
+    });
+    expect(option.exists()).toEqual(false);
+
+    // Be able to choose a numeric-like option for any()
+    selectByLabel(wrapper, 'measurements.lcp', {
+      name: 'parameter',
+      at: 0,
+      control: true,
+    });
+
+    await clickSubmit(wrapper);
+
+    expect(widget.displayType).toEqual('line');
+    expect(widget.queries).toHaveLength(1);
+    expect(widget.queries[0].fields).toEqual(['any(measurements.lcp)']);
+  });
+
+  it('should not filter y-axis choices for big number widget charts', async function () {
+    let widget = undefined;
+    const wrapper = mountModal({
+      initialData,
+      onAddWidget: data => (widget = data),
+    });
+    // No delete button as there is only one field.
+    expect(wrapper.find('IconDelete')).toHaveLength(0);
+
+    // Select Big number display
+    selectByLabel(wrapper, 'Big Number', {name: 'displayType', at: 0, control: true});
+    expect(getDisplayType(wrapper).props().value).toEqual('big_number');
+
+    selectByLabel(wrapper, 'count_unique(\u2026)', {
+      name: 'field',
+      at: 0,
+      control: true,
+    });
+
+    // Be able to choose a non numeric-like option for count_unique()
+    selectByLabel(wrapper, 'user.display', {
+      name: 'parameter',
+      at: 0,
+      control: true,
+    });
+
+    await clickSubmit(wrapper);
+
+    expect(widget.displayType).toEqual('big_number');
+    expect(widget.queries).toHaveLength(1);
+    expect(widget.queries[0].fields).toEqual(['count_unique(user.display)']);
+  });
+
+  it('should not filter y-axis choices for world map widget charts', async function () {
+    let widget = undefined;
+    const wrapper = mountModal({
+      initialData,
+      onAddWidget: data => (widget = data),
+    });
+    // No delete button as there is only one field.
+    expect(wrapper.find('IconDelete')).toHaveLength(0);
+
+    // Select World Map display
+    selectByLabel(wrapper, 'World Map', {name: 'displayType', at: 0, control: true});
+    expect(getDisplayType(wrapper).props().value).toEqual('world_map');
+
+    selectByLabel(wrapper, 'count_unique(\u2026)', {
+      name: 'field',
+      at: 0,
+      control: true,
+    });
+
+    // Be able to choose a non numeric-like option for count_unique()
+    selectByLabel(wrapper, 'user.display', {
+      name: 'parameter',
+      at: 0,
+      control: true,
+    });
+
+    await clickSubmit(wrapper);
+
+    expect(widget.displayType).toEqual('world_map');
+    expect(widget.queries).toHaveLength(1);
+    expect(widget.queries[0].fields).toEqual(['count_unique(user.display)']);
   });
 });


### PR DESCRIPTION
Fix for regression introduced in https://github.com/getsentry/sentry/pull/24840

Y-axis options should not be validated for World Map and Big Number widgets.