### PR TITLE
 feat(breakdowns): Rename span_op_breakdowns.key to spans.key field

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -23,6 +23,8 @@ from sentry.utils.snuba import (
     SNUBA_OR,
     Dataset,
     SnubaTSResult,
+    get_array_column_alias,
+    get_array_column_field,
     get_measurement_name,
     get_span_op_breakdown_name,
     is_measurement,
@@ -1155,7 +1157,11 @@ def normalize_histogram_results(fields, key_column, histogram_params, results, a
     for row in results["data"]:
         # Fall back to the first field name if there is no `key_name`,
         # otherwise, this is an array value name and format it as such.
-        key = fields[0] if key_name is None else f"{array_column}.{row[key_name]}"
+        key = (
+            fields[0]
+            if key_name is None
+            else f"{get_array_column_alias(array_column)}.{get_array_column_field(array_column, row[key_name])}"
+        )
         # we expect the bin the be an integer, this is because all floating
         # point values are rounded during the calculation
         bucket = int(row[bin_name])

--- a/src/sentry/static/sentry/app/utils/discover/fields.tsx
+++ b/src/sentry/static/sentry/app/utils/discover/fields.tsx
@@ -574,7 +574,7 @@ export const TRACING_FIELDS = [
 ];
 
 export const MEASUREMENT_PATTERN = /^measurements\.([a-zA-Z0-9-_.]+)$/;
-export const SPAN_OP_BREAKDOWN_PATTERN = /^span_op_breakdowns\.ops\.([a-zA-Z0-9-_.]+)$/;
+export const SPAN_OP_BREAKDOWN_PATTERN = /^spans\.([a-zA-Z0-9-_.]+)$/;
 
 export function isMeasurement(field: string): boolean {
   const results = field.match(MEASUREMENT_PATTERN);
@@ -819,7 +819,7 @@ export function isLegalYAxisType(match: ColumnType) {
 }
 
 export function isSpanOperationBreakdownField(field: string) {
-  return field.startsWith('span_op_breakdowns.');
+  return field.startsWith('spans.');
 }
 
 export function getSpanOperationName(field: string): string | null {

--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
@@ -228,7 +228,7 @@ export function filterToField(option: SpanOperationBreakdownFilter) {
     case SpanOperationBreakdownFilter.None:
       return undefined;
     default: {
-      return `span_op_breakdowns.ops.${option}`;
+      return `spans.${option}`;
     }
   }
 }

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -62,7 +62,7 @@ def test_get_json_meta_type():
     assert get_json_meta_type("count_thing", "Nullable(String)") == "string"
     assert get_json_meta_type("measurements.size", "Float64") == "number"
     assert get_json_meta_type("measurements.fp", "Float64") == "duration"
-    assert get_json_meta_type("spans.ops.browser", "Float64") == "duration"
+    assert get_json_meta_type("spans.browser", "Float64") == "duration"
     assert get_json_meta_type("spans.total.time", "Float64") == "duration"
     assert (
         get_json_meta_type(
@@ -126,9 +126,9 @@ def test_parse_function():
         None,
     )
     assert parse_function("p75(measurements.lcp)") == ("p75", ["measurements.lcp"], None)
-    assert parse_function("p75(spans.ops.http)") == (
+    assert parse_function("p75(spans.http)") == (
         "p75",
-        ["spans.ops.http"],
+        ["spans.http"],
         None,
     )
     assert parse_function("apdex(300)") == ("apdex", ["300"], None)
@@ -1195,41 +1195,41 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
     def test_numeric_aggregate_op_breakdowns_filter(self):
-        assert parse_search_query("min(spans.ops.browser):3.1415") == [
+        assert parse_search_query("min(spans.browser):3.1415") == [
             SearchFilter(
-                key=SearchKey(name="min(spans.ops.browser)"),
+                key=SearchKey(name="min(spans.browser)"),
                 operator="=",
                 value=SearchValue(raw_value=3.1415),
             )
         ]
 
-        assert parse_search_query("min(spans.ops.browser):>3.1415") == [
+        assert parse_search_query("min(spans.browser):>3.1415") == [
             SearchFilter(
-                key=SearchKey(name="min(spans.ops.browser)"),
+                key=SearchKey(name="min(spans.browser)"),
                 operator=">",
                 value=SearchValue(raw_value=3.1415),
             )
         ]
 
-        assert parse_search_query("min(spans.ops.browser):<3.1415") == [
+        assert parse_search_query("min(spans.browser):<3.1415") == [
             SearchFilter(
-                key=SearchKey(name="min(spans.ops.browser)"),
+                key=SearchKey(name="min(spans.browser)"),
                 operator="<",
                 value=SearchValue(raw_value=3.1415),
             )
         ]
 
-        assert parse_search_query("min(spans.ops.browser):<3k") == [
+        assert parse_search_query("min(spans.browser):<3k") == [
             SearchFilter(
-                key=SearchKey(name="min(spans.ops.browser)"),
+                key=SearchKey(name="min(spans.browser)"),
                 operator="<",
                 value=SearchValue(raw_value=3000.0),
             )
         ]
 
-        assert parse_search_query("min(spans.ops.browser):2m") == [
+        assert parse_search_query("min(spans.browser):2m") == [
             SearchFilter(
-                key=SearchKey(name="min(spans.ops.browser)"),
+                key=SearchKey(name="min(spans.browser)"),
                 operator="=",
                 value=SearchValue(raw_value=120000.0),
             )
@@ -1267,25 +1267,25 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
     def test_duration_op_breakdowns_filter(self):
-        assert parse_search_query("spans.ops.browser:1.5s") == [
+        assert parse_search_query("spans.browser:1.5s") == [
             SearchFilter(
-                key=SearchKey(name="spans.ops.browser"),
+                key=SearchKey(name="spans.browser"),
                 operator="=",
                 value=SearchValue(raw_value=1500),
             )
         ]
 
-        assert parse_search_query("spans.ops.browser:>1.5s") == [
+        assert parse_search_query("spans.browser:>1.5s") == [
             SearchFilter(
-                key=SearchKey(name="spans.ops.browser"),
+                key=SearchKey(name="spans.browser"),
                 operator=">",
                 value=SearchValue(raw_value=1500),
             )
         ]
 
-        assert parse_search_query("spans.ops.browser:<1.5s") == [
+        assert parse_search_query("spans.browser:<1.5s") == [
             SearchFilter(
-                key=SearchKey(name="spans.ops.browser"),
+                key=SearchKey(name="spans.browser"),
                 operator="<",
                 value=SearchValue(raw_value=1500),
             )
@@ -1317,25 +1317,25 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
     def test_duration_aggregate_op_breakdowns_filter(self):
-        assert parse_search_query("percentile(spans.ops.browser, 0.5):3.3s") == [
+        assert parse_search_query("percentile(spans.browser, 0.5):3.3s") == [
             SearchFilter(
-                key=SearchKey(name="percentile(spans.ops.browser, 0.5)"),
+                key=SearchKey(name="percentile(spans.browser, 0.5)"),
                 operator="=",
                 value=SearchValue(raw_value=3300),
             )
         ]
 
-        assert parse_search_query("percentile(spans.ops.browser, 0.5):>3.3s") == [
+        assert parse_search_query("percentile(spans.browser, 0.5):>3.3s") == [
             SearchFilter(
-                key=SearchKey(name="percentile(spans.ops.browser, 0.5)"),
+                key=SearchKey(name="percentile(spans.browser, 0.5)"),
                 operator=">",
                 value=SearchValue(raw_value=3300),
             )
         ]
 
-        assert parse_search_query("percentile(spans.ops.browser, 0.5):<3.3s") == [
+        assert parse_search_query("percentile(spans.browser, 0.5):<3.3s") == [
             SearchFilter(
-                key=SearchKey(name="percentile(spans.ops.browser, 0.5)"),
+                key=SearchKey(name="percentile(spans.browser, 0.5)"),
                 operator="<",
                 value=SearchValue(raw_value=3300),
             )
@@ -2968,7 +2968,7 @@ class ResolveFieldListTest(unittest.TestCase):
     def test_stddev_function(self):
         fields = [
             "stddev(measurements.fcp)",
-            "stddev(spans.ops.browser)",
+            "stddev(spans.browser)",
             "stddev(transaction.duration)",
         ]
         result = resolve_field_list(fields, eventstore.Filter())
@@ -2976,8 +2976,8 @@ class ResolveFieldListTest(unittest.TestCase):
             ["stddevSamp", "measurements.fcp", "stddev_measurements_fcp"],
             [
                 "stddevSamp",
-                "spans.ops.browser",
-                "stddev_spans_ops_browser",
+                "spans.browser",
+                "stddev_spans_browser",
             ],
             ["stddevSamp", "transaction.duration", "stddev_transaction_duration"],
         ]
@@ -3479,7 +3479,7 @@ class ResolveFieldListTest(unittest.TestCase):
             "measurements.lcp",
             "measurements.fid",
             "measurements.bar",
-            "spans.ops.browser",
+            "spans.browser",
         ]
 
         for column in columns:
@@ -3661,7 +3661,7 @@ class ResolveFieldListTest(unittest.TestCase):
             "avg(measurements.foo)",
             "percentile(measurements.fcp, 0.5)",
             "stddev(measurements.foo)",
-            "percentile(spans.ops.browser, 0.5)",
+            "percentile(spans.browser, 0.5)",
             "avg(spans.total.time)",
         ]
         result = resolve_field_list(fields, eventstore.Filter())
@@ -3688,9 +3688,9 @@ class ResolveFieldListTest(unittest.TestCase):
         assert functions["stddev_measurements_foo"].instance.name == "stddev"
         assert functions["stddev_measurements_foo"].arguments == {"column": "measurements.foo"}
 
-        assert functions["percentile_spans_ops_browser_0_5"].instance.name == "percentile"
-        assert functions["percentile_spans_ops_browser_0_5"].arguments == {
-            "column": "spans.ops.browser",
+        assert functions["percentile_spans_browser_0_5"].instance.name == "percentile"
+        assert functions["percentile_spans_browser_0_5"].arguments == {
+            "column": "spans.browser",
             "percentile": 0.5,
         }
 
@@ -3811,13 +3811,13 @@ class ResolveFieldListTest(unittest.TestCase):
             ["last_seen()", "timestamp"],
             ["avg(measurements.lcp)", "measurements.lcp"],
             ["stddev(measurements.lcp)", "measurements.lcp"],
-            ["avg(spans.ops.browser)", "spans.ops.browser"],
-            ["stddev(spans.ops.browser)", "spans.ops.browser"],
+            ["avg(spans.browser)", "spans.browser"],
+            ["stddev(spans.browser)", "spans.browser"],
             ["min(timestamp)", "timestamp"],
             ["max(timestamp)", "timestamp"],
             ["p95()", "transaction.duration"],
             ["any(measurements.fcp)", "measurements.fcp"],
-            ["any(spans.ops.browser)", "spans.ops.browser"],
+            ["any(spans.browser)", "spans.browser"],
         ]
         for field in fields:
             with pytest.raises(InvalidSearchQuery) as error:

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -62,8 +62,8 @@ def test_get_json_meta_type():
     assert get_json_meta_type("count_thing", "Nullable(String)") == "string"
     assert get_json_meta_type("measurements.size", "Float64") == "number"
     assert get_json_meta_type("measurements.fp", "Float64") == "duration"
-    assert get_json_meta_type("span_op_breakdowns.ops.browser", "Float64") == "duration"
-    assert get_json_meta_type("span_op_breakdowns.total.time", "Float64") == "duration"
+    assert get_json_meta_type("spans.ops.browser", "Float64") == "duration"
+    assert get_json_meta_type("spans.total.time", "Float64") == "duration"
     assert (
         get_json_meta_type(
             "percentile_measurements_fp_0_5",
@@ -90,24 +90,24 @@ def test_get_json_meta_type():
     )
     assert (
         get_json_meta_type(
-            "percentile_span_op_breakdowns_fp_0_5",
+            "percentile_spans_fp_0_5",
             "Nullable(Float64)",
             FunctionDetails(
-                "percentile(span_op_breakdowns.fp, 0.5)",
+                "percentile(spans.fp, 0.5)",
                 FUNCTIONS["percentile"],
-                {"column": "span_op_breakdowns.fp", "percentile": 0.5},
+                {"column": "spans.fp", "percentile": 0.5},
             ),
         )
         == "duration"
     )
     assert (
         get_json_meta_type(
-            "percentile_span_op_breakdowns_foo_0_5",
+            "percentile_spans_foo_0_5",
             "Nullable(Float64)",
             FunctionDetails(
-                "percentile(span_op_breakdowns.foo, 0.5)",
+                "percentile(spans.foo, 0.5)",
                 FUNCTIONS["percentile"],
-                {"column": "span_op_breakdowns.foo", "percentile": 0.5},
+                {"column": "spans.foo", "percentile": 0.5},
             ),
         )
         == "duration"
@@ -126,9 +126,9 @@ def test_parse_function():
         None,
     )
     assert parse_function("p75(measurements.lcp)") == ("p75", ["measurements.lcp"], None)
-    assert parse_function("p75(span_op_breakdowns.ops.http)") == (
+    assert parse_function("p75(spans.ops.http)") == (
         "p75",
-        ["span_op_breakdowns.ops.http"],
+        ["spans.ops.http"],
         None,
     )
     assert parse_function("apdex(300)") == ("apdex", ["300"], None)
@@ -138,9 +138,9 @@ def test_parse_function():
         ["measurements_value", "1", "0", "1"],
         None,
     )
-    assert parse_function("histogram(span_op_breakdowns_value, 1,0,1)") == (
+    assert parse_function("histogram(spans_value, 1,0,1)") == (
         "histogram",
-        ["span_op_breakdowns_value", "1", "0", "1"],
+        ["spans_value", "1", "0", "1"],
         None,
     )
     assert parse_function("count_unique(transaction.status)") == (
@@ -1195,41 +1195,41 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
     def test_numeric_aggregate_op_breakdowns_filter(self):
-        assert parse_search_query("min(span_op_breakdowns.ops.browser):3.1415") == [
+        assert parse_search_query("min(spans.ops.browser):3.1415") == [
             SearchFilter(
-                key=SearchKey(name="min(span_op_breakdowns.ops.browser)"),
+                key=SearchKey(name="min(spans.ops.browser)"),
                 operator="=",
                 value=SearchValue(raw_value=3.1415),
             )
         ]
 
-        assert parse_search_query("min(span_op_breakdowns.ops.browser):>3.1415") == [
+        assert parse_search_query("min(spans.ops.browser):>3.1415") == [
             SearchFilter(
-                key=SearchKey(name="min(span_op_breakdowns.ops.browser)"),
+                key=SearchKey(name="min(spans.ops.browser)"),
                 operator=">",
                 value=SearchValue(raw_value=3.1415),
             )
         ]
 
-        assert parse_search_query("min(span_op_breakdowns.ops.browser):<3.1415") == [
+        assert parse_search_query("min(spans.ops.browser):<3.1415") == [
             SearchFilter(
-                key=SearchKey(name="min(span_op_breakdowns.ops.browser)"),
+                key=SearchKey(name="min(spans.ops.browser)"),
                 operator="<",
                 value=SearchValue(raw_value=3.1415),
             )
         ]
 
-        assert parse_search_query("min(span_op_breakdowns.ops.browser):<3k") == [
+        assert parse_search_query("min(spans.ops.browser):<3k") == [
             SearchFilter(
-                key=SearchKey(name="min(span_op_breakdowns.ops.browser)"),
+                key=SearchKey(name="min(spans.ops.browser)"),
                 operator="<",
                 value=SearchValue(raw_value=3000.0),
             )
         ]
 
-        assert parse_search_query("min(span_op_breakdowns.ops.browser):2m") == [
+        assert parse_search_query("min(spans.ops.browser):2m") == [
             SearchFilter(
-                key=SearchKey(name="min(span_op_breakdowns.ops.browser)"),
+                key=SearchKey(name="min(spans.ops.browser)"),
                 operator="=",
                 value=SearchValue(raw_value=120000.0),
             )
@@ -1267,25 +1267,25 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
     def test_duration_op_breakdowns_filter(self):
-        assert parse_search_query("span_op_breakdowns.ops.browser:1.5s") == [
+        assert parse_search_query("spans.ops.browser:1.5s") == [
             SearchFilter(
-                key=SearchKey(name="span_op_breakdowns.ops.browser"),
+                key=SearchKey(name="spans.ops.browser"),
                 operator="=",
                 value=SearchValue(raw_value=1500),
             )
         ]
 
-        assert parse_search_query("span_op_breakdowns.ops.browser:>1.5s") == [
+        assert parse_search_query("spans.ops.browser:>1.5s") == [
             SearchFilter(
-                key=SearchKey(name="span_op_breakdowns.ops.browser"),
+                key=SearchKey(name="spans.ops.browser"),
                 operator=">",
                 value=SearchValue(raw_value=1500),
             )
         ]
 
-        assert parse_search_query("span_op_breakdowns.ops.browser:<1.5s") == [
+        assert parse_search_query("spans.ops.browser:<1.5s") == [
             SearchFilter(
-                key=SearchKey(name="span_op_breakdowns.ops.browser"),
+                key=SearchKey(name="spans.ops.browser"),
                 operator="<",
                 value=SearchValue(raw_value=1500),
             )
@@ -1317,25 +1317,25 @@ class ParseSearchQueryTest(unittest.TestCase):
         ]
 
     def test_duration_aggregate_op_breakdowns_filter(self):
-        assert parse_search_query("percentile(span_op_breakdowns.ops.browser, 0.5):3.3s") == [
+        assert parse_search_query("percentile(spans.ops.browser, 0.5):3.3s") == [
             SearchFilter(
-                key=SearchKey(name="percentile(span_op_breakdowns.ops.browser, 0.5)"),
+                key=SearchKey(name="percentile(spans.ops.browser, 0.5)"),
                 operator="=",
                 value=SearchValue(raw_value=3300),
             )
         ]
 
-        assert parse_search_query("percentile(span_op_breakdowns.ops.browser, 0.5):>3.3s") == [
+        assert parse_search_query("percentile(spans.ops.browser, 0.5):>3.3s") == [
             SearchFilter(
-                key=SearchKey(name="percentile(span_op_breakdowns.ops.browser, 0.5)"),
+                key=SearchKey(name="percentile(spans.ops.browser, 0.5)"),
                 operator=">",
                 value=SearchValue(raw_value=3300),
             )
         ]
 
-        assert parse_search_query("percentile(span_op_breakdowns.ops.browser, 0.5):<3.3s") == [
+        assert parse_search_query("percentile(spans.ops.browser, 0.5):<3.3s") == [
             SearchFilter(
-                key=SearchKey(name="percentile(span_op_breakdowns.ops.browser, 0.5)"),
+                key=SearchKey(name="percentile(spans.ops.browser, 0.5)"),
                 operator="<",
                 value=SearchValue(raw_value=3300),
             )
@@ -2968,7 +2968,7 @@ class ResolveFieldListTest(unittest.TestCase):
     def test_stddev_function(self):
         fields = [
             "stddev(measurements.fcp)",
-            "stddev(span_op_breakdowns.ops.browser)",
+            "stddev(spans.ops.browser)",
             "stddev(transaction.duration)",
         ]
         result = resolve_field_list(fields, eventstore.Filter())
@@ -2976,8 +2976,8 @@ class ResolveFieldListTest(unittest.TestCase):
             ["stddevSamp", "measurements.fcp", "stddev_measurements_fcp"],
             [
                 "stddevSamp",
-                "span_op_breakdowns.ops.browser",
-                "stddev_span_op_breakdowns_ops_browser",
+                "spans.ops.browser",
+                "stddev_spans_ops_browser",
             ],
             ["stddevSamp", "transaction.duration", "stddev_transaction_duration"],
         ]
@@ -3479,7 +3479,7 @@ class ResolveFieldListTest(unittest.TestCase):
             "measurements.lcp",
             "measurements.fid",
             "measurements.bar",
-            "span_op_breakdowns.ops.browser",
+            "spans.ops.browser",
         ]
 
         for column in columns:
@@ -3661,8 +3661,8 @@ class ResolveFieldListTest(unittest.TestCase):
             "avg(measurements.foo)",
             "percentile(measurements.fcp, 0.5)",
             "stddev(measurements.foo)",
-            "percentile(span_op_breakdowns.ops.browser, 0.5)",
-            "avg(span_op_breakdowns.total.time)",
+            "percentile(spans.ops.browser, 0.5)",
+            "avg(spans.total.time)",
         ]
         result = resolve_field_list(fields, eventstore.Filter())
         functions = result["functions"]
@@ -3688,18 +3688,14 @@ class ResolveFieldListTest(unittest.TestCase):
         assert functions["stddev_measurements_foo"].instance.name == "stddev"
         assert functions["stddev_measurements_foo"].arguments == {"column": "measurements.foo"}
 
-        assert (
-            functions["percentile_span_op_breakdowns_ops_browser_0_5"].instance.name == "percentile"
-        )
-        assert functions["percentile_span_op_breakdowns_ops_browser_0_5"].arguments == {
-            "column": "span_op_breakdowns.ops.browser",
+        assert functions["percentile_spans_ops_browser_0_5"].instance.name == "percentile"
+        assert functions["percentile_spans_ops_browser_0_5"].arguments == {
+            "column": "spans.ops.browser",
             "percentile": 0.5,
         }
 
-        assert functions["avg_span_op_breakdowns_total_time"].instance.name == "avg"
-        assert functions["avg_span_op_breakdowns_total_time"].arguments == {
-            "column": "span_op_breakdowns.total.time"
-        }
+        assert functions["avg_spans_total_time"].instance.name == "avg"
+        assert functions["avg_spans_total_time"].arguments == {"column": "spans.total.time"}
 
     def test_to_other_function_basic(self):
         fields = [
@@ -3815,13 +3811,13 @@ class ResolveFieldListTest(unittest.TestCase):
             ["last_seen()", "timestamp"],
             ["avg(measurements.lcp)", "measurements.lcp"],
             ["stddev(measurements.lcp)", "measurements.lcp"],
-            ["avg(span_op_breakdowns.ops.browser)", "span_op_breakdowns.ops.browser"],
-            ["stddev(span_op_breakdowns.ops.browser)", "span_op_breakdowns.ops.browser"],
+            ["avg(spans.ops.browser)", "spans.ops.browser"],
+            ["stddev(spans.ops.browser)", "spans.ops.browser"],
             ["min(timestamp)", "timestamp"],
             ["max(timestamp)", "timestamp"],
             ["p95()", "transaction.duration"],
             ["any(measurements.fcp)", "measurements.fcp"],
-            ["any(span_op_breakdowns.ops.browser)", "span_op_breakdowns.ops.browser"],
+            ["any(spans.ops.browser)", "spans.ops.browser"],
         ]
         for field in fields:
             with pytest.raises(InvalidSearchQuery) as error:

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -8,7 +8,7 @@ from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils.compat.mock import patch
 from sentry.utils.samples import load_data
-from sentry.utils.snuba import Dataset
+from sentry.utils.snuba import Dataset, get_array_column_alias
 
 ARRAY_COLUMNS = ["measurements", "span_op_breakdowns"]
 
@@ -560,7 +560,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
             selected_columns=[
                 "p50(measurements.lcp)",
                 "p50(measurements.foo)",
-                "p50(span_op_breakdowns.foo)",
+                "p50(spans.foo)",
             ],
             query="event.type:transaction",
             params={"project_id": [self.project.id]},
@@ -570,7 +570,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         assert results["meta"] == {
             "p50_measurements_lcp": "duration",
             "p50_measurements_foo": "number",
-            "p50_span_op_breakdowns_foo": "duration",
+            "p50_spans_foo": "duration",
         }
 
 
@@ -1648,17 +1648,18 @@ class QueryTransformTest(TestCase):
     @patch("sentry.snuba.discover.raw_query")
     def test_find_histogram_min_max(self, mock_query):
         for array_column in ARRAY_COLUMNS:
+            alias = get_array_column_alias(array_column)
             # no rows returned from snuba
             mock_query.side_effect = [{"meta": [], "data": []}]
             values = discover.find_histogram_min_max(
-                [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
+                [f"{alias}.foo"], None, None, "", {"project_id": [self.project.id]}
             )
             assert values == (None, None), f"failing for {array_column}"
 
             # more than 2 rows returned snuba
             mock_query.side_effect = [{"meta": [], "data": [{}, {}]}]
             values = discover.find_histogram_min_max(
-                [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
+                [f"{alias}.foo"], None, None, "", {"project_id": [self.project.id]}
             )
             assert values == (None, None), f"failing for {array_column}"
 
@@ -1666,32 +1667,32 @@ class QueryTransformTest(TestCase):
             mock_query.side_effect = [
                 {
                     "meta": [
-                        {"name": f"min_{array_column}_foo"},
-                        {"name": f"max_{array_column}_foo"},
+                        {"name": f"min_{alias}_foo"},
+                        {"name": f"max_{alias}_foo"},
                     ],
-                    "data": [{f"min_{array_column}_foo": None, f"max_{array_column}_foo": None}],
+                    "data": [{f"min_{alias}_foo": None, f"max_{alias}_foo": None}],
                 },
             ]
             values = discover.find_histogram_min_max(
-                [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
+                [f"{alias}.foo"], None, None, "", {"project_id": [self.project.id]}
             )
             assert values == (None, None), f"failing for {array_column}"
 
             # use the given min/max
             values = discover.find_histogram_min_max(
-                [f"{array_column}.foo"], 1, 2, "", {"project_id": [self.project.id]}
+                [f"{alias}.foo"], 1, 2, "", {"project_id": [self.project.id]}
             )
             assert values == (1, 2), f"failing for {array_column}"
 
             # use the given min, but query for max
             mock_query.side_effect = [
                 {
-                    "meta": [{"name": f"max_{array_column}_foo"}],
-                    "data": [{f"max_{array_column}_foo": 3.45}],
+                    "meta": [{"name": f"max_{alias}_foo"}],
+                    "data": [{f"max_{alias}_foo": 3.45}],
                 },
             ]
             values = discover.find_histogram_min_max(
-                [f"{array_column}.foo"], 1.23, None, "", {"project_id": [self.project.id]}
+                [f"{alias}.foo"], 1.23, None, "", {"project_id": [self.project.id]}
             )
             assert values == (
                 1.23,
@@ -1702,12 +1703,12 @@ class QueryTransformTest(TestCase):
             # the queried max
             mock_query.side_effect = [
                 {
-                    "meta": [{"name": f"max_{array_column}_foo"}],
-                    "data": [{f"max_{array_column}_foo": 3.45}],
+                    "meta": [{"name": f"max_{alias}_foo"}],
+                    "data": [{f"max_{alias}_foo": 3.45}],
                 },
             ]
             values = discover.find_histogram_min_max(
-                [f"{array_column}.foo"], 3.5, None, "", {"project_id": [self.project.id]}
+                [f"{alias}.foo"], 3.5, None, "", {"project_id": [self.project.id]}
             )
             assert values == (
                 3.5,
@@ -1718,12 +1719,12 @@ class QueryTransformTest(TestCase):
             # the queried min
             mock_query.side_effect = [
                 {
-                    "meta": [{"name": f"min_{array_column}_foo"}],
-                    "data": [{f"min_{array_column}_foo": 3.45}],
+                    "meta": [{"name": f"min_{alias}_foo"}],
+                    "data": [{f"min_{alias}_foo": 3.45}],
                 },
             ]
             values = discover.find_histogram_min_max(
-                [f"{array_column}.foo"], None, 3.4, "", {"project_id": [self.project.id]}
+                [f"{alias}.foo"], None, 3.4, "", {"project_id": [self.project.id]}
             )
             assert values == (
                 3.4,
@@ -1733,12 +1734,12 @@ class QueryTransformTest(TestCase):
             # use the given max, but query for min
             mock_query.side_effect = [
                 {
-                    "meta": [{"name": f"min_{array_column}_foo"}],
-                    "data": [{f"min_{array_column}_foo": 1.23}],
+                    "meta": [{"name": f"min_{alias}_foo"}],
+                    "data": [{f"min_{alias}_foo": 1.23}],
                 },
             ]
             values = discover.find_histogram_min_max(
-                [f"{array_column}.foo"], None, 3.45, "", {"project_id": [self.project.id]}
+                [f"{alias}.foo"], None, 3.45, "", {"project_id": [self.project.id]}
             )
             assert values == (
                 1.23,
@@ -1749,14 +1750,14 @@ class QueryTransformTest(TestCase):
             mock_query.side_effect = [
                 {
                     "meta": [
-                        {"name": f"min_{array_column}_foo"},
-                        {"name": f"max_{array_column}_foo"},
+                        {"name": f"min_{alias}_foo"},
+                        {"name": f"max_{alias}_foo"},
                     ],
-                    "data": [{f"min_{array_column}_foo": 1.23, f"max_{array_column}_foo": 3.45}],
+                    "data": [{f"min_{alias}_foo": 1.23, f"max_{alias}_foo": 3.45}],
                 },
             ]
             values = discover.find_histogram_min_max(
-                [f"{array_column}.foo"], None, None, "", {"project_id": [self.project.id]}
+                [f"{alias}.foo"], None, None, "", {"project_id": [self.project.id]}
             )
             assert values == (
                 1.23,
@@ -1767,27 +1768,27 @@ class QueryTransformTest(TestCase):
             mock_query.side_effect = [
                 {
                     "meta": [
-                        {"name": f"min_{array_column}_foo"},
-                        {"name": f"min_{array_column}_bar"},
-                        {"name": f"min_{array_column}_baz"},
-                        {"name": f"max_{array_column}_foo"},
-                        {"name": f"max_{array_column}_bar"},
-                        {"name": f"max_{array_column}_baz"},
+                        {"name": f"min_{alias}_foo"},
+                        {"name": f"min_{alias}_bar"},
+                        {"name": f"min_{alias}_baz"},
+                        {"name": f"max_{alias}_foo"},
+                        {"name": f"max_{alias}_bar"},
+                        {"name": f"max_{alias}_baz"},
                     ],
                     "data": [
                         {
-                            f"min_{array_column}_foo": 1.23,
-                            f"min_{array_column}_bar": 1.34,
-                            f"min_{array_column}_baz": 1.45,
-                            f"max_{array_column}_foo": 3.45,
-                            f"max_{array_column}_bar": 3.56,
-                            f"max_{array_column}_baz": 3.67,
+                            f"min_{alias}_foo": 1.23,
+                            f"min_{alias}_bar": 1.34,
+                            f"min_{alias}_baz": 1.45,
+                            f"max_{alias}_foo": 3.45,
+                            f"max_{alias}_bar": 3.56,
+                            f"max_{alias}_baz": 3.67,
                         }
                     ],
                 },
             ]
             values = discover.find_histogram_min_max(
-                [f"{array_column}.foo", f"{array_column}.bar", f"{array_column}.baz"],
+                [f"{alias}.foo", f"{alias}.bar", f"{alias}.baz"],
                 None,
                 None,
                 "",
@@ -1802,27 +1803,27 @@ class QueryTransformTest(TestCase):
             mock_query.side_effect = [
                 {
                     "meta": [
-                        {"name": f"min_{array_column}_foo"},
-                        {"name": f"min_{array_column}_bar"},
-                        {"name": f"min_{array_column}_baz"},
-                        {"name": f"max_{array_column}_foo"},
-                        {"name": f"max_{array_column}_bar"},
-                        {"name": f"max_{array_column}_baz"},
+                        {"name": f"min_{alias}_foo"},
+                        {"name": f"min_{alias}_bar"},
+                        {"name": f"min_{alias}_baz"},
+                        {"name": f"max_{alias}_foo"},
+                        {"name": f"max_{alias}_bar"},
+                        {"name": f"max_{alias}_baz"},
                     ],
                     "data": [
                         {
-                            f"min_{array_column}_foo": 1.23,
-                            f"min_{array_column}_bar": None,
-                            f"min_{array_column}_baz": 1.45,
-                            f"max_{array_column}_foo": 3.45,
-                            f"max_{array_column}_bar": None,
-                            f"max_{array_column}_baz": 3.67,
+                            f"min_{alias}_foo": 1.23,
+                            f"min_{alias}_bar": None,
+                            f"min_{alias}_baz": 1.45,
+                            f"max_{alias}_foo": 3.45,
+                            f"max_{alias}_bar": None,
+                            f"max_{alias}_baz": 3.67,
                         }
                     ],
                 },
             ]
             values = discover.find_histogram_min_max(
-                [f"{array_column}.foo", f"{array_column}.bar", f"{array_column}.baz"],
+                [f"{alias}.foo", f"{alias}.bar", f"{alias}.baz"],
                 None,
                 None,
                 "",
@@ -1908,6 +1909,7 @@ class QueryTransformTest(TestCase):
 
     def test_normalize_histogram_results_full(self):
         for array_column in ARRAY_COLUMNS:
+            alias = get_array_column_alias(array_column)
             results = {
                 "meta": {
                     f"array_join_{array_column}_key": "string",
@@ -1933,14 +1935,14 @@ class QueryTransformTest(TestCase):
                 ],
             }
             normalized_results = discover.normalize_histogram_results(
-                [f"{array_column}.foo"],
+                [f"{alias}.foo"],
                 f"array_join({array_column}_key)",
                 discover.HistogramParams(3, 1, 0, 1),
                 results,
                 array_column,
             )
             assert normalized_results == {
-                f"{array_column}.foo": [
+                f"{alias}.foo": [
                     {"bin": 0, "count": 3},
                     {"bin": 1, "count": 2},
                     {"bin": 2, "count": 1},
@@ -1949,6 +1951,7 @@ class QueryTransformTest(TestCase):
 
     def test_normalize_histogram_results_full_multiple(self):
         for array_column in ARRAY_COLUMNS:
+            alias = get_array_column_alias(array_column)
             results = {
                 "meta": {
                     f"array_join_{array_column}_key": "string",
@@ -1989,19 +1992,19 @@ class QueryTransformTest(TestCase):
                 ],
             }
             normalized_results = discover.normalize_histogram_results(
-                [f"{array_column}.bar", f"{array_column}.foo"],
+                [f"{alias}.bar", f"{alias}.foo"],
                 f"array_join({array_column}_key)",
                 discover.HistogramParams(3, 1, 0, 1),
                 results,
                 array_column,
             )
             assert normalized_results == {
-                f"{array_column}.bar": [
+                f"{alias}.bar": [
                     {"bin": 0, "count": 1},
                     {"bin": 1, "count": 2},
                     {"bin": 2, "count": 3},
                 ],
-                f"{array_column}.foo": [
+                f"{alias}.foo": [
                     {"bin": 0, "count": 3},
                     {"bin": 1, "count": 2},
                     {"bin": 2, "count": 1},
@@ -2010,6 +2013,7 @@ class QueryTransformTest(TestCase):
 
     def test_normalize_histogram_results_partial(self):
         for array_column in ARRAY_COLUMNS:
+            alias = get_array_column_alias(array_column)
             results = {
                 "meta": {
                     f"array_join_{array_column}_key": "string",
@@ -2025,14 +2029,14 @@ class QueryTransformTest(TestCase):
                 ],
             }
             normalized_results = discover.normalize_histogram_results(
-                [f"{array_column}.foo"],
+                [f"{alias}.foo"],
                 f"array_join({array_column}_key)",
                 discover.HistogramParams(3, 1, 0, 1),
                 results,
                 array_column,
             )
             assert normalized_results == {
-                f"{array_column}.foo": [
+                f"{alias}.foo": [
                     {"bin": 0, "count": 3},
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 0},
@@ -2041,6 +2045,7 @@ class QueryTransformTest(TestCase):
 
     def test_normalize_histogram_results_partial_multiple(self):
         for array_column in ARRAY_COLUMNS:
+            alias = get_array_column_alias(array_column)
             results = {
                 "meta": {
                     f"array_join_{array_column}_key": "string",
@@ -2061,19 +2066,19 @@ class QueryTransformTest(TestCase):
                 ],
             }
             normalized_results = discover.normalize_histogram_results(
-                [f"{array_column}.bar", f"{array_column}.foo"],
+                [f"{alias}.bar", f"{alias}.foo"],
                 f"array_join({array_column}_key)",
                 discover.HistogramParams(3, 1, 0, 1),
                 results,
                 array_column,
             )
             assert normalized_results == {
-                f"{array_column}.bar": [
+                f"{alias}.bar": [
                     {"bin": 0, "count": 0},
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 3},
                 ],
-                f"{array_column}.foo": [
+                f"{alias}.foo": [
                     {"bin": 0, "count": 3},
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 0},
@@ -2082,6 +2087,7 @@ class QueryTransformTest(TestCase):
 
     def test_normalize_histogram_results_ignore_unexpected_rows(self):
         for array_column in ARRAY_COLUMNS:
+            alias = get_array_column_alias(array_column)
             results = {
                 "meta": {
                     f"array_join_{array_column}_key": "string",
@@ -2114,19 +2120,19 @@ class QueryTransformTest(TestCase):
                 ],
             }
             normalized_results = discover.normalize_histogram_results(
-                [f"{array_column}.bar", f"{array_column}.foo"],
+                [f"{alias}.bar", f"{alias}.foo"],
                 f"array_join({array_column}_key)",
                 discover.HistogramParams(3, 1, 0, 1),
                 results,
                 array_column,
             )
             assert normalized_results == {
-                f"{array_column}.bar": [
+                f"{alias}.bar": [
                     {"bin": 0, "count": 0},
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 3},
                 ],
-                f"{array_column}.foo": [
+                f"{alias}.foo": [
                     {"bin": 0, "count": 3},
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 0},
@@ -2135,6 +2141,7 @@ class QueryTransformTest(TestCase):
 
     def test_normalize_histogram_results_adjust_for_precision(self):
         for array_column in ARRAY_COLUMNS:
+            alias = get_array_column_alias(array_column)
             results = {
                 "meta": {
                     f"array_join_{array_column}_key": "string",
@@ -2165,14 +2172,14 @@ class QueryTransformTest(TestCase):
                 ],
             }
             normalized_results = discover.normalize_histogram_results(
-                [f"{array_column}.foo"],
+                [f"{alias}.foo"],
                 f"array_join({array_column}_key)",
                 discover.HistogramParams(4, 25, 0, 100),
                 results,
                 array_column,
             )
             assert normalized_results == {
-                f"{array_column}.foo": [
+                f"{alias}.foo": [
                     {"bin": 0, "count": 3},
                     {"bin": 0.25, "count": 2},
                     {"bin": 0.50, "count": 1},
@@ -2183,18 +2190,19 @@ class QueryTransformTest(TestCase):
     @patch("sentry.snuba.discover.raw_query")
     def test_histogram_query(self, mock_query):
         for array_column in ARRAY_COLUMNS:
+            alias = get_array_column_alias(array_column)
             mock_query.side_effect = [
                 {
                     "meta": [
-                        {"name": f"min_{array_column}_foo"},
-                        {"name": f"max_{array_column}_foo"},
+                        {"name": f"min_{alias}_foo"},
+                        {"name": f"max_{alias}_foo"},
                     ],
                     "data": [
                         {
-                            f"min_{array_column}_bar": 2,
-                            f"min_{array_column}_foo": 0,
-                            f"max_{array_column}_bar": 2,
-                            f"max_{array_column}_foo": 2,
+                            f"min_{alias}_bar": 2,
+                            f"min_{alias}_foo": 0,
+                            f"max_{alias}_bar": 2,
+                            f"max_{alias}_foo": 2,
                         }
                     ],
                 },
@@ -2224,19 +2232,19 @@ class QueryTransformTest(TestCase):
                 },
             ]
             results = discover.histogram_query(
-                [f"{array_column}.bar", f"{array_column}.foo"],
+                [f"{alias}.bar", f"{alias}.foo"],
                 "",
                 {"project_id": [self.project.id]},
                 3,
                 0,
             )
             assert results == {
-                f"{array_column}.bar": [
+                f"{alias}.bar": [
                     {"bin": 0, "count": 3},
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 0},
                 ],
-                f"{array_column}.foo": [
+                f"{alias}.foo": [
                     {"bin": 0, "count": 3},
                     {"bin": 1, "count": 0},
                     {"bin": 2, "count": 1},
@@ -2245,9 +2253,10 @@ class QueryTransformTest(TestCase):
 
     def test_histogram_query_with_bad_fields(self):
         for array_column in ARRAY_COLUMNS:
+            alias = get_array_column_alias(array_column)
             with pytest.raises(InvalidSearchQuery) as err:
                 discover.histogram_query(
-                    [f"{array_column}.bar", "transaction.duration"],
+                    [f"{alias}.bar", "transaction.duration"],
                     "",
                     {"project_id": [self.project.id]},
                     3,
@@ -2260,6 +2269,7 @@ class QueryTransformTest(TestCase):
     @patch("sentry.snuba.discover.raw_query")
     def test_histogram_query_with_optionals(self, mock_query):
         for array_column in ARRAY_COLUMNS:
+            alias = get_array_column_alias(array_column)
             mock_query.side_effect = [
                 {
                     "meta": [
@@ -2299,7 +2309,7 @@ class QueryTransformTest(TestCase):
                 },
             ]
             results = discover.histogram_query(
-                [f"{array_column}.bar", f"{array_column}.foo"],
+                [f"{alias}.bar", f"{alias}.foo"],
                 "",
                 {"project_id": [self.project.id]},
                 3,
@@ -2308,12 +2318,12 @@ class QueryTransformTest(TestCase):
                 2,
             )
             assert results == {
-                f"{array_column}.bar": [
+                f"{alias}.bar": [
                     {"bin": 0.5, "count": 0},
                     {"bin": 1.0, "count": 2},
                     {"bin": 1.5, "count": 0},
                 ],
-                f"{array_column}.foo": [
+                f"{alias}.foo": [
                     {"bin": 0.5, "count": 3},
                     {"bin": 1.0, "count": 0},
                     {"bin": 1.5, "count": 1},

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -185,6 +185,36 @@ class SnubaUtilsTest(TestCase):
             get_snuba_column_name("measurements.KEY", Dataset.Transactions) == "measurements[key]"
         )
 
+        # span op breakdowns are not available on the Events dataset, so it's seen as a tag
+        assert (
+            get_snuba_column_name("span_op_breakdowns_key", Dataset.Events)
+            == "tags[span_op_breakdowns_key]"
+        )
+        assert (
+            get_snuba_column_name("span_op_breakdowns.key", Dataset.Events)
+            == "tags[span_op_breakdowns.key]"
+        )
+
+        # span op breakdowns are available on the Discover and Transactions dataset, so its parsed as such
+        assert (
+            get_snuba_column_name("span_op_breakdowns_key", Dataset.Discover)
+            == "span_op_breakdowns.key"
+        )
+        assert (
+            get_snuba_column_name("span_op_breakdowns_key", Dataset.Transactions)
+            == "span_op_breakdowns.key"
+        )
+        assert get_snuba_column_name("spans.key", Dataset.Discover) == "span_op_breakdowns[ops.key]"
+        assert (
+            get_snuba_column_name("spans.key", Dataset.Transactions)
+            == "span_op_breakdowns[ops.key]"
+        )
+        assert get_snuba_column_name("spans.KEY", Dataset.Discover) == "span_op_breakdowns[ops.key]"
+        assert (
+            get_snuba_column_name("spans.KEY", Dataset.Transactions)
+            == "span_op_breakdowns[ops.key]"
+        )
+
 
 class PrepareQueryParamsTest(TestCase):
     def test_events_dataset_with_project_id(self):


### PR DESCRIPTION
The `span_op_breakdowns.key` field should only be used internally. On the product it's aliased as `spans.key`.

This rename is to prepare to expose these fields on the Discover column builder.