### PR TITLE
ui(span-view): Add padding after processing errors

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/index.tsx
@@ -11,6 +11,7 @@ import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {EventTransaction} from 'app/types/event';
+import {objectIsEmpty} from 'app/utils';
 import DiscoverQuery, {TableData} from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
 import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
@@ -152,7 +153,7 @@ class SpansInterface extends React.Component<Props, State> {
     });
 
     return (
-      <div>
+      <Container hasErrors={!objectIsEmpty(event.errors)}>
         <DiscoverQuery
           location={location}
           eventView={traceErrorsEventView}
@@ -199,10 +200,22 @@ class SpansInterface extends React.Component<Props, State> {
             );
           }}
         </DiscoverQuery>
-      </div>
+      </Container>
     );
   }
 }
+
+const Container = styled('div')<{hasErrors: boolean}>`
+  ${p =>
+    p.hasErrors &&
+    `
+  padding: ${space(2)} 0;
+
+  @media (min-width: ${p.theme.breakpoints[0]}) {
+    padding: ${space(3)} 0 0 0;
+  }
+  `}
+`;
 
 const Search = styled('div')`
   display: flex;


### PR DESCRIPTION
The span interface does not make use of the `EventSectionData` component because
it does not render the headers. This also means it does not get rendered with
the appropriate padding as well. This change takes processing errors into
account and adds in padding where necessary.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/113634333-91028e00-963c-11eb-863c-d515067f34d0.png)

## After

![image](https://user-images.githubusercontent.com/10239353/113634305-87792600-963c-11eb-9b8f-9b9e62e67151.png)
