### PR TITLE
Add default <15m filter to frontend performance views

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -401,6 +401,11 @@ function generateFrontendPageloadPerformanceEventView(
   const searchQuery = decodeScalar(query.query, '');
   const conditions = tokenizeSearch(searchQuery);
 
+  // This is not an override condition since we want the duration to appear in the search bar as a default.
+  if (!conditions.hasTag('transaction.duration')) {
+    conditions.setTagValues('transaction.duration', ['<15m']);
+  }
+
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.
   if (conditions.query.length > 0) {
@@ -451,6 +456,11 @@ function generateFrontendOtherPerformanceEventView(
 
   const searchQuery = decodeScalar(query.query, '');
   const conditions = tokenizeSearch(searchQuery);
+
+  // This is not an override condition since we want the duration to appear in the search bar as a default.
+  if (!conditions.hasTag('transaction.duration')) {
+    conditions.setTagValues('transaction.duration', ['<15m']);
+  }
 
   // If there is a bare text search, we want to treat it as a search
   // on the transaction name.


### PR DESCRIPTION
This change makes the performance homepage more consistent across all four views (All, FE (pageload), FE (other) and Backend). The main benefit is that when clicking through to a transaction summary for a frontend transaction the `transaction.duration:<15m` persists.