### PR TITLE
fix(histogram): Ensure min/max values are consistent

### DIFF
--- a/src/sentry/api/endpoints/organization_events_histogram.py
+++ b/src/sentry/api/endpoints/organization_events_histogram.py
@@ -21,6 +21,11 @@ class HistogramSerializer(serializers.Serializer):
     max = serializers.FloatField(required=False)
     dataFilter = serializers.ChoiceField(choices=DATA_FILTERS, required=False)
 
+    def validate(self, data):
+        if "min" in data and "max" in data and data["min"] > data["max"]:
+            raise serializers.ValidationError("min cannot be greater than max.")
+        return data
+
     def validate_field(self, fields):
         if len(fields) > 1:
             # Due to how the data is stored in snuba, multihistograms

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1060,6 +1060,8 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
         min_values = [row[get_function_alias(column)] for column in min_columns]
         min_values = list(filter(lambda v: v is not None, min_values))
         min_value = min(min_values) if min_values else None
+        if max_value is not None and min_value is not None:
+            min_value = min([max_value, min_value])
 
     if max_value is None:
         max_values = [row[get_function_alias(column)] for column in max_columns]

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1061,6 +1061,11 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
         min_values = list(filter(lambda v: v is not None, min_values))
         min_value = min(min_values) if min_values else None
         if max_value is not None and min_value is not None:
+            # max_value was provided by the user, and min_value was queried.
+            # If min_value > max_value, then we adjust min_value with respect to
+            # max_value. The rationale is that if the user provided max_value,
+            # then any and all data above max_value should be ignored since it is
+            # and upper bound.
             min_value = min([max_value, min_value])
 
     if max_value is None:
@@ -1095,6 +1100,10 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
         candidates = list(filter(lambda v: v is not None, candidates))
         max_value = min(candidates) if candidates else None
         if max_value is not None and min_value is not None:
+            # min_value may be either queried or provided by the user. max_value was queried.
+            # If min_value > max_value, then max_value should be adjusted with respect to
+            # min_value, since min_value is a lower bound, and any and all data below
+            # min_value should be ignored.
             max_value = max([max_value, min_value])
 
     return min_value, max_value

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -1092,6 +1092,8 @@ def find_histogram_min_max(fields, min_value, max_value, user_query, params, dat
         candidates = [max_fence_value, max_value]
         candidates = list(filter(lambda v: v is not None, candidates))
         max_value = min(candidates) if candidates else None
+        if max_value is not None and min_value is not None:
+            max_value = max([max_value, min_value])
 
     return min_value, max_value
 

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1698,6 +1698,22 @@ class QueryTransformTest(TestCase):
                 3.45,
             ), f"failing for {array_column}"
 
+            # use the given min, but query for max. the given min will be out of range
+            # of the queried max
+            mock_query.side_effect = [
+                {
+                    "meta": [{"name": f"max_{array_column}_foo"}],
+                    "data": [{f"max_{array_column}_foo": 3.45}],
+                },
+            ]
+            values = discover.find_histogram_min_max(
+                [f"{array_column}.foo"], 3.5, None, "", {"project_id": [self.project.id]}
+            )
+            assert values == (
+                3.5,
+                3.5,
+            ), f"failing for {array_column}"
+
             # use the given max, but query for min
             mock_query.side_effect = [
                 {

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1698,8 +1698,8 @@ class QueryTransformTest(TestCase):
                 3.45,
             ), f"failing for {array_column}"
 
-            # use the given min, but query for max. the given min will be out of range
-            # of the queried max
+            # use the given min, but query for max. the given min will be above
+            # the queried max
             mock_query.side_effect = [
                 {
                     "meta": [{"name": f"max_{array_column}_foo"}],

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -1714,6 +1714,22 @@ class QueryTransformTest(TestCase):
                 3.5,
             ), f"failing for {array_column}"
 
+            # use the given max, but query for min. the given max will be below
+            # the queried min
+            mock_query.side_effect = [
+                {
+                    "meta": [{"name": f"min_{array_column}_foo"}],
+                    "data": [{f"min_{array_column}_foo": 3.45}],
+                },
+            ]
+            values = discover.find_histogram_min_max(
+                [f"{array_column}.foo"], None, 3.4, "", {"project_id": [self.project.id]}
+            )
+            assert values == (
+                3.4,
+                3.4,
+            ), f"failing for {array_column}"
+
             # use the given max, but query for min
             mock_query.side_effect = [
                 {

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -99,6 +99,21 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             response = self.do_request(query)
             assert response.status_code == 200, f"failing for {array_column}"
 
+    def test_bad_params_reverse_min_max(self):
+        for array_column in ARRAY_COLUMNS:
+            query = {
+                "query": "event.type:transaction",
+                "project": [self.project.id],
+                "field": [f"{array_column}.foo", f"{array_column}.bar"],
+                "numBuckets": 10,
+                "precision": 0,
+                "min": 10,
+                "max": 5,
+            }
+
+            response = self.do_request(query)
+            assert response.data == {"non_field_errors": ["min cannot be greater than max."]}
+
     def test_bad_params_missing_fields(self):
         query = {
             "project": [self.project.id],

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -346,7 +346,7 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             ]
             assert response.data == self.as_response_data(expected), f"failing for {array_column}"
 
-    def test_histogram_simple_using_min_out_of_range_of_implicit_max(self):
+    def test_histogram_simple_using_given_min_above_queried_max(self):
         # All these events are out of range of the query parameters,
         # and should not appear in the results.
         specs = [

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -347,7 +347,8 @@ class OrganizationEventsHistogramEndpointTest(APITestCase, SnubaTestCase):
             assert response.data == self.as_response_data(expected), f"failing for {array_column}"
 
     def test_histogram_simple_using_min_out_of_range_of_implicit_max(self):
-        # range is [0, 5), so it is divided into 5 buckets of width 1
+        # All these events are out of range of the query parameters,
+        # and should not appear in the results.
         specs = [
             (0, 1, [("foo", 1)]),
             (1, 2, [("foo", 1)]),


### PR DESCRIPTION
- Add query parameter validation to ensure `min <= max`.
- If the queries `max` value is lower than a given `min` value, then normalize the `max` value to be at least `min`.


Fixes SENTRY-PHZ