### PR TITLE
fix(notifications): Respect User's Notification Settings Defaults

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -262,11 +262,10 @@ class MailAdapter:
             settings = notification_settings_by_user.get(user)
             if settings:
                 # Check per-project settings first, fallback to project-independent settings.
-                if (
-                    settings.get(NotificationScopeType.PROJECT)
-                    == NotificationSettingOptionValues.NEVER
-                    or settings.get(NotificationScopeType.USER)
-                    == NotificationSettingOptionValues.NEVER
+                project_setting = settings.get(NotificationScopeType.PROJECT)
+                user_setting = settings.get(NotificationScopeType.USER)
+                if project_setting == NotificationSettingOptionValues.NEVER or (
+                    not project_setting and user_setting == NotificationSettingOptionValues.NEVER
                 ):
                     output.add(user.id)
         return output

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -261,8 +261,13 @@ class MailAdapter:
         for user in users:
             settings = notification_settings_by_user.get(user)
             if settings:
-                setting = settings.get(NotificationScopeType.PROJECT)
-                if setting == NotificationSettingOptionValues.NEVER:
+                # Check per-project settings first, fallback to project-independent settings.
+                if (
+                    settings.get(NotificationScopeType.PROJECT)
+                    == NotificationSettingOptionValues.NEVER
+                    or settings.get(NotificationScopeType.USER)
+                    == NotificationSettingOptionValues.NEVER
+                ):
                     output.add(user.id)
         return output
 


### PR DESCRIPTION
My PRs clobbered https://github.com/getsentry/sentry/pull/24855, so I'm rewriting it from master.

> This fixes a bug when users disabled alerts for all projects in their user settings (before fine-tuning it per project). If "Default" or "On" was selected for the project in fine-tuning, alert notifications would still be sent to Issue Owners and/or Teams that user was part of.

FIXES [WOR-140](https://getsentry.atlassian.net/browse/WOR-140)