### PR TITLE
fix(alerts): Remove data source from issues query

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -377,7 +377,6 @@ export default class DetailsBody extends React.Component<Props> {
                             rule.projects.includes(project.slug)
                           )}
                           timePeriod={timePeriod}
-                          filter={queryWithTypeFilter}
                         />
                       )}
                       {rule?.dataset === Dataset.TRANSACTIONS && (

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
@@ -18,7 +18,6 @@ type Props = {
   organization: OrganizationSummary;
   rule: IncidentRule;
   projects: Project[];
-  filter: string;
   timePeriod: TimePeriodType;
 };
 
@@ -36,7 +35,7 @@ class RelatedIssues extends React.Component<Props> {
   };
 
   render() {
-    const {rule, projects, filter, organization, timePeriod} = this.props;
+    const {rule, projects, organization, timePeriod} = this.props;
     const {start, end} = timePeriod;
 
     const path = `/organizations/${organization.slug}/issues/`;
@@ -46,7 +45,7 @@ class RelatedIssues extends React.Component<Props> {
       groupStatsPeriod: 'auto',
       limit: 5,
       sort: rule.aggregate === 'count_unique(user)' ? 'user' : 'freq',
-      query: `${rule.query} ${filter}`,
+      query: rule.query,
       project: projects.map(project => project.id),
     };
     const issueSearch = {


### PR DESCRIPTION
This removes the data source from the issues query. When data source is `event.type:error OR event.type:default` the endpoint returns a 500. We can redo this a little differently after IN-search [#24889](https://github.com/getsentry/sentry/pull/24889l)

Before:
![Screen Shot 2021-04-06 at 3 39 59 PM](https://user-images.githubusercontent.com/15015880/113786634-5f49ff80-96ee-11eb-98b0-dbf6099620b6.png)

After:
![Screen Shot 2021-04-06 at 3 39 53 PM](https://user-images.githubusercontent.com/15015880/113786647-68d36780-96ee-11eb-8a21-4b669eee8051.png)
