### PR TITLE
fix(alert): Fix redirect from project details page to go to wizard

### DIFF
--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -340,9 +340,8 @@ const CreateAlertButton = withApi(
       const hasWizard = organization.features.includes('alert-wizard');
       const createAlertUrl = (providedProj: string) => {
         const alertsBaseUrl = `/organizations/${organization.slug}/alerts/${providedProj}`;
-        return `${alertsBaseUrl}/${hasWizard ? 'wizard' : 'new'}/${
-          referrer ? `?referrer=${referrer}` : ''
-        }`;
+        const subUrl = hasWizard ? 'wizard' : 'new';
+        return `${alertsBaseUrl}/${subUrl}/${referrer ? `?referrer=${referrer}` : ''}`;
       };
 
       function handleClickWithoutProject(event: React.MouseEvent) {

--- a/src/sentry/static/sentry/app/components/createAlertButton.tsx
+++ b/src/sentry/static/sentry/app/components/createAlertButton.tsx
@@ -337,24 +337,18 @@ const CreateAlertButton = withApi(
       showPermissionGuide,
       ...buttonProps
     }: Props) => {
+      const hasWizard = organization.features.includes('alert-wizard');
+      const createAlertUrl = (providedProj: string) => {
+        const alertsBaseUrl = `/organizations/${organization.slug}/alerts/${providedProj}`;
+        return `${alertsBaseUrl}/${hasWizard ? 'wizard' : 'new'}/${
+          referrer ? `?referrer=${referrer}` : ''
+        }`;
+      };
+
       function handleClickWithoutProject(event: React.MouseEvent) {
         event.preventDefault();
 
-        if (organization.features.includes('alert-wizard')) {
-          navigateTo(
-            `/organizations/${organization.slug}/alerts/:projectId/wizard/${
-              referrer ? `?referrer=${referrer}` : ''
-            }`,
-            router
-          );
-        } else {
-          navigateTo(
-            `/organizations/${organization.slug}/alerts/:projectId/new/${
-              referrer ? `?referrer=${referrer}` : ''
-            }`,
-            router
-          );
-        }
+        navigateTo(createAlertUrl(':projectId'), router);
       }
 
       async function enableAlertsMemberWrite() {
@@ -383,11 +377,7 @@ const CreateAlertButton = withApi(
           disabled={!hasAccess}
           title={!hasAccess ? permissionTooltipText : undefined}
           icon={!hideIcon && <IconSiren {...iconProps} />}
-          to={
-            projectSlug
-              ? `/organizations/${organization.slug}/alerts/${projectSlug}/new/`
-              : undefined
-          }
+          to={projectSlug ? createAlertUrl(projectSlug) : undefined}
           tooltipProps={{
             isHoverable: true,
             position: 'top',

--- a/tests/js/spec/components/createAlertButton.spec.jsx
+++ b/tests/js/spec/components/createAlertButton.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 
+import * as navigation from 'app/actionCreators/navigation';
 import CreateAlertButton, {
   CreateAlertFromViewButton,
 } from 'app/components/createAlertButton';
@@ -11,13 +12,6 @@ import {ALL_VIEWS, DEFAULT_EVENT_VIEW} from 'app/views/eventsV2/data';
 const onIncompatibleQueryMock = jest.fn();
 const onCloseMock = jest.fn();
 const onSuccessMock = jest.fn();
-
-jest.mock('app/actionCreators/navigation', () => ({
-  ...jest.requireActual('app/actionCreators/navigation'),
-  navigateTo: jest.fn(),
-}));
-
-import {navigateTo} from 'app/actionCreators/navigation';
 
 function generateWrappedComponent(organization, eventView) {
   return mountWithTheme(
@@ -234,9 +228,11 @@ describe('CreateAlertFromViewButton', () => {
   });
 
   it('redirects to alert builder with no project', async () => {
+    jest.spyOn(navigation, 'navigateTo');
+
     const wrapper = generateWrappedComponentButton(organization);
     wrapper.simulate('click');
-    expect(navigateTo).toHaveBeenCalledWith(
+    expect(navigation.navigateTo).toHaveBeenCalledWith(
       `/organizations/org-slug/alerts/:projectId/new/`,
       undefined
     );
@@ -253,6 +249,7 @@ describe('CreateAlertFromViewButton', () => {
   });
 
   it('redirects to the alert wizard w/ feature flag with no project', async () => {
+    jest.spyOn(navigation, 'navigateTo');
     const wizardOrg = {
       ...organization,
       features: ['alert-wizard'],
@@ -260,7 +257,7 @@ describe('CreateAlertFromViewButton', () => {
 
     const wrapper = generateWrappedComponentButton(wizardOrg);
     wrapper.simulate('click');
-    expect(navigateTo).toHaveBeenCalledWith(
+    expect(navigation.navigateTo).toHaveBeenCalledWith(
       `/organizations/org-slug/alerts/:projectId/wizard/`,
       undefined
     );

--- a/tests/js/spec/views/projectDetail/projectLatestAlerts.spec.jsx
+++ b/tests/js/spec/views/projectDetail/projectLatestAlerts.spec.jsx
@@ -127,7 +127,7 @@ describe('ProjectDetail > ProjectLatestAlerts', function () {
 
     expect(createRuleButton.text()).toBe('Create Alert');
     expect(createRuleButton.prop('to')).toBe(
-      `/organizations/${organization.slug}/alerts/${project.slug}/new/`
+      `/organizations/${organization.slug}/alerts/${project.slug}/new/?referrer=project_detail`
     );
 
     expect(learnMoreButton.text()).toBe('Learn More');


### PR DESCRIPTION
Currently with the wizard flag turned on the project details page `create alert` redirects to a blank alert builder. Instead we should redirect them to the wizard.

**Before:**
![Kapture 2021-04-08 at 15 23 13](https://user-images.githubusercontent.com/9372512/114084582-5ab45100-987e-11eb-9e43-f626ec0d498a.gif)

**After:**
![Kapture 2021-04-08 at 15 21 32](https://user-images.githubusercontent.com/9372512/114084378-1d4fc380-987e-11eb-93e7-74ed586e7a1d.gif)
