### PR TITLE
test: Fix issueless eventstream test so it works with the errors storage

### DIFF
--- a/tests/snuba/eventstream/test_eventstream.py
+++ b/tests/snuba/eventstream/test_eventstream.py
@@ -2,6 +2,8 @@ from datetime import datetime, timedelta
 import time
 import logging
 from sentry.utils.compat.mock import patch, Mock
+from sentry.utils.samples import load_data
+
 
 from sentry.event_manager import EventManager
 from sentry.eventstream.kafka import KafkaEventStream
@@ -27,6 +29,11 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
             "tags": [],
         }
         manager = EventManager(raw_event)
+        manager.normalize()
+        return manager.save(self.project.id)
+
+    def __build_transaction_event(self):
+        manager = EventManager(load_data("transaction"))
         manager.normalize()
         return manager.save(self.project.id)
 
@@ -82,8 +89,7 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
     @patch("sentry.eventstream.insert")
     def test_issueless(self, mock_eventstream_insert):
         now = datetime.utcnow()
-        event = self.__build_event(now)
-
+        event = self.__build_transaction_event()
         event.group_id = None
         insert_args = ()
         insert_kwargs = {
@@ -99,11 +105,11 @@ class SnubaEventStreamTest(TestCase, SnubaTestCase):
 
         self.__produce_event(*insert_args, **insert_kwargs)
         result = snuba.raw_query(
+            dataset=snuba.Dataset.Transactions,
             start=now - timedelta(days=1),
             end=now + timedelta(days=1),
-            selected_columns=["event_id", "group_id"],
+            selected_columns=["event_id"],
             groupby=None,
             filter_keys={"project_id": [self.project.id], "event_id": [event.event_id]},
         )
         assert len(result["data"]) == 1
-        assert result["data"][0]["group_id"] is None


### PR DESCRIPTION
Rewrite the issueless event eventstream test so it passes for both the
events and errors storages. The only valid issueless event is a transaction
event - we do not support errors and other event types as issueless like
the example in this test previously was.