### PR TITLE
feat(django): Move `window.__initialData` definition to a template block

### DIFF
--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -31,7 +31,7 @@
 
   <title>{% block title %}Sentry{% endblock %}</title>
 
-  {% block initial-data %}
+  {% block initial_data %}
     {% script %}
     <script>
       window.__initialData = {% get_react_config %};

--- a/src/sentry/templates/sentry/layout.html
+++ b/src/sentry/templates/sentry/layout.html
@@ -31,11 +31,13 @@
 
   <title>{% block title %}Sentry{% endblock %}</title>
 
-  {% script %}
-  <script>
-    window.__initialData = {% get_react_config %};
-  </script>
-  {% endscript %}
+  {% block initial-data %}
+    {% script %}
+    <script>
+      window.__initialData = {% get_react_config %};
+    </script>
+    {% endscript %}
+  {% endblock %}
 
   {% script %}
     {% include "sentry/partial/preload-data.html" %}


### PR DESCRIPTION
This will allow it to be overriden (e.g. in getsentry).