### PR TITLE
feat(breakdowns): Add span op breakdown support for histograms

### DIFF
--- a/src/sentry/api/endpoints/organization_events_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_histogram.py
@@ -25,7 +25,7 @@ class HistogramSerializer(serializers.Serializer):
         if len(fields) > 1:
             # Due to how the data is stored in snuba, multihistograms
             # are only possible when they are all measurements or all span op breakdowns.
-            histogram_type = discover.check_histogram_fields(fields)
+            histogram_type = discover.check_multihistogram_fields(fields)
             if not histogram_type:
                 detail = "You can only generate histogram for one column at a time unless they are all measurements or all span op breakdowns."
                 raise serializers.ValidationError(detail)

--- a/src/sentry/api/endpoints/organization_events_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_histogram.py
@@ -5,17 +5,17 @@ from rest_framework.response import Response
 from sentry import features
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.snuba import discover
-from sentry.utils.snuba import is_measurement
+from sentry.utils.snuba import is_measurement, is_span_op_breakdown
 
-# The maximum number of measurements allowed to be queried at at time
-MAX_MEASUREMENTS = 4
+# The maximum number of array columns allowed to be queried at at time
+MAX_ARRAY_COLS = 4
 
 DATA_FILTERS = ["all", "exclude_outliers"]
 
 
 class HistogramSerializer(serializers.Serializer):
     query = serializers.CharField(required=False)
-    field = serializers.ListField(allow_empty=False, max_length=MAX_MEASUREMENTS)
+    field = serializers.ListField(allow_empty=False, max_length=MAX_ARRAY_COLS)
     numBuckets = serializers.IntegerField(min_value=1, max_value=100)
     precision = serializers.IntegerField(default=0, min_value=0, max_value=4)
     min = serializers.FloatField(required=False)
@@ -25,9 +25,12 @@ class HistogramSerializer(serializers.Serializer):
     def validate_field(self, fields):
         if len(fields) > 1:
             # Due to how the data is stored in snuba, multihistograms
-            # are only possible when they are all measurements.
-            if any(not is_measurement(field) for field in fields):
-                detail = "You can only generate histogram for one column at a time unless they are all measurements."
+            # are only possible when they are all measurements or all span op breakdowns.
+            if not (
+                all(is_measurement(field) for field in fields)
+                or all(is_span_op_breakdown(field) for field in fields)
+            ):
+                detail = "You can only generate histogram for one column at a time unless they are all measurements or all span op breakdowns."
                 raise serializers.ValidationError(detail)
         return fields
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -45,6 +45,7 @@ __all__ = (
     "transform_data",
     "zerofill",
     "histogram_query",
+    "check_histogram_fields",
 )
 
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -904,14 +904,12 @@ def histogram_query(
     histogram_function = None
     conditions = []
     if len(fields) > 1:
-        histogram_type = check_histogram_fields(fields)
-        if histogram_type == "measurements":
+        array_column = check_histogram_fields(fields)
+        if array_column == "measurements":
             key_column = "array_join(measurements_key)"
-            array_column = "measurements"
             histogram_function = get_measurement_name
-        elif histogram_type == "op_breakdown":
+        elif array_column == "span_op_breakdowns":
             key_column = "array_join(span_op_breakdowns_key)"
-            array_column = "span_op_breakdowns"
             histogram_function = get_span_op_breakdown_name
         else:
             raise InvalidSearchQuery(
@@ -1153,7 +1151,7 @@ def check_histogram_fields(fields):
     """
     Returns histogram type if all the given fields are of the same histogram type.
     Return false otherwise, or if any of the fields are not a compatible histogram type.
-    Possible histogram types: measurements, op_breakdown
+    Possible histogram types: measurements, span_op_breakdowns
 
     :param [str] fields: The list of fields for which you want to generate histograms for.
     """
@@ -1163,11 +1161,11 @@ def check_histogram_fields(fields):
             if is_measurement(field):
                 histogram_type = "measurements"
             elif is_span_op_breakdown(field):
-                histogram_type = "op_breakdown"
+                histogram_type = "span_op_breakdowns"
             else:
                 return False
         elif histogram_type == "measurements" and not is_measurement(field):
             return False
-        elif histogram_type == "op_breakdown" and not is_span_op_breakdown(field):
+        elif histogram_type == "span_op_breakdowns" and not is_span_op_breakdown(field):
             return False
     return histogram_type

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -961,10 +961,7 @@ def get_histogram_column(fields, key_column, histogram_params, array_column):
     :param HistogramParms histogram_params: The histogram parameters used.
     :param str array_column: Array column prefix
     """
-    array_column_value = "measurements_value"
-    if array_column:
-        array_column_value = f"{array_column}_value"
-    field = fields[0] if key_column is None else array_column_value
+    field = fields[0] if key_column is None else f"{array_column}_value"
     return f"histogram({field}, {histogram_params.bucket_size:d}, {histogram_params.start_offset:d}, {histogram_params.multiplier:d})"
 
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -45,7 +45,7 @@ __all__ = (
     "transform_data",
     "zerofill",
     "histogram_query",
-    "check_histogram_fields",
+    "check_multihistogram_fields",
 )
 
 
@@ -904,7 +904,7 @@ def histogram_query(
     histogram_function = None
     conditions = []
     if len(fields) > 1:
-        array_column = check_histogram_fields(fields)
+        array_column = check_multihistogram_fields(fields)
         if array_column == "measurements":
             key_column = "array_join(measurements_key)"
             histogram_function = get_measurement_name

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1144,9 +1144,9 @@ def normalize_histogram_results(fields, key_column, histogram_params, results, a
     return new_data
 
 
-def check_histogram_fields(fields):
+def check_multihistogram_fields(fields):
     """
-    Returns histogram type if all the given fields are of the same histogram type.
+    Returns multihistogram type if all the given fields are of the same histogram type.
     Return false otherwise, or if any of the fields are not a compatible histogram type.
     Possible histogram types: measurements, span_op_breakdowns
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -10,6 +10,8 @@ from sentry.testutils.helpers.datetime import iso_format, before_now
 from sentry.utils.samples import load_data
 from sentry.utils.snuba import Dataset
 
+ARRAY_COLUMNS = ["measurements", "span_op_breakdowns"]
+
 
 class QueryIntegrationTest(SnubaTestCase, TestCase):
     def setUp(self):
@@ -515,23 +517,25 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
 
         # using private functions in an aggregation without access should error
         with pytest.raises(InvalidSearchQuery, match="histogram: no access to private function"):
-            discover.query(
-                selected_columns=["histogram(measurements_value, 1,0,1)"],
-                query="histogram(measurements_value, 1,0,1):>0",
-                params={"project_id": [self.project.id]},
-                use_aggregate_conditions=True,
-            )
+            for array_column in ARRAY_COLUMNS:
+                discover.query(
+                    selected_columns=[f"histogram({array_column}_value, 1,0,1)"],
+                    query=f"histogram({array_column}_value, 1,0,1):>0",
+                    params={"project_id": [self.project.id]},
+                    use_aggregate_conditions=True,
+                )
 
         # using private functions in an aggregation without access should error
         # with auto aggregation on
         with pytest.raises(InvalidSearchQuery, match="histogram: no access to private function"):
-            discover.query(
-                selected_columns=["count()"],
-                query="histogram(measurements_value, 1,0,1):>0",
-                params={"project_id": [self.project.id]},
-                auto_aggregations=True,
-                use_aggregate_conditions=True,
-            )
+            for array_column in ARRAY_COLUMNS:
+                discover.query(
+                    selected_columns=["count()"],
+                    query=f"histogram({array_column}_value, 1,0,1):>0",
+                    params={"project_id": [self.project.id]},
+                    auto_aggregations=True,
+                    use_aggregate_conditions=True,
+                )
 
     def test_any_function(self):
         data = load_data("transaction", timestamp=before_now(seconds=3))
@@ -1643,131 +1647,132 @@ class QueryTransformTest(TestCase):
 
     @patch("sentry.snuba.discover.raw_query")
     def test_find_histogram_min_max(self, mock_query):
-        # no rows returned from snuba
-        mock_query.side_effect = [{"meta": [], "data": []}]
-        values = discover.find_histogram_min_max(
-            ["measurements.foo"], None, None, "", {"project_id": [self.project.id]}
-        )
-        assert values == (None, None)
+        for array_column in ARRAY_COLUMNS:
+            # no rows returned from snuba
+            mock_query.side_effect = [{"meta": [], "data": []}]
+            values = discover.find_histogram_min_max(
+                [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
+            )
+            assert values == (None, None)
 
-        # more than 2 rows returned snuba
-        mock_query.side_effect = [{"meta": [], "data": [{}, {}]}]
-        values = discover.find_histogram_min_max(
-            ["measurements.foo"], None, None, "", {"project_id": [self.project.id]}
-        )
-        assert values == (None, None)
+            # more than 2 rows returned snuba
+            mock_query.side_effect = [{"meta": [], "data": [{}, {}]}]
+            values = discover.find_histogram_min_max(
+                [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
+            )
+            assert values == (None, None)
 
-        # None rows are returned from snuba
-        mock_query.side_effect = [
-            {
-                "meta": [{"name": "min_measurements_foo"}, {"name": "max_measurements_foo"}],
-                "data": [{"min_measurements_foo": None, "max_measurements_foo": None}],
-            },
-        ]
-        values = discover.find_histogram_min_max(
-            ["measurements.foo"], None, None, "", {"project_id": [self.project.id]}
-        )
-        assert values == (None, None)
+            # None rows are returned from snuba
+            mock_query.side_effect = [
+                {
+                    "meta": [{"name": f"min_{array_column}_foo"}, {"name": f"max_{array_column}_foo"}],
+                    "data": [{f"min_{array_column}_foo": None, f"max_{array_column}_foo": None}],
+                },
+            ]
+            values = discover.find_histogram_min_max(
+                [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
+            )
+            assert values == (None, None)
 
-        # use the given min/max
-        values = discover.find_histogram_min_max(
-            ["measurements.foo"], 1, 2, "", {"project_id": [self.project.id]}
-        )
-        assert values == (1, 2)
+            # use the given min/max
+            values = discover.find_histogram_min_max(
+                [f"{array_column}.foo"], 1, 2, "", {"project_id": [self.project.id]}
+            )
+            assert values == (1, 2)
 
-        # use the given min, but query for max
-        mock_query.side_effect = [
-            {"meta": [{"name": "max_measurements_foo"}], "data": [{"max_measurements_foo": 3.45}]},
-        ]
-        values = discover.find_histogram_min_max(
-            ["measurements.foo"], 1.23, None, "", {"project_id": [self.project.id]}
-        )
-        assert values == (1.23, 3.45)
+            # use the given min, but query for max
+            mock_query.side_effect = [
+                {"meta": [{"name": f"max_{array_column}_foo"}], "data": [{f"max_{array_column}_foo": 3.45}]},
+            ]
+            values = discover.find_histogram_min_max(
+                [f"{array_column}.foo"], 1.23, None, "", {"project_id": [self.project.id]}
+            )
+            assert values == (1.23, 3.45)
 
-        # use the given max, but query for min
-        mock_query.side_effect = [
-            {"meta": [{"name": "min_measurements_foo"}], "data": [{"min_measurements_foo": 1.23}]},
-        ]
-        values = discover.find_histogram_min_max(
-            ["measurements.foo"], None, 3.45, "", {"project_id": [self.project.id]}
-        )
-        assert values == (1.23, 3.45)
+            # use the given max, but query for min
+            mock_query.side_effect = [
+                {"meta": [{"name": f"min_{array_column}_foo"}], "data": [{f"min_{array_column}_foo": 1.23}]},
+            ]
+            values = discover.find_histogram_min_max(
+                [f"{array_column}.foo"], None, 3.45, "", {"project_id": [self.project.id]}
+            )
+            assert values == (1.23, 3.45)
 
-        # single min/max returned from snuba
-        mock_query.side_effect = [
-            {
-                "meta": [{"name": "min_measurements_foo"}, {"name": "max_measurements_foo"}],
-                "data": [{"min_measurements_foo": 1.23, "max_measurements_foo": 3.45}],
-            },
-        ]
-        values = discover.find_histogram_min_max(
-            ["measurements.foo"], None, None, "", {"project_id": [self.project.id]}
-        )
-        assert values == (1.23, 3.45)
+            # single min/max returned from snuba
+            mock_query.side_effect = [
+                {
+                    "meta": [{"name": f"min_{array_column}_foo"}, {"name": f"max_{array_column}_foo"}],
+                    "data": [{f"min_{array_column}_foo": 1.23, f"max_{array_column}_foo": 3.45}],
+                },
+            ]
+            values = discover.find_histogram_min_max(
+                [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
+            )
+            assert values == (1.23, 3.45)
 
-        # multiple min/max returned from snuba
-        mock_query.side_effect = [
-            {
-                "meta": [
-                    {"name": "min_measurements_foo"},
-                    {"name": "min_measurements_bar"},
-                    {"name": "min_measurements_baz"},
-                    {"name": "max_measurements_foo"},
-                    {"name": "max_measurements_bar"},
-                    {"name": "max_measurements_baz"},
-                ],
-                "data": [
-                    {
-                        "min_measurements_foo": 1.23,
-                        "min_measurements_bar": 1.34,
-                        "min_measurements_baz": 1.45,
-                        "max_measurements_foo": 3.45,
-                        "max_measurements_bar": 3.56,
-                        "max_measurements_baz": 3.67,
-                    }
-                ],
-            },
-        ]
-        values = discover.find_histogram_min_max(
-            ["measurements.foo", "measurements.bar", "measurements.baz"],
-            None,
-            None,
-            "",
-            {"project_id": [self.project.id]},
-        )
-        assert values == (1.23, 3.67)
+            # multiple min/max returned from snuba
+            mock_query.side_effect = [
+                {
+                    "meta": [
+                        {"name": f"min_{array_column}_foo"},
+                        {"name": f"min_{array_column}_bar"},
+                        {"name": f"min_{array_column}_baz"},
+                        {"name": f"max_{array_column}_foo"},
+                        {"name": f"max_{array_column}_bar"},
+                        {"name": f"max_{array_column}_baz"},
+                    ],
+                    "data": [
+                        {
+                            f"min_{array_column}_foo": 1.23,
+                            f"min_{array_column}_bar": 1.34,
+                            f"min_{array_column}_baz": 1.45,
+                            f"max_{array_column}_foo": 3.45,
+                            f"max_{array_column}_bar": 3.56,
+                            f"max_{array_column}_baz": 3.67,
+                        }
+                    ],
+                },
+            ]
+            values = discover.find_histogram_min_max(
+                [f"{array_column}.foo", f"{array_column}.bar", f"{array_column}.baz"],
+                None,
+                None,
+                "",
+                {"project_id": [self.project.id]},
+            )
+            assert values == (1.23, 3.67)
 
-        # multiple min/max with some Nones returned from snuba
-        mock_query.side_effect = [
-            {
-                "meta": [
-                    {"name": "min_measurements_foo"},
-                    {"name": "min_measurements_bar"},
-                    {"name": "min_measurements_baz"},
-                    {"name": "max_measurements_foo"},
-                    {"name": "max_measurements_bar"},
-                    {"name": "max_measurements_baz"},
-                ],
-                "data": [
-                    {
-                        "min_measurements_foo": 1.23,
-                        "min_measurements_bar": None,
-                        "min_measurements_baz": 1.45,
-                        "max_measurements_foo": 3.45,
-                        "max_measurements_bar": None,
-                        "max_measurements_baz": 3.67,
-                    }
-                ],
-            },
-        ]
-        values = discover.find_histogram_min_max(
-            ["measurements.foo", "measurements.bar", "measurements.baz"],
-            None,
-            None,
-            "",
-            {"project_id": [self.project.id]},
-        )
-        assert values == (1.23, 3.67)
+            # multiple min/max with some Nones returned from snuba
+            mock_query.side_effect = [
+                {
+                    "meta": [
+                        {"name": f"min_{array_column}_foo"},
+                        {"name": f"min_{array_column}_bar"},
+                        {"name": f"min_{array_column}_baz"},
+                        {"name": f"max_{array_column}_foo"},
+                        {"name": f"max_{array_column}_bar"},
+                        {"name": f"max_{array_column}_baz"},
+                    ],
+                    "data": [
+                        {
+                            f"min_{array_column}_foo": 1.23,
+                            f"min_{array_column}_bar": None,
+                            f"min_{array_column}_baz": 1.45,
+                            f"max_{array_column}_foo": 3.45,
+                            f"max_{array_column}_bar": None,
+                            f"max_{array_column}_baz": 3.67,
+                        }
+                    ],
+                },
+            ]
+            values = discover.find_histogram_min_max(
+                [f"{array_column}.foo", f"{array_column}.bar", f"{array_column}.baz"],
+                None,
+                None,
+                "",
+                {"project_id": [self.project.id]},
+            )
+            assert values == (1.23, 3.67)
 
     def test_find_histogram_params(self):
         # min and max is None
@@ -1788,447 +1793,471 @@ class QueryTransformTest(TestCase):
         assert discover.find_histogram_params(10, 10, 20, 100) == (9, 120, 1000, 100)
 
     def test_normalize_histogram_results_empty(self):
-        results = {
-            "meta": {
-                "array_join_measurements_key": "string",
-                "histogram_measurements_value_1_0_1": "number",
-                "count": "integer",
-            },
-            "data": [],
-        }
-        normalized_results = discover.normalize_histogram_results(
-            ["measurements.foo"],
-            "array_join(measurements_key)",
-            discover.HistogramParams(3, 1, 0, 1),
-            results,
-        )
-        assert normalized_results == {
-            "measurements.foo": [
-                {"bin": 0, "count": 0},
-                {"bin": 1, "count": 0},
-                {"bin": 2, "count": 0},
-            ],
-        }
+        for array_column in ARRAY_COLUMNS:
+            results = {
+                "meta": {
+                    f"array_join_{array_column}_key": "string",
+                    f"histogram_{array_column}_value_1_0_1": "number",
+                    "count": "integer",
+                },
+                "data": [],
+            }
+            normalized_results = discover.normalize_histogram_results(
+                [f"{array_column}.foo"],
+                f"array_join({array_column}_key)",
+                discover.HistogramParams(3, 1, 0, 1),
+                results,
+                array_column,
+            )
+            assert normalized_results == {
+                f"{array_column}.foo": [
+                    {"bin": 0, "count": 0},
+                    {"bin": 1, "count": 0},
+                    {"bin": 2, "count": 0},
+                ],
+            }
 
     def test_normalize_histogram_results_empty_multiple(self):
-        results = {
-            "meta": {
-                "array_join_measurements_key": "string",
-                "histogram_measurements_value_1_0_1": "number",
-                "count": "integer",
-            },
-            "data": [],
-        }
-        normalized_results = discover.normalize_histogram_results(
-            ["measurements.bar", "measurements.foo"],
-            "array_join(measurements_key)",
-            discover.HistogramParams(3, 1, 0, 1),
-            results,
-        )
-        assert normalized_results == {
-            "measurements.bar": [
-                {"bin": 0, "count": 0},
-                {"bin": 1, "count": 0},
-                {"bin": 2, "count": 0},
-            ],
-            "measurements.foo": [
-                {"bin": 0, "count": 0},
-                {"bin": 1, "count": 0},
-                {"bin": 2, "count": 0},
-            ],
-        }
+        for array_column in ARRAY_COLUMNS:
+            results = {
+                "meta": {
+                    f"array_join_{array_column}_key": "string",
+                    f"histogram_{array_column}_value_1_0_1": "number",
+                    "count": "integer",
+                },
+                "data": [],
+            }
+            normalized_results = discover.normalize_histogram_results(
+                [f"{array_column}.bar", f"{array_column}.foo"],
+                f"array_join({array_column}_key)",
+                discover.HistogramParams(3, 1, 0, 1),
+                results,
+                array_column,
+            )
+            assert normalized_results == {
+                f"{array_column}.bar": [
+                    {"bin": 0, "count": 0},
+                    {"bin": 1, "count": 0},
+                    {"bin": 2, "count": 0},
+                ],
+                f"{array_column}.foo": [
+                    {"bin": 0, "count": 0},
+                    {"bin": 1, "count": 0},
+                    {"bin": 2, "count": 0},
+                ],
+            }
 
     def test_normalize_histogram_results_full(self):
-        results = {
-            "meta": {
-                "array_join_measurements_key": "string",
-                "histogram_measurements_value_1_0_1": "number",
-                "count": "integer",
-            },
-            "data": [
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_1_0_1": 0,
-                    "count": 3,
+        for array_column in ARRAY_COLUMNS:
+            results = {
+                "meta": {
+                    f"array_join_{array_column}_key": "string",
+                    f"histogram_{array_column}_value_1_0_1": "number",
+                    "count": "integer",
                 },
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_1_0_1": 1,
-                    "count": 2,
-                },
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_1_0_1": 2,
-                    "count": 1,
-                },
-            ],
-        }
-        normalized_results = discover.normalize_histogram_results(
-            ["measurements.foo"],
-            "array_join(measurements_key)",
-            discover.HistogramParams(3, 1, 0, 1),
-            results,
-        )
-        assert normalized_results == {
-            "measurements.foo": [
-                {"bin": 0, "count": 3},
-                {"bin": 1, "count": 2},
-                {"bin": 2, "count": 1},
-            ],
-        }
-
-    def test_normalize_histogram_results_full_multiple(self):
-        results = {
-            "meta": {
-                "array_join_measurements_key": "string",
-                "histogram_measurements_value_1_0_1": "number",
-                "count": "integer",
-            },
-            "data": [
-                {
-                    "array_join_measurements_key": "bar",
-                    "histogram_measurements_value_1_0_1": 0,
-                    "count": 1,
-                },
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_1_0_1": 0,
-                    "count": 3,
-                },
-                {
-                    "array_join_measurements_key": "bar",
-                    "histogram_measurements_value_1_0_1": 1,
-                    "count": 2,
-                },
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_1_0_1": 1,
-                    "count": 2,
-                },
-                {
-                    "array_join_measurements_key": "bar",
-                    "histogram_measurements_value_1_0_1": 2,
-                    "count": 3,
-                },
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_1_0_1": 2,
-                    "count": 1,
-                },
-            ],
-        }
-        normalized_results = discover.normalize_histogram_results(
-            ["measurements.bar", "measurements.foo"],
-            "array_join(measurements_key)",
-            discover.HistogramParams(3, 1, 0, 1),
-            results,
-        )
-        assert normalized_results == {
-            "measurements.bar": [
-                {"bin": 0, "count": 1},
-                {"bin": 1, "count": 2},
-                {"bin": 2, "count": 3},
-            ],
-            "measurements.foo": [
-                {"bin": 0, "count": 3},
-                {"bin": 1, "count": 2},
-                {"bin": 2, "count": 1},
-            ],
-        }
-
-    def test_normalize_histogram_results_partial(self):
-        results = {
-            "meta": {
-                "array_join_measurements_key": "string",
-                "histogram_measurements_value_1_0_1": "number",
-                "count": "integer",
-            },
-            "data": [
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_1_0_1": 0,
-                    "count": 3,
-                },
-            ],
-        }
-        normalized_results = discover.normalize_histogram_results(
-            ["measurements.foo"],
-            "array_join(measurements_key)",
-            discover.HistogramParams(3, 1, 0, 1),
-            results,
-        )
-        assert normalized_results == {
-            "measurements.foo": [
-                {"bin": 0, "count": 3},
-                {"bin": 1, "count": 0},
-                {"bin": 2, "count": 0},
-            ],
-        }
-
-    def test_normalize_histogram_results_partial_multiple(self):
-        results = {
-            "meta": {
-                "array_join_measurements_key": "string",
-                "histogram_measurements_value_1_0_1": "number",
-                "count": "integer",
-            },
-            "data": [
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_1_0_1": 0,
-                    "count": 3,
-                },
-                {
-                    "array_join_measurements_key": "bar",
-                    "histogram_measurements_value_1_0_1": 2,
-                    "count": 3,
-                },
-            ],
-        }
-        normalized_results = discover.normalize_histogram_results(
-            ["measurements.bar", "measurements.foo"],
-            "array_join(measurements_key)",
-            discover.HistogramParams(3, 1, 0, 1),
-            results,
-        )
-        assert normalized_results == {
-            "measurements.bar": [
-                {"bin": 0, "count": 0},
-                {"bin": 1, "count": 0},
-                {"bin": 2, "count": 3},
-            ],
-            "measurements.foo": [
-                {"bin": 0, "count": 3},
-                {"bin": 1, "count": 0},
-                {"bin": 2, "count": 0},
-            ],
-        }
-
-    def test_normalize_histogram_results_ignore_unexpected_rows(self):
-        results = {
-            "meta": {
-                "array_join_measurements_key": "string",
-                "histogram_measurements_value_1_0_1": "number",
-                "count": "integer",
-            },
-            "data": [
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_1_0_1": 0,
-                    "count": 3,
-                },
-                # this row shouldn't be used because "baz" isn't an expected measurement
-                {
-                    "array_join_measurements_key": "baz",
-                    "histogram_measurements_value_1_0_1": 1,
-                    "count": 3,
-                },
-                {
-                    "array_join_measurements_key": "bar",
-                    "histogram_measurements_value_1_0_1": 2,
-                    "count": 3,
-                },
-                # this row shouldn't be used because 3 isn't an expected bin
-                {
-                    "array_join_measurements_key": "bar",
-                    "histogram_measurements_value_1_0_1": 3,
-                    "count": 3,
-                },
-            ],
-        }
-        normalized_results = discover.normalize_histogram_results(
-            ["measurements.bar", "measurements.foo"],
-            "array_join(measurements_key)",
-            discover.HistogramParams(3, 1, 0, 1),
-            results,
-        )
-        assert normalized_results == {
-            "measurements.bar": [
-                {"bin": 0, "count": 0},
-                {"bin": 1, "count": 0},
-                {"bin": 2, "count": 3},
-            ],
-            "measurements.foo": [
-                {"bin": 0, "count": 3},
-                {"bin": 1, "count": 0},
-                {"bin": 2, "count": 0},
-            ],
-        }
-
-    def test_normalize_histogram_results_adjust_for_precision(self):
-        results = {
-            "meta": {
-                "array_join_measurements_key": "string",
-                "histogram_measurements_value_25_0_100": "number",
-                "count": "integer",
-            },
-            "data": [
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_25_0_100": 0,
-                    "count": 3,
-                },
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_25_0_100": 25,
-                    "count": 2,
-                },
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_25_0_100": 50,
-                    "count": 1,
-                },
-                {
-                    "array_join_measurements_key": "foo",
-                    "histogram_measurements_value_25_0_100": 75,
-                    "count": 1,
-                },
-            ],
-        }
-        normalized_results = discover.normalize_histogram_results(
-            ["measurements.foo"],
-            "array_join(measurements_key)",
-            discover.HistogramParams(4, 25, 0, 100),
-            results,
-        )
-        assert normalized_results == {
-            "measurements.foo": [
-                {"bin": 0, "count": 3},
-                {"bin": 0.25, "count": 2},
-                {"bin": 0.50, "count": 1},
-                {"bin": 0.75, "count": 1},
-            ],
-        }
-
-    @patch("sentry.snuba.discover.raw_query")
-    def test_histogram_query(self, mock_query):
-        mock_query.side_effect = [
-            {
-                "meta": [{"name": "min_measurements_foo"}, {"name": "max_measurements_foo"}],
                 "data": [
                     {
-                        "min_measurements_bar": 2,
-                        "min_measurements_foo": 0,
-                        "max_measurements_bar": 2,
-                        "max_measurements_foo": 2,
-                    }
-                ],
-            },
-            {
-                "meta": [
-                    {"name": "array_join_measurements_key", "type": "String"},
-                    {"name": "histogram_measurements_value_1_0_1", "type": "Float64"},
-                    {"name": "count", "type": "UInt64"},
-                ],
-                "data": [
-                    {
-                        "array_join_measurements_key": "bar",
-                        "histogram_measurements_value_1_0_1": 0,
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_1_0_1": 0,
                         "count": 3,
                     },
                     {
-                        "array_join_measurements_key": "foo",
-                        "histogram_measurements_value_1_0_1": 0,
-                        "count": 3,
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_1_0_1": 1,
+                        "count": 2,
                     },
                     {
-                        "array_join_measurements_key": "foo",
-                        "histogram_measurements_value_1_0_1": 2,
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_1_0_1": 2,
                         "count": 1,
                     },
                 ],
-            },
-        ]
-        results = discover.histogram_query(
-            ["measurements.bar", "measurements.foo"], "", {"project_id": [self.project.id]}, 3, 0
-        )
-        assert results == {
-            "measurements.bar": [
-                {"bin": 0, "count": 3},
-                {"bin": 1, "count": 0},
-                {"bin": 2, "count": 0},
-            ],
-            "measurements.foo": [
-                {"bin": 0, "count": 3},
-                {"bin": 1, "count": 0},
-                {"bin": 2, "count": 1},
-            ],
-        }
+            }
+            normalized_results = discover.normalize_histogram_results(
+                [f"{array_column}.foo"],
+                f"array_join({array_column}_key)",
+                discover.HistogramParams(3, 1, 0, 1),
+                results,
+                array_column,
+            )
+            assert normalized_results == {
+                f"{array_column}.foo": [
+                    {"bin": 0, "count": 3},
+                    {"bin": 1, "count": 2},
+                    {"bin": 2, "count": 1},
+                ],
+            }
 
-    def test_histogram_query_with_bad_fields(self):
-        with pytest.raises(InvalidSearchQuery) as err:
-            discover.histogram_query(
-                ["measurements.bar", "transaction.duration"],
+    def test_normalize_histogram_results_full_multiple(self):
+        for array_column in ARRAY_COLUMNS:
+            results = {
+                "meta": {
+                    f"array_join_{array_column}_key": "string",
+                    f"histogram_{array_column}_value_1_0_1": "number",
+                    "count": "integer",
+                },
+                "data": [
+                    {
+                        f"array_join_{array_column}_key": "bar",
+                        f"histogram_{array_column}_value_1_0_1": 0,
+                        "count": 1,
+                    },
+                    {
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_1_0_1": 0,
+                        "count": 3,
+                    },
+                    {
+                        f"array_join_{array_column}_key": "bar",
+                        f"histogram_{array_column}_value_1_0_1": 1,
+                        "count": 2,
+                    },
+                    {
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_1_0_1": 1,
+                        "count": 2,
+                    },
+                    {
+                        f"array_join_{array_column}_key": "bar",
+                        f"histogram_{array_column}_value_1_0_1": 2,
+                        "count": 3,
+                    },
+                    {
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_1_0_1": 2,
+                        "count": 1,
+                    },
+                ],
+            }
+            normalized_results = discover.normalize_histogram_results(
+                [f"{array_column}.bar", f"{array_column}.foo"],
+                f"array_join({array_column}_key)",
+                discover.HistogramParams(3, 1, 0, 1),
+                results,
+                array_column,
+            )
+            assert normalized_results == {
+                f"{array_column}.bar": [
+                    {"bin": 0, "count": 1},
+                    {"bin": 1, "count": 2},
+                    {"bin": 2, "count": 3},
+                ],
+                f"{array_column}.foo": [
+                    {"bin": 0, "count": 3},
+                    {"bin": 1, "count": 2},
+                    {"bin": 2, "count": 1},
+                ],
+            }
+
+    def test_normalize_histogram_results_partial(self):
+        for array_column in ARRAY_COLUMNS:
+            results = {
+                "meta": {
+                    f"array_join_{array_column}_key": "string",
+                    f"histogram_{array_column}_value_1_0_1": "number",
+                    "count": "integer",
+                },
+                "data": [
+                    {
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_1_0_1": 0,
+                        "count": 3,
+                    },
+                ],
+            }
+            normalized_results = discover.normalize_histogram_results(
+                [f"{array_column}.foo"],
+                f"array_join({array_column}_key)",
+                discover.HistogramParams(3, 1, 0, 1),
+                results,
+                array_column,
+            )
+            assert normalized_results == {
+                f"{array_column}.foo": [
+                    {"bin": 0, "count": 3},
+                    {"bin": 1, "count": 0},
+                    {"bin": 2, "count": 0},
+                ],
+            }
+
+    def test_normalize_histogram_results_partial_multiple(self):
+        for array_column in ARRAY_COLUMNS:
+            results = {
+                "meta": {
+                    f"array_join_{array_column}_key": "string",
+                    f"histogram_{array_column}_value_1_0_1": "number",
+                    "count": "integer",
+                },
+                "data": [
+                    {
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_1_0_1": 0,
+                        "count": 3,
+                    },
+                    {
+                        f"array_join_{array_column}_key": "bar",
+                        f"histogram_{array_column}_value_1_0_1": 2,
+                        "count": 3,
+                    },
+                ],
+            }
+            normalized_results = discover.normalize_histogram_results(
+                [f"{array_column}.bar", f"{array_column}.foo"],
+                f"array_join({array_column}_key)",
+                discover.HistogramParams(3, 1, 0, 1),
+                results,
+                array_column,
+            )
+            assert normalized_results == {
+                f"{array_column}.bar": [
+                    {"bin": 0, "count": 0},
+                    {"bin": 1, "count": 0},
+                    {"bin": 2, "count": 3},
+                ],
+                f"{array_column}.foo": [
+                    {"bin": 0, "count": 3},
+                    {"bin": 1, "count": 0},
+                    {"bin": 2, "count": 0},
+                ],
+            }
+
+    def test_normalize_histogram_results_ignore_unexpected_rows(self):
+        for array_column in ARRAY_COLUMNS:
+            results = {
+                "meta": {
+                    f"array_join_{array_column}_key": "string",
+                    f"histogram_{array_column}_value_1_0_1": "number",
+                    "count": "integer",
+                },
+                "data": [
+                    {
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_1_0_1": 0,
+                        "count": 3,
+                    },
+                    # this row shouldn't be used because "baz" isn't an expected array_column
+                    {
+                        f"array_join_{array_column}_key": "baz",
+                        f"histogram_{array_column}_value_1_0_1": 1,
+                        "count": 3,
+                    },
+                    {
+                        f"array_join_{array_column}_key": "bar",
+                        f"histogram_{array_column}_value_1_0_1": 2,
+                        "count": 3,
+                    },
+                    # this row shouldn't be used because 3 isn't an expected bin
+                    {
+                        f"array_join_{array_column}_key": "bar",
+                        f"histogram_{array_column}_value_1_0_1": 3,
+                        "count": 3,
+                    },
+                ],
+            }
+            normalized_results = discover.normalize_histogram_results(
+                [f"{array_column}.bar", f"{array_column}.foo"],
+                f"array_join({array_column}_key)",
+                discover.HistogramParams(3, 1, 0, 1),
+                results,
+                array_column,
+            )
+            assert normalized_results == {
+                f"{array_column}.bar": [
+                    {"bin": 0, "count": 0},
+                    {"bin": 1, "count": 0},
+                    {"bin": 2, "count": 3},
+                ],
+                f"{array_column}.foo": [
+                    {"bin": 0, "count": 3},
+                    {"bin": 1, "count": 0},
+                    {"bin": 2, "count": 0},
+                ],
+            }
+
+    def test_normalize_histogram_results_adjust_for_precision(self):
+        for array_column in ARRAY_COLUMNS:
+            results = {
+                "meta": {
+                    f"array_join_{array_column}_key": "string",
+                    f"histogram_{array_column}_value_25_0_100": "number",
+                    "count": "integer",
+                },
+                "data": [
+                    {
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_25_0_100": 0,
+                        "count": 3,
+                    },
+                    {
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_25_0_100": 25,
+                        "count": 2,
+                    },
+                    {
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_25_0_100": 50,
+                        "count": 1,
+                    },
+                    {
+                        f"array_join_{array_column}_key": "foo",
+                        f"histogram_{array_column}_value_25_0_100": 75,
+                        "count": 1,
+                    },
+                ],
+            }
+            normalized_results = discover.normalize_histogram_results(
+                [f"{array_column}.foo"],
+                f"array_join({array_column}_key)",
+                discover.HistogramParams(4, 25, 0, 100),
+                results,
+                array_column,
+            )
+            assert normalized_results == {
+                f"{array_column}.foo": [
+                    {"bin": 0, "count": 3},
+                    {"bin": 0.25, "count": 2},
+                    {"bin": 0.50, "count": 1},
+                    {"bin": 0.75, "count": 1},
+                ],
+            }
+
+    @patch("sentry.snuba.discover.raw_query")
+    def test_histogram_query(self, mock_query):
+        for array_column in ARRAY_COLUMNS:
+            mock_query.side_effect = [
+                {
+                    "meta": [
+                        {"name": f"min_{array_column}_foo"},
+                        {"name": f"max_{array_column}_foo"},
+                    ],
+                    "data": [
+                        {
+                            f"min_{array_column}_bar": 2,
+                            f"min_{array_column}_foo": 0,
+                            f"max_{array_column}_bar": 2,
+                            f"max_{array_column}_foo": 2,
+                        }
+                    ],
+                },
+                {
+                    "meta": [
+                        {"name": f"array_join_{array_column}_key", "type": "String"},
+                        {"name": f"histogram_{array_column}_value_1_0_1", "type": "Float64"},
+                        {"name": "count", "type": "UInt64"},
+                    ],
+                    "data": [
+                        {
+                            f"array_join_{array_column}_key": "bar",
+                            f"histogram_{array_column}_value_1_0_1": 0,
+                            "count": 3,
+                        },
+                        {
+                            f"array_join_{array_column}_key": "foo",
+                            f"histogram_{array_column}_value_1_0_1": 0,
+                            "count": 3,
+                        },
+                        {
+                            f"array_join_{array_column}_key": "foo",
+                            f"histogram_{array_column}_value_1_0_1": 2,
+                            "count": 1,
+                        },
+                    ],
+                },
+            ]
+            results = discover.histogram_query(
+                [f"{array_column}.bar", f"{array_column}.foo"],
                 "",
                 {"project_id": [self.project.id]},
                 3,
                 0,
             )
-        assert "multihistogram expected all measurements, received: transaction.duration" in str(
-            err
-        )
+            assert results == {
+                f"{array_column}.bar": [
+                    {"bin": 0, "count": 3},
+                    {"bin": 1, "count": 0},
+                    {"bin": 2, "count": 0},
+                ],
+                f"{array_column}.foo": [
+                    {"bin": 0, "count": 3},
+                    {"bin": 1, "count": 0},
+                    {"bin": 2, "count": 1},
+                ],
+            }
+
+    def test_histogram_query_with_bad_fields(self):
+        for array_column in ARRAY_COLUMNS:
+            with pytest.raises(InvalidSearchQuery) as err:
+                discover.histogram_query(
+                    [f"{array_column}.bar", "transaction.duration"],
+                    "",
+                    {"project_id": [self.project.id]},
+                    3,
+                    0,
+                )
+            assert "multihistogram expected either all measurements or all breakdowns" in str(err)
 
     @patch("sentry.snuba.discover.raw_query")
     def test_histogram_query_with_optionals(self, mock_query):
-        mock_query.side_effect = [
-            {
-                "meta": [
-                    {"name": "array_join_measurements_key", "type": "String"},
-                    {"name": "histogram_measurements_value_5_5_10", "type": "Float64"},
-                    {"name": "count", "type": "UInt64"},
+        for array_column in ARRAY_COLUMNS:
+            mock_query.side_effect = [
+                {
+                    "meta": [
+                        {"name": f"array_join_{array_column}_key", "type": "String"},
+                        {"name": f"histogram_{array_column}_value_5_5_10", "type": "Float64"},
+                        {"name": "count", "type": "UInt64"},
+                    ],
+                    "data": [
+                        # this row shouldn't be used because it lies outside the boundary
+                        {
+                            f"array_join_{array_column}_key": "foo",
+                            f"histogram_{array_column}_value_5_5_10": 0,
+                            "count": 1,
+                        },
+                        {
+                            f"array_join_{array_column}_key": "foo",
+                            f"histogram_{array_column}_value_5_5_10": 5,
+                            "count": 3,
+                        },
+                        {
+                            f"array_join_{array_column}_key": "bar",
+                            f"histogram_{array_column}_value_5_5_10": 10,
+                            "count": 2,
+                        },
+                        {
+                            f"array_join_{array_column}_key": "foo",
+                            f"histogram_{array_column}_value_5_5_10": 15,
+                            "count": 1,
+                        },
+                        # this row shouldn't be used because it lies outside the boundary
+                        {
+                            f"array_join_{array_column}_key": "bar",
+                            f"histogram_{array_column}_value_5_5_10": 30,
+                            "count": 2,
+                        },
+                    ],
+                },
+            ]
+            results = discover.histogram_query(
+                [f"{array_column}.bar", f"{array_column}.foo"],
+                "",
+                {"project_id": [self.project.id]},
+                3,
+                1,
+                0.5,
+                2,
+            )
+            assert results == {
+                f"{array_column}.bar": [
+                    {"bin": 0.5, "count": 0},
+                    {"bin": 1.0, "count": 2},
+                    {"bin": 1.5, "count": 0},
                 ],
-                "data": [
-                    # this row shouldn't be used because it lies outside the boundary
-                    {
-                        "array_join_measurements_key": "foo",
-                        "histogram_measurements_value_5_5_10": 0,
-                        "count": 1,
-                    },
-                    {
-                        "array_join_measurements_key": "foo",
-                        "histogram_measurements_value_5_5_10": 5,
-                        "count": 3,
-                    },
-                    {
-                        "array_join_measurements_key": "bar",
-                        "histogram_measurements_value_5_5_10": 10,
-                        "count": 2,
-                    },
-                    {
-                        "array_join_measurements_key": "foo",
-                        "histogram_measurements_value_5_5_10": 15,
-                        "count": 1,
-                    },
-                    # this row shouldn't be used because it lies outside the boundary
-                    {
-                        "array_join_measurements_key": "bar",
-                        "histogram_measurements_value_5_5_10": 30,
-                        "count": 2,
-                    },
+                f"{array_column}.foo": [
+                    {"bin": 0.5, "count": 3},
+                    {"bin": 1.0, "count": 0},
+                    {"bin": 1.5, "count": 1},
                 ],
-            },
-        ]
-        results = discover.histogram_query(
-            ["measurements.bar", "measurements.foo"],
-            "",
-            {"project_id": [self.project.id]},
-            3,
-            1,
-            0.5,
-            2,
-        )
-        assert results == {
-            "measurements.bar": [
-                {"bin": 0.5, "count": 0},
-                {"bin": 1.0, "count": 2},
-                {"bin": 1.5, "count": 0},
-            ],
-            "measurements.foo": [
-                {"bin": 0.5, "count": 3},
-                {"bin": 1.0, "count": 0},
-                {"bin": 1.5, "count": 1},
-            ],
-        }
+            }
 
 
 class TimeseriesBase(SnubaTestCase, TestCase):

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1653,62 +1653,83 @@ class QueryTransformTest(TestCase):
             values = discover.find_histogram_min_max(
                 [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
             )
-            assert values == (None, None)
+            assert values == (None, None), f"failing for {array_column}"
 
             # more than 2 rows returned snuba
             mock_query.side_effect = [{"meta": [], "data": [{}, {}]}]
             values = discover.find_histogram_min_max(
                 [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
             )
-            assert values == (None, None)
+            assert values == (None, None), f"failing for {array_column}"
 
             # None rows are returned from snuba
             mock_query.side_effect = [
                 {
-                    "meta": [{"name": f"min_{array_column}_foo"}, {"name": f"max_{array_column}_foo"}],
+                    "meta": [
+                        {"name": f"min_{array_column}_foo"},
+                        {"name": f"max_{array_column}_foo"},
+                    ],
                     "data": [{f"min_{array_column}_foo": None, f"max_{array_column}_foo": None}],
                 },
             ]
             values = discover.find_histogram_min_max(
                 [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
             )
-            assert values == (None, None)
+            assert values == (None, None), f"failing for {array_column}"
 
             # use the given min/max
             values = discover.find_histogram_min_max(
                 [f"{array_column}.foo"], 1, 2, "", {"project_id": [self.project.id]}
             )
-            assert values == (1, 2)
+            assert values == (1, 2), f"failing for {array_column}"
 
             # use the given min, but query for max
             mock_query.side_effect = [
-                {"meta": [{"name": f"max_{array_column}_foo"}], "data": [{f"max_{array_column}_foo": 3.45}]},
+                {
+                    "meta": [{"name": f"max_{array_column}_foo"}],
+                    "data": [{f"max_{array_column}_foo": 3.45}],
+                },
             ]
             values = discover.find_histogram_min_max(
                 [f"{array_column}.foo"], 1.23, None, "", {"project_id": [self.project.id]}
             )
-            assert values == (1.23, 3.45)
+            assert values == (
+                1.23,
+                3.45,
+            ), f"failing for {array_column}"
 
             # use the given max, but query for min
             mock_query.side_effect = [
-                {"meta": [{"name": f"min_{array_column}_foo"}], "data": [{f"min_{array_column}_foo": 1.23}]},
+                {
+                    "meta": [{"name": f"min_{array_column}_foo"}],
+                    "data": [{f"min_{array_column}_foo": 1.23}],
+                },
             ]
             values = discover.find_histogram_min_max(
                 [f"{array_column}.foo"], None, 3.45, "", {"project_id": [self.project.id]}
             )
-            assert values == (1.23, 3.45)
+            assert values == (
+                1.23,
+                3.45,
+            ), f"failing for {array_column}"
 
             # single min/max returned from snuba
             mock_query.side_effect = [
                 {
-                    "meta": [{"name": f"min_{array_column}_foo"}, {"name": f"max_{array_column}_foo"}],
+                    "meta": [
+                        {"name": f"min_{array_column}_foo"},
+                        {"name": f"max_{array_column}_foo"},
+                    ],
                     "data": [{f"min_{array_column}_foo": 1.23, f"max_{array_column}_foo": 3.45}],
                 },
             ]
             values = discover.find_histogram_min_max(
                 [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
             )
-            assert values == (1.23, 3.45)
+            assert values == (
+                1.23,
+                3.45,
+            ), f"failing for {array_column}"
 
             # multiple min/max returned from snuba
             mock_query.side_effect = [
@@ -1740,7 +1761,10 @@ class QueryTransformTest(TestCase):
                 "",
                 {"project_id": [self.project.id]},
             )
-            assert values == (1.23, 3.67)
+            assert values == (
+                1.23,
+                3.67,
+            ), f"failing for {array_column}"
 
             # multiple min/max with some Nones returned from snuba
             mock_query.side_effect = [
@@ -1772,7 +1796,10 @@ class QueryTransformTest(TestCase):
                 "",
                 {"project_id": [self.project.id]},
             )
-            assert values == (1.23, 3.67)
+            assert values == (
+                1.23,
+                3.67,
+            ), f"failing for {array_column}"
 
     def test_find_histogram_params(self):
         # min and max is None
@@ -1815,7 +1842,7 @@ class QueryTransformTest(TestCase):
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 0},
                 ],
-            }
+            }, f"failing for {array_column}"
 
     def test_normalize_histogram_results_empty_multiple(self):
         for array_column in ARRAY_COLUMNS:
@@ -1845,7 +1872,7 @@ class QueryTransformTest(TestCase):
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 0},
                 ],
-            }
+            }, f"failing for {array_column}"
 
     def test_normalize_histogram_results_full(self):
         for array_column in ARRAY_COLUMNS:
@@ -1886,7 +1913,7 @@ class QueryTransformTest(TestCase):
                     {"bin": 1, "count": 2},
                     {"bin": 2, "count": 1},
                 ],
-            }
+            }, f"failing for {array_column}"
 
     def test_normalize_histogram_results_full_multiple(self):
         for array_column in ARRAY_COLUMNS:
@@ -1947,7 +1974,7 @@ class QueryTransformTest(TestCase):
                     {"bin": 1, "count": 2},
                     {"bin": 2, "count": 1},
                 ],
-            }
+            }, f"failing for {array_column}"
 
     def test_normalize_histogram_results_partial(self):
         for array_column in ARRAY_COLUMNS:
@@ -1978,7 +2005,7 @@ class QueryTransformTest(TestCase):
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 0},
                 ],
-            }
+            }, f"failing for {array_column}"
 
     def test_normalize_histogram_results_partial_multiple(self):
         for array_column in ARRAY_COLUMNS:
@@ -2019,7 +2046,7 @@ class QueryTransformTest(TestCase):
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 0},
                 ],
-            }
+            }, f"failing for {array_column}"
 
     def test_normalize_histogram_results_ignore_unexpected_rows(self):
         for array_column in ARRAY_COLUMNS:
@@ -2072,7 +2099,7 @@ class QueryTransformTest(TestCase):
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 0},
                 ],
-            }
+            }, f"failing for {array_column}"
 
     def test_normalize_histogram_results_adjust_for_precision(self):
         for array_column in ARRAY_COLUMNS:
@@ -2119,7 +2146,7 @@ class QueryTransformTest(TestCase):
                     {"bin": 0.50, "count": 1},
                     {"bin": 0.75, "count": 1},
                 ],
-            }
+            }, f"failing for {array_column}"
 
     @patch("sentry.snuba.discover.raw_query")
     def test_histogram_query(self, mock_query):
@@ -2182,7 +2209,7 @@ class QueryTransformTest(TestCase):
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 1},
                 ],
-            }
+            }, f"failing for {array_column}"
 
     def test_histogram_query_with_bad_fields(self):
         for array_column in ARRAY_COLUMNS:
@@ -2194,7 +2221,9 @@ class QueryTransformTest(TestCase):
                     3,
                     0,
                 )
-            assert "multihistogram expected either all measurements or all breakdowns" in str(err)
+            assert "multihistogram expected either all measurements or all breakdowns" in str(
+                err
+            ), f"failing for {array_column}"
 
     @patch("sentry.snuba.discover.raw_query")
     def test_histogram_query_with_optionals(self, mock_query):
@@ -2257,7 +2286,7 @@ class QueryTransformTest(TestCase):
                     {"bin": 1.0, "count": 0},
                     {"bin": 1.5, "count": 1},
                 ],
-            }
+            }, f"failing for {array_column}"
 
 
 class TimeseriesBase(SnubaTestCase, TestCase):

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -9,9 +9,10 @@ from django.core.urlresolvers import reverse
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils.samples import load_data
-from sentry.utils.snuba import get_measurement_name, is_measurement
 
 HistogramSpec = namedtuple("HistogramSpec", ["start", "end", "fields"])
+
+PREFIXES = ["measurements", "span_op_breakdowns"]
 
 
 class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
@@ -20,24 +21,28 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
         self.min_ago = iso_format(before_now(minutes=1))
         self.data = load_data("transaction")
 
-    def populate_measurements(self, specs):
+    def populate_events(self, specs):
         start = before_now(minutes=5)
         for spec in specs:
             spec = HistogramSpec(*spec)
-            for field, count in spec.fields:
-                if not is_measurement(field):
-                    continue
-
-                measurement = get_measurement_name(field)
+            for suffix_key, count in spec.fields:
                 for i in range(count):
                     data = deepcopy(self.data)
+
+                    measurement_name = suffix_key
+                    breakdown_name = suffix_key
 
                     data["timestamp"] = iso_format(start)
                     data["start_timestamp"] = iso_format(start - timedelta(seconds=i))
                     value = random.random() * (spec.end - spec.start) + spec.start
-                    data["transaction"] = f"/measurement/{measurement}/value/{value}"
+                    data["transaction"] = f"/measurement/{measurement_name}/value/{value}"
 
-                    data["measurements"] = {measurement: {"value": value}}
+                    data["measurements"] = {measurement_name: {"value": value}}
+                    data["breakdowns"] = {
+                        "span_ops": {
+                            breakdown_name: {"value": value},
+                        }
+                    }
                     self.store_event(data, self.project.id)
 
     def as_response_data(self, specs):
@@ -68,29 +73,31 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
         assert response.data == {}
 
     def test_good_params(self):
-        query = {
-            "query": "event.type:transaction",
-            "project": [self.project.id],
-            "field": ["measurements.foo", "measurements.bar"],
-            "numBuckets": 10,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "query": "event.type:transaction",
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo", f"{prefix}.bar"],
+                "numBuckets": 10,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
+            response = self.do_request(query)
+            assert response.status_code == 200
 
     def test_good_params_with_optionals(self):
-        query = {
-            "query": "event.type:transaction",
-            "project": [self.project.id],
-            "field": ["measurements.foo", "measurements.bar"],
-            "numBuckets": 10,
-            "precision": 0,
-            "min": 0,
-            "max": 10,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "query": "event.type:transaction",
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo", f"{prefix}.bar"],
+                "numBuckets": 10,
+                "precision": 0,
+                "min": 0,
+                "max": 10,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
+            response = self.do_request(query)
+            assert response.status_code == 200
 
     def test_bad_params_missing_fields(self):
         query = {
@@ -121,22 +128,24 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
         }
 
     def test_bad_params_mixed_fields(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["foo", "measurements.bar"],
-            "numBuckets": 10,
-            "min": 0,
-            "max": 100,
-            "precision": 0,
-        }
+        for prefix in PREFIXES:
+            for other_prefix in PREFIXES:
+                query = {
+                    "project": [self.project.id],
+                    "field": ["foo", f"{prefix}.foo", f"{other_prefix}.bar"],
+                    "numBuckets": 10,
+                    "min": 0,
+                    "max": 100,
+                    "precision": 0,
+                }
 
-        response = self.do_request(query)
-        assert response.status_code == 400
-        assert response.data == {
-            "field": [
-                "You can only generate histogram for one column at a time unless they are all measurements."
-            ],
-        }
+                response = self.do_request(query)
+                assert response.status_code == 400
+                assert response.data == {
+                    "field": [
+                        "You can only generate histogram for one column at a time unless they are all measurements or all span op breakdowns."
+                    ],
+                }
 
     def test_bad_params_missing_num_buckets(self):
         query = {
@@ -150,621 +159,653 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
         }
 
     def test_bad_params_invalid_num_buckets(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo", "measurements.bar"],
-            "numBuckets": "baz",
-        }
-        response = self.do_request(query)
-        assert response.status_code == 400
-        assert response.data == {
-            "numBuckets": ["A valid integer is required."],
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo", f"{prefix}.bar"],
+                "numBuckets": "baz",
+            }
+            response = self.do_request(query)
+            assert response.status_code == 400
+            assert response.data == {
+                "numBuckets": ["A valid integer is required."],
+            }
 
     def test_bad_params_invalid_negative_num_buckets(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo", "measurements.bar"],
-            "numBuckets": -1,
-        }
-        response = self.do_request(query)
-        assert response.status_code == 400
-        assert response.data == {
-            "numBuckets": ["Ensure this value is greater than or equal to 1."],
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo", f"{prefix}.bar"],
+                "numBuckets": -1,
+            }
+            response = self.do_request(query)
+            assert response.status_code == 400
+            assert response.data == {
+                "numBuckets": ["Ensure this value is greater than or equal to 1."],
+            }
 
     def test_bad_params_num_buckets_too_large(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo", "measurements.bar"],
-            "numBuckets": 150,
-        }
-        response = self.do_request(query)
-        assert response.status_code == 400
-        assert response.data == {
-            "numBuckets": ["Ensure this value is less than or equal to 100."],
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo", f"{prefix}.bar"],
+                "numBuckets": 150,
+            }
+            response = self.do_request(query)
+            assert response.status_code == 400
+            assert response.data == {
+                "numBuckets": ["Ensure this value is less than or equal to 100."],
+            }
 
     def test_bad_params_invalid_precision_too_small(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo", "measurements.bar"],
-            "numBuckets": 10,
-            "precision": -1,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo", f"{prefix}.bar"],
+                "numBuckets": 10,
+                "precision": -1,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 400
-        assert response.data == {
-            "precision": ["Ensure this value is greater than or equal to 0."],
-        }
+            response = self.do_request(query)
+            assert response.status_code == 400
+            assert response.data == {
+                "precision": ["Ensure this value is greater than or equal to 0."],
+            }
 
     def test_bad_params_invalid_precision_too_big(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo", "measurements.bar"],
-            "numBuckets": 10,
-            "precision": 100,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo", f"{prefix}.bar"],
+                "numBuckets": 10,
+                "precision": 100,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 400
-        assert response.data == {
-            "precision": ["Ensure this value is less than or equal to 4."],
-        }
+            response = self.do_request(query)
+            assert response.status_code == 400
+            assert response.data == {
+                "precision": ["Ensure this value is less than or equal to 4."],
+            }
 
     def test_bad_params_invalid_min(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo", "measurements.bar"],
-            "numBuckets": 10,
-            "min": "qux",
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo", f"{prefix}.bar"],
+                "numBuckets": 10,
+                "min": "qux",
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 400
-        assert response.data == {
-            "min": ["A valid number is required."],
-        }
+            response = self.do_request(query)
+            assert response.status_code == 400
+            assert response.data == {
+                "min": ["A valid number is required."],
+            }
 
     def test_bad_params_invalid_max(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo", "measurements.bar"],
-            "numBuckets": 10,
-            "max": "qux",
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo", f"{prefix}.bar"],
+                "numBuckets": 10,
+                "max": "qux",
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 400
-        assert response.data == {
-            "max": ["A valid number is required."],
-        }
+            response = self.do_request(query)
+            assert response.status_code == 400
+            assert response.data == {
+                "max": ["A valid number is required."],
+            }
 
     def test_histogram_empty(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo", "measurements.bar"],
-            "numBuckets": 5,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo", f"{prefix}.bar"],
+                "numBuckets": 5,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (i, i + 1, [("measurements.foo", 0), ("measurements.bar", 0)]) for i in range(5)
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [(i, i + 1, [(f"{prefix}.foo", 0), (f"{prefix}.bar", 0)]) for i in range(5)]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_simple(self):
         # range is [0, 5), so it is divided into 5 buckets of width 1
         specs = [
-            (0, 1, [("measurements.foo", 1)]),
-            (1, 2, [("measurements.foo", 1)]),
-            (2, 3, [("measurements.foo", 1)]),
-            (4, 5, [("measurements.foo", 1)]),
+            (0, 1, [("foo", 1)]),
+            (1, 2, [("foo", 1)]),
+            (2, 3, [("foo", 1)]),
+            (4, 5, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (0, 1, [("measurements.foo", 1)]),
-            (1, 2, [("measurements.foo", 1)]),
-            (2, 3, [("measurements.foo", 1)]),
-            (3, 4, [("measurements.foo", 0)]),
-            (4, 5, [("measurements.foo", 1)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (0, 1, [(f"{prefix}.foo", 1)]),
+                (1, 2, [(f"{prefix}.foo", 1)]),
+                (2, 3, [(f"{prefix}.foo", 1)]),
+                (3, 4, [(f"{prefix}.foo", 0)]),
+                (4, 5, [(f"{prefix}.foo", 1)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_simple_using_min_max(self):
         # range is [0, 5), so it is divided into 5 buckets of width 1
         specs = [
-            (0, 1, [("measurements.foo", 1)]),
-            (1, 2, [("measurements.foo", 1)]),
-            (2, 3, [("measurements.foo", 1)]),
-            (4, 5, [("measurements.foo", 1)]),
+            (0, 1, [("foo", 1)]),
+            (1, 2, [("foo", 1)]),
+            (2, 3, [("foo", 1)]),
+            (4, 5, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-            "min": 0,
-            "max": 5,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+                "min": 0,
+                "max": 5,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (0, 1, [("measurements.foo", 1)]),
-            (1, 2, [("measurements.foo", 1)]),
-            (2, 3, [("measurements.foo", 1)]),
-            (3, 4, [("measurements.foo", 0)]),
-            (4, 5, [("measurements.foo", 1)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (0, 1, [(f"{prefix}.foo", 1)]),
+                (1, 2, [(f"{prefix}.foo", 1)]),
+                (2, 3, [(f"{prefix}.foo", 1)]),
+                (3, 4, [(f"{prefix}.foo", 0)]),
+                (4, 5, [(f"{prefix}.foo", 1)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_large_buckets(self):
         # make sure that it works for large width buckets
         # range is [0, 99], so it is divided into 5 buckets of width 20
         specs = [
-            (0, 0, [("measurements.foo", 2)]),
-            (99, 99, [("measurements.foo", 2)]),
+            (0, 0, [("foo", 2)]),
+            (99, 99, [("foo", 2)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (0, 20, [("measurements.foo", 2)]),
-            (20, 40, [("measurements.foo", 0)]),
-            (40, 60, [("measurements.foo", 0)]),
-            (60, 80, [("measurements.foo", 0)]),
-            (80, 100, [("measurements.foo", 2)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (0, 20, [(f"{prefix}.foo", 2)]),
+                (20, 40, [(f"{prefix}.foo", 0)]),
+                (40, 60, [(f"{prefix}.foo", 0)]),
+                (60, 80, [(f"{prefix}.foo", 0)]),
+                (80, 100, [(f"{prefix}.foo", 2)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_non_zero_offset(self):
         # range is [10, 15), so it is divided into 5 buckets of width 1
         specs = [
-            (10, 11, [("measurements.foo", 1)]),
-            (12, 13, [("measurements.foo", 1)]),
-            (13, 14, [("measurements.foo", 1)]),
-            (14, 15, [("measurements.foo", 1)]),
+            (10, 11, [("foo", 1)]),
+            (12, 13, [("foo", 1)]),
+            (13, 14, [("foo", 1)]),
+            (14, 15, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (10, 11, [("measurements.foo", 1)]),
-            (11, 12, [("measurements.foo", 0)]),
-            (12, 13, [("measurements.foo", 1)]),
-            (13, 14, [("measurements.foo", 1)]),
-            (14, 15, [("measurements.foo", 1)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (10, 11, [(f"{prefix}.foo", 1)]),
+                (11, 12, [(f"{prefix}.foo", 0)]),
+                (12, 13, [(f"{prefix}.foo", 1)]),
+                (13, 14, [(f"{prefix}.foo", 1)]),
+                (14, 15, [(f"{prefix}.foo", 1)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_extra_data(self):
         # range is [11, 16), so it is divided into 5 buckets of width 1
         # make sure every bin has some value
         specs = [
-            (10, 11, [("measurements.foo", 1)]),
-            (11, 12, [("measurements.foo", 1)]),
-            (12, 13, [("measurements.foo", 1)]),
-            (13, 14, [("measurements.foo", 1)]),
-            (14, 15, [("measurements.foo", 1)]),
-            (15, 16, [("measurements.foo", 1)]),
-            (16, 17, [("measurements.foo", 1)]),
+            (10, 11, [("foo", 1)]),
+            (11, 12, [("foo", 1)]),
+            (12, 13, [("foo", 1)]),
+            (13, 14, [("foo", 1)]),
+            (14, 15, [("foo", 1)]),
+            (15, 16, [("foo", 1)]),
+            (16, 17, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-            "min": 11,
-            "max": 16,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+                "min": 11,
+                "max": 16,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (11, 12, [("measurements.foo", 1)]),
-            (12, 13, [("measurements.foo", 1)]),
-            (13, 14, [("measurements.foo", 1)]),
-            (14, 15, [("measurements.foo", 1)]),
-            (15, 16, [("measurements.foo", 1)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (11, 12, [(f"{prefix}.foo", 1)]),
+                (12, 13, [(f"{prefix}.foo", 1)]),
+                (13, 14, [(f"{prefix}.foo", 1)]),
+                (14, 15, [(f"{prefix}.foo", 1)]),
+                (15, 16, [(f"{prefix}.foo", 1)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_non_zero_min_large_buckets(self):
         # range is [10, 59], so it is divided into 5 buckets of width 10
         specs = [
-            (10, 10, [("measurements.foo", 1)]),
-            (40, 50, [("measurements.foo", 1)]),
-            (59, 59, [("measurements.foo", 2)]),
+            (10, 10, [("foo", 1)]),
+            (40, 50, [("foo", 1)]),
+            (59, 59, [("foo", 2)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (10, 20, [("measurements.foo", 1)]),
-            (20, 30, [("measurements.foo", 0)]),
-            (30, 40, [("measurements.foo", 0)]),
-            (40, 50, [("measurements.foo", 1)]),
-            (50, 60, [("measurements.foo", 2)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (10, 20, [(f"{prefix}.foo", 1)]),
+                (20, 30, [(f"{prefix}.foo", 0)]),
+                (30, 40, [(f"{prefix}.foo", 0)]),
+                (40, 50, [(f"{prefix}.foo", 1)]),
+                (50, 60, [(f"{prefix}.foo", 2)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     @pytest.mark.xfail(reason="snuba does not allow - in alias names")
     def test_histogram_negative_values(self):
         # range is [-9, -4), so it is divided into 5 buckets of width 1
         specs = [
-            (-9, -8, [("measurements.foo", 3)]),
-            (-5, -4, [("measurements.foo", 1)]),
+            (-9, -8, [("foo", 3)]),
+            (-5, -4, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (-9, -8, [("measurements.foo", 3)]),
-            (-8, -7, [("measurements.foo", 0)]),
-            (-7, -6, [("measurements.foo", 0)]),
-            (-6, -5, [("measurements.foo", 0)]),
-            (-5, -4, [("measurements.foo", 1)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (-9, -8, [(f"{prefix}.foo", 3)]),
+                (-8, -7, [(f"{prefix}.foo", 0)]),
+                (-7, -6, [(f"{prefix}.foo", 0)]),
+                (-6, -5, [(f"{prefix}.foo", 0)]),
+                (-5, -4, [(f"{prefix}.foo", 1)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     @pytest.mark.xfail(reason="snuba does not allow - in alias names")
     def test_histogram_positive_and_negative_values(self):
         # range is [-50, 49], so it is divided into 5 buckets of width 10
         specs = [
-            (-50, -50, [("measurements.foo", 1)]),
-            (-10, 10, [("measurements.foo", 2)]),
-            (49, 49, [("measurements.foo", 1)]),
+            (-50, -50, [("foo", 1)]),
+            (-10, 10, [("foo", 2)]),
+            (49, 49, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (-50, -30, [("measurements.foo", 1)]),
-            (-30, -10, [("measurements.foo", 0)]),
-            (-10, 10, [("measurements.foo", 2)]),
-            (10, 30, [("measurements.foo", 0)]),
-            (30, 50, [("measurements.foo", 1)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (-50, -30, [(f"{prefix}.foo", 1)]),
+                (-30, -10, [(f"{prefix}.foo", 0)]),
+                (-10, 10, [(f"{prefix}.foo", 2)]),
+                (10, 30, [(f"{prefix}.foo", 0)]),
+                (30, 50, [(f"{prefix}.foo", 1)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_increased_precision(self):
         # range is [1.00, 2.24], so it is divided into 5 buckets of width 0.25
         specs = [
-            (1.00, 1.00, [("measurements.foo", 3)]),
-            (2.24, 2.24, [("measurements.foo", 1)]),
+            (1.00, 1.00, [("foo", 3)]),
+            (2.24, 2.24, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-            "precision": 2,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+                "precision": 2,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (1.00, 1.25, [("measurements.foo", 3)]),
-            (1.25, 1.50, [("measurements.foo", 0)]),
-            (1.50, 1.75, [("measurements.foo", 0)]),
-            (1.75, 2.00, [("measurements.foo", 0)]),
-            (2.00, 2.25, [("measurements.foo", 1)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (1.00, 1.25, [(f"{prefix}.foo", 3)]),
+                (1.25, 1.50, [(f"{prefix}.foo", 0)]),
+                (1.50, 1.75, [(f"{prefix}.foo", 0)]),
+                (1.75, 2.00, [(f"{prefix}.foo", 0)]),
+                (2.00, 2.25, [(f"{prefix}.foo", 1)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_increased_precision_with_min_max(self):
         # range is [1.25, 2.24], so it is divided into 5 buckets of width 0.25
         specs = [
-            (1.00, 1.25, [("measurements.foo", 3)]),
-            (2.00, 2.25, [("measurements.foo", 1)]),
+            (1.00, 1.25, [("foo", 3)]),
+            (2.00, 2.25, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 3,
-            "precision": 2,
-            "min": 1.25,
-            "max": 2.00,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 3,
+                "precision": 2,
+                "min": 1.25,
+                "max": 2.00,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (1.25, 1.50, [("measurements.foo", 0)]),
-            (1.50, 1.75, [("measurements.foo", 0)]),
-            (1.75, 2.00, [("measurements.foo", 0)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (1.25, 1.50, [(f"{prefix}.foo", 0)]),
+                (1.50, 1.75, [(f"{prefix}.foo", 0)]),
+                (1.75, 2.00, [(f"{prefix}.foo", 0)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_increased_precision_large_buckets(self):
         # range is [10.0000, 59.9999] so it is divided into 5 buckets of width 10
         specs = [
-            (10.0000, 10.0000, [("measurements.foo", 1)]),
-            (30.0000, 40.0000, [("measurements.foo", 1)]),
-            (59.9999, 59.9999, [("measurements.foo", 2)]),
+            (10.0000, 10.0000, [("foo", 1)]),
+            (30.0000, 40.0000, [("foo", 1)]),
+            (59.9999, 59.9999, [("foo", 2)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-            "precision": 4,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+                "precision": 4,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (10.0000, 20.0000, [("measurements.foo", 1)]),
-            (20.0000, 30.0000, [("measurements.foo", 0)]),
-            (30.0000, 40.0000, [("measurements.foo", 1)]),
-            (40.0000, 50.0000, [("measurements.foo", 0)]),
-            (50.0000, 60.0000, [("measurements.foo", 2)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (10.0000, 20.0000, [(f"{prefix}.foo", 1)]),
+                (20.0000, 30.0000, [(f"{prefix}.foo", 0)]),
+                (30.0000, 40.0000, [(f"{prefix}.foo", 1)]),
+                (40.0000, 50.0000, [(f"{prefix}.foo", 0)]),
+                (50.0000, 60.0000, [(f"{prefix}.foo", 2)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_multiple_measures(self):
         # range is [10, 59] so it is divided into 5 buckets of width 10
         specs = [
-            (10, 10, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
-            (30, 40, [("measurements.bar", 2), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (59, 59, [("measurements.bar", 0), ("measurements.baz", 1), ("measurements.foo", 0)]),
+            (10, 10, [("bar", 0), ("baz", 0), ("foo", 1)]),
+            (30, 40, [("bar", 2), ("baz", 0), ("foo", 0)]),
+            (59, 59, [("bar", 0), ("baz", 1), ("foo", 0)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.bar", "measurements.baz", "measurements.foo"],
-            "numBuckets": 5,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.bar", f"{prefix}.baz", f"{prefix}.foo"],
+                "numBuckets": 5,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (10, 20, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
-            (20, 30, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (30, 40, [("measurements.bar", 2), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (40, 50, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (50, 60, [("measurements.bar", 0), ("measurements.baz", 1), ("measurements.foo", 0)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (10, 20, [(f"{prefix}.bar", 0), (f"{prefix}.baz", 0), (f"{prefix}.foo", 1)]),
+                (20, 30, [(f"{prefix}.bar", 0), (f"{prefix}.baz", 0), (f"{prefix}.foo", 0)]),
+                (30, 40, [(f"{prefix}.bar", 2), (f"{prefix}.baz", 0), (f"{prefix}.foo", 0)]),
+                (40, 50, [(f"{prefix}.bar", 0), (f"{prefix}.baz", 0), (f"{prefix}.foo", 0)]),
+                (50, 60, [(f"{prefix}.bar", 0), (f"{prefix}.baz", 1), (f"{prefix}.foo", 0)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_max_value_on_edge(self):
         # range is [11, 21] so it is divided into 5 buckets of width 5
         # because using buckets of width 2 will exclude 21, and the next
         # nice number is 5
         specs = [
-            (11, 11, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
-            (21, 21, [("measurements.bar", 1), ("measurements.baz", 1), ("measurements.foo", 1)]),
+            (11, 11, [("bar", 0), ("baz", 0), ("foo", 1)]),
+            (21, 21, [("bar", 1), ("baz", 1), ("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.bar", "measurements.baz", "measurements.foo"],
-            "numBuckets": 5,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.bar", f"{prefix}.baz", f"{prefix}.foo"],
+                "numBuckets": 5,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (10, 15, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
-            (15, 20, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (20, 25, [("measurements.bar", 1), ("measurements.baz", 1), ("measurements.foo", 1)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (10, 15, [(f"{prefix}.bar", 0), (f"{prefix}.baz", 0), (f"{prefix}.foo", 1)]),
+                (15, 20, [(f"{prefix}.bar", 0), (f"{prefix}.baz", 0), (f"{prefix}.foo", 0)]),
+                (20, 25, [(f"{prefix}.bar", 1), (f"{prefix}.baz", 1), (f"{prefix}.foo", 1)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_bins_exceed_max(self):
         specs = [
-            (10, 15, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
-            (30, 30, [("measurements.bar", 1), ("measurements.baz", 1), ("measurements.foo", 1)]),
+            (10, 15, [("bar", 0), ("baz", 0), ("foo", 1)]),
+            (30, 30, [("bar", 1), ("baz", 1), ("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.bar", "measurements.baz", "measurements.foo"],
-            "numBuckets": 5,
-            "min": 10,
-            "max": 21,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.bar", f"{prefix}.baz", f"{prefix}.foo"],
+                "numBuckets": 5,
+                "min": 10,
+                "max": 21,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (10, 15, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 1)]),
-            (15, 20, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-            (20, 25, [("measurements.bar", 0), ("measurements.baz", 0), ("measurements.foo", 0)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (10, 15, [(f"{prefix}.bar", 0), (f"{prefix}.baz", 0), (f"{prefix}.foo", 1)]),
+                (15, 20, [(f"{prefix}.bar", 0), (f"{prefix}.baz", 0), (f"{prefix}.foo", 0)]),
+                (20, 25, [(f"{prefix}.bar", 0), (f"{prefix}.baz", 0), (f"{prefix}.foo", 0)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_bad_params_invalid_data_filter(self):
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo", "measurements.bar"],
-            "numBuckets": 10,
-            "dataFilter": "invalid",
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo", f"{prefix}.bar"],
+                "numBuckets": 10,
+                "dataFilter": "invalid",
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 400
-        assert response.data == {
-            "dataFilter": ['"invalid" is not a valid choice.'],
-        }
+            response = self.do_request(query)
+            assert response.status_code == 400
+            assert response.data == {
+                "dataFilter": ['"invalid" is not a valid choice.'],
+            }
 
     def test_histogram_all_data_filter(self):
         specs = [
-            (0, 1, [("measurements.foo", 4)]),
-            (4000, 5000, [("measurements.foo", 1)]),
+            (0, 1, [("foo", 4)]),
+            (4000, 5000, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-            "dataFilter": "all",
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+                "dataFilter": "all",
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (0, 1000, [("measurements.foo", 4)]),
-            (1000, 2000, [("measurements.foo", 0)]),
-            (2000, 3000, [("measurements.foo", 0)]),
-            (3000, 4000, [("measurements.foo", 0)]),
-            (4000, 5000, [("measurements.foo", 1)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (0, 1000, [(f"{prefix}.foo", 4)]),
+                (1000, 2000, [(f"{prefix}.foo", 0)]),
+                (2000, 3000, [(f"{prefix}.foo", 0)]),
+                (3000, 4000, [(f"{prefix}.foo", 0)]),
+                (4000, 5000, [(f"{prefix}.foo", 1)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_exclude_outliers_data_filter(self):
         specs = [
-            (0, 0, [("measurements.foo", 4)]),
-            (4000, 4001, [("measurements.foo", 1)]),
+            (0, 0, [("foo", 4)]),
+            (4000, 4001, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-            "dataFilter": "exclude_outliers",
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+                "dataFilter": "exclude_outliers",
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (0, 1, [("measurements.foo", 4)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (0, 1, [(f"{prefix}.foo", 4)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_missing_measurement_data(self):
         # make sure there is at least one transaction
         specs = [
-            (0, 1, [("measurements.foo", 1)]),
+            (0, 1, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            # make sure to query a measurement that does not exist
-            "field": ["measurements.bar"],
-            "numBuckets": 5,
-            "dataFilter": "exclude_outliers",
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                # make sure to query a measurement that does not exist
+                "field": [f"{prefix}.bar"],
+                "numBuckets": 5,
+                "dataFilter": "exclude_outliers",
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (0, 1, [("measurements.bar", 0)]),
-            (1, 1, [("measurements.bar", 0)]),
-            (2, 2, [("measurements.bar", 0)]),
-            (3, 3, [("measurements.bar", 0)]),
-            (4, 4, [("measurements.bar", 0)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (0, 1, [(f"{prefix}.bar", 0)]),
+                (1, 1, [(f"{prefix}.bar", 0)]),
+                (2, 2, [(f"{prefix}.bar", 0)]),
+                (3, 3, [(f"{prefix}.bar", 0)]),
+                (4, 4, [(f"{prefix}.bar", 0)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_missing_measurement_data_with_explicit_bounds(self):
         # make sure there is at least one transaction
         specs = [
-            (0, 1, [("measurements.foo", 1)]),
+            (0, 1, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            # make sure to query a measurement that does not exist
-            "field": ["measurements.bar"],
-            "numBuckets": 5,
-            "dataFilter": "exclude_outliers",
-            "min": 10,
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                # make sure to query a measurement that does not exist
+                "field": [f"{prefix}.bar"],
+                "numBuckets": 5,
+                "dataFilter": "exclude_outliers",
+                "min": 10,
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = [
-            (10, 11, [("measurements.bar", 0)]),
-            (11, 11, [("measurements.bar", 0)]),
-            (12, 12, [("measurements.bar", 0)]),
-            (13, 13, [("measurements.bar", 0)]),
-            (14, 14, [("measurements.bar", 0)]),
-        ]
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (10, 11, [(f"{prefix}.bar", 0)]),
+                (11, 11, [(f"{prefix}.bar", 0)]),
+                (12, 12, [(f"{prefix}.bar", 0)]),
+                (13, 13, [(f"{prefix}.bar", 0)]),
+                (14, 14, [(f"{prefix}.bar", 0)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_ignores_aggregate_conditions(self):
         # range is [0, 5), so it is divided into 5 buckets of width 1
         specs = [
-            (0, 1, [("measurements.foo", 1)]),
-            (1, 2, [("measurements.foo", 1)]),
-            (2, 3, [("measurements.foo", 1)]),
-            (3, 4, [("measurements.foo", 0)]),
-            (4, 5, [("measurements.foo", 1)]),
+            (0, 1, [("foo", 1)]),
+            (1, 2, [("foo", 1)]),
+            (2, 3, [("foo", 1)]),
+            (3, 4, [("foo", 0)]),
+            (4, 5, [("foo", 1)]),
         ]
-        self.populate_measurements(specs)
+        self.populate_events(specs)
 
-        query = {
-            "project": [self.project.id],
-            "field": ["measurements.foo"],
-            "numBuckets": 5,
-            "query": "tpm():>0.001",
-        }
+        for prefix in PREFIXES:
+            query = {
+                "project": [self.project.id],
+                "field": [f"{prefix}.foo"],
+                "numBuckets": 5,
+                "query": "tpm():>0.001",
+            }
 
-        response = self.do_request(query)
-        assert response.status_code == 200
-        expected = specs
-        assert response.data == self.as_response_data(expected)
+            response = self.do_request(query)
+            assert response.status_code == 200
+            expected = [
+                (0, 1, [(f"{prefix}.foo", 1)]),
+                (1, 2, [(f"{prefix}.foo", 1)]),
+                (2, 3, [(f"{prefix}.foo", 1)]),
+                (3, 4, [(f"{prefix}.foo", 0)]),
+                (4, 5, [(f"{prefix}.foo", 1)]),
+            ]
+            assert response.data == self.as_response_data(expected)
 
     def test_histogram_outlier_filtering_with_no_rows(self):
         query = {


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/24886

Add span op breakdown support for the histogram endpoint.