### PR TITLE
feat(breakdowns): Expose span op breakdowns to Discover column builder

### DIFF
--- a/src/sentry/static/sentry/app/utils/performance/spanOperationBreakdowns/constants.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/spanOperationBreakdowns/constants.tsx
@@ -1,0 +1,6 @@
+export const SPAN_OP_BREAKDOWN_FIELDS = [
+  'spans.browser',
+  'spans.http',
+  'spans.db',
+  'spans.resource',
+];

--- a/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/columnEditModal.tsx
@@ -22,6 +22,7 @@ type Props = {
   organization: LightWeightOrganization;
   tagKeys: null | string[];
   measurementKeys: null | string[];
+  spanOperationBreakdownKeys?: string[];
   // Fired when column selections have been applied.
   onApply: (columns: Column[]) => void;
 } & ModalRenderProps;
@@ -61,6 +62,7 @@ class ColumnEditModal extends React.Component<Props, State> {
       Footer,
       tagKeys,
       measurementKeys,
+      spanOperationBreakdownKeys,
       organization,
       closeModal,
     } = this.props;
@@ -68,6 +70,7 @@ class ColumnEditModal extends React.Component<Props, State> {
       organization,
       tagKeys,
       measurementKeys,
+      spanOperationBreakdownKeys,
     });
     return (
       <React.Fragment>

--- a/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/index.tsx
@@ -11,6 +11,7 @@ import {TableData} from 'app/utils/discover/discoverQuery';
 import EventView, {isAPIPayloadSimilar} from 'app/utils/discover/eventView';
 import Measurements from 'app/utils/measurements/measurements';
 import parseLinkHeader from 'app/utils/parseLinkHeader';
+import {SPAN_OP_BREAKDOWN_FIELDS} from 'app/utils/performance/spanOperationBreakdowns/constants';
 import withApi from 'app/utils/withApi';
 import withTags from 'app/utils/withTags';
 
@@ -162,6 +163,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
         <Measurements>
           {({measurements}) => {
             const measurementKeys = Object.values(measurements).map(({key}) => key);
+
             return (
               <TableView
                 {...this.props}
@@ -172,6 +174,7 @@ class Table extends React.PureComponent<TableProps, TableState> {
                 tableData={tableData}
                 tagKeys={tagKeys}
                 measurementKeys={measurementKeys}
+                spanOperationBreakdownKeys={SPAN_OP_BREAKDOWN_FIELDS}
               />
             );
           }}

--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -409,7 +409,7 @@ class QueryField extends React.Component<Props> {
         break;
       case FieldValueKind.BREAKDOWN:
         text = 'breakdown';
-        tagType = 'info';
+        tagType = 'error';
         break;
       case FieldValueKind.TAG:
         text = kind;

--- a/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/queryField.tsx
@@ -92,6 +92,7 @@ class QueryField extends React.Component<Props> {
     switch (value.kind) {
       case FieldValueKind.TAG:
       case FieldValueKind.MEASUREMENT:
+      case FieldValueKind.BREAKDOWN:
       case FieldValueKind.FIELD:
         fieldValue = {kind: 'field', field: value.meta.name};
         break;
@@ -128,7 +129,8 @@ class QueryField extends React.Component<Props> {
           } else if (
             (field.kind === FieldValueKind.FIELD ||
               field.kind === FieldValueKind.TAG ||
-              field.kind === FieldValueKind.MEASUREMENT) &&
+              field.kind === FieldValueKind.MEASUREMENT ||
+              field.kind === FieldValueKind.BREAKDOWN) &&
             validateColumnTypes(param.columnTypes as ValidateColumnTypes, field)
           ) {
             // New function accepts current field.
@@ -199,6 +201,11 @@ class QueryField extends React.Component<Props> {
       return fieldOptions[measurementName].value;
     }
 
+    const spanOperationBreakdownName = `span_op_breakdown:${name}`;
+    if (fieldOptions[spanOperationBreakdownName]) {
+      return fieldOptions[spanOperationBreakdownName].value;
+    }
+
     const tagName =
       name.indexOf('tags[') === 0
         ? `tag:${name.replace(/tags\[(.*?)\]/, '$1')}`
@@ -264,7 +271,8 @@ class QueryField extends React.Component<Props> {
                 ({value}) =>
                   (value.kind === FieldValueKind.FIELD ||
                     value.kind === FieldValueKind.TAG ||
-                    value.kind === FieldValueKind.MEASUREMENT) &&
+                    value.kind === FieldValueKind.MEASUREMENT ||
+                    value.kind === FieldValueKind.BREAKDOWN) &&
                   validateColumnTypes(param.columnTypes as ValidateColumnTypes, value)
               ),
             };
@@ -397,6 +405,10 @@ class QueryField extends React.Component<Props> {
         break;
       case FieldValueKind.MEASUREMENT:
         text = 'measure';
+        tagType = 'info';
+        break;
+      case FieldValueKind.BREAKDOWN:
+        text = 'breakdown';
         tagType = 'info';
         break;
       case FieldValueKind.TAG:

--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableView.tsx
@@ -51,6 +51,7 @@ export type TableViewProps = {
   tableData: TableData | null | undefined;
   tagKeys: null | string[];
   measurementKeys: null | string[];
+  spanOperationBreakdownKeys?: string[];
   title: string;
 
   onChangeShowTags: () => void;
@@ -301,7 +302,17 @@ class TableView extends React.Component<TableViewProps> {
   };
 
   handleEditColumns = () => {
-    const {organization, eventView, tagKeys, measurementKeys} = this.props;
+    const {
+      organization,
+      eventView,
+      tagKeys,
+      measurementKeys,
+      spanOperationBreakdownKeys,
+    } = this.props;
+
+    const hasBreakdownFeature = organization.features.includes(
+      'performance-ops-breakdown'
+    );
 
     openModal(
       modalProps => (
@@ -310,6 +321,9 @@ class TableView extends React.Component<TableViewProps> {
           organization={organization}
           tagKeys={tagKeys}
           measurementKeys={measurementKeys}
+          spanOperationBreakdownKeys={
+            hasBreakdownFeature ? spanOperationBreakdownKeys : undefined
+          }
           columns={eventView.getColumns().map(col => col.column)}
           onApply={this.handleUpdateColumns}
         />

--- a/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/types.tsx
@@ -31,6 +31,7 @@ export type TableState = {
 export enum FieldValueKind {
   TAG = 'tag',
   MEASUREMENT = 'measurement',
+  BREAKDOWN = 'breakdown',
   FIELD = 'field',
   FUNCTION = 'function',
 }
@@ -50,6 +51,13 @@ export type FieldValueColumns =
       meta: {
         name: string;
         dataType: ColumnType;
+      };
+    }
+  | {
+      kind: FieldValueKind.BREAKDOWN;
+      meta: {
+        name: string;
+        dataType: 'duration';
       };
     }
   | {

--- a/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/utils.tsx
@@ -413,6 +413,7 @@ type FieldGeneratorOpts = {
   organization: LightWeightOrganization;
   tagKeys?: string[] | null;
   measurementKeys?: string[] | null;
+  spanOperationBreakdownKeys?: string[];
   aggregations?: Record<string, Aggregation>;
   fields?: Record<string, ColumnType>;
 };
@@ -421,6 +422,7 @@ export function generateFieldOptions({
   organization,
   tagKeys,
   measurementKeys,
+  spanOperationBreakdownKeys,
   aggregations = AGGREGATIONS,
   fields = FIELDS,
 }: FieldGeneratorOpts) {
@@ -498,6 +500,18 @@ export function generateFieldOptions({
         value: {
           kind: FieldValueKind.MEASUREMENT,
           meta: {name: measurement, dataType: measurementType(measurement)},
+        },
+      };
+    });
+  }
+
+  if (Array.isArray(spanOperationBreakdownKeys)) {
+    spanOperationBreakdownKeys.forEach(breakdownField => {
+      fieldOptions[`span_op_breakdown:${breakdownField}`] = {
+        label: breakdownField,
+        value: {
+          kind: FieldValueKind.BREAKDOWN,
+          meta: {name: breakdownField, dataType: 'duration'},
         },
       };
     });


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/25168

<img width="798" alt="Screen Shot 2021-04-14 at 4 12 31 PM" src="https://user-images.githubusercontent.com/139499/114774003-b890df00-9d3d-11eb-80ac-4c3e9b8f9648.png">

