### PR TITLE
ref(ui): Remove `parseurl` lib in favor of `URL()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "moment-timezone": "0.5.28",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "papaparse": "^5.2.0",
-    "parseurl": "^1.3.2",
     "platformicons": "^4.1.4",
     "po-catalog-loader": "2.0.0",
     "prism-sentry": "^1.0.2",

--- a/src/sentry/static/sentry/app/utils/queryString.tsx
+++ b/src/sentry/static/sentry/app/utils/queryString.tsx
@@ -1,5 +1,4 @@
 import isString from 'lodash/isString';
-import parseurl from 'parseurl';
 import * as queryString from 'query-string';
 
 import {escapeDoubleQuotes} from 'app/utils';
@@ -13,14 +12,19 @@ export function addQueryParamsToExistingUrl(
   origUrl: string,
   queryParams: object
 ): string {
-  const url = parseurl({url: origUrl});
-  if (!url) {
+  let url;
+
+  try {
+    url = new URL(origUrl);
+  } catch {
     return '';
   }
+
+  const searchEntries = url.searchParams.entries();
   // Order the query params alphabetically.
   // Otherwise ``queryString`` orders them randomly and it's impossible to test.
   const params = JSON.parse(JSON.stringify(queryParams));
-  const query = url.query ? {...queryString.parse(url.query), ...params} : params;
+  const query = {...Object.fromEntries(searchEntries), ...params};
 
   return `${url.protocol}//${url.host}${url.pathname}?${queryString.stringify(query)}`;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11542,7 +11542,7 @@ parse5@^6.0.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
-parseurl@^1.3.2, parseurl@~1.3.2, parseurl@~1.3.3:
+parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==


### PR DESCRIPTION
Remove `parseurl` library which depends on a node polyfill for `url`. Instead use browser [`URL()` interface](https://developer.mozilla.org/en-US/docs/Web/API/URL).