### PR TITLE
ref(notifications): Move `ExternalProviders` to a file

### DIFF
--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -9,7 +9,8 @@ from sentry import features
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
-from sentry.models import EXTERNAL_PROVIDERS, ExternalTeam
+from sentry.models import ExternalTeam
+from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders, get_provider_enum
 
 logger = logging.getLogger(__name__)
 
@@ -23,12 +24,14 @@ class ExternalTeamSerializer(CamelSnakeModelSerializer):
         model = ExternalTeam
         fields = ["team_id", "external_name", "provider"]
 
-    def validate_provider(self, provider):
-        if provider not in EXTERNAL_PROVIDERS.values():
-            raise serializers.ValidationError(
-                f'The provider "{provider}" is not supported. We currently accept GitHub and GitLab team identities.'
-            )
-        return ExternalTeam.get_provider_enum(provider)
+    def validate_provider(self, provider: str) -> int:
+        provider_option = get_provider_enum(provider)
+        if provider_option in [ExternalProviders.GITHUB, ExternalProviders.GITLAB]:
+            return provider_option.value
+
+        raise serializers.ValidationError(
+            f'The provider "{provider}" is not supported. We currently accept GitHub and GitLab team identities.'
+        )
 
     def create(self, validated_data):
         return ExternalTeam.objects.get_or_create(**validated_data)

--- a/src/sentry/api/endpoints/external_user.py
+++ b/src/sentry/api/endpoints/external_user.py
@@ -9,7 +9,8 @@ from sentry import features
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
-from sentry.models import EXTERNAL_PROVIDERS, ExternalUser, OrganizationMember
+from sentry.models import ExternalUser, OrganizationMember
+from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders, get_provider_enum
 
 logger = logging.getLogger(__name__)
 
@@ -23,12 +24,14 @@ class ExternalUserSerializer(CamelSnakeModelSerializer):
         model = ExternalUser
         fields = ["member_id", "external_name", "provider"]
 
-    def validate_provider(self, provider):
-        if provider not in EXTERNAL_PROVIDERS.values():
-            raise serializers.ValidationError(
-                f'The provider "{provider}" is not supported. We currently accept Github and Gitlab user identities.'
-            )
-        return ExternalUser.get_provider_enum(provider)
+    def validate_provider(self, provider: str) -> int:
+        provider_option = get_provider_enum(provider)
+        if provider_option in [ExternalProviders.GITHUB, ExternalProviders.GITLAB]:
+            return provider_option.value
+
+        raise serializers.ValidationError(
+            f'The provider "{provider}" is not supported. We currently accept GitHub and GitLab user identities.'
+        )
 
     def validate_member_id(self, member_id):
         try:

--- a/src/sentry/api/endpoints/external_user.py
+++ b/src/sentry/api/endpoints/external_user.py
@@ -38,7 +38,7 @@ class ExternalUserSerializer(CamelSnakeModelSerializer):
             return OrganizationMember.objects.get(
                 id=member_id, organization=self.context["organization"]
             )
-        except OrganizationMember.DoesNotExists:
+        except OrganizationMember.DoesNotExist:
             raise serializers.ValidationError("This member does not exist.")
 
     def create(self, validated_data):

--- a/src/sentry/api/endpoints/project_details.py
+++ b/src/sentry/api/endpoints/project_details.py
@@ -37,10 +37,10 @@ from sentry.models import (
     ProjectStatus,
     ProjectTeam,
 )
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.legacy_mappings import get_option_value_from_boolean
 from sentry.notifications.types import NotificationSettingTypes
 from sentry.tasks.deletion import delete_project
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 from sentry.utils.compat import filter
 

--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -7,7 +7,6 @@ from sentry.api.bases.user import UserEndpoint
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.serializers import Serializer, serialize
 from sentry.models import NotificationSetting, UserOption
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.legacy_mappings import (
     USER_OPTION_SETTINGS,
     get_option_value_from_int,
@@ -15,6 +14,7 @@ from sentry.notifications.legacy_mappings import (
     map_notification_settings_to_legacy,
 )
 from sentry.notifications.types import NotificationScopeType, UserOptionsSettingsKey
+from sentry.types.integrations import ExternalProviders
 
 
 class UserNotificationsSerializer(Serializer):

--- a/src/sentry/api/endpoints/user_notification_fine_tuning.py
+++ b/src/sentry/api/endpoints/user_notification_fine_tuning.py
@@ -6,12 +6,12 @@ from sentry.api.bases.user import UserEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models import UserNotificationsSerializer
 from sentry.models import NotificationSetting, Project, UserEmail, UserOption
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.legacy_mappings import (
     get_option_value_from_int,
     get_type_from_fine_tuning_key,
 )
 from sentry.notifications.types import FineTuningAPIKey
+from sentry.types.integrations import ExternalProviders
 
 INVALID_EMAIL_MSG = (
     "Invalid email value(s) provided. Email values must be verified emails for the given user."

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -22,7 +22,6 @@ from sentry.models import (
     ApiToken,
     Commit,
     Environment,
-    ExternalProviders,
     Group,
     GroupAssignee,
     GroupBookmark,
@@ -53,6 +52,7 @@ from sentry.notifications.types import NotificationSettingOptionValues, Notifica
 from sentry.reprocessing2 import get_progress
 from sentry.tagstore.snuba.backend import fix_tag_value_data
 from sentry.tsdb.snuba import SnubaTSDB
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import snuba
 from sentry.utils.cache import cache
 from sentry.utils.compat import zip

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -11,6 +11,7 @@ from sentry.models import (
     OrganizationIntegration,
 )
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.types.integrations import get_provider_string
 
 logger = logging.getLogger(__name__)
 
@@ -211,7 +212,7 @@ class IntegrationIssueSerializer(IntegrationSerializer):
 @register(ExternalTeam)
 class ExternalTeamSerializer(Serializer):
     def serialize(self, obj, attrs, user):
-        provider = ExternalTeam.get_provider_string(obj.provider)
+        provider = get_provider_string(obj.provider)
         return {
             "id": str(obj.id),
             "teamId": str(obj.team_id),
@@ -223,7 +224,7 @@ class ExternalTeamSerializer(Serializer):
 @register(ExternalUser)
 class ExternalUserSerializer(Serializer):
     def serialize(self, obj, attrs, user):
-        provider = ExternalUser.get_provider_string(obj.provider)
+        provider = get_provider_string(obj.provider)
         return {
             "id": str(obj.id),
             "memberId": str(obj.organizationmember_id),

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -20,7 +20,6 @@ from sentry.ingest.inbound_filters import FilterTypes
 from sentry.lang.native.utils import convert_crashreport_count
 from sentry.models import (
     EnvironmentProject,
-    ExternalProviders,
     NotificationSetting,
     Project,
     ProjectAvatar,
@@ -35,6 +34,7 @@ from sentry.models import (
 from sentry.notifications.helpers import transform_to_notification_settings_by_parent_id
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.snuba import discover
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.compat import zip
 
 STATUS_LABELS = {

--- a/src/sentry/api/serializers/models/user_notifications.py
+++ b/src/sentry/api/serializers/models/user_notifications.py
@@ -3,12 +3,12 @@ from typing import Iterable
 
 from sentry.api.serializers import Serializer
 from sentry.models import NotificationSetting, UserOption
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.legacy_mappings import (
     get_type_from_fine_tuning_key,
     map_notification_settings_to_legacy,
 )
 from sentry.notifications.types import FineTuningAPIKey, NotificationScopeType
+from sentry.types.integrations import ExternalProviders
 
 
 def handle_legacy(notification_type: FineTuningAPIKey, users: Iterable) -> Iterable:

--- a/src/sentry/api/validators/notifications.py
+++ b/src/sentry/api/validators/notifications.py
@@ -1,13 +1,13 @@
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
 from sentry.api.exceptions import ParameterValidationError
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.helpers import validate as helper_validate
 from sentry.notifications.types import (
     NotificationScopeType,
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
+from sentry.types.integrations import ExternalProviders
 
 
 def intersect_dict_set(d: Dict[int, Any], s: Set[int]) -> Dict[int, Any]:

--- a/src/sentry/api/validators/notifications.py
+++ b/src/sentry/api/validators/notifications.py
@@ -7,7 +7,7 @@ from sentry.notifications.types import (
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
-from sentry.types.integrations import ExternalProviders
+from sentry.types.integrations import ExternalProviders, get_provider_enum
 
 
 def intersect_dict_set(d: Dict[int, Any], s: Set[int]) -> Dict[int, Any]:
@@ -101,10 +101,10 @@ def validate_scope(
 
 
 def validate_provider(provider: str, context: Optional[List[str]] = None) -> ExternalProviders:
-    try:
-        return ExternalProviders(provider)
-    except ValueError:
-        raise ParameterValidationError(f"Unknown provider: {provider}", context)
+    provider_option = get_provider_enum(provider)
+    if provider_option:
+        return provider_option
+    raise ParameterValidationError(f"Unknown provider: {provider}", context)
 
 
 def validate_value(

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -11,8 +11,8 @@ from sentry.incidents.models import (
     IncidentTrigger,
     TriggerStatus,
 )
-from sentry.models.integration import ExternalProviders
 from sentry.models.notificationsetting import NotificationSetting
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 from sentry.utils.email import MessageBuilder
 from sentry.utils.http import absolute_uri

--- a/src/sentry/mail/activity/base.py
+++ b/src/sentry/mail/activity/base.py
@@ -5,8 +5,8 @@ from django.utils.html import escape, mark_safe
 
 from sentry import options
 from sentry.models import GroupSubscription, ProjectOption, UserAvatar, UserOption
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import GroupSubscriptionReason
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 from sentry.utils.assets import get_asset_url
 from sentry.utils.avatar import get_email_avatar

--- a/src/sentry/mail/activity/new_processing_issues.py
+++ b/src/sentry/mail/activity/new_processing_issues.py
@@ -1,6 +1,6 @@
 from sentry.models import EventError, NotificationSetting
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import GroupSubscriptionReason
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.http import absolute_uri
 
 from .base import ActivityEmail

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -24,7 +24,6 @@ from sentry.models import (
     Team,
     User,
 )
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.helpers import transform_to_notification_settings_by_user
 from sentry.notifications.types import (
     GroupSubscriptionReason,
@@ -35,6 +34,7 @@ from sentry.notifications.types import (
 from sentry.plugins.base import plugins
 from sentry.plugins.base.structs import Notification
 from sentry.tasks.digests import deliver_digest
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache
 from sentry.utils.committers import get_serialized_event_file_committers

--- a/src/sentry/models/__init__.py
+++ b/src/sentry/models/__init__.py
@@ -33,6 +33,7 @@ from .eventattachment import *  # NOQA
 from .eventerror import *  # NOQA
 from .eventuser import *  # NOQA
 from .externalissue import *  # NOQA
+from .externaluser import *  # NOQA
 from .featureadoption import *  # NOQA
 from .file import *  # NOQA
 from .group import *  # NOQA

--- a/src/sentry/models/externaluser.py
+++ b/src/sentry/models/externaluser.py
@@ -1,0 +1,46 @@
+import logging
+
+from django.db import models
+
+from sentry.db.models import BoundedPositiveIntegerField, DefaultFieldsModel, FlexibleForeignKey
+from sentry.types.integrations import ExternalProviders
+
+logger = logging.getLogger(__name__)
+
+
+class ExternalTeam(DefaultFieldsModel):
+    __core__ = False
+
+    team = FlexibleForeignKey("sentry.Team")
+    provider = BoundedPositiveIntegerField(
+        choices=(
+            (ExternalProviders.GITHUB, "github"),
+            (ExternalProviders.GITLAB, "gitlab"),
+        ),
+    )
+    # external_name => the Github/Gitlab team name. Column name is vague to be reused for more external team identities.
+    external_name = models.TextField()
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_externalteam"
+        unique_together = (("team", "provider", "external_name"),)
+
+
+class ExternalUser(DefaultFieldsModel):
+    __core__ = False
+
+    organizationmember = FlexibleForeignKey("sentry.OrganizationMember")
+    provider = BoundedPositiveIntegerField(
+        choices=(
+            (ExternalProviders.GITHUB, "github"),
+            (ExternalProviders.GITLAB, "gitlab"),
+        ),
+    )
+    # external_name => the Github/Gitlab username. Column name is vague to be reused for more external user identities.
+    external_name = models.TextField()
+
+    class Meta:
+        app_label = "sentry"
+        db_table = "sentry_externaluser"
+        unique_together = (("organizationmember", "provider", "external_name"),)

--- a/src/sentry/models/integration.py
+++ b/src/sentry/models/integration.py
@@ -229,3 +229,7 @@ class Integration(DefaultFieldsModel):
             )
 
             return org_integration
+
+
+# REQUIRED for migrations to run
+from sentry.types.integrations import ExternalProviders  # NOQA

--- a/src/sentry/models/integration.py
+++ b/src/sentry/models/integration.py
@@ -1,6 +1,4 @@
 import logging
-from enum import Enum
-from typing import Optional
 
 from django.db import IntegrityError, models
 from django.utils import timezone
@@ -61,72 +59,6 @@ class RepositoryProjectPathConfig(DefaultFieldsModel):
         app_label = "sentry"
         db_table = "sentry_repositoryprojectpathconfig"
         unique_together = (("project", "stack_root"),)
-
-
-class ExternalProviders(Enum):
-    GITHUB = 0
-    GITLAB = 1
-    EMAIL = 100
-    SLACK = 110
-
-
-EXTERNAL_PROVIDERS = {
-    ExternalProviders.GITHUB: "github",
-    ExternalProviders.GITLAB: "gitlab",
-    ExternalProviders.EMAIL: "email",
-    ExternalProviders.SLACK: "slack",
-}
-
-
-def get_provider_name(value: int) -> Optional[str]:
-    return EXTERNAL_PROVIDERS.get(ExternalProviders(value))
-
-
-class ExternalProviderMixin:
-    def get_provider_string(provider_int):
-        return get_provider_name(provider_int) or "unknown"
-
-    def get_provider_enum(provider_str):
-        inv_providers_map = {v: k for k, v in EXTERNAL_PROVIDERS.items()}
-        return inv_providers_map[provider_str].value if inv_providers_map[provider_str] else None
-
-
-class ExternalTeam(DefaultFieldsModel, ExternalProviderMixin):
-    __core__ = False
-
-    team = FlexibleForeignKey("sentry.Team")
-    provider = BoundedPositiveIntegerField(
-        choices=(
-            (ExternalProviders.GITHUB, "github"),
-            (ExternalProviders.GITLAB, "gitlab"),
-        ),
-    )
-    # external_name => the Github/Gitlab team name. Column name is vague to be reused for more external team identities.
-    external_name = models.TextField()
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_externalteam"
-        unique_together = (("team", "provider", "external_name"),)
-
-
-class ExternalUser(DefaultFieldsModel, ExternalProviderMixin):
-    __core__ = False
-
-    organizationmember = FlexibleForeignKey("sentry.OrganizationMember")
-    provider = BoundedPositiveIntegerField(
-        choices=(
-            (ExternalProviders.GITHUB, "github"),
-            (ExternalProviders.GITLAB, "gitlab"),
-        ),
-    )
-    # external_name => the Github/Gitlab username. Column name is vague to be reused for more external user identities.
-    external_name = models.TextField()
-
-    class Meta:
-        app_label = "sentry"
-        db_table = "sentry_externaluser"
-        unique_together = (("organizationmember", "provider", "external_name"),)
 
 
 class OrganizationIntegration(DefaultFieldsModel):

--- a/src/sentry/models/notificationsetting.py
+++ b/src/sentry/models/notificationsetting.py
@@ -7,7 +7,6 @@ from sentry.db.models import (
     Model,
     sane_repr,
 )
-from sentry.models.integration import ExternalProviders, get_provider_name
 from sentry.notifications.manager import NotificationsManager
 from sentry.notifications.types import (
     NotificationScopeType,
@@ -17,6 +16,7 @@ from sentry.notifications.types import (
     get_notification_setting_type_name,
     get_notification_setting_value_name,
 )
+from sentry.types.integrations import ExternalProviders, get_provider_name
 
 
 class NotificationSetting(Model):

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
     NOTIFICATION_SETTING_DEFAULTS,
     SUBSCRIPTION_REASON_MAP,
@@ -10,6 +9,7 @@ from sentry.notifications.types import (
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
+from sentry.types.integrations import ExternalProviders
 
 
 def _get_setting_mapping_from_mapping(

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -5,7 +5,6 @@ from django.db import transaction
 from django.db.models import Q, QuerySet
 
 from sentry.db.models.manager import BaseManager
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.helpers import (
     get_scope,
     get_scope_type,
@@ -19,6 +18,7 @@ from sentry.notifications.types import (
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
+from sentry.types.integrations import ExternalProviders
 
 
 class NotificationsManager(BaseManager):  # type: ignore

--- a/src/sentry/notifications/notify.py
+++ b/src/sentry/notifications/notify.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import NotificationSettingTypes
+from sentry.types.integrations import ExternalProviders
 
 
 def notify(

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -9,10 +9,10 @@ from requests.exceptions import HTTPError, SSLError
 from sentry import digests, ratelimits
 from sentry.exceptions import PluginError
 from sentry.models import NotificationSetting
-from sentry.models.integration import ExternalProviders
 from sentry.plugins.base import Notification, Plugin
 from sentry.plugins.base.configuration import react_plugin_config
 from sentry.shared_integrations.exceptions import ApiError
+from sentry.types.integrations import ExternalProviders
 
 
 class NotificationConfigurationForm(forms.Form):

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -75,6 +75,7 @@ from sentry.models import (
 from sentry.models.integrationfeature import Feature, IntegrationFeature
 from sentry.signals import project_created
 from sentry.snuba.models import QueryDatasets
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import json, loremipsum
 
 
@@ -954,14 +955,14 @@ class Factories:
 
     @staticmethod
     def create_external_user(organizationmember, **kwargs):
-        kwargs.setdefault("provider", ExternalUser.get_provider_enum("github"))
+        kwargs.setdefault("provider", ExternalProviders.GITHUB.value)
         kwargs.setdefault("external_name", "")
 
         return ExternalUser.objects.create(organizationmember=organizationmember, **kwargs)
 
     @staticmethod
     def create_external_team(team, **kwargs):
-        kwargs.setdefault("provider", ExternalTeam.get_provider_enum("github"))
+        kwargs.setdefault("provider", ExternalProviders.GITHUB.value)
         kwargs.setdefault("external_name", "@getsentry/ecosystem")
 
         return ExternalTeam.objects.create(team=team, **kwargs)

--- a/src/sentry/types/__init__.py
+++ b/src/sentry/types/__init__.py
@@ -1,0 +1,9 @@
+"""
+Types Directory - a place to keep types and enums.
+
+In order to avoid circular imports, DO NOT import any models or serializers
+anywhere in this directory.
+
+There are going to naming collisions between classes like "Type" and "Status".
+The best way to resolve this is to prefix them with more context.
+"""

--- a/src/sentry/types/integrations.py
+++ b/src/sentry/types/integrations.py
@@ -1,0 +1,30 @@
+from enum import Enum
+from typing import Optional
+
+
+class ExternalProviders(Enum):
+    GITHUB = 0
+    GITLAB = 1
+    EMAIL = 100
+    SLACK = 110
+
+
+EXTERNAL_PROVIDERS = {
+    ExternalProviders.GITHUB: "github",
+    ExternalProviders.GITLAB: "gitlab",
+    ExternalProviders.EMAIL: "email",
+    ExternalProviders.SLACK: "slack",
+}
+
+
+def get_provider_name(value: int) -> Optional[str]:
+    return EXTERNAL_PROVIDERS.get(ExternalProviders(value))
+
+
+def get_provider_string(provider_int: int) -> str:
+    return get_provider_name(provider_int) or "unknown"
+
+
+def get_provider_enum(value: Optional[str]) -> Optional[ExternalProviders]:
+    return {v: k for k, v in EXTERNAL_PROVIDERS.items()}.get(value)
+

--- a/src/sentry/types/integrations.py
+++ b/src/sentry/types/integrations.py
@@ -27,4 +27,3 @@ def get_provider_string(provider_int: int) -> str:
 
 def get_provider_enum(value: Optional[str]) -> Optional[ExternalProviders]:
     return {v: k for k, v in EXTERNAL_PROVIDERS.items()}.get(value)
-

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -14,10 +14,10 @@ from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_http_methods
 
 from sentry.models import Authenticator, LostPasswordHash, NotificationSetting, Project, UserEmail
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.security import capture_security_activity
 from sentry.signals import email_verified
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import auth
 from sentry.web.decorators import login_required, set_referrer_policy, signed_auth_required
 from sentry.web.forms.accounts import ChangePasswordRecoverForm, RecoverPasswordForm

--- a/tests/sentry/api/endpoints/test_external_team.py
+++ b/tests/sentry/api/endpoints/test_external_team.py
@@ -2,6 +2,7 @@ from django.core.urlresolvers import reverse
 
 from sentry.models import ExternalTeam
 from sentry.testutils import APITestCase
+from sentry.types.integrations import ExternalProviders, get_provider_string
 
 
 class ExternalTeamTest(APITestCase):
@@ -55,12 +56,12 @@ class ExternalTeamTest(APITestCase):
     def test_create_existing_association(self):
         self.external_team = ExternalTeam.objects.create(
             team_id=str(self.team.id),
-            provider=ExternalTeam.get_provider_enum("github"),
+            provider=ExternalProviders.GITHUB,
             external_name="@getsentry/ecosystem",
         )
         data = {
             "externalName": self.external_team.external_name,
-            "provider": ExternalTeam.get_provider_string(self.external_team.provider),
+            "provider": get_provider_string(self.external_team.provider),
         }
         with self.feature({"organizations:import-codeowners": True}):
             response = self.client.post(self.url, data)

--- a/tests/sentry/api/endpoints/test_external_team_details.py
+++ b/tests/sentry/api/endpoints/test_external_team_details.py
@@ -2,6 +2,7 @@ from django.core.urlresolvers import reverse
 
 from sentry.models import ExternalTeam
 from sentry.testutils import APITestCase
+from sentry.types.integrations import ExternalProviders
 
 
 class ExternalTeamDetailsTest(APITestCase):
@@ -12,7 +13,7 @@ class ExternalTeamDetailsTest(APITestCase):
         self.team = self.create_team(organization=self.org, name="Mariachi Band")
         self.external_team = ExternalTeam.objects.create(
             team_id=str(self.team.id),
-            provider=ExternalTeam.get_provider_enum("github"),
+            provider=ExternalProviders.GITHUB,
             external_name="@getsentry/ecosystem",
         )
         self.url = reverse(

--- a/tests/sentry/api/endpoints/test_external_team_details.py
+++ b/tests/sentry/api/endpoints/test_external_team_details.py
@@ -1,41 +1,46 @@
-from django.core.urlresolvers import reverse
-
 from sentry.models import ExternalTeam
 from sentry.testutils import APITestCase
 from sentry.types.integrations import ExternalProviders
 
 
 class ExternalTeamDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-external-team-details"
+    method = "put"
+
     def setUp(self):
         super().setUp()
-        self.login_as(user=self.user)
-        self.org = self.create_organization(owner=self.user, name="baz")
-        self.team = self.create_team(organization=self.org, name="Mariachi Band")
+        self.login_as(self.user)
         self.external_team = ExternalTeam.objects.create(
             team_id=str(self.team.id),
-            provider=ExternalProviders.GITHUB,
+            provider=ExternalProviders.GITHUB.value,
             external_name="@getsentry/ecosystem",
-        )
-        self.url = reverse(
-            "sentry-api-0-external-team-details",
-            args=[self.org.slug, self.team.slug, self.external_team.id],
         )
 
     def test_basic_delete(self):
         with self.feature({"organizations:import-codeowners": True}):
-            resp = self.client.delete(self.url)
-        assert resp.status_code == 204
+            self.get_success_response(
+                self.organization.slug, self.team.slug, self.external_team.id, method="delete"
+            )
         assert not ExternalTeam.objects.filter(id=str(self.external_team.id)).exists()
 
     def test_basic_update(self):
         with self.feature({"organizations:import-codeowners": True}):
-            resp = self.client.put(self.url, {"externalName": "@getsentry/growth"})
-        assert resp.status_code == 200
-        assert resp.data["id"] == str(self.external_team.id)
-        assert resp.data["externalName"] == "@getsentry/growth"
+            data = {"externalName": "@getsentry/growth"}
+            response = self.get_success_response(
+                self.organization.slug, self.team.slug, self.external_team.id, **data
+            )
+
+        assert response.data["id"] == str(self.external_team.id)
+        assert response.data["externalName"] == "@getsentry/growth"
 
     def test_invalid_provider_update(self):
+        data = {"provider": "git"}
         with self.feature({"organizations:import-codeowners": True}):
-            resp = self.client.put(self.url, {"provider": "git"})
-        assert resp.status_code == 400
-        assert resp.data == {"provider": ['"git" is not a valid choice.']}
+            response = self.get_error_response(
+                self.organization.slug,
+                self.team.slug,
+                self.external_team.id,
+                status_code=400,
+                **data,
+            )
+        assert response.data == {"provider": ['"git" is not a valid choice.']}

--- a/tests/sentry/api/endpoints/test_external_user.py
+++ b/tests/sentry/api/endpoints/test_external_user.py
@@ -1,17 +1,15 @@
-from django.core.urlresolvers import reverse
-
 from sentry.models import OrganizationMember
 from sentry.testutils import APITestCase
 
 
 class ExternalUserTest(APITestCase):
+    endpoint = "sentry-api-0-organization-external-user"
+    method = "post"
+
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
-        self.url = reverse(
-            "sentry-api-0-organization-external-user",
-            args=[self.organization.slug],
-        )
+        self.org_slug = self.organization.slug  # force creation
         self.organization_member = OrganizationMember.objects.get(user=self.user)
         self.data = {
             "externalName": "@NisanthanNanthakumar",
@@ -21,8 +19,7 @@ class ExternalUserTest(APITestCase):
 
     def test_basic_post(self):
         with self.feature({"organizations:import-codeowners": True}):
-            response = self.client.post(self.url, self.data)
-        assert response.status_code == 201, response.content
+            response = self.get_success_response(self.org_slug, status_code=201, **self.data)
         assert response.data == {
             **self.data,
             "id": str(response.data["id"]),
@@ -30,36 +27,31 @@ class ExternalUserTest(APITestCase):
         }
 
     def test_without_feature_flag(self):
-        response = self.client.post(self.url, self.data)
-        assert response.status_code == 403
+        response = self.get_error_response(self.org_slug, status_code=403, **self.data)
         assert response.data == {"detail": "You do not have permission to perform this action."}
 
     def test_missing_provider(self):
         self.data.pop("provider")
         with self.feature({"organizations:import-codeowners": True}):
-            response = self.client.post(self.url, self.data)
-        assert response.status_code == 400
+            response = self.get_error_response(self.org_slug, status_code=400, **self.data)
         assert response.data == {"provider": ["This field is required."]}
 
     def test_missing_externalName(self):
         self.data.pop("externalName")
         with self.feature({"organizations:import-codeowners": True}):
-            response = self.client.post(self.url, self.data)
-        assert response.status_code == 400
+            response = self.get_error_response(self.org_slug, status_code=400, **self.data)
         assert response.data == {"externalName": ["This field is required."]}
 
     def test_missing_memberId(self):
         self.data.pop("memberId")
         with self.feature({"organizations:import-codeowners": True}):
-            response = self.client.post(self.url, self.data)
-        assert response.status_code == 400
+            response = self.get_error_response(self.org_slug, status_code=400, **self.data)
         assert response.data == {"memberId": ["This field is required."]}
 
     def test_invalid_provider(self):
         self.data.update(provider="unknown")
         with self.feature({"organizations:import-codeowners": True}):
-            response = self.client.post(self.url, self.data)
-        assert response.status_code == 400
+            response = self.get_error_response(self.org_slug, status_code=400, **self.data)
         assert response.data == {"provider": ['"unknown" is not a valid choice.']}
 
     def test_create_existing_association(self):
@@ -68,8 +60,7 @@ class ExternalUserTest(APITestCase):
         )
 
         with self.feature({"organizations:import-codeowners": True}):
-            response = self.client.post(self.url, self.data)
-        assert response.status_code == 200
+            response = self.get_success_response(self.org_slug, **self.data)
         assert response.data == {
             **self.data,
             "id": str(self.external_user.id),

--- a/tests/sentry/api/endpoints/test_external_user_details.py
+++ b/tests/sentry/api/endpoints/test_external_user_details.py
@@ -1,36 +1,38 @@
-from django.core.urlresolvers import reverse
-
 from sentry.models import ExternalUser
 from sentry.testutils import APITestCase
 
 
 class ExternalUserDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-external-user-details"
+    method = "put"
+
     def setUp(self):
         super().setUp()
         self.login_as(user=self.user)
         self.external_user = self.create_external_user(
             self.user, self.organization, external_name="@NisanthanNanthakumar"
         )
-        self.url = reverse(
-            "sentry-api-0-organization-external-user-details",
-            args=[self.organization.slug, self.external_user.id],
-        )
 
     def test_basic_delete(self):
         with self.feature({"organizations:import-codeowners": True}):
-            resp = self.client.delete(self.url)
-        assert resp.status_code == 204
+            self.get_success_response(
+                self.organization.slug, self.external_user.id, method="delete"
+            )
         assert not ExternalUser.objects.filter(id=str(self.external_user.id)).exists()
 
     def test_basic_update(self):
         with self.feature({"organizations:import-codeowners": True}):
-            resp = self.client.put(self.url, {"externalName": "@new_username"})
-        assert resp.status_code == 200
-        assert resp.data["id"] == str(self.external_user.id)
-        assert resp.data["externalName"] == "@new_username"
+            data = {"externalName": "@new_username"}
+            response = self.get_success_response(
+                self.organization.slug, self.external_user.id, **data
+            )
+        assert response.data["id"] == str(self.external_user.id)
+        assert response.data["externalName"] == "@new_username"
 
     def test_invalid_provider_update(self):
         with self.feature({"organizations:import-codeowners": True}):
-            resp = self.client.put(self.url, {"provider": "unknown"})
-        assert resp.status_code == 400
-        assert resp.data == {"provider": ['"unknown" is not a valid choice.']}
+            data = {"provider": "unknown"}
+            response = self.get_error_response(
+                self.organization.slug, self.external_user.id, status_code=400, **data
+            )
+        assert response.data == {"provider": ['"unknown" is not a valid choice.']}

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -23,9 +23,9 @@ from sentry.models import (
     ProjectTeam,
     Rule,
 )
-from sentry.models.integration import ExternalProviders
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.compat import mock, zip
 
 

--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -1,7 +1,7 @@
 from sentry.models import NotificationSetting
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import APITestCase
+from sentry.types.integrations import ExternalProviders
 
 
 class UserNotificationDetailsTestBase(APITestCase):

--- a/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
+++ b/tests/sentry/api/endpoints/test_user_notification_fine_tuning.py
@@ -1,7 +1,7 @@
 from sentry.models import NotificationSetting, UserEmail, UserOption
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import APITestCase
+from sentry.types.integrations import ExternalProviders
 
 
 class UserNotificationFineTuningTestBase(APITestCase):

--- a/tests/sentry/api/serializers/test_group.py
+++ b/tests/sentry/api/serializers/test_group.py
@@ -15,9 +15,9 @@ from sentry.models import (
     NotificationSetting,
     UserOption,
 )
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import TestCase
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.compat import mock
 from sentry.utils.compat.mock import patch
 

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -25,9 +25,9 @@ from sentry.incidents.models import (
     TriggerStatus,
 )
 from sentry.models import Integration, NotificationSetting, PagerDutyService
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import TestCase
+from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 from sentry.utils.http import absolute_uri
 

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -14,13 +14,13 @@ from sentry.models import (
     Repository,
     UserEmail,
 )
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
     GroupSubscriptionReason,
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
 from sentry.testutils import TestCase
+from sentry.types.integrations import ExternalProviders
 
 
 class ReleaseTestCase(TestCase):

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -25,7 +25,6 @@ from sentry.models import (
     User,
     UserReport,
 )
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.ownership import grammar
 from sentry.ownership.grammar import Matcher, Owner, dump_schema
@@ -33,6 +32,7 @@ from sentry.plugins.base import Notification
 from sentry.rules.processor import RuleFuture
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.compat import mock
 from sentry.utils.email import MessageBuilder
 

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -1,13 +1,13 @@
 import functools
 
 from sentry.models import GroupSubscription, NotificationSetting
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
     GroupSubscriptionReason,
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
 from sentry.testutils import TestCase
+from sentry.types.integrations import ExternalProviders
 
 
 class SubscribeTest(TestCase):

--- a/tests/sentry/models/test_notificationsetting.py
+++ b/tests/sentry/models/test_notificationsetting.py
@@ -1,7 +1,7 @@
 from sentry.models import NotificationSetting
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import TestCase
+from sentry.types.integrations import ExternalProviders
 
 
 def _get_kwargs(kwargs):

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -12,9 +12,9 @@ from sentry.models import (
     ReleaseProjectEnvironment,
     Rule,
 )
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import TestCase
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.compat import zip
 
 

--- a/tests/snuba/api/serializers/test_group.py
+++ b/tests/snuba/api/serializers/test_group.py
@@ -21,10 +21,10 @@ from sentry.models import (
     NotificationSetting,
     UserOption,
 )
-from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
+from sentry.types.integrations import ExternalProviders
 from sentry.utils.compat import mock
 from sentry.utils.compat.mock import patch
 


### PR DESCRIPTION
We're getting some circular dependency problems importing `ExternalProviders` from `sentry.models.integrations` so I've moved it to a file.