### PR TITLE
feat(alerts): Historic alerts from snapshots in alert details

### DIFF
--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -73,16 +73,12 @@ class AlertRuleSerializer(Serializer):
                 result[alert_rule]["owner"] = f"{type}:{resolved_actors[type][alert_rule.owner_id]}"
 
         if "original_alert_rule" in self.expand:
-            for alert_rule in alert_rules.values():
-                if alert_rule.status == AlertRuleStatus.SNAPSHOT.value:
-                    snapshot_activity = AlertRuleActivity.objects.filter(
-                        alert_rule=alert_rule,
-                        type=AlertRuleActivityType.SNAPSHOT.value,
-                    )
-                    if snapshot_activity:
-                        result[alert_rule][
-                            "originalAlertRuleId"
-                        ] = snapshot_activity.get().previous_alert_rule.id
+            snapshot_activities = AlertRuleActivity.objects.filter(
+                alert_rule__in=item_list,
+                type=AlertRuleActivityType.SNAPSHOT.value,
+            )
+            for activity in snapshot_activities:
+                result[activity.alert_rule]["originalAlertRuleId"] = activity.previous_alert_rule_id
 
         return result
 

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -78,7 +78,7 @@ class AlertRuleSerializer(Serializer):
                 type=AlertRuleActivityType.SNAPSHOT.value,
             )
             for activity in snapshot_activities:
-                result[activity.alert_rule]["originalAlertRuleId"] = activity.previous_alert_rule_id
+                result[alert_rules[activity.alert_rule_id]]["originalAlertRuleId"] = activity.previous_alert_rule_id
 
         return result
 

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -78,7 +78,9 @@ class AlertRuleSerializer(Serializer):
                 type=AlertRuleActivityType.SNAPSHOT.value,
             )
             for activity in snapshot_activities:
-                result[alert_rules[activity.alert_rule_id]]["originalAlertRuleId"] = activity.previous_alert_rule_id
+                result[alert_rules[activity.alert_rule_id]][
+                    "originalAlertRuleId"
+                ] = activity.previous_alert_rule_id
 
         return result
 

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -7,7 +7,6 @@ from sentry.incidents.models import (
     AlertRuleActivity,
     AlertRuleActivityType,
     AlertRuleExcludedProjects,
-    AlertRuleStatus,
     AlertRuleTrigger,
 )
 from sentry.models import ACTOR_TYPES, Rule, actor_type_to_class, actor_type_to_string

--- a/src/sentry/api/serializers/models/alert_rule.py
+++ b/src/sentry/api/serializers/models/alert_rule.py
@@ -80,7 +80,9 @@ class AlertRuleSerializer(Serializer):
                         type=AlertRuleActivityType.SNAPSHOT.value,
                     )
                     if snapshot_activity:
-                        result[alert_rule]["originalAlertRuleId"] = snapshot_activity.get().previous_alert_rule.id
+                        result[alert_rule][
+                            "originalAlertRuleId"
+                        ] = snapshot_activity.get().previous_alert_rule.id
 
         return result
 

--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -29,7 +29,11 @@ class IncidentSerializer(Serializer):
 
         alert_rules = {
             d["id"]: d
-            for d in serialize({i.alert_rule for i in item_list if i.alert_rule.id}, user, AlertRuleSerializer(expand=self.expand))
+            for d in serialize(
+                {i.alert_rule for i in item_list if i.alert_rule.id},
+                user,
+                AlertRuleSerializer(expand=self.expand),
+            )
         }
 
         results = {}

--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -2,6 +2,9 @@ from collections import defaultdict
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.incidents.models import (
+    AlertRule,
+    AlertRuleActivity,
+    AlertRuleStatus,
     Incident,
     IncidentActivity,
     IncidentProject,
@@ -26,15 +29,32 @@ class IncidentSerializer(Serializer):
         ).select_related("project"):
             incident_projects[incident_project.incident_id].append(incident_project.project.slug)
 
-        alert_rules = {
-            d["id"]: d
-            for d in serialize({i.alert_rule for i in item_list if i.alert_rule.id}, user)
-        }
-
+        alert_rule_list = serialize({i.alert_rule for i in item_list if i.alert_rule.id}, user)
+        alert_rules = {d["id"]: d for d in alert_rule_list}
         results = {}
         for incident in item_list:
             results[incident] = {"projects": incident_projects.get(incident.id, [])}
             results[incident]["alert_rule"] = alert_rules.get(str(incident.alert_rule.id))
+
+        if "original_alert_rule" in self.expand:
+            snapshot_alert_rules = filter(lambda a: a["status"] == AlertRuleStatus.SNAPSHOT.value, alert_rule_list)
+            snapshot_alert_rule_ids = [int(a["id"]) for a in snapshot_alert_rules]
+            alert_rule_activities = list(AlertRuleActivity.objects.filter(alert_rule__in=snapshot_alert_rule_ids))
+
+            orig_alert_rules = serialize(list(
+                AlertRule.objects.filter(id__in=map(lambda a: a.previous_alert_rule.id, alert_rule_activities))
+            ), user)
+
+            orig_alert_rules_dict = dict()
+            for alert_rule_activity, serialized_orig_alert_rule in zip(alert_rule_activities, serialize(orig_alert_rules, user)):
+                orig_alert_rules_dict[alert_rule_activity.alert_rule.id] = serialized_orig_alert_rule
+
+            for incident in item_list:
+                # for missing alert rule activity events we can't include the original alert rule
+                if incident.alert_rule.status == AlertRuleStatus.SNAPSHOT.value and incident.alert_rule.id in orig_alert_rules_dict:
+                    results[incident]["orig_alert_rule"] = orig_alert_rules_dict[incident.alert_rule.id]
+                else:
+                    results[incident]["orig_alert_rule"] = None
 
         if "seen_by" in self.expand:
             incident_seen_list = list(
@@ -71,6 +91,7 @@ class IncidentSerializer(Serializer):
             "organizationId": str(obj.organization_id),
             "projects": attrs["projects"],
             "alertRule": attrs["alert_rule"],
+            "originalAlertRule": attrs["orig_alert_rule"] if "original_alert_rule" in self.expand else None,
             "activities": attrs["activities"] if "activities" in self.expand else None,
             "seenBy": attrs["seen_by"] if "seen_by" in self.expand else None,
             "hasSeen": attrs["has_seen"] if "seen_by" in self.expand else None,

--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -37,22 +37,40 @@ class IncidentSerializer(Serializer):
             results[incident]["alert_rule"] = alert_rules.get(str(incident.alert_rule.id))
 
         if "original_alert_rule" in self.expand:
-            snapshot_alert_rules = filter(lambda a: a["status"] == AlertRuleStatus.SNAPSHOT.value, alert_rule_list)
+            snapshot_alert_rules = filter(
+                lambda a: a["status"] == AlertRuleStatus.SNAPSHOT.value, alert_rule_list
+            )
             snapshot_alert_rule_ids = [int(a["id"]) for a in snapshot_alert_rules]
-            alert_rule_activities = list(AlertRuleActivity.objects.filter(alert_rule__in=snapshot_alert_rule_ids))
+            alert_rule_activities = list(
+                AlertRuleActivity.objects.filter(alert_rule__in=snapshot_alert_rule_ids)
+            )
 
-            orig_alert_rules = serialize(list(
-                AlertRule.objects.filter(id__in=map(lambda a: a.previous_alert_rule.id, alert_rule_activities))
-            ), user)
+            orig_alert_rules = serialize(
+                list(
+                    AlertRule.objects.filter(
+                        id__in=map(lambda a: a.previous_alert_rule.id, alert_rule_activities)
+                    )
+                ),
+                user,
+            )
 
             orig_alert_rules_dict = dict()
-            for alert_rule_activity, serialized_orig_alert_rule in zip(alert_rule_activities, serialize(orig_alert_rules, user)):
-                orig_alert_rules_dict[alert_rule_activity.alert_rule.id] = serialized_orig_alert_rule
+            for alert_rule_activity, serialized_orig_alert_rule in zip(
+                alert_rule_activities, serialize(orig_alert_rules, user)
+            ):
+                orig_alert_rules_dict[
+                    alert_rule_activity.alert_rule.id
+                ] = serialized_orig_alert_rule
 
             for incident in item_list:
                 # for missing alert rule activity events we can't include the original alert rule
-                if incident.alert_rule.status == AlertRuleStatus.SNAPSHOT.value and incident.alert_rule.id in orig_alert_rules_dict:
-                    results[incident]["orig_alert_rule"] = orig_alert_rules_dict[incident.alert_rule.id]
+                if (
+                    incident.alert_rule.status == AlertRuleStatus.SNAPSHOT.value
+                    and incident.alert_rule.id in orig_alert_rules_dict
+                ):
+                    results[incident]["orig_alert_rule"] = orig_alert_rules_dict[
+                        incident.alert_rule.id
+                    ]
                 else:
                     results[incident]["orig_alert_rule"] = None
 
@@ -91,7 +109,9 @@ class IncidentSerializer(Serializer):
             "organizationId": str(obj.organization_id),
             "projects": attrs["projects"],
             "alertRule": attrs["alert_rule"],
-            "originalAlertRule": attrs["orig_alert_rule"] if "original_alert_rule" in self.expand else None,
+            "originalAlertRule": attrs["orig_alert_rule"]
+            if "original_alert_rule" in self.expand
+            else None,
             "activities": attrs["activities"] if "activities" in self.expand else None,
             "seenBy": attrs["seen_by"] if "seen_by" in self.expand else None,
             "hasSeen": attrs["has_seen"] if "seen_by" in self.expand else None,

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -5,7 +5,12 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.incident import IncidentSerializer
-from sentry.incidents.models import AlertRuleActivity, AlertRuleActivityType, Incident, IncidentStatus
+from sentry.incidents.models import (
+    AlertRuleActivity,
+    AlertRuleActivityType,
+    Incident,
+    IncidentStatus,
+)
 from sentry.snuba.dataset import Dataset
 
 
@@ -38,7 +43,10 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
             alert_rule_ids = [int(query_alert_rule)]
             if query_include_snapshots:
                 snapshot_alerts = list(
-                    AlertRuleActivity.objects.filter(previous_alert_rule=query_alert_rule, type=AlertRuleActivityType.SNAPSHOT.value,)
+                    AlertRuleActivity.objects.filter(
+                        previous_alert_rule=query_alert_rule,
+                        type=AlertRuleActivityType.SNAPSHOT.value,
+                    )
                 )
                 for snapshot_alert in snapshot_alerts:
                     alert_rule_ids.append(snapshot_alert.alert_rule_id)

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -212,7 +212,11 @@ export default class DetailsBody extends React.Component<Props> {
       !isIssueAlert(incident?.alertRule) &&
       organization.features.includes('alert-details-redesign');
     const alertRuleLink = hasRedesign
-      ? `/organizations/${organization.slug}/alerts/rules/details/${incident?.alertRule?.id}/`
+      ? `/organizations/${organization.slug}/alerts/rules/details/${incident?.alertRule.status === AlertRuleStatus.SNAPSHOT &&
+        incident?.alertRule.originalAlertRuleId
+          ? incident?.alertRule.originalAlertRuleId
+          : incident?.alertRule.id
+      }/`
       : `/organizations/${params.orgId}/alerts/metric-rules/${incident?.projects[0]}/${incident?.alertRule?.id}/`;
 
     return (

--- a/src/sentry/static/sentry/app/views/alerts/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/body.tsx
@@ -212,11 +212,12 @@ export default class DetailsBody extends React.Component<Props> {
       !isIssueAlert(incident?.alertRule) &&
       organization.features.includes('alert-details-redesign');
     const alertRuleLink = hasRedesign
-      ? `/organizations/${organization.slug}/alerts/rules/details/${incident?.alertRule.status === AlertRuleStatus.SNAPSHOT &&
-        incident?.alertRule.originalAlertRuleId
-          ? incident?.alertRule.originalAlertRuleId
-          : incident?.alertRule.id
-      }/`
+      ? `/organizations/${organization.slug}/alerts/rules/details/${
+          incident?.alertRule.status === AlertRuleStatus.SNAPSHOT &&
+          incident?.alertRule.originalAlertRuleId
+            ? incident?.alertRule.originalAlertRuleId
+            : incident?.alertRule.id
+        }/`
       : `/organizations/${params.orgId}/alerts/metric-rules/${incident?.projects[0]}/${incident?.alertRule?.id}/`;
 
     return (

--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -39,11 +39,6 @@ type State = {
 };
 
 class IncidentDetails extends React.Component<Props, State> {
-  constructor(props) {
-    super(props);
-    this.fetchData();
-  }
-
   state: State = {isLoading: false, hasError: false};
 
   componentDidMount() {
@@ -57,6 +52,8 @@ class IncidentDetails extends React.Component<Props, State> {
     });
 
     fetchOrgMembers(api, params.orgId);
+
+    this.fetchData();
   }
 
   fetchData = async () => {

--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -40,6 +40,10 @@ type State = {
 
 class IncidentDetails extends React.Component<Props, State> {
   state: State = {isLoading: false, hasError: false};
+  constructor(props) {
+    super(props);
+    this.fetchData();
+  }
 
   componentDidMount() {
     const {api, organization, params} = this.props;
@@ -52,8 +56,6 @@ class IncidentDetails extends React.Component<Props, State> {
     });
 
     fetchOrgMembers(api, params.orgId);
-
-    this.fetchData();
   }
 
   fetchData = async () => {

--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -13,7 +13,7 @@ import {trackAnalyticsEvent} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
 import {makeRuleDetailsQuery} from 'app/views/alerts/list/row';
 
-import {Incident, IncidentStats, IncidentStatus} from '../types';
+import {AlertRuleStatus, Incident, IncidentStats, IncidentStatus} from '../types';
 import {
   fetchIncident,
   fetchIncidentStats,
@@ -78,7 +78,12 @@ class IncidentDetails extends React.Component<Props, State> {
           location && location.query && location.query.redirect === 'false';
         if (hasRedesign && !stopRedirect) {
           browserHistory.replace({
-            pathname: `/organizations/${orgId}/alerts/rules/details/${incident.alertRule?.id}/`,
+            pathname: `/organizations/${orgId}/alerts/rules/details/${
+              incident.alertRule.status === AlertRuleStatus.SNAPSHOT &&
+              incident.alertRule.originalAlertRuleId
+                ? incident.alertRule.originalAlertRuleId
+                : incident.alertRule.id
+            }/`,
             query: makeRuleDetailsQuery(incident),
           });
         }

--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -39,11 +39,12 @@ type State = {
 };
 
 class IncidentDetails extends React.Component<Props, State> {
-  state: State = {isLoading: false, hasError: false};
   constructor(props) {
     super(props);
     this.fetchData();
   }
+
+  state: State = {isLoading: false, hasError: false};
 
   componentDidMount() {
     const {api, organization, params} = this.props;

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -71,7 +71,7 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
       [
         'incidentList',
         `/organizations/${params && params.orgId}/incidents/`,
-        {query: {...query, status}},
+        {query: {...query, expand: ['original_alert_rule'], status}},
       ],
     ];
   }

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -68,9 +68,11 @@ class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state'
     const status = getQueryStatus(query.status);
     const incidentsQuery = {
       ...query,
-      ...(organization.features.includes('alert-details-redesign') ? {expand: ['original_alert_rule']} : {}),
+      ...(organization.features.includes('alert-details-redesign')
+        ? {expand: ['original_alert_rule']}
+        : {}),
       status,
-    }
+    };
 
     return [
       [

--- a/src/sentry/static/sentry/app/views/alerts/list/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/index.tsx
@@ -63,15 +63,20 @@ type State = {
 
 class IncidentsList extends AsyncComponent<Props, State & AsyncComponent['state']> {
   getEndpoints(): ReturnType<AsyncComponent['getEndpoints']> {
-    const {params, location} = this.props;
+    const {params, location, organization} = this.props;
     const {query} = location;
     const status = getQueryStatus(query.status);
+    const incidentsQuery = {
+      ...query,
+      ...(organization.features.includes('alert-details-redesign') ? {expand: ['original_alert_rule']} : {}),
+      status,
+    }
 
     return [
       [
         'incidentList',
         `/organizations/${params && params.orgId}/incidents/`,
-        {query: {...query, expand: ['original_alert_rule'], status}},
+        {query: incidentsQuery},
       ],
     ];
   }

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -148,8 +148,8 @@ class AlertListRow extends AsyncComponent<Props, State> {
       ? {
           pathname: `/organizations/${orgId}/alerts/rules/details/${
             incident.alertRule.status === AlertRuleStatus.SNAPSHOT &&
-            incident.originalAlertRule
-              ? incident.originalAlertRule.id
+            incident.alertRule.originalAlertRuleId
+              ? incident.alertRule.originalAlertRuleId
               : incident.alertRule.id
           }/`,
           query: makeRuleDetailsQuery(incident),

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -24,7 +24,7 @@ import {
   API_INTERVAL_POINTS_LIMIT,
   API_INTERVAL_POINTS_MIN,
 } from '../rules/details/constants';
-import {Incident, IncidentStats, IncidentStatus} from '../types';
+import {AlertRuleStatus, Incident, IncidentStats, IncidentStatus} from '../types';
 import {getIncidentMetricPreset, isIssueAlert} from '../utils';
 
 import SparkLine from './sparkLine';
@@ -140,14 +140,16 @@ class AlertListRow extends AsyncComponent<Props, State> {
       .as('seconds');
     const slug = incident.projects[0];
 
-    const hasRedesign =
-      incident.alertRule &&
-      !isIssueAlert(incident.alertRule) &&
+    const hasRedesign = !isIssueAlert(incident.alertRule) &&
       organization.features.includes('alert-details-redesign');
 
     const alertLink = hasRedesign
       ? {
-          pathname: `/organizations/${orgId}/alerts/rules/details/${incident.alertRule?.id}/`,
+          pathname: `/organizations/${orgId}/alerts/rules/details/${
+            incident.alertRule.status === AlertRuleStatus.SNAPSHOT && incident.originalAlertRule 
+              ? incident.originalAlertRule.id 
+              : incident.alertRule.id
+          }/`,
           query: makeRuleDetailsQuery(incident),
         }
       : {

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -140,14 +140,16 @@ class AlertListRow extends AsyncComponent<Props, State> {
       .as('seconds');
     const slug = incident.projects[0];
 
-    const hasRedesign = !isIssueAlert(incident.alertRule) &&
+    const hasRedesign =
+      !isIssueAlert(incident.alertRule) &&
       organization.features.includes('alert-details-redesign');
 
     const alertLink = hasRedesign
       ? {
           pathname: `/organizations/${orgId}/alerts/rules/details/${
-            incident.alertRule.status === AlertRuleStatus.SNAPSHOT && incident.originalAlertRule 
-              ? incident.originalAlertRule.id 
+            incident.alertRule.status === AlertRuleStatus.SNAPSHOT &&
+            incident.originalAlertRule
+              ? incident.originalAlertRule.id
               : incident.alertRule.id
           }/`,
           query: makeRuleDetailsQuery(incident),

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -117,8 +117,8 @@ export default class DetailsBody extends React.Component<Props> {
 
     return (
       <Filters>
-          <code>{DATASET_EVENT_TYPE_FILTERS[rule.dataset]}</code>&nbsp;&nbsp;
-          {rule.query && <code>{rule.query}</code>}
+        <code>{DATASET_EVENT_TYPE_FILTERS[rule.dataset]}</code>&nbsp;&nbsp;
+        {rule.query && <code>{rule.query}</code>}
       </Filters>
     );
   }

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import isEqual from 'lodash/isEqual';
 import moment from 'moment';
 
 import {Client} from 'app/api';
@@ -28,7 +27,6 @@ import {Actor, Organization, Project} from 'app/types';
 import Projects from 'app/utils/projects';
 import theme from 'app/utils/theme';
 import Timeline from 'app/views/alerts/rules/details/timeline';
-import {fetchIncidentStats} from 'app/views/alerts/utils';
 import {DATASET_EVENT_TYPE_FILTERS} from 'app/views/settings/incidentRules/constants';
 import {
   AlertRuleThresholdType,
@@ -38,7 +36,7 @@ import {
 } from 'app/views/settings/incidentRules/types';
 import {extractEventTypeFilterFromRule} from 'app/views/settings/incidentRules/utils/getEventTypeFilter';
 
-import {Incident, IncidentStats, IncidentStatus} from '../../types';
+import {Incident, IncidentStatus} from '../../types';
 
 import {API_INTERVAL_POINTS_LIMIT, TIME_OPTIONS} from './constants';
 import MetricChart from './metricChart';
@@ -291,7 +289,6 @@ export default class DetailsBody extends React.Component<Props> {
       timePeriod,
       params: {orgId},
     } = this.props;
-    const {incidentStats} = this.state;
 
     if (!rule) {
       return this.renderLoading();

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -63,15 +63,7 @@ type Props = {
   handleTimePeriodChange: (value: string) => void;
 } & RouteComponentProps<{orgId: string}, {}>;
 
-type State = {
-  incidentStats: IncidentStats[];
-};
-
-export default class DetailsBody extends React.Component<Props, State> {
-  state = {
-    incidentStats: [],
-  };
-
+export default class DetailsBody extends React.Component<Props> {
   getMetricText(): React.ReactNode {
     const {rule} = this.props;
 
@@ -132,33 +124,6 @@ export default class DetailsBody extends React.Component<Props, State> {
       </Filters>
     );
   }
-
-  componentDidMount() {
-    this.fetchData();
-  }
-
-  componentDidUpdate(prevProps: Props) {
-    if (
-      prevProps.params.orgId !== this.props.params.orgId ||
-      !isEqual(prevProps.incidents, this.props.incidents)
-    ) {
-      this.fetchData();
-    }
-  }
-
-  fetchData = async () => {
-    const {
-      api,
-      incidents,
-      params: {orgId},
-    } = this.props;
-
-    if (incidents?.length) {
-      await Promise.all(
-        incidents.map(incident => fetchIncidentStats(api, orgId, incident.identifier))
-      ).then(incidentStats => this.setState({incidentStats}));
-    }
-  };
 
   renderTrigger(trigger: Trigger): React.ReactNode {
     const {rule} = this.props;
@@ -402,7 +367,6 @@ export default class DetailsBody extends React.Component<Props, State> {
                     filter={this.getFilter()}
                     query={queryWithTypeFilter}
                     orgId={orgId}
-                    incidentStats={incidentStats}
                   />
                   <DetailWrapper>
                     <ActivityWrapper>

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
-import moment from 'moment';
 import isEqual from 'lodash/isEqual';
+import moment from 'moment';
 
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
@@ -27,8 +27,8 @@ import space from 'app/styles/space';
 import {Actor, Organization, Project} from 'app/types';
 import Projects from 'app/utils/projects';
 import theme from 'app/utils/theme';
-import {fetchIncidentStats} from 'app/views/alerts/utils';
 import Timeline from 'app/views/alerts/rules/details/timeline';
+import {fetchIncidentStats} from 'app/views/alerts/utils';
 import {DATASET_EVENT_TYPE_FILTERS} from 'app/views/settings/incidentRules/constants';
 import {
   AlertRuleThresholdType,
@@ -70,7 +70,7 @@ type State = {
 export default class DetailsBody extends React.Component<Props, State> {
   state = {
     incidentStats: [],
-  }
+  };
 
   getMetricText(): React.ReactNode {
     const {rule} = this.props;
@@ -147,11 +147,16 @@ export default class DetailsBody extends React.Component<Props, State> {
   }
 
   fetchData = async () => {
-    const {api, incidents, params: {orgId}} = this.props;
+    const {
+      api,
+      incidents,
+      params: {orgId},
+    } = this.props;
 
     if (incidents?.length) {
-      await Promise.all(incidents.map(incident => fetchIncidentStats(api, orgId, incident.identifier)))
-        .then(incidentStats => this.setState({incidentStats}));
+      await Promise.all(
+        incidents.map(incident => fetchIncidentStats(api, orgId, incident.identifier))
+      ).then(incidentStats => this.setState({incidentStats}));
     }
   };
 

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -117,10 +117,8 @@ export default class DetailsBody extends React.Component<Props> {
 
     return (
       <Filters>
-        <span>
-          {rule?.dataset && <code>{DATASET_EVENT_TYPE_FILTERS[rule.dataset]}</code>}
-        </span>
-        <span>{rule?.query && <code>{rule?.query}</code>}</span>
+          <code>{DATASET_EVENT_TYPE_FILTERS[rule.dataset]}</code>&nbsp;&nbsp;
+          {rule.query && <code>{rule.query}</code>}
       </Filters>
     );
   }
@@ -519,8 +517,7 @@ const RuleText = styled('div')`
   font-size: ${p => p.theme.fontSizeLarge};
 `;
 
-const Filters = styled('div')`
-  display: inline-flex;
+const Filters = styled('span')`
   width: 100%;
   overflow-wrap: break-word;
   font-size: ${p => p.theme.fontSizeMedium};

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -444,7 +444,10 @@ class MetricChart extends React.PureComponent<Props, State> {
                   seriesName: t('Alert %s', incidents[idx].identifier),
                   type: 'line',
                   data: incidentStat.eventStats.data
-                    .filter(([timeStamp]) => timeStamp * 1000 < lastPoint && timeStamp * 1000 > firstPoint)
+                    .filter(
+                      ([timeStamp]) =>
+                        timeStamp * 1000 < lastPoint && timeStamp * 1000 > firstPoint
+                    )
                     .map(([timeStamp, valueArr]) => ({
                       name: timeStamp * 1000,
                       value: valueArr.length ? valueArr[0].count : 0,

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -26,10 +26,8 @@ import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePrese
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
 import {
-  AlertRuleStatus,
   Incident,
   IncidentActivityType,
-  IncidentStats,
   IncidentStatus,
 } from '../../types';
 import {getIncidentRuleMetricPreset} from '../../utils';
@@ -380,7 +378,6 @@ class MetricChart extends React.PureComponent<Props, State> {
       filter,
       query,
       incidents,
-      incidentStats,
     } = this.props;
 
     if (!rule) {

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -398,7 +398,7 @@ class MetricChart extends React.PureComponent<Props, State> {
         organization={organization}
         query={query}
         environment={rule.environment ? [rule.environment] : undefined}
-        project={(projects as Project[]).map(project => Number(project.id))}
+        project={(projects as Project[]).filter(p => p && p.slug).map(project => Number(project.id))}
         interval={interval}
         start={viableStartDate}
         end={timePeriod.end}

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -424,21 +424,6 @@ class MetricChart extends React.PureComponent<Props, State> {
 
           const series: LineChartSeries[] = [...timeseriesData];
 
-          if (incidentStats.length && incidents?.length) {
-            incidentStats.forEach((incidentStat, idx) => {
-              if (incidents[idx].alertRule.status === AlertRuleStatus.SNAPSHOT) {
-                series.push({
-                  seriesName: t('Alert %s', incidents[idx].identifier),
-                  type: 'line',
-                  data: incidentStat.eventStats.data.map(([name, valueArr]) => ({
-                    name: name * 1000,
-                    value: valueArr.length ? valueArr[0].count : 0,
-                  })),
-                });
-              }
-            });
-          }
-
           // Ensure series data appears above incident lines
           series[0].z = 100;
           const dataArr = timeseriesData[0].data;
@@ -451,6 +436,23 @@ class MetricChart extends React.PureComponent<Props, State> {
           const totalDuration = lastPoint - firstPoint;
           let criticalDuration = 0;
           let warningDuration = 0;
+
+          if (incidentStats.length && incidents?.length) {
+            incidentStats.forEach((incidentStat, idx) => {
+              if (incidents[idx].alertRule.status === AlertRuleStatus.SNAPSHOT) {
+                series.push({
+                  seriesName: t('Alert %s', incidents[idx].identifier),
+                  type: 'line',
+                  data: incidentStat.eventStats.data
+                    .filter(([timeStamp]) => timeStamp * 1000 < lastPoint && timeStamp * 1000 > firstPoint)
+                    .map(([timeStamp, valueArr]) => ({
+                      name: timeStamp * 1000,
+                      value: valueArr.length ? valueArr[0].count : 0,
+                    })),
+                });
+              }
+            });
+          }
 
           series.push(createStatusAreaSeries(theme.green300, firstPoint, lastPoint));
           if (incidents) {

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -49,7 +49,6 @@ type Props = WithRouterProps & {
   filter: React.ReactNode;
   query: string;
   orgId: string;
-  incidentStats: IncidentStats[];
 };
 
 type State = {
@@ -436,26 +435,6 @@ class MetricChart extends React.PureComponent<Props, State> {
           const totalDuration = lastPoint - firstPoint;
           let criticalDuration = 0;
           let warningDuration = 0;
-
-          if (incidentStats.length && incidents?.length) {
-            incidentStats.forEach((incidentStat, idx) => {
-              if (incidents[idx].alertRule.status === AlertRuleStatus.SNAPSHOT) {
-                series.push({
-                  seriesName: t('Alert %s', incidents[idx].identifier),
-                  type: 'line',
-                  data: incidentStat.eventStats.data
-                    .filter(
-                      ([timeStamp]) =>
-                        timeStamp * 1000 < lastPoint && timeStamp * 1000 > firstPoint
-                    )
-                    .map(([timeStamp, valueArr]) => ({
-                      name: timeStamp * 1000,
-                      value: valueArr.length ? valueArr[0].count : 0,
-                    })),
-                });
-              }
-            });
-          }
 
           series.push(createStatusAreaSeries(theme.green300, firstPoint, lastPoint));
           if (incidents) {

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -25,11 +25,7 @@ import {TimePeriodType} from 'app/views/alerts/rules/details/body';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
-import {
-  Incident,
-  IncidentActivityType,
-  IncidentStatus,
-} from '../../types';
+import {Incident, IncidentActivityType, IncidentStatus} from '../../types';
 import {getIncidentRuleMetricPreset} from '../../utils';
 
 const X_AXIS_BOUNDARY_GAP = 20;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -25,7 +25,13 @@ import {TimePeriodType} from 'app/views/alerts/rules/details/body';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
-import {AlertRuleStatus, Incident, IncidentActivityType, IncidentStats, IncidentStatus} from '../../types';
+import {
+  AlertRuleStatus,
+  Incident,
+  IncidentActivityType,
+  IncidentStats,
+  IncidentStatus,
+} from '../../types';
 import {getIncidentRuleMetricPreset} from '../../utils';
 
 const X_AXIS_BOUNDARY_GAP = 20;
@@ -426,11 +432,11 @@ class MetricChart extends React.PureComponent<Props, State> {
                   type: 'line',
                   data: incidentStat.eventStats.data.map(([name, valueArr]) => ({
                     name: name * 1000,
-                    value: valueArr.length ? valueArr[0].count : 0
+                    value: valueArr.length ? valueArr[0].count : 0,
                   })),
-                })
+                });
               }
-            })
+            });
           }
 
           // Ensure series data appears above incident lines

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -398,7 +398,9 @@ class MetricChart extends React.PureComponent<Props, State> {
         organization={organization}
         query={query}
         environment={rule.environment ? [rule.environment] : undefined}
-        project={(projects as Project[]).filter(p => p && p.slug).map(project => Number(project.id))}
+        project={(projects as Project[])
+          .filter(p => p && p.slug)
+          .map(project => Number(project.id))}
         interval={interval}
         start={viableStartDate}
         end={timePeriod.end}

--- a/src/sentry/static/sentry/app/views/alerts/types.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/types.tsx
@@ -21,7 +21,6 @@ export type Incident = {
   title: string;
   hasSeen: boolean;
   alertRule: IncidentRule;
-  originalAlertRule?: IncidentRule;
   activities?: ActivityType[];
 };
 

--- a/src/sentry/static/sentry/app/views/alerts/types.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/types.tsx
@@ -21,6 +21,7 @@ export type Incident = {
   title: string;
   hasSeen: boolean;
   alertRule: IncidentRule;
+  originalAlertRule?: IncidentRule;
   activities?: ActivityType[];
 };
 

--- a/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
@@ -35,6 +35,7 @@ export function fetchIncidentsForRule(
   return uncancellableApi.requestPromise(`/organizations/${orgId}/incidents/`, {
     query: {
       alertRule,
+      includeSnapshots: true,
       start,
       end,
       expand: ['activities', 'seen_by', 'original_alert_rule'],

--- a/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
@@ -33,7 +33,12 @@ export function fetchIncidentsForRule(
   end: string
 ): Promise<Incident[]> {
   return uncancellableApi.requestPromise(`/organizations/${orgId}/incidents/`, {
-    query: {alertRule, start, end, expand: ['activities', 'seen_by', 'original_alert_rule']},
+    query: {
+      alertRule,
+      start,
+      end,
+      expand: ['activities', 'seen_by', 'original_alert_rule'],
+    },
   });
 }
 

--- a/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/utils/index.tsx
@@ -33,7 +33,7 @@ export function fetchIncidentsForRule(
   end: string
 ): Promise<Incident[]> {
   return uncancellableApi.requestPromise(`/organizations/${orgId}/incidents/`, {
-    query: {alertRule, start, end, expand: ['activities', 'seen_by']},
+    query: {alertRule, start, end, expand: ['activities', 'seen_by', 'original_alert_rule']},
   });
 }
 

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/types.tsx
@@ -74,6 +74,7 @@ export type SavedIncidentRule = UnsavedIncidentRule & {
   status: number;
   name: string;
   createdBy?: {id: number; email: string; name: string} | null;
+  originalAlertRuleId?: number | null;
 };
 
 export type IncidentRule = Partial<SavedIncidentRule> & UnsavedIncidentRule;


### PR DESCRIPTION
This adds historical incidents to the alert details chart Auto resolved incidents have the original alert rule id in the alert rule and open in alert details, they are also returned for the original alert rule. Stats from snapshotted incident stats are shown in the chart if they are in the time range.

[WOR-753](https://getsentry.atlassian.net/browse/WOR-753)