### PR TITLE
fix(demo): bug when pressing next for certain guides

### DIFF
--- a/src/sentry/static/sentry/app/actionCreators/guides.tsx
+++ b/src/sentry/static/sentry/app/actionCreators/guides.tsx
@@ -30,13 +30,13 @@ export function toStep(step: number) {
   GuideActions.toStep(step);
 }
 
-export function closeGuide() {
-  GuideActions.closeGuide();
+export function closeGuide(dismissed?: boolean) {
+  GuideActions.closeGuide(dismissed);
 }
 
 export function dismissGuide(guide: string, step: number, orgId: string) {
   recordDismiss(guide, step, orgId);
-  closeGuide();
+  closeGuide(true);
 }
 
 export function recordFinish(guide: string, orgId: string) {

--- a/src/sentry/static/sentry/app/stores/guideStore.tsx
+++ b/src/sentry/static/sentry/app/stores/guideStore.tsx
@@ -130,12 +130,15 @@ const guideStoreConfig: Reflux.StoreDefinition & GuideStoreInterface = {
     this.updateCurrentGuide();
   },
 
-  onCloseGuide() {
+  onCloseGuide(dismissed?: boolean) {
     const {currentGuide, guides} = this.state;
-    //update the current guide seen to true or all guides if markOthersAsSeen is true
+    //update the current guide seen to true or all guides
+    //if markOthersAsSeen is true and the user is dismissing
     guides
       .filter(
-        guide => guide.guide === currentGuide?.guide || currentGuide?.markOthersAsSeen
+        guide =>
+          guide.guide === currentGuide?.guide ||
+          (currentGuide?.markOthersAsSeen && dismissed)
       )
       .forEach(guide => (guide.seen = true));
     this.state.forceShow = false;


### PR DESCRIPTION
Recently, I introduced a change to mark all active guides as seen when the user presses dismiss (https://github.com/getsentry/sentry/pull/24793). However, that PR created the unpleasant side effect of marking all guides as seen even when the user presses "next" and doesn't actually dismiss the guides. This PR addresses it by adding a new parameter called `dismissed` for the `closeGuide` action. We should only dismiss other guides if the user is pressing "dismiss" instead of successfully completing a guide.