### PR TITLE
fix(autocomplete): Don't try to autocomplete IDs

### DIFF
--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -21,15 +21,16 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
         except NoProjects:
             paginator = SequencePaginator([])
         else:
-            paginator = tagstore.get_tag_value_paginator_for_projects(
-                filter_params["project_id"],
-                filter_params.get("environment"),
-                key,
-                filter_params["start"],
-                filter_params["end"],
-                query=request.GET.get("query"),
-                include_transactions=request.GET.get("includeTransactions") == "1",
-            )
+            with self.handle_query_errors():
+                paginator = tagstore.get_tag_value_paginator_for_projects(
+                    filter_params["project_id"],
+                    filter_params.get("environment"),
+                    key,
+                    filter_params["start"],
+                    filter_params["end"],
+                    query=request.GET.get("query"),
+                    include_transactions=request.GET.get("includeTransactions") == "1",
+                )
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/endpoints/organization_tagkey_values.py
+++ b/src/sentry/api/endpoints/organization_tagkey_values.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 from rest_framework.response import Response
 
 from sentry import tagstore
@@ -11,6 +12,8 @@ class OrganizationTagKeyValuesEndpoint(OrganizationEventsEndpointBase):
     def get(self, request, organization, key):
         if not TAG_KEY_RE.match(key):
             return Response({"detail": f'Invalid tag key format for "{key}"'}, status=400)
+
+        sentry_sdk.set_tag("query.tag_key", key)
 
         try:
             # still used by events v1 which doesn't require global views

--- a/src/sentry/tagstore/snuba/backend.py
+++ b/src/sentry/tagstore/snuba/backend.py
@@ -734,6 +734,8 @@ class SnubaTagStorage(TagStorage):
         #               but does work with !=. However, for consistency sake we disallow it
         #               entirely, furthermore, suggesting an event_id is not a very useful feature
         #               as they are not human readable.
+        # trace.*:      The same logic of event_id not being useful applies to the trace fields
+        #               which are all also non human readable ids
         # timestamp:    This is a DateTime which disallows us to use both LIKE and != on it when
         #               searching. Suggesting a timestamp can potentially be useful but as it does
         #               work at all, we opt to disable it here. A potential solution can be to
@@ -743,7 +745,11 @@ class SnubaTagStorage(TagStorage):
         # time:         This is a column computed from timestamp so it suffers the same issues
         if snuba_key in {"group_id"}:
             snuba_key = f"tags[{snuba_key}]"
-        if snuba_key in {"event_id", "timestamp", "time"}:
+        if snuba_key in {"event_id", "timestamp", "time"} or key in {
+            "trace",
+            "trace.span",
+            "trace.parent_span",
+        }:
             return SequencePaginator([])
 
         # These columns have fixed values and we don't need to emit queries to find out the

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -284,7 +284,13 @@ class TransactionTagKeyValues(OrganizationTagKeyTestCase):
             }
         )
         self.transaction["contexts"]["trace"].update(
-            {"status": "unknown_error", "parent_span_id": "9000cec7cc0779c1", "op": "bar.server"}
+            {
+                "status": "unknown_error",
+                "trace": "a" * 32,
+                "span": "abcd1234abcd1234",
+                "parent_span_id": "9000cec7cc0779c1",
+                "op": "bar.server",
+            }
         )
         self.store_event(
             self.transaction,
@@ -331,18 +337,11 @@ class TransactionTagKeyValues(OrganizationTagKeyTestCase):
         )
         self.run_test("transaction", qs_params={"query": "city"}, expected=[("/city_by_code/", 1)])
 
-    def test_parent_span(self):
-        self.run_test(
-            "trace.parent_span", expected=[("9000cec7cc0779c1", 1), ("8988cec7cc0779c1", 1)]
-        )
-        self.run_test(
-            "trace.parent_span",
-            qs_params={"query": "cec7cc"},
-            expected=[("9000cec7cc0779c1", 1), ("8988cec7cc0779c1", 1)],
-        )
-        self.run_test(
-            "trace.parent_span", qs_params={"query": "9000"}, expected=[("9000cec7cc0779c1", 1)]
-        )
+    def test_invalid_keys(self):
+        self.run_test("trace.parent_span", expected=[])
+        self.run_test("trace.span", expected=[])
+        self.run_test("trace", expected=[])
+        self.run_test("event_id", expected=[])
 
     def test_boolean_fields(self):
         self.run_test("error.handled", expected=[("true", None), ("false", None)])


### PR DESCRIPTION
- Fixes SENTRY-PC7
- This prevents autocomplete queries on ID like fields, which isn't very
  usable since they aren't human readable in the first place.
- Also adding a tag for the tag_key to make this easier to debug in the
  future