### PR TITLE
fix(ui): Align project badge and time on similar items page

### DIFF
--- a/src/sentry/static/sentry/app/components/group/inboxBadges/shortId.tsx
+++ b/src/sentry/static/sentry/app/components/group/inboxBadges/shortId.tsx
@@ -22,6 +22,7 @@ export default ShortId;
 
 const Wrapper = styled('div')`
   display: flex;
+  align-items: center;
   white-space: nowrap;
   text-overflow: ellipsis;
   font-size: ${p => p.theme.fontSizeExtraSmall};

--- a/src/sentry/static/sentry/app/components/group/inboxBadges/timesTag.tsx
+++ b/src/sentry/static/sentry/app/components/group/inboxBadges/timesTag.tsx
@@ -46,6 +46,7 @@ const TimesTag = ({lastSeen, firstSeen}: Props) => {
 
 const Wrapper = styled('div')`
   display: flex;
+  align-items: center;
   font-size: ${p => p.theme.fontSizeSmall};
 `;
 


### PR DESCRIPTION
fixes alignment in group details on similar issues page 
![image](https://user-images.githubusercontent.com/1400464/113750369-91903880-96bf-11eb-9e8c-8b7858d1dd75.png)
