### PR TITLE
ref(counter): Option to use pg 9.5+ upsert for short_id counters

### DIFF
--- a/src/sentry/models/counter.py
+++ b/src/sentry/models/counter.py
@@ -1,7 +1,10 @@
+import random
+
 from django.conf import settings
 from django.db import connections, transaction
 from django.db.models.signals import post_migrate
 
+from sentry import options
 from sentry.db.models import BoundedBigIntegerField, FlexibleForeignKey, Model, sane_repr
 
 
@@ -28,6 +31,10 @@ def increment_project_counter(project, delta=1, using="default"):
     if delta <= 0:
         raise ValueError("There is only one way, and that's up.")
 
+    sample_rate = options.get("store.projectcounter-modern-upsert-sample-rate")
+
+    modern_upsert = sample_rate and random.random() <= sample_rate
+
     # To prevent the statement_timeout leaking into the session we need to use
     # set local which can be used only within a transaction
     with transaction.atomic(using=using):
@@ -40,10 +47,23 @@ def increment_project_counter(project, delta=1, using="default"):
                     "set local statement_timeout = %s",
                     [settings.SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT],
                 )
-            cur.execute(
-                "select sentry_increment_project_counter(%s, %s)",
-                [project.id, delta],
-            )
+
+            if modern_upsert:
+                # Our postgres wrapper thing does not allow for named arguments
+                cur.execute(
+                    "insert into sentry_projectcounter (project_id, value) "
+                    "values (%s, %s) "
+                    "on conflict (project_id) do update "
+                    "set value = sentry_projectcounter.value + %s "
+                    "returning value",
+                    [project.id, delta, delta],
+                )
+            else:
+                cur.execute(
+                    "select sentry_increment_project_counter(%s, %s)",
+                    [project.id, delta],
+                )
+
             return cur.fetchone()[0]
         finally:
             cur.close()

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -300,3 +300,6 @@ register("store.load-shed-group-creation-projects", type=Sequence, default=[])
 
 # Killswitch for dropping events in ingest consumer or really anywhere
 register("store.load-shed-pipeline-projects", type=Sequence, default=[])
+
+# Switch for more performant project counter incr
+register("store.projectcounter-modern-upsert-sample-rate", default=0.0)

--- a/tests/sentry/models/test_projectcounter.py
+++ b/tests/sentry/models/test_projectcounter.py
@@ -1,13 +1,13 @@
+import pytest
+
+from sentry import options
 from sentry.models import Counter
-from sentry.testutils import TestCase
 
 
-class ProjectCounterTest(TestCase):
-    def test_increment(self):
-        user = self.create_user()
-        org = self.create_organization(owner=user)
-        team = self.create_team(organization=org)
-        project = self.create_project(teams=[team])
+@pytest.mark.django_db
+@pytest.mark.parametrize("upsert_sample_rate", [0, 1])
+def test_increment(default_project, upsert_sample_rate):
+    options.set("store.projectcounter-modern-upsert-sample-rate", upsert_sample_rate)
 
-        assert Counter.increment(project, 42) == 42
-        assert Counter.increment(project, 1) == 43
+    assert Counter.increment(default_project, 42) == 42
+    assert Counter.increment(default_project, 1) == 43


### PR DESCRIPTION
We're trying to come up with ways to reduce time spent in projectcounter, and we realized that we could try out the new upsert syntax in postgres.

https://www.notion.so/sentry/Projectcounter-Performance-4c494598fc68433b9a9aa9009a00aecb