### PR TITLE
ref(Slack): Don't alert on expired/deleted issues

### DIFF
--- a/src/sentry/integrations/slack/action_endpoint.py
+++ b/src/sentry/integrations/slack/action_endpoint.py
@@ -192,7 +192,7 @@ class SlackActionEndpoint(Endpoint):
                 id=group_id,
             )
         except Group.DoesNotExist:
-            logger.error("slack.action.invalid-issue", extra=logging_data, exc_info=True)
+            logger.info("slack.action.invalid-issue", extra=logging_data)
             return self.respond(status=403)
 
         logging_data["organization_id"] = group.organization.id


### PR DESCRIPTION
If a user clicks resolve, ignore, or assign on a Sentry issue in Slack, but the issue has since been deleted or expired, we get a Sentry issue about it but it's not actionable. Instead, let's just log it. 