### PR TITLE
feat(trace-view): Add project slug to trace view

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
@@ -6,6 +6,7 @@ import Count from 'app/components/count';
 import * as DividerHandlerManager from 'app/components/events/interfaces/spans/dividerHandlerManager';
 import * as ScrollbarManager from 'app/components/events/interfaces/spans/scrollbarManager';
 import ProjectBadge from 'app/components/idBadge/projectBadge';
+import Tooltip from 'app/components/tooltip';
 import {Organization} from 'app/types';
 import {TraceFullDetailed} from 'app/utils/performance/quickTrace/types';
 import Projects from 'app/utils/projects';
@@ -206,11 +207,13 @@ class TransactionBar extends React.Component<Props, State> {
           {({projects}) => {
             const project = projects.find(p => p.slug === transaction.project_slug);
             return (
-              <ProjectBadge
-                project={project ? project : {slug: transaction.project_slug}}
-                avatarSize={16}
-                hideName
-              />
+              <Tooltip title={transaction.project_slug}>
+                <ProjectBadge
+                  project={project ? project : {slug: transaction.project_slug}}
+                  avatarSize={16}
+                  hideName
+                />
+              </Tooltip>
             );
           }}
         </Projects>

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/transactionDetail.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/transactionDetail.tsx
@@ -203,6 +203,7 @@ class TransactionDetail extends React.Component<Props> {
               {transaction.transaction}
             </Row>
             <Row title="Transaction Status">{transaction['transaction.status']}</Row>
+            <Row title="Project">{transaction.project_slug}</Row>
             <Row title="Start Date">
               {getDynamicText({
                 fixed: 'Mar 19, 2021 11:06:27 AM UTC',


### PR DESCRIPTION
This adds the project slug to the expanded transaction details and when hovering
over the project badge.