### PR TITLE
feat(trace-view): Add broken traces warnings to trace view

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
@@ -3,12 +3,14 @@ import {Params} from 'react-router/lib/Router';
 import * as Sentry from '@sentry/react';
 import {Location} from 'history';
 
+import Alert from 'app/components/alert';
 import * as DividerHandlerManager from 'app/components/events/interfaces/spans/dividerHandlerManager';
 import FeatureBadge from 'app/components/featureBadge';
 import * as Layout from 'app/components/layouts/thirds';
 import LoadingError from 'app/components/loadingError';
 import LoadingIndicator from 'app/components/loadingIndicator';
 import TimeSince from 'app/components/timeSince';
+import {IconInfo} from 'app/icons';
 import {t, tct, tn} from 'app/locale';
 import {Organization} from 'app/types';
 import {getDuration} from 'app/utils/formatters';
@@ -28,7 +30,7 @@ import {
 } from './styles';
 import TransactionGroup from './transactionGroup';
 import {TraceInfo, TreeDepth} from './types';
-import {getTraceInfo} from './utils';
+import {getTraceInfo, isRootTransaction} from './utils';
 
 type AccType = {
   renderedChildren: React.ReactNode[];
@@ -167,6 +169,50 @@ class TraceDetailsContent extends React.Component<Props, State> {
         />
       </TraceDetailHeader>
     );
+  }
+
+  renderTraceWarnings() {
+    const {traces} = this.props;
+
+    const {roots, orphans} = (traces ?? []).reduce(
+      (counts, trace) => {
+        if (isRootTransaction(trace)) {
+          counts.roots++;
+        } else {
+          counts.orphans++;
+        }
+        return counts;
+      },
+      {roots: 0, orphans: 0}
+    );
+
+    let warning: React.ReactNode = null;
+
+    if (roots === 0 && orphans > 0) {
+      warning = (
+        <Alert type="info" icon={<IconInfo size="md" />}>
+          {t(
+            'A root Transaction is missing. Transaction linked by a dashed line have been orphaned and cannot be directly linked to the root.'
+          )}
+        </Alert>
+      );
+    } else if (roots === 1 && orphans > 0) {
+      warning = (
+        <Alert type="info" icon={<IconInfo size="md" />}>
+          {t(
+            'This trace has broken subtraces. Transaction linked by a dashed line have been orphaned and cannot be directly linked to the root.'
+          )}
+        </Alert>
+      );
+    } else if (roots > 1) {
+      warning = (
+        <Alert type="info" icon={<IconInfo size="md" />}>
+          {t('Multiple root transactions have been found with this trace ID.')}
+        </Alert>
+      );
+    }
+
+    return warning;
   }
 
   renderInfoMessage({
@@ -326,7 +372,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
         const result = this.renderTransaction(trace, {
           ...acc,
           // if the root of a subtrace has a parent_span_idk, then it must be an orphan
-          isOrphan: trace.parent_span_id !== null,
+          isOrphan: !isRootTransaction(trace),
           isLast: isLastTransaction,
           continuingDepths:
             !isLastTransaction && hasChildren
@@ -397,6 +443,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
         <React.Fragment>
           {this.renderSearchBar()}
           {this.renderTraceHeader(traceInfo)}
+          {this.renderTraceWarnings()}
           {this.renderTraceView(traceInfo)}
         </React.Fragment>
       );

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
@@ -57,6 +57,7 @@ export const TraceDetailHeader = styled('div')`
   grid-template-columns: repeat(3, 1fr);
   grid-gap: ${space(2)};
   margin-top: ${space(2)};
+  margin-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     grid-template-columns: minmax(160px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr) 6fr;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/utils.tsx
@@ -78,3 +78,8 @@ export function isTraceFullDetailed(transaction): transaction is TraceFullDetail
 export {getDurationDisplay} from 'app/components/events/interfaces/spans/spanBar';
 
 export {getHumanDuration, toPercent} from 'app/components/events/interfaces/spans/utils';
+
+export function isRootTransaction(trace: TraceFullDetailed): boolean {
+  // Root transactions has no parent_span_id
+  return trace.parent_span_id === null;
+}


### PR DESCRIPTION
Traces can be broken for various reasons like missing a root, missing an
intermediate transaction. This adds warnings to the trace view to indicate these
situations have occurred.