### PR TITLE
fix(native/demangling): Normalize platform differences in anon namespaces

### DIFF
--- a/src/sentry/stacktraces/functions.py
+++ b/src/sentry/stacktraces/functions.py
@@ -144,6 +144,7 @@ def trim_native_function_name(function, normalize_lambdas=True):
         .replace("operator()", "operator◯")
         .replace(" -> ", " ⟿ ")
         .replace("`anonymous namespace'", "〔anonymousnamespace〕")
+        .replace("(anonymous namespace)", "〔anonymousnamespace〕")
     )
 
     # normalize C++ lambdas.  This is necessary because different

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-03-08T16:39:06.173578Z'
+created: '2021-04-02T13:00:19.630109Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -24,7 +24,7 @@ app-depth-max:
             filename*
               "main.cpp"
             function*
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame (non app frame)
             filename*
               "main.cpp"
@@ -41,7 +41,7 @@ app-depth-max:
           "Fatal Error: EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
 --------------------------------------------------------------------------
 system:
-  hash: "c29439027eafcf7642f641554ab0f0ef"
+  hash: "72e3ce74a0c25e3f14c8aaf34f875a3e"
   tree_label: "main"
   component:
     system*
@@ -56,7 +56,7 @@ system:
             filename*
               "main.cpp"
             function*
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame*
             filename*
               "main.cpp"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:17.654076Z'
+created: '2021-04-02T13:00:20.760130Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,23 +18,23 @@ app:
             filename*
               "main.cpp"
             function* (isolated function)
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame (non app frame)
             filename*
               "main.cpp"
             function* (isolated function)
-              "(anonymous namespace)::crash"
+              "`anonymous namespace'::crash"
           frame (non app frame)
             filename*
               "main.cpp"
             function* (isolated function)
-              "(anonymous namespace)::something::nested::Foo"
+              "`anonymous namespace'::something::nested::Foo"
         type (ignored because exception is synthetic)
           "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"
       threads (thread has no stacktrace)
 --------------------------------------------------------------------------
 system:
-  hash: "282d9d4e85027e073026ace9ad3d05fd"
+  hash: "85da85d9a2ef4672c4c4137f9413785c"
   component:
     system*
       exception*
@@ -48,16 +48,16 @@ system:
             filename*
               "main.cpp"
             function* (isolated function)
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame*
             filename*
               "main.cpp"
             function* (isolated function)
-              "(anonymous namespace)::crash"
+              "`anonymous namespace'::crash"
           frame*
             filename*
               "main.cpp"
             function* (isolated function)
-              "(anonymous namespace)::something::nested::Foo"
+              "`anonymous namespace'::something::nested::Foo"
         type (ignored because exception is synthetic)
           "EXC_BAD_ACCESS / KERN_INVALID_ADDRESS"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:20.644008Z'
+created: '2021-04-02T13:00:21.358468Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,7 +18,7 @@ app:
             filename*
               "main.cpp"
             function*
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame (non app frame)
             filename*
               "main.cpp"
@@ -36,7 +36,7 @@ app:
       threads (thread has no stacktrace)
 --------------------------------------------------------------------------
 system:
-  hash: "c29439027eafcf7642f641554ab0f0ef"
+  hash: "72e3ce74a0c25e3f14c8aaf34f875a3e"
   component:
     system*
       exception*
@@ -50,7 +50,7 @@ system:
             filename*
               "main.cpp"
             function*
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame*
             filename*
               "main.cpp"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:10.140603Z'
+created: '2021-04-02T13:00:19.623882Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,7 +18,7 @@ app:
             filename*
               "main.cpp"
             function*
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame (non app frame)
             filename*
               "main.cpp"
@@ -36,7 +36,7 @@ app:
       threads (thread has no stacktrace)
 --------------------------------------------------------------------------
 system:
-  hash: "c29439027eafcf7642f641554ab0f0ef"
+  hash: "72e3ce74a0c25e3f14c8aaf34f875a3e"
   component:
     system*
       exception*
@@ -50,7 +50,7 @@ system:
             filename*
               "main.cpp"
             function*
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame*
             filename*
               "main.cpp"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:12.669017Z'
+created: '2021-04-02T13:00:17.620597Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,7 +18,7 @@ app:
             filename*
               "main.cpp"
             function*
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame (non app frame)
             filename*
               "main.cpp"
@@ -36,7 +36,7 @@ app:
       threads (thread has no stacktrace)
 --------------------------------------------------------------------------
 system:
-  hash: "c29439027eafcf7642f641554ab0f0ef"
+  hash: "72e3ce74a0c25e3f14c8aaf34f875a3e"
   component:
     system*
       exception*
@@ -50,7 +50,7 @@ system:
             filename*
               "main.cpp"
             function*
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame*
             filename*
               "main.cpp"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/native_with_function_name.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/native_with_function_name.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:22.874528Z'
+created: '2021-04-02T13:00:22.431046Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -18,7 +18,7 @@ app:
             filename*
               "main.cpp"
             function*
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame (non app frame)
             filename*
               "main.cpp"
@@ -36,7 +36,7 @@ app:
       threads (thread has no stacktrace)
 --------------------------------------------------------------------------
 system:
-  hash: "c29439027eafcf7642f641554ab0f0ef"
+  hash: "72e3ce74a0c25e3f14c8aaf34f875a3e"
   component:
     system*
       exception*
@@ -50,7 +50,7 @@ system:
             filename*
               "main.cpp"
             function*
-              "(anonymous namespace)::start"
+              "`anonymous namespace'::start"
           frame*
             filename*
               "main.cpp"

--- a/tests/sentry/stacktraces/test_functions.py
+++ b/tests/sentry/stacktraces/test_functions.py
@@ -89,6 +89,16 @@ from sentry.stacktraces.functions import (
         ["main::{lambda()#42}", "main::lambda"],
         ["lambda_7156c3ceaa11256748687ab67e3ef4cd", "lambda"],
         ["<lambda_7156c3ceaa11256748687ab67e3ef4cd>::operator()", "<lambda>::operator()"],
+        # macOS
+        [
+            "abccore::threads::(anonymous namespace)::FunctionQueue::ExecuteOneFunction",
+            "abccore::threads::`anonymous namespace'::FunctionQueue::ExecuteOneFunction",
+        ],
+        # Windows
+        [
+            "abccore::threads::`anonymous namespace'::FunctionQueue::ExecuteOneFunction",
+            "abccore::threads::`anonymous namespace'::FunctionQueue::ExecuteOneFunction",
+        ],
     ],
 )
 def test_trim_native_function_name(input, output):


### PR DESCRIPTION
This is a slightly dodgy change extracted from #24346. I think the diff itself looks innocuous but if you look at the full function it may be less clear that this would be a good idea, particularly not in the way it is implemented.

Note that the difference in `()` vs `\`'` may not actually be macos vs windows, that's just strong correlation I saw in prod.