### PR TITLE
fix(discover): Include unknown as a txn tag referrer

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -665,7 +665,6 @@ def bulk_raw_query(
     headers = {}
     if referrer:
         headers["referer"] = referrer
-        sentry_sdk.set_tag("query.referrer", referrer)
 
     # Store the original position of the query so that we can maintain the order
     query_param_list: List[Tuple[int, SnubaQuery]] = list(
@@ -714,7 +713,11 @@ def _bulk_snuba_query(
         op="start_snuba_query",
         description=f"running {len(snuba_param_list)} snuba queries",
     ) as span:
-        span.set_tag("referrer", headers.get("referer", "<unknown>"))
+        query_referrer = headers.get("referer", "<unknown>")
+        # We set both span + sdk level, this is cause 1 txn/error might query snuba more than once
+        # but we still want to know a general sense of how referrers impact performance
+        span.set_tag("query.referrer", query_referrer)
+        sentry_sdk.set_tag("query.referrer", query_referrer)
         query_fn = _snql_query if use_snql else _snuba_query
 
         if len(snuba_param_list) > 1:


### PR DESCRIPTION
- So we were already tagging these on the span level, but because spans
  are not searchable, we want to set these at the txn level too
- With multiple queries, we'll just get the last one as the tag instead