### PR TITLE
fix(docs-links): Fix links to help.sentry.io

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/actions/utils.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/actions/utils.tsx
@@ -61,7 +61,7 @@ export function getConfirm(
           'Bulk deletion is only recommended for junk data. To clear your stream, consider resolving or ignoring. [link:When should I delete events?]',
           {
             link: (
-              <ExternalLink href="https://help.sentry.io/hc/en-us/articles/360003443113-When-should-I-delete-events" />
+              <ExternalLink href="https://help.sentry.io/account/billing/when-should-i-delete-events/" />
             ),
           }
         );

--- a/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
+++ b/src/sentry/templates/sentry/emails/unable-to-fetch-commits.html
@@ -6,7 +6,7 @@
   <p>{{ error_message }}</p>
   <p><strong>Troubleshooting &amp; References</strong></p>
   <ul>
-    <li><a href="https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-">Why am I receiving the email "Unable to Fetch Commits"?</a></li>
+    <li><a href="https://help.sentry.io/product-features/integrations/why-am-i-receiving-the-email-unable-to-fetch-commits/">Why am I receiving the email "Unable to Fetch Commits"?</a></li>
     <li><a href="https://docs.sentry.io/product/releases/setup/">Associate Commits with a Release</a></li>
   </ul>
 {% endblock %}

--- a/src/sentry/templates/sentry/emails/unable-to-fetch-commits.txt
+++ b/src/sentry/templates/sentry/emails/unable-to-fetch-commits.txt
@@ -7,5 +7,5 @@ We were unable to fetch the commit log for your release ({{ release.version }}) 
 
 Troubleshooting &amp; References
 
-https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-
+https://help.sentry.io/product-features/integrations/why-am-i-receiving-the-email-unable-to-fetch-commits/
 https://docs.sentry.io/product/releases/setup/

--- a/tests/fixtures/emails/unable_to_fetch_commits.txt
+++ b/tests/fixtures/emails/unable_to_fetch_commits.txt
@@ -7,5 +7,5 @@ An internal server error occurred
 
 Troubleshooting &amp; References
 
-https://help.sentry.io/hc/en-us/articles/360019866834-Why-am-I-receiving-the-email-Unable-to-Fetch-Commits-
+https://help.sentry.io/product-features/integrations/why-am-i-receiving-the-email-unable-to-fetch-commits/
 https://docs.sentry.io/product/releases/setup/


### PR DESCRIPTION
"when should i delete events" was a 404, the others redirected to new urls