### PR TITLE
feat(notifications): Handle Multiple Providers 2

### DIFF
--- a/src/sentry/api/endpoints/group_notes.py
+++ b/src/sentry/api/endpoints/group_notes.py
@@ -8,7 +8,8 @@ from sentry.api.bases.group import GroupEndpoint
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.group_notes import NoteSerializer
 from sentry.api.serializers.rest_framework.mentions import extract_user_ids_from_mentions
-from sentry.models import Activity, GroupSubscription, GroupSubscriptionReason
+from sentry.models import Activity, GroupSubscription
+from sentry.notifications.types import GroupSubscriptionReason
 from sentry.utils.functional import extract_lazy_object
 
 

--- a/src/sentry/api/helpers/group_index.py
+++ b/src/sentry/api/helpers/group_index.py
@@ -15,7 +15,6 @@ from sentry.api.fields import ActorField
 from sentry.api.issue_search import InvalidSearchQuery, convert_query_values, parse_search_query
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializer
-from sentry.api.serializers.models.group import SUBSCRIPTION_REASON_MAP
 from sentry.app import ratelimiter
 from sentry.constants import DEFAULT_SORT_OPTION
 from sentry.db.models.query import create_or_update
@@ -37,7 +36,6 @@ from sentry.models import (
     GroupSnooze,
     GroupStatus,
     GroupSubscription,
-    GroupSubscriptionReason,
     GroupTombstone,
     Release,
     Repository,
@@ -48,6 +46,7 @@ from sentry.models import (
 )
 from sentry.models.group import STATUS_UPDATE_CHOICES, looks_like_short_id
 from sentry.models.groupinbox import GroupInbox, GroupInboxRemoveAction, add_group_to_inbox
+from sentry.notifications.types import SUBSCRIPTION_REASON_MAP, GroupSubscriptionReason
 from sentry.signals import (
     advanced_search_feature_gated,
     issue_deleted,

--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, Mapping, Optional, Sequence, Union
+from typing import Any, Mapping, Optional, Sequence, Union
 
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
@@ -79,7 +79,7 @@ class Serializer:
             return
         return self.serialize(obj, attrs, user, **kwargs)
 
-    def get_attrs(self, item_list: Iterable[Any], user: Any, **kwargs) -> Mapping[Any, Any]:
+    def get_attrs(self, item_list: Sequence[Any], user: Any, **kwargs) -> Mapping[Any, Any]:
         """
         Fetch all of the associated data needed to serialize the objects in `item_list`.
 

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -35,7 +35,6 @@ from sentry.models import (
     GroupSnooze,
     GroupStatus,
     GroupSubscription,
-    GroupSubscriptionReason,
     Integration,
     NotificationSetting,
     SentryAppInstallationToken,
@@ -60,15 +59,6 @@ from sentry.utils.compat import zip
 from sentry.utils.db import attach_foreignkey
 from sentry.utils.safe import safe_execute
 from sentry.utils.snuba import Dataset, raw_query
-
-SUBSCRIPTION_REASON_MAP = {
-    GroupSubscriptionReason.comment: "commented",
-    GroupSubscriptionReason.assigned: "assigned",
-    GroupSubscriptionReason.bookmark: "bookmarked",
-    GroupSubscriptionReason.status_change: "changed_status",
-    GroupSubscriptionReason.mentioned: "mentioned",
-}
-
 
 # TODO(jess): remove when snuba is primary backend
 snuba_tsdb = SnubaTSDB(**settings.SENTRY_TSDB_OPTIONS)

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -2,7 +2,7 @@ import functools
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import Any, Iterable, Mapping, Optional, Tuple
+from typing import Iterable, Mapping, Optional, Tuple
 
 import pytz
 import sentry_sdk
@@ -175,8 +175,8 @@ class GroupSerializerBase(Serializer):
 
     @staticmethod
     def _get_subscriptions(
-        groups: Iterable[Any], user: Any
-    ) -> Mapping[int, Tuple[bool, bool, Optional[Any]]]:
+        groups: Iterable[Group], user: User
+    ) -> Mapping[int, Tuple[bool, bool, Optional[GroupSubscription]]]:
         """
         Returns a mapping of group IDs to a two-tuple of (is_disabled: bool,
         subscribed: bool, subscription: Optional[GroupSubscription]) for the

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -66,7 +66,6 @@ class EmailActionHandler(ActionHandler):
                 targets = [(target.id, target.email)]
             elif self.action.target_type == AlertRuleTriggerAction.TargetType.TEAM.value:
                 users = NotificationSetting.objects.filter_to_subscribed_users(
-                    ExternalProviders.EMAIL,
                     self.project,
                     {member.user for member in target.member_set},
                 )[ExternalProviders.EMAIL]

--- a/src/sentry/integrations/slack/event_endpoint.py
+++ b/src/sentry/integrations/slack/event_endpoint.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, List
+from typing import Any, Dict, List
 
 from sentry.api.base import Endpoint
 from sentry.shared_integrations.exceptions import ApiError
@@ -70,7 +70,7 @@ class SlackEventEndpoint(Endpoint):
         return self.respond()
 
     def on_link_shared(self, request, integration, token, data):
-        matches: DefaultDict[LinkType, List[UnfurlableUrl]] = defaultdict(list)
+        matches: Dict[LinkType, List[UnfurlableUrl]] = defaultdict(list)
         links_seen = set()
 
         # An unfurl may have multiple links to unfurl

--- a/src/sentry/mail/activity/base.py
+++ b/src/sentry/mail/activity/base.py
@@ -4,14 +4,9 @@ from django.core.urlresolvers import reverse
 from django.utils.html import escape, mark_safe
 
 from sentry import options
-from sentry.models import (
-    GroupSubscription,
-    GroupSubscriptionReason,
-    ProjectOption,
-    UserAvatar,
-    UserOption,
-)
+from sentry.models import GroupSubscription, ProjectOption, UserAvatar, UserOption
 from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import GroupSubscriptionReason
 from sentry.utils import json
 from sentry.utils.assets import get_asset_url
 from sentry.utils.avatar import get_email_avatar

--- a/src/sentry/mail/activity/new_processing_issues.py
+++ b/src/sentry/mail/activity/new_processing_issues.py
@@ -1,5 +1,6 @@
-from sentry.models import EventError, GroupSubscriptionReason, NotificationSetting
+from sentry.models import EventError, NotificationSetting
 from sentry.models.integration import ExternalProviders
+from sentry.notifications.types import GroupSubscriptionReason
 from sentry.utils.http import absolute_uri
 
 from .base import ActivityEmail

--- a/src/sentry/mail/activity/new_processing_issues.py
+++ b/src/sentry/mail/activity/new_processing_issues.py
@@ -27,9 +27,9 @@ class NewProcessingIssuesActivityEmail(ActivityEmail):
         self.issues = summarize_issues(self.activity.data["issues"])
 
     def get_participants(self):
-        users = NotificationSetting.objects.get_notification_recipients(
-            ExternalProviders.EMAIL, self.project
-        )[ExternalProviders.EMAIL]
+        users = NotificationSetting.objects.get_notification_recipients(self.project)[
+            ExternalProviders.EMAIL
+        ]
         return {user: GroupSubscriptionReason.processing_issue for user in users}
 
     def get_context(self):

--- a/src/sentry/mail/activity/release.py
+++ b/src/sentry/mail/activity/release.py
@@ -10,7 +10,6 @@ from sentry.models import (
     Environment,
     Group,
     GroupLink,
-    GroupSubscriptionReason,
     NotificationSetting,
     ProjectTeam,
     Release,
@@ -21,6 +20,7 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.notifications.types import (
+    GroupSubscriptionReason,
     NotificationScopeType,
     NotificationSettingOptionValues,
     NotificationSettingTypes,

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -15,7 +15,6 @@ from sentry.models import (
     Commit,
     Group,
     GroupSubscription,
-    GroupSubscriptionReason,
     Integration,
     NotificationSetting,
     Project,
@@ -28,6 +27,7 @@ from sentry.models import (
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.helpers import transform_to_notification_settings_by_user
 from sentry.notifications.types import (
+    GroupSubscriptionReason,
     NotificationScopeType,
     NotificationSettingOptionValues,
     NotificationSettingTypes,

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -156,9 +156,9 @@ class MailAdapter:
         Return a collection of USERS that are eligible to receive
         notifications for the provided project.
         """
-        return NotificationSetting.objects.get_notification_recipients(
-            ExternalProviders.EMAIL, project
-        )[ExternalProviders.EMAIL]
+        return NotificationSetting.objects.get_notification_recipients(project)[
+            ExternalProviders.EMAIL
+        ]
 
     def get_sendable_user_ids(self, project):
         users = self.get_sendable_user_objects(project)

--- a/src/sentry/models/groupassignee.py
+++ b/src/sentry/models/groupassignee.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from sentry.db.models import BaseManager, FlexibleForeignKey, Model, sane_repr
 from sentry.models.activity import Activity
+from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import issue_assigned
 from sentry.utils import metrics
 
@@ -125,7 +126,7 @@ def sync_group_assignee_outbound(group, user_id, assign=True):
 class GroupAssigneeManager(BaseManager):
     def assign(self, group, assigned_to, acting_user=None):
         from sentry import features
-        from sentry.models import GroupSubscription, GroupSubscriptionReason, Team, User
+        from sentry.models import GroupSubscription, Team, User
 
         GroupSubscription.objects.subscribe_actor(
             group=group, actor=assigned_to, reason=GroupSubscriptionReason.assigned

--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -16,36 +16,7 @@ from sentry.notifications.helpers import (
     transform_to_notification_settings_by_user,
     where_should_be_participating,
 )
-from sentry.notifications.types import NotificationSettingTypes
-
-
-class GroupSubscriptionReason:
-    implicit = -1  # not for use as a persisted field value
-    committed = -2  # not for use as a persisted field value
-    processing_issue = -3  # not for use as a persisted field value
-
-    unknown = 0
-    comment = 1
-    assigned = 2
-    bookmark = 3
-    status_change = 4
-    deploy_setting = 5
-    mentioned = 6
-    team_mentioned = 7
-
-    descriptions = {
-        implicit: "have opted to receive updates for all issues within "
-        "projects that you are a member of",
-        committed: "were involved in a commit that is part of this release",
-        processing_issue: "are subscribed to alerts for this project",
-        comment: "have commented on this issue",
-        assigned: "have been assigned to this issue",
-        bookmark: "have bookmarked this issue",
-        status_change: "have changed the resolution status of this issue",
-        deploy_setting: "opted to receive all deploy notifications for this organization",
-        mentioned: "have been mentioned in this issue",
-        team_mentioned: "are a member of a team mentioned in this issue",
-    }
+from sentry.notifications.types import GroupSubscriptionReason, NotificationSettingTypes
 
 
 class GroupSubscriptionManager(BaseManager):

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
+from sentry.api.serializers.models.group import SUBSCRIPTION_REASON_MAP
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
     NOTIFICATION_SETTING_DEFAULTS,
@@ -117,6 +118,7 @@ def transform_to_notification_settings_by_user(
     return notification_settings_by_user
 
 
+# TODO MARCOS 2
 def transform_to_notification_settings_by_parent_id(
     notification_settings: Iterable[Any],
 ) -> Tuple[
@@ -130,15 +132,14 @@ def transform_to_notification_settings_by_parent_id(
     notification_settings_by_parent_id = {}
     notification_setting_user_default = None
     for notification_setting in notification_settings:
-        if notification_setting.scope_type == NotificationScopeType.USER.value:
-            notification_setting_user_default = NotificationSettingOptionValues(
-                notification_setting.value
-            )
+        scope_type = NotificationScopeType(notification_setting.scope_type)
+        value = NotificationSettingOptionValues(notification_setting.value)
+
+        if scope_type == NotificationScopeType.USER:
+            notification_setting_user_default = value
         else:
             key = int(notification_setting.scope_identifier)
-            notification_settings_by_parent_id[key] = NotificationSettingOptionValues(
-                notification_setting.value
-            )
+            notification_settings_by_parent_id[key] = value
     return notification_settings_by_parent_id, notification_setting_user_default
 
 
@@ -186,3 +187,108 @@ def get_target_id(user: Optional[Any] = None, team: Optional[Any] = None) -> int
         return int(team.actor_id)
 
     raise Exception("target must be either a user or a team")
+
+
+def get_subscription_from_attributes(
+    attrs: Mapping[str, Any]
+) -> Tuple[bool, Optional[Mapping[str, Union[str, bool]]]]:
+    subscription_details = None
+    is_disabled, is_subscribed, subscription = attrs["subscription"]
+    if is_disabled:
+        subscription_details = {"disabled": True}
+    elif subscription and subscription.is_active:
+        subscription_details = {
+            "reason": SUBSCRIPTION_REASON_MAP.get(subscription.reason, "unknown")
+        }
+
+    return is_subscribed, subscription_details
+
+
+def get_groups_for_query(
+    groups_by_project: Mapping[Any, Set[Any]],
+    notification_settings_by_key: Mapping[int, NotificationSettingOptionValues],
+    global_default_workflow_option: NotificationSettingOptionValues,
+) -> Set[Any]:
+    """
+    If there is a subscription record associated with the group, we can just use
+    that to know if a user is subscribed or not, as long as notifications aren't
+    disabled for the project.
+    """
+    # Although this can be done with a comprehension, looping for clarity.
+    output = set()
+    for project, groups in groups_by_project.items():
+        value = notification_settings_by_key.get(project.id, global_default_workflow_option)
+        if value != NotificationSettingOptionValues.NEVER:
+            output |= groups
+    return output
+
+
+def collect_groups_by_project(groups: Iterable[Any]) -> Mapping[Any, Set[Any]]:
+    """
+    Collect all of the projects to look up, and keep a set of groups that are
+    part of that project. (Note that the common -- but not only -- case here is
+    that all groups are part of the same project.)
+    """
+    projects = defaultdict(set)
+    for group in groups:
+        projects[group.project].add(group)
+    return projects
+
+
+def get_notification_settings_by_key(
+    notification_settings: Iterable[Any],
+) -> Tuple[Mapping[int, NotificationSettingOptionValues], NotificationSettingOptionValues]:
+    """
+    Fetch the options for each project -- we'll need this to identify if a user
+    has totally disabled workflow notifications for a project.
+    """
+    # This is the user's default value for any projects that don't have the
+    # option value specifically recorded. (The default "participating_only"
+    # value is convention.)
+    global_default_workflow_option = NotificationSettingOptionValues.SUBSCRIBE_ONLY
+
+    # TODO MARCOS 1
+    options = {}
+    for notification_setting in notification_settings:
+        scope_type = NotificationScopeType(notification_setting.scope_type)
+        value = NotificationSettingOptionValues(notification_setting.value)
+        if scope_type != NotificationScopeType.PROJECT:
+            global_default_workflow_option = value
+        else:
+            options[notification_setting.scope_identifier] = value
+
+    return options, global_default_workflow_option
+
+
+def get_user_subscriptions_for_groups(
+    groups_by_project: Mapping[Any, Set[Any]],
+    notification_settings_by_key: Mapping[int, NotificationSettingOptionValues],
+    subscriptions_by_group_id: Mapping[int, Any],
+    global_default_workflow_option: NotificationSettingOptionValues,
+) -> Mapping[int, Tuple[bool, bool, Optional[Any]]]:
+    """
+    Takes collected data and returns a mapping of group IDs to a two-tuple of
+    (subscribed: bool, subscription: Optional[GroupSubscription]).
+    """
+    results = {}
+    for project, groups in groups_by_project.items():
+        project_default_workflow_option = notification_settings_by_key.get(
+            project.id, global_default_workflow_option
+        )
+        for group in groups:
+            subscription = subscriptions_by_group_id.get(group.id)
+
+            is_disabled = False
+            if subscription:
+                is_active = subscription.is_active
+            elif project_default_workflow_option == NotificationSettingOptionValues.NEVER:
+                is_active = False
+                is_disabled = True
+            else:
+                is_active = (
+                    project_default_workflow_option == NotificationSettingOptionValues.ALWAYS
+                )
+
+            results[group.id] = (is_disabled, is_active, subscription)
+
+    return results

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -1,11 +1,11 @@
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
-from sentry.api.serializers.models.group import SUBSCRIPTION_REASON_MAP
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
     NOTIFICATION_SETTING_DEFAULTS,
     VALID_VALUES_FOR_KEY,
+    SUBSCRIPTION_REASON_MAP,
     NotificationScopeType,
     NotificationSettingOptionValues,
     NotificationSettingTypes,

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Uni
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
     NOTIFICATION_SETTING_DEFAULTS,
-    VALID_VALUES_FOR_KEY,
     SUBSCRIPTION_REASON_MAP,
+    VALID_VALUES_FOR_KEY,
     NotificationScopeType,
     NotificationSettingOptionValues,
     NotificationSettingTypes,
@@ -123,7 +123,7 @@ def transform_to_notification_settings_by_parent_id(
     user_default: Optional[NotificationSettingOptionValues] = None,
 ) -> Tuple[
     Mapping[ExternalProviders, Mapping[int, NotificationSettingOptionValues]],
-    Mapping[ExternalProviders, NotificationSettingOptionValues],
+    Mapping[ExternalProviders, Optional[NotificationSettingOptionValues]],
 ]:
     """
     Given a unorganized list of notification settings, create a mapping of
@@ -137,7 +137,9 @@ def transform_to_notification_settings_by_parent_id(
 
     # This is the user's default value for any projects or organizations that
     # don't have the option value specifically recorded.
-    notification_setting_user_default = defaultdict(lambda: user_default)
+    notification_setting_user_default: Dict[
+        ExternalProviders, Optional[NotificationSettingOptionValues]
+    ] = defaultdict(lambda: user_default)
     for notification_setting in notification_settings:
         scope_type = NotificationScopeType(notification_setting.scope_type)
         provider = ExternalProviders(notification_setting.provider)
@@ -200,7 +202,7 @@ def get_target_id(user: Optional[Any] = None, team: Optional[Any] = None) -> int
 def get_subscription_from_attributes(
     attrs: Mapping[str, Any]
 ) -> Tuple[bool, Optional[Mapping[str, Union[str, bool]]]]:
-    subscription_details = None
+    subscription_details: Optional[Mapping[str, Union[str, bool]]] = None
     is_disabled, is_subscribed, subscription = attrs["subscription"]
     if is_disabled:
         subscription_details = {"disabled": True}

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -189,14 +189,13 @@ class NotificationsManager(BaseManager):  # type: ignore
 
     def get_for_user_by_projects(
         self,
-        provider: ExternalProviders,
         type: NotificationSettingTypes,
         user: Any,
         parents: List[Any],
     ) -> QuerySet:
         """
-        Find all of a user's notification settings for a list of projects or organizations.
-        This will include the user's  setting.
+        Find all of a user's notification settings for a list of projects or
+        organizations. This will include the user's parent-independent setting.
         """
         scope_type = get_scope_type(type)
         return self.filter(
@@ -208,7 +207,6 @@ class NotificationsManager(BaseManager):  # type: ignore
                 scope_type=NotificationScopeType.USER.value,
                 scope_identifier=user.id,
             ),
-            provider=provider.value,
             type=type.value,
             target=user.actor,
         )
@@ -239,7 +237,6 @@ class NotificationsManager(BaseManager):  # type: ignore
 
     def filter_to_subscribed_users(
         self,
-        provider: ExternalProviders,
         project: Any,
         users: List[Any],
     ) -> Mapping[ExternalProviders, List[Any]]:
@@ -260,9 +257,7 @@ class NotificationsManager(BaseManager):  # type: ignore
                 mapping[provider].append(user)
         return mapping
 
-    def get_notification_recipients(
-        self, provider: ExternalProviders, project: Any
-    ) -> Mapping[ExternalProviders, List[Any]]:
+    def get_notification_recipients(self, project: Any) -> Mapping[ExternalProviders, List[Any]]:
         """
         Return a set of users that should receive Issue Alert emails for a given
         project. To start, we get the set of all users. Then we fetch all of
@@ -274,7 +269,7 @@ class NotificationsManager(BaseManager):  # type: ignore
 
         user_ids = project.member_set.values_list("user", flat=True)
         users = User.objects.filter(id__in=user_ids)
-        return self.filter_to_subscribed_users(provider, project, users)
+        return self.filter_to_subscribed_users(project, users)
 
     def update_settings_bulk(
         self,

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Union
 
 from django.db import transaction
 from django.db.models import Q, QuerySet
@@ -242,7 +242,7 @@ class NotificationsManager(BaseManager):  # type: ignore
         provider: ExternalProviders,
         project: Any,
         users: List[Any],
-    ) -> DefaultDict[Any, List[Any]]:
+    ) -> Mapping[ExternalProviders, List[Any]]:
         """
         Filters a list of users down to the users by provider who are subscribed to alerts.
         We check both the project level settings and global default settings.
@@ -262,7 +262,7 @@ class NotificationsManager(BaseManager):  # type: ignore
 
     def get_notification_recipients(
         self, provider: ExternalProviders, project: Any
-    ) -> DefaultDict[Any, List[Any]]:
+    ) -> Mapping[ExternalProviders, List[Any]]:
         """
         Return a set of users that should receive Issue Alert emails for a given
         project. To start, we get the set of all users. Then we fetch all of

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -135,3 +135,41 @@ NOTIFICATION_SETTING_DEFAULTS = {
     NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingOptionValues.ALWAYS,
     NotificationSettingTypes.WORKFLOW: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
 }
+
+
+class GroupSubscriptionReason:
+    implicit = -1  # not for use as a persisted field value
+    committed = -2  # not for use as a persisted field value
+    processing_issue = -3  # not for use as a persisted field value
+
+    unknown = 0
+    comment = 1
+    assigned = 2
+    bookmark = 3
+    status_change = 4
+    deploy_setting = 5
+    mentioned = 6
+    team_mentioned = 7
+
+    descriptions = {
+        implicit: "have opted to receive updates for all issues within "
+        "projects that you are a member of",
+        committed: "were involved in a commit that is part of this release",
+        processing_issue: "are subscribed to alerts for this project",
+        comment: "have commented on this issue",
+        assigned: "have been assigned to this issue",
+        bookmark: "have bookmarked this issue",
+        status_change: "have changed the resolution status of this issue",
+        deploy_setting: "opted to receive all deploy notifications for this organization",
+        mentioned: "have been mentioned in this issue",
+        team_mentioned: "are a member of a team mentioned in this issue",
+    }
+
+
+SUBSCRIPTION_REASON_MAP = {
+    GroupSubscriptionReason.comment: "commented",
+    GroupSubscriptionReason.assigned: "assigned",
+    GroupSubscriptionReason.bookmark: "bookmarked",
+    GroupSubscriptionReason.status_change: "changed_status",
+    GroupSubscriptionReason.mentioned: "mentioned",
+}

--- a/src/sentry/plugins/bases/notify.py
+++ b/src/sentry/plugins/bases/notify.py
@@ -135,9 +135,9 @@ class NotificationPlugin(Plugin):
         notifications for the provided project.
         """
         if self.get_conf_key() == "mail":
-            return NotificationSetting.objects.get_notification_recipients(
-                ExternalProviders.EMAIL, project
-            )[ExternalProviders.EMAIL]
+            return NotificationSetting.objects.get_notification_recipients(project)[
+                ExternalProviders.EMAIL
+            ]
 
         return self.get_notification_recipients(project, "%s:alert" % self.get_conf_key())
 

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -12,13 +12,13 @@ from sentry.models import (
     GroupLink,
     GroupStatus,
     GroupSubscription,
-    GroupSubscriptionReason,
     PullRequest,
     Release,
     Repository,
     UserOption,
     remove_group_from_inbox,
 )
+from sentry.notifications.types import GroupSubscriptionReason
 from sentry.signals import issue_resolved
 from sentry.tasks.clear_expired_resolutions import clear_expired_resolutions
 

--- a/src/sentry/web/frontend/debug/debug_new_processing_issues_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_processing_issues_email.py
@@ -1,6 +1,7 @@
 from django.views.generic import View
 
-from sentry.models import GroupSubscriptionReason, Organization, Project
+from sentry.models import Organization, Project
+from sentry.notifications.types import GroupSubscriptionReason
 from sentry.utils.http import absolute_uri
 
 from .mail import MailPreview

--- a/src/sentry/web/frontend/debug/debug_new_release_email.py
+++ b/src/sentry/web/frontend/debug/debug_new_release_email.py
@@ -3,16 +3,8 @@ import datetime
 import pytz
 from django.views.generic import View
 
-from sentry.models import (
-    Commit,
-    CommitAuthor,
-    Deploy,
-    GroupSubscriptionReason,
-    Organization,
-    Project,
-    Release,
-    User,
-)
+from sentry.models import Commit, CommitAuthor, Deploy, Organization, Project, Release, User
+from sentry.notifications.types import GroupSubscriptionReason
 from sentry.utils.compat import zip
 from sentry.utils.http import absolute_uri
 

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -25,7 +25,6 @@ from sentry.models import (
     Activity,
     Group,
     GroupStatus,
-    GroupSubscriptionReason,
     Organization,
     OrganizationMember,
     Project,
@@ -33,6 +32,7 @@ from sentry.models import (
     Rule,
     Team,
 )
+from sentry.notifications.types import GroupSubscriptionReason
 from sentry.utils import loremipsum
 from sentry.utils.dates import to_datetime, to_timestamp
 from sentry.utils.email import inline_css

--- a/tests/sentry/api/endpoints/test_group_notes.py
+++ b/tests/sentry/api/endpoints/test_group_notes.py
@@ -3,10 +3,10 @@ from sentry.models import (
     ExternalIssue,
     GroupLink,
     GroupSubscription,
-    GroupSubscriptionReason,
     Integration,
     OrganizationIntegration,
 )
+from sentry.notifications.types import GroupSubscriptionReason
 from sentry.testutils import APITestCase
 
 

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -8,7 +8,6 @@ from sentry.models import (
     CommitAuthor,
     Deploy,
     Environment,
-    GroupSubscriptionReason,
     NotificationSetting,
     Release,
     ReleaseCommit,
@@ -16,7 +15,11 @@ from sentry.models import (
     UserEmail,
 )
 from sentry.models.integration import ExternalProviders
-from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.notifications.types import (
+    GroupSubscriptionReason,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+)
 from sentry.testutils import TestCase
 
 

--- a/tests/sentry/models/test_groupsubscription.py
+++ b/tests/sentry/models/test_groupsubscription.py
@@ -1,8 +1,12 @@
 import functools
 
-from sentry.models import GroupSubscription, GroupSubscriptionReason, NotificationSetting
+from sentry.models import GroupSubscription, NotificationSetting
 from sentry.models.integration import ExternalProviders
-from sentry.notifications.types import NotificationSettingOptionValues, NotificationSettingTypes
+from sentry.notifications.types import (
+    GroupSubscriptionReason,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
+)
 from sentry.testutils import TestCase
 
 

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -296,9 +296,9 @@ class CopyProjectSettingsTest(TestCase):
 class FilterToSubscribedUsersTest(TestCase):
     def run_test(self, users, expected_users):
         assert (
-            NotificationSetting.objects.filter_to_subscribed_users(
-                ExternalProviders.EMAIL, self.project, users
-            )[ExternalProviders.EMAIL]
+            NotificationSetting.objects.filter_to_subscribed_users(self.project, users)[
+                ExternalProviders.EMAIL
+            ]
             == expected_users
         )
 


### PR DESCRIPTION
Update the rest of the manager calls and helpers to stop assuming that "email" is the only provider.