### PR TITLE
fix(traceview): alert typo

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
@@ -192,7 +192,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
       warning = (
         <Alert type="info" icon={<IconInfo size="md" />}>
           {t(
-            'A root Transaction is missing. Transaction linked by a dashed line have been orphaned and cannot be directly linked to the root.'
+            'A root transaction is missing. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
           )}
         </Alert>
       );
@@ -200,7 +200,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
       warning = (
         <Alert type="info" icon={<IconInfo size="md" />}>
           {t(
-            'This trace has broken subtraces. Transaction linked by a dashed line have been orphaned and cannot be directly linked to the root.'
+            'This trace has broken subtraces. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
           )}
         </Alert>
       );


### PR DESCRIPTION
**Before:**
<img width="1047" alt="Screen Shot 2021-04-02 at 11 20 03 AM" src="https://user-images.githubusercontent.com/4830259/113442698-64811480-93a5-11eb-95c3-0fab1c85cca7.png">

**After:**
<img width="1027" alt="Screen Shot 2021-04-02 at 11 20 56 AM" src="https://user-images.githubusercontent.com/4830259/113442799-909c9580-93a5-11eb-922d-21fc4bac4f77.png">