### PR TITLE
ref(perf): Improve suspect tag values for explorer

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from rest_framework.exceptions import ParseError
 
 import sentry_sdk
 from rest_framework.response import Response
@@ -24,7 +25,10 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsV2EndpointBa
             return Response([])
 
         aggregate_column = request.GET.get("aggregateColumn", "duration")
-        orderby = request.GET.getlist("order", None)
+        orderby = request.GET.get("order", None)
+
+        if len(params.get("project_id", [])) > 1:
+            raise ParseError(detail="You cannot view facets from multiple projects.")
 
         with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
             with self.handle_query_errors():
@@ -46,8 +50,10 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsV2EndpointBa
                     {
                         "name": tagstore.get_tag_value_label(row.key, row.value),
                         "value": row.value,
-                        "count": row.count,
+                        "count": row.frequency,
                         "aggregate": row.performance,
+                        "comparison": row.comparison,
+                        "sumdelta": row.sumdelta,
                     }
                 )
         return Response(list(resp.values()))

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -28,7 +28,7 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsV2EndpointBa
         orderby = request.GET.get("order", None)
 
         if len(params.get("project_id", [])) > 1:
-            raise ParseError(detail="You cannot view facets from multiple projects.")
+            raise ParseError(detail="You cannot view facet performance for multiple projects.")
 
         with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
             with self.handle_query_errors():

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
-from rest_framework.exceptions import ParseError
 
 import sentry_sdk
+from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
 from sentry import features, tagstore

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -272,9 +272,6 @@ register("discover2.max_tags_to_combine", default=3, flags=FLAG_PRIORITIZE_DISK)
 # Enables setting a sampling rate when producing the tag facet.
 register("discover2.tags_facet_enable_sampling", default=True, flags=FLAG_PRIORITIZE_DISK)
 
-# Enables setting a sampling rate when producing the tag facet.
-register("discover2.tags_performance_facet_sample_rate", default=0.1)
-
 # Killswitch for datascrubbing after stacktrace processing. Set to False to
 # disable datascrubbers.
 register("processing.can-use-scrubbers", default=True)

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -803,11 +803,7 @@ def get_performance_facets(
     target_sample = 10000 * (math.log(transaction_count, 10) - 3)
 
     dynamic_sample_rate = 0 if transaction_count <= 0 else (target_sample / transaction_count)
-    options_sample_rate = (
-        options.get("discover2.tags_performance_facet_sample_rate") or dynamic_sample_rate
-    )
-
-    sample_rate = options_sample_rate if sampling_enabled else None
+    sample_rate = dynamic_sample_rate if sampling_enabled else None
 
     excluded_tags = [
         "tags_key",

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -787,7 +787,7 @@ def get_performance_facets(
             referrer=referrer,
         )
         counts = [r["count"] for r in key_names["data"]]
-        if not counts:
+        if len(counts) != 1:
             return []
 
     results = []

--- a/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/genericDiscoverQuery.tsx
@@ -76,7 +76,7 @@ type Props<T, P> = RequestProps<P> &
     /**
      * A hook to modify data into the correct output after data has been received
      */
-    afterFetch?: (data: any, props: Props<T, P>) => T;
+    afterFetch?: (data: any, props?: Props<T, P>) => T;
   };
 
 type State<T> = {

--- a/src/sentry/static/sentry/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
@@ -8,21 +8,41 @@ import GenericDiscoverQuery, {
 } from 'app/utils/discover/genericDiscoverQuery';
 import withApi from 'app/utils/withApi';
 
-/**
- * An individual row in a Segment explorer result
- */
-export type TableDataRow = {
+type IncomingDataRow = {
   id: string;
   key: string;
-  [key: string]: string | number | TopValue[];
+  topValues: TopValue[];
+  [key: string]: string | number | IncomingTopValue[];
 };
 
-export type TopValue = {
+type IncomingTopValue = {
   name: string;
   value: string;
   aggregate: number;
   count: number;
+  comparison: number;
+  isOther?: boolean;
 };
+
+type IncomingTableData = IncomingDataRow[];
+
+/**
+ * An individual row in a Segment explorer result
+ */
+export type TableDataRow = IncomingDataRow & {
+  aggregate: number;
+  tagValue: TagHint;
+  frequency: number;
+  comparison: number;
+  otherValues: TopValue[];
+};
+
+export type TagHint = {
+  name: string;
+  value: string;
+};
+
+export type TopValue = IncomingTopValue & {};
 
 /**
  * A Segment Explorer result including rows and metadata.
@@ -64,12 +84,37 @@ function shouldRefetchData(prevProps: QueryProps, nextProps: QueryProps) {
   );
 }
 
+function afterFetch(data: IncomingTableData) {
+  const newData = data as TableData;
+  return newData.map(row => {
+    const firstItem = row.topValues[0];
+    row.tagValue = firstItem;
+    row.aggregate = firstItem.aggregate;
+    row.frequency = firstItem.count;
+    row.comparison = firstItem.comparison;
+    row.otherValues = row.topValues.slice(0);
+    const otherEventValue = row.topValues.reduce((acc, curr) => acc - curr.count, 1);
+    if (otherEventValue > 0.01) {
+      row.otherValues.push({
+        name: 'other',
+        value: 'other',
+        isOther: true,
+        aggregate: 0,
+        count: otherEventValue,
+        comparison: 0,
+      });
+    }
+    return row;
+  });
+}
+
 function SegmentExplorerQuery(props: QueryProps) {
   return (
     <GenericDiscoverQuery<TableData, QueryProps>
       route="events-facets-performance"
       getRequestPayload={getRequestFunction(props)}
       shouldRefetchData={shouldRefetchData}
+      afterFetch={afterFetch}
       {...props}
     />
   );

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -1,20 +1,23 @@
 import React from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
+import {Location, LocationDescriptor} from 'history';
 
+import {TagSegment} from 'app/actionCreators/events';
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import GridEditable from 'app/components/gridEditable';
 import Link from 'app/components/links/link';
 import Pagination from 'app/components/pagination';
+import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
-import {formatAbbreviatedNumber} from 'app/utils/formatters';
+import {formatPercentage} from 'app/utils/formatters';
 import SegmentExplorerQuery, {
   TableDataRow,
+  TagHint,
   TopValue,
 } from 'app/utils/performance/segmentExplorer/segmentExplorerQuery';
 import {decodeScalar} from 'app/utils/queryString';
@@ -33,8 +36,32 @@ const COLUMN_ORDER = [
     },
   },
   {
-    key: 'topValues',
-    name: 'Values',
+    key: 'tagValue',
+    name: 'Tag Values',
+    width: -1,
+    column: {
+      kind: 'field',
+    },
+  },
+  {
+    key: 'frequency',
+    name: 'Frequency',
+    width: -1,
+    column: {
+      kind: 'field',
+    },
+  },
+  {
+    key: 'comparison',
+    name: 'Comparison',
+    width: -1,
+    column: {
+      kind: 'field',
+    },
+  },
+  {
+    key: 'otherValues',
+    name: 'Facet Map',
     width: -1,
     column: {
       kind: 'field',
@@ -44,16 +71,16 @@ const COLUMN_ORDER = [
 
 const HEADER_OPTIONS: DropdownOption[] = [
   {
+    label: 'Suspect Tag Values',
+    value: '-sumdelta',
+  },
+  {
     label: 'Slowest Tag Values',
     value: '-aggregate',
   },
   {
     label: 'Fastest Tag Values',
     value: 'aggregate',
-  },
-  {
-    label: 'Most Frequent Tag Values',
-    value: '-count',
   },
 ];
 
@@ -92,31 +119,140 @@ const renderBodyCell = (
   const value = dataRow[column.key];
   const {location} = parentProps;
 
-  if (Array.isArray(value)) {
+  if (column.key === 'tagValue') {
+    const localValue = dataRow.tagValue;
     return (
-      // TODO(Kevan): Remove ts any
-      <TagValueContainer>
-        {value.map(v => {
-          return (
-            <TagInner key={v.value}>
-              <Link
-                to=""
-                onClick={() => handleTagValueClick(location, dataRow.key, v.value)}
-              >
-                <TagValue value={v} />
-              </Link>
-              <DurationCountSplit>
-                <PerformanceDuration milliseconds={v.aggregate} />
-                <div>{formatAbbreviatedNumber(v.count)}</div>
-              </DurationCountSplit>
-            </TagInner>
-          );
-        })}
-      </TagValueContainer>
+      <Link
+        to=""
+        onClick={() => handleTagValueClick(location, dataRow.key, localValue.value)}
+      >
+        <TagValue value={localValue} />
+      </Link>
     );
+  }
+
+  if (column.key === 'frequency') {
+    const localValue = dataRow.frequency;
+    return formatPercentage(localValue, 0);
+  }
+
+  if (column.key === 'comparison') {
+    const localValue = dataRow.comparison;
+
+    let text = '';
+    if (localValue > 1) {
+      const pct = formatPercentage(localValue - 1, 0);
+      text = `+${pct} slower`;
+    } else {
+      const pct = formatPercentage(localValue - 1, 0);
+      text = `${pct} faster`;
+    }
+
+    return (
+      <Tooltip title={PerformanceDuration({milliseconds: dataRow.aggregate})}>
+        {t(text)}
+      </Tooltip>
+    );
+  }
+
+  if (column.key === 'otherValues' && Array.isArray(value)) {
+    const converted = dataRow.otherValues;
+    const segments = converted.map(val => {
+      return {
+        count: val.count,
+        name: val.name,
+        key: dataRow.key,
+        value: val.value,
+        isOther: val.isOther,
+        url: '',
+      };
+    });
+
+    return <SegmentVisualization location={location} segments={segments} />;
   }
   return value;
 };
+
+type SegmentValue = {
+  to: LocationDescriptor;
+  onClick: () => void;
+  index: number;
+};
+type SegmentProps = {
+  location: Location;
+  segments: TagSegment[];
+};
+const SegmentVisualization = (props: SegmentProps) => {
+  const {location, segments} = props;
+  return (
+    <SegmentBar>
+      {segments.map((value, index) => {
+        const pct = value.count * 100;
+        const pctLabel = Math.floor(pct);
+        const renderTooltipValue = () => {
+          return value.name || t('n/a');
+        };
+
+        const tooltipHtml = (
+          <React.Fragment>
+            <div className="truncate">{renderTooltipValue()}</div>
+            {pctLabel}%
+          </React.Fragment>
+        );
+
+        const segmentProps: SegmentValue = {
+          index,
+          to: value.url,
+          onClick: () => handleTagValueClick(location, value.key ?? '', value.value),
+        };
+
+        return (
+          <div key={value.value} style={{width: pct + '%'}}>
+            <Tooltip title={tooltipHtml} containerDisplayMode="block">
+              {value.isOther ? <OtherSegment /> : <Segment {...segmentProps} />}
+            </Tooltip>
+          </div>
+        );
+      })}
+    </SegmentBar>
+  );
+};
+
+const SegmentBar = styled('div')`
+  display: flex;
+  overflow: hidden;
+  border-radius: 2px;
+`;
+
+const COLORS = [
+  '#3A3387',
+  '#5F40A3',
+  '#8C4FBD',
+  '#B961D3',
+  '#DE76E4',
+  '#EF91E8',
+  '#F7B2EC',
+  '#FCD8F4',
+  '#FEEBF9',
+];
+
+const OtherSegment = styled('span')`
+  display: block;
+  width: 100%;
+  height: 16px;
+  color: inherit;
+  outline: none;
+  background-color: ${COLORS[COLORS.length - 1]};
+`;
+
+const Segment = styled(Link)<SegmentValue>`
+  display: block;
+  width: 100%;
+  height: 16px;
+  color: inherit;
+  outline: none;
+  background-color: ${p => COLORS[p.index]};
+`;
 
 const renderBodyCellWithData = (parentProps: Props) => {
   return (
@@ -125,21 +261,8 @@ const renderBodyCellWithData = (parentProps: Props) => {
   ): React.ReactNode => renderBodyCell(parentProps, column, dataRow);
 };
 
-const TagValueContainer = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
-  grid-gap: ${space(1)};
-`;
-const TagInner = styled('div')`
-  display: grid;
-`;
-const DurationCountSplit = styled('div')`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-`;
-
 type TagValueProps = {
-  value: TopValue;
+  value: TopValue | TagHint;
 };
 
 function TagValue(props: TagValueProps) {
@@ -322,7 +445,6 @@ const Header = styled('div')`
 const StyledDropdownButton = styled(DropdownButton)`
   min-width: 145px;
 `;
-
 const StyledPagination = styled(Pagination)`
   margin: 0 0 ${space(3)} 0;
 `;

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -2743,24 +2743,19 @@ class GetPerformanceFacetsTest(SnubaTestCase, TestCase):
 
         params = {"project_id": [self.project.id], "start": self.day_ago, "end": self.min_ago}
 
-        with self.options(
-            {
-                "discover2.tags_performance_facet_sample_rate": 1,
-            }
-        ):
-            result = discover.get_performance_facets("", params)
+        result = discover.get_performance_facets("", params)
 
-            assert len(result) == 11
-            for r in result:
-                if r.key == "color" and r.value == "red":
-                    assert r.frequency == 0.5
-                    assert r.performance == 1000
-                elif r.key == "color" and r.value == "blue":
-                    assert r.frequency == 0.5
-                    assert r.performance == 2000
-                else:
-                    assert r.frequency == 1.0
-                    assert r.performance == 1500
+        assert len(result) == 11
+        for r in result:
+            if r.key == "color" and r.value == "red":
+                assert r.frequency == 0.5
+                assert r.performance == 1000
+            elif r.key == "color" and r.value == "blue":
+                assert r.frequency == 0.5
+                assert r.performance == 2000
+            else:
+                assert r.frequency == 1.0
+                assert r.performance == 1500
 
 
 def test_zerofill():

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -2750,16 +2750,16 @@ class GetPerformanceFacetsTest(SnubaTestCase, TestCase):
         ):
             result = discover.get_performance_facets("", params)
 
-            assert len(result) == 12
+            assert len(result) == 11
             for r in result:
                 if r.key == "color" and r.value == "red":
-                    assert r.count == 1
+                    assert r.frequency == 0.5
                     assert r.performance == 1000
                 elif r.key == "color" and r.value == "blue":
-                    assert r.count == 1
+                    assert r.frequency == 0.5
                     assert r.performance == 2000
                 else:
-                    assert r.count == 2
+                    assert r.frequency == 1.0
                     assert r.performance == 1500
 
 

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
@@ -1,0 +1,42 @@
+from django.core.urlresolvers import reverse
+from uuid import uuid4
+
+from sentry.testutils import APITestCase, SnubaTestCase
+from sentry.testutils.helpers.datetime import before_now
+
+
+class OrganizationEventsFacetsPerformanceEndpointTest(SnubaTestCase, APITestCase):
+    feature_list = (
+        "organizations:discover-basic",
+        "organizations:global-views",
+        "organizations:performance-tag-explorer",
+    )
+
+    def setUp(self):
+        super().setUp()
+        self.min_ago = before_now(minutes=1).replace(microsecond=0)
+        self.day_ago = before_now(days=1).replace(microsecond=0)
+        self.login_as(user=self.user)
+        self.project = self.create_project()
+        self.project2 = self.create_project()
+        self.url = reverse(
+            "sentry-api-0-organization-events-facets-performance",
+            kwargs={"organization_slug": self.project.organization.slug},
+        )
+
+    def test_multiple_projects_without_global_view(self):
+        self.store_event(data={"event_id": uuid4().hex}, project_id=self.project.id)
+        self.store_event(data={"event_id": uuid4().hex}, project_id=self.project2.id)
+
+        with self.feature(
+            [
+                "organizations:discover-basic",
+                "organizations:global-views",
+                "organizations:performance-tag-explorer",
+            ]
+        ):
+            response = self.client.get(self.url, format="json")
+        assert response.status_code == 400, response.content
+        assert response.data == {
+            "detail": "You cannot view facet performance for multiple projects."
+        }

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
@@ -1,5 +1,6 @@
-from django.core.urlresolvers import reverse
 from uuid import uuid4
+
+from django.core.urlresolvers import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now


### PR DESCRIPTION
### Summary
This changes the api to be able to sort on the delta between tag value durations and the aggregate. This also adds dynamic sampling to reduce the performance overhead on requests with a large transaction count, and helps limit the cardinality of tag values in those extreme situations. Currently this is still experimental as we'll need to confirm performance before going ahead with this approach

### Screenshots
![Screen Shot 2021-04-08 at 11 13 37 AM](https://user-images.githubusercontent.com/6111995/114076411-7bb77a80-985b-11eb-95b3-9dfdc51c5486.png)

