### PR TITLE
fix(notifications): Return `subscribe_by_default` Key in Legacy Objects

### DIFF
--- a/src/sentry/notifications/legacy_mappings.py
+++ b/src/sentry/notifications/legacy_mappings.py
@@ -93,8 +93,12 @@ LEGACY_VALUE_TO_KEY = {
 }
 
 
-def get_legacy_key(type: NotificationSettingTypes) -> Optional[str]:
+def get_legacy_key(
+    type: NotificationSettingTypes, scope_type: NotificationScopeType
+) -> Optional[str]:
     """ Temporary mapping from new enum types to legacy strings. """
+    if scope_type == NotificationScopeType.USER and type == NotificationSettingTypes.ISSUE_ALERTS:
+        return "subscribe_by_default"
 
     return KEYS_TO_LEGACY_KEYS.get(type)
 
@@ -165,9 +169,9 @@ def get_legacy_object(
     organization_mapping: Mapping[int, Any],
 ) -> Any:
     type = NotificationSettingTypes(notification_setting.type)
-    key = get_legacy_key(type)
     value = NotificationSettingOptionValues(notification_setting.value)
     scope_type = NotificationScopeType(notification_setting.scope_type)
+    key = get_legacy_key(type, scope_type)
 
     data = {
         "key": key,

--- a/tests/sentry/api/endpoints/test_user_notification_details.py
+++ b/tests/sentry/api/endpoints/test_user_notification_details.py
@@ -57,6 +57,21 @@ class UserNotificationDetailsGetTest(UserNotificationDetailsTestBase):
         assert response.data.get("subscribeByDefault") is True
         assert response.data.get("workflowNotifications") == 1
 
+    def test_subscribe_by_default(self):
+        """
+        Test that we expect project-independent issue alert preferences to be
+        returned as `subscribe_by_default`.
+        """
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.EMAIL,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.NEVER,
+            user=self.user,
+        )
+
+        response = self.get_valid_response("me")
+        assert response.data.get("subscribeByDefault") is False
+
 
 class UserNotificationDetailsPutTest(UserNotificationDetailsTestBase):
     method = "put"


### PR DESCRIPTION
The GET endpoint for `user_notification_details` is having trouble returning a user's project-independent issue alert notification preferences in a format the frontend expects.