### PR TITLE
feat(trace-view): Add flame icons to transactions with errors

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
@@ -9,7 +9,7 @@ import {SpanRow} from 'app/components/events/interfaces/spans/styles';
 import {Panel} from 'app/components/panels';
 import Pills from 'app/components/pills';
 import SearchBar from 'app/components/searchBar';
-import {IconChevron} from 'app/icons';
+import {IconChevron, IconFire} from 'app/icons';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {defined} from 'app/utils';
@@ -110,6 +110,33 @@ export const TransactionBarTitle = styled(SpanBarTitle)`
 export const TransactionBarTitleContent = styled('span')`
   margin-left: ${space(0.75)};
 `;
+
+export const DividerContainer = styled('div')`
+  position: relative;
+`;
+
+const BadgeBorder = styled('div')<{showDetail: boolean}>`
+  position: absolute;
+  margin: ${space(0.25)};
+  left: -11.5px;
+  background: ${p => (p.showDetail ? p.theme.textColor : p.theme.background)};
+  width: ${space(3)};
+  height: ${space(3)};
+  border: 1px solid ${p => p.theme.red300};
+  border-radius: 50%;
+  z-index: ${p => p.theme.zIndex.traceView.dividerLine};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export function ErrorBadge({showDetail}: {showDetail: boolean}) {
+  return (
+    <BadgeBorder showDetail={showDetail}>
+      <IconFire color="red300" size="xs" />
+    </BadgeBorder>
+  );
+}
 
 const StyledPills = styled(Pills)`
   padding-top: ${space(1.5)};

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/transactionBar.tsx
@@ -13,9 +13,11 @@ import {Theme} from 'app/utils/theme';
 
 import {
   ConnectorBar,
+  DividerContainer,
   DividerLine,
   DividerLineGhostContainer,
   DurationPill,
+  ErrorBadge,
   OperationName,
   StyledIconChevron,
   TRANSACTION_ROW_HEIGHT,
@@ -258,7 +260,7 @@ class TransactionBar extends React.Component<Props, State> {
         <DividerLine
           showDetail
           style={{
-            position: 'relative',
+            position: 'absolute',
           }}
         />
       );
@@ -270,7 +272,7 @@ class TransactionBar extends React.Component<Props, State> {
       <DividerLine
         ref={addDividerLineRef()}
         style={{
-          position: 'relative',
+          position: 'absolute',
         }}
         onMouseEnter={() => {
           dividerHandlerChildrenProps.setHover(true);
@@ -318,6 +320,17 @@ class TransactionBar extends React.Component<Props, State> {
         />
       </DividerLineGhostContainer>
     );
+  }
+
+  renderErrorBadge() {
+    const {transaction} = this.props;
+    const {showDetail} = this.state;
+
+    if (!isTraceFullDetailed(transaction) || !transaction.errors.length) {
+      return null;
+    }
+
+    return <ErrorBadge showDetail={showDetail} />;
   }
 
   renderRectangle() {
@@ -382,7 +395,10 @@ class TransactionBar extends React.Component<Props, State> {
         >
           {this.renderTitle(scrollbarManagerChildrenProps)}
         </TransactionRowCell>
-        {this.renderDivider(dividerHandlerChildrenProps)}
+        <DividerContainer>
+          {this.renderDivider(dividerHandlerChildrenProps)}
+          {this.renderErrorBadge()}
+        </DividerContainer>
         <TransactionRowCell
           data-type="span-row-cell"
           showStriping={index % 2 !== 0}


### PR DESCRIPTION
Currently, the only visual indication that a transaction has errors associated
with is the red text. This change adds a red flame icon to the row to make that
more obvious.

# Screenshots

![image](https://user-images.githubusercontent.com/10239353/114242711-5ad54f00-9959-11eb-898a-6c1859fe3fb3.png)

![image](https://user-images.githubusercontent.com/10239353/114242699-56109b00-9959-11eb-9e3e-36bf8604b6a8.png)
