### PR TITLE
fix(notifications): python inheritance bug

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -166,7 +166,8 @@ class MailAdapter:
 
     def get_sendable_users(self, project):
         """ @deprecated Do not change this function, it is being used in getsentry. """
-        return self.get_sendable_user_ids(project)
+        users = self.get_sendable_user_objects(project)
+        return [user.id for user in users]
 
     def should_notify(self, target_type, group):
         metrics.incr("mail_adapter.should_notify")


### PR DESCRIPTION
This PR fixes a python inheritance bug. We expected sentry's `get_sendable_users` to call sentry's `get_sendable_user_ids`, but it actually calls the one from getsentry.

getsentry:
```
def get_sendable_users(self, project):
    return self.get_sendable_user_ids(project)
def get_sendable_user_ids(self, project):
    send_to_list = super().get_sendable_users(project)
	...
```

sentry:
```
def get_sendable_user_ids(self, project):
    users = self.get_sendable_user_objects(project)
    return [user.id for user in users]
def get_sendable_users(self, project):
    return self.get_sendable_user_ids(project)
```
