### PR TITLE
ref(images-loaded): Minor adjusts

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/information/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/information/index.tsx
@@ -47,13 +47,13 @@ function Information({
   function getFilenameOrLocation() {
     if (
       candidate.download.status === CandidateDownloadStatus.UNAPPLIED ||
-      candidate.download.status === CandidateDownloadStatus.OK
+      (candidate.download.status === CandidateDownloadStatus.OK && isInternalSource)
     ) {
       const {symbolType, filename} = candidate as
         | ImageCandidateUnApplied
         | ImageCandidateInternalOk;
 
-      return symbolType === 'proguard' && filename === 'proguard-mapping'
+      return symbolType === SymbolType.PROGUARD && filename === 'proguard-mapping'
         ? null
         : filename;
     }

--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/debugImageDetails/index.tsx
@@ -347,7 +347,7 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
           </Content>
         </Body>
         <Footer>
-          <ButtonBar gap={1}>
+          <StyledButtonBar gap={1}>
             <Button
               href="https://docs.sentry.io/platforms/native/data-management/debug-files/"
               external
@@ -365,7 +365,7 @@ class DebugImageDetails extends AsyncComponent<Props, State> {
                 {t('Open in Settings')}
               </Button>
             )}
-          </ButtonBar>
+          </StyledButtonBar>
         </Footer>
       </React.Fragment>
     );
@@ -394,6 +394,10 @@ const FileName = styled('span')`
   font-family: ${p => p.theme.text.familyMono};
 `;
 
+const StyledButtonBar = styled(ButtonBar)`
+  white-space: nowrap;
+`;
+
 export const modalCss = css`
   .modal-content {
     overflow: initial;
@@ -403,13 +407,6 @@ export const modalCss = css`
     .modal-dialog {
       width: 90%;
       margin-left: -45%;
-    }
-  }
-
-  @media (min-width: ${theme.breakpoints[2]}) {
-    .modal-dialog {
-      width: 80%;
-      margin-left: -40%;
     }
   }
 


### PR DESCRIPTION
. Replace string comparison with `SymbolType` enum
. Fixes minor issue with the dialog size/button label on smaller devices
. Updates getFilenameOrLocation's logic 
