### PR TITLE
feat(trace-view): Add a meta specifically for traces

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -127,7 +127,6 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):
                 orderby=["-root", "-timestamp", "id"],
                 params=params,
                 query=f"event.type:transaction trace:{trace_id}",
-                # get 1 more so we know if the attempted trace was over 100
                 limit=MAX_TRACE_SIZE,
                 referrer="api.trace-view.get-ids",
             )
@@ -484,3 +483,39 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
         root_traces.sort(key=child_sort_key)
         orphans.sort(key=child_sort_key)
         return root_traces + orphans
+
+
+class OrganizationEventsTraceMetaEndpoint(OrganizationEventsTraceEndpointBase):
+    def get(self, request, organization, trace_id):
+        if not self.has_feature(organization, request):
+            return Response(status=404)
+
+        try:
+            # The trace meta isn't useful without global views, so skipping the check here
+            params = self.get_snuba_params(request, organization, check_global_views=False)
+        except NoProjects:
+            return Response(status=404)
+
+        with self.handle_query_errors():
+            result = discover.query(
+                selected_columns=[
+                    "count_unique(project_id) as projects",
+                    'count_if(event.type, equals, "transaction") as transactions',
+                    'count_if(event.type, notEquals, "transaction") as errors',
+                ],
+                params=params,
+                query=f"trace:{trace_id}",
+                limit=1,
+                referrer="api.trace-view.get-meta",
+            )
+            if len(result["data"]) == 0:
+                return Response(status=404)
+        return Response(self.serialize(result["data"][0]))
+
+    def serialize(self, results):
+        return {
+            # Values can be null if there's no result
+            "projects": results.get("projects") or 0,
+            "transactions": results.get("transactions") or 0,
+            "errors": results.get("errors") or 0,
+        }

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -500,8 +500,8 @@ class OrganizationEventsTraceMetaEndpoint(OrganizationEventsTraceEndpointBase):
             result = discover.query(
                 selected_columns=[
                     "count_unique(project_id) as projects",
-                    'count_if(event.type, equals, "transaction") as transactions',
-                    'count_if(event.type, notEquals, "transaction") as errors',
+                    "count_if(event.type, equals, transaction) as transactions",
+                    "count_if(event.type, notEquals, transaction) as errors",
                 ],
                 params=params,
                 query=f"trace:{trace_id}",
@@ -513,6 +513,7 @@ class OrganizationEventsTraceMetaEndpoint(OrganizationEventsTraceEndpointBase):
         return Response(self.serialize(result["data"][0]))
 
     def serialize(self, results):
+        return results
         return {
             # Values can be null if there's no result
             "projects": results.get("projects") or 0,

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -513,7 +513,6 @@ class OrganizationEventsTraceMetaEndpoint(OrganizationEventsTraceEndpointBase):
         return Response(self.serialize(result["data"][0]))
 
     def serialize(self, results):
-        return results
         return {
             # Values can be null if there's no result
             "projects": results.get("projects") or 0,

--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -2395,6 +2395,29 @@ FUNCTIONS = {
             ],
             default_result_type="number",
         ),
+        # Currently only used by trace meta so we can count event types which is why this only accepts strings
+        Function(
+            "count_if",
+            required_args=[
+                FieldColumn("column"),
+                ConditionArg("condition"),
+                StringArg("value", unquote=True, unescape_quotes=True),
+            ],
+            aggregate=[
+                "countIf",
+                [
+                    [
+                        ArgValue("condition"),
+                        [
+                            ArgValue("column"),
+                            ArgValue("value"),
+                        ],
+                    ]
+                ],
+                None,
+            ],
+            default_result_type="integer",
+        ),
         Function(
             "compare_numeric_aggregate",
             required_args=[

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -159,6 +159,7 @@ from .endpoints.organization_events_stats import OrganizationEventsStatsEndpoint
 from .endpoints.organization_events_trace import (
     OrganizationEventsTraceEndpoint,
     OrganizationEventsTraceLightEndpoint,
+    OrganizationEventsTraceMetaEndpoint,
 )
 from .endpoints.organization_events_trends import (
     OrganizationEventsTrendsEndpoint,
@@ -957,6 +958,11 @@ urlpatterns = [
                     r"^(?P<organization_slug>[^\/]+)/events-trace/(?P<trace_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
                     OrganizationEventsTraceEndpoint.as_view(),
                     name="sentry-api-0-organization-events-trace",
+                ),
+                url(
+                    r"^(?P<organization_slug>[^\/]+)/events-trace-meta/(?P<trace_id>(?:\d+|[A-Fa-f0-9-]{32,36}))/$",
+                    OrganizationEventsTraceMetaEndpoint.as_view(),
+                    name="sentry-api-0-organization-events-trace-meta",
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/issues/new/$",

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -3098,20 +3098,20 @@ class ResolveFieldListTest(unittest.TestCase):
 
     def test_count_if(self):
         fields = [
-            'count_if(event.type,equals,"transaction")',
-            'count_if(event.type,notEquals,"transaction")',
+            "count_if(event.type,equals,transaction)",
+            "count_if(event.type,notEquals,transaction)",
         ]
         result = resolve_field_list(fields, eventstore.Filter())
         assert result["aggregations"] == [
             [
                 "countIf",
                 [["equals", ["event.type", "'transaction'"]]],
-                "count_if_event_type_equals__transaction",
+                "count_if_event_type_equals_transaction",
             ],
             [
                 "countIf",
                 [["notEquals", ["event.type", "'transaction'"]]],
-                "count_if_event_type_notEquals__transaction",
+                "count_if_event_type_notEquals_transaction",
             ],
         ]
 

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -3096,6 +3096,25 @@ class ResolveFieldListTest(unittest.TestCase):
             resolve_field_list(fields, eventstore.Filter())
         assert "middle argument invalid: today is in the wrong format" in str(err)
 
+    def test_count_if(self):
+        fields = [
+            'count_if(event.type,equals,"transaction")',
+            'count_if(event.type,notEquals,"transaction")',
+        ]
+        result = resolve_field_list(fields, eventstore.Filter())
+        assert result["aggregations"] == [
+            [
+                "countIf",
+                [["equals", ["event.type", "'transaction'"]]],
+                "count_if_event_type_equals__transaction",
+            ],
+            [
+                "countIf",
+                [["notEquals", ["event.type", "'transaction'"]]],
+                "count_if_event_type_notEquals__transaction",
+            ],
+        ]
+
     def test_absolute_correlation(self):
         fields = ["absolute_correlation()"]
         result = resolve_field_list(fields, eventstore.Filter())

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -158,6 +158,22 @@ class OrganizationEventsTraceEndpointBase(APITestCase, SnubaTestCase):
             self.url_name,
             kwargs={"organization_slug": self.project.organization.slug, "trace_id": self.trace_id},
         )
+        start, _ = self.get_start_end(1000)
+
+    def load_errors(self):
+        start, _ = self.get_start_end(1000)
+        error_data = load_data(
+            "javascript",
+            timestamp=start,
+        )
+        error_data["contexts"]["trace"] = {
+            "type": "trace",
+            "trace_id": self.trace_id,
+            "span_id": self.gen1_span_ids[0],
+        }
+        error = self.store_event(error_data, project_id=self.gen1_project.id)
+        error1 = self.store_event(error_data, project_id=self.gen1_project.id)
+        return error, error1
 
 
 class OrganizationEventsTraceLightEndpointTest(OrganizationEventsTraceEndpointBase):
@@ -820,18 +836,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         assert grandchild["generation"] == 2
 
     def test_with_errors(self):
-        start, _ = self.get_start_end(1000)
-        error_data = load_data(
-            "javascript",
-            timestamp=start,
-        )
-        error_data["contexts"]["trace"] = {
-            "type": "trace",
-            "trace_id": self.trace_id,
-            "span_id": self.gen1_span_ids[0],
-        }
-        error = self.store_event(error_data, project_id=self.gen1_project.id)
-        error1 = self.store_event(error_data, project_id=self.gen1_project.id)
+        error, error1 = self.load_errors()
 
         with self.feature(self.FEATURES):
             response = self.client.get(
@@ -892,3 +897,81 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
             "project_id": self.gen1_project.id,
             "project_slug": self.gen1_project.slug,
         } in root_event["errors"]
+
+
+class OrganizationEventsTraceMetaEndpointTest(OrganizationEventsTraceEndpointBase):
+    url_name = "sentry-api-0-organization-events-trace-meta"
+
+    def test_no_projects(self):
+        user = self.create_user()
+        org = self.create_organization(owner=user)
+        self.login_as(user=user)
+
+        url = reverse(
+            self.url_name,
+            kwargs={"organization_slug": org.slug, "trace_id": uuid4().hex},
+        )
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                url,
+                format="json",
+            )
+
+        assert response.status_code == 404, response.content
+
+    def test_bad_ids(self):
+        # Fake trace id
+        self.url = reverse(
+            self.url_name,
+            kwargs={"organization_slug": self.project.organization.slug, "trace_id": uuid4().hex},
+        )
+
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                format="json",
+            )
+
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert data["projects"] == 0
+        assert data["transactions"] == 0
+        assert data["errors"] == 0
+
+        # Invalid trace id
+        with self.assertRaises(NoReverseMatch):
+            self.url = reverse(
+                self.url_name,
+                kwargs={
+                    "organization_slug": self.project.organization.slug,
+                    "trace_id": "not-a-trace",
+                },
+            )
+
+    def test_simple(self):
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={"project": -1},
+                format="json",
+            )
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert data["projects"] == 4
+        assert data["transactions"] == 8
+        assert data["errors"] == 0
+
+    def test_with_errors(self):
+        self.load_errors()
+        with self.feature(self.FEATURES):
+            response = self.client.get(
+                self.url,
+                data={"project": -1},
+                format="json",
+            )
+        assert response.status_code == 200, response.content
+        data = response.data
+        assert data["projects"] == 4
+        assert data["transactions"] == 8
+        assert data["errors"] == 2


### PR DESCRIPTION
- This is because we need to know for a given trace the counts of unique
  projects, and transactions compared to errors
- We can't re-use eventsv2 or meta for this either because we need to
  allow global views regardless of plan
- Adding a count_if function so that we can accomplish this query with a
  single call to snuba
  
Example Response:
```json
{
  "projects": 5,
  "transactions": 21,
  "errors": 3
}
```