### PR TITLE
fix(vercel): Disable link for project dropdown

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/projectMapperField.tsx
@@ -180,6 +180,7 @@ export class RenderField extends React.Component<RenderProps, State> {
             avatarSize={20}
             displayName={project.slug}
             avatarProps={{consistentWidth: true}}
+            disableLink
           />
         </components.ValueContainer>
       );
@@ -198,6 +199,7 @@ export class RenderField extends React.Component<RenderProps, State> {
             avatarSize={20}
             displayName={project.slug}
             avatarProps={{consistentWidth: true}}
+            disableLink
           />
         </components.Option>
       );


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/24473, the project badge defaulted to linking to the project details page (which I guess previously was behind a feature flag). This breaks the Vercel integration because when someone tries to select a Sentry project for their Vercel configuration it redirects them instead of finishing the installation. 

This PR disables the link for the dropdown, but I decided to leave in the link if they have the project selected already:

> ![Screen Shot 2021-04-09 at 10 36 41 AM](https://user-images.githubusercontent.com/15368179/114219985-43c63b00-9920-11eb-86f4-58e7252921c5.png)
