### PR TITLE
feat(search): Handle IN search in postgres

### DIFF
--- a/src/sentry/api/endpoints/organization_group_index.py
+++ b/src/sentry/api/endpoints/organization_group_index.py
@@ -87,7 +87,11 @@ def inbox_search(
     if not get_search_filter(search_filters, "for_review", "="):
         raise InvalidSearchQuery("Sort key 'inbox' only supported for inbox search")
 
-    if get_search_filter(search_filters, "status", "=") != GroupStatus.UNRESOLVED:
+    if get_search_filter(
+        search_filters, "status", "="
+    ) != GroupStatus.UNRESOLVED and get_search_filter(search_filters, "status", "IN") != [
+        GroupStatus.UNRESOLVED
+    ]:
         raise InvalidSearchQuery("Inbox search only works for 'unresolved' status")
 
     # We just filter on `GroupInbox.date_added` here, and don't filter by date
@@ -107,7 +111,7 @@ def inbox_search(
             .distinct()
         )
 
-    owner_search = get_search_filter(search_filters, "assigned_or_suggested", "=")
+    owner_search = get_search_filter(search_filters, "assigned_or_suggested", "IN")
     if owner_search:
         qs = qs.filter(
             assigned_or_suggested_filter(owner_search, projects, field_filter="group_id")

--- a/src/sentry/api/endpoints/project_group_index.py
+++ b/src/sentry/api/endpoints/project_group_index.py
@@ -15,7 +15,7 @@ from sentry.api.helpers.group_index import (
 )
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.group import StreamGroupSerializer
-from sentry.models import Environment, Group, GroupStatus, Organization
+from sentry.models import QUERY_STATUS_LOOKUP, Environment, Group, GroupStatus, Organization
 from sentry.signals import advanced_search
 from sentry.utils.validators import normalize_event_id
 
@@ -137,8 +137,9 @@ class ProjectGroupIndexEndpoint(ProjectEndpoint, EnvironmentMixin):
             for search_filter in query_kwargs.get("search_filters", [])
             if search_filter.key.name == "status"
         ]
-        if status and status[0].value.raw_value == GroupStatus.UNRESOLVED:
-            context = [r for r in context if r["status"] == "unresolved"]
+        if status and (GroupStatus.UNRESOLVED in status[0].value.raw_value):
+            status_labels = {QUERY_STATUS_LOOKUP[s] for s in status[0].value.raw_value}
+            context = [r for r in context if "status" not in r or r["status"] in status_labels]
 
         response = Response(context)
 

--- a/src/sentry/api/issue_search.py
+++ b/src/sentry/api/issue_search.py
@@ -13,7 +13,6 @@ from sentry.api.event_search import (
 from sentry.models.group import STATUS_QUERY_CHOICES
 from sentry.search.utils import (
     parse_actor_or_none_value,
-    parse_actor_value,
     parse_release,
     parse_status_value,
     parse_user_value,
@@ -88,10 +87,6 @@ def parse_search_query(query):
             )
         )
     return IssueSearchVisitor(allow_boolean=False).visit(tree)
-
-
-def convert_actor_value(value, projects, user, environments):
-    return parse_actor_value(projects, value, user)
 
 
 def convert_actor_or_none_value(value, projects, user, environments):

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -143,6 +143,9 @@ STATUS_QUERY_CHOICES = {
     "muted": GroupStatus.IGNORED,
     "reprocessing": GroupStatus.REPROCESSING,
 }
+QUERY_STATUS_LOOKUP = {
+    status: query for query, status in STATUS_QUERY_CHOICES.items() if query != "muted"
+}
 
 # Statuses that can be updated from the regular "update group" API
 #

--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -1,12 +1,14 @@
 import functools
 from abc import ABCMeta, abstractmethod
+from collections import defaultdict
 from datetime import timedelta
 
 from django.db.models import Q
 from django.utils import timezone
+from django.utils.functional import SimpleLazyObject
 
 from sentry import quotas
-from sentry.api.event_search import InvalidSearchQuery
+from sentry.api.event_search import InvalidSearchQuery, equality_operators
 from sentry.models import (
     Group,
     GroupAssignee,
@@ -26,52 +28,58 @@ from sentry.search.base import SearchBackend
 from sentry.search.snuba.executors import PostgresSnubaQueryExecutor
 
 
-def assigned_to_filter(actor, projects, field_filter="id"):
+def assigned_to_filter(actors, projects, field_filter="id"):
     from sentry.models import OrganizationMember, OrganizationMemberTeam, Team
 
-    if isinstance(actor, Team):
-        return Q(
+    include_none = False
+    types_to_actors = defaultdict(list)
+    for actor in actors:
+        if isinstance(actor, list) and actor[0] == "me_or_none":
+            include_none = True
+            actor = actor[1]
+        types_to_actors[type(actor) if not isinstance(actor, SimpleLazyObject) else User].append(
+            actor
+        )
+
+    query = Q()
+
+    if Team in types_to_actors:
+        query |= Q(
             **{
                 f"{field_filter}__in": GroupAssignee.objects.filter(
-                    team=actor, project_id__in=[p.id for p in projects]
+                    team__in=types_to_actors[Team], project_id__in=[p.id for p in projects]
                 ).values_list("group_id", flat=True)
             }
         )
 
-    include_none = False
-    if isinstance(actor, list) and actor[0] == "me_or_none":
-        include_none = True
-        actor = actor[1]
-
-    assigned_to_user = Q(
-        **{
-            f"{field_filter}__in": GroupAssignee.objects.filter(
-                user=actor, project_id__in=[p.id for p in projects]
-            ).values_list("group_id", flat=True)
-        }
-    )
-    assigned_to_team = Q(
-        **{
-            f"{field_filter}__in": GroupAssignee.objects.filter(
-                project_id__in=[p.id for p in projects],
-                team_id__in=Team.objects.filter(
-                    id__in=OrganizationMemberTeam.objects.filter(
-                        organizationmember__in=OrganizationMember.objects.filter(
-                            user=actor, organization_id=projects[0].organization_id
-                        ),
-                        is_active=True,
-                    ).values("team")
-                ),
-            ).values_list("group_id", flat=True)
-        }
-    )
-
-    assigned_query = assigned_to_user | assigned_to_team
+    if User in types_to_actors:
+        users = types_to_actors[User]
+        query |= Q(
+            **{
+                f"{field_filter}__in": GroupAssignee.objects.filter(
+                    user__in=users, project_id__in=[p.id for p in projects]
+                ).values_list("group_id", flat=True)
+            }
+        )
+        query |= Q(
+            **{
+                f"{field_filter}__in": GroupAssignee.objects.filter(
+                    project_id__in=[p.id for p in projects],
+                    team_id__in=Team.objects.filter(
+                        id__in=OrganizationMemberTeam.objects.filter(
+                            organizationmember__in=OrganizationMember.objects.filter(
+                                user__in=users, organization_id=projects[0].organization_id
+                            ),
+                            is_active=True,
+                        ).values("team")
+                    ),
+                ).values_list("group_id", flat=True)
+            }
+        )
 
     if include_none:
-        return assigned_query | unassigned_filter(True, projects, field_filter=field_filter)
-    else:
-        return assigned_query
+        query |= unassigned_filter(True, projects, field_filter=field_filter)
+    return query
 
 
 def unassigned_filter(unassigned, projects, field_filter="id"):
@@ -124,18 +132,29 @@ def linked_filter(linked, projects):
     return query
 
 
-def first_release_all_environments_filter(version, projects):
-    try:
-        release_id = Release.objects.get(
-            organization=projects[0].organization_id, version=version
-        ).id
-    except Release.DoesNotExist:
-        release_id = -1
+def first_release_all_environments_filter(versions, projects):
+    releases = {
+        id_: version
+        for id_, version in Release.objects.filter(
+            organization=projects[0].organization_id, version__in=versions
+        ).values_list("version", "id")
+    }
+    for version in versions:
+        if version not in releases:
+            # TODO: This is mostly around for legacy reasons - we should probably just
+            # raise a validation here an inform the user that they passed an invalid
+            # release
+            releases[None] = -1
+            # We only need to find the first non-existent release here
+            break
+
     return Q(
         # If no specific environments are supplied, we look at the
         # first_release of any environment that the group has been
         # seen in.
-        id__in=GroupEnvironment.objects.filter(first_release_id=release_id).values_list("group_id")
+        id__in=GroupEnvironment.objects.filter(
+            first_release_id__in=list(releases.values()),
+        ).values_list("group_id")
     )
 
 
@@ -148,16 +167,30 @@ def inbox_filter(inbox, projects):
     return query
 
 
-def assigned_or_suggested_filter(owner, projects, field_filter="id"):
+def assigned_or_suggested_filter(owners, projects, field_filter="id"):
     organization_id = projects[0].organization_id
     project_ids = [p.id for p in projects]
-    if isinstance(owner, Team):
-        return (
+
+    types_to_owners = defaultdict(list)
+    include_none = False
+    for owner in owners:
+        if isinstance(owner, list) and owner[0] == "me_or_none":
+            include_none = True
+            owner = owner[1]
+        types_to_owners[type(owner) if not isinstance(owner, SimpleLazyObject) else User].append(
+            owner
+        )
+
+    query = Q()
+
+    if Team in types_to_owners:
+        teams = types_to_owners[Team]
+        query |= (
             Q(
                 **{
                     f"{field_filter}__in": GroupOwner.objects.filter(
                         Q(group__assignee_set__isnull=True),
-                        team=owner,
+                        team__in=teams,
                         project_id__in=project_ids,
                         organization_id=organization_id,
                     )
@@ -165,18 +198,15 @@ def assigned_or_suggested_filter(owner, projects, field_filter="id"):
                     .distinct()
                 }
             )
-            | assigned_to_filter(owner, projects, field_filter=field_filter)
+            | assigned_to_filter(teams, projects, field_filter=field_filter)
         )
-    elif isinstance(owner, User) or (isinstance(owner, list) and owner[0] == "me_or_none"):
-        include_none = False
-        if isinstance(owner, list) and owner[0] == "me_or_none":
-            include_none = True
-            owner = owner[1]
 
+    if User in types_to_owners:
+        users = types_to_owners[User]
         teams = Team.objects.filter(
             id__in=OrganizationMemberTeam.objects.filter(
                 organizationmember__in=OrganizationMember.objects.filter(
-                    user=owner, organization_id=organization_id
+                    user__in=users, organization_id=organization_id
                 ),
                 is_active=True,
             ).values("team")
@@ -184,7 +214,7 @@ def assigned_or_suggested_filter(owner, projects, field_filter="id"):
         owned_by_me = Q(
             **{
                 f"{field_filter}__in": GroupOwner.objects.filter(
-                    Q(user_id=owner.id) | Q(team__in=teams),
+                    Q(user__in=users) | Q(team__in=teams),
                     group__assignee_set__isnull=True,
                     project_id__in=[p.id for p in projects],
                     organization_id=organization_id,
@@ -194,21 +224,23 @@ def assigned_or_suggested_filter(owner, projects, field_filter="id"):
             }
         )
 
-        owner_query = owned_by_me | assigned_to_filter(owner, projects, field_filter=field_filter)
+        owner_query = owned_by_me | assigned_to_filter(users, projects, field_filter=field_filter)
 
-        if include_none:
-            no_owner = unassigned_filter(True, projects, field_filter) & ~Q(
+        query |= owner_query
+
+    if include_none:
+        query |= Q(
+            unassigned_filter(True, projects, field_filter),
+            ~Q(
                 **{
                     f"{field_filter}__in": GroupOwner.objects.filter(
                         project_id__in=[p.id for p in projects],
                     ).values_list("group_id", flat=True)
                 }
-            )
-            return no_owner | owner_query
-        else:
-            return owner_query
+            ),
+        )
 
-    raise InvalidSearchQuery("Unsupported owner type.")
+    return query
 
 
 class Condition:
@@ -228,11 +260,13 @@ class QCallbackCondition(Condition):
     def apply(self, queryset, search_filter):
         value = search_filter.value.raw_value
         q = self.callback(value)
-        if search_filter.operator not in ("=", "!="):
+        if search_filter.operator not in ("=", "!=", "IN", "NOT IN"):
             raise InvalidSearchQuery(
                 f"Operator {search_filter.operator} not valid for search {search_filter}"
             )
-        queryset_method = queryset.filter if search_filter.operator == "=" else queryset.exclude
+        queryset_method = (
+            queryset.filter if search_filter.operator in equality_operators else queryset.exclude
+        )
         queryset = queryset_method(q)
         return queryset
 
@@ -383,7 +417,9 @@ class SnubaSearchBackendBase(SearchBackend, metaclass=ABCMeta):
         if environments is not None:
             environment_ids = [environment.id for environment in environments]
             group_queryset = group_queryset.filter(
-                groupenvironment__environment_id__in=environment_ids
+                id__in=GroupEnvironment.objects.filter(environment__in=environment_ids).values_list(
+                    "group_id"
+                )
             )
         return group_queryset
 
@@ -407,9 +443,9 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
 
     def _get_queryset_conditions(self, projects, environments, search_filters):
         queryset_conditions = {
-            "status": QCallbackCondition(lambda status: Q(status=status)),
+            "status": QCallbackCondition(lambda statuses: Q(status__in=statuses)),
             "bookmarked_by": QCallbackCondition(
-                lambda user: Q(bookmark_set__project__in=projects, bookmark_set__user=user)
+                lambda users: Q(bookmark_set__project__in=projects, bookmark_set__user__in=users)
             ),
             "assigned_to": QCallbackCondition(
                 functools.partial(assigned_to_filter, projects=projects)
@@ -419,9 +455,9 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             ),
             "linked": QCallbackCondition(functools.partial(linked_filter, projects=projects)),
             "subscribed_by": QCallbackCondition(
-                lambda user: Q(
+                lambda users: Q(
                     id__in=GroupSubscription.objects.filter(
-                        project__in=projects, user=user, is_active=True
+                        project__in=projects, user__in=users, is_active=True
                     ).values_list("group")
                 )
             ),
@@ -437,14 +473,14 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             queryset_conditions.update(
                 {
                     "first_release": QCallbackCondition(
-                        lambda version: Q(
+                        lambda versions: Q(
                             # if environment(s) are selected, we just filter on the group
                             # environment's first_release attribute.
-                            groupenvironment__first_release__organization_id=projects[
-                                0
-                            ].organization_id,
-                            groupenvironment__first_release__version=version,
-                            groupenvironment__environment_id__in=environment_ids,
+                            id__in=GroupEnvironment.objects.filter(
+                                first_release__organization_id=projects[0].organization_id,
+                                first_release__version__in=versions,
+                                environment_id__in=environment_ids,
+                            ).values_list("group_id"),
                         )
                     ),
                     "first_seen": ScalarCondition(
@@ -457,7 +493,10 @@ class EventsDatasetSnubaSearchBackend(SnubaSearchBackendBase):
             queryset_conditions.update(
                 {
                     "first_release": QCallbackCondition(
-                        functools.partial(first_release_all_environments_filter, projects=projects)
+                        functools.partial(
+                            first_release_all_environments_filter,
+                            projects=projects,
+                        )
                     ),
                     "first_seen": ScalarCondition("first_seen"),
                 }

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -30,7 +30,7 @@ def get_search_filter(search_filters, name, operator):
     """
     if not search_filters:
         return None
-    assert operator in ("<", ">", "=")
+    assert operator in ("<", ">", "=", "IN")
     comparator = max if operator.startswith(">") else min
     found_val = None
     for search_filter in search_filters:

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -7,7 +7,7 @@ from sentry.api.event_search import (
     SearchValue,
 )
 from sentry.api.issue_search import (
-    convert_actor_value,
+    convert_actor_or_none_value,
     convert_query_values,
     convert_release_value,
     convert_user_value,
@@ -192,20 +192,28 @@ class ConvertStatusValueTest(TestCase):
             convert_query_values(filters, [self.project], self.user, None)
 
 
-class ConvertActorValueTest(TestCase):
+class ConvertActorOrNoneValueTest(TestCase):
     def test_user(self):
-        assert convert_actor_value("me", [self.project], self.user, None) == convert_user_value(
+        assert convert_actor_or_none_value(
             "me", [self.project], self.user, None
-        )
+        ) == convert_user_value("me", [self.project], self.user, None)
+
+    def test_me_or_none(self):
+        assert convert_actor_or_none_value("me_or_none", [self.project], self.user, None) == [
+            "me_or_none",
+            self.user,
+        ]
 
     def test_team(self):
         assert (
-            convert_actor_value("#%s" % self.team.slug, [self.project], self.user, None)
+            convert_actor_or_none_value("#%s" % self.team.slug, [self.project], self.user, None)
             == self.team
         )
 
     def test_invalid_team(self):
-        assert convert_actor_value("#never_upgrade", [self.project], self.user, None).id == 0
+        assert (
+            convert_actor_or_none_value("#never_upgrade", [self.project], self.user, None).id == 0
+        )
 
 
 class ConvertUserValueTest(TestCase):

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -156,7 +156,7 @@ class ConvertQueryValuesTest(TestCase):
     def test_valid_converter(self):
         filters = [SearchFilter(SearchKey("assigned_to"), "=", SearchValue("me"))]
         expected = value_converters["assigned_to"](
-            filters[0].value.raw_value, [self.project], self.user, None
+            [filters[0].value.raw_value], [self.project], self.user, None
         )
         filters = convert_query_values(filters, [self.project], self.user, None)
         assert filters[0].value.raw_value == expected
@@ -171,13 +171,13 @@ class ConvertQueryValuesTest(TestCase):
 class ConvertStatusValueTest(TestCase):
     def test_valid(self):
         for status_string, status_val in STATUS_QUERY_CHOICES.items():
-            filters = [SearchFilter(SearchKey("status"), "=", SearchValue(status_string))]
+            filters = [SearchFilter(SearchKey("status"), "=", SearchValue([status_string]))]
             result = convert_query_values(filters, [self.project], self.user, None)
-            assert result[0].value.raw_value == status_val
+            assert result[0].value.raw_value == [status_val]
 
-            filters = [SearchFilter(SearchKey("status"), "=", SearchValue(status_val))]
+            filters = [SearchFilter(SearchKey("status"), "=", SearchValue([status_val]))]
             result = convert_query_values(filters, [self.project], self.user, None)
-            assert result[0].value.raw_value == status_val
+            assert result[0].value.raw_value == [status_val]
 
     def test_invalid(self):
         filters = [SearchFilter(SearchKey("status"), "=", SearchValue("wrong"))]
@@ -195,43 +195,47 @@ class ConvertStatusValueTest(TestCase):
 class ConvertActorOrNoneValueTest(TestCase):
     def test_user(self):
         assert convert_actor_or_none_value(
-            "me", [self.project], self.user, None
-        ) == convert_user_value("me", [self.project], self.user, None)
+            ["me"], [self.project], self.user, None
+        ) == convert_user_value(["me"], [self.project], self.user, None)
 
     def test_me_or_none(self):
-        assert convert_actor_or_none_value("me_or_none", [self.project], self.user, None) == [
-            "me_or_none",
-            self.user,
+        assert convert_actor_or_none_value(["me_or_none"], [self.project], self.user, None) == [
+            [
+                "me_or_none",
+                self.user,
+            ]
         ]
 
     def test_team(self):
-        assert (
-            convert_actor_or_none_value("#%s" % self.team.slug, [self.project], self.user, None)
-            == self.team
-        )
+        assert convert_actor_or_none_value(
+            [f"#{self.team.slug}"], [self.project], self.user, None
+        ) == [self.team]
 
     def test_invalid_team(self):
         assert (
-            convert_actor_or_none_value("#never_upgrade", [self.project], self.user, None).id == 0
+            convert_actor_or_none_value(["#never_upgrade"], [self.project], self.user, None)[0].id
+            == 0
         )
 
 
 class ConvertUserValueTest(TestCase):
     def test_me(self):
-        assert convert_user_value("me", [self.project], self.user, None) == self.user
+        assert convert_user_value(["me"], [self.project], self.user, None) == [self.user]
 
     def test_specified_user(self):
         user = self.create_user()
-        assert convert_user_value(user.username, [self.project], self.user, None) == user
+        assert convert_user_value([user.username], [self.project], self.user, None) == [user]
 
     def test_invalid_user(self):
-        assert convert_user_value("fake-user", [], None, None).id == 0
+        assert convert_user_value(["fake-user"], [], None, None)[0].id == 0
 
 
 class ConvertReleaseValueTest(TestCase):
     def test(self):
-        assert convert_release_value("123", [self.project], self.user, None) == "123"
+        assert convert_release_value(["123"], [self.project], self.user, None) == ["123"]
 
     def test_latest(self):
         release = self.create_release(self.project)
-        assert convert_release_value("latest", [self.project], self.user, None) == release.version
+        assert convert_release_value(["latest"], [self.project], self.user, None) == [
+            release.version
+        ]

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -761,7 +761,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             GroupAssignee.objects.assign(ag, self.user)
 
         response = self.get_response(limit=10, query="assigned:me")
-        assert len(response.data) == 2
+        assert [row["id"] for row in response.data] == [str(g.id) for g in assigned_groups]
 
         response = self.get_response(limit=10, query="assigned:me_or_none")
         assert len(response.data) == 5

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -20,6 +20,7 @@ from sentry.models import (
     Integration,
 )
 from sentry.models.groupinbox import GroupInboxReason, add_group_to_inbox
+from sentry.models.groupowner import GroupOwner
 from sentry.search.snuba.backend import EventsDatasetSnubaSearchBackend
 from sentry.testutils import SnubaTestCase, TestCase, xfail_if_not_postgres
 from sentry.testutils.helpers.datetime import before_now, iso_format
@@ -228,6 +229,18 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             **kwargs,
         )
 
+    def run_test_query_in_syntax(
+        self, query, expected_groups, expected_negative_groups=None, environments=None
+    ):
+        results = self.make_query(search_filter_query=query, environments=environments)
+        sort_key = lambda result: result.id
+        print("results", results.results)
+        assert sorted(results, key=sort_key) == sorted(expected_groups, key=sort_key)
+
+        if expected_negative_groups is not None:
+            results = self.make_query(search_filter_query=f"!{query}")
+            assert sorted(results, key=sort_key) == sorted(expected_negative_groups, key=sort_key)
+
     def test_query(self):
         results = self.make_query(search_filter_query="foo")
         assert set(results) == {self.group1}
@@ -345,6 +358,25 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         results = self.make_query(search_filter_query="is:resolved")
         assert set(results) == {self.group2}
 
+        event_3 = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group3"],
+                "event_id": "c" * 32,
+                "timestamp": iso_format(self.base_datetime - timedelta(days=20)),
+            },
+            project_id=self.project.id,
+        )
+        group_3 = event_3.group
+        group_3.status = GroupStatus.MUTED
+        group_3.save()
+
+        self.run_test_query_in_syntax(
+            "status:[unresolved, resolved]", [self.group1, self.group2], [group_3]
+        )
+        self.run_test_query_in_syntax(
+            "status:[resolved, muted]", [self.group2, group_3], [self.group1]
+        )
+
     def test_status_with_environment(self):
         results = self.make_query(
             environments=[self.environments["production"]], search_filter_query="is:unresolved"
@@ -420,6 +452,16 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
     def test_bookmarked_by(self):
         results = self.make_query(search_filter_query="bookmarks:%s" % self.user.username)
         assert set(results) == {self.group2}
+
+    def test_bookmarked_by_in_syntax(self):
+        self.run_test_query_in_syntax(
+            f"bookmarks:[{self.user.username}]", [self.group2], [self.group1]
+        )
+        user_2 = self.create_user()
+        GroupBookmark.objects.create(user=user_2, group=self.group1, project=self.group2.project)
+        self.run_test_query_in_syntax(
+            f"bookmarks:[{self.user.username}, {user_2.username}]", [self.group2, self.group1], []
+        )
 
     def test_bookmarked_by_with_environment(self):
         results = self.make_query(
@@ -927,6 +969,196 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         results = self.make_query(search_filter_query="assigned:%s" % owner.username)
         assert set(results) == set()
 
+    def test_assigned_to_in_syntax(self):
+        group_3 = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group3"],
+                "event_id": "c" * 32,
+                "timestamp": iso_format(self.base_datetime - timedelta(days=20)),
+            },
+            project_id=self.project.id,
+        ).group
+        group_3.status = GroupStatus.MUTED
+        group_3.save()
+        other_user = self.create_user()
+        self.run_test_query_in_syntax(
+            f"assigned:[{self.user.username}, {other_user.username}]",
+            [self.group2],
+            [self.group1, group_3],
+        )
+
+        GroupAssignee.objects.create(project=self.project, group=group_3, user=other_user)
+        self.run_test_query_in_syntax(
+            f"assigned:[{self.user.username}, {other_user.username}]",
+            [self.group2, group_3],
+            [self.group1],
+        )
+
+        self.run_test_query_in_syntax(
+            f"assigned:[#{self.team.slug}, {other_user.username}]",
+            [group_3],
+            [self.group1, self.group2],
+        )
+
+        ga_2 = GroupAssignee.objects.get(
+            user=self.user, group=self.group2, project=self.group2.project
+        )
+        ga_2.update(team=self.team, user=None)
+        self.run_test_query_in_syntax(
+            f"assigned:[{self.user.username}, {other_user.username}]",
+            [self.group2, group_3],
+            [self.group1],
+        )
+        self.run_test_query_in_syntax(
+            f"assigned:[#{self.team.slug}, {other_user.username}]",
+            [self.group2, group_3],
+            [self.group1],
+        )
+
+        self.run_test_query_in_syntax(
+            f"assigned:[me_or_none, {other_user.username}]",
+            [self.group1, self.group2, group_3],
+            [],
+        )
+
+    def test_assigned_or_suggested_in_syntax(self):
+        Group.objects.all().delete()
+        group = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=180)),
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        ).group
+        group1 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=185)),
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+        ).group
+        group2 = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=190)),
+                "fingerprint": ["group-3"],
+            },
+            project_id=self.project.id,
+        ).group
+
+        assigned_group = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=195)),
+                "fingerprint": ["group-4"],
+            },
+            project_id=self.project.id,
+        ).group
+
+        assigned_to_other_group = self.store_event(
+            data={
+                "timestamp": iso_format(before_now(seconds=195)),
+                "fingerprint": ["group-5"],
+            },
+            project_id=self.project.id,
+        ).group
+
+        self.run_test_query_in_syntax(
+            "assigned_or_suggested:[me]",
+            [],
+            [group, group1, group2, assigned_group, assigned_to_other_group],
+        )
+
+        GroupOwner.objects.create(
+            group=assigned_to_other_group,
+            project=self.project,
+            organization=self.organization,
+            type=0,
+            team_id=None,
+            user_id=self.user.id,
+        )
+        GroupOwner.objects.create(
+            group=group,
+            project=self.project,
+            organization=self.organization,
+            type=0,
+            team_id=None,
+            user_id=self.user.id,
+        )
+        self.run_test_query_in_syntax(
+            "assigned_or_suggested:[me]",
+            [group, assigned_to_other_group],
+            [group1, group2, assigned_group],
+        )
+
+        # Because assigned_to_other_event is assigned to self.other_user, it should not show up in assigned_or_suggested search for anyone but self.other_user. (aka. they are now the only owner)
+        other_user = self.create_user("other@user.com", is_superuser=False)
+        GroupAssignee.objects.create(
+            group=assigned_to_other_group,
+            project=self.project,
+            user=other_user,
+        )
+        self.run_test_query_in_syntax(
+            "assigned_or_suggested:[me]",
+            [group],
+            [group1, group2, assigned_group, assigned_to_other_group],
+        )
+
+        self.run_test_query_in_syntax(
+            f"assigned_or_suggested:[{other_user.email}]",
+            [assigned_to_other_group],
+            [group, group1, group2, assigned_group],
+        )
+
+        GroupAssignee.objects.create(group=assigned_group, project=self.project, user=self.user)
+        self.run_test_query_in_syntax(
+            f"assigned_or_suggested:[{self.user.email}]",
+            [assigned_group, group],
+        )
+
+        GroupOwner.objects.create(
+            group=group,
+            project=self.project,
+            organization=self.organization,
+            type=0,
+            team_id=self.team.id,
+            user_id=None,
+        )
+        self.run_test_query_in_syntax(
+            f"assigned_or_suggested:[#{self.team.slug}]",
+            [group],
+        )
+
+        self.run_test_query_in_syntax(
+            "assigned_or_suggested:[me_or_none]",
+            [group, group1, group2, assigned_group],
+            [assigned_to_other_group],
+        )
+
+        not_me = self.create_user(email="notme@sentry.io")
+        GroupOwner.objects.create(
+            group=group2,
+            project=self.project,
+            organization=self.organization,
+            type=0,
+            team_id=None,
+            user_id=not_me.id,
+        )
+        self.run_test_query_in_syntax(
+            "assigned_or_suggested:[me_or_none]",
+            [group, group1, assigned_group],
+            [assigned_to_other_group, group2],
+        )
+        GroupOwner.objects.filter(group=group, user=self.user).delete()
+        self.run_test_query_in_syntax(
+            f"assigned_or_suggested:[me_or_none, #{self.team.slug}]",
+            [group, group1, assigned_group],
+            [assigned_to_other_group, group2],
+        )
+        self.run_test_query_in_syntax(
+            f"assigned_or_suggested:[me_or_none, #{self.team.slug}, {not_me.email}]",
+            [group, group1, assigned_group, group2],
+            [assigned_to_other_group],
+        )
+
     def test_assigned_to_with_environment(self):
         results = self.make_query(
             environments=[self.environments["staging"]],
@@ -945,6 +1177,18 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             [self.group1.project], search_filter_query="subscribed:%s" % self.user.username
         )
         assert set(results) == {self.group1}
+
+    def test_subscribed_by_in_syntax(self):
+        self.run_test_query_in_syntax(
+            f"subscribed:[{self.user.username}]", [self.group1], [self.group2]
+        )
+        user_2 = self.create_user()
+        GroupSubscription.objects.create(
+            user=user_2, group=self.group2, project=self.project, is_active=True
+        )
+        self.run_test_query_in_syntax(
+            f"subscribed:[{self.user.username}, {user_2.username}]", [self.group1, self.group2], []
+        )
 
     def test_subscribed_by_with_environment(self):
         results = self.make_query(
@@ -1200,10 +1444,62 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         results = self.make_query(search_filter_query="first_release:%s" % release_1.version)
         assert set(results) == {group}
 
+    def test_first_release_in_syntax(self):
+        # expect no groups within the results since there are no releases
+        self.run_test_query_in_syntax("first_release:[fake, fake2]", [])
+
+        # expect no groups even though there is a release; since no group
+        # is attached to a release
+        release_1 = self.create_release(self.project)
+        release_2 = self.create_release(self.project)
+
+        self.run_test_query_in_syntax(
+            f"first_release:[{release_1.version}, {release_2.version}]", []
+        )
+
+        # Create a new event so that we get a group in this release
+        group = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group9001"],
+                "event_id": "a" * 32,
+                "message": "hello",
+                "environment": "production",
+                "tags": {"server": "example.com"},
+                "release": release_1.version,
+                "stacktrace": {"frames": [{"module": "group1"}]},
+            },
+            project_id=self.project.id,
+        ).group
+
+        self.run_test_query_in_syntax(
+            f"first_release:[{release_1.version}, {release_2.version}]",
+            [group],
+            [self.group1, self.group2],
+        )
+
+        # Create a new event so that we get a group in this release
+        group_2 = self.store_event(
+            data={
+                "fingerprint": ["put-me-in-group9002"],
+                "event_id": "a" * 32,
+                "message": "hello",
+                "environment": "production",
+                "tags": {"server": "example.com"},
+                "release": release_2.version,
+                "stacktrace": {"frames": [{"module": "group1"}]},
+            },
+            project_id=self.project.id,
+        ).group
+
+        self.run_test_query_in_syntax(
+            f"first_release:[{release_1.version}, {release_2.version}]",
+            [group, group_2],
+        )
+
     def test_first_release_environments(self):
         results = self.make_query(
             environments=[self.environments["production"]],
-            search_filter_query="first_release:%s" % "fake",
+            search_filter_query="first_release:fake",
         )
         assert set(results) == set()
 
@@ -1214,7 +1510,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
 
         results = self.make_query(
             environments=[self.environments["production"]],
-            search_filter_query="first_release:%s" % release.version,
+            search_filter_query=f"first_release:{release.version}",
         )
         assert set(results) == set()
 
@@ -1223,9 +1519,54 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
 
         results = self.make_query(
             environments=[self.environments["production"]],
-            search_filter_query="first_release:%s" % release.version,
+            search_filter_query=f"first_release:{release.version}",
         )
         assert set(results) == {self.group1}
+
+    def test_first_release_environments_in_syntax(self):
+        self.run_test_query_in_syntax(
+            "first_release:[fake, fake2]",
+            [],
+            [self.group1, self.group2],
+            environments=[self.environments["production"]],
+        )
+
+        release = self.create_release(self.project)
+        group_1_env = GroupEnvironment.objects.get(
+            group_id=self.group1.id, environment_id=self.environments["production"].id
+        )
+        group_1_env.update(first_release=release)
+
+        self.run_test_query_in_syntax(
+            f"first_release:[{release.version}, fake2]",
+            [self.group1],
+            [self.group2],
+            environments=[self.environments["production"]],
+        )
+
+        group_2_env = GroupEnvironment.objects.get(
+            group_id=self.group2.id, environment_id=self.environments["staging"].id
+        )
+        group_2_env.update(first_release=release)
+        self.run_test_query_in_syntax(
+            f"first_release:[{release.version}, fake2]",
+            [self.group1, self.group2],
+            [],
+            environments=[self.environments["production"], self.environments["staging"]],
+        )
+
+        # Make sure we don't get duplicate groups
+        GroupEnvironment.objects.create(
+            group_id=self.group1.id,
+            environment_id=self.environments["staging"].id,
+            first_release=release,
+        )
+        self.run_test_query_in_syntax(
+            f"first_release:[{release.version}, fake2]",
+            [self.group1, self.group2],
+            [],
+            environments=[self.environments["production"], self.environments["staging"]],
+        )
 
     def test_query_enclosed_in_quotes(self):
         results = self.make_query(search_filter_query='"foo"')
@@ -1497,6 +1838,10 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
 
         with pytest.raises(InvalidSearchQuery):
             self.make_query([self.project], sort_by="inbox", search_filter_query="!is:for_review")
+
+    def test_in_syntax_is_invalid(self):
+        with pytest.raises(InvalidSearchQuery, match='"in" syntax invalid for "is" search'):
+            self.make_query(search_filter_query="is:[unresolved, resolved]")
 
     def test_first_release_any_or_no_environments(self):
         # test scenarios for tickets:


### PR DESCRIPTION
This builds on grammar work done in #24692 and the snuba
search work done in #24889.

This alters the postgres query backend to take the `SearchFilters` generated by the parser and
convert them into Django queries. This should enable IN search in the issue list.

To make things work generally I just convert all the filters to `IN` statements, so we don't need 
to handle both exact matches and in lookups.