### PR TITLE
fix(workflow): Make "date added" sort strictly for tab query

### DIFF
--- a/src/sentry/static/sentry/app/views/issueList/overview.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/overview.tsx
@@ -791,7 +791,7 @@ class IssueListOverview extends React.Component<Props, State> {
     }
 
     // Remove inbox tab specific sort
-    if (query.sort === IssueSortOptions.INBOX && !isForReviewQuery(query.query)) {
+    if (query.sort === IssueSortOptions.INBOX && query.query !== Query.FOR_REVIEW) {
       delete query.sort;
     }
 

--- a/src/sentry/static/sentry/app/views/issueList/sortOptions.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/sortOptions.tsx
@@ -5,11 +5,7 @@ import Feature from 'app/components/acl/feature';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
-import {
-  getSortLabel,
-  isForReviewQuery,
-  IssueSortOptions,
-} from 'app/views/issueList/utils';
+import {getSortLabel, IssueSortOptions, Query} from 'app/views/issueList/utils';
 
 type Props = {
   sort: string;
@@ -57,7 +53,7 @@ const IssueListSortOptions = ({onSelect, sort, query}: Props) => {
     <DropdownControl buttonProps={{prefix: t('Sort by')}} label={getSortLabel(sortKey)}>
       <React.Fragment>
         <Feature features={['inbox']}>
-          {isForReviewQuery(query) && getMenuItem(IssueSortOptions.INBOX)}
+          {query === Query.FOR_REVIEW && getMenuItem(IssueSortOptions.INBOX)}
         </Feature>
         {getMenuItem(IssueSortOptions.DATE)}
         {getMenuItem(IssueSortOptions.NEW)}


### PR DESCRIPTION
Allowing users to sort by date added with any query using `is:for_review` often is not compatible. This change will remove the date added sort for all queries other than the one on the for review tab.