### PR TITLE
test: Fix tests for errors storage

### DIFF
--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -288,7 +288,6 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         event_data = generate_transaction()
 
         self.store_event(data=event_data, project_id=self.project.id, assert_no_errors=True)
-        self.wait_for_event_count(self.project.id, 1)
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.result_path + "?" + transactions_query())

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -375,7 +375,6 @@ class OrganizationEventsV2Test(AcceptanceTestCase, SnubaTestCase):
         child_event["transaction"] = "z-child-transaction"
         child_event["spans"] = child_event["spans"][0:3]
         self.store_event(data=child_event, project_id=self.project.id, assert_no_errors=True)
-        self.wait_for_event_count(self.project.id, 2)
 
         with self.feature(FEATURE_NAMES):
             # Get the list page

--- a/tests/acceptance/test_performance_landing.py
+++ b/tests/acceptance/test_performance_landing.py
@@ -37,7 +37,6 @@ class PerformanceLandingTest(AcceptanceTestCase, SnubaTestCase):
         event = load_data("transaction", timestamp=before_now(minutes=1))
         self.store_event(data=event, project_id=self.project.id)
         self.project.update(flags=F("flags").bitor(Project.flags.has_transactions))
-        self.wait_for_event_count(self.project.id, 1)
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.path)

--- a/tests/acceptance/test_performance_overview.py
+++ b/tests/acceptance/test_performance_overview.py
@@ -45,7 +45,6 @@ class PerformanceOverviewTest(AcceptanceTestCase, SnubaTestCase):
         event = load_data("transaction", timestamp=before_now(minutes=1))
         self.store_event(data=event, project_id=self.project.id)
         self.project.update(flags=F("flags").bitor(Project.flags.has_transactions))
-        self.wait_for_event_count(self.project.id, 1)
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(self.path)

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -104,7 +104,6 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
         event_data["measurements"]["fp"]["value"] = 5000
         event = make_event(event_data)
         self.store_event(data=event, project_id=self.project.id)
-        self.wait_for_event_count(self.project.id, 1)
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(vitals_path)

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -44,7 +44,6 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
         # Create a transaction
         event = make_event(load_data("transaction", timestamp=before_now(minutes=1)))
         self.store_event(data=event, project_id=self.project.id)
-        self.wait_for_event_count(self.project.id, 1)
 
         self.store_event(
             data={
@@ -162,8 +161,6 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
         event_data["measurements"]["fid"]["value"] = 3000000000
         event_data["measurements"]["cls"]["value"] = 3000000000
         self.store_event(data=event_data, project_id=self.project.id)
-
-        self.wait_for_event_count(self.project.id, 5)
 
         with self.feature(FEATURE_NAMES):
             self.browser.get(vitals_path)

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1823,6 +1823,13 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         # because we're ordering by `user.display`, we expect the results in sorted order
         assert result == ["catherine", "cathy@example.com"]
 
+    @pytest.mark.skip(
+        """
+         For some reason ClickHouse errors when there are two of the same string literals
+         (in this case the empty string "") in a query and one is in the prewhere clause.
+         Does not affect production or ClickHouse versions > 20.4.
+         """
+    )
     def test_has_message(self):
         project = self.create_project()
         event = self.store_event(


### PR DESCRIPTION
This fixes/skips the Sentry tests that do not properly work with the errors storage.