### PR TITLE
feat(trace-view): Link docs for missing services

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -86,8 +86,9 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
         # Skip the method prefix on http spans
         child_domain = child["description"].split()[-1]
         # string contains is significantly faster than urlparse
-        if (
-            domain in child_domain and urlparse(child_domain).netloc == domain
+        if any(
+            value in child_domain and urlparse(child_domain).netloc == value
+            for value in [domain, "127.0.0.1", "localhost"]
         ) or child_domain.startswith("/"):
             event["missing_service"] = {"child": "HTTP call to a service in the same domain"}
             # don't do this check anymore

--- a/src/sentry/static/sentry/app/components/quickTrace/index.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/index.tsx
@@ -500,11 +500,11 @@ class MissingServiceNode extends React.Component<
         >
           <DropdownItem first width="small">
             <ExternalDropdownLink href="https://docs.sentry.io/platforms/javascript/performance/connect-services/">
-              Connect to a service
+              {t('Connect to a service')}
             </ExternalDropdownLink>
           </DropdownItem>
           <DropdownItem onSelect={this.dismissMissingService} width="small">
-            Dismiss
+            {t('Dismiss')}
           </DropdownItem>
         </DropdownLink>
       </React.Fragment>

--- a/src/sentry/static/sentry/app/components/quickTrace/index.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/index.tsx
@@ -488,7 +488,7 @@ class MissingServiceNode extends React.Component<
     const {hideMissing} = this.state;
     const {anchor} = this.props;
     if (hideMissing) {
-      return <React.Fragment />;
+      return null;
     }
     return (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/components/quickTrace/styles.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/styles.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {LocationDescriptor} from 'history';
 
+import ExternalLink from 'app/components/links/externalLink';
 import MenuItem from 'app/components/menuItem';
 import Tag, {Background} from 'app/components/tag';
 import Truncate from 'app/components/truncate';
@@ -60,9 +61,9 @@ export const TraceConnector = styled('div')`
   border-top: 1px solid ${p => p.theme.textColor};
 `;
 
-const StyledMenuItem = styled(MenuItem)<{first?: boolean}>`
+const StyledMenuItem = styled(MenuItem)<{first?: boolean; width: 'small' | 'large'}>`
   border-top: ${p => (!p.first ? `1px solid ${p.theme.innerBorder}` : null)};
-  width: 350px;
+  width: ${p => (p.width === 'large' ? '350px' : '200px')};
 `;
 
 const MenuItemContent = styled('div')`
@@ -76,11 +77,18 @@ type DropdownItemProps = {
   to?: string | LocationDescriptor;
   onSelect?: (eventKey: any) => void;
   first?: boolean;
+  width?: 'small' | 'large';
 };
 
-export function DropdownItem({children, first, onSelect, to}: DropdownItemProps) {
+export function DropdownItem({
+  children,
+  first,
+  onSelect,
+  to,
+  width = 'large',
+}: DropdownItemProps) {
   return (
-    <StyledMenuItem to={to} onSelect={onSelect} first={first}>
+    <StyledMenuItem to={to} onSelect={onSelect} first={first} width={width}>
       <MenuItemContent>{children}</MenuItemContent>
     </StyledMenuItem>
   );
@@ -104,6 +112,15 @@ export const ErrorNodeContent = styled('div')`
   grid-template-columns: repeat(2, auto);
   grid-gap: ${space(0.25)};
   align-items: center;
+`;
+
+export const ExternalDropdownLink = styled(ExternalLink)`
+  display: inherit !important;
+  padding: 0 !important;
+  color: ${p => p.theme.textColor};
+  &:hover {
+    color: ${p => p.theme.textColor};
+  }
 `;
 
 export function SingleEventHoverText({event}: {event: QuickTraceEvent}) {

--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/types.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/types.tsx
@@ -5,6 +5,14 @@ import {
 } from 'app/utils/discover/genericDiscoverQuery';
 
 /**
+ * Suggestions that we might be missing a service
+ */
+export type MissingService = {
+  child?: string;
+  parent?: string;
+};
+
+/**
  * `EventLite` represents the type of a simplified event from
  * the `events-trace` and `events-trace-light` endpoints.
  */
@@ -18,6 +26,7 @@ export type EventLite = {
   project_slug: string;
   parent_event_id: string | null;
   parent_span_id: string | null;
+  missing_service?: MissingService;
 };
 
 export type TraceError = {


### PR DESCRIPTION
- This adds a new `(???)` node to quick trace when we think that there's
  probably a service that isn't being instrumented by Sentry
- This only shows up when the trace has exactly one event, and there's
  an HTTP span without a domain, or in the same domain as the current
  transaction
- The dropdown has a dismiss that is permanent, we can probably change
  the key if we decide we want to start showing this again after EA or
  when we add more methods for determining missing services
- [ ] TODO: update reload

  
Preview:
<img width="258" alt="image" src="https://user-images.githubusercontent.com/4205004/113958471-280f4780-97ef-11eb-8696-b49f968a8746.png">
<img width="253" alt="image" src="https://user-images.githubusercontent.com/4205004/113958485-2fceec00-97ef-11eb-9657-305ed0e8768e.png">
