### PR TITLE
fix(summary): relocated paginator, changed label to percentile and aligned pill margins

### DIFF
--- a/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
+++ b/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
@@ -192,18 +192,16 @@ class TransactionsList extends React.Component<Props> {
           ))}
         </DropdownControl>
         {!this.isTrend() && (
-          <HeaderButtonContainer>
-            <GuideAnchor target="release_transactions_open_in_discover">
-              <DiscoverButton
-                onClick={handleOpenInDiscoverClick}
-                to={this.getEventView().getResultsViewUrlTarget(organization.slug)}
-                size="small"
-                data-test-id="discover-open"
-              >
-                {t('Open in Discover')}
-              </DiscoverButton>
-            </GuideAnchor>
-          </HeaderButtonContainer>
+          <GuideAnchor target="release_transactions_open_in_discover">
+            <DiscoverButton
+              onClick={handleOpenInDiscoverClick}
+              to={this.getEventView().getResultsViewUrlTarget(organization.slug)}
+              size="small"
+              data-test-id="discover-open"
+            >
+              {t('Open in Discover')}
+            </DiscoverButton>
+          </GuideAnchor>
         )}
       </React.Fragment>
     );
@@ -598,11 +596,6 @@ const Header = styled('div')`
   display: grid;
   grid-template-columns: 1fr auto auto;
   margin-bottom: ${space(1)};
-`;
-
-const HeaderButtonContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
 `;
 
 const StyledDropdownButton = styled(DropdownButton)`

--- a/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
+++ b/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
@@ -165,7 +165,7 @@ class TransactionsList extends React.Component<Props> {
     } = this.props;
 
     return (
-      <Header>
+      <React.Fragment>
         <DropdownControl
           data-test-id="filter-transactions"
           button={({isOpen, getActorProps}) => (
@@ -205,7 +205,7 @@ class TransactionsList extends React.Component<Props> {
             </GuideAnchor>
           </HeaderButtonContainer>
         )}
-      </Header>
+      </React.Fragment>
     );
   }
 
@@ -234,6 +234,14 @@ class TransactionsList extends React.Component<Props> {
 
     let tableRenderer = ({isLoading, pageLinks, tableData, baselineData}) => (
       <React.Fragment>
+        <Header>
+          {this.renderHeader()}
+          <StyledPagination
+            pageLinks={pageLinks}
+            onCursor={this.handleCursor}
+            size="small"
+          />
+        </Header>
         <TransactionsTable
           eventView={eventView}
           organization={organization}
@@ -246,11 +254,6 @@ class TransactionsList extends React.Component<Props> {
           generateLink={generateLink}
           baselineTransactionName={baselineTransactionName}
           handleCellAction={handleCellAction}
-        />
-        <StyledPagination
-          pageLinks={pageLinks}
-          onCursor={this.handleCursor}
-          size="small"
         />
       </React.Fragment>
     );
@@ -324,6 +327,14 @@ class TransactionsList extends React.Component<Props> {
       >
         {({isLoading, trendsData, pageLinks}) => (
           <React.Fragment>
+            <Header>
+              {this.renderHeader()}
+              <StyledPagination
+                pageLinks={pageLinks}
+                onCursor={this.handleCursor}
+                size="small"
+              />
+            </Header>
             <TransactionsTable
               eventView={sortedEventView}
               organization={organization}
@@ -340,11 +351,6 @@ class TransactionsList extends React.Component<Props> {
               generateLink={generateLink}
               baselineTransactionName={null}
             />
-            <StyledPagination
-              pageLinks={pageLinks}
-              onCursor={this.handleCursor}
-              size="small"
-            />
           </React.Fragment>
         )}
       </TrendsEventsDiscoverQuery>
@@ -359,7 +365,6 @@ class TransactionsList extends React.Component<Props> {
   render() {
     return (
       <React.Fragment>
-        {this.renderHeader()}
         {this.isTrend() ? this.renderTrendsTable() : this.renderTransactionTable()}
       </React.Fragment>
     );
@@ -575,7 +580,7 @@ class TransactionsTable extends React.PureComponent<TableProps> {
     const loader = <LoadingIndicator style={{margin: '70px auto'}} />;
 
     return (
-      <StyledPanelTable
+      <PanelTable
         isEmpty={!hasResults}
         emptyMessage={t('No transactions found')}
         headers={this.renderHeader()}
@@ -584,16 +589,16 @@ class TransactionsTable extends React.PureComponent<TableProps> {
         loader={loader}
       >
         {this.renderResults()}
-      </StyledPanelTable>
+      </PanelTable>
     );
   }
 }
 
 const Header = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin: 0 0 ${space(1)} 0;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  grid-gap: ${space(1)};
+  margin-bottom: ${space(1)};
 `;
 
 const HeaderButtonContainer = styled('div')`
@@ -603,10 +608,6 @@ const HeaderButtonContainer = styled('div')`
 
 const StyledDropdownButton = styled(DropdownButton)`
   min-width: 145px;
-`;
-
-const StyledPanelTable = styled(PanelTable)`
-  margin-bottom: ${space(1)};
 `;
 
 const HeadCellContainer = styled('div')`
@@ -619,7 +620,7 @@ const BodyCellContainer = styled('div')`
 `;
 
 const StyledPagination = styled(Pagination)`
-  margin: 0 0 ${space(3)} 0;
+  margin: 0;
 `;
 
 export default TransactionsList;

--- a/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
+++ b/src/sentry/static/sentry/app/components/discover/transactionsList.tsx
@@ -597,7 +597,6 @@ class TransactionsTable extends React.PureComponent<TableProps> {
 const Header = styled('div')`
   display: grid;
   grid-template-columns: 1fr auto auto;
-  grid-gap: ${space(1)};
   margin-bottom: ${space(1)};
 `;
 
@@ -620,7 +619,7 @@ const BodyCellContainer = styled('div')`
 `;
 
 const StyledPagination = styled(Pagination)`
-  margin: 0;
+  margin: 0 0 0 ${space(1)};
 `;
 
 export default TransactionsList;

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
@@ -112,7 +112,7 @@ export const TransactionBarTitleContent = styled('span')`
 `;
 
 const StyledPills = styled(Pills)`
-  padding: ${space(1)};
+  padding-top: ${space(1.5)};
 `;
 
 export function Tags({

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/charts.tsx
@@ -205,7 +205,7 @@ class TransactionSummaryCharts extends React.Component<Props> {
           <InlineContainer>
             {display === DisplayModes.TREND && (
               <OptionSelector
-                title={t('Trend')}
+                title={t('Percentile')}
                 selected={trendFunction}
                 options={TREND_FUNCTIONS_OPTIONS}
                 onChange={this.handleTrendDisplayChange}


### PR DESCRIPTION
**Before:**
<img width="825" alt="Screen Shot 2021-04-07 at 7 04 56 PM" src="https://user-images.githubusercontent.com/4830259/113957503-33a14500-97d4-11eb-81c5-7841fca398d5.png">
<img width="794" alt="Screen Shot 2021-04-07 at 7 05 59 PM" src="https://user-images.githubusercontent.com/4830259/113957598-5e8b9900-97d4-11eb-9331-15eb4f5966ae.png">

**After:**
<img width="832" alt="Screen Shot 2021-04-07 at 7 04 17 PM" src="https://user-images.githubusercontent.com/4830259/113957523-3d2aad00-97d4-11eb-9b76-82643d761383.png">
<img width="780" alt="Screen Shot 2021-04-07 at 7 06 13 PM" src="https://user-images.githubusercontent.com/4830259/113957604-621f2000-97d4-11eb-9a99-604fa9e79254.png">

Related to https://getsentry.atlassian.net/browse/VIS-672