### PR TITLE
feat(trace-view): Link docs for missing services

### DIFF
--- a/src/sentry/static/sentry/app/components/quickTrace/index.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/index.tsx
@@ -168,7 +168,7 @@ export default function QuickTrace({
         {({projects}) => {
           const project = projects.find(p => p.slug === current.project_slug);
           if (project?.platform) {
-            if (BACKEND_PLATFORMS.includes(project.platform as string))
+            if (BACKEND_PLATFORMS.includes(project.platform as string)) {
               return (
                 <React.Fragment>
                   <MissingServiceNode
@@ -180,7 +180,7 @@ export default function QuickTrace({
                   {currentNode}
                 </React.Fragment>
               );
-            else if (FRONTEND_PLATFORMS.includes(project.platform as string))
+            } else if (FRONTEND_PLATFORMS.includes(project.platform as string)) {
               return (
                 <React.Fragment>
                   {currentNode}
@@ -192,6 +192,7 @@ export default function QuickTrace({
                   />
                 </React.Fragment>
               );
+            }
           }
           return currentNode;
         }}

--- a/src/sentry/static/sentry/app/components/quickTrace/index.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/index.tsx
@@ -503,10 +503,17 @@ type MissingServiceState = {
 };
 
 const HIDE_MISSING_SERVICE_KEY = 'quick-trace:hide-missing-services';
+// 30 days
+const HIDE_MISSING_EXPIRES = 1000 * 60 * 60 * 24 * 30;
 
-function readMissingServiceState() {
+function readHideMissingServiceState() {
   const value = localStorage.getItem(HIDE_MISSING_SERVICE_KEY);
-  return value === '1';
+  if (value === null) {
+    return false;
+  }
+  const expires = parseInt(value, 10);
+  const now = new Date().getTime();
+  return expires > now;
 }
 
 class MissingServiceNode extends React.Component<
@@ -514,12 +521,16 @@ class MissingServiceNode extends React.Component<
   MissingServiceState
 > {
   state: MissingServiceState = {
-    hideMissing: readMissingServiceState(),
+    hideMissing: readHideMissingServiceState(),
   };
 
   dismissMissingService = () => {
     const {organization} = this.props;
-    localStorage.setItem(HIDE_MISSING_SERVICE_KEY, '1');
+    const now = new Date().getTime();
+    localStorage.setItem(
+      HIDE_MISSING_SERVICE_KEY,
+      (now + HIDE_MISSING_EXPIRES).toString()
+    );
     this.setState({hideMissing: true});
     trackAnalyticsEvent({
       eventKey: 'quick_trace.hide.missing-service',

--- a/src/sentry/static/sentry/app/components/quickTrace/index.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/index.tsx
@@ -536,7 +536,7 @@ class MissingServiceNode extends React.Component<
     );
     this.setState({hideMissing: true});
     trackAnalyticsEvent({
-      eventKey: 'quick_trace.missing-service.dismiss',
+      eventKey: 'quick_trace.missing_service.dismiss',
       eventName: 'Quick Trace: Missing Service Dismissed',
       organization_id: parseInt(organization.id, 10),
       platform,
@@ -546,7 +546,7 @@ class MissingServiceNode extends React.Component<
   trackExternalLink = () => {
     const {organization, platform} = this.props;
     trackAnalyticsEvent({
-      eventKey: 'quick_trace.missing-service.docs',
+      eventKey: 'quick_trace.missing_service.docs',
       eventName: 'Quick Trace: Missing Service Clicked',
       organization_id: parseInt(organization.id, 10),
       platform,

--- a/src/sentry/static/sentry/app/components/quickTrace/styles.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/styles.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {LocationDescriptor} from 'history';
 
+import ExternalLink from 'app/components/links/externalLink';
 import MenuItem from 'app/components/menuItem';
 import Tag, {Background} from 'app/components/tag';
 import Truncate from 'app/components/truncate';
@@ -60,9 +61,9 @@ export const TraceConnector = styled('div')`
   border-top: 1px solid ${p => p.theme.textColor};
 `;
 
-const StyledMenuItem = styled(MenuItem)<{first?: boolean}>`
+const StyledMenuItem = styled(MenuItem)<{first?: boolean; width: 'small' | 'large'}>`
   border-top: ${p => (!p.first ? `1px solid ${p.theme.innerBorder}` : null)};
-  width: 350px;
+  width: ${p => (p.width === 'large' ? '350px' : '200px')};
 `;
 
 const MenuItemContent = styled('div')`
@@ -76,11 +77,18 @@ type DropdownItemProps = {
   to?: string | LocationDescriptor;
   onSelect?: (eventKey: any) => void;
   first?: boolean;
+  width?: 'small' | 'large';
 };
 
-export function DropdownItem({children, first, onSelect, to}: DropdownItemProps) {
+export function DropdownItem({
+  children,
+  first,
+  onSelect,
+  to,
+  width = 'large',
+}: DropdownItemProps) {
   return (
-    <StyledMenuItem to={to} onSelect={onSelect} first={first}>
+    <StyledMenuItem to={to} onSelect={onSelect} first={first} width={width}>
       <MenuItemContent>{children}</MenuItemContent>
     </StyledMenuItem>
   );
@@ -104,6 +112,15 @@ export const ErrorNodeContent = styled('div')`
   grid-template-columns: repeat(2, auto);
   grid-gap: ${space(0.25)};
   align-items: center;
+`;
+
+export const ExternalDropdownLink = styled(ExternalLink)`
+  display: inherit !important;
+  padding: 0 !important;
+  color: ${p => p.theme.textColor};
+  &:hover {
+    color: ${p => p.theme.textColor};
+  }
 `;
 
 export function SingleEventHoverText({event}: {event: QuickTraceEvent}) {


### PR DESCRIPTION
- This replaces an earlier attempt from https://github.com/getsentry/sentry/pull/25055
- This adds a new (???) node to quick trace when we think that there's
  probably a service that isn't being instrumented by Sentry
- This only shows up when the trace has exactly one transaction, and a
  platform recognized as backend or frontend
  - for Frontend services we show a (???) node in the cild spot
  - for Backend services we show a (???) node in the parent spot
- The dropdown has a dismiss that is permanent per user, we can probably
  change the key if we decide we want to start showing this again after
  EA or when we add more methods for determining missing services
  
## Preview:
- For an "angular" service
![image](https://user-images.githubusercontent.com/4205004/114246829-a25fd900-9961-11eb-9c6b-e14dacbd3954.png)
- For a ".NET" service
![image](https://user-images.githubusercontent.com/4205004/114246857-b9063000-9961-11eb-9e13-db6ab8a2ca9a.png)
