### PR TITLE
feat(trace-view): update header to not be relevant to search

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
@@ -188,11 +188,14 @@ class TraceDetailsContent extends React.Component<Props, State> {
           tooltipText={t(
             'The number of transactions and errors there are in this trace.'
           )}
-          bodyText={t(
-            '%s Transactions  |  %s Errors',
-            traceInfo.transactions.size,
-            traceInfo.errors.size
-          )}
+          bodyText={tct('[transactions]  |  [errors]', {
+            transactions: tn(
+              '%s Transaction',
+              '%s Transactions',
+              traceInfo.transactions.size
+            ),
+            errors: tn('%s Error', '%s Errors', traceInfo.errors.size),
+          })}
           subtext={tn('Across %s project', 'Across %s projects', traceInfo.projects.size)}
         />
         <MetaData

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
@@ -184,27 +184,19 @@ class TraceDetailsContent extends React.Component<Props, State> {
     return (
       <TraceDetailHeader>
         <MetaData
-          headingText={t('Transactions')}
-          tooltipText={t('All the transactions that are a part of this trace.')}
+          headingText={t('Event Breakdown')}
+          tooltipText={t(
+            'The number of transactions and errors there are in this trace.'
+          )}
           bodyText={t(
-            '%s of %s',
-            traceInfo.relevantTransactions.size,
-            traceInfo.transactions.size
+            '%s Transactions  |  %s Errors',
+            traceInfo.transactions.size,
+            traceInfo.errors.size
           )}
           subtext={tn(
             'Across %s project',
             'Across %s projects',
             traceInfo.relevantProjectsWithTransactions.size
-          )}
-        />
-        <MetaData
-          headingText={t('Errors')}
-          tooltipText={t('All the errors that are a part of this trace.')}
-          bodyText={t('%s of %s', traceInfo.relevantErrors.size, traceInfo.errors.size)}
-          subtext={tn(
-            'Across %s project',
-            'Across %s projects',
-            traceInfo.relevantProjectsWithErrors.size
           )}
         />
         <MetaData
@@ -240,7 +232,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
 
     if (roots === 0 && orphans > 0) {
       warning = (
-        <Alert type="info" icon={<IconInfo size="md" />}>
+        <Alert type="info" icon={<IconInfo size="sm" />}>
           <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
             {t(
               'A root transaction is missing. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
@@ -250,7 +242,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
       );
     } else if (roots === 1 && orphans > 0) {
       warning = (
-        <Alert type="info" icon={<IconInfo size="md" />}>
+        <Alert type="info" icon={<IconInfo size="sm" />}>
           <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#orphan-traces-and-broken-subtraces">
             {t(
               'This trace has broken subtraces. Transactions linked by a dashed line have been orphaned and cannot be directly linked to the root.'
@@ -260,7 +252,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
       );
     } else if (roots > 1) {
       warning = (
-        <Alert type="info" icon={<IconInfo size="md" />}>
+        <Alert type="info" icon={<IconInfo size="sm" />}>
           <ExternalLink href="https://docs.sentry.io/product/performance/trace-view/#multiple-roots">
             {t('Multiple root transactions have been found with this trace ID.')}
           </ExternalLink>
@@ -530,9 +522,9 @@ class TraceDetailsContent extends React.Component<Props, State> {
       const traceInfo = getTraceInfo(traces, this.isTransactionVisible);
       return (
         <React.Fragment>
-          {this.renderSearchBar()}
-          {this.renderTraceHeader(traceInfo)}
           {this.renderTraceWarnings()}
+          {this.renderTraceHeader(traceInfo)}
+          {this.renderSearchBar()}
           {this.renderTraceView(traceInfo)}
         </React.Fragment>
       );

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/content.tsx
@@ -193,11 +193,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
             traceInfo.transactions.size,
             traceInfo.errors.size
           )}
-          subtext={tn(
-            'Across %s project',
-            'Across %s projects',
-            traceInfo.relevantProjectsWithTransactions.size
-          )}
+          subtext={tn('Across %s project', 'Across %s projects', traceInfo.projects.size)}
         />
         <MetaData
           headingText={t('Total Duration')}
@@ -519,7 +515,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
     } else if (error !== null || traces === null || traces.length <= 0) {
       return this.renderTraceNotFound();
     } else {
-      const traceInfo = getTraceInfo(traces, this.isTransactionVisible);
+      const traceInfo = getTraceInfo(traces);
       return (
         <React.Fragment>
           {this.renderTraceWarnings()}

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
@@ -71,11 +71,10 @@ export const TraceDetailHeader = styled('div')`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-gap: ${space(2)};
-  margin-top: ${space(2)};
   margin-bottom: ${space(2)};
 
   @media (min-width: ${p => p.theme.breakpoints[1]}) {
-    grid-template-columns: minmax(160px, 1fr) minmax(160px, 1fr) minmax(160px, 1fr) 6fr;
+    grid-template-columns: minmax(250px, 1fr) minmax(160px, 1fr) 6fr;
     grid-row-gap: 0;
   }
 `;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/types.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/types.tsx
@@ -2,21 +2,9 @@ import {TraceFullDetailed} from 'app/utils/performance/quickTrace/types';
 
 export type TraceInfo = {
   /**
-   * The projects in the trace with an error that matched the user condition.
-   */
-  relevantProjectsWithErrors: Set<string>;
-  /**
    * The projects in the trace wth a transaction that matched the user condition.
    */
   relevantProjectsWithTransactions: Set<string>;
-  /**
-   * The errors in the trace that matched the user conditions.
-   */
-  relevantErrors: Set<string>;
-  /**
-   * The transactions in the trace that matched the user conditions.
-   */
-  relevantTransactions: Set<string>;
   /**
    * The errors in the trace.
    */

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/types.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/types.tsx
@@ -2,9 +2,9 @@ import {TraceFullDetailed} from 'app/utils/performance/quickTrace/types';
 
 export type TraceInfo = {
   /**
-   * The projects in the trace wth a transaction that matched the user condition.
+   * The projects in the trace
    */
-  relevantProjectsWithTransactions: Set<string>;
+  projects: Set<string>;
   /**
    * The errors in the trace.
    */

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/utils.tsx
@@ -18,18 +18,14 @@ export function getTraceDetailsUrl(
   };
 }
 
-function traceVisitor(isRelevant: (transaction: TraceFullDetailed) => boolean) {
+function traceVisitor() {
   return (accumulator: TraceInfo, event: TraceFullDetailed) => {
-    const relevant = isRelevant(event);
-
     for (const error of event.errors ?? []) {
       accumulator.errors.add(error.event_id);
     }
 
     accumulator.transactions.add(event.event_id);
-    if (relevant) {
-      accumulator.relevantProjectsWithTransactions.add(event.project_slug);
-    }
+    accumulator.projects.add(event.project_slug);
 
     accumulator.startTimestamp = Math.min(
       accumulator.startTimestamp,
@@ -43,12 +39,9 @@ function traceVisitor(isRelevant: (transaction: TraceFullDetailed) => boolean) {
   };
 }
 
-export function getTraceInfo(
-  traces: TraceFullDetailed[],
-  isRelevant: (transaction: TraceFullDetailed) => boolean
-) {
+export function getTraceInfo(traces: TraceFullDetailed[]) {
   const initial = {
-    relevantProjectsWithTransactions: new Set<string>(),
+    projects: new Set<string>(),
     errors: new Set<string>(),
     transactions: new Set<string>(),
     startTimestamp: Number.MAX_SAFE_INTEGER,
@@ -58,7 +51,7 @@ export function getTraceInfo(
 
   return traces.reduce(
     (info: TraceInfo, trace: TraceFullDetailed) =>
-      reduceTrace<TraceInfo>(trace, traceVisitor(isRelevant), info),
+      reduceTrace<TraceInfo>(trace, traceVisitor(), info),
     initial
   );
 }

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/utils.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/utils.tsx
@@ -24,15 +24,10 @@ function traceVisitor(isRelevant: (transaction: TraceFullDetailed) => boolean) {
 
     for (const error of event.errors ?? []) {
       accumulator.errors.add(error.event_id);
-      if (relevant) {
-        accumulator.relevantErrors.add(error.event_id);
-        accumulator.relevantProjectsWithErrors.add(error.project_slug);
-      }
     }
 
     accumulator.transactions.add(event.event_id);
     if (relevant) {
-      accumulator.relevantTransactions.add(event.event_id);
       accumulator.relevantProjectsWithTransactions.add(event.project_slug);
     }
 
@@ -53,10 +48,7 @@ export function getTraceInfo(
   isRelevant: (transaction: TraceFullDetailed) => boolean
 ) {
   const initial = {
-    relevantProjectsWithErrors: new Set<string>(),
     relevantProjectsWithTransactions: new Set<string>(),
-    relevantErrors: new Set<string>(),
-    relevantTransactions: new Set<string>(),
     errors: new Set<string>(),
     transactions: new Set<string>(),
     startTimestamp: Number.MAX_SAFE_INTEGER,

--- a/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionDetails/styles.tsx
@@ -48,7 +48,7 @@ const StyledSectionHeading = styled(SectionHeading)`
 `;
 
 const SectionBody = styled('div')`
-  font-size: ${p => p.theme.headerFontSize};
+  font-size: ${p => p.theme.fontSizeExtraLarge};
   padding: ${space(0.5)} 0;
   max-height: 32px;
 `;


### PR DESCRIPTION
- Moved search down in trace view
- Moved alert up in trace view
- Merges transactions and error count to one in trace view
- Made SectionBody slightly smaller in font 

**Before:**
![Screen Shot 2021-04-07 at 2 46 20 PM](https://user-images.githubusercontent.com/4830259/113938884-135f8f00-97b0-11eb-924c-7e43cee9c21a.png)
![Screen Shot 2021-04-07 at 2 48 12 PM](https://user-images.githubusercontent.com/4830259/113939149-78b38000-97b0-11eb-8d02-d176d3dd462e.png)

**After:**
![Screen Shot 2021-04-07 at 2 45 55 PM](https://user-images.githubusercontent.com/4830259/113938891-165a7f80-97b0-11eb-9f96-dedc614807a5.png)
![Screen Shot 2021-04-07 at 2 48 04 PM](https://user-images.githubusercontent.com/4830259/113939157-7c470700-97b0-11eb-8888-ca3c014d41ba.png)