### PR TITLE
feat(notifications): Create Notification Settings API

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,11 +1,11 @@
 [mypy]
 python_version = 3.6
 files = src/sentry/notifications/*.py,
+        src/sentry/snuba/outcomes.py,
         src/sentry/snuba/query_subscription_consumer.py,
         src/sentry/utils/codecs.py,
         src/sentry/utils/kvstore,
-        src/sentry/utils/snql.py,
-        src/sentry/snuba/outcomes.py
+        src/sentry/utils/snql.py
 
 ; Enable all options used with --strict
 warn_unused_configs=True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,8 @@
 [mypy]
 python_version = 3.6
-files = src/sentry/notifications/*.py,
+files = src/sentry/api/serializers/models/notification_setting.py,
+        src/sentry/api/validators/notifications.py,
+        src/sentry/notifications/*.py,
         src/sentry/snuba/outcomes.py,
         src/sentry/snuba/query_subscription_consumer.py,
         src/sentry/utils/codecs.py,

--- a/src/sentry/api/endpoints/team_notification_settings_details.py
+++ b/src/sentry/api/endpoints/team_notification_settings_details.py
@@ -26,7 +26,9 @@ class TeamNotificationSettingsDetailsEndpoint(TeamEndpoint):
         :qparam string type: If set, filter the NotificationSettings to this type.
         :auth required:
         """
-        if not features.has("organizations:incidents", team.organization, actor=request.user):
+        if not features.has(
+            "organizations:notification-platform", team.organization, actor=request.user
+        ):
             raise ResourceDoesNotExist
 
         type_option = validate_type_option(request.GET.get("type"))
@@ -70,7 +72,9 @@ class TeamNotificationSettingsDetailsEndpoint(TeamEndpoint):
 
         :auth required:
         """
-        if not features.has("organizations:incidents", team.organization, actor=request.user):
+        if not features.has(
+            "organizations:notification-platform", team.organization, actor=request.user
+        ):
             raise ResourceDoesNotExist
 
         notification_settings = NotificationSettingsSerializer.validate(request.data, team=team)

--- a/src/sentry/api/endpoints/team_notification_settings_details.py
+++ b/src/sentry/api/endpoints/team_notification_settings_details.py
@@ -54,8 +54,7 @@ class TeamNotificationSettingsDetailsEndpoint(TeamEndpoint):
               - scope_type (str),
               - scope_identifier (int)
               - provider (str)
-            Example:
-            {
+            Example: {
                 "workflow": {
                     "project": {
                         1: {

--- a/src/sentry/api/endpoints/team_notification_settings_details.py
+++ b/src/sentry/api/endpoints/team_notification_settings_details.py
@@ -1,0 +1,79 @@
+from typing import Any
+
+from rest_framework import status
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.bases.team import TeamEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.notification_setting import NotificationSettingsSerializer
+from sentry.api.validators.notifications import validate_type_option
+from sentry.models.notificationsetting import NotificationSetting
+
+
+class TeamNotificationSettingsDetailsEndpoint(TeamEndpoint):
+    """
+    This Notification Settings endpoint is the generic way to interact with the
+    NotificationSettings table via the API.
+    """
+
+    def get(self, request: Any, team: Any) -> Response:
+        """
+        Get the Notification Settings for a given User.
+        ````````````````````````````````
+        :pparam string team_slug: The slug of the team to get.
+        :qparam string type: If set, filter the NotificationSettings to this type.
+        :auth required:
+        """
+        if not features.has("organizations:incidents", team.organization, actor=request.user):
+            raise ResourceDoesNotExist
+
+        type_option = validate_type_option(request.GET.get("type"))
+
+        return Response(
+            serialize(
+                team.actor,
+                request.user,
+                NotificationSettingsSerializer(),
+                type=type_option,
+            ),
+        )
+
+    def put(self, request: Any, team: Any) -> Response:
+        """
+        Update the Notification Settings for a given Team.
+        ````````````````````````````````
+        :pparam string team_slug: The slug of the team to get.
+        :param map <anonymous>: The POST data for this request should be several
+            nested JSON mappings. The bottommost value is the "value" of the
+            notification setting and the order of scoping is:
+              - type (str),
+              - scope_type (str),
+              - scope_identifier (int)
+              - provider (str)
+            Example:
+            {
+                "workflow": {
+                    "project": {
+                        1: {
+                            "email": "always",
+                            "slack": "always"
+                        },
+                        2: {
+                            "email": "subscribe_only",
+                            "slack": "subscribe_only"
+                        }
+                    }
+                }
+            }
+
+        :auth required:
+        """
+        if not features.has("organizations:incidents", team.organization, actor=request.user):
+            raise ResourceDoesNotExist
+
+        notification_settings = NotificationSettingsSerializer.validate(request.data, team=team)
+        NotificationSetting.objects.update_settings_bulk(notification_settings, team.actor_id)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/team_notification_settings_details.py
+++ b/src/sentry/api/endpoints/team_notification_settings_details.py
@@ -8,7 +8,7 @@ from sentry.api.bases.team import TeamEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.notification_setting import NotificationSettingsSerializer
-from sentry.api.validators.notifications import validate_type_option
+from sentry.api.validators.notifications import validate, validate_type_option
 from sentry.models.notificationsetting import NotificationSetting
 
 
@@ -77,7 +77,7 @@ class TeamNotificationSettingsDetailsEndpoint(TeamEndpoint):
         ):
             raise ResourceDoesNotExist
 
-        notification_settings = NotificationSettingsSerializer.validate(request.data, team=team)
+        notification_settings = validate(request.data, team=team)
         NotificationSetting.objects.update_settings_bulk(notification_settings, team.actor_id)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/user_notification_settings_details.py
+++ b/src/sentry/api/endpoints/user_notification_settings_details.py
@@ -64,8 +64,7 @@ class UserNotificationSettingsDetailsEndpoint(UserEndpoint):
               - scope_type (str),
               - scope_identifier (int or str)
               - provider (str)
-            Example:
-            {
+            Example: {
                 "workflow": {
                     "user": {
                         "me": {

--- a/src/sentry/api/endpoints/user_notification_settings_details.py
+++ b/src/sentry/api/endpoints/user_notification_settings_details.py
@@ -7,7 +7,7 @@ from sentry.api.bases.user import UserEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.notification_setting import NotificationSettingsSerializer
-from sentry.api.validators.notifications import validate_type_option
+from sentry.api.validators.notifications import validate, validate_type_option
 from sentry.models.notificationsetting import NotificationSetting
 
 
@@ -89,6 +89,7 @@ class UserNotificationSettingsDetailsEndpoint(UserEndpoint):
         :auth required:
         """
         validate_has_feature(user)
-        NotificationSetting.objects.update_settings_bulk(request.data, user=user)
+        notification_settings = validate(request.data)
+        NotificationSetting.objects.update_settings_bulk(notification_settings, user=user)
 
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/user_notification_settings_details.py
+++ b/src/sentry/api/endpoints/user_notification_settings_details.py
@@ -14,7 +14,7 @@ from sentry.models.notificationsetting import NotificationSetting
 def validate_has_feature(user: Any) -> None:
     if not any(
         [
-            features.has("organizations:incidents", organization, actor=user)
+            features.has("organizations:notification-platform", organization, actor=user)
             for organization in user.get_orgs()
         ]
     ):

--- a/src/sentry/api/endpoints/user_notification_settings_details.py
+++ b/src/sentry/api/endpoints/user_notification_settings_details.py
@@ -1,0 +1,94 @@
+from typing import Any
+from rest_framework import status
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.bases.user import UserEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.notification_setting import NotificationSettingsSerializer
+from sentry.api.validators.notifications import validate_type_option
+from sentry.models.notificationsetting import NotificationSetting
+
+
+def validate_has_feature(user: Any) -> None:
+    if not any(
+        [
+            features.has("organizations:incidents", organization, actor=user)
+            for organization in user.get_orgs()
+        ]
+    ):
+        raise ResourceDoesNotExist
+
+
+class UserNotificationSettingsDetailsEndpoint(UserEndpoint):
+    """
+    This Notification Settings endpoint is the generic way to interact with the
+    NotificationSettings table via the API.
+    TODO(mgaeta): If this is going to replace the UserNotificationDetailsEndpoint
+     and UserNotificationFineTuningEndpoint endpoints, then it should probably
+     be able to translate legacy values from UserOptions.
+    """
+
+    def get(self, request: Any, user: Any) -> Response:
+        """
+        Get the Notification Settings for a given User.
+        ````````````````````````````````
+        :pparam string user_id: A User's `user_id` or "me" for current user.
+        :qparam string type: If set, filter the NotificationSettings to this type.
+
+        :auth required:
+        """
+        validate_has_feature(user)
+
+        type_option = validate_type_option(request.GET.get("type"))
+
+        return Response(
+            serialize(
+                user.actor,
+                request.user,
+                NotificationSettingsSerializer(),
+                type=type_option,
+            ),
+        )
+
+    def put(self, request: Any, user: Any) -> Response:
+        """
+        Update the Notification Settings for a given User.
+        ````````````````````````````````
+        :pparam string user_id: A User's `user_id` or "me" for current user.
+        :param map <anonymous>: The POST data for this request should be several
+            nested JSON mappings. The bottommost value is the "value" of the
+            notification setting and the order of scoping is:
+              - type (str),
+              - scope_type (str),
+              - scope_identifier (int or str)
+              - provider (str)
+            Example:
+            {
+                "workflow": {
+                    "user": {
+                        "me": {
+                            "email": "never",
+                            "slack": "never"
+                        },
+                    },
+                    "project": {
+                        1: {
+                            "email": "always",
+                            "slack": "always"
+                        },
+                        2: {
+                            "email": "subscribe_only",
+                            "slack": "subscribe_only"
+                        }
+                    }
+                }
+            }
+
+        :auth required:
+        """
+        validate_has_feature(user)
+        NotificationSetting.objects.update_settings_bulk(request.data, user=user)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -27,6 +27,14 @@ class SentryAPIException(APIException):
         self.detail = {"detail": detail}
 
 
+class ParameterValidationError(SentryAPIException):  # type: ignore
+    status_code = status.HTTP_400_BAD_REQUEST
+    code = "parameter-validation-error"
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message=message)
+
+
 class ProjectMoved(SentryAPIException):
     status_code = status.HTTP_302_FOUND
     # code/message currently don't get used

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from django.core.urlresolvers import reverse
 from rest_framework import status
 from rest_framework.exceptions import APIException
@@ -27,12 +29,12 @@ class SentryAPIException(APIException):
         self.detail = {"detail": detail}
 
 
-class ParameterValidationError(SentryAPIException):  # type: ignore
+class ParameterValidationError(SentryAPIException):
     status_code = status.HTTP_400_BAD_REQUEST
     code = "parameter-validation-error"
 
-    def __init__(self, message: str) -> None:
-        super().__init__(message=message)
+    def __init__(self, message: str, context: Optional[List[str]] = None) -> None:
+        super().__init__(message=message, context=".".join(context))
 
 
 class ProjectMoved(SentryAPIException):

--- a/src/sentry/api/serializers/models/notification_setting.py
+++ b/src/sentry/api/serializers/models/notification_setting.py
@@ -19,9 +19,8 @@ class NotificationSettingsSerializer(Serializer):  # type: ignore
         This takes a list of either Users or Teams (which we will refer to as
         "targets") because both can have Notification Settings. The function
         returns a mapping of targets to flat lists of object to be passed to the
-        `serialize` function. TODO explain why this returns a flat list.
+        `serialize` function.
 
-        TODO Should this take strings instead of enums?
         :param item_list: List of user or team objects whose notification
             settings should be serialized.
         :param user: The user who will be viewing the notification settings.

--- a/src/sentry/api/serializers/models/notification_setting.py
+++ b/src/sentry/api/serializers/models/notification_setting.py
@@ -1,0 +1,157 @@
+from collections import defaultdict
+from typing import Any, Dict, Iterable, Mapping, Optional, Set, Tuple
+
+from sentry.api.exceptions import ParameterValidationError
+from sentry.api.serializers import Serializer
+from sentry.api.validators.notifications import (
+    validate_organizations,
+    validate_projects,
+    validate_provider,
+    validate_scope,
+    validate_scope_type,
+    validate_type,
+    validate_value,
+)
+from sentry.models.integration import ExternalProviders
+from sentry.models.notificationsetting import NotificationSetting
+from sentry.notifications.types import (
+    NotificationScopeType,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+)
+
+
+class NotificationSettingsSerializer(Serializer):  # type: ignore
+    """
+    This Serializer fetches and serializes NotificationSettings for a list of
+    targets (users or teams.) Pass filters like `project=project` and
+    `type=NotificationSettingTypes.DEPLOY` to kwargs.
+    """
+
+    def get_attrs(
+        self, item_list: Iterable[Any], user: Any, **kwargs: Any
+    ) -> Mapping[Any, Iterable[NotificationSetting]]:
+        """
+        This takes a list of either Users or Teams (which we will refer to as
+        "targets") because both can have Notification Settings. The function
+        returns a mapping of targets to flat lists of object to be passed to the
+        `serialize` function. TODO explain why this returns a flat list.
+
+        TODO Should this take strings instead of enums?
+        :param item_list: List of user or team objects whose notification
+            settings should be serialized.
+        :param user: The user who will be viewing the notification settings.
+        :param kwargs: Dict of optional filter options:
+            - type: NotificationSettingTypes enum value. e.g. WORKFLOW, DEPLOY.
+            - provider: ExternalProvider enum value. e.g. SLACK, EMAIL.
+        """
+        actor_mapping = {target.actor_id: target for target in item_list}
+        filter_kwargs = dict(target_ids=actor_mapping.keys())
+
+        type_option = kwargs.get("type")
+        if type_option:
+            filter_kwargs["type"] = type_option
+
+        provider_option = kwargs.get("provider")
+        if provider_option:
+            filter_kwargs["provider"] = provider_option
+
+        notifications_settings = NotificationSetting.objects._filter(**filter_kwargs)
+
+        results = defaultdict(list)
+        for notifications_setting in notifications_settings:
+            target = actor_mapping.get(notifications_setting.target_id)
+            results[target].append(notifications_setting)
+
+        return results
+
+    def serialize(
+        self,
+        obj: Any,
+        attrs: Iterable[Any],
+        user: Any,
+        **kwargs: Any,
+    ) -> Mapping[str, Mapping[str, Mapping[int, Mapping[str, str]]]]:
+        """
+        Convert a user or team's NotificationSettings to a python object comprised of primitives.
+
+        :param obj: A user or team.
+        :param attrs: The `obj` target's NotificationSettings
+        :param user: The user who will be viewing the NotificationSettings.
+        :param kwargs: Currently unused but the same `kwargs` as `get_attrs`.
+        :returns A mapping
+        """
+        data: Dict[str, Dict[str, Dict[int, Dict[str, str]]]] = defaultdict(
+            lambda: defaultdict(lambda: defaultdict(dict))
+        )
+        for n in attrs:  # Forgive the variable name, I wanted the next line to be legible.
+            data[n.type_str][n.scope_str][n.scope_identifier][n.provider_str] = n.value_str
+
+        return data
+
+    @staticmethod
+    def validate(
+        data: Mapping[str, Mapping[str, Mapping[int, Mapping[str, str]]]],
+        user: Optional[Any] = None,
+        team: Optional[Any] = None,
+    ) -> Iterable[
+        Tuple[
+            ExternalProviders,
+            NotificationSettingTypes,
+            NotificationScopeType,
+            int,
+            NotificationSettingOptionValues,
+        ],
+    ]:
+        """
+        Validate some serialized notification settings. If invalid, raise an
+        exception. Otherwise, return them as a list of tuples.
+        """
+        if not data or len(data) < 1:
+            raise ParameterValidationError("Payload required")
+
+        notification_settings_to_update: Dict[
+            Tuple[
+                NotificationSettingTypes,
+                NotificationScopeType,
+                int,
+                ExternalProviders,
+            ],
+            NotificationSettingOptionValues,
+        ] = {}
+        project_ids_to_look_up: Set[int] = set()
+        organization_ids_to_look_up: Set[int] = set()
+        for type_key, notifications_by_type in data.items():
+            type = validate_type(type_key)
+
+            for scope_type_key, notifications_by_scope_type in notifications_by_type.items():
+                scope_type = validate_scope_type(scope_type_key)
+
+                for scope_id, notifications_by_scope_id in notifications_by_scope_type.items():
+                    scope_id = validate_scope(scope_id, scope_type, user)
+
+                    if scope_type == NotificationScopeType.PROJECT:
+                        project_ids_to_look_up.add(scope_id)
+                    elif scope_type == NotificationScopeType.ORGANIZATION:
+                        organization_ids_to_look_up.add(scope_id)
+
+                    for provider_key, value_key in notifications_by_scope_id.items():
+                        provider = validate_provider(provider_key)
+                        value = validate_value(type, value_key)
+
+                        notification_settings_to_update[
+                            (type, scope_type, scope_id, provider)
+                        ] = value
+
+        validate_projects(project_ids_to_look_up, user=user, team=team)
+        validate_organizations(organization_ids_to_look_up, user=user, team=team)
+
+        return {
+            (provider, type, scope_type, scope_id, value)
+            for (
+                type,
+                scope_type,
+                scope_id,
+                provider,
+            ), value in notification_settings_to_update.items()
+        }

--- a/src/sentry/api/serializers/models/notification_setting.py
+++ b/src/sentry/api/serializers/models/notification_setting.py
@@ -58,12 +58,26 @@ class NotificationSettingsSerializer(Serializer):  # type: ignore
     ) -> Mapping[str, Mapping[str, Mapping[int, Mapping[str, str]]]]:
         """
         Convert a user or team's NotificationSettings to a python object comprised of primitives.
+        Example: {
+            "workflow": {
+                "project": {
+                    1: {
+                        "email": "always",
+                        "slack": "always"
+                    },
+                    2: {
+                        "email": "subscribe_only",
+                        "slack": "subscribe_only"
+                    }
+                }
+            }
+        }
 
         :param obj: A user or team.
         :param attrs: The `obj` target's NotificationSettings
         :param user: The user who will be viewing the NotificationSettings.
         :param kwargs: Currently unused but the same `kwargs` as `get_attrs`.
-        :returns A mapping
+        :returns A mapping. See example.
         """
         data: Dict[str, Dict[str, Dict[int, Dict[str, str]]]] = defaultdict(
             lambda: defaultdict(lambda: defaultdict(dict))

--- a/src/sentry/api/serializers/models/notification_setting.py
+++ b/src/sentry/api/serializers/models/notification_setting.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from typing import Any, Dict, Iterable, Mapping
 
 from sentry.api.serializers import Serializer
-from sentry.models.notificationsetting import NotificationSetting
 
 
 class NotificationSettingsSerializer(Serializer):  # type: ignore
@@ -14,7 +13,7 @@ class NotificationSettingsSerializer(Serializer):  # type: ignore
 
     def get_attrs(
         self, item_list: Iterable[Any], user: Any, **kwargs: Any
-    ) -> Mapping[Any, Iterable[NotificationSetting]]:
+    ) -> Mapping[Any, Iterable[Any]]:
         """
         This takes a list of either Users or Teams (which we will refer to as
         "targets") because both can have Notification Settings. The function
@@ -28,6 +27,8 @@ class NotificationSettingsSerializer(Serializer):  # type: ignore
             - type: NotificationSettingTypes enum value. e.g. WORKFLOW, DEPLOY.
             - provider: ExternalProvider enum value. e.g. SLACK, EMAIL.
         """
+        from sentry.models import NotificationSetting
+
         actor_mapping = {target.actor_id: target for target in item_list}
         filter_kwargs = dict(target_ids=actor_mapping.keys())
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -604,14 +604,14 @@ urlpatterns = [
                     name="sentry-api-0-user-notifications",
                 ),
                 url(
-                    r"^(?P<user_id>[^\/]+)/password/$",
-                    UserPasswordEndpoint.as_view(),
-                    name="sentry-api-0-user-password",
-                ),
-                url(
                     r"^(?P<user_id>[^\/]+)/notifications/(?P<notification_type>[^\/]+)/$",
                     UserNotificationFineTuningEndpoint.as_view(),
                     name="sentry-api-0-user-notifications-fine-tuning",
+                ),
+                url(
+                    r"^(?P<user_id>[^\/]+)/password/$",
+                    UserPasswordEndpoint.as_view(),
+                    name="sentry-api-0-user-password",
                 ),
                 url(
                     r"^(?P<user_id>[^\/]+)/social-identities/$",

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -358,6 +358,7 @@ from .endpoints.team_details import TeamDetailsEndpoint
 from .endpoints.team_groups_new import TeamGroupsNewEndpoint
 from .endpoints.team_groups_trending import TeamGroupsTrendingEndpoint
 from .endpoints.team_members import TeamMembersEndpoint
+from .endpoints.team_notification_settings_details import TeamNotificationSettingsDetailsEndpoint
 from .endpoints.team_projects import TeamProjectsEndpoint
 from .endpoints.team_stats import TeamStatsEndpoint
 from .endpoints.user_authenticator_details import UserAuthenticatorDetailsEndpoint
@@ -371,6 +372,7 @@ from .endpoints.user_index import UserIndexEndpoint
 from .endpoints.user_ips import UserIPsEndpoint
 from .endpoints.user_notification_details import UserNotificationDetailsEndpoint
 from .endpoints.user_notification_fine_tuning import UserNotificationFineTuningEndpoint
+from .endpoints.user_notification_settings_details import UserNotificationSettingsDetailsEndpoint
 from .endpoints.user_organizations import UserOrganizationsEndpoint
 from .endpoints.user_password import UserPasswordEndpoint
 from .endpoints.user_social_identities_index import UserSocialIdentitiesIndexEndpoint
@@ -597,6 +599,11 @@ urlpatterns = [
                     r"^(?P<user_id>[^\/]+)/organizations/$",
                     UserOrganizationsEndpoint.as_view(),
                     name="sentry-api-0-user-organizations",
+                ),
+                url(
+                    r"^(?P<user_id>[^\/]+)/notification-settings/$",
+                    UserNotificationSettingsDetailsEndpoint.as_view(),
+                    name="sentry-api-0-user-notification-settings",
                 ),
                 url(
                     r"^(?P<user_id>[^\/]+)/notifications/$",
@@ -1318,6 +1325,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/(?:issues|groups)/trending/$",
                     TeamGroupsTrendingEndpoint.as_view(),
                     name="sentry-api-0-team-groups-trending",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/notification-settings/$",
+                    TeamNotificationSettingsDetailsEndpoint.as_view(),
+                    name="sentry-api-0-user-notification-settings",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/members/$",

--- a/src/sentry/api/validators/notifications.py
+++ b/src/sentry/api/validators/notifications.py
@@ -1,0 +1,118 @@
+from typing import Any, Dict, Mapping, Optional, Set, Union
+
+from sentry.api.exceptions import ParameterValidationError
+from sentry.models.integration import ExternalProviders
+from sentry.notifications.helpers import validate as helper_validate
+from sentry.notifications.types import (
+    NotificationScopeType,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+)
+
+
+def intersect_dict_set(d: Dict[int, Any], s: Set[int]) -> Dict[int, Any]:
+    """ Get the sub-dictionary where the keys are in the intersections the original keys and the set. """
+    # TODO(mgaeta): Genericize the key type and move to sentry.utils.
+    return {k: v for k, v in d.items() if k in s}
+
+
+def validate_organizations(
+    organization_ids_to_look_up: Set[int],
+    user: Optional[Any] = None,
+    team: Optional[Any] = None,
+) -> Mapping[int, Any]:
+    if not organization_ids_to_look_up:
+        return {}
+
+    if user:
+        organizations_by_id = {organization.id: organization for organization in user.get_orgs()}
+    elif team:
+        organizations_by_id = {team.organization.id: team.organization}
+    else:
+        raise Exception("User or Team must be set.")
+
+    missing_organization_ids = organization_ids_to_look_up - organizations_by_id.keys()
+    if missing_organization_ids:
+        raise ParameterValidationError(f"Invalid organization IDs: {missing_organization_ids}")
+
+    return intersect_dict_set(organizations_by_id, organization_ids_to_look_up)
+
+
+def validate_projects(
+    project_ids_to_look_up: Set[int],
+    user: Optional[Any] = None,
+    team: Optional[Any] = None,
+) -> Mapping[int, Any]:
+    if not project_ids_to_look_up:
+        return {}
+
+    if user:
+        projects_by_id = {project.id: project for project in user.get_projects()}
+    elif team:
+        projects_by_id = {project.id: project for project in team.get_projects()}
+    else:
+        raise Exception("User or Team must be set.")
+
+    missing_project_ids = project_ids_to_look_up - projects_by_id.keys()
+    if missing_project_ids:
+        raise ParameterValidationError(f"Invalid project IDs: {missing_project_ids}")
+
+    return intersect_dict_set(projects_by_id, project_ids_to_look_up)
+
+
+def validate_type_option(type: Optional[str]) -> Optional[NotificationSettingTypes]:
+    return validate_type(type) if type else None
+
+
+def validate_provider_option(provider: Optional[str]) -> Optional[ExternalProviders]:
+    return validate_provider(provider) if provider else None
+
+
+def validate_type(type: str, context: Optional[str] = None) -> NotificationSettingTypes:
+    try:
+        return NotificationSettingTypes(type)
+    except ValueError:
+        raise ParameterValidationError(f"Unknown type: {type} in {context}")
+
+
+def validate_scope_type(scope_type: str, context: Optional[str] = None) -> NotificationScopeType:
+    try:
+        return NotificationScopeType(scope_type)
+    except ValueError:
+        raise ParameterValidationError(f"Unknown scope_type: {scope_type} in {context}")
+
+
+def validate_scope(
+    scope_id: Union[int, str],
+    scope_type: NotificationScopeType,
+    user: Optional[Any] = None,
+    context: Optional[str] = None,
+) -> int:
+    if user and scope_type == NotificationScopeType.USER:
+        # Overwrite every user ID with the current user's ID.
+        scope_id = user.id
+
+    try:
+        return int(scope_id)
+    except ValueError:
+        raise ParameterValidationError(f"Invalid ID: {scope_id} in {context}")
+
+
+def validate_provider(provider: str, context: Optional[str] = None) -> ExternalProviders:
+    try:
+        return ExternalProviders(provider)
+    except ValueError:
+        raise ParameterValidationError(f"Unknown provider: {provider} in {context}")
+
+
+def validate_value(
+    type: NotificationSettingTypes, value: str, context: Optional[str] = None
+) -> NotificationSettingOptionValues:
+    try:
+        value = NotificationSettingOptionValues(value)
+    except ValueError:
+        raise ParameterValidationError(f"Unknown value: {value} in {context}")
+
+    if not helper_validate(type, value):
+        raise ParameterValidationError(f"Invalid value for type {type}: {value} in {context}")
+    return value

--- a/src/sentry/api/validators/notifications.py
+++ b/src/sentry/api/validators/notifications.py
@@ -106,12 +106,12 @@ def validate_provider(provider: str, context: Optional[str] = None) -> ExternalP
 
 
 def validate_value(
-    type: NotificationSettingTypes, value: str, context: Optional[str] = None
+    type: NotificationSettingTypes, value_param: str, context: Optional[str] = None
 ) -> NotificationSettingOptionValues:
     try:
-        value = NotificationSettingOptionValues(value)
+        value = NotificationSettingOptionValues(value_param)
     except ValueError:
-        raise ParameterValidationError(f"Unknown value: {value} in {context}")
+        raise ParameterValidationError(f"Unknown value: {value_param} in {context}")
 
     if not helper_validate(type, value):
         raise ParameterValidationError(f"Invalid value for type {type}: {value} in {context}")

--- a/src/sentry/api/validators/notifications.py
+++ b/src/sentry/api/validators/notifications.py
@@ -68,7 +68,6 @@ def validate_provider_option(provider: Optional[str]) -> Optional[ExternalProvid
     return validate_provider(provider) if provider else None
 
 
-# TODO MARCOS FIRST fix contexts!
 def validate_type(type: str, context: Optional[List[str]] = None) -> NotificationSettingTypes:
     try:
         return NotificationSettingTypes(type)

--- a/src/sentry/api/validators/notifications.py
+++ b/src/sentry/api/validators/notifications.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
 from sentry.api.exceptions import ParameterValidationError
 from sentry.models.integration import ExternalProviders
@@ -68,25 +68,28 @@ def validate_provider_option(provider: Optional[str]) -> Optional[ExternalProvid
     return validate_provider(provider) if provider else None
 
 
-def validate_type(type: str, context: Optional[str] = None) -> NotificationSettingTypes:
+# TODO MARCOS FIRST fix contexts!
+def validate_type(type: str, context: Optional[List[str]] = None) -> NotificationSettingTypes:
     try:
         return NotificationSettingTypes(type)
     except ValueError:
-        raise ParameterValidationError(f"Unknown type: {type} in {context}")
+        raise ParameterValidationError(f"Unknown type: {type}", context)
 
 
-def validate_scope_type(scope_type: str, context: Optional[str] = None) -> NotificationScopeType:
+def validate_scope_type(
+    scope_type: str, context: Optional[List[str]] = None
+) -> NotificationScopeType:
     try:
         return NotificationScopeType(scope_type)
     except ValueError:
-        raise ParameterValidationError(f"Unknown scope_type: {scope_type} in {context}")
+        raise ParameterValidationError(f"Unknown scope_type: {scope_type}", context)
 
 
 def validate_scope(
     scope_id: Union[int, str],
     scope_type: NotificationScopeType,
     user: Optional[Any] = None,
-    context: Optional[str] = None,
+    context: Optional[List[str]] = None,
 ) -> int:
     if user and scope_type == NotificationScopeType.USER:
         # Overwrite every user ID with the current user's ID.
@@ -95,26 +98,26 @@ def validate_scope(
     try:
         return int(scope_id)
     except ValueError:
-        raise ParameterValidationError(f"Invalid ID: {scope_id} in {context}")
+        raise ParameterValidationError(f"Invalid ID: {scope_id}", context)
 
 
-def validate_provider(provider: str, context: Optional[str] = None) -> ExternalProviders:
+def validate_provider(provider: str, context: Optional[List[str]] = None) -> ExternalProviders:
     try:
         return ExternalProviders(provider)
     except ValueError:
-        raise ParameterValidationError(f"Unknown provider: {provider} in {context}")
+        raise ParameterValidationError(f"Unknown provider: {provider}", context)
 
 
 def validate_value(
-    type: NotificationSettingTypes, value_param: str, context: Optional[str] = None
+    type: NotificationSettingTypes, value_param: str, context: Optional[List[str]] = None
 ) -> NotificationSettingOptionValues:
     try:
         value = NotificationSettingOptionValues(value_param)
     except ValueError:
-        raise ParameterValidationError(f"Unknown value: {value_param} in {context}")
+        raise ParameterValidationError(f"Unknown value: {value_param}", context)
 
     if not helper_validate(type, value):
-        raise ParameterValidationError(f"Invalid value for type {type}: {value} in {context}")
+        raise ParameterValidationError(f"Invalid value for type {type}: {value}", context)
     return value
 
 
@@ -139,6 +142,8 @@ def validate(
     if not data:
         raise ParameterValidationError("Payload required")
 
+    parent_context = ["notification_settings"]
+    context = parent_context
     notification_settings_to_update: Dict[
         Tuple[
             NotificationSettingTypes,
@@ -151,22 +156,24 @@ def validate(
     project_ids_to_look_up: Set[int] = set()
     organization_ids_to_look_up: Set[int] = set()
     for type_key, notifications_by_type in data.items():
-        type = validate_type(type_key)
+        type = validate_type(type_key, context)
+        context = parent_context + [type_key]
 
         for scope_type_key, notifications_by_scope_type in notifications_by_type.items():
-            scope_type = validate_scope_type(scope_type_key)
-
+            scope_type = validate_scope_type(scope_type_key, context)
+            context = parent_context + [type_key, scope_type_key]
             for scope_id, notifications_by_scope_id in notifications_by_scope_type.items():
-                scope_id = validate_scope(scope_id, scope_type, user)
+                scope_id = validate_scope(scope_id, scope_type, user, context)
 
                 if scope_type == NotificationScopeType.PROJECT:
                     project_ids_to_look_up.add(scope_id)
                 elif scope_type == NotificationScopeType.ORGANIZATION:
                     organization_ids_to_look_up.add(scope_id)
 
+                context = parent_context + [type_key, scope_type_key, str(scope_id)]
                 for provider_key, value_key in notifications_by_scope_id.items():
-                    provider = validate_provider(provider_key)
-                    value = validate_value(type, value_key)
+                    provider = validate_provider(provider_key, context)
+                    value = validate_value(type, value_key, context)
 
                     notification_settings_to_update[(type, scope_type, scope_id, provider)] = value
 

--- a/src/sentry/auth/system.py
+++ b/src/sentry/auth/system.py
@@ -1,4 +1,5 @@
 import ipaddress
+from typing import Any
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -83,5 +84,6 @@ class SystemToken:
         pass
 
 
-def is_system_auth(auth):
+def is_system_auth(auth: Any) -> bool:
+    """ :returns True when Sentry itself is hitting the API. """
     return isinstance(auth, SystemToken)

--- a/src/sentry/models/actor.py
+++ b/src/sentry/models/actor.py
@@ -1,4 +1,5 @@
 from collections import defaultdict, namedtuple
+from typing import Any
 
 from django.db import models
 from django.db.models.signals import pre_save
@@ -7,11 +8,10 @@ from rest_framework import serializers
 from sentry.db.models import Model
 from sentry.utils.compat import filter
 
-
 ACTOR_TYPES = {"team": 0, "user": 1}
 
 
-def actor_type_to_class(type):
+def actor_type_to_class(type: int) -> Any:
     # type will be 0 or 1 and we want to get Team or User
     from sentry.models import Team, User
 

--- a/src/sentry/models/integration.py
+++ b/src/sentry/models/integration.py
@@ -1,5 +1,6 @@
 import logging
 from enum import Enum
+from typing import Optional
 
 from django.db import models, IntegrityError
 from django.utils import timezone
@@ -78,9 +79,13 @@ EXTERNAL_PROVIDERS = {
 }
 
 
+def get_provider_name(value: int) -> Optional[str]:
+    return EXTERNAL_PROVIDERS.get(ExternalProviders(value))
+
+
 class ExternalProviderMixin:
     def get_provider_string(provider_int):
-        return EXTERNAL_PROVIDERS.get(ExternalProviders(provider_int), "unknown")
+        return get_provider_name(provider_int) or "unknown"
 
     def get_provider_enum(provider_str):
         inv_providers_map = {v: k for k, v in EXTERNAL_PROVIDERS.items()}

--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -7,9 +7,12 @@ from sentry.db.models import (
     Model,
     sane_repr,
 )
-from sentry.models.integration import ExternalProviders
+from sentry.models.integration import ExternalProviders, get_provider_name
 from sentry.notifications.manager import NotificationsManager
 from sentry.notifications.types import (
+    get_notification_scope_name,
+    get_notification_setting_type_name,
+    get_notification_setting_value_name,
     NotificationScopeType,
     NotificationSettingOptionValues,
     NotificationSettingTypes,
@@ -25,6 +28,22 @@ class NotificationSetting(Model):
     """
 
     __core__ = False
+
+    @property
+    def scope_str(self) -> str:
+        return get_notification_scope_name(self.scope_type)
+
+    @property
+    def type_str(self) -> str:
+        return get_notification_setting_type_name(self.type)
+
+    @property
+    def value_str(self) -> str:
+        return get_notification_setting_value_name(self.value)
+
+    @property
+    def provider_str(self) -> str:
+        return get_provider_name(self.provider)
 
     scope_type = BoundedPositiveIntegerField(
         choices=(

--- a/src/sentry/models/team.py
+++ b/src/sentry/models/team.py
@@ -245,3 +245,13 @@ class Team(Model):
 
     def get_audit_log_data(self):
         return {"id": self.id, "slug": self.slug, "name": self.name, "status": self.status}
+
+    def get_projects(self):
+        from sentry.models import Project, ProjectStatus, ProjectTeam
+
+        return Project.objects.filter(
+            status=ProjectStatus.VISIBLE,
+            id__in=ProjectTeam.objects.filter(
+                team_id=self.id,
+            ).values_list("project_id", flat=True),
+        )

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Optional
 
 """
 TODO(postgres): We've encoded these enums as integers to facilitate
@@ -7,6 +8,18 @@ communication with the API and plan to do so as soon as we use native enums in
 Postgres. In the meantime each enum has an adjacent object that maps the
 integers to their string values.
 """
+
+
+def get_notification_setting_type_name(value: int) -> Optional[str]:
+    return NOTIFICATION_SETTING_TYPES.get(NotificationSettingTypes(value))
+
+
+def get_notification_setting_value_name(value: int) -> Optional[str]:
+    return NOTIFICATION_SETTING_OPTION_VALUES.get(NotificationSettingOptionValues(value))
+
+
+def get_notification_scope_name(value: int) -> Optional[str]:
+    return NOTIFICATION_SCOPE_TYPE.get(NotificationScopeType(value))
 
 
 class NotificationSettingTypes(Enum):


### PR DESCRIPTION
This PR creates a new endpoint for the API that lets users directly interact with their NotificationSettings. For the most part I expect that users will just be using the `/notification_settings/me/"` URL rather than updating settings for an Actor. This will be gated behind a feature flag so that we can worry about permissions later.