### PR TITLE
 feat(breakdowns): Filter by span op breakdowns in transaction summary

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
@@ -28,6 +28,7 @@ import {
 
 import DurationChart from './durationChart';
 import DurationPercentileChart from './durationPercentileChart';
+import {SpanOperationBreakdownFilter} from './filter';
 import LatencyChart from './latencyChart';
 import TrendChart from './trendChart';
 import VitalsChart from './vitalsChart';
@@ -40,13 +41,29 @@ export enum DisplayModes {
   VITALS = 'vitals',
 }
 
-const DISPLAY_OPTIONS: SelectValue<string>[] = [
-  {value: DisplayModes.DURATION, label: t('Duration Breakdown')},
-  {value: DisplayModes.DURATION_PERCENTILE, label: t('Duration Percentiles')},
-  {value: DisplayModes.LATENCY, label: t('Duration Distribution')},
-  {value: DisplayModes.TREND, label: t('Trends')},
-  {value: DisplayModes.VITALS, label: t('Web Vitals')},
-];
+function generateDisplayOptions(
+  currentFilter: SpanOperationBreakdownFilter
+): SelectValue<string>[] {
+  if (currentFilter === SpanOperationBreakdownFilter.None) {
+    return [
+      {value: DisplayModes.DURATION, label: t('Duration Breakdown')},
+      {value: DisplayModes.DURATION_PERCENTILE, label: t('Duration Percentiles')},
+      {value: DisplayModes.LATENCY, label: t('Duration Distribution')},
+      {value: DisplayModes.TREND, label: t('Trends')},
+      {value: DisplayModes.VITALS, label: t('Web Vitals')},
+    ];
+  }
+
+  // A span operation name breakdown has been chosen.
+
+  return [
+    {value: DisplayModes.DURATION, label: t('Span Operation Breakdown')},
+    {value: DisplayModes.DURATION_PERCENTILE, label: t('Span Operation Percentiles')},
+    {value: DisplayModes.LATENCY, label: t('Span Operation Distribution')},
+    {value: DisplayModes.TREND, label: t('Trends')},
+    {value: DisplayModes.VITALS, label: t('Web Vitals')},
+  ];
+}
 
 const TREND_FUNCTIONS_OPTIONS: SelectValue<string>[] = TRENDS_FUNCTIONS.map(
   ({field, label}) => ({
@@ -66,6 +83,7 @@ type Props = {
   location: Location;
   eventView: EventView;
   totalValues: number | null;
+  currentFilter: SpanOperationBreakdownFilter;
 };
 
 class TransactionSummaryCharts extends React.Component<Props> {
@@ -94,7 +112,7 @@ class TransactionSummaryCharts extends React.Component<Props> {
   };
 
   render() {
-    const {totalValues, eventView, organization, location} = this.props;
+    const {totalValues, eventView, organization, location, currentFilter} = this.props;
     let display = decodeScalar(location.query.display, DisplayModes.DURATION);
     let trendFunction = decodeScalar(
       location.query.trendFunction,
@@ -138,6 +156,7 @@ class TransactionSummaryCharts extends React.Component<Props> {
               start={eventView.start}
               end={eventView.end}
               statsPeriod={eventView.statsPeriod}
+              currentFilter={currentFilter}
             />
           )}
           {display === DisplayModes.DURATION && (
@@ -150,6 +169,7 @@ class TransactionSummaryCharts extends React.Component<Props> {
               start={eventView.start}
               end={eventView.end}
               statsPeriod={eventView.statsPeriod}
+              currentFilter={currentFilter}
             />
           )}
           {display === DisplayModes.DURATION_PERCENTILE && (
@@ -162,6 +182,7 @@ class TransactionSummaryCharts extends React.Component<Props> {
               start={eventView.start}
               end={eventView.end}
               statsPeriod={eventView.statsPeriod}
+              currentFilter={currentFilter}
             />
           )}
           {display === DisplayModes.TREND && (
@@ -222,7 +243,7 @@ class TransactionSummaryCharts extends React.Component<Props> {
             <OptionSelector
               title={t('Display')}
               selected={display}
-              options={DISPLAY_OPTIONS}
+              options={generateDisplayOptions(currentFilter)}
               onChange={this.handleDisplayChange}
             />
           </InlineContainer>

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -215,6 +215,7 @@ class SummaryContent extends React.Component<Props, State> {
           <Layout.Main>
             <Search>
               <Filter
+                organization={organization}
                 currentFilter={this.state.spanOperationBreakdownFilter}
                 onChangeFilter={this.onChangeFilter}
               />

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -36,6 +36,7 @@ import {
 import {getTransactionDetailsUrl} from '../utils';
 
 import TransactionSummaryCharts from './charts';
+import Filter, {filterToSearchConditions, SpanOperationBreakdownFilter} from './filter';
 import TransactionHeader, {Tab} from './header';
 import RelatedIssues from './relatedIssues';
 import SidebarCharts from './sidebarCharts';
@@ -57,11 +58,13 @@ type Props = {
 
 type State = {
   incompatibleAlertNotice: React.ReactNode;
+  spanOperationBreakdownFilter: SpanOperationBreakdownFilter;
 };
 
 class SummaryContent extends React.Component<Props, State> {
   state: State = {
     incompatibleAlertNotice: null,
+    spanOperationBreakdownFilter: SpanOperationBreakdownFilter.None,
   };
 
   handleSearch = (query: string) => {
@@ -152,11 +155,17 @@ class SummaryContent extends React.Component<Props, State> {
     });
   };
 
+  onChangeFilter = (newFilter: SpanOperationBreakdownFilter) => {
+    this.setState({
+      spanOperationBreakdownFilter: newFilter,
+    });
+  };
+
   render() {
+    let {eventView} = this.props;
     const {
       transactionName,
       location,
-      eventView,
       organization,
       projects,
       isLoading,
@@ -166,6 +175,14 @@ class SummaryContent extends React.Component<Props, State> {
     const {incompatibleAlertNotice} = this.state;
     const query = decodeScalar(location.query.query, '');
     const totalCount = totalValues === null ? null : totalValues.count;
+
+    const spanOperationBreakdownConditions = filterToSearchConditions(
+      this.state.spanOperationBreakdownFilter
+    );
+    if (spanOperationBreakdownConditions) {
+      eventView = eventView.clone();
+      eventView.query = `${eventView.query} ${spanOperationBreakdownConditions}`.trim();
+    }
 
     // NOTE: This is not a robust check for whether or not a transaction is a front end
     // transaction, however it will suffice for now.
@@ -196,19 +213,26 @@ class SummaryContent extends React.Component<Props, State> {
             <Layout.Main fullWidth>{incompatibleAlertNotice}</Layout.Main>
           )}
           <Layout.Main>
-            <StyledSearchBar
-              organization={organization}
-              projectIds={eventView.project}
-              query={query}
-              fields={eventView.fields}
-              onSearch={this.handleSearch}
-              maxQueryLength={MAX_QUERY_LENGTH}
-            />
+            <Search>
+              <Filter
+                currentFilter={this.state.spanOperationBreakdownFilter}
+                onChangeFilter={this.onChangeFilter}
+              />
+              <StyledSearchBar
+                organization={organization}
+                projectIds={eventView.project}
+                query={query}
+                fields={eventView.fields}
+                onSearch={this.handleSearch}
+                maxQueryLength={MAX_QUERY_LENGTH}
+              />
+            </Search>
             <TransactionSummaryCharts
               organization={organization}
               location={location}
               eventView={eventView}
               totalValues={totalCount}
+              currentFilter={this.state.spanOperationBreakdownFilter}
             />
             <TransactionsList
               location={location}
@@ -361,8 +385,14 @@ function getTransactionsListSort(
   return {selected: selectedSort, options: sortOptions};
 }
 
-const StyledSearchBar = styled(SearchBar)`
+const Search = styled('div')`
+  display: flex;
+  width: 100%;
   margin-bottom: ${space(3)};
+`;
+
+const StyledSearchBar = styled(SearchBar)`
+  flex-grow: 1;
 `;
 
 const StyledSdkUpdatesAlert = styled(GlobalSdkUpdateAlert)`

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -18,7 +18,7 @@ import {getParams} from 'app/components/organizations/globalSelectionHeader/getP
 import Placeholder from 'app/components/placeholder';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {IconWarning} from 'app/icons';
-import {t} from 'app/locale';
+import {t, tct} from 'app/locale';
 import {OrganizationSummary} from 'app/types';
 import {getUtcToLocalDateObject} from 'app/utils/dates';
 import {axisLabelFormatter, tooltipFormatter} from 'app/utils/discover/charts';
@@ -26,6 +26,8 @@ import EventView from 'app/utils/discover/eventView';
 import getDynamicText from 'app/utils/getDynamicText';
 import {Theme} from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
+
+import {filterToField, filterToString, SpanOperationBreakdownFilter} from './filter';
 
 const QUERY_KEYS = [
   'environment',
@@ -45,9 +47,24 @@ type Props = ReactRouter.WithRouterProps &
     location: Location;
     organization: OrganizationSummary;
     queryExtra: Query;
+    currentFilter: SpanOperationBreakdownFilter;
   };
 
-const YAXIS_VALUES = ['p50()', 'p75()', 'p95()', 'p99()', 'p100()'];
+function generateYAxisValues(filter: SpanOperationBreakdownFilter) {
+  if (filter === SpanOperationBreakdownFilter.None) {
+    return ['p50()', 'p75()', 'p95()', 'p99()', 'p100()'];
+  }
+
+  const field = filterToField(filter);
+
+  return [
+    `p50(${field})`,
+    `p75(${field})`,
+    `p95(${field})`,
+    `p99(${field})`,
+    `p100(${field})`,
+  ];
+}
 
 /**
  * Fetch and render a stacked area chart that shows duration
@@ -81,6 +98,7 @@ class DurationChart extends React.Component<Props> {
       statsPeriod,
       router,
       queryExtra,
+      currentFilter,
     } = this.props;
 
     const start = this.props.start ? getUtcToLocalDateObject(this.props.start) : null;
@@ -122,10 +140,17 @@ class DurationChart extends React.Component<Props> {
       },
     };
 
+    const headerTitle =
+      currentFilter === SpanOperationBreakdownFilter.None
+        ? t('Duration Breakdown')
+        : tct('Span Operation Breakdown - [operationName]', {
+            operationName: filterToString(currentFilter) as string,
+          });
+
     return (
       <React.Fragment>
         <HeaderTitleLegend>
-          {t('Duration Breakdown')}
+          {headerTitle}
           <QuestionTooltip
             size="sm"
             position="top"
@@ -154,7 +179,7 @@ class DurationChart extends React.Component<Props> {
               showLoading={false}
               query={query}
               includePrevious={false}
-              yAxis={YAXIS_VALUES}
+              yAxis={generateYAxisValues(currentFilter)}
               partial
             >
               {({results, errored, loading, reloading}) => {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationChart.tsx
@@ -27,7 +27,7 @@ import getDynamicText from 'app/utils/getDynamicText';
 import {Theme} from 'app/utils/theme';
 import withApi from 'app/utils/withApi';
 
-import {filterToField, filterToString, SpanOperationBreakdownFilter} from './filter';
+import {filterToField, SpanOperationBreakdownFilter} from './filter';
 
 const QUERY_KEYS = [
   'environment',
@@ -144,7 +144,7 @@ class DurationChart extends React.Component<Props> {
       currentFilter === SpanOperationBreakdownFilter.None
         ? t('Duration Breakdown')
         : tct('Span Operation Breakdown - [operationName]', {
-            operationName: filterToString(currentFilter) as string,
+            operationName: currentFilter,
           });
 
     return (

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/durationPercentileChart.tsx
@@ -18,12 +18,7 @@ import EventView from 'app/utils/discover/eventView';
 import {getDuration} from 'app/utils/formatters';
 import {Theme} from 'app/utils/theme';
 
-import {
-  filterToColour,
-  filterToField,
-  filterToString,
-  SpanOperationBreakdownFilter,
-} from './filter';
+import {filterToColour, filterToField, SpanOperationBreakdownFilter} from './filter';
 
 const QUERY_KEYS = [
   'environment',
@@ -210,7 +205,7 @@ class DurationPercentileChart extends AsyncComponent<Props, State> {
       currentFilter === SpanOperationBreakdownFilter.None
         ? t('Duration Percentiles')
         : tct('Span Operation Percentiles - [operationName]', {
-            operationName: filterToString(currentFilter) as string,
+            operationName: currentFilter,
           });
 
     return (

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
@@ -1,0 +1,258 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import DropdownButton from 'app/components/dropdownButton';
+import DropdownControl from 'app/components/dropdownControl';
+import {pickSpanBarColour} from 'app/components/events/interfaces/spans/utils';
+import Radio from 'app/components/radio';
+import {IconFilter} from 'app/icons';
+import {t, tct} from 'app/locale';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
+import space from 'app/styles/space';
+
+type DropdownButtonProps = React.ComponentProps<typeof DropdownButton>;
+
+export enum SpanOperationBreakdownFilter {
+  None,
+  Http,
+  Db,
+  Browser,
+  Resource,
+}
+
+const OPTIONS: SpanOperationBreakdownFilter[] = [
+  SpanOperationBreakdownFilter.Http,
+  SpanOperationBreakdownFilter.Db,
+  SpanOperationBreakdownFilter.Browser,
+  SpanOperationBreakdownFilter.Resource,
+];
+
+type Props = {
+  currentFilter: SpanOperationBreakdownFilter;
+  onChangeFilter: (newFilter: SpanOperationBreakdownFilter) => void;
+};
+
+class Filter extends React.Component<Props> {
+  render() {
+    const {currentFilter, onChangeFilter} = this.props;
+
+    const dropDownButtonProps: Pick<DropdownButtonProps, 'children' | 'priority'> & {
+      hasDarkBorderBottomColor: boolean;
+    } = {
+      children: (
+        <React.Fragment>
+          <IconFilter size="xs" />
+          <FilterLabel>
+            {currentFilter === SpanOperationBreakdownFilter.None
+              ? t('Filter')
+              : tct('Filter - [operationName]', {
+                  operationName: filterToString(currentFilter) as string,
+                })}
+          </FilterLabel>
+        </React.Fragment>
+      ),
+      priority: 'default',
+      hasDarkBorderBottomColor: false,
+    };
+
+    return (
+      <Wrapper>
+        <DropdownControl
+          menuWidth="240px"
+          blendWithActor
+          button={({isOpen, getActorProps}) => (
+            <StyledDropdownButton
+              {...getActorProps()}
+              showChevron={false}
+              isOpen={isOpen}
+              hasDarkBorderBottomColor={dropDownButtonProps.hasDarkBorderBottomColor}
+              priority={dropDownButtonProps.priority as DropdownButtonProps['priority']}
+              data-test-id="filter-button"
+            >
+              {dropDownButtonProps.children}
+            </StyledDropdownButton>
+          )}
+        >
+          <MenuContent
+            onClick={event => {
+              // propagated clicks will dismiss the menu; we stop this here
+              event.stopPropagation();
+            }}
+          >
+            <Header>
+              <HeaderTitle>{t('Operation')}</HeaderTitle>
+              <Radio
+                radioSize="small"
+                checked={SpanOperationBreakdownFilter.None === currentFilter}
+                onChange={() => onChangeFilter(SpanOperationBreakdownFilter.None)}
+              />
+            </Header>
+            <List>
+              {Array.from([...OPTIONS], (filterOption, index) => {
+                const operationName = filterToString(filterOption);
+                return (
+                  <ListItem key={String(index)} isChecked={false}>
+                    <OperationDot backgroundColor={pickSpanBarColour(operationName)} />
+                    <OperationName>{operationName}</OperationName>
+                    <Radio
+                      radioSize="small"
+                      checked={filterOption === currentFilter}
+                      onChange={() => onChangeFilter(filterOption)}
+                    />
+                  </ListItem>
+                );
+              })}
+            </List>
+          </MenuContent>
+        </DropdownControl>
+      </Wrapper>
+    );
+  }
+}
+
+const FilterLabel = styled('span')`
+  margin-left: ${space(1)};
+`;
+
+const Wrapper = styled('div')`
+  position: relative;
+  display: flex;
+
+  margin-right: ${space(1)};
+`;
+
+const StyledDropdownButton = styled(DropdownButton)<{hasDarkBorderBottomColor?: boolean}>`
+  white-space: nowrap;
+  max-width: 200px;
+
+  z-index: ${p => p.theme.zIndex.dropdown};
+
+  &:hover,
+  &:active {
+    ${p =>
+      !p.isOpen &&
+      p.hasDarkBorderBottomColor &&
+      `
+          border-bottom-color: ${p.theme.button.primary.border};
+        `}
+  }
+
+  ${p =>
+    !p.isOpen &&
+    p.hasDarkBorderBottomColor &&
+    `
+      border-bottom-color: ${p.theme.button.primary.border};
+    `}
+`;
+
+const MenuContent = styled('div')`
+  max-height: 250px;
+  overflow-y: auto;
+  border-top: 1px solid ${p => p.theme.gray200};
+`;
+
+const Header = styled('div')`
+  display: grid;
+  grid-template-columns: auto min-content;
+  grid-column-gap: ${space(1)};
+  align-items: center;
+
+  margin: 0;
+  background-color: ${p => p.theme.backgroundSecondary};
+  color: ${p => p.theme.gray300};
+  font-weight: normal;
+  font-size: ${p => p.theme.fontSizeMedium};
+  padding: ${space(1)} ${space(2)};
+  border-bottom: 1px solid ${p => p.theme.border};
+`;
+
+const HeaderTitle = styled('span')`
+  font-size: ${p => p.theme.fontSizeMedium};
+`;
+
+const List = styled('ul')`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+`;
+
+const ListItem = styled('li')<{isChecked?: boolean}>`
+  display: grid;
+  grid-template-columns: max-content 1fr max-content;
+  grid-column-gap: ${space(1)};
+  align-items: center;
+  padding: ${space(1)} ${space(2)};
+  border-bottom: 1px solid ${p => p.theme.border};
+  :hover {
+    background-color: ${p => p.theme.backgroundSecondary};
+  }
+
+  &:hover span {
+    color: ${p => p.theme.blue300};
+    text-decoration: underline;
+  }
+`;
+
+const OperationDot = styled('div')<{backgroundColor: string}>`
+  content: '';
+  display: block;
+  width: 8px;
+  min-width: 8px;
+  height: 8px;
+  margin-right: ${space(1)};
+  border-radius: 100%;
+
+  background-color: ${p => p.backgroundColor};
+`;
+
+const OperationName = styled('div')`
+  font-size: ${p => p.theme.fontSizeMedium};
+  ${overflowEllipsis};
+`;
+
+export function filterToString(option: SpanOperationBreakdownFilter): string {
+  switch (option) {
+    case SpanOperationBreakdownFilter.Http:
+      return 'http';
+    case SpanOperationBreakdownFilter.Db:
+      return 'db';
+    case SpanOperationBreakdownFilter.Browser:
+      return 'browser';
+    case SpanOperationBreakdownFilter.Resource:
+      return 'resource';
+    default:
+      throw Error(`Unknown option: ${option}`);
+  }
+}
+
+export function filterToField(option: SpanOperationBreakdownFilter) {
+  switch (option) {
+    case SpanOperationBreakdownFilter.None:
+      return undefined;
+    default: {
+      return `span_op_breakdowns.ops.${filterToString(option)}`;
+    }
+  }
+}
+
+export function filterToSearchConditions(option: SpanOperationBreakdownFilter) {
+  switch (option) {
+    case SpanOperationBreakdownFilter.None:
+      return undefined;
+    default: {
+      return `has:${filterToField(option)}`;
+    }
+  }
+}
+
+export function filterToColour(option: SpanOperationBreakdownFilter) {
+  switch (option) {
+    case SpanOperationBreakdownFilter.None:
+      return pickSpanBarColour('');
+    default: {
+      return pickSpanBarColour(filterToString(option));
+    }
+  }
+}
+
+export default Filter;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
@@ -85,26 +85,33 @@ class Filter extends React.Component<Props> {
               event.stopPropagation();
             }}
           >
-            <Header>
+            <Header
+              onClick={event => {
+                event.stopPropagation();
+                onChangeFilter(SpanOperationBreakdownFilter.None);
+              }}
+            >
               <HeaderTitle>{t('Operation')}</HeaderTitle>
               <Radio
                 radioSize="small"
                 checked={SpanOperationBreakdownFilter.None === currentFilter}
-                onChange={() => onChangeFilter(SpanOperationBreakdownFilter.None)}
               />
             </Header>
             <List>
               {Array.from([...OPTIONS], (filterOption, index) => {
                 const operationName = filterOption;
                 return (
-                  <ListItem key={String(index)} isChecked={false}>
+                  <ListItem
+                    key={String(index)}
+                    isChecked={false}
+                    onClick={event => {
+                      event.stopPropagation();
+                      onChangeFilter(filterOption);
+                    }}
+                  >
                     <OperationDot backgroundColor={pickSpanBarColour(operationName)} />
                     <OperationName>{operationName}</OperationName>
-                    <Radio
-                      radioSize="small"
-                      checked={filterOption === currentFilter}
-                      onChange={() => onChangeFilter(filterOption)}
-                    />
+                    <Radio radioSize="small" checked={filterOption === currentFilter} />
                   </ListItem>
                 );
               })}

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
@@ -9,6 +9,7 @@ import {IconFilter} from 'app/icons';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
+import {OrganizationSummary} from 'app/types';
 
 type DropdownButtonProps = React.ComponentProps<typeof DropdownButton>;
 
@@ -28,13 +29,18 @@ const OPTIONS: SpanOperationBreakdownFilter[] = [
 ];
 
 type Props = {
+  organization: OrganizationSummary;
   currentFilter: SpanOperationBreakdownFilter;
   onChangeFilter: (newFilter: SpanOperationBreakdownFilter) => void;
 };
 
 class Filter extends React.Component<Props> {
   render() {
-    const {currentFilter, onChangeFilter} = this.props;
+    const {currentFilter, onChangeFilter, organization} = this.props;
+
+    if (!organization.features.includes('performance-ops-breakdown')) {
+      return null;
+    }
 
     const dropDownButtonProps: Pick<DropdownButtonProps, 'children' | 'priority'> & {
       hasDarkBorderBottomColor: boolean;

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
@@ -14,11 +14,11 @@ import {OrganizationSummary} from 'app/types';
 type DropdownButtonProps = React.ComponentProps<typeof DropdownButton>;
 
 export enum SpanOperationBreakdownFilter {
-  None,
-  Http,
-  Db,
-  Browser,
-  Resource,
+  None = 'none',
+  Http = 'http',
+  Db = 'db',
+  Browser = 'browser',
+  Resource = 'resource',
 }
 
 const OPTIONS: SpanOperationBreakdownFilter[] = [
@@ -52,7 +52,7 @@ class Filter extends React.Component<Props> {
             {currentFilter === SpanOperationBreakdownFilter.None
               ? t('Filter')
               : tct('Filter - [operationName]', {
-                  operationName: filterToString(currentFilter) as string,
+                  operationName: currentFilter,
                 })}
           </FilterLabel>
         </React.Fragment>
@@ -95,7 +95,7 @@ class Filter extends React.Component<Props> {
             </Header>
             <List>
               {Array.from([...OPTIONS], (filterOption, index) => {
-                const operationName = filterToString(filterOption);
+                const operationName = filterOption;
                 return (
                   <ListItem key={String(index)} isChecked={false}>
                     <OperationDot backgroundColor={pickSpanBarColour(operationName)} />
@@ -216,27 +216,12 @@ const OperationName = styled('div')`
   ${overflowEllipsis};
 `;
 
-export function filterToString(option: SpanOperationBreakdownFilter): string {
-  switch (option) {
-    case SpanOperationBreakdownFilter.Http:
-      return 'http';
-    case SpanOperationBreakdownFilter.Db:
-      return 'db';
-    case SpanOperationBreakdownFilter.Browser:
-      return 'browser';
-    case SpanOperationBreakdownFilter.Resource:
-      return 'resource';
-    default:
-      throw Error(`Unknown option: ${option}`);
-  }
-}
-
 export function filterToField(option: SpanOperationBreakdownFilter) {
   switch (option) {
     case SpanOperationBreakdownFilter.None:
       return undefined;
     default: {
-      return `span_op_breakdowns.ops.${filterToString(option)}`;
+      return `span_op_breakdowns.ops.${option}`;
     }
   }
 }
@@ -256,7 +241,7 @@ export function filterToColour(option: SpanOperationBreakdownFilter) {
     case SpanOperationBreakdownFilter.None:
       return pickSpanBarColour('');
     default: {
-      return pickSpanBarColour(filterToString(option));
+      return pickSpanBarColour(option);
     }
   }
 }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/latencyChart.tsx
@@ -18,12 +18,7 @@ import {computeBuckets, formatHistogramData} from 'app/utils/performance/histogr
 import {decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 
-import {
-  filterToColour,
-  filterToField,
-  filterToString,
-  SpanOperationBreakdownFilter,
-} from './filter';
+import {filterToColour, filterToField, SpanOperationBreakdownFilter} from './filter';
 
 const NUM_BUCKETS = 50;
 const QUERY_KEYS = [
@@ -217,7 +212,7 @@ class LatencyChart extends React.Component<Props, State> {
       currentFilter === SpanOperationBreakdownFilter.None
         ? t('Duration Distribution')
         : tct('Span Operation Distribution - [operationName]', {
-            operationName: filterToString(currentFilter) as string,
+            operationName: currentFilter,
           });
 
     return (


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/24915

This PR introduces the initial UI for filtering on span operation names on the transaction summary page. Additional UI pieces will be introduced in follow up PRs.

The dropdown filter by span operation name wIll only be shown if the organization has `performance-ops-breakdown` feature.

### Dropdown filter

<img width="1309" alt="Screen Shot 2021-04-05 at 4 00 26 PM" src="https://user-images.githubusercontent.com/139499/113621033-1ed47e00-9629-11eb-9c68-a546904f6602.png">

## Display Options when an operation name is chosen

<img width="1299" alt="Screen Shot 2021-04-05 at 4 02 29 PM" src="https://user-images.githubusercontent.com/139499/113621020-1bd98d80-9629-11eb-9084-203a81da5b9f.png">

### Span Operation Distribution

<img width="1302" alt="Screen Shot 2021-04-05 at 4 01 24 PM" src="https://user-images.githubusercontent.com/139499/113621027-1d0aba80-9629-11eb-961d-d82c02d3c535.png">

### Span Operation Percentiles

<img width="1302" alt="Screen Shot 2021-04-05 at 4 01 17 PM" src="https://user-images.githubusercontent.com/139499/113621029-1da35100-9629-11eb-927a-4677c718e246.png">

### Span Operation Breakdown

<img width="1305" alt="Screen Shot 2021-04-05 at 4 01 10 PM" src="https://user-images.githubusercontent.com/139499/113621032-1e3be780-9629-11eb-93bb-3b05f17c997d.png">
