### PR TITLE
feat(codeowners): Limit query to the Organization's members

### DIFF
--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -1,10 +1,10 @@
 import logging
+
 from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
-from sentry import features, analytics
-from sentry.utils import metrics
+from sentry import analytics, features
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.endpoints.project_ownership import ProjectOwnershipMixin, ProjectOwnershipSerializer
 from sentry.api.serializers import serialize
@@ -18,6 +18,7 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.ownership.grammar import convert_codeowners_syntax, parse_code_owners
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -1,5 +1,5 @@
 import logging
-
+from django.db.models import Exists, OuterRef
 from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
@@ -17,6 +17,7 @@ from sentry.models import (
     ProjectCodeOwners,
     RepositoryProjectPathConfig,
     UserEmail,
+    OrganizationMember,
 )
 from sentry.ownership.grammar import convert_codeowners_syntax, parse_code_owners
 
@@ -48,7 +49,13 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):
         teamnames, usernames, emails = parse_code_owners(attrs["raw"])
 
         # Check if there exists Sentry users with the emails listed in CODEOWNERS
-        user_emails = UserEmail.objects.filter(email__in=emails)
+        user_emails = UserEmail.objects.annotate(
+            user_in_org=Exists(
+                OrganizationMember.objects.filter(
+                    user=OuterRef("user"), organization=self.context["project"].organization
+                )
+            )
+        ).filter(email__in=emails, user_in_org=True)
         user_emails_diff = self._validate_association(emails, user_emails, "emails")
 
         external_association_err.extend(user_emails_diff)

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -248,3 +248,18 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
                 }
             ],
         }
+
+    def test_codeowners_scope_emails_to_org_security(self):
+        self.user2 = self.create_user("user2@sentry.io")
+        self.data = {
+            "raw": "docs/*    @NisanthanNanthakumar   user2@sentry.io\n",
+            "codeMappingId": self.code_mapping.id,
+        }
+        with self.feature({"organizations:import-codeowners": True}):
+            response = self.client.post(self.url, self.data)
+        assert response.status_code == 400
+        assert response.data == {
+            "raw": [
+                f"The following emails do not have an association in Sentry: {self.user2.email}."
+            ]
+        }


### PR DESCRIPTION
## Objective:
When checking if the emails in the CODEOWNERS file has an associated Sentry User, we should be limiting this query to the organization’s members.