### PR TITLE
feat(components): Make PickProjectToContinue reusable

### DIFF
--- a/src/sentry/static/sentry/app/components/pickProjectToContinue.tsx
+++ b/src/sentry/static/sentry/app/components/pickProjectToContinue.tsx
@@ -3,22 +3,35 @@ import * as ReactRouter from 'react-router';
 import styled from '@emotion/styled';
 
 import {openModal} from 'app/actionCreators/modal';
-import ContextPickerModalContainer from 'app/components/contextPickerModal';
-import {ReleaseProject} from 'app/types';
+import ContextPickerModal from 'app/components/contextPickerModal';
 
-type Props = {
-  orgSlug: string;
-  version: string;
-  router: ReactRouter.InjectedRouter;
-  projects: ReleaseProject[];
+type Project = {
+  id: string;
+  slug: string;
 };
 
-const PickProjectToContinue = ({orgSlug, version, router, projects}: Props) => {
+type Props = {
+  /**
+   * Path used on the redirect router if the user did not select a project
+   */
+  noProjectRedirectPath: string;
+  /**
+   * Path used on the redirect router if the user did select a project
+   */
+  nextPath: string;
+  router: ReactRouter.InjectedRouter;
+  projects: Project[];
+};
+
+function PickProjectToContinue({
+  noProjectRedirectPath,
+  nextPath,
+  router,
+  projects,
+}: Props) {
   let navigating = false;
 
-  const path = `/organizations/${orgSlug}/releases/${encodeURIComponent(
-    version
-  )}/?project=`;
+  const path = `${nextPath}?project=`;
 
   // if the project in URL is missing, but this release belongs to only one project, redirect there
   if (projects.length === 1) {
@@ -28,7 +41,7 @@ const PickProjectToContinue = ({orgSlug, version, router, projects}: Props) => {
 
   openModal(
     modalProps => (
-      <ContextPickerModalContainer
+      <ContextPickerModal
         {...modalProps}
         needOrg={false}
         needProject
@@ -45,14 +58,14 @@ const PickProjectToContinue = ({orgSlug, version, router, projects}: Props) => {
         // we want this to be executed only if the user didn't select any project
         // (closed modal either via button, Esc, clicking outside, ...)
         if (!navigating) {
-          router.push(`/organizations/${orgSlug}/releases/`);
+          router.push(noProjectRedirectPath);
         }
       },
     }
   );
 
   return <ContextPickerBackground />;
-};
+}
 
 const ContextPickerBackground = styled('div')`
   height: 100vh;

--- a/src/sentry/static/sentry/app/views/releases/detail/index.tsx
+++ b/src/sentry/static/sentry/app/views/releases/detail/index.tsx
@@ -10,6 +10,7 @@ import LightWeightNoProjectMessage from 'app/components/lightWeightNoProjectMess
 import LoadingIndicator from 'app/components/loadingIndicator';
 import GlobalSelectionHeader from 'app/components/organizations/globalSelectionHeader';
 import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import PickProjectToContinue from 'app/components/pickProjectToContinue';
 import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {URL_PARAM} from 'app/constants/globalSelectionHeader';
 import {IconInfo, IconWarning} from 'app/icons';
@@ -36,7 +37,6 @@ import ReleaseHealthRequest, {
   ReleaseHealthRequestRenderProps,
 } from '../utils/releaseHealthRequest';
 
-import PickProjectToContinue from './pickProjectToContinue';
 import ReleaseHeader from './releaseHeader';
 
 const DEFAULT_FRESH_RELEASE_STATS_PERIOD = '24h';
@@ -300,10 +300,15 @@ class ReleasesDetailContainer extends AsyncComponent<
     if (this.isProjectMissingInUrl()) {
       return (
         <PickProjectToContinue
-          orgSlug={organization.slug}
-          version={params.release}
+          projects={projects.map(({id, slug}) => ({
+            id: String(id),
+            slug,
+          }))}
           router={router}
-          projects={projects}
+          nextPath={`/organizations/${organization.slug}/releases/${encodeURIComponent(
+            params.release
+          )}/`}
+          noProjectRedirectPath={`/organizations/${organization.slug}/releases/`}
         />
       );
     }


### PR DESCRIPTION
This component is already in use on the Release details page and will soon be used in the widget builder

Tests and "add to storybook" will be done in a follow up PR 

#sync-getsentry 