### PR TITLE
feat(ui): Remove stack trace analytics

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/frame/line.tsx
@@ -24,7 +24,6 @@ import space from 'app/styles/space';
 import {Frame, Organization, PlatformType, SentryAppComponent} from 'app/types';
 import {Event} from 'app/types/event';
 import {defined, objectIsEmpty} from 'app/utils';
-import {trackAnalyticsEvent} from 'app/utils/analytics';
 import withOrganization from 'app/utils/withOrganization';
 import withSentryAppComponents from 'app/utils/withSentryAppComponents';
 
@@ -93,16 +92,6 @@ export class Line extends React.Component<Props, State> {
 
   toggleContext = evt => {
     evt && evt.preventDefault();
-    const {isFirst, isHoverPreviewed, organization} = this.props;
-
-    if (isFirst && isHoverPreviewed) {
-      trackAnalyticsEvent({
-        eventKey: 'stacktrace.preview.first_frame_expand',
-        eventName: 'Stack Trace Preview: Expand First Frame',
-        organization_id: organization?.id ? parseInt(organization.id, 10) : undefined,
-        issue_id: this.props.event.groupID,
-      });
-    }
 
     this.setState({
       isExpanded: !this.state.isExpanded,

--- a/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/stacktraceContent.tsx
@@ -12,7 +12,6 @@ import {t} from 'app/locale';
 import {Frame, Organization, PlatformType} from 'app/types';
 import {Event} from 'app/types/event';
 import {StacktraceType} from 'app/types/stacktrace';
-import {trackAnalyticsEvent} from 'app/utils/analytics';
 import withOrganization from 'app/utils/withOrganization';
 
 const defaultProps = {
@@ -47,19 +46,6 @@ class StacktraceContent extends React.Component<Props, State> {
     showingAbsoluteAddresses: false,
     showCompleteFunctionName: false,
   };
-
-  componentDidMount() {
-    const {isHoverPreviewed, organization, event} = this.props;
-
-    if (isHoverPreviewed) {
-      trackAnalyticsEvent({
-        eventKey: 'stacktrace.preview.open',
-        eventName: 'Stack Trace Preview: Open',
-        organization_id: organization?.id ? parseInt(organization.id, 10) : '',
-        issue_id: event.groupID,
-      });
-    }
-  }
 
   renderOmittedFrames = (firstFrameOmitted, lastFrameOmitted) => {
     const props = {


### PR DESCRIPTION
We have the information we needed and considering how frequent these events are there's no need to leave it here and let it eat our quota.