### PR TITLE
fix(sidebarpanel): padding and font size

### DIFF
--- a/src/sentry/static/sentry/app/components/sidebar/broadcastSdkUpdates.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/broadcastSdkUpdates.tsx
@@ -113,13 +113,11 @@ const SdkProjectBadge = styled(ProjectBadge)`
 
 const SdkName = styled('div')`
   font-family: ${p => p.theme.text.familyMono};
-  font-size: ${p => p.theme.fontSizeSmall};
   font-weight: bold;
 `;
 
 const SdkOutdatedVersion = styled('span')`
   color: ${p => p.theme.subText};
-  font-size: ${p => p.theme.fontSizeExtraSmall};
 `;
 
 export default withSdkUpdates(withProjects(BroadcastSdkUpdates));

--- a/src/sentry/static/sentry/app/components/sidebar/sidebarPanelItem.tsx
+++ b/src/sentry/static/sentry/app/components/sidebar/sidebarPanelItem.tsx
@@ -51,7 +51,7 @@ const SidebarPanelItemRoot = styled('div')`
   border-bottom: 1px solid ${p => p.theme.innerBorder};
   background: ${p => p.theme.background};
   font-size: ${p => p.theme.fontSizeMedium};
-  padding: ${space(4)};
+  padding: ${space(3)};
 `;
 
 const ImageBox = styled('div')`


### PR DESCRIPTION
- Aligned content and header
- Removed unnecessary tininess

**Before:**
![Screen Shot 2021-04-05 at 9 16 20 AM](https://user-images.githubusercontent.com/4830259/113597139-1c096700-95f0-11eb-90de-6e9a663b7b4b.png)

**After:**
![Screen Shot 2021-04-05 at 9 16 37 AM](https://user-images.githubusercontent.com/4830259/113597146-1f9cee00-95f0-11eb-8e0c-5c8cd6361493.png)