### PR TITLE
feat: Autodiscover releases from sessions

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -169,10 +169,8 @@ class OrganizationReleasesEndpoint(
             return Response([])
 
         # This should get us all the projects into postgres that have received
-        # health data in the last 24 hours.  If health data is not requested
-        # we don't upsert releases.
-        if with_health:
-            debounce_update_release_health_data(organization, filter_params["project_id"])
+        # health data in the last 24 hours.
+        debounce_update_release_health_data(organization, filter_params["project_id"])
 
         queryset = Release.objects.filter(organization=organization)
 


### PR DESCRIPTION
This used to trigger only when requesting health data. Now we never ask for health data from that endpoint so removing the check.