### PR TITLE
feat(sdk): Add timeOrigin tags

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap/initializeSdk.tsx
+++ b/src/sentry/static/sentry/app/bootstrap/initializeSdk.tsx
@@ -3,6 +3,7 @@ import {ExtraErrorData} from '@sentry/integrations';
 import * as Sentry from '@sentry/react';
 import SentryRRWeb from '@sentry/rrweb';
 import {Integrations} from '@sentry/tracing';
+import {_browserPerformanceTimeOriginMode} from '@sentry/utils';
 
 import {DISABLE_RR_WEB, SPA_DSN} from 'app/constants';
 import {Config} from 'app/types';
@@ -77,6 +78,13 @@ export function initializeSdk(config: Config, {routes}: {routes?: Function} = {}
       : sentryConfig?.whitelistUrls,
     integrations: getSentryIntegrations(hasReplays, routes),
     tracesSampleRate,
+  });
+
+  // Track timeOrigin Selection by the SDK to see if it improves transaction durations
+  Sentry.addGlobalEventProcessor((event: Sentry.Event, _hint?: Sentry.EventHint) => {
+    event.tags = event.tags || {};
+    event.tags['timeOrigin.mode'] = _browserPerformanceTimeOriginMode;
+    return event;
   });
 
   if (userIdentity) {


### PR DESCRIPTION
- This also adds a tag `timeOrigin.mode` so we can track how often we're
  changing timeOrigin to get a better calculation
- This now depends on https://github.com/getsentry/sentry/pull/25217 getting merged first to get the SDK update
- More context https://github.com/getsentry/sentry-javascript/pull/3356 and https://github.com/getsentry/sentry-javascript/issues/2590