### PR TITLE
fix(notifications): Fix Workflow Defaults

### DIFF
--- a/src/sentry/models/groupsubscription.py
+++ b/src/sentry/models/groupsubscription.py
@@ -1,6 +1,6 @@
+from collections import defaultdict
 from typing import Any, Mapping
 
-from collections import defaultdict
 from django.conf import settings
 from django.db import IntegrityError, models, transaction
 from django.utils import timezone
@@ -13,8 +13,8 @@ from sentry.db.models import (
     sane_repr,
 )
 from sentry.notifications.helpers import (
-    where_should_be_participating,
     transform_to_notification_settings_by_user,
+    where_should_be_participating,
 )
 from sentry.notifications.types import NotificationSettingTypes
 
@@ -111,7 +111,7 @@ class GroupSubscriptionManager(BaseManager):
                 if i == 0:
                     raise e
 
-    def get_participants(self, group) -> Mapping[Any, GroupSubscriptionReason]:
+    def get_participants(self, group) -> Mapping[Any, Mapping[Any, GroupSubscriptionReason]]:
         """
         Identify all users who are participating with a given issue.
         :param group: Group object
@@ -132,8 +132,8 @@ class GroupSubscriptionManager(BaseManager):
         notification_settings_by_user = transform_to_notification_settings_by_user(
             notification_settings, users
         )
-        result = defaultdict(dict)
 
+        result = defaultdict(dict)
         for user in users:
             providers = where_should_be_participating(
                 user,

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from sentry.models.integration import ExternalProviders
 from sentry.notifications.types import (
+    NOTIFICATION_SETTING_DEFAULTS,
     VALID_VALUES_FOR_KEY,
     NotificationScopeType,
     NotificationSettingOptionValues,
@@ -28,7 +29,8 @@ def _get_setting_mapping_from_mapping(
         ) or notification_settings_mapping.get(NotificationScopeType.USER)
         if notification_setting_option:
             return notification_setting_option
-    return {ExternalProviders.EMAIL: NotificationSettingOptionValues.ALWAYS}
+
+    return {ExternalProviders.EMAIL: NOTIFICATION_SETTING_DEFAULTS[type]}
 
 
 def where_should_user_be_notified(
@@ -47,9 +49,22 @@ def where_should_user_be_notified(
         user,
         NotificationSettingTypes.ISSUE_ALERTS,
     )
-    return list(
-        filter(lambda elem: mapping[elem] == NotificationSettingOptionValues.ALWAYS, mapping)
-    )
+    return [
+        provider
+        for provider, value in mapping.items()
+        if value == NotificationSettingOptionValues.ALWAYS
+    ]
+
+
+def should_be_participating(
+    subscriptions_by_user_id: Mapping[int, Any],
+    user: Any,
+    value: NotificationSettingOptionValues,
+) -> bool:
+    subscription = subscriptions_by_user_id.get(user.id)
+    return (
+        subscription and subscription.is_active and value != NotificationSettingOptionValues.NEVER
+    ) or (not subscription and value == NotificationSettingOptionValues.ALWAYS)
 
 
 def where_should_be_participating(
@@ -72,18 +87,11 @@ def where_should_be_participating(
         user,
         NotificationSettingTypes.WORKFLOW,
     )
-    output = []
-    for provider, value in mapping.items():
-        subscription = subscriptions_by_user_id.get(user.id)
-        if (subscription and not subscription.is_active) or (
-            value == NotificationSettingOptionValues.NEVER
-        ):
-            continue
-        if (subscription and subscription.is_active) or (
-            value == NotificationSettingOptionValues.ALWAYS
-        ):
-            output.append(provider)
-    return output
+    return [
+        provider
+        for provider, value in mapping.items()
+        if should_be_participating(subscriptions_by_user_id, user, value)
+    ]
 
 
 def transform_to_notification_settings_by_user(

--- a/src/sentry/notifications/types.py
+++ b/src/sentry/notifications/types.py
@@ -128,3 +128,10 @@ VALID_VALUES_FOR_KEY = {
         NotificationSettingOptionValues.NEVER,
     },
 }
+
+
+NOTIFICATION_SETTING_DEFAULTS = {
+    NotificationSettingTypes.DEPLOY: NotificationSettingOptionValues.COMMITTED_ONLY,
+    NotificationSettingTypes.ISSUE_ALERTS: NotificationSettingOptionValues.ALWAYS,
+    NotificationSettingTypes.WORKFLOW: NotificationSettingOptionValues.SUBSCRIBE_ONLY,
+}


### PR DESCRIPTION
The logic for deciding whether a user should receive a "workflow" notification was defaulting to "always" rather than "subscribed_only". I've added a mapping from notification type to the correct default.