### PR TITLE
ref(save): Add statement timeout for project counter

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2147,7 +2147,7 @@ SENTRY_REPROCESSING_SYNC_REDIS_CLUSTER = "default"
 # In case of contention on the project counter, prevent workers saturation with
 # save_event tasks from single project.
 # Value is in milliseconds. Set to `None` to disable.
-SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT = 3000
+SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT = 1000
 
 # Implemented in getsentry to run additional devserver workers.
 SENTRY_EXTRA_WORKERS = None

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2143,6 +2143,12 @@ SENTRY_REPROCESSING_ATTACHMENT_CHUNK_SIZE = 2 ** 20
 
 SENTRY_REPROCESSING_SYNC_REDIS_CLUSTER = "default"
 
+# Timeout for the project counter statement execution.
+# In case of contention on the project counter, prevent workers saturation with
+# save_event tasks from single project.
+# Value is in milliseconds. Set to `None` to disable.
+SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT = 3000
+
 # Implemented in getsentry to run additional devserver workers.
 SENTRY_EXTRA_WORKERS = None
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -936,6 +936,10 @@ def _save_aggregate2(event, flat_hashes, hierarchical_hashes, release, **kwargs)
     existing_group_id = _find_group_id(all_hashes)
 
     if existing_group_id is None:
+
+        if project.id in (options.get("store.load-shed-group-creation-projects") or ()):
+            raise HashDiscarded("Load shedding group creation")
+
         with sentry_sdk.start_span(
             op="event_manager.create_group_transaction"
         ) as span, metrics.timer(

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -34,6 +34,8 @@ def increment_project_counter(project, delta=1, using="default"):
         cur = connections[using].cursor()
         try:
             if settings.SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT:
+                # WARNING: This is not a proper fix and should be removed once
+                #          we have better way of generating next_short_id.
                 cur.execute(
                     "set local statement_timeout = %s",
                     [settings.SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT],

--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -1,4 +1,5 @@
-from django.db import connection, connections
+from django.conf import settings
+from django.db import connections, transaction
 from django.db.models.signals import post_migrate
 
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr, BoundedBigIntegerField
@@ -22,22 +23,28 @@ class Counter(Model):
         return increment_project_counter(project, delta)
 
 
-def increment_project_counter(project, delta=1):
+def increment_project_counter(project, delta=1, using="default"):
     """This method primarily exists so that south code can use it."""
     if delta <= 0:
         raise ValueError("There is only one way, and that's up.")
 
-    cur = connection.cursor()
-    try:
-        cur.execute(
-            """
-            select sentry_increment_project_counter(%s, %s)
-        """,
-            [project.id, delta],
-        )
-        return cur.fetchone()[0]
-    finally:
-        cur.close()
+    # To prevent the statement_timeout leaking into the session we need to use
+    # set local which can be used only within a transaction
+    with transaction.atomic(using=using):
+        cur = connections[using].cursor()
+        try:
+            if settings.SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT:
+                cur.execute(
+                    "set local statement_timeout = %s",
+                    [settings.SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT],
+                )
+            cur.execute(
+                "select sentry_increment_project_counter(%s, %s)",
+                [project.id, delta],
+            )
+            return cur.fetchone()[0]
+        finally:
+            cur.close()
 
 
 # this must be idempotent because it seems to execute twice


### PR DESCRIPTION
This PR introduces a configurable statement timeout for the project counter pgsql function call. The timeout should prevent a single project from saturating all save event workers in case of contention on the project counter row due to the row-level locking.

This happens when a project is creating too many groups at the same time, usually due to bad grouping config, unique id/timestamp in event message without stack trace etc. 