### PR TITLE
fix(ui): Alert details ga design

### DIFF
--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -38,6 +38,7 @@ type Props = {
   endpointPath: string;
   renderEmptyMessage?: () => React.ReactNode;
   queryParams?: Record<string, number | string | string[] | undefined | null>;
+  statsPeriodSummary?: string;
 } & Partial<typeof defaultProps>;
 
 type State = {
@@ -181,6 +182,7 @@ class GroupList extends React.Component<Props, State> {
       renderEmptyMessage,
       withPagination,
       useFilteredStats,
+      statsPeriodSummary,
       queryParams,
     } = this.props;
     const {loading, error, groups, memberList, pageLinks} = this.state;
@@ -231,6 +233,7 @@ class GroupList extends React.Component<Props, State> {
                   withChart={withChart}
                   memberList={members}
                   useFilteredStats={useFilteredStats}
+                  statsPeriodSummary={statsPeriodSummary}
                   statsPeriod={statsPeriod}
                 />
               );

--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -21,6 +21,7 @@ import {Group} from 'app/types';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import StreamManager from 'app/utils/streamManager';
 import withApi from 'app/utils/withApi';
+import {TimePeriodType} from 'app/views/alerts/rules/details/body';
 
 import GroupListHeader from './groupListHeader';
 
@@ -38,7 +39,7 @@ type Props = {
   endpointPath: string;
   renderEmptyMessage?: () => React.ReactNode;
   queryParams?: Record<string, number | string | string[] | undefined | null>;
-  statsPeriodSummary?: string;
+  customStatsPeriod?: TimePeriodType;
 } & Partial<typeof defaultProps>;
 
 type State = {
@@ -182,7 +183,7 @@ class GroupList extends React.Component<Props, State> {
       renderEmptyMessage,
       withPagination,
       useFilteredStats,
-      statsPeriodSummary,
+      customStatsPeriod,
       queryParams,
     } = this.props;
     const {loading, error, groups, memberList, pageLinks} = this.state;
@@ -233,7 +234,7 @@ class GroupList extends React.Component<Props, State> {
                   withChart={withChart}
                   memberList={members}
                   useFilteredStats={useFilteredStats}
-                  statsPeriodSummary={statsPeriodSummary}
+                  customStatsPeriod={customStatsPeriod}
                   statsPeriod={statsPeriod}
                 />
               );

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -349,7 +349,9 @@ class StreamGroup extends React.Component<Props, State> {
     } = this.props;
 
     const {period, start, end} = selection.datetime || {};
-    const summary = customStatsPeriod?.label.toLowerCase() ?? (!!start && !!end
+    const summary =
+      customStatsPeriod?.label.toLowerCase() ??
+      (!!start && !!end
         ? 'time range'
         : getRelativeSummary(period || DEFAULT_STATS_PERIOD).toLowerCase());
 

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -42,6 +42,7 @@ import EventView from 'app/utils/discover/eventView';
 import {queryToObj} from 'app/utils/stream';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
+import {TimePeriodType} from 'app/views/alerts/rules/details/body';
 import {getTabs, isForReviewQuery, Query} from 'app/views/issueList/utils';
 
 const DiscoveryExclusionFields: string[] = [
@@ -78,7 +79,7 @@ type Props = {
   memberList?: User[];
   showInboxTime?: boolean;
   index?: number;
-  statsPeriodSummary?: string;
+  customStatsPeriod?: TimePeriodType;
   // TODO(ts): higher order functions break defaultprops export types
 } & Partial<typeof defaultProps>;
 
@@ -232,7 +233,7 @@ class StreamGroup extends React.Component<Props, State> {
   };
 
   getDiscoverUrl(isFiltered?: boolean) {
-    const {organization, query, selection} = this.props;
+    const {organization, query, selection, customStatsPeriod} = this.props;
     const {data} = this.state;
 
     // when there is no discover feature open events page
@@ -260,7 +261,7 @@ class StreamGroup extends React.Component<Props, State> {
     const searchQuery = (queryTerms.length ? ' ' : '') + queryTerms.join(' ');
 
     if (hasDiscoverQuery) {
-      const {period, start, end} = selection.datetime || {};
+      const {period, start, end} = customStatsPeriod ?? (selection.datetime || {});
 
       const discoverQuery: NewQuery = {
         ...commonQuery,
@@ -344,11 +345,11 @@ class StreamGroup extends React.Component<Props, State> {
       displayReprocessingLayout,
       showInboxTime,
       useFilteredStats,
-      statsPeriodSummary,
+      customStatsPeriod,
     } = this.props;
 
     const {period, start, end} = selection.datetime || {};
-    const summary = statsPeriodSummary ?? (!!start && !!end
+    const summary = customStatsPeriod?.label.toLowerCase() ?? (!!start && !!end
         ? 'time range'
         : getRelativeSummary(period || DEFAULT_STATS_PERIOD).toLowerCase());
 

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -78,6 +78,7 @@ type Props = {
   memberList?: User[];
   showInboxTime?: boolean;
   index?: number;
+  statsPeriodSummary?: string;
   // TODO(ts): higher order functions break defaultprops export types
 } & Partial<typeof defaultProps>;
 
@@ -343,13 +344,13 @@ class StreamGroup extends React.Component<Props, State> {
       displayReprocessingLayout,
       showInboxTime,
       useFilteredStats,
+      statsPeriodSummary,
     } = this.props;
 
     const {period, start, end} = selection.datetime || {};
-    const summary =
-      !!start && !!end
+    const summary = statsPeriodSummary ?? (!!start && !!end
         ? 'time range'
-        : getRelativeSummary(period || DEFAULT_STATS_PERIOD).toLowerCase();
+        : getRelativeSummary(period || DEFAULT_STATS_PERIOD).toLowerCase());
 
     // Use data.filtered to decide on which value to use
     // In case of the query has filters but we avoid showing both sets of filtered/unfiltered stats

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -43,16 +43,18 @@ import MetricChart from './metricChart';
 import RelatedIssues from './relatedIssues';
 import RelatedTransactions from './relatedTransactions';
 
+export type TimePeriodType = {
+  start: string;
+  end: string;
+  label: string;
+  custom?: boolean;
+};
+
 type Props = {
   api: Client;
   rule?: IncidentRule;
   incidents?: Incident[];
-  timePeriod: {
-    start: string;
-    end: string;
-    label: string;
-    custom?: boolean;
-  };
+  timePeriod: TimePeriodType;
   organization: Organization;
   location: Location;
   handleTimePeriodChange: (value: string) => void;
@@ -357,8 +359,7 @@ export default class DetailsBody extends React.Component<Props> {
                           projects={((projects as Project[]) || []).filter(project =>
                             rule.projects.includes(project.slug)
                           )}
-                          start={timePeriod.start}
-                          end={timePeriod.end}
+                          timePeriod={timePeriod}
                           filter={queryWithTypeFilter}
                         />
                       )}

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -46,6 +46,7 @@ import RelatedTransactions from './relatedTransactions';
 export type TimePeriodType = {
   start: string;
   end: string;
+  period: string;
   label: string;
   custom?: boolean;
 };

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -109,6 +109,22 @@ export default class DetailsBody extends React.Component<Props> {
     return getInterval({start, end}, true);
   }
 
+  getFilter() {
+    const {rule} = this.props;
+    if (!rule) {
+      return null;
+    }
+
+    return (
+      <Filters>
+        <span>
+          {rule?.dataset && <code>{DATASET_EVENT_TYPE_FILTERS[rule.dataset]}</code>}
+        </span>
+        <span>{rule?.query && <code>{rule?.query}</code>}</span>
+      </Filters>
+    );
+  }
+
   renderTrigger(trigger: Trigger): React.ReactNode {
     const {rule} = this.props;
 
@@ -158,12 +174,7 @@ export default class DetailsBody extends React.Component<Props> {
         <RuleText>{rule.environment ?? 'All'}</RuleText>
 
         <SidebarHeading>{t('Filters')}</SidebarHeading>
-        <Filters>
-          <span>
-            {rule?.dataset && <code>{DATASET_EVENT_TYPE_FILTERS[rule.dataset]}</code>}
-          </span>
-          <span>{rule?.query && <code>{rule?.query}</code>}</span>
-        </Filters>
+        {this.getFilter()}
 
         <SidebarHeading>{t('Conditions')}</SidebarHeading>
         {criticalTrigger && this.renderTrigger(criticalTrigger)}
@@ -352,6 +363,7 @@ export default class DetailsBody extends React.Component<Props> {
                     projects={projects}
                     metricText={this.getMetricText()}
                     interval={this.getInterval()}
+                    filter={this.getFilter()}
                     query={queryWithTypeFilter}
                     orgId={orgId}
                   />
@@ -509,9 +521,11 @@ const RuleText = styled('div')`
 `;
 
 const Filters = styled('div')`
+  display: inline-flex;
   width: 100%;
   overflow-wrap: break-word;
   font-size: ${p => p.theme.fontSizeMedium};
+  gap: ${space(1)};
 `;
 
 const TriggerCondition = styled('div')`

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -329,7 +329,11 @@ export default class DetailsBody extends React.Component<Props> {
                     <div>
                       <SidebarHeading noMargin>
                         {t('Time Interval')}
-                        <Tooltip title="This is the time period which the metric is evaluated by.">
+                        <Tooltip
+                          title={t(
+                            'This is the time period which the metric is evaluated by.'
+                          )}
+                        >
                           <IconInfo size="xs" />
                         </Tooltip>
                       </SidebarHeading>
@@ -410,6 +414,8 @@ const HeaderContainer = styled('div')`
 `;
 
 const StyledLayoutBody = styled(Layout.Body)`
+  flex-grow: 0;
+  padding-bottom: 0 !important;
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
     grid-template-columns: auto;
   }

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -55,16 +55,18 @@ class AlertRuleDetails extends React.Component<Props, State> {
   getTimePeriod() {
     const {location} = this.props;
 
+    const timePeriod = location.query.period ?? ALERT_RULE_DETAILS_DEFAULT_PERIOD;
+
     if (location.query.start && location.query.end) {
       return {
         start: location.query.start,
         end: location.query.end,
+        period: timePeriod,
         label: t('Custom time'),
         custom: true,
       };
     }
 
-    const timePeriod = location.query.period ?? ALERT_RULE_DETAILS_DEFAULT_PERIOD;
     const timeOption =
       TIME_OPTIONS.find(item => item.value === timePeriod) ?? TIME_OPTIONS[1];
     const start = getUtcDateString(
@@ -76,6 +78,7 @@ class AlertRuleDetails extends React.Component<Props, State> {
       start,
       end,
       label: timeOption.label as string,
+      period: timePeriod,
     };
   }
 

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -40,6 +40,7 @@ type Props = WithRouterProps & {
   projects: Project[] | AvatarProject[];
   metricText: React.ReactNode;
   interval: string;
+  filter: React.ReactNode;
   query: string;
   orgId: string;
 };
@@ -370,6 +371,7 @@ class MetricChart extends React.PureComponent<Props, State> {
       projects,
       interval,
       metricText,
+      filter,
       query,
       incidents,
     } = this.props;
@@ -550,8 +552,11 @@ class MetricChart extends React.PureComponent<Props, State> {
             <ChartPanel>
               <PanelBody withPadding>
                 <ChartHeader>
-                  <PresetName>{this.metricPreset?.name ?? t('Custom metric')}</PresetName>
-                  {metricText}
+                  <ChartTitle>
+                    <PresetName>{this.metricPreset?.name ?? t('Custom metric')}</PresetName>
+                    {metricText}
+                  </ChartTitle>
+                  {filter}
                 </ChartHeader>
                 {this.renderChart(
                   timeseriesData,
@@ -575,8 +580,11 @@ const ChartPanel = styled(Panel)`
   margin-top: ${space(2)};
 `;
 
-const ChartHeader = styled('header')`
-  margin-bottom: ${space(1)};
+const ChartHeader = styled('div')`
+  margin-bottom: ${space(3)};
+`;
+
+const ChartTitle = styled('header')`
   display: flex;
   flex-direction: row;
 `;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -553,7 +553,9 @@ class MetricChart extends React.PureComponent<Props, State> {
               <PanelBody withPadding>
                 <ChartHeader>
                   <ChartTitle>
-                    <PresetName>{this.metricPreset?.name ?? t('Custom metric')}</PresetName>
+                    <PresetName>
+                      {this.metricPreset?.name ?? t('Custom metric')}
+                    </PresetName>
                     {metricText}
                   </ChartTitle>
                   {filter}

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -21,6 +21,7 @@ import {AvatarProject, Organization, Project} from 'app/types';
 import {ReactEchartsRef} from 'app/types/echarts';
 import {getFormattedDate, getUtcDateString} from 'app/utils/dates';
 import theme from 'app/utils/theme';
+import {TimePeriodType} from 'app/views/alerts/rules/details/body';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
@@ -34,12 +35,7 @@ type Props = WithRouterProps & {
   api: Client;
   rule?: IncidentRule;
   incidents?: Incident[];
-  timePeriod: {
-    start: string;
-    end: string;
-    label: string;
-    custom?: boolean;
-  };
+  timePeriod: TimePeriodType;
   organization: Organization;
   projects: Project[] | AvatarProject[];
   metricText: React.ReactNode;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
@@ -37,7 +37,7 @@ class RelatedIssues extends React.Component<Props> {
 
   render() {
     const {rule, projects, filter, organization, timePeriod} = this.props;
-    const {start, end, label} = timePeriod;
+    const {start, end} = timePeriod;
 
     const path = `/organizations/${organization.slug}/issues/`;
     const queryParams = {
@@ -78,8 +78,8 @@ class RelatedIssues extends React.Component<Props> {
             renderEmptyMessage={this.renderEmptyMessage}
             withChart
             withPagination={false}
-            useFilteredStats={true}
-            statsPeriodSummary={label.toLowerCase()}
+            useFilteredStats
+            customStatsPeriod={timePeriod}
           />
         </TableWrapper>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
@@ -11,8 +11,8 @@ import {IconInfo} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {OrganizationSummary, Project} from 'app/types';
-import {IncidentRule} from 'app/views/settings/incidentRules/types';
 import {TimePeriodType} from 'app/views/alerts/rules/details/body';
+import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
 type Props = {
   organization: OrganizationSummary;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
@@ -6,18 +6,20 @@ import {SectionHeading} from 'app/components/charts/styles';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import GroupList from 'app/components/issues/groupList';
 import {Panel, PanelBody} from 'app/components/panels';
+import Tooltip from 'app/components/tooltip';
+import {IconInfo} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {OrganizationSummary, Project} from 'app/types';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
+import {TimePeriodType} from 'app/views/alerts/rules/details/body';
 
 type Props = {
   organization: OrganizationSummary;
   rule: IncidentRule;
   projects: Project[];
   filter: string;
-  start?: string;
-  end?: string;
+  timePeriod: TimePeriodType;
 };
 
 class RelatedIssues extends React.Component<Props> {
@@ -34,7 +36,8 @@ class RelatedIssues extends React.Component<Props> {
   };
 
   render() {
-    const {rule, projects, filter, organization, start, end} = this.props;
+    const {rule, projects, filter, organization, timePeriod} = this.props;
+    const {start, end, label} = timePeriod;
 
     const path = `/organizations/${organization.slug}/issues/`;
     const queryParams = {
@@ -54,7 +57,12 @@ class RelatedIssues extends React.Component<Props> {
     return (
       <React.Fragment>
         <ControlsWrapper>
-          <SectionHeading>{t('Related Issues')}</SectionHeading>
+          <SectionHeading>
+            {t('Related Issues')}
+            <Tooltip title={t('Top issues containing events matching the metric.')}>
+              <IconInfo size="xs" />
+            </Tooltip>
+          </SectionHeading>
           <Button data-test-id="issues-open" size="small" to={issueSearch}>
             {t('Open in Issues')}
           </Button>
@@ -70,7 +78,8 @@ class RelatedIssues extends React.Component<Props> {
             renderEmptyMessage={this.renderEmptyMessage}
             withChart
             withPagination={false}
-            useFilteredStats={false}
+            useFilteredStats={true}
+            statsPeriodSummary={label.toLowerCase()}
           />
         </TableWrapper>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -8,10 +8,8 @@ import {SectionHeading} from 'app/components/charts/styles';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import GroupList from 'app/components/issues/groupList';
 import {Panel, PanelBody} from 'app/components/panels';
-import Tooltip from 'app/components/tooltip';
 import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
-import {IconInfo} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {OrganizationSummary} from 'app/types';
@@ -109,9 +107,6 @@ class RelatedIssues extends React.Component<Props> {
       <React.Fragment>
         <ControlsWrapper>
           <SectionHeading>{t('Related Issues')}</SectionHeading>
-          <Tooltip title={t('Top issues containing events matching the metric.')}>
-            <IconInfo size="xs" />
-          </Tooltip>
           <Button
             data-test-id="issues-open"
             size="small"

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -8,8 +8,10 @@ import {SectionHeading} from 'app/components/charts/styles';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import GroupList from 'app/components/issues/groupList';
 import {Panel, PanelBody} from 'app/components/panels';
+import Tooltip from 'app/components/tooltip';
 import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
+import {IconInfo} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {OrganizationSummary} from 'app/types';
@@ -107,6 +109,9 @@ class RelatedIssues extends React.Component<Props> {
       <React.Fragment>
         <ControlsWrapper>
           <SectionHeading>{t('Related Issues')}</SectionHeading>
+          <Tooltip title={t('Top issues containing events matching the metric.')}>
+            <IconInfo size="xs" />
+          </Tooltip>
           <Button
             data-test-id="issues-open"
             size="small"

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -8,6 +8,8 @@ import {SectionHeading} from 'app/components/charts/styles';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import GroupList from 'app/components/issues/groupList';
 import {Panel, PanelBody} from 'app/components/panels';
+import Tooltip from 'app/components/tooltip';
+import {IconInfo} from 'app/icons';
 import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {t, tct} from 'app/locale';
@@ -107,6 +109,9 @@ class RelatedIssues extends React.Component<Props> {
       <React.Fragment>
         <ControlsWrapper>
           <SectionHeading>{t('Related Issues')}</SectionHeading>
+          <Tooltip title={t('Top issues containing events matching the metric.')}>
+            <IconInfo size="xs" />
+          </Tooltip>
           <Button
             data-test-id="issues-open"
             size="small"

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -8,8 +8,6 @@ import {SectionHeading} from 'app/components/charts/styles';
 import EmptyStateWarning from 'app/components/emptyStateWarning';
 import GroupList from 'app/components/issues/groupList';
 import {Panel, PanelBody} from 'app/components/panels';
-import Tooltip from 'app/components/tooltip';
-import {IconInfo} from 'app/icons';
 import {DEFAULT_RELATIVE_PERIODS} from 'app/constants';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {t, tct} from 'app/locale';
@@ -109,9 +107,6 @@ class RelatedIssues extends React.Component<Props> {
       <React.Fragment>
         <ControlsWrapper>
           <SectionHeading>{t('Related Issues')}</SectionHeading>
-          <Tooltip title={t('Top issues containing events matching the metric.')}>
-            <IconInfo size="xs" />
-          </Tooltip>
           <Button
             data-test-id="issues-open"
             size="small"


### PR DESCRIPTION
This changes the alert rule details page design slightly in a couple of places for the ga release:
- Added metric definition to the chart 
- Added a tooltip for related issues, added translation for one that was missing
- Added dynamic count styles for the issue list
- Made the alert full width, added space below (was in [#24946](https://github.com/getsentry/sentry/pull/24946))

[WOR-633](https://getsentry.atlassian.net/browse/WOR-633)
[WOR-771](https://getsentry.atlassian.net/browse/WOR-771)
[WOR-772](https://getsentry.atlassian.net/browse/WOR-772)
[WOR-786](https://getsentry.atlassian.net/browse/WOR-786)