### PR TITLE
fix(ui): Show all matching Suggested Assignees

### DIFF
--- a/src/sentry/static/sentry/app/components/group/suggestedOwners/suggestedAssignees.tsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners/suggestedAssignees.tsx
@@ -62,6 +62,6 @@ const Subheading = styled('small')`
 
 const Content = styled('div')`
   display: grid;
-  grid-gap: ${space(0.5)};
+  grid-gap: ${space(1)};
   grid-template-columns: repeat(auto-fill, 20px);
 `;

--- a/src/sentry/static/sentry/app/components/group/suggestedOwners/suggestedOwners.tsx
+++ b/src/sentry/static/sentry/app/components/group/suggestedOwners/suggestedOwners.tsx
@@ -112,7 +112,11 @@ class SuggestedOwners extends React.Component<Props, State> {
         rules: findMatchedRules(this.state.rules || [], owner),
       };
 
-      const existingIdx = owners.findIndex(o => o.actor.email === owner.email);
+      const existingIdx = owners.findIndex(o =>
+        this.props.committers.length === 0
+          ? o.actor === owner
+          : o.actor.email === owner.email
+      );
       if (existingIdx > -1) {
         owners[existingIdx] = {...normalizedOwner, ...owners[existingIdx]};
         return;


### PR DESCRIPTION
Fix an issue where the Suggested Assignees on an Issue Details page was not displaying all Teams that matched the Issue Owners > Ownership rules.

cc @getsentry/cops 

FIXES [WOR-760](https://getsentry.atlassian.net/browse/WOR-760)

### Before
_This should display 2 teams as a Suggested Assignee_
<img width="343" alt="Screen Shot 2021-04-11 at 8 50 45 PM" src="https://user-images.githubusercontent.com/20312973/114338855-c90c4400-9b08-11eb-9f29-ac4564b4fa1b.png">

### After
<img width="351" alt="Screen Shot 2021-04-11 at 8 52 35 PM" src="https://user-images.githubusercontent.com/20312973/114338882-d9bcba00-9b08-11eb-9844-8b00689f0fd6.png">

