### PR TITLE
fix(discover): Top 5 events with timestamp fields

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -458,7 +458,7 @@ def top_events_timeseries(
     ) as span:
         span.set_data("query", user_query)
         snuba_filter, translated_columns = get_timeseries_snuba_filter(
-            list(set(timeseries_columns + selected_columns)),
+            list(sorted(set(timeseries_columns + selected_columns))),
             user_query,
             params,
             rollup,
@@ -474,16 +474,18 @@ def top_events_timeseries(
                 field = FIELD_ALIASES[field].alias
             # Note that because orderby shouldn't be an array field its not included in the values
             values = list(
-                {
-                    event.get(field)
-                    for event in top_events["data"]
-                    if field in event and not isinstance(event.get(field), list)
-                }
+                sorted(
+                    {
+                        event.get(field)
+                        for event in top_events["data"]
+                        if field in event and not isinstance(event.get(field), list)
+                    }
+                )
             )
             if values:
-                # timestamp needs special handling, creating a big OR instead
-                if field == "timestamp":
-                    snuba_filter.conditions.append([["timestamp", "=", value] for value in values])
+                # timestamp fields needs special handling, creating a big OR instead
+                if field == "timestamp" or field.startswith("timestamp.to_"):
+                    snuba_filter.conditions.append([[field, "=", value] for value in values])
                 elif None in values:
                     non_none_values = [value for value in values if value is not None]
                     condition = [[["isNull", [resolve_discover_column(field)]], "=", 1]]

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -474,18 +474,18 @@ def top_events_timeseries(
                 field = FIELD_ALIASES[field].alias
             # Note that because orderby shouldn't be an array field its not included in the values
             values = list(
-                sorted(
-                    {
-                        event.get(field)
-                        for event in top_events["data"]
-                        if field in event and not isinstance(event.get(field), list)
-                    }
-                )
+                {
+                    event.get(field)
+                    for event in top_events["data"]
+                    if field in event and not isinstance(event.get(field), list)
+                }
             )
             if values:
                 # timestamp fields needs special handling, creating a big OR instead
                 if field == "timestamp" or field.startswith("timestamp.to_"):
-                    snuba_filter.conditions.append([[field, "=", value] for value in values])
+                    snuba_filter.conditions.append(
+                        [[field, "=", value] for value in sorted(values)]
+                    )
                 elif None in values:
                     non_none_values = [value for value in values if value is not None]
                     condition = [[["isNull", [resolve_discover_column(field)]], "=", 1]]

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -1506,3 +1506,39 @@ class OrganizationEventsStatsTopNEvents(APITestCase, SnubaTestCase):
             )
         assert response.status_code == 400
         assert "zero duration" in response.data["detail"]
+
+    def test_top_events_timestamp_fields(self):
+        with self.feature("organizations:discover-basic"):
+            response = self.client.get(
+                self.url,
+                format="json",
+                data={
+                    "start": iso_format(self.day_ago),
+                    "end": iso_format(self.day_ago + timedelta(hours=2)),
+                    "interval": "1h",
+                    "yAxis": "count()",
+                    "orderby": ["-count()"],
+                    "field": ["count()", "timestamp", "timestamp.to_hour", "timestamp.to_day"],
+                    "topEvents": 5,
+                },
+            )
+        assert response.status_code == 200
+        data = response.data
+        assert len(data) == 3
+
+        # these are the timestamps corresponding to the events stored
+        timestamps = [
+            self.day_ago + timedelta(minutes=2),
+            self.day_ago + timedelta(hours=1, minutes=2),
+            self.day_ago + timedelta(minutes=4),
+        ]
+        timestamp_hours = [timestamp.replace(minute=0, second=0) for timestamp in timestamps]
+        timestamp_days = [timestamp.replace(hour=0, minute=0, second=0) for timestamp in timestamps]
+
+        for ts, ts_hr, ts_day in zip(timestamps, timestamp_hours, timestamp_days):
+            key = f"{iso_format(ts)}+00:00,{iso_format(ts_day)}+00:00,{iso_format(ts_hr)}+00:00"
+            count = sum(
+                e["count"] for e in self.event_data if e["data"]["timestamp"] == iso_format(ts)
+            )
+            results = data[key]
+            assert [{"count": count}] in [attrs for time, attrs in results["data"]]


### PR DESCRIPTION
The top 5 stats query fails when combined with timestamp.to_hour or
timestamp.to_day. This change special cases these fields and handles them like
the timestamp field with an OR query.

Fixes SENTRY-PGF