### PR TITLE
feat(notifications): Stop Writes to UserOptions

### DIFF
--- a/src/sentry/api/endpoints/user_notification_details.py
+++ b/src/sentry/api/endpoints/user_notification_details.py
@@ -19,11 +19,10 @@ from sentry.notifications.types import NotificationScopeType, UserOptionsSetting
 
 class UserNotificationsSerializer(Serializer):
     def get_attrs(self, item_list, user, *args, **kwargs):
-        data = list(
-            UserOption.objects.filter(
-                user__in=item_list, organization=None, project=None
-            ).select_related("user")
-        )
+        user_options = UserOption.objects.filter(
+            user__in=item_list, organization=None, project=None
+        ).select_related("user")
+        keys_to_user_option_objects = {user_option.key: user_option for user_option in user_options}
 
         actor_mapping = {user.actor_id: user for user in item_list}
         notification_settings = NotificationSetting.objects._filter(
@@ -31,11 +30,17 @@ class UserNotificationsSerializer(Serializer):
             scope_type=NotificationScopeType.USER,
             target_ids=actor_mapping.keys(),
         )
-        data += map_notification_settings_to_legacy(notification_settings, actor_mapping)
+        notification_settings_as_user_options = map_notification_settings_to_legacy(
+            notification_settings, actor_mapping
+        )
+
+        # Override deprecated UserOption rows with NotificationSettings.
+        for user_option in notification_settings_as_user_options:
+            keys_to_user_option_objects[user_option.key] = user_option
 
         results = defaultdict(list)
-        for uo in data:
-            results[uo.user].append(uo)
+        for user_option in keys_to_user_option_objects.values():
+            results[user_option.user].append(user_option)
         return results
 
     def serialize(self, obj, attrs, user, *args, **kwargs):

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
+    VALID_VALUES_FOR_KEY,
     NotificationScopeType,
     NotificationSettingOptionValues,
     NotificationSettingTypes,
-    VALID_VALUES_FOR_KEY,
 )
 
 

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -2,11 +2,11 @@ from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from sentry.models.integration import ExternalProviders
-from sentry.notifications.legacy_mappings import get_legacy_value
 from sentry.notifications.types import (
     NotificationScopeType,
     NotificationSettingOptionValues,
     NotificationSettingTypes,
+    VALID_VALUES_FOR_KEY,
 )
 
 
@@ -136,7 +136,7 @@ def transform_to_notification_settings_by_parent_id(
 
 def validate(type: NotificationSettingTypes, value: NotificationSettingOptionValues) -> bool:
     """ :returns boolean. True if the "value" is valid for the "type". """
-    return get_legacy_value(type, value) is not None
+    return value in VALID_VALUES_FOR_KEY.get(type, {})
 
 
 def get_scope_type(type: NotificationSettingTypes) -> NotificationScopeType:

--- a/src/sentry/notifications/legacy_mappings.py
+++ b/src/sentry/notifications/legacy_mappings.py
@@ -167,6 +167,7 @@ def get_legacy_object(
     type = NotificationSettingTypes(notification_setting.type)
     key = get_legacy_key(type)
     value = NotificationSettingOptionValues(notification_setting.value)
+    scope_type = NotificationScopeType(notification_setting.scope_type)
 
     data = {
         "key": key,
@@ -176,9 +177,9 @@ def get_legacy_object(
         "organization": None,
     }
 
-    if notification_setting.scope_type == NotificationScopeType.PROJECT.value:
+    if scope_type == NotificationScopeType.PROJECT:
         data["project"] = parent_mapping.get(notification_setting.scope_identifier)
-    if notification_setting.scope_type == NotificationScopeType.ORGANIZATION.value:
+    if scope_type == NotificationScopeType.ORGANIZATION:
         data["organization"] = organization_mapping.get(notification_setting.scope_identifier)
 
     return LegacyUserOptionClone(**data)

--- a/src/sentry/notifications/legacy_mappings.py
+++ b/src/sentry/notifications/legacy_mappings.py
@@ -165,7 +165,7 @@ def get_legacy_object(
     organization_mapping: Mapping[int, Any],
 ) -> Any:
     type = NotificationSettingTypes(notification_setting.type)
-    key = get_legacy_key(notification_setting.type)
+    key = get_legacy_key(type)
     value = NotificationSettingOptionValues(notification_setting.value)
 
     data = {

--- a/src/sentry/notifications/manager.py
+++ b/src/sentry/notifications/manager.py
@@ -1,8 +1,8 @@
+from collections import defaultdict
 from typing import Any, DefaultDict, Dict, Iterable, List, Optional, Union
 
 from django.db import transaction
 from django.db.models import Q, QuerySet
-from collections import defaultdict
 
 from sentry.db.models.manager import BaseManager
 from sentry.models.integration import ExternalProviders
@@ -11,8 +11,8 @@ from sentry.notifications.helpers import (
     get_scope_type,
     get_target_id,
     transform_to_notification_settings_by_user,
-    where_should_user_be_notified,
     validate,
+    where_should_user_be_notified,
 )
 from sentry.notifications.types import (
     NotificationScopeType,

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -110,3 +110,21 @@ class UserOptionsSettingsKey(Enum):
     SELF_ASSIGN = "selfAssignOnResolve"
     SUBSCRIBE_BY_DEFAULT = "subscribeByDefault"
     WORKFLOW = "workflowNotifications"
+
+
+VALID_VALUES_FOR_KEY = {
+    NotificationSettingTypes.DEPLOY: {
+        NotificationSettingOptionValues.ALWAYS,
+        NotificationSettingOptionValues.COMMITTED_ONLY,
+        NotificationSettingOptionValues.NEVER,
+    },
+    NotificationSettingTypes.ISSUE_ALERTS: {
+        NotificationSettingOptionValues.ALWAYS,
+        NotificationSettingOptionValues.NEVER,
+    },
+    NotificationSettingTypes.WORKFLOW: {
+        NotificationSettingOptionValues.ALWAYS,
+        NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+        NotificationSettingOptionValues.NEVER,
+    },
+}

--- a/tests/sentry/api/endpoints/test_project_details.py
+++ b/tests/sentry/api/endpoints/test_project_details.py
@@ -10,6 +10,9 @@ from sentry.models import (
     AuditLogEntryEvent,
     DeletedProject,
     EnvironmentProject,
+    NotificationSetting,
+    NotificationSettingOptionValues,
+    NotificationSettingTypes,
     OrganizationMember,
     OrganizationOption,
     Project,
@@ -19,8 +22,8 @@ from sentry.models import (
     ProjectStatus,
     ProjectTeam,
     Rule,
-    UserOption,
 )
+from sentry.models.integration import ExternalProviders
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers import Feature
 from sentry.utils.compat import mock, zip
@@ -373,10 +376,22 @@ class ProjectUpdateTest(APITestCase):
 
     def test_subscription(self):
         self.get_valid_response(self.org_slug, self.proj_slug, isSubscribed="true")
-        assert UserOption.objects.get(user=self.user, project=self.project).value == 1
+        value0 = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.ISSUE_ALERTS,
+            user=self.user,
+            project=self.project,
+        )
+        assert value0 == NotificationSettingOptionValues.ALWAYS
 
         self.get_valid_response(self.org_slug, self.proj_slug, isSubscribed="false")
-        assert UserOption.objects.get(user=self.user, project=self.project).value == 0
+        value1 = NotificationSetting.objects.get_settings(
+            provider=ExternalProviders.EMAIL,
+            type=NotificationSettingTypes.ISSUE_ALERTS,
+            user=self.user,
+            project=self.project,
+        )
+        assert value1 == NotificationSettingOptionValues.NEVER
 
     def test_security_token(self):
         resp = self.get_valid_response(self.org_slug, self.proj_slug, securityToken="fizzbuzz")


### PR DESCRIPTION
Before we drop the UserOption rows, let's make sure we've stopped adding new ones.