### PR TITLE
fix(ui): Don't show divider if org or user is missing

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarDropdown/index.tsx
@@ -119,10 +119,11 @@ const SidebarDropdown = ({api, org, orientation, collapsed, config, user}: Props
                 </React.Fragment>
               )}
 
+              {hasOrganization && user && <Divider />}
+
               <DemoModeGate>
                 {!!user && (
                   <React.Fragment>
-                    <Divider />
                     <UserSummary to="/settings/account/details/">
                       <UserBadgeNoOverflow user={user} avatarSize={32} />
                     </UserSummary>


### PR DESCRIPTION
This thing

![image](https://user-images.githubusercontent.com/1421724/113350618-8f5c6180-92ee-11eb-90a6-b35f835991f5.png)
