### PR TITLE
fix(ui): Add related issues tooltip reduce alert gap

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -327,7 +327,7 @@ export default class DetailsBody extends React.Component<Props> {
                     <div>
                       <SidebarHeading noMargin>
                         {t('Time Interval')}
-                        <Tooltip title="This is the time period which the metric is evaluated by.">
+                        <Tooltip title={t("This is the time period which the metric is evaluated by.")}>
                           <IconInfo size="xs" />
                         </Tooltip>
                       </SidebarHeading>
@@ -409,6 +409,9 @@ const HeaderContainer = styled('div')`
 `;
 
 const StyledLayoutBody = styled(Layout.Body)`
+  flex-grow: 0;
+  padding-bottom: 0 !important;
+
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     grid-template-columns: auto;
   }

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -327,7 +327,11 @@ export default class DetailsBody extends React.Component<Props> {
                     <div>
                       <SidebarHeading noMargin>
                         {t('Time Interval')}
-                        <Tooltip title={t("This is the time period which the metric is evaluated by.")}>
+                        <Tooltip
+                          title={t(
+                            'This is the time period which the metric is evaluated by.'
+                          )}
+                        >
                           <IconInfo size="xs" />
                         </Tooltip>
                       </SidebarHeading>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
@@ -6,6 +6,8 @@ import {SectionHeading} from 'app/components/charts/styles';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import GroupList from 'app/components/issues/groupList';
 import {Panel, PanelBody} from 'app/components/panels';
+import Tooltip from 'app/components/tooltip';
+import {IconInfo} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {OrganizationSummary, Project} from 'app/types';
@@ -55,6 +57,9 @@ class RelatedIssues extends React.Component<Props> {
       <React.Fragment>
         <ControlsWrapper>
           <SectionHeading>{t('Related Issues')}</SectionHeading>
+          <Tooltip title={t('Top issues containing events matching the metric.')}>
+            <IconInfo size="xs" />
+          </Tooltip>
           <Button data-test-id="issues-open" size="small" to={issueSearch}>
             {t('Open in Issues')}
           </Button>


### PR DESCRIPTION
This adds a small tooltip to the related issues in alerts. Also adds a translation to another tooltip in the page and reduces the gap between the banner and the page content (forgot this in the last pr.)

[WOR-771](https://getsentry.atlassian.net/browse/WOR-771)