### PR TITLE
fix(workflow): Tooltip issue caused by button as link

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -120,7 +120,7 @@ class RuleListRow extends React.Component<Props, State> {
                   type="button"
                   icon={<IconSettings />}
                   title={t('Edit')}
-                  to={editLink}
+                  href={editLink}
                 />
               </ButtonBar>
             )}


### PR DESCRIPTION
Currently "edit" button tooltip is rendering in the top left area of the screen.