### PR TITLE
fix(trace-view): Only show full link when available

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -75,29 +75,59 @@ class GroupEventToolbar extends React.Component<Props> {
     const {event, organization, location} = this.props;
 
     return (
-      <QuickTraceWrapper>
-        <ErrorBoundary mini>
-          <QuickTraceQuery event={event} location={location} orgSlug={organization.slug}>
-            {results =>
-              results.isLoading ? (
-                <Placeholder height="24px" />
-              ) : results.error || results.trace === null ? (
-                '\u2014'
+      <ErrorBoundary mini>
+        <QuickTraceQuery event={event} location={location} orgSlug={organization.slug}>
+          {results => (
+            <span>
+              {results.isLoading || results.error || results.trace === null ? (
+                ''
               ) : (
-                <QuickTrace
-                  event={event}
-                  quickTrace={results}
-                  location={location}
-                  organization={organization}
-                  anchor="left"
-                  errorDest="issue"
-                  transactionDest="performance"
-                />
-              )
-            }
-          </QuickTraceQuery>
-        </ErrorBoundary>
-      </QuickTraceWrapper>
+                <LinkContainer>
+                  <Feature
+                    features={['trace-view-summary']}
+                    hookName="feature-disabled:trace-view-link"
+                    renderDisabled={renderDisabledHoverCard}
+                  >
+                    {({hasFeature}) =>
+                      hasFeature ? (
+                        <Link
+                          to={generateTraceTarget(event, organization)}
+                          onClick={() => this.handleTraceLink(organization)}
+                        >
+                          View Full Trace
+                          <FeatureBadge type="beta" />
+                        </Link>
+                      ) : (
+                        <DisabledLink>
+                          View Full Trace
+                          <FeatureBadge type="beta" />
+                        </DisabledLink>
+                      )
+                    }
+                  </Feature>
+                </LinkContainer>
+              )}
+              <QuickTraceWrapper>
+                {results.isLoading ? (
+                  <Placeholder height="24px" />
+                ) : results.error || results.trace === null ? (
+                  '\u2014'
+                ) : (
+                  <QuickTrace
+                    event={event}
+                    quickTrace={results}
+                    location={location}
+                    organization={organization}
+                    anchor="left"
+                    errorDest="issue"
+                    transactionDest="performance"
+                  />
+                )}
+              </QuickTraceWrapper>
+            </span>
+          )}
+        </QuickTraceQuery>
+      </ErrorBoundary>
     );
   }
 
@@ -182,32 +212,6 @@ class GroupEventToolbar extends React.Component<Props> {
           />
           {isOverLatencyThreshold && <StyledIconWarning color="yellow300" />}
         </Tooltip>
-        {hasQuickTraceView && (
-          <LinkContainer>
-            <Feature
-              features={['trace-view-summary']}
-              hookName="feature-disabled:trace-view-link"
-              renderDisabled={renderDisabledHoverCard}
-            >
-              {({hasFeature}) =>
-                hasFeature ? (
-                  <Link
-                    to={generateTraceTarget(evt, organization)}
-                    onClick={() => this.handleTraceLink(organization)}
-                  >
-                    View Full Trace
-                    <FeatureBadge type="beta" />
-                  </Link>
-                ) : (
-                  <DisabledLink>
-                    View Full Trace
-                    <FeatureBadge type="beta" />
-                  </DisabledLink>
-                )
-              }
-            </Feature>
-          </LinkContainer>
-        )}
         {hasQuickTraceView && this.renderQuickTrace()}
       </Wrapper>
     );

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -79,9 +79,7 @@ class GroupEventToolbar extends React.Component<Props> {
         <QuickTraceQuery event={event} location={location} orgSlug={organization.slug}>
           {results => (
             <React.Fragment>
-              {results.isLoading || results.error || results.trace === null ? (
-                ''
-              ) : (
+              {!results.isLoading && results.error === null && results.trace !== null && (
                 <LinkContainer>
                   <Feature
                     features={['trace-view-summary']}

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -78,7 +78,7 @@ class GroupEventToolbar extends React.Component<Props> {
       <ErrorBoundary mini>
         <QuickTraceQuery event={event} location={location} orgSlug={organization.slug}>
           {results => (
-            <span>
+            <React.Fragment>
               {results.isLoading || results.error || results.trace === null ? (
                 ''
               ) : (
@@ -124,7 +124,7 @@ class GroupEventToolbar extends React.Component<Props> {
                   />
                 )}
               </QuickTraceWrapper>
-            </span>
+            </React.Fragment>
           )}
         </QuickTraceQuery>
       </ErrorBoundary>


### PR DESCRIPTION
- This means we're no longer linking to a broken or empty page since we can check the results here


https://user-images.githubusercontent.com/4205004/113584856-6a6f3380-95f9-11eb-8cae-de1ca2bf5bae.mp4