### PR TITLE
ref(integrations): Fix `get_sendable_users`

### DIFF
--- a/src/sentry/management/commands/check_notifications.py
+++ b/src/sentry/management/commands/check_notifications.py
@@ -16,7 +16,7 @@ def handle_project(project: Project, stream) -> None:
     """
     stream.write("# Project: %s\n" % project)
 
-    users = mail_adapter.get_sendable_users(project)
+    users = mail_adapter.get_sendable_user_objects(project)
     users_map = {user.id: user for user in users}
     emails = get_email_addresses(users_map.keys(), project)
     for user_id, email in emails.items():

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -128,7 +128,7 @@ class NotificationPlugin(Plugin):
 
         return member_set
 
-    def get_sendable_users(self, project):
+    def get_sendable_user_objects(self, project):
         """
         Return a collection of user IDs that are eligible to receive
         notifications for the provided project.

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -137,7 +137,7 @@ class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
 
 
 class MailAdapterGetSendableUsersTest(BaseMailAdapterTest, TestCase):
-    def test_get_sendable_users(self):
+    def test_get_sendable_user_objects(self):
         user = self.create_user(email="foo@example.com", is_active=True)
         user2 = self.create_user(email="baz@example.com", is_active=True)
         self.create_user(email="baz2@example.com", is_active=True)
@@ -158,7 +158,7 @@ class MailAdapterGetSendableUsersTest(BaseMailAdapterTest, TestCase):
         self.create_member(user=user2, organization=organization, teams=[team])
 
         # all members
-        users = self.adapter.get_sendable_users(project)
+        users = self.adapter.get_sendable_user_objects(project)
         assert sorted({user.id, user2.id}) == sorted([user.id for user in users])
 
         # disabled user2
@@ -170,11 +170,11 @@ class MailAdapterGetSendableUsersTest(BaseMailAdapterTest, TestCase):
             project=project,
         )
 
-        assert user2 not in self.adapter.get_sendable_users(project)
+        assert user2 not in self.adapter.get_sendable_user_objects(project)
 
         user4 = User.objects.create(username="baz4", email="bar@example.com", is_active=True)
         self.create_member(user=user4, organization=organization, teams=[team])
-        assert user4 in self.adapter.get_sendable_users(project)
+        assert user4 in self.adapter.get_sendable_user_objects(project)
 
         # disabled by default user4
         NotificationSetting.objects.update_settings(
@@ -184,7 +184,7 @@ class MailAdapterGetSendableUsersTest(BaseMailAdapterTest, TestCase):
             user=user4,
         )
 
-        assert user4 not in self.adapter.get_sendable_users(project)
+        assert user4 not in self.adapter.get_sendable_user_objects(project)
 
         NotificationSetting.objects.remove_settings(
             ExternalProviders.EMAIL,
@@ -199,7 +199,7 @@ class MailAdapterGetSendableUsersTest(BaseMailAdapterTest, TestCase):
             user=user4,
         )
 
-        assert user4 not in self.adapter.get_sendable_users(project)
+        assert user4 not in self.adapter.get_sendable_user_objects(project)
 
 
 class MailAdapterBuildSubjectPrefixTest(BaseMailAdapterTest, TestCase):


### PR DESCRIPTION
I changed the return type of `get_sendable_users` to return `User` objects instead of a list of IDs.
This PR renames the function in the code and makes sure `get_sendable_users` works like before.