### PR TITLE
ref(images-loaded): Don't dismiss menu on Click

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/filter/index.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/debugMeta-v2/filter/index.tsx
@@ -29,22 +29,20 @@ function Filter({options, onFilter, className}: Props) {
     .filter(option => option.isChecked).length;
 
   function handleClick(category: string, option: Option) {
-    return function () {
-      const updatedOptions = {
-        ...options,
-        [category]: options[category].map(groupedOption => {
-          if (option.id === groupedOption.id) {
-            return {
-              ...groupedOption,
-              isChecked: !groupedOption.isChecked,
-            };
-          }
-          return groupedOption;
-        }),
-      };
-
-      onFilter(updatedOptions);
+    const updatedOptions = {
+      ...options,
+      [category]: options[category].map(groupedOption => {
+        if (option.id === groupedOption.id) {
+          return {
+            ...groupedOption,
+            isChecked: !groupedOption.isChecked,
+          };
+        }
+        return groupedOption;
+      }),
     };
+
+    onFilter(updatedOptions);
   }
 
   return (
@@ -77,7 +75,10 @@ function Filter({options, onFilter, className}: Props) {
                     return (
                       <StyledListItem
                         key={id}
-                        onClick={handleClick(category, groupedOption)}
+                        onClick={event => {
+                          event.stopPropagation();
+                          handleClick(category, groupedOption);
+                        }}
                         isChecked={isChecked}
                       >
                         {symbol}

--- a/src/sentry/static/sentry/app/components/list/listItem.tsx
+++ b/src/sentry/static/sentry/app/components/list/listItem.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 type Props = {
   children?: React.ReactNode;
   symbol?: React.ReactElement;
-  onClick?: () => void;
+  onClick?: (event: React.MouseEvent) => void;
   className?: string;
 };
 


### PR DESCRIPTION
propagated clicks will dismiss the menu; added `event.stopPropagation()` to stop the propagation and keep the menu