### PR TITLE
feat(breakdowns): Render span op breakdown bars on the transaction summary table

### DIFF
--- a/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
+++ b/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
@@ -451,8 +451,14 @@ class TransactionsTable extends React.PureComponent<TableProps> {
       baselineData,
       handleBaselineClick,
       handleCellAction,
+      titles,
     } = this.props;
     const fields = eventView.getFields();
+
+    if (titles && titles.length) {
+      // Slice to match length of given titles
+      columnOrder = columnOrder.slice(0, titles.length);
+    }
 
     const resultsRow = columnOrder.map((column, index) => {
       const field = String(column.key);

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -496,7 +496,7 @@ const spanOperationBreakdownRenderer = (field: string) => (
   const operationName = getSpanOperationName(field) ?? 'op';
 
   return (
-    <div style={{outline: '1px solod red'}}>
+    <div style={{position: 'relative'}}>
       <SpanBarRectangle
         spanBarHatch={false}
         style={{

--- a/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fieldRenderers.tsx
@@ -5,6 +5,16 @@ import partial from 'lodash/partial';
 
 import Count from 'app/components/count';
 import Duration from 'app/components/duration';
+import {
+  DurationPill,
+  getDurationDisplay,
+  SpanBarRectangle,
+} from 'app/components/events/interfaces/spans/spanBar';
+import {
+  getHumanDuration,
+  pickSpanBarColour,
+  toPercent,
+} from 'app/components/events/interfaces/spans/utils';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
 import UserBadge from 'app/components/idBadge/userBadge';
 import UserMisery from 'app/components/userMisery';
@@ -12,7 +22,12 @@ import Version from 'app/components/version';
 import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {defined} from 'app/utils';
-import {AGGREGATIONS, getAggregateAlias} from 'app/utils/discover/fields';
+import {
+  AGGREGATIONS,
+  getAggregateAlias,
+  getSpanOperationName,
+  isSpanOperationBreakdownField,
+} from 'app/utils/discover/fields';
 import {getShortEventId} from 'app/utils/events';
 import {formatFloat, formatPercentage} from 'app/utils/formatters';
 import getDynamicText from 'app/utils/getDynamicText';
@@ -468,6 +483,43 @@ export function getSortField(
   return null;
 }
 
+const spanOperationBreakdownRenderer = (field: string) => (
+  data: EventData
+): React.ReactNode => {
+  if (!('transaction.duration' in data)) {
+    return FIELD_FORMATTERS.duration.renderFunc(field, data);
+  }
+  const transactionDuration = data['transaction.duration'];
+  const spanOpDuration = data[field];
+
+  const widthPercentage = spanOpDuration / transactionDuration;
+  const operationName = getSpanOperationName(field) ?? 'op';
+
+  return (
+    <div style={{outline: '1px solod red'}}>
+      <SpanBarRectangle
+        spanBarHatch={false}
+        style={{
+          backgroundColor: pickSpanBarColour(operationName),
+          left: 0,
+          width: toPercent(widthPercentage || 0),
+        }}
+      >
+        <DurationPill
+          durationDisplay={getDurationDisplay({
+            left: 0,
+            width: widthPercentage,
+          })}
+          showDetail={false}
+          spanBarHatch={false}
+        >
+          {getHumanDuration(spanOpDuration / 1000)}
+        </DurationPill>
+      </SpanBarRectangle>
+    </div>
+  );
+};
+
 /**
  * Get the field renderer for the named field and metadata
  *
@@ -482,6 +534,11 @@ export function getFieldRenderer(
   if (SPECIAL_FIELDS.hasOwnProperty(field)) {
     return SPECIAL_FIELDS[field].renderFunc;
   }
+
+  if (isSpanOperationBreakdownField(field)) {
+    return spanOperationBreakdownRenderer(field);
+  }
+
   const fieldName = getAggregateAlias(field);
   const fieldType = meta[fieldName];
 

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -574,6 +574,7 @@ export const TRACING_FIELDS = [
 ];
 
 export const MEASUREMENT_PATTERN = /^measurements\.([a-zA-Z0-9-_.]+)$/;
+export const SPAN_OP_BREAKDOWN_PATTERN = /^span_op_breakdowns\.ops\.([a-zA-Z0-9-_.]+)$/;
 
 export function isMeasurement(field: string): boolean {
   const results = field.match(MEASUREMENT_PATTERN);
@@ -815,4 +816,16 @@ export function fieldAlignment(
  */
 export function isLegalYAxisType(match: ColumnType) {
   return ['number', 'integer', 'duration', 'percentage'].includes(match);
+}
+
+export function isSpanOperationBreakdownField(field: string) {
+  return field.startsWith('span_op_breakdowns.');
+}
+
+export function getSpanOperationName(field: string): string | null {
+  const results = field.match(SPAN_OP_BREAKDOWN_PATTERN);
+  if (results && results.length >= 2) {
+    return results[1];
+  }
+  return null;
 }

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/content.tsx
@@ -39,7 +39,6 @@ import TransactionSummaryCharts from './charts';
 import Filter, {
   filterToField,
   filterToSearchConditions,
-  filterToString,
   SpanOperationBreakdownFilter,
 } from './filter';
 import TransactionHeader, {Tab} from './header';
@@ -200,7 +199,7 @@ class SummaryContent extends React.Component<Props, State> {
     const durationTableTitle =
       spanOperationBreakdownFilter === SpanOperationBreakdownFilter.None
         ? t('duration')
-        : `${filterToString(spanOperationBreakdownFilter)} duration`;
+        : `${spanOperationBreakdownFilter} duration`;
 
     return (
       <React.Fragment>
@@ -389,7 +388,7 @@ function getFilterOptions({
   }
 
   const field = filterToField(spanOperationBreakdownFilter)!;
-  const operationName = filterToString(spanOperationBreakdownFilter);
+  const operationName = spanOperationBreakdownFilter;
 
   return [
     {


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/24972

https://user-images.githubusercontent.com/139499/113939169-a6f18980-97c9-11eb-86b4-bcec07e702d6.mp4

