### PR TITLE
feat(demo): more aggressive cleanup of demo orgs

### DIFF
--- a/src/sentry/demo/settings.py
+++ b/src/sentry/demo/settings.py
@@ -20,7 +20,7 @@ CELERYBEAT_SCHEDULE["demo_delete_users_orgs"] = {
 }
 CELERYBEAT_SCHEDULE["demo_delete_initializing_orgs"] = {
     "task": "sentry.demo.tasks.delete_initializing_orgs",
-    "schedule": timedelta(hours=1),
+    "schedule": timedelta(minutes=10),
     "options": {"expires": 3600, "queue": "cleanup"},
 }
 MIDDLEWARE_CLASSES = MIDDLEWARE_CLASSES + ("sentry.demo.middleware.DemoMiddleware",)
@@ -41,7 +41,7 @@ DEMO_DATA_GEN_PARAMS = {
     "DURATION_ALPHA": 1.1,  # Alpha value in the gamma distribution
     "DURATION_BETA": 1.1,  # Beta value in the gamma distribution
     "MIN_FRONTEND_DURATION": 400,  # absolute minimum duration of a FE transaction in ms
-    "MAX_INITIALIZATION_TIME": 60,  # number of minutes to give an organization to initialize
+    "MAX_INITIALIZATION_TIME": 30,  # number of minutes to give an organization to initialize
     "DISABLE_SESSIONS": False,  # disables generating sessions
 }
 


### PR DESCRIPTION
The average demo initialization time is around 10 minutes now so I want to reduce both the threshold time (60 minutes to 30 minutes) as well how often it runs. This way, cleanup will happen more quickly after restarting docker when orgs get stuck initializing.