### PR TITLE
ref(py): Sort imports in discover module

### DIFF
--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -3,8 +3,8 @@ from rest_framework.response import Response
 
 from sentry.api.bases import KeyTransactionBase
 from sentry.api.bases.organization import OrganizationPermission
-from sentry.discover.models import KeyTransaction
 from sentry.discover.endpoints.serializers import KeyTransactionSerializer
+from sentry.discover.models import KeyTransaction
 
 
 class KeyTransactionPermission(OrganizationPermission):

--- a/src/sentry/discover/endpoints/discover_query.py
+++ b/src/sentry/discover/endpoints/discover_query.py
@@ -1,19 +1,19 @@
 import logging
-from functools import partial
 from copy import deepcopy
+from functools import partial
 
 from rest_framework.response import Response
 
-from sentry.api.bases.organization import OrganizationPermission
+from sentry import features
 from sentry.api.bases import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.utils import snuba
 from sentry.discover.utils import transform_aliases_and_query
-from sentry import features
+from sentry.utils import snuba
+from sentry.utils.compat import map
 
 from .serializers import DiscoverQuerySerializer
-from sentry.utils.compat import map
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/discover/endpoints/discover_saved_queries.py
+++ b/src/sentry/discover/endpoints/discover_saved_queries.py
@@ -1,14 +1,14 @@
 from django.db.models import Case, When
-from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
+from rest_framework.response import Response
 
 from sentry import features
-from sentry.api.serializers import serialize
-from sentry.api.bases import OrganizationEndpoint, NoProjects
+from sentry.api.bases import NoProjects, OrganizationEndpoint
 from sentry.api.paginator import GenericOffsetPaginator
-from sentry.discover.models import DiscoverSavedQuery
+from sentry.api.serializers import serialize
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
+from sentry.discover.models import DiscoverSavedQuery
 from sentry.search.utils import tokenize_query
 
 

--- a/src/sentry/discover/endpoints/discover_saved_query_detail.py
+++ b/src/sentry/discover/endpoints/discover_saved_query_detail.py
@@ -1,13 +1,13 @@
-from rest_framework.response import Response
 from rest_framework.exceptions import ParseError
+from rest_framework.response import Response
 
-from sentry.api.serializers import serialize
-from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.bases import OrganizationEndpoint, NoProjects
 from sentry import features
+from sentry.api.bases import NoProjects, OrganizationEndpoint
+from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.serializers import serialize
 from sentry.discover.endpoints.bases import DiscoverSavedQueryPermission
-from sentry.discover.models import DiscoverSavedQuery
 from sentry.discover.endpoints.serializers import DiscoverSavedQuerySerializer
+from sentry.discover.models import DiscoverSavedQuery
 
 
 class DiscoverSavedQueryDetailEndpoint(OrganizationEndpoint):

--- a/src/sentry/discover/endpoints/serializers.py
+++ b/src/sentry/discover/endpoints/serializers.py
@@ -1,13 +1,14 @@
 import re
+
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 
-from sentry.discover.models import KeyTransaction, MAX_KEY_TRANSACTIONS
+from sentry.api.event_search import InvalidSearchQuery, get_filter
 from sentry.api.fields.empty_integer import EmptyIntegerField
-from sentry.api.event_search import get_filter, InvalidSearchQuery
 from sentry.api.serializers.rest_framework import ListField
-from sentry.api.utils import get_date_range_from_params, InvalidParams
+from sentry.api.utils import InvalidParams, get_date_range_from_params
 from sentry.constants import ALL_ACCESS_PROJECTS
+from sentry.discover.models import MAX_KEY_TRANSACTIONS, KeyTransaction
 from sentry.utils.snuba import SENTRY_SNUBA_MAP
 
 

--- a/src/sentry/discover/models.py
+++ b/src/sentry/discover/models.py
@@ -1,7 +1,7 @@
 from django.db import models, transaction
-from sentry.db.models.fields import JSONField
-from sentry.db.models import Model, FlexibleForeignKey, sane_repr
 
+from sentry.db.models import FlexibleForeignKey, Model, sane_repr
+from sentry.db.models.fields import JSONField
 
 MAX_KEY_TRANSACTIONS = 10
 

--- a/src/sentry/discover/utils.py
+++ b/src/sentry/discover/utils.py
@@ -1,9 +1,8 @@
-from sentry.utils.snuba import Dataset, aliased_query, get_snuba_column_name, get_function_index
-
 # TODO(mark) Once this import is removed, transform_data should not
 # be exported.
 from sentry import eventstore
 from sentry.snuba.discover import transform_data
+from sentry.utils.snuba import Dataset, aliased_query, get_function_index, get_snuba_column_name
 
 
 def parse_columns_in_functions(col, context=None, index=None):


### PR DESCRIPTION
This is part of my effort to apply isort to everything over a slowish period of time to avoid any major problems. + avoid lots of merge conflicts.