### PR TITLE
fix(ui): Do not prevent default in stack trace preview

### DIFF
--- a/src/sentry/static/sentry/app/components/stacktracePreview.tsx
+++ b/src/sentry/static/sentry/app/components/stacktracePreview.tsx
@@ -66,7 +66,6 @@ class StacktracePreview extends React.Component<Props, State> {
 
   handleStacktracePreviewClick = (event: React.MouseEvent) => {
     event.stopPropagation();
-    event.preventDefault();
   };
 
   getStacktrace(): StacktraceType | undefined {


### PR DESCRIPTION
We do not need to prevent default anymore as we hide the actions we do not want to support in preview mode.
And we want stack trace links to work.