### PR TITLE
feat(notification platform): Handle multiple providers

### DIFF
--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -69,7 +69,7 @@ class EmailActionHandler(ActionHandler):
                     ExternalProviders.EMAIL,
                     self.project,
                     {member.user for member in target.member_set},
-                )
+                )[ExternalProviders.EMAIL]
                 targets = [(user.id, user.email) for user in users]
         # TODO: We need some sort of verification system to make sure we're not being
         # used as an email relay.

--- a/src/sentry/mail/activity/base.py
+++ b/src/sentry/mail/activity/base.py
@@ -11,6 +11,7 @@ from sentry.models import (
     UserAvatar,
     UserOption,
 )
+from sentry.models.integration import ExternalProviders
 from sentry.utils import json
 from sentry.utils.assets import get_asset_url
 from sentry.utils.avatar import get_email_avatar
@@ -40,7 +41,9 @@ class ActivityEmail:
         if not self.group:
             return []
 
-        participants = GroupSubscription.objects.get_participants(group=self.group)
+        participants = GroupSubscription.objects.get_participants(group=self.group)[
+            ExternalProviders.EMAIL
+        ]
 
         if self.activity.user is not None and self.activity.user in participants:
             receive_own_activity = (

--- a/src/sentry/mail/activity/new_processing_issues.py
+++ b/src/sentry/mail/activity/new_processing_issues.py
@@ -33,7 +33,7 @@ class NewProcessingIssuesActivityEmail(ActivityEmail):
     def get_participants(self):
         users = NotificationSetting.objects.get_notification_recipients(
             ExternalProviders.EMAIL, self.project
-        )
+        )[ExternalProviders.EMAIL]
         return {user: GroupSubscriptionReason.processing_issue for user in users}
 
     def get_context(self):

--- a/src/sentry/mail/activity/release.py
+++ b/src/sentry/mail/activity/release.py
@@ -20,7 +20,6 @@ from sentry.models import (
     User,
     UserEmail,
 )
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
     NotificationSettingOptionValues,
     NotificationScopeType,
@@ -129,7 +128,6 @@ class ReleaseActivityEmail(ActivityEmail):
         # get all the involved users' settings for deploy-emails (user default
         # saved without org set)
         notification_settings = NotificationSetting.objects.get_for_users_by_parent(
-            ExternalProviders.EMAIL,
             NotificationSettingTypes.DEPLOY,
             users=users,
             parent=self.organization,

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -158,7 +158,7 @@ class MailAdapter:
         """
         return NotificationSetting.objects.get_notification_recipients(
             ExternalProviders.EMAIL, project
-        )
+        )[ExternalProviders.EMAIL]
 
     def get_sendable_user_ids(self, project):
         users = self.get_sendable_user_objects(project)

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -247,7 +247,6 @@ class MailAdapter:
         user_ids = project.member_set.values_list("user", flat=True)
         users = User.objects.filter(id__in=user_ids)
         notification_settings = NotificationSetting.objects.get_for_users_by_parent(
-            provider=ExternalProviders.EMAIL,
             type=NotificationSettingTypes.ISSUE_ALERTS,
             parent=project,
             users=users,

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -11,7 +11,6 @@ from sentry.db.models import (
     Model,
     sane_repr,
 )
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.helpers import (
     should_be_participating,
     transform_to_notification_settings_by_user,
@@ -122,7 +121,6 @@ class GroupSubscriptionManager(BaseManager):
         user_ids = [user.id for user in users]
         subscriptions = self.filter(group=group, user_id__in=user_ids)
         notification_settings = NotificationSetting.objects.get_for_users_by_parent(
-            ExternalProviders.EMAIL,
             NotificationSettingTypes.WORKFLOW,
             users=users,
             parent=group.project,

--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -101,12 +101,12 @@ class NotificationSetting(Model):
         )
 
     __repr__ = sane_repr(
-        "scope_type",
+        "scope_str",
         "scope_identifier",
         "target",
-        "provider",
-        "type",
-        "value",
+        "provider_str",
+        "type_str",
+        "value_str",
     )
 
 

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -55,7 +55,7 @@ def should_user_be_notified(
         Any, Mapping[NotificationScopeType, NotificationSettingOptionValues]
     ],
     user: Any,
-) -> bool:
+) -> Any:
     """
     Given a mapping of default and specific notification settings by user,
     determine if a user should receive an ISSUE_ALERT notification.
@@ -122,7 +122,7 @@ def should_be_participating(
     if subscription:
         return bool(subscription.is_active)
 
-    return value == NotificationSettingOptionValues.ALWAYS
+    return bool(value == NotificationSettingOptionValues.ALWAYS)
 
 
 def where_should_be_participating(

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
-from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
+from sentry.models.integration import ExternalProviders
 from sentry.notifications.legacy_mappings import get_legacy_value
 from sentry.notifications.types import (
     NotificationScopeType,
@@ -28,6 +29,27 @@ def _get_setting_value_from_mapping(
     return default
 
 
+def _get_setting_mapping_from_mapping(
+    notification_settings_by_user: Mapping[
+        Any,
+        Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
+    ],
+    user: Any,
+    type: NotificationSettingTypes,
+) -> Mapping[ExternalProviders, NotificationSettingOptionValues]:
+    # XXX(CEO): may not respect granularity of a setting for Slack a setting for email
+    # but we'll worry about that later since we don't have a FE for it yet
+    specific_scope = get_scope_type(type)
+    notification_settings_mapping = notification_settings_by_user.get(user)
+    if notification_settings_mapping:
+        notification_setting_option = notification_settings_mapping.get(
+            specific_scope
+        ) or notification_settings_mapping.get(NotificationScopeType.USER)
+        if notification_setting_option:
+            return notification_setting_option
+    return {ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS}
+
+
 def should_user_be_notified(
     notification_settings_by_user: Mapping[
         Any, Mapping[NotificationScopeType, NotificationSettingOptionValues]
@@ -47,6 +69,29 @@ def should_user_be_notified(
         )
         == NotificationSettingOptionValues.ALWAYS
     )
+
+
+def where_should_user_be_notified(
+    notification_settings_by_user: Mapping[
+        Any,
+        Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]],
+    ],
+    user: Any,
+) -> List[ExternalProviders]:
+    """
+    Given a mapping of default and specific notification settings by user,
+    return the list of providers after verifying the user has opted into this notification.
+    """
+    mapping = _get_setting_mapping_from_mapping(
+        notification_settings_by_user,
+        user,
+        NotificationSettingTypes.ISSUE_ALERTS,
+    )
+    output = []
+    for provider, value in mapping.items():
+        if value == NotificationSettingOptionValues.ALWAYS:
+            output.append(provider)
+    return output
 
 
 def should_be_participating(
@@ -83,20 +128,23 @@ def should_be_participating(
 def transform_to_notification_settings_by_user(
     notification_settings: Iterable[Any],
     users: Iterable[Any],
-) -> Mapping[Any, Mapping[NotificationScopeType, NotificationSettingOptionValues]]:
+) -> Mapping[
+    Any, Mapping[NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]]
+]:
     """
     Given a unorganized list of notification settings, create a mapping of
     users to a map of notification scopes to setting values.
     """
     actor_mapping = {user.actor_id: user for user in users}
     notification_settings_by_user: Dict[
-        Any, Dict[NotificationScopeType, NotificationSettingOptionValues]
-    ] = defaultdict(dict)
+        Any, Dict[NotificationScopeType, Dict[ExternalProviders, NotificationSettingOptionValues]]
+    ] = defaultdict(lambda: defaultdict(dict))
     for notification_setting in notification_settings:
         user = actor_mapping.get(notification_setting.target_id)
-        notification_settings_by_user[user][
-            NotificationScopeType(notification_setting.scope_type)
-        ] = NotificationSettingOptionValues(notification_setting.value)
+        scope_type = NotificationScopeType(notification_setting.scope_type)
+        value = NotificationSettingOptionValues(notification_setting.value)
+        provider = ExternalProviders(notification_setting.provider)
+        notification_settings_by_user[user][scope_type][provider] = value
     return notification_settings_by_user
 
 

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -87,11 +87,9 @@ def where_should_user_be_notified(
         user,
         NotificationSettingTypes.ISSUE_ALERTS,
     )
-    output = []
-    for provider, value in mapping.items():
-        if value == NotificationSettingOptionValues.ALWAYS:
-            output.append(provider)
-    return output
+    return list(
+        filter(lambda elem: mapping[elem] == NotificationSettingOptionValues.ALWAYS, mapping)
+    )
 
 
 def should_be_participating(

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -299,7 +299,7 @@ class NotificationsManager(BaseManager):  # type: ignore
         users: List[Any],
     ) -> List[Any]:
         """
-        Filters a list of users down to the users who are subscribed to alerts.
+        Filters a list of users down to the users by provider who are subscribed to alerts.
         We check both the project level settings and global default settings.
         """
         notification_settings = self.get_for_users_by_parent(

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 from django.db import transaction
 from django.db.models import Q, QuerySet
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Union
 
 from sentry.db.models.manager import BaseManager
 from sentry.models.integration import ExternalProviders
@@ -297,7 +297,7 @@ class NotificationsManager(BaseManager):  # type: ignore
         provider: ExternalProviders,
         project: Any,
         users: List[Any],
-    ) -> List[Any]:
+    ) -> DefaultDict[Any, List[Any]]:
         """
         Filters a list of users down to the users by provider who are subscribed to alerts.
         We check both the project level settings and global default settings.
@@ -315,7 +315,9 @@ class NotificationsManager(BaseManager):  # type: ignore
                 mapping[provider].append(user)
         return mapping
 
-    def get_notification_recipients(self, provider: ExternalProviders, project: Any) -> List[Any]:
+    def get_notification_recipients(
+        self, provider: ExternalProviders, project: Any
+    ) -> DefaultDict[Any, List[Any]]:
         """
         Return a set of users that should receive Issue Alert emails for a given
         project. To start, we get the set of all users. Then we fetch all of

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Union
 
 from django.db import transaction
 from django.db.models import Q, QuerySet
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Union
 
 from sentry.db.models.manager import BaseManager
 from sentry.models.integration import ExternalProviders

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -137,7 +137,7 @@ class NotificationPlugin(Plugin):
         if self.get_conf_key() == "mail":
             return NotificationSetting.objects.get_notification_recipients(
                 ExternalProviders.EMAIL, project
-            )
+            )[ExternalProviders.EMAIL]
 
         return self.get_notification_recipients(project, "%s:alert" % self.get_conf_key())
 

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -87,46 +87,92 @@ class SubscribeTest(TestCase):
 
 
 class GetParticipantsTest(TestCase):
-    def test_simple(self):
-        org = self.create_organization()
-        team = self.create_team(organization=org)
-        # Include an extra team here to prove the subquery works
-        team_2 = self.create_team(organization=org)
-        project = self.create_project(teams=[team, team_2], organization=org)
-        group = self.create_group(project=project)
-        user = self.create_user("foo@example.com")
-        user2 = self.create_user("bar@example.com")
-        self.create_member(user=user, organization=org, teams=[team])
-        self.create_member(user=user2, organization=org)
+    def setUp(self):
+        self.org = self.create_organization()
+        self.team = self.create_team(organization=self.org)
+        self.project = self.create_project(teams=[self.team], organization=self.org)
+        self.group = self.create_group(project=self.project)
+        self.user = self.create_user()
+        self.create_member(user=self.user, organization=self.org, teams=[self.team])
+        self.update_user_settings_always()
 
+    def update_user_settings_always(self):
         NotificationSetting.objects.update_settings(
             ExternalProviders.EMAIL,
             NotificationSettingTypes.WORKFLOW,
             NotificationSettingOptionValues.ALWAYS,
-            user=user,
+            user=self.user,
         )
+
+    def update_user_setting_subscribe_only(self):
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+            user=self.user,
+        )
+
+    def update_user_setting_never(self):
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+        )
+
+    def update_project_setting_always(self):
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.ALWAYS,
+            user=self.user,
+            project=self.group.project,
+        )
+
+    def update_project_setting_subscribe_only(self):
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+            user=self.user,
+            project=self.group.project,
+        )
+
+    def update_project_setting_never(self):
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.WORKFLOW,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+            project=self.project,
+        )
+
+    def test_simple(self):
+        # Include an extra team here to prove the subquery works
+        team_2 = self.create_team(organization=self.org)
+        project = self.create_project(teams=[self.team, team_2], organization=self.org)
+        group = self.create_group(project=project)
+        user2 = self.create_user("bar@example.com")
+        self.create_member(user=user2, organization=self.org)
 
         # implicit membership
         users = GroupSubscription.objects.get_participants(group=group)
 
-        assert users == {ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}}
+        assert users == {ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.implicit}}
 
         # unsubscribed
-        GroupSubscription.objects.create(user=user, group=group, project=project, is_active=False)
+        GroupSubscription.objects.create(
+            user=self.user, group=group, project=project, is_active=False
+        )
 
         users = GroupSubscription.objects.get_participants(group=group)
 
         assert users == {}
 
         # not participating by default
-        GroupSubscription.objects.filter(user=user, group=group).delete()
+        GroupSubscription.objects.filter(user=self.user, group=group).delete()
 
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
-            user=user,
-        )
+        self.update_user_setting_subscribe_only()
 
         users = GroupSubscription.objects.get_participants(group=group)
 
@@ -134,7 +180,7 @@ class GetParticipantsTest(TestCase):
 
         # explicitly participating
         GroupSubscription.objects.create(
-            user=user,
+            user=self.user,
             group=group,
             project=project,
             is_active=True,
@@ -143,298 +189,182 @@ class GetParticipantsTest(TestCase):
 
         users = GroupSubscription.objects.get_participants(group=group)
 
-        assert users == {ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}}
+        assert users == {ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.comment}}
 
     def test_no_conversations(self):
-        org = self.create_organization()
-        team = self.create_team(organization=org)
-        project = self.create_project(teams=[team], organization=org)
-        group = self.create_group(project=project)
-        user = self.create_user()
-        self.create_member(user=user, organization=org, teams=[team])
-
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.ALWAYS,
-            user=user,
-        )
-
-        get_participants = functools.partial(GroupSubscription.objects.get_participants, group)
+        get_participants = functools.partial(GroupSubscription.objects.get_participants, self.group)
         # Implicit subscription, ensure the project setting overrides the
         # default global option.
 
         with self.assertChanges(
             get_participants,
-            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}},
+            before={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.implicit}},
             after={},
         ):
-            NotificationSetting.objects.update_settings(
-                ExternalProviders.EMAIL,
-                NotificationSettingTypes.WORKFLOW,
-                NotificationSettingOptionValues.NEVER,
-                user=user,
-                project=project,
-            )
+            self.update_project_setting_never()
 
-        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
+        NotificationSetting.objects.remove_for_user(self.user, NotificationSettingTypes.WORKFLOW)
 
         # Implicit subscription, ensure the project setting overrides the
         # explicit global option.
 
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.ALWAYS,
-            user=user,
-        )
+        self.update_user_settings_always()
 
         with self.assertChanges(
             get_participants,
-            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}},
+            before={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.implicit}},
             after={},
         ):
-            NotificationSetting.objects.update_settings(
-                ExternalProviders.EMAIL,
-                NotificationSettingTypes.WORKFLOW,
-                NotificationSettingOptionValues.NEVER,
-                user=user,
-                project=project,
-            )
+            self.update_project_setting_never()
 
-        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
+        NotificationSetting.objects.remove_for_user(self.user, NotificationSettingTypes.WORKFLOW)
 
         # Explicit subscription, overridden by the global option.
 
         GroupSubscription.objects.create(
-            user=user,
-            group=group,
-            project=project,
+            user=self.user,
+            group=self.group,
+            project=self.project,
             is_active=True,
             reason=GroupSubscriptionReason.comment,
         )
 
         with self.assertChanges(
             get_participants,
-            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
+            before={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.comment}},
             after={},
         ):
-            NotificationSetting.objects.update_settings(
-                ExternalProviders.EMAIL,
-                NotificationSettingTypes.WORKFLOW,
-                NotificationSettingOptionValues.NEVER,
-                user=user,
-            )
+            self.update_user_setting_never()
 
-        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
+        NotificationSetting.objects.remove_for_user(self.user, NotificationSettingTypes.WORKFLOW)
 
         # Explicit subscription, overridden by the project option.
 
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
-            user=user,
-        )
+        self.update_user_setting_subscribe_only()
 
         with self.assertChanges(
             get_participants,
-            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
+            before={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.comment}},
             after={},
         ):
-            NotificationSetting.objects.update_settings(
-                ExternalProviders.EMAIL,
-                NotificationSettingTypes.WORKFLOW,
-                NotificationSettingOptionValues.NEVER,
-                user=user,
-                project=project,
-            )
+            self.update_project_setting_never()
 
-        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
+        NotificationSetting.objects.remove_for_user(self.user, NotificationSettingTypes.WORKFLOW)
 
         # Explicit subscription, overridden by the project option which also
         # overrides the default option.
 
         with self.assertChanges(
             get_participants,
-            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
+            before={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.comment}},
             after={},
         ):
-            NotificationSetting.objects.update_settings(
-                ExternalProviders.EMAIL,
-                NotificationSettingTypes.WORKFLOW,
-                NotificationSettingOptionValues.NEVER,
-                user=user,
-                project=project,
-            )
+            self.update_project_setting_never()
 
     def test_participating_only(self):
-        org = self.create_organization()
-        team = self.create_team(organization=org)
-        project = self.create_project(teams=[team], organization=org)
-        group = self.create_group(project=project)
-        user = self.create_user()
-        self.create_member(user=user, organization=org, teams=[team])
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.ALWAYS,
-            user=user,
-        )
+        get_participants = functools.partial(GroupSubscription.objects.get_participants, self.group)
 
-        get_participants = functools.partial(GroupSubscription.objects.get_participants, group)
-
-        # Implicit subscription, ensure the project setting overrides the
-        # default global option.
+        # Implicit subscription, ensure the project setting overrides the default global option.
 
         with self.assertChanges(
             get_participants,
-            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}},
+            before={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.implicit}},
             after={},
         ):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
                 NotificationSettingTypes.WORKFLOW,
                 NotificationSettingOptionValues.SUBSCRIBE_ONLY,
-                user=user,
-                project=project,
+                user=self.user,
+                project=self.project,
             )
 
-        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
+        NotificationSetting.objects.remove_for_user(self.user, NotificationSettingTypes.WORKFLOW)
 
         # Implicit subscription, ensure the project setting overrides the
         # explicit global option.
-
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.ALWAYS,
-            user=user,
-        )
+        self.update_user_settings_always()
 
         with self.assertChanges(
             get_participants,
-            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}},
+            before={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.implicit}},
             after={},
         ):
-            NotificationSetting.objects.update_settings(
-                ExternalProviders.EMAIL,
-                NotificationSettingTypes.WORKFLOW,
-                NotificationSettingOptionValues.NEVER,
-                user=user,
-                project=project,
-            )
+            self.update_project_setting_never()
 
-        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
+        NotificationSetting.objects.remove_for_user(self.user, NotificationSettingTypes.WORKFLOW)
 
         # Ensure the global default is applied.
-
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
-            user=user,
-        )
+        self.update_user_setting_subscribe_only()
 
         with self.assertChanges(
             get_participants,
             before={},
-            after={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
+            after={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.comment}},
         ):
             subscription = GroupSubscription.objects.create(
-                user=user,
-                group=group,
-                project=project,
+                user=self.user,
+                group=self.group,
+                project=self.project,
                 is_active=True,
                 reason=GroupSubscriptionReason.comment,
             )
 
         subscription.delete()
-        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
+        NotificationSetting.objects.remove_for_user(self.user, NotificationSettingTypes.WORKFLOW)
 
         # Ensure the project setting overrides the global default.
-
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
-            user=user,
-            project=group.project,
-        )
+        self.update_project_setting_subscribe_only()
 
         with self.assertChanges(
             get_participants,
             before={},
-            after={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
+            after={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.comment}},
         ):
             subscription = GroupSubscription.objects.create(
-                user=user,
-                group=group,
-                project=project,
+                user=self.user,
+                group=self.group,
+                project=self.project,
                 is_active=True,
                 reason=GroupSubscriptionReason.comment,
             )
 
         subscription.delete()
-        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
+        NotificationSetting.objects.remove_for_user(self.user, NotificationSettingTypes.WORKFLOW)
 
         # Ensure the project setting overrides the global setting.
 
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.ALWAYS,
-            user=user,
-        )
-
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
-            user=user,
-            project=group.project,
-        )
+        self.update_user_settings_always()
+        self.update_project_setting_subscribe_only()
 
         with self.assertChanges(
             get_participants,
             before={},
-            after={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
+            after={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.comment}},
         ):
             subscription = GroupSubscription.objects.create(
-                user=user,
-                group=group,
-                project=project,
+                user=self.user,
+                group=self.group,
+                project=self.project,
                 is_active=True,
                 reason=GroupSubscriptionReason.comment,
             )
 
         subscription.delete()
-        NotificationSetting.objects.remove_for_user(user, NotificationSettingTypes.WORKFLOW)
+        NotificationSetting.objects.remove_for_user(self.user, NotificationSettingTypes.WORKFLOW)
 
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.SUBSCRIBE_ONLY,
-            user=user,
-        )
-
-        NotificationSetting.objects.update_settings(
-            ExternalProviders.EMAIL,
-            NotificationSettingTypes.WORKFLOW,
-            NotificationSettingOptionValues.ALWAYS,
-            user=user,
-            project=group.project,
-        )
+        self.update_user_setting_subscribe_only()
+        self.update_project_setting_always()
 
         with self.assertChanges(
             get_participants,
-            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}},
-            after={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
+            before={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.implicit}},
+            after={ExternalProviders.EMAIL: {self.user: GroupSubscriptionReason.comment}},
         ):
             subscription = GroupSubscription.objects.create(
-                user=user,
-                group=group,
-                project=project,
+                user=self.user,
+                group=self.group,
+                project=self.project,
                 is_active=True,
                 reason=GroupSubscriptionReason.comment,
             )

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -109,7 +109,7 @@ class GetParticipantsTest(TestCase):
         # implicit membership
         users = GroupSubscription.objects.get_participants(group=group)
 
-        assert users == {user: GroupSubscriptionReason.implicit}
+        assert users == {ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}}
 
         # unsubscribed
         GroupSubscription.objects.create(user=user, group=group, project=project, is_active=False)
@@ -143,7 +143,7 @@ class GetParticipantsTest(TestCase):
 
         users = GroupSubscription.objects.get_participants(group=group)
 
-        assert users == {user: GroupSubscriptionReason.comment}
+        assert users == {ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}}
 
     def test_no_conversations(self):
         org = self.create_organization()
@@ -161,12 +161,13 @@ class GetParticipantsTest(TestCase):
         )
 
         get_participants = functools.partial(GroupSubscription.objects.get_participants, group)
-
         # Implicit subscription, ensure the project setting overrides the
         # default global option.
 
         with self.assertChanges(
-            get_participants, before={user: GroupSubscriptionReason.implicit}, after={}
+            get_participants,
+            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}},
+            after={},
         ):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
@@ -189,7 +190,9 @@ class GetParticipantsTest(TestCase):
         )
 
         with self.assertChanges(
-            get_participants, before={user: GroupSubscriptionReason.implicit}, after={}
+            get_participants,
+            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}},
+            after={},
         ):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
@@ -212,7 +215,9 @@ class GetParticipantsTest(TestCase):
         )
 
         with self.assertChanges(
-            get_participants, before={user: GroupSubscriptionReason.comment}, after={}
+            get_participants,
+            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
+            after={},
         ):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
@@ -233,7 +238,9 @@ class GetParticipantsTest(TestCase):
         )
 
         with self.assertChanges(
-            get_participants, before={user: GroupSubscriptionReason.comment}, after={}
+            get_participants,
+            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
+            after={},
         ):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
@@ -249,7 +256,9 @@ class GetParticipantsTest(TestCase):
         # overrides the default option.
 
         with self.assertChanges(
-            get_participants, before={user: GroupSubscriptionReason.comment}, after={}
+            get_participants,
+            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
+            after={},
         ):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
@@ -279,7 +288,9 @@ class GetParticipantsTest(TestCase):
         # default global option.
 
         with self.assertChanges(
-            get_participants, before={user: GroupSubscriptionReason.implicit}, after={}
+            get_participants,
+            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}},
+            after={},
         ):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
@@ -302,7 +313,9 @@ class GetParticipantsTest(TestCase):
         )
 
         with self.assertChanges(
-            get_participants, before={user: GroupSubscriptionReason.implicit}, after={}
+            get_participants,
+            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}},
+            after={},
         ):
             NotificationSetting.objects.update_settings(
                 ExternalProviders.EMAIL,
@@ -324,7 +337,9 @@ class GetParticipantsTest(TestCase):
         )
 
         with self.assertChanges(
-            get_participants, before={}, after={user: GroupSubscriptionReason.comment}
+            get_participants,
+            before={},
+            after={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
         ):
             subscription = GroupSubscription.objects.create(
                 user=user,
@@ -348,7 +363,9 @@ class GetParticipantsTest(TestCase):
         )
 
         with self.assertChanges(
-            get_participants, before={}, after={user: GroupSubscriptionReason.comment}
+            get_participants,
+            before={},
+            after={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
         ):
             subscription = GroupSubscription.objects.create(
                 user=user,
@@ -379,7 +396,9 @@ class GetParticipantsTest(TestCase):
         )
 
         with self.assertChanges(
-            get_participants, before={}, after={user: GroupSubscriptionReason.comment}
+            get_participants,
+            before={},
+            after={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
         ):
             subscription = GroupSubscription.objects.create(
                 user=user,
@@ -409,8 +428,8 @@ class GetParticipantsTest(TestCase):
 
         with self.assertChanges(
             get_participants,
-            before={user: GroupSubscriptionReason.implicit},
-            after={user: GroupSubscriptionReason.comment},
+            before={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.implicit}},
+            after={ExternalProviders.EMAIL: {user: GroupSubscriptionReason.comment}},
         ):
             subscription = GroupSubscription.objects.create(
                 user=user,

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -301,7 +301,7 @@ class FilterToSubscribedUsersTest(TestCase):
         assert (
             NotificationSetting.objects.filter_to_subscribed_users(
                 ExternalProviders.EMAIL, self.project, users
-            )
+            )[ExternalProviders.EMAIL]
             == expected_users
         )
 


### PR DESCRIPTION
This is one of several PRs to update the notification settings manager functions to return a mapping of providers to a list of users instead of a list of users (what we had previously) to account for the fact that email is no longer the only means of contacting a user.

Ex: `{"email": [<User 1>, <User 2>], "slack", ["User 1, User 3]}`