### PR TITLE
chore(trace-view): Remove the upsells from trace view

### DIFF
--- a/src/sentry/static/sentry/app/components/quickTrace/index.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {browserHistory} from 'react-router';
 import {Location, LocationDescriptor} from 'history';
 
-import Feature from 'app/components/acl/feature';
 import DropdownLink from 'app/components/dropdownLink';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
 import {
@@ -10,7 +9,6 @@ import {
   generateMultiTransactionsTarget,
   generateSingleErrorTarget,
   generateSingleTransactionTarget,
-  renderDisabledHoverCard,
   TransactionDestination,
 } from 'app/components/quickTrace/utils';
 import Tooltip from 'app/components/tooltip';
@@ -31,7 +29,6 @@ import Projects from 'app/utils/projects';
 import {Theme} from 'app/utils/theme';
 
 import {
-  DisabledDropdownItem,
   DropdownItem,
   DropdownItemSubContainer,
   ErrorNodeContent,
@@ -373,25 +370,11 @@ function EventNodeSelector({
           );
         })}
         {events.length > numEvents && hoverText && extrasTarget && (
-          <Feature
-            features={['trace-view-summary']}
-            hookName="feature-disabled:trace-view-link"
-            renderDisabled={renderDisabledHoverCard}
+          <DropdownItem
+            onSelect={() => handleDropdownItem(extrasTarget, nodeKey, organization, true)}
           >
-            {({hasFeature}) =>
-              hasFeature ? (
-                <DropdownItem
-                  onSelect={() =>
-                    handleDropdownItem(extrasTarget, nodeKey, organization, true)
-                  }
-                >
-                  {hoverText}
-                </DropdownItem>
-              ) : (
-                <DisabledDropdownItem>{hoverText}</DisabledDropdownItem>
-              )
-            }
-          </Feature>
+            {hoverText}
+          </DropdownItem>
         )}
       </DropdownLink>
     );

--- a/src/sentry/static/sentry/app/components/quickTrace/styles.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/styles.tsx
@@ -86,12 +86,6 @@ export function DropdownItem({children, first, onSelect, to}: DropdownItemProps)
   );
 }
 
-export const DisabledDropdownItem = styled(StyledMenuItem)`
-  span {
-    cursor: not-allowed;
-  }
-`;
-
 export const DropdownItemSubContainer = styled('div')`
   display: flex;
   flex-direction: row;
@@ -99,10 +93,6 @@ export const DropdownItemSubContainer = styled('div')`
   > a {
     padding-left: 0 !important;
   }
-`;
-
-export const DisabledLink = styled('a')`
-  cursor: not-allowed;
 `;
 
 export const StyledTruncate = styled(Truncate)`

--- a/src/sentry/static/sentry/app/components/quickTrace/utils.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/utils.tsx
@@ -1,8 +1,5 @@
-import React from 'react';
 import {Location, LocationDescriptor} from 'history';
 
-import FeatureDisabled from 'app/components/acl/featureDisabled';
-import Hovercard from 'app/components/hovercard';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import {OrganizationSummary} from 'app/types';
@@ -144,21 +141,4 @@ export function generateTraceTarget(
     ...dateSelection,
   });
   return eventView.getResultsViewUrlTarget(organization.slug);
-}
-
-export function renderDisabledHoverCard(p: any) {
-  return (
-    <Hovercard
-      body={
-        <FeatureDisabled
-          features={['trace-view-summary']}
-          hideHelpToggle
-          message="The Trace View is disabled"
-          featureName="Trace View"
-        />
-      }
-    >
-      {p.children(p)}
-    </Hovercard>
-  );
 }

--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 import {Location} from 'history';
 import moment from 'moment-timezone';
 
-import Feature from 'app/components/acl/feature';
 import DateTime from 'app/components/dateTime';
 import ErrorBoundary from 'app/components/errorBoundary';
 import FeatureBadge from 'app/components/featureBadge';
@@ -13,11 +12,7 @@ import ExternalLink from 'app/components/links/externalLink';
 import NavigationButtonGroup from 'app/components/navigationButtonGroup';
 import Placeholder from 'app/components/placeholder';
 import QuickTrace from 'app/components/quickTrace';
-import {DisabledLink} from 'app/components/quickTrace/styles';
-import {
-  generateTraceTarget,
-  renderDisabledHoverCard,
-} from 'app/components/quickTrace/utils';
+import {generateTraceTarget} from 'app/components/quickTrace/utils';
 import Tooltip from 'app/components/tooltip';
 import {IconWarning} from 'app/icons';
 import {t} from 'app/locale';
@@ -81,28 +76,13 @@ class GroupEventToolbar extends React.Component<Props> {
             <React.Fragment>
               {!results.isLoading && results.error === null && results.trace !== null && (
                 <LinkContainer>
-                  <Feature
-                    features={['trace-view-summary']}
-                    hookName="feature-disabled:trace-view-link"
-                    renderDisabled={renderDisabledHoverCard}
+                  <Link
+                    to={generateTraceTarget(event, organization)}
+                    onClick={() => this.handleTraceLink(organization)}
                   >
-                    {({hasFeature}) =>
-                      hasFeature ? (
-                        <Link
-                          to={generateTraceTarget(event, organization)}
-                          onClick={() => this.handleTraceLink(organization)}
-                        >
-                          View Full Trace
-                          <FeatureBadge type="beta" />
-                        </Link>
-                      ) : (
-                        <DisabledLink>
-                          View Full Trace
-                          <FeatureBadge type="beta" />
-                        </DisabledLink>
-                      )
-                    }
-                  </Feature>
+                    View Full Trace
+                    <FeatureBadge type="beta" />
+                  </Link>
                 </LinkContainer>
               )}
               <QuickTraceWrapper>

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import {Location} from 'history';
 
-import Feature from 'app/components/acl/feature';
 import ErrorBoundary from 'app/components/errorBoundary';
 import Link from 'app/components/links/link';
 import Placeholder from 'app/components/placeholder';
 import QuickTrace from 'app/components/quickTrace';
-import {DisabledLink} from 'app/components/quickTrace/styles';
-import {
-  generateTraceTarget,
-  renderDisabledHoverCard,
-} from 'app/components/quickTrace/utils';
+import {generateTraceTarget} from 'app/components/quickTrace/utils';
 import {t} from 'app/locale';
 import {OrganizationSummary} from 'app/types';
 import {Event} from 'app/types/event';
@@ -88,21 +83,9 @@ export default function QuickTraceMeta({
         traceId === null ? (
           '\u2014'
         ) : (
-          <Feature
-            hookName="feature-disabled:trace-view-link"
-            features={['trace-view-summary']}
-            renderDisabled={renderDisabledHoverCard}
-          >
-            {({hasFeature}) =>
-              hasFeature ? (
-                <Link to={traceTarget} onClick={() => handleTraceLink(organization)}>
-                  {linkText}
-                </Link>
-              ) : (
-                <DisabledLink>{linkText}</DisabledLink>
-              )
-            }
-          </Feature>
+          <Link to={traceTarget} onClick={() => handleTraceLink(organization)}>
+            {linkText}
+          </Link>
         )
       }
     />


### PR DESCRIPTION
- We're going to allow all plans access to the trace view, removing the
  upsells
- Going to remove the hooks in a later PR so that I don't have to merge
  2 PRs at the same time