### PR TITLE
ref(frontend): Allow failed org access to still render the page

### DIFF
--- a/src/sentry/static/sentry/app/constants/index.tsx
+++ b/src/sentry/static/sentry/app/constants/index.tsx
@@ -243,6 +243,7 @@ export const FILTER_MASK = '[Filtered]';
 // Errors that may occur during the fetching of organization details
 export const ORGANIZATION_FETCH_ERROR_TYPES = {
   ORG_NOT_FOUND: 'ORG_NOT_FOUND',
+  ORG_NO_ACCESS: 'ORG_NO_ACCESS',
 };
 
 export const CONFIG_DOCS_URL = 'https://develop.sentry.dev/config/';

--- a/src/sentry/static/sentry/app/stores/organizationStore.tsx
+++ b/src/sentry/static/sentry/app/stores/organizationStore.tsx
@@ -76,6 +76,9 @@ const storeConfig: Reflux.StoreDefinition & OrganizationStoreInterface = {
     this.errorType = null;
 
     switch (err?.status) {
+      case 401:
+        this.errorType = ORGANIZATION_FETCH_ERROR_TYPES.ORG_NO_ACCESS;
+        break;
       case 404:
         this.errorType = ORGANIZATION_FETCH_ERROR_TYPES.ORG_NOT_FOUND;
         break;

--- a/src/sentry/static/sentry/app/utils/getPreloadedData.ts
+++ b/src/sentry/static/sentry/app/utils/getPreloadedData.ts
@@ -1,7 +1,7 @@
 export async function getPreloadedDataPromise(
   name: string,
   slug: string,
-  fallback,
+  fallback: () => Promise<any>,
   isInitialFetch?: boolean
 ) {
   try {

--- a/src/sentry/static/sentry/app/views/organizationContext.tsx
+++ b/src/sentry/static/sentry/app/views/organizationContext.tsx
@@ -323,6 +323,10 @@ class OrganizationContext extends React.Component<Props, State> {
     let errorComponent: React.ReactElement;
 
     switch (this.state.errorType) {
+      case ORGANIZATION_FETCH_ERROR_TYPES.ORG_NO_ACCESS:
+        // We can still render when an org can't be loaded due to 401. The
+        // backend will handle redirects when this is a problem.
+        return this.renderBody();
       case ORGANIZATION_FETCH_ERROR_TYPES.ORG_NOT_FOUND:
         errorComponent = (
           <Alert type="error">
@@ -335,6 +339,18 @@ class OrganizationContext extends React.Component<Props, State> {
     }
 
     return <ErrorWrapper>{errorComponent}</ErrorWrapper>;
+  }
+
+  renderBody() {
+    return (
+      <DocumentTitle title={this.getTitle()}>
+        <div className="app">
+          {this.state.hooks}
+          {this.renderSidebar()}
+          {this.props.children}
+        </div>
+      </DocumentTitle>
+    );
   }
 
   render() {
@@ -355,15 +371,7 @@ class OrganizationContext extends React.Component<Props, State> {
       );
     }
 
-    return (
-      <DocumentTitle title={this.getTitle()}>
-        <div className="app">
-          {this.state.hooks}
-          {this.renderSidebar()}
-          {this.props.children}
-        </div>
-      </DocumentTitle>
-    );
+    return this.renderBody();
   }
 }
 


### PR DESCRIPTION
This is a little tricky.. without this you can't get to your account settings (in single org mode).

But now if you navigate once the app has loaded to some org page, it will not be happy. The only way I can figure out how to do that though is by clicking `Settings` in the breadcrumbs.

This will usually happen when the user isn't part of an org, but they
should still be able to access their user settings