### PR TITLE
feat(codeowners): List view UI and edit IssueOwners

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/modal.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/modal.tsx
@@ -6,7 +6,15 @@ import {css} from '@emotion/core';
 import ModalActions from 'app/actions/modalActions';
 import type {DashboardWidgetModalOptions} from 'app/components/modals/addDashboardWidgetModal';
 import type {ReprocessEventModalOptions} from 'app/components/modals/reprocessEventModal';
-import {DebugFileSource, Group, Organization, Project, SentryApp, Team} from 'app/types';
+import {
+  DebugFileSource,
+  Group,
+  IssueOwnership,
+  Organization,
+  Project,
+  SentryApp,
+  Team,
+} from 'app/types';
 import {Event} from 'app/types/event';
 
 export type ModalRenderProps = {
@@ -109,9 +117,25 @@ type CreateOwnershipRuleModalOptions = {
   issueId: string;
 };
 
+export type EditOwnershipRulesModalOptions = {
+  organization: Organization;
+  project: Project;
+  ownership: IssueOwnership;
+  onSave: (text: string | null) => void;
+};
+
 export async function openCreateOwnershipRule(options: CreateOwnershipRuleModalOptions) {
   const mod = await import(
     /* webpackChunkName: "CreateOwnershipRuleModal" */ 'app/components/modals/createOwnershipRuleModal'
+  );
+  const {default: Modal, modalCss} = mod;
+
+  openModal(deps => <Modal {...deps} {...options} />, {modalCss});
+}
+
+export async function openEditOwnershipRules(options: EditOwnershipRulesModalOptions) {
+  const mod = await import(
+    /* webpackChunkName: "EditOwnershipRulesModal" */ 'app/components/modals/editOwnershipRulesModal'
   );
   const {default: Modal, modalCss} = mod;
 

--- a/src/sentry/static/sentry/app/actionCreators/modal.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/modal.tsx
@@ -139,7 +139,7 @@ export async function openEditOwnershipRules(options: EditOwnershipRulesModalOpt
   );
   const {default: Modal, modalCss} = mod;
 
-  openModal(deps => <Modal {...deps} {...options} />, {modalCss});
+  openModal(deps => <Modal {...deps} {...options} />, {backdrop: 'static', modalCss});
 }
 
 export async function openCommandPalette(options: ModalOptions = {}) {

--- a/src/sentry/static/sentry/app/components/modals/editOwnershipRulesModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/editOwnershipRulesModal.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {css} from '@emotion/core';
+
+import {EditOwnershipRulesModalOptions, ModalRenderProps} from 'app/actionCreators/modal';
+import {t} from 'app/locale';
+import theme from 'app/utils/theme';
+import OwnershipModal from 'app/views/settings/project/projectOwnership/editRulesModal';
+
+type Props = ModalRenderProps & EditOwnershipRulesModalOptions;
+
+const EditOwnershipRulesModal = ({Body, Header, closeModal, onSave, ...props}: Props) => {
+  return (
+    <React.Fragment>
+      <Header closeButton onHide={closeModal}>
+        {t('Edit Ownership Rules')}
+      </Header>
+      <Body>
+        <OwnershipModal {...props} onSave={onSave} />
+      </Body>
+    </React.Fragment>
+  );
+};
+
+export const modalCss = css`
+  @media (min-width: ${theme.breakpoints[0]}) {
+    .modal-dialog {
+      width: 80%;
+      margin-left: -40%;
+    }
+  }
+  .modal-content {
+    overflow: initial;
+  }
+
+  .modal-header {
+    font-size: 20px;
+    font-weight: bold;
+  }
+`;
+
+export default EditOwnershipRulesModal;

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1975,3 +1975,12 @@ export enum HealthStatsPeriodOption {
   AUTO = 'auto',
   TWENTY_FOUR_HOURS = '24h',
 }
+
+export type IssueOwnership = {
+  raw: string;
+  fallthrough: boolean;
+  dateCreated: string;
+  lastUpdated: string;
+  isActive: boolean;
+  autoAssignment: boolean;
+};

--- a/src/sentry/static/sentry/app/types/index.tsx
+++ b/src/sentry/static/sentry/app/types/index.tsx
@@ -1984,3 +1984,11 @@ export type IssueOwnership = {
   isActive: boolean;
   autoAssignment: boolean;
 };
+
+export type CodeOwners = {
+  id: string;
+  raw: string;
+  dateCreated: string;
+  dateUpdated: string;
+  provider: 'github' | 'gitlab';
+};

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -1,20 +1,12 @@
 import React from 'react';
-import TextareaAutosize from 'react-autosize-textarea';
-import styled from '@emotion/styled';
-import {withTheme} from 'emotion-theming';
-import moment from 'moment';
 
 import AsyncComponent from 'app/components/asyncComponent';
-import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
-import Tag from 'app/components/tag';
-import {IconGithub, IconGitlab} from 'app/icons';
-import {inputStyles} from 'app/styles/input';
-import space from 'app/styles/space';
+import Button from 'app/components/button';
+import {IconDelete} from 'app/icons';
 import {Organization, Project} from 'app/types';
-import {Theme} from 'app/utils/theme';
+import RulesPanel from 'app/views/settings/project/projectOwnership/rulesPanel';
 
 type Props = AsyncComponent['props'] & {
-  theme: Theme;
   organization: Organization;
   project: Project;
 };
@@ -31,159 +23,33 @@ class CodeOwners extends AsyncComponent<Props, State> {
       ],
     ];
   }
-  renderIcon(provider) {
-    switch (provider) {
-      case 'github':
-        return <IconGithub size="md" />;
-      case 'gitlab':
-        return <IconGitlab size="md" />;
-      default:
-        return null;
-    }
-  }
-  renderView(data) {
-    const {theme} = this.props;
-    const {
-      raw,
-      dateUpdated,
-      provider,
-      codeMapping: {repoName},
-    } = data;
-    return (
-      <Container>
-        <RulesHeader>
-          <TitleContainer>
-            {this.renderIcon(provider)}
-            <Title>CODEOWNERS</Title>
-          </TitleContainer>
-          <ReadOnlyTag type="default">{'Read Only'}</ReadOnlyTag>
-          <Repository>{repoName}</Repository>
-          <Detail />
-        </RulesHeader>
-        <RulesView>
-          <InnerPanel>
-            <InnerPanelHeader>{`Last synced ${moment(
-              dateUpdated
-            ).fromNow()}`}</InnerPanelHeader>
-            <InnerPanelBody>
-              <StyledTextArea
-                value={raw}
-                spellCheck="false"
-                autoComplete="off"
-                autoCorrect="off"
-                autoCapitalize="off"
-                theme={theme}
-              />
-            </InnerPanelBody>
-          </InnerPanel>
-        </RulesView>
-      </Container>
-    );
-  }
 
   renderBody() {
     const {codeowners} = this.state;
-    return codeowners.map(codeowner => (
-      <React.Fragment key={codeowner.id}>{this.renderView(codeowner)}</React.Fragment>
-    ));
+    return codeowners.map(codeowner => {
+      const {
+        raw,
+        dateUpdated,
+        provider,
+        codeMapping: {repoName},
+      } = codeowner;
+      return (
+        <React.Fragment key={codeowner.id}>
+          <RulesPanel
+            type="codeowners"
+            raw={raw}
+            dateUpdated={dateUpdated}
+            provider={provider}
+            repoName={repoName}
+            readOnly
+            controls={[
+              <Button key="delete" icon={<IconDelete size="xs" />} size="xsmall" />,
+            ]}
+          />
+        </React.Fragment>
+      );
+    });
   }
 }
 
-export default withTheme(CodeOwners);
-
-const Container = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 2fr;
-  grid-template-areas: 'rules-header rules-view';
-  margin-bottom: ${space(3)};
-`;
-
-const RulesHeader = styled('div')`
-  grid-area: rules-header;
-  display: grid;
-  grid-template-columns: 2fr 1fr;
-  grid-template-rows: 45px 1fr 1fr 1fr 1fr;
-  grid-template-areas: 'title tag' 'repository repository' '. .' '. .' 'detail detail';
-  border: 1px solid #c6becf;
-  border-radius: 4px 0 0 4px;
-  border-right: none;
-  box-shadow: 0 2px 0 rgb(37 11 54 / 4%);
-  background-color: #ffffff;
-`;
-const TitleContainer = styled('div')`
-  grid-area: title;
-  align-self: center;
-  padding-left: ${space(2)};
-  display: flex;
-  * {
-    padding-right: ${space(0.5)};
-  }
-`;
-const Title = styled('div')`
-  align-self: center;
-`;
-const ReadOnlyTag = styled(Tag)`
-  grid-area: tag;
-  align-self: center;
-  justify-self: end;
-  padding-right: ${space(1)};
-`;
-const Repository = styled('div')`
-  grid-area: repository;
-  padding-left: calc(${space(2)} + ${space(3)});
-  color: #9386a0;
-  font-size: 14px;
-`;
-const Detail = styled('div')`
-  grid-area: detail;
-  align-self: end;
-  padding: 0 0 ${space(2)} ${space(2)};
-  color: #9386a0;
-  font-size: 14px;
-`;
-
-const RulesView = styled('div')`
-  grid-area: rules-view;
-`;
-
-const InnerPanel = styled(Panel)`
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0px;
-  margin: 0px;
-  height: 100%;
-`;
-
-const InnerPanelHeader = styled(PanelHeader)`
-  text-transform: none;
-  font-size: 16px;
-  font-weight: 400;
-`;
-
-const InnerPanelBody = styled(PanelBody)`
-  height: auto;
-`;
-
-const StyledTextArea = styled(TextareaAutosize)`
-  ${inputStyles};
-  height: calc(400px - ${space(2)} - ${space(1)} - ${space(3)}) !important;
-  overflow: auto;
-  outline: 0;
-  width: 100%;
-  resize: none;
-  margin: 0;
-  font-family: ${p => p.theme.text.familyMono};
-  word-break: break-all;
-  white-space: pre-wrap;
-  line-height: ${space(3)};
-  border: none;
-  box-shadow: none;
-  padding: ${space(2)};
-  color: #9386a0;
-
-  &:hover,
-  &:focus,
-  &:active {
-    border: none;
-    box-shadow: none;
-  }
-`;
+export default CodeOwners;

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -58,6 +58,7 @@ class CodeOwnersPanel extends AsyncComponent<Props, State> {
       return (
         <React.Fragment key={codeowner.id}>
           <RulesPanel
+            data-test-id="codeowners-panel"
             type="codeowners"
             raw={raw}
             dateUpdated={dateUpdated}
@@ -67,7 +68,7 @@ class CodeOwnersPanel extends AsyncComponent<Props, State> {
             controls={[
               <Confirm
                 onConfirm={() => this.handleDelete(codeowner)}
-                message={t('Are you sure you want to remove this CodeOwners?')}
+                message={t('Are you sure you want to remove this CODEOWNERS file?')}
                 key="confirm-delete"
               >
                 <Button key="delete" icon={<IconDelete size="xs" />} size="xsmall" />

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/editRulesModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/editRulesModal.tsx
@@ -22,7 +22,7 @@ class EditOwnershipRulesModal extends React.Component<Props, State> {
         </Block>
         <Block>
           {t('Globbing Syntax:')}
-          <CodeBlock>{'* matches everything\n? mathes any single character'}</CodeBlock>
+          <CodeBlock>{'* matches everything\n? matches any single character'}</CodeBlock>
         </Block>
         <Block>
           {t('Examples')}

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/editRulesModal.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/editRulesModal.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import {EditOwnershipRulesModalOptions} from 'app/actionCreators/modal';
+import {t} from 'app/locale';
+import TextBlock from 'app/views/settings/components/text/textBlock';
+import OwnerInput from 'app/views/settings/project/projectOwnership/ownerInput';
+
+type Props = EditOwnershipRulesModalOptions;
+type State = {};
+
+class EditOwnershipRulesModal extends React.Component<Props, State> {
+  render() {
+    const {ownership} = this.props;
+    return (
+      <React.Fragment>
+        <Block>
+          {t('Rules follow the pattern: ')} <code>type:glob owner owner</code>
+        </Block>
+        <Block>
+          {t('Owners can be team identifiers starting with #, or user emails')}
+        </Block>
+        <Block>
+          {t('Globbing Syntax:')}
+          <CodeBlock>{'* matches everything\n? mathes any single character'}</CodeBlock>
+        </Block>
+        <Block>
+          {t('Examples')}
+          <CodeBlock>
+            path:src/example/pipeline/* person@sentry.io #infrastructure
+            {'\n'}
+            url:http://example.com/settings/* #product
+            {'\n'}
+            tags.sku_class:enterprise #enterprise
+          </CodeBlock>
+        </Block>
+        {ownership && <OwnerInput {...this.props} initialText={ownership.raw || ''} />}
+      </React.Fragment>
+    );
+  }
+}
+
+const Block = styled(TextBlock)`
+  margin-bottom: 16px;
+`;
+
+const CodeBlock = styled('pre')`
+  word-break: break-all;
+  white-space: pre-wrap;
+`;
+
+export default EditOwnershipRulesModal;

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.tsx
@@ -87,6 +87,7 @@ tags.sku_class:enterprise #enterprise`;
         />
         <PermissionAlert />
         <RulesPanel
+          data-test-id="issueowners-panel"
           type="issueowners"
           raw={ownership.raw || ''}
           dateUpdated={ownership.lastUpdated}

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import {RouteComponentProps} from 'react-router';
-import styled from '@emotion/styled';
 
+import {openEditOwnershipRules} from 'app/actionCreators/modal';
 import Feature from 'app/components/acl/feature';
 import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
-import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
 import {t, tct} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import routeTitleGen from 'app/utils/routeTitle';
@@ -13,10 +12,9 @@ import AsyncView from 'app/views/asyncView';
 import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
-import TextBlock from 'app/views/settings/components/text/textBlock';
 import PermissionAlert from 'app/views/settings/project/permissionAlert';
 import CodeOwners from 'app/views/settings/project/projectOwnership/codeowners';
-import OwnerInput from 'app/views/settings/project/projectOwnership/ownerInput';
+import RulesPanel from 'app/views/settings/project/projectOwnership/rulesPanel';
 
 type Props = {
   organization: Organization;
@@ -37,6 +35,33 @@ class ProjectOwnership extends AsyncView<Props, State> {
     const {organization, project} = this.props;
     return [['ownership', `/projects/${organization.slug}/${project.slug}/ownership/`]];
   }
+
+  getPlaceholder() {
+    return `#example usage
+path:src/example/pipeline/* person@sentry.io #infra
+url:http://example.com/settings/* #product
+tags.sku_class:enterprise #enterprise`;
+  }
+
+  getDetail() {
+    return tct(
+      `Automatically assign issues and send alerts to the right people based on issue properties. [link:Learn more].`,
+      {
+        link: (
+          <ExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
+        ),
+      }
+    );
+  }
+
+  handleOwnershipSave = (text: string | null) => {
+    this.setState(prevState => ({
+      ownership: {
+        ...prevState.ownership,
+        raw: text,
+      },
+    }));
+  };
 
   renderBody() {
     const {project, organization} = this.props;
@@ -60,55 +85,31 @@ class ProjectOwnership extends AsyncView<Props, State> {
             </Button>
           }
         />
-        <TextBlock>
-          {tct(
-            `Automatically assign issues and send alerts to the right people based on issue properties. To learn more about Issue Owners, [link:view the docs].`,
-            {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
-              ),
-            }
-          )}
-        </TextBlock>
         <PermissionAlert />
-        <Panel>
-          <PanelHeader>{t('Ownership Rules')}</PanelHeader>
-          <PanelBody withPadding>
-            <Block>
-              {t('An owner for an issue can be a team such as ')}{' '}
-              <code>#infrastructure</code>
-              {t('or a member’s email like ')} <code>tom@sentry.io</code>
-              {'. Here are some examples: '}
-            </Block>
-            <Block>
-              <CodeBlock>
-                path:src/example/pipeline/* person@sentry.io #infrastructure
-                {'\n'}
-                url:http://example.com/settings/* #product
-                {'\n'}
-                tags.sku_class:enterprise #enterprise
-                {'\n'}
-                module:example.api.base tom@sentry.io
-              </CodeBlock>
-            </Block>
-            <Block>
-              {t('These rules follow the pattern: ')}
-              <code>matcher:pattern owner1 owner2 ...</code>{' '}
-              {t('and the globbing syntax works like this:')}
-            </Block>
-            <Block>
-              <CodeBlock>
-                {`* matches everything
-? matches any single character`}
-              </CodeBlock>
-            </Block>
-            <OwnerInput
-              {...this.props}
+        <RulesPanel
+          type="issueowners"
+          raw={ownership.raw || ''}
+          dateUpdated={ownership.lastUpdated}
+          placeholder={this.getPlaceholder()}
+          detail={this.getDetail()}
+          controls={[
+            <Button
+              key="edit"
+              size="small"
+              onClick={() =>
+                openEditOwnershipRules({
+                  organization,
+                  project,
+                  ownership,
+                  onSave: this.handleOwnershipSave,
+                })
+              }
               disabled={disabled}
-              initialText={ownership.raw || ''}
-            />
-          </PanelBody>
-        </Panel>
+            >
+              {t('Edit')}
+            </Button>,
+          ]}
+        />
         <Feature features={['import-codeowners']}>
           <CodeOwners {...this.props} />
         </Feature>
@@ -169,12 +170,3 @@ class ProjectOwnership extends AsyncView<Props, State> {
 }
 
 export default ProjectOwnership;
-
-const Block = styled(TextBlock)`
-  margin-bottom: 16px;
-`;
-
-const CodeBlock = styled('pre')`
-  word-break: break-all;
-  white-space: pre-wrap;
-`;

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/index.tsx
@@ -13,7 +13,7 @@ import Form from 'app/views/settings/components/forms/form';
 import JsonForm from 'app/views/settings/components/forms/jsonForm';
 import SettingsPageHeader from 'app/views/settings/components/settingsPageHeader';
 import PermissionAlert from 'app/views/settings/project/permissionAlert';
-import CodeOwners from 'app/views/settings/project/projectOwnership/codeowners';
+import CodeOwnersPanel from 'app/views/settings/project/projectOwnership/codeowners';
 import RulesPanel from 'app/views/settings/project/projectOwnership/rulesPanel';
 
 type Props = {
@@ -112,7 +112,7 @@ tags.sku_class:enterprise #enterprise`;
           ]}
         />
         <Feature features={['import-codeowners']}>
-          <CodeOwners {...this.props} />
+          <CodeOwnersPanel {...this.props} />
         </Feature>
         <Form
           apiEndpoint={`/projects/${organization.slug}/${project.slug}/ownership/`}

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ownerInput.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/ownerInput.tsx
@@ -27,6 +27,7 @@ type Props = {
   organization: Organization;
   project: Project;
   initialText: string;
+  onSave?: (text: string | null) => void;
 } & typeof defaultProps;
 
 type State = {
@@ -62,7 +63,7 @@ class OwnerInput extends React.Component<Props, State> {
   }
 
   handleUpdateOwnership = () => {
-    const {organization, project} = this.props;
+    const {organization, project, onSave} = this.props;
     const {text} = this.state;
     this.setState({error: null});
 
@@ -78,10 +79,13 @@ class OwnerInput extends React.Component<Props, State> {
     request
       .then(() => {
         addSuccessMessage(t('Updated issue ownership rules'));
-        this.setState({
-          hasChanges: false,
-          text,
-        });
+        this.setState(
+          {
+            hasChanges: false,
+            text,
+          },
+          () => onSave && onSave(text)
+        );
       })
       .catch(error => {
         this.setState({error: error.responseJSON});

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/rulesPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/rulesPanel.tsx
@@ -196,7 +196,8 @@ const StyledTextArea = styled(TextareaAutosize)`
   border: none;
   box-shadow: none;
   padding: ${space(2)};
-  color: #9386a0;
+  color: transparent;
+  text-shadow: 0 0 0 #9386a0;
 
   &:hover,
   &:focus,

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/rulesPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/rulesPanel.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import TextareaAutosize from 'react-autosize-textarea';
+import styled from '@emotion/styled';
+import {withTheme} from 'emotion-theming';
+import moment from 'moment';
+
+import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
+import Tag from 'app/components/tag';
+import {IconGithub, IconGitlab, IconSentry} from 'app/icons';
+import {inputStyles} from 'app/styles/input';
+import space from 'app/styles/space';
+import {Theme} from 'app/utils/theme';
+
+type Props = {
+  theme: Theme;
+  raw: string;
+  dateUpdated: string | null;
+  provider?: string;
+  repoName?: string;
+  readOnly?: boolean;
+  type: 'codeowners' | 'issueowners';
+  placeholder?: string;
+  detail?: React.ReactNode;
+  controls?: React.ReactNode[];
+};
+
+type State = {};
+
+class RulesPanel extends React.Component<Props, State> {
+  renderIcon(provider) {
+    switch (provider) {
+      case 'github':
+        return <IconGithub size="md" />;
+      case 'gitlab':
+        return <IconGitlab size="md" />;
+      default:
+        return <IconSentry size="md" />;
+    }
+  }
+  renderTitle() {
+    switch (this.props.type) {
+      case 'codeowners':
+        return 'CODEOWNERS';
+      case 'issueowners':
+        return 'Ownership Rules';
+      default:
+        return null;
+    }
+  }
+
+  render() {
+    const {
+      theme,
+      raw,
+      dateUpdated,
+      provider,
+      repoName,
+      readOnly,
+      placeholder,
+      detail,
+      controls,
+    } = this.props;
+    return (
+      <Container>
+        <RulesHeader>
+          <TitleContainer>
+            {this.renderIcon(provider)}
+            <Title>{this.renderTitle()}</Title>
+          </TitleContainer>
+          {readOnly && <ReadOnlyTag type="default">{'Read Only'}</ReadOnlyTag>}
+          {repoName && <Repository>{repoName}</Repository>}
+          {detail && <Detail>{detail}</Detail>}
+        </RulesHeader>
+        <RulesView>
+          <InnerPanel>
+            <InnerPanelHeader>
+              <SyncDate>
+                {dateUpdated && `Last synced ${moment(dateUpdated).fromNow()}`}
+              </SyncDate>
+              <Controls>
+                {(controls || []).map((c, n) => (
+                  <span key={n}> {c}</span>
+                ))}
+              </Controls>
+            </InnerPanelHeader>
+            <InnerPanelBody>
+              <StyledTextArea
+                value={raw}
+                spellCheck="false"
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                theme={theme}
+                placeholder={placeholder}
+              />
+            </InnerPanelBody>
+          </InnerPanel>
+        </RulesView>
+      </Container>
+    );
+  }
+}
+
+export default withTheme(RulesPanel);
+
+const Container = styled('div')`
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  grid-template-areas: 'rules-header rules-view';
+  margin-bottom: ${space(3)};
+`;
+
+const RulesHeader = styled('div')`
+  grid-area: rules-header;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: 45px 1fr 1fr 1fr 1fr;
+  grid-template-areas: 'title tag' 'repository repository' '. .' '. .' 'detail detail';
+  border: 1px solid #c6becf;
+  border-radius: 4px 0 0 4px;
+  border-right: none;
+  box-shadow: 0 2px 0 rgb(37 11 54 / 4%);
+  background-color: #ffffff;
+`;
+const TitleContainer = styled('div')`
+  grid-area: title;
+  align-self: center;
+  padding-left: ${space(2)};
+  display: flex;
+  * {
+    padding-right: ${space(0.5)};
+  }
+`;
+const Title = styled('div')`
+  align-self: center;
+`;
+const ReadOnlyTag = styled(Tag)`
+  grid-area: tag;
+  align-self: center;
+  justify-self: end;
+  padding-right: ${space(1)};
+`;
+const Repository = styled('div')`
+  grid-area: repository;
+  padding-left: calc(${space(2)} + ${space(3)});
+  color: #9386a0;
+  font-size: 14px;
+`;
+const Detail = styled('div')`
+  grid-area: detail;
+  align-self: end;
+  padding: 0 ${space(2)} ${space(2)} ${space(2)};
+  color: #9386a0;
+  font-size: 14px;
+  line-height: 1.4;
+`;
+
+const RulesView = styled('div')`
+  grid-area: rules-view;
+`;
+
+const InnerPanel = styled(Panel)`
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0px;
+  margin: 0px;
+  height: 100%;
+`;
+
+const InnerPanelHeader = styled(PanelHeader)`
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-template-areas: 'sync-date controis';
+  text-transform: none;
+  font-size: 16px;
+  font-weight: 400;
+`;
+
+const InnerPanelBody = styled(PanelBody)`
+  height: auto;
+`;
+
+const StyledTextArea = styled(TextareaAutosize)`
+  ${inputStyles};
+  height: 350px !important;
+  overflow: auto;
+  outline: 0;
+  width: 100%;
+  resize: none;
+  margin: 0;
+  font-family: ${p => p.theme.text.familyMono};
+  word-break: break-all;
+  white-space: pre-wrap;
+  line-height: ${space(3)};
+  border: none;
+  box-shadow: none;
+  padding: ${space(2)};
+  color: #9386a0;
+
+  &:hover,
+  &:focus,
+  &:active {
+    border: none;
+    box-shadow: none;
+  }
+`;
+
+const SyncDate = styled('div')`
+  grid-area: sync-date;
+`;
+const Controls = styled('div')`
+  display: grid;
+  align-items: center;
+  grid-gap: ${space(1)};
+  grid-auto-flow: column;
+  justify-content: flex-end;
+`;

--- a/src/sentry/static/sentry/app/views/settings/project/projectOwnership/rulesPanel.tsx
+++ b/src/sentry/static/sentry/app/views/settings/project/projectOwnership/rulesPanel.tsx
@@ -22,6 +22,7 @@ type Props = {
   placeholder?: string;
   detail?: React.ReactNode;
   controls?: React.ReactNode[];
+  'data-test-id': string;
 };
 
 type State = {};
@@ -59,9 +60,10 @@ class RulesPanel extends React.Component<Props, State> {
       placeholder,
       detail,
       controls,
+      ['data-test-id']: dataTestId,
     } = this.props;
     return (
-      <Container>
+      <Container data-test-id={dataTestId}>
         <RulesHeader>
           <TitleContainer>
             {this.renderIcon(provider)}

--- a/tests/acceptance/test_project_ownership.py
+++ b/tests/acceptance/test_project_ownership.py
@@ -12,3 +12,11 @@ class ProjectOwnershipTest(AcceptanceTestCase):
         self.browser.wait_until_not(".loading")
         self.browser.wait_until_test_id("issueowners-panel")
         self.browser.snapshot("project ownership")
+
+    def test_open_modal(self):
+        self.browser.get(self.path)
+        self.browser.wait_until_not(".loading")
+        self.browser.wait_until_test_id("issueowners-panel")
+        self.browser.click('[aria-label="Edit"]')
+        self.browser.wait_until(".modal-dialog")
+        self.browser.snapshot("project ownership modal")

--- a/tests/acceptance/test_project_ownership.py
+++ b/tests/acceptance/test_project_ownership.py
@@ -10,6 +10,5 @@ class ProjectOwnershipTest(AcceptanceTestCase):
     def test_simple(self):
         self.browser.get(self.path)
         self.browser.wait_until_not(".loading")
-        self.browser.wait_until('[name="select-type"]')
-        self.browser.wait_until_not(".Select-loading")
+        self.browser.wait_until_test_id("issueowners-panel")
         self.browser.snapshot("project ownership")


### PR DESCRIPTION
## Objective:
There is a new UI for the Issue Owners page. This PR implements the List View and the Edit Ownership Rules Modal with full functionality.

## UI
_List View:_
![localhost_8000_settings_sentry_projects_earth-vt_ownership_](https://user-images.githubusercontent.com/10491193/113370726-75844400-9319-11eb-817b-f787919fa238.png)

_Edit Modal:_
![localhost_8000_settings_sentry_projects_earth-vt_ownership_ (1)](https://user-images.githubusercontent.com/10491193/113370774-96e53000-9319-11eb-81d8-0fb9ee65b264.png)
