### PR TITLE
feat(demo) deep link scenarios and maintaining the demo org

### DIFF
--- a/src/sentry/demo/demo_org_manager.py
+++ b/src/sentry/demo/demo_org_manager.py
@@ -84,7 +84,7 @@ def create_demo_org(quick=False) -> Organization:
     return org
 
 
-def assign_demo_org() -> Tuple[Organization, User]:
+def assign_demo_org() -> Tuple[Organization, User, OrganizationMember]:
     from .tasks import build_up_org_buffer
 
     demo_org = None
@@ -123,4 +123,4 @@ def assign_demo_org() -> Tuple[Organization, User]:
     # build up the buffer
     build_up_org_buffer.apply_async()
 
-    return (org, user)
+    return (org, user, member)

--- a/src/sentry/demo/demo_org_manager.py
+++ b/src/sentry/demo/demo_org_manager.py
@@ -84,7 +84,7 @@ def create_demo_org(quick=False) -> Organization:
     return org
 
 
-def assign_demo_org() -> Tuple[Organization, User, OrganizationMember]:
+def assign_demo_org() -> Tuple[Organization, User]:
     from .tasks import build_up_org_buffer
 
     demo_org = None
@@ -123,4 +123,4 @@ def assign_demo_org() -> Tuple[Organization, User, OrganizationMember]:
     # build up the buffer
     build_up_org_buffer.apply_async()
 
-    return (org, user, member)
+    return (org, user)

--- a/src/sentry/demo/demo_start.py
+++ b/src/sentry/demo/demo_start.py
@@ -30,9 +30,9 @@ class DemoStartView(BaseView):
 
         if member_id:
             try:
-                # only assign them to an active org
+                # only assign them to an active org for a member role
                 member = OrganizationMember.objects.get(
-                    id=member_id, organization__status=OrganizationStatus.ACTIVE
+                    id=member_id, organization__status=OrganizationStatus.ACTIVE, role="member"
                 )
             except OrganizationMember.DoesNotExist:
                 pass

--- a/src/sentry/demo/demo_start.py
+++ b/src/sentry/demo/demo_start.py
@@ -25,7 +25,7 @@ class DemoStartView(BaseView):
 
         org = None
         # see if the user already was assigned a member
-        member_id = request.COOKIES.get(MEMBER_ID_COOKIE)
+        member_id = request.get_signed_cookie(MEMBER_ID_COOKIE, default="")
         logger.info("post.start", extra={"cookie_member_id": member_id})
 
         if member_id:
@@ -64,7 +64,7 @@ class DemoStartView(BaseView):
             resp.set_cookie(ACCEPTED_TRACKING_COOKIE, accepted_tracking)
 
         # set the member id
-        resp.set_cookie(MEMBER_ID_COOKIE, member.id)
+        resp.set_signed_cookie(MEMBER_ID_COOKIE, member.id)
         return resp
 
 

--- a/src/sentry/demo/demo_start.py
+++ b/src/sentry/demo/demo_start.py
@@ -47,7 +47,8 @@ class DemoStartView(BaseView):
             from .demo_org_manager import assign_demo_org
 
             # assign the demo org and get the user
-            org, user, member = assign_demo_org()
+            org, user = assign_demo_org()
+            member = OrganizationMember.objects.get(organization=org, user=user)
 
             logger.info("post.assigned_org", extra={"organization_slug": org.slug})
 
@@ -63,7 +64,7 @@ class DemoStartView(BaseView):
             resp.set_cookie(ACCEPTED_TRACKING_COOKIE, accepted_tracking)
 
         # set the member id
-        resp.set_cookie(MEMBER_ID_COOKIE, member.id, max_age=60 * 60 * 24)
+        resp.set_cookie(MEMBER_ID_COOKIE, member.id)
         return resp
 
 

--- a/src/sentry/demo/demo_start.py
+++ b/src/sentry/demo/demo_start.py
@@ -3,10 +3,15 @@ import logging
 from django.http import Http404
 from django.conf import settings
 
+from sentry.models import OrganizationMember, OrganizationStatus
 from sentry.utils import auth
 from sentry.web.frontend.base import BaseView
 
+
 logger = logging.getLogger(__name__)
+
+ACCEPTED_TRACKING_COOKIE = "accepted_tracking"
+MEMBER_ID_COOKIE = "demo_member_id"
 
 
 class DemoStartView(BaseView):
@@ -14,35 +19,69 @@ class DemoStartView(BaseView):
     auth_required = False
 
     def post(self, request):
-        # need this check for tests since the route will exist even if DEMO_MODE=False
+        # double check DEMO_MODE is disabled
         if not settings.DEMO_MODE:
             raise Http404
 
-        logger.info("post.start")
+        org = None
+        # see if the user already was assigned a member
+        member_id = request.COOKIES.get(MEMBER_ID_COOKIE)
+        logger.info("post.start", extra={"cookie_member_id": member_id})
 
-        # move this import here so we Django doesn't discover the models
-        # for demo mode except when Demo mode is actually active
-        from .demo_org_manager import assign_demo_org
+        if member_id:
+            try:
+                # only assign them to an active org
+                member = OrganizationMember.objects.get(
+                    id=member_id, organization__status=OrganizationStatus.ACTIVE
+                )
+            except OrganizationMember.DoesNotExist:
+                pass
+            else:
+                org = member.organization
+                user = member.user
+                logger.info("post.retrieved_user", extra={"organization_slug": org.slug})
 
-        # assign the demo org and get the user
-        org, user = assign_demo_org()
+        if not org:
+            # move this import here so we Django doesn't discover the models
+            # for demo mode except when Demo mode is actually active
+            from .demo_org_manager import assign_demo_org
 
-        logger.info("post.assigned_org", extra={"organization_slug": org.slug})
+            # assign the demo org and get the user
+            org, user, member = assign_demo_org()
+
+            logger.info("post.assigned_org", extra={"organization_slug": org.slug})
 
         auth.login(request, user)
+        resp = self.redirect(get_redirect_url(request, org))
 
-        url = auth.get_login_redirect(request)
-        # user is logged in so will be automatically redirected
-        # after landing on login page
-        url += "?allow_login=1"
-
-        resp = self.redirect(url)
         # set a cookie of whether the user accepteed tracking so we know
         # whether to initialize analytics when accepted_tracking=1
         # 0 means don't show the footer to accept cookies (user already declined)
         # no value means we show the footer to accept cookies (user has neither accepted nor declined)
-        accepted_tracking = request.POST.get("accepted_tracking")
+        accepted_tracking = request.POST.get(ACCEPTED_TRACKING_COOKIE)
         if accepted_tracking in ["0", "1"]:
-            resp.set_cookie("accepted_tracking", accepted_tracking)
+            resp.set_cookie(ACCEPTED_TRACKING_COOKIE, accepted_tracking)
 
+        # set the member id
+        resp.set_cookie(MEMBER_ID_COOKIE, member.id, max_age=60 * 60 * 24)
         return resp
+
+
+def get_redirect_url(request, org):
+    # determine the redirect based on the scenario
+    scenario = request.POST.get("scenario")
+    if scenario == "performance":
+        return f"/organizations/{org.slug}/performance/"
+    if scenario == "releases":
+        return f"/organizations/{org.slug}/releases/"
+    if scenario == "alerts":
+        return f"/organizations/{org.slug}/alerts/"
+    if scenario == "discover":
+        return f"/organizations/{org.slug}/discover/queries/"
+    if scenario == "dashboards":
+        return f"/organizations/{org.slug}/dashboards/"
+    url = auth.get_login_redirect(request)
+    # user is logged in so will be automatically redirected
+    # after landing on login page
+    url += "?allow_login=1"
+    return url

--- a/tests/sentry/demo/test_demo_org_manager.py
+++ b/tests/sentry/demo/test_demo_org_manager.py
@@ -66,7 +66,7 @@ class DemoOrgManagerTest(TestCase):
 
         Team.objects.create(organization=org)
 
-        (org, user, member) = assign_demo_org()
+        (org, user) = assign_demo_org()
 
         assert OrganizationMember.objects.filter(
             user=user, organization=org, role="member"
@@ -75,8 +75,6 @@ class DemoOrgManagerTest(TestCase):
 
         demo_org = DemoOrganization.objects.get(organization=org, status=DemoOrgStatus.ACTIVE)
         demo_user = DemoUser.objects.get(user=user)
-        assert member.user == user
-
         assert demo_org.date_assigned == curr_time
         assert demo_user.date_assigned == curr_time
 

--- a/tests/sentry/demo/test_demo_org_manager.py
+++ b/tests/sentry/demo/test_demo_org_manager.py
@@ -66,7 +66,7 @@ class DemoOrgManagerTest(TestCase):
 
         Team.objects.create(organization=org)
 
-        (org, user) = assign_demo_org()
+        (org, user, member) = assign_demo_org()
 
         assert OrganizationMember.objects.filter(
             user=user, organization=org, role="member"
@@ -75,6 +75,7 @@ class DemoOrgManagerTest(TestCase):
 
         demo_org = DemoOrganization.objects.get(organization=org, status=DemoOrgStatus.ACTIVE)
         demo_user = DemoUser.objects.get(user=user)
+        assert member.user == user
 
         assert demo_org.date_assigned == curr_time
         assert demo_user.date_assigned == curr_time

--- a/tests/sentry/demo/test_demo_start.py
+++ b/tests/sentry/demo/test_demo_start.py
@@ -3,29 +3,68 @@ from sentry.utils.compat import mock
 from django.test.utils import override_settings
 from exam import fixture
 
+from sentry.demo.demo_start import MEMBER_ID_COOKIE
+from sentry.models import OrganizationStatus
 from sentry.testutils import TestCase
 
 
+@override_settings(DEMO_MODE=True, ROOT_URLCONF="sentry.demo.urls")
 class AuthLoginTest(TestCase):
     @fixture
     def path(self):
         return "/demo/start/"
 
-    @override_settings(DEMO_MODE=True, ROOT_URLCONF="sentry.demo.urls")
+    def setUp(self):
+        super().setUp()
+        self.user = self.create_user()
+        self.org = self.create_organization()
+        self.member = self.create_member(organization=self.org, role="member", user=self.user)
+
     @mock.patch("sentry.demo.demo_start.auth.login")
     @mock.patch("sentry.demo.demo_org_manager.assign_demo_org")
     def test_basic(self, mock_assign_demo_org, mock_auth_login):
-
-        user = self.create_user()
-        org = self.create_organization()
-
-        mock_assign_demo_org.return_value = (org, user)
+        mock_assign_demo_org.return_value = (self.org, self.user)
         resp = self.client.post(self.path)
         assert resp.status_code == 302
-
-        mock_auth_login.assert_called_once_with(mock.ANY, user)
+        mock_auth_login.assert_called_once_with(mock.ANY, self.user)
+        assert resp.cookies[MEMBER_ID_COOKIE].value == str(self.member.id)
 
     @override_settings(DEMO_MODE=False, ROOT_URLCONF="sentry.demo.urls")
     def test_disabled(self):
         resp = self.client.post(self.path)
         assert resp.status_code == 404
+
+    @mock.patch("sentry.demo.demo_start.auth.login")
+    def test_member_cookie(self, mock_auth_login):
+        self.save_cookie(MEMBER_ID_COOKIE, self.member.id)
+        resp = self.client.post(self.path)
+        assert resp.status_code == 302
+        mock_auth_login.assert_called_once_with(mock.ANY, self.user)
+
+    @mock.patch("sentry.demo.demo_start.auth.login")
+    @mock.patch("sentry.demo.demo_org_manager.assign_demo_org")
+    def test_member_cookie_deactivated_org(self, mock_assign_demo_org, mock_auth_login):
+        self.org.status = OrganizationStatus.PENDING_DELETION
+        self.org.save()
+        self.save_cookie(MEMBER_ID_COOKIE, self.member.id)
+
+        new_user = self.create_user()
+        new_org = self.create_organization()
+        new_member = self.create_member(organization=new_org, role="member", user=new_user)
+        mock_assign_demo_org.return_value = (new_org, new_user)
+
+        resp = self.client.post(self.path)
+        assert resp.status_code == 302
+        mock_auth_login.assert_called_once_with(mock.ANY, new_user)
+        assert resp.cookies[MEMBER_ID_COOKIE].value == str(new_member.id)
+
+    @mock.patch("sentry.demo.demo_start.auth.login")
+    @mock.patch("sentry.demo.demo_org_manager.assign_demo_org")
+    def test_redirects(self, mock_assign_demo_org, mock_auth_login):
+        mock_assign_demo_org.return_value = (self.org, self.user)
+
+        for scenario in ["performance", "releases", "alerts", "discover", "dashboards"]:
+            resp = self.client.post(self.path, data={"scenario": scenario})
+            partial_url = f"/organizations/{self.org.slug}/{scenario}/"
+            assert resp.status_code == 302
+            assert partial_url in resp.url


### PR DESCRIPTION
This PR makes two changes to how demos are kicked off:
1. Adds an optional parameter called `scenario` which determines the initial URL to send the user. The purpose of this is to embed links to specific places in the demo/sandbox on marketing or docs pages. The current possible values of `scenario` are just (some) of the items in the sidebar for now.
2. Adds a cookie for the member ID that was generated during kickoff. When a user clicks the "Enter Sandbox" button a second time, we will look up the member from the cookie and re-use the org associated with that member. The cookie is also signed to prevent people from just entering a member ID to get access to someone else's organization. I didn't add a signing salt because someone could brute force guess an organization slug and get access.