### PR TITLE
fix(alerts): Allow the whole radio panel to be clicked

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/wizard/radioPanelGroup.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/radioPanelGroup.tsx
@@ -28,7 +28,7 @@ const RadioPanelGroup = <C extends string>({
   <Container {...props} role="radiogroup" aria-labelledby={label}>
     {(choices || []).map(([id, name, extraContent], index) => (
       <RadioPanel key={index}>
-        <RadioPanelBody>
+        <PanelBody>
           <RadioLineItem role="radio" index={index} aria-checked={value === id}>
             <Radio
               radioSize="small"
@@ -39,7 +39,7 @@ const RadioPanelGroup = <C extends string>({
             <div>{name}</div>
             {extraContent}
           </RadioLineItem>
-        </RadioPanelBody>
+        </PanelBody>
       </RadioPanel>
     ))}
   </Container>
@@ -66,12 +66,9 @@ export const RadioLineItem = styled('label')<{
   outline: none;
   font-weight: normal;
   margin: 0;
+  padding: ${space(1.5)};
 `;
 
 const RadioPanel = styled(Panel)`
   margin: 0;
-`;
-
-const RadioPanelBody = styled(PanelBody)`
-  padding: ${space(1.5)};
 `;


### PR DESCRIPTION
Moving the padding from the panel to the radio label so that the whole panel is clickable.


![image](https://user-images.githubusercontent.com/9372512/114438486-d02d6380-9b95-11eb-9197-cb4a7b4c33c1.png)
