### PR TITLE
feat(ecosystem): Reduce 'error noise' in Sentry

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -14,7 +14,7 @@ import tempfile
 import sentry
 from sentry.utils.celery import crontab_with_minute_jitter
 from sentry.utils.types import type_from_value
-
+from sentry.shared_integrations.exceptions import UnrecoverableApiError, RetryableApiError
 from datetime import timedelta
 from urllib.parse import urlparse
 
@@ -1749,6 +1749,7 @@ SENTRY_SDK_CONFIG = {
     "debug": True,
     "send_default_pii": True,
     "auto_enabling_integrations": False,
+    "ignore_errors": [UnrecoverableApiError, RetryableApiError],
 }
 
 # Callable to bind additional context for the Sentry SDK

--- a/tests/sentry_plugins/test_client.py
+++ b/tests/sentry_plugins/test_client.py
@@ -6,9 +6,9 @@ from sentry.testutils import TestCase
 
 from sentry.shared_integrations.exceptions import (
     ApiError,
-    ApiHostError,
     ApiUnauthorized,
     UnsupportedResponseType,
+    RetryableApiError,
 )
 from sentry_plugins.client import ApiClient, AuthApiClient
 
@@ -89,7 +89,7 @@ class AuthApiClientTest(TestCase):
 
     @responses.activate
     def test_invalid_host(self):
-        with pytest.raises(ApiHostError):
+        with pytest.raises(RetryableApiError):
             AuthApiClient().get("http://example.com")
 
     @responses.activate


### PR DESCRIPTION
## Objective:
Currently, there are too many "errors" recorded in Sentry associated to the Ecosystem team for which we cannot do much about. This is causing alert fatigue and could cause us to miss real, actionable errors. 

This PR investigates a potential solution where we wrap common, non-actionable errors with an ignorable exception in Sentry.

Associated [Notion doc](https://www.notion.so/sentry/Reducing-Ecosystem-s-Error-footprint-98cf7dae6e084fc68da804b298aef165).