### PR TITLE
fix(dashboards): Fix dashboard field options

### DIFF
--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -127,7 +127,7 @@ function WidgetQueryFields({
               fieldOptions={fieldOptions}
               onChange={value => handleChangeField(value, i)}
               filterPrimaryOptions={option => {
-                // Only validate function parameters for timeseries widgets and
+                // Only validate function names for timeseries widgets and
                 // world map widgets.
                 if (
                   !doNotValidateYAxis &&

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -118,69 +118,74 @@ function WidgetQueryFields({
       required
       stacked
     >
-      {fields.map((field, i) => (
-        <QueryFieldWrapper key={`${field}:${i}`}>
-          <QueryField
-            fieldValue={explodeField({field})}
-            fieldOptions={fieldOptions}
-            onChange={value => handleChangeField(value, i)}
-            filterPrimaryOptions={option => {
-              // Only validate function parameters for timeseries widgets and
-              // world map widgets.
-              if (!doNotValidateYAxis && option.value.kind === FieldValueKind.FUNCTION) {
+      {fields.map((field, i) => {
+        const fieldValue = explodeField({field});
+        return (
+          <QueryFieldWrapper key={`${field}:${i}`}>
+            <QueryField
+              fieldValue={fieldValue}
+              fieldOptions={fieldOptions}
+              onChange={value => handleChangeField(value, i)}
+              filterPrimaryOptions={option => {
+                // Only validate function parameters for timeseries widgets and
+                // world map widgets.
+                if (
+                  !doNotValidateYAxis &&
+                  option.value.kind === FieldValueKind.FUNCTION
+                ) {
+                  const primaryOutput = aggregateFunctionOutputType(
+                    option.value.meta.name,
+                    undefined
+                  );
+                  if (primaryOutput) {
+                    // If a function returns a specific type, then validate it.
+                    return isLegalYAxisType(primaryOutput);
+                  }
+                }
+
+                return option.value.kind === FieldValueKind.FUNCTION;
+              }}
+              filterAggregateParameters={option => {
+                // Only validate function parameters for timeseries widgets and
+                // world map widgets.
+                if (doNotValidateYAxis) {
+                  return true;
+                }
+
+                if (fieldValue.kind !== 'function') {
+                  return true;
+                }
+
+                const functionName = fieldValue.function[0];
                 const primaryOutput = aggregateFunctionOutputType(
-                  option.value.meta.name,
-                  undefined
+                  functionName as string,
+                  option.value.meta.name
                 );
                 if (primaryOutput) {
-                  // If a function returns a specific type, then validate it.
                   return isLegalYAxisType(primaryOutput);
                 }
-              }
 
-              return option.value.kind === FieldValueKind.FUNCTION;
-            }}
-            filterAggregateParameters={option => {
-              // Only validate function parameters for timeseries widgets and
-              // world map widgets.
-              if (doNotValidateYAxis) {
-                return true;
-              }
+                if (option.value.kind === FieldValueKind.FUNCTION) {
+                  // Functions are not legal options as an aggregate/function parameter.
+                  return false;
+                }
 
-              const exploded = explodeField({field});
-              if (exploded.kind !== 'function') {
-                return true;
-              }
-
-              const functionName = exploded.function[0];
-              const primaryOutput = aggregateFunctionOutputType(
-                functionName as string,
-                option.value.meta.name
-              );
-              if (primaryOutput) {
-                return isLegalYAxisType(primaryOutput);
-              }
-
-              if (option.value.kind === FieldValueKind.FUNCTION) {
-                // Functions are not legal options as an aggregate/function parameter.
-                return false;
-              }
-
-              return isLegalYAxisType(option.value.meta.dataType);
-            }}
-          />
-          {fields.length > 1 && (
-            <Button
-              size="zero"
-              borderless
-              onClick={event => handleRemove(event, i)}
-              icon={<IconDelete />}
-              title={t('Remove this Y-Axis')}
-              label={t('Remove this Y-Axis')}
+                return isLegalYAxisType(option.value.meta.dataType);
+              }}
             />
-          )}
-        </QueryFieldWrapper>
-      ))}
+            {fields.length > 1 && (
+              <Button
+                size="zero"
+                borderless
+                onClick={event => handleRemove(event, i)}
+                icon={<IconDelete />}
+                title={t('Remove this Y-Axis')}
+                label={t('Remove this Y-Axis')}
+              />
+            )}
+          </QueryFieldWrapper>
+        );
+      })}
       {!hideAddYAxisButton && (
         <div>
           <Button size="small" icon={<IconAdd isCircled />} onClick={handleAdd}>

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -101,10 +101,11 @@ function WidgetQueryFields({
     (['line', 'area', 'stacked_area', 'bar'].includes(displayType) &&
       fields.length === 3);
 
-  // Any column choice for World Map and Big Number widgets is legal since the
+  // Any function/field choice for Big Number widgets is legal since the
   // data source is from an endpoint that is not timeseries-based.
+  // The function/field choice for World Map widget will need to be numeric-like.
   // Column builder for Table widget is already handled above.
-  const doNotValidateYAxis = ['world_map', 'big_number'].includes(displayType);
+  const doNotValidateYAxis = ['big_number'].includes(displayType);
 
   return (
     <Field

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -140,9 +140,24 @@ function WidgetQueryFields({
               return option.value.kind === FieldValueKind.FUNCTION;
             }}
             filterAggregateParameters={option => {
-              // Only validate function parameters for timeseries widgets.
+              // Only validate function parameters for timeseries widgets and
+              // world map widgets.
               if (doNotValidateYAxis) {
                 return true;
+              }
+
+              const exploded = explodeField({field});
+              if (exploded.kind !== 'function') {
+                return true;
+              }
+
+              const functionName = exploded.function[0];
+              const primaryOutput = aggregateFunctionOutputType(
+                functionName as string,
+                option.value.meta.name
+              );
+              if (primaryOutput) {
+                return isLegalYAxisType(primaryOutput);
               }
 
               if (option.value.kind === FieldValueKind.FUNCTION) {

--- a/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
+++ b/src/sentry/static/sentry/app/components/dashboards/widgetQueryFields.tsx
@@ -105,7 +105,7 @@ function WidgetQueryFields({
   // data source is from an endpoint that is not timeseries-based.
   // The function/field choice for World Map widget will need to be numeric-like.
   // Column builder for Table widget is already handled above.
-  const doNotValidateYAxis = ['big_number'].includes(displayType);
+  const doNotValidateYAxis = displayType === 'big_number';
 
   return (
     <Field
@@ -125,7 +125,8 @@ function WidgetQueryFields({
             fieldOptions={fieldOptions}
             onChange={value => handleChangeField(value, i)}
             filterPrimaryOptions={option => {
-              // Only validate functions for timeseries widgets.
+              // Only validate function parameters for timeseries widgets and
+              // world map widgets.
               if (!doNotValidateYAxis && option.value.kind === FieldValueKind.FUNCTION) {
                 const primaryOutput = aggregateFunctionOutputType(
                   option.value.meta.name,

--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -18,7 +18,11 @@ import {PanelAlert} from 'app/components/panels';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {GlobalSelection, Organization, TagCollection} from 'app/types';
-import {isAggregateField} from 'app/utils/discover/fields';
+import {
+  aggregateOutputType,
+  isAggregateField,
+  isLegalYAxisType,
+} from 'app/utils/discover/fields';
 import Measurements from 'app/utils/measurements/measurements';
 import withApi from 'app/utils/withApi';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
@@ -115,6 +119,11 @@ function normalizeQueries(
     if (isTimeseriesChart && fields.length && fields.length > 3) {
       // Timeseries charts supports at most 3 fields.
       fields = fields.slice(0, 3);
+    }
+
+    if (isTimeseriesChart || displayType === 'world_map') {
+      // Filter out fields that will not generate numeric output types
+      fields = fields.filter(field => isLegalYAxisType(aggregateOutputType(field)));
     }
 
     return {

--- a/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
+++ b/src/sentry/static/sentry/app/components/modals/addDashboardWidgetModal.tsx
@@ -116,14 +116,14 @@ function normalizeQueries(
   queries = queries.map(query => {
     let fields = query.fields.filter(isAggregateField);
 
-    if (isTimeseriesChart && fields.length && fields.length > 3) {
-      // Timeseries charts supports at most 3 fields.
-      fields = fields.slice(0, 3);
-    }
-
     if (isTimeseriesChart || displayType === 'world_map') {
       // Filter out fields that will not generate numeric output types
       fields = fields.filter(field => isLegalYAxisType(aggregateOutputType(field)));
+    }
+
+    if (isTimeseriesChart && fields.length && fields.length > 3) {
+      // Timeseries charts supports at most 3 fields.
+      fields = fields.slice(0, 3);
     }
 
     return {

--- a/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
+++ b/tests/js/spec/components/modals/addDashboardWidgetModal.spec.jsx
@@ -494,7 +494,7 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     expect(widget.queries[0].fields).toEqual(['count_unique(user.display)']);
   });
 
-  it('should not filter y-axis choices for world map widget charts', async function () {
+  it('should filter y-axis choices for world map widget charts', async function () {
     let widget = undefined;
     const wrapper = mountModal({
       initialData,
@@ -507,14 +507,43 @@ describe('Modals -> AddDashboardWidgetModal', function () {
     selectByLabel(wrapper, 'World Map', {name: 'displayType', at: 0, control: true});
     expect(getDisplayType(wrapper).props().value).toEqual('world_map');
 
+    // Choose any()
+    selectByLabel(wrapper, 'any(\u2026)', {
+      name: 'field',
+      at: 0,
+      control: true,
+    });
+
+    // user.display should be filtered out for any()
+    const option = getOptionByLabel(wrapper, 'user.display', {
+      name: 'parameter',
+      at: 0,
+      control: true,
+    });
+    expect(option.exists()).toEqual(false);
+
+    selectByLabel(wrapper, 'measurements.lcp', {
+      name: 'parameter',
+      at: 0,
+      control: true,
+    });
+
+    // Choose count_unique()
     selectByLabel(wrapper, 'count_unique(\u2026)', {
       name: 'field',
       at: 0,
       control: true,
     });
 
-    // Be able to choose a non numeric-like option for count_unique()
+    // user.display not should be filtered out for count_unique()
     selectByLabel(wrapper, 'user.display', {
+      name: 'parameter',
+      at: 0,
+      control: true,
+    });
+
+    // Be able to choose a numeric-like option
+    selectByLabel(wrapper, 'measurements.lcp', {
       name: 'parameter',
       at: 0,
       control: true,
@@ -524,6 +553,6 @@ describe('Modals -> AddDashboardWidgetModal', function () {
 
     expect(widget.displayType).toEqual('world_map');
     expect(widget.queries).toHaveLength(1);
-    expect(widget.queries[0].fields).toEqual(['count_unique(user.display)']);
+    expect(widget.queries[0].fields).toEqual(['count_unique(measurements.lcp)']);
   });
 });


### PR DESCRIPTION
- Y-axis fields should be validated for World Map widgets since it can only display numeric-like data. For example: `count_unique(user.email)`. Regression from https://github.com/getsentry/sentry/pull/24899
- When validating function parameters, we should consider the output type of both the function and their parameters. For example: `user.display` should not be filtered out for `count_unique()` on timeseries widget charts.
- When switching between widgets, fields should be normalized based on their types such that they're compatible with the types that the widget supports.