### PR TITLE
fix(api): Fix N+1 queries in GroupSerializerBase._get_permalink

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -273,7 +273,9 @@ class GroupSerializerBase(Serializer):
 
         GroupMeta.objects.populate_cache(item_list)
 
-        attach_foreignkey(item_list, Group.project)
+        # Note that organization is necessary here for use in `_get_permalink` to avoid
+        # making unnecessary queries.
+        attach_foreignkey(item_list, Group.project, related=("organization",))
 
         if user.is_authenticated() and item_list:
             bookmarks = set(


### PR DESCRIPTION
`_get_permalink` accesses `group.project.organization`, which causes a query to fetch the org for
each group. We can avoid this by prefetching this as part of an existing call to `attach_foreignkey`