### PR TITLE
feat(demo): gamma distribution

### DIFF
--- a/src/sentry/demo/data_population.py
+++ b/src/sentry/demo/data_population.py
@@ -157,9 +157,9 @@ def gen_measurements(full_duration):
     Generate measurements that are random but based on the full duration
     """
     return {
-        "fp": {"value": duration_ms - random_normal(400, 100, 100)},
-        "fcp": {"value": duration_ms - random_normal(400, 100, 100)},
-        "lcp": {"value": duration_ms + random_normal(400, 100, 100)},
+        "fp": {"value": duration_ms * random.uniform(0.8, 0.95)},
+        "fcp": {"value": duration_ms * random.uniform(0.8, 0.95)},
+        "lcp": {"value": duration_ms * random.uniform(1.05, 1.2)},
         "fid": {"value": random_normal(5, 2, 1)},
     }
 
@@ -701,9 +701,6 @@ def iter_timestamps(disribution_fn_num: int, quick: bool, starting_release: int 
     NUM_RELEASES = config["NUM_RELEASES"]
     start_time = timezone.now() - timedelta(days=MAX_DAYS)
 
-    # ensure each event has at least on full cycle per release
-    hour_multiplier = max(1, NUM_RELEASES * 1.0 / MAX_DAYS)
-
     # offset by the release time
     hourly_release_cadence = MAX_DAYS * 24.0 / NUM_RELEASES
     start_time += timedelta(hours=hourly_release_cadence * starting_release)
@@ -715,9 +712,7 @@ def iter_timestamps(disribution_fn_num: int, quick: bool, starting_release: int 
             if end_time > timezone.now():
                 return
 
-            # need to map the hour if we have releases less than a day long
-            mapped_hour = int(hour * hour_multiplier) % 24
-            base = distribution_fn(mapped_hour)
+            base = distribution_fn(hour)
             # determine the number of events we want in this hour
             num_events = int((BASE_OFFSET + SCALE_FACTOR * base) * random.uniform(0.6, 1.0))
             timestamps = []

--- a/src/sentry/demo/settings.py
+++ b/src/sentry/demo/settings.py
@@ -38,11 +38,12 @@ DEMO_DATA_GEN_PARAMS = {
     "ERROR_BACKOFF_TIME": 0.5,  # backoff time after a snuba error
     "NUM_RELEASES": 3,
     "ORG_BUFFER_SIZE": 3,  # number of pre-populated organizations in the buffer
-    "DAY_DURATION_IMPACT": 500,  # the maximum impact of the day on the durationn
-    "DURATION_SIGMA": 600,  # the variability in durations
-    "BASE_FRONTEND_DURATION": 2000,  # the average front end duration discounting the day impact
-    "MIN_FRONTEND_DURATION": 600,  # absolute minimum duration of a FE transaction
+    "DAY_DURATION_IMPACT": 0.2,  # the maximum impact of the day on the duration as a ratio
+    "DURATION_ALPHA": 1.1,  # Alpha value in the gamma distribution
+    "DURATION_BETA": 1.1,  # Beta value in the gamma distribution
+    "MIN_FRONTEND_DURATION": 400,  # absolute minimum duration of a FE transaction in ms
     "MAX_INITIALIZATION_TIME": 60,  # number of minutes to give an organization to initialize
+    "DISABLE_SESSIONS": False,  # disables generating sessions
 }
 
 # parameters for an org when quickly generating them synchronously


### PR DESCRIPTION
In order to make load times more realistic, I switched to a gamma distribution for transaction times which gives us a longer tail for outlier events.

![Screen Shot 2021-04-08 at 4 13 25 PM](https://user-images.githubusercontent.com/8533851/114109190-9d2f5b00-9889-11eb-842a-e897d8f111f7.png)
![Screen Shot 2021-04-08 at 4 13 45 PM](https://user-images.githubusercontent.com/8533851/114109192-9dc7f180-9889-11eb-9b8d-0bcd4bf7d650.png)

I also added a switch to turn of sessions in case we have to do that because Relay is becoming too finicky