### PR TITLE
fix(snql) Add more sessions referrers to dry run

### DIFF
--- a/src/sentry/utils/snql.py
+++ b/src/sentry/utils/snql.py
@@ -3,7 +3,19 @@ from typing import Optional
 
 from sentry import options
 
-snql_referrers = {"sessions.stability-sort"}
+snql_referrers = {
+    "sessions.stability-sort",
+    "sessions.crash-free-breakdown",
+    "sessions.get-adoption",
+    "sessions.health-data-check",
+    "sessions.oldest-data-backfill",
+    "sessions.release-adoption-list",
+    "sessions.release-adoption-total-users-and-sessions",
+    "sessions.release-overview",
+    "sessions.release-sessions-time-bounds",
+    "sessions.release-stats",
+    "sessions.release-stats-details",
+}
 
 
 def should_use_snql(referrer: Optional[str]) -> bool:


### PR DESCRIPTION
Add more of the session referrers to the SnQL dry run. All of them are very low
volume referrers.