### PR TITLE
ref(webpack): Refactor `statics-setup` to be part of entrypoint

### DIFF
--- a/src/sentry/static/sentry/app/bootstrap.tsx
+++ b/src/sentry/static/sentry/app/bootstrap.tsx
@@ -2,7 +2,6 @@ import 'bootstrap/js/alert';
 import 'bootstrap/js/tab';
 import 'bootstrap/js/dropdown';
 import 'focus-visible';
-import 'app/utils/statics-setup';
 
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/src/sentry/static/sentry/app/index.tsx
+++ b/src/sentry/static/sentry/app/index.tsx
@@ -7,14 +7,13 @@ import {Config} from 'app/types';
 const BOOTSTRAP_URL = '/api/client-config/';
 
 const bootApplication = (data: Config) => {
-  const {distPrefix, csrfCookieName, sentryConfig, userIdentity} = data;
+  const {csrfCookieName, sentryConfig, userIdentity} = data;
 
   // TODO(epurkhiser): Would be great if we could remove some of these from
   // existing on the window object and instead pass into a bootstrap function.
   // We can't currently do this due to some of these globals needing to be
   // available for modules imported by the bootstrap.
   window.csrfCookieName = csrfCookieName;
-  window.__sentryGlobalStaticPrefix = distPrefix;
   window.__SENTRY__OPTIONS = sentryConfig;
   window.__SENTRY__USER = userIdentity;
   window.__initialData = data;
@@ -26,12 +25,6 @@ const bootApplication = (data: Config) => {
 async function bootWithHydration() {
   const response = await fetch(BOOTSTRAP_URL);
   const data: Config = await response.json();
-
-  // XXX(epurkhiser): Currently we only boot with hydration in experimental SPA
-  // mode, where assets are *currently not versioned*. We hardcode this here
-  // for now as a quick workaround for the index.html being aware of versioned
-  // asset paths.
-  data.distPrefix = '/_assets/';
 
   bootApplication(data);
 

--- a/src/sentry/static/sentry/app/utils/statics-setup.tsx
+++ b/src/sentry/static/sentry/app/utils/statics-setup.tsx
@@ -4,11 +4,13 @@
 declare var __webpack_public_path__: string;
 
 /**
- * Set the webpack public path at runtime. The __sentryGlobalStaticPrefix will
- * be declared in layout.html.
+ * Set the webpack public path at runtime. This is necessary so that imports can be resolved properly
  *
  * NOTE: This MUST be loaded before any other app modules in the entrypoint.
+ *
+ * XXX(epurkhiser): Currently we only boot with hydration in experimental SPA
+ * mode, where assets are *currently not versioned*. We hardcode `/_assets/` here
+ * for now as a quick workaround for the index.html being aware of versioned
+ * asset paths.
  */
-if (window.__sentryGlobalStaticPrefix) {
-  __webpack_public_path__ = window.__sentryGlobalStaticPrefix;
-}
+__webpack_public_path__ = window.__initialData?.distPrefix || '/_assets/';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -224,8 +224,10 @@ let appConfig = {
   entry: {
     /**
      * Main Sentry SPA
+     *
+     * The order here matters for `getsentry`
      */
-    app: 'app',
+    app: ['app/utils/statics-setup', 'app'],
 
     /**
      * Legacy CSS Webpack appConfig for Django-powered views.


### PR DESCRIPTION
This changes our `statics-setup` for loading webpack assets. Instead of importing in `bootstrap`, this is moved to be part of the webpack entrypoint. This is so we can have it load before getsentry entrypoint.

Fixes the loader being broken.