### PR TITLE
.pre-commit-config.yaml: git:// -> https://

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
       exclude: 'src/sentry/templates/sentry/reprocessing-script.sh'
       types: [shell]
 
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
     - id: check-case-conflict


### PR DESCRIPTION
A malicious actor on an insecure network could MITM the hooks download during initial setup and run arbitrary code on a developer's machine. Using https the risk is limited to the owners of the pre-commit GitHub account and GitHub itself (and the Web PKI system).