### PR TITLE
wizard: qt in category desktop

### DIFF
--- a/src/sentry/static/sentry/app/data/platformCategories.tsx
+++ b/src/sentry/static/sentry/app/data/platformCategories.tsx
@@ -115,6 +115,7 @@ const desktop = [
   'native-crashpad',
   'native-breakpad',
   'native-minidump',
+  'native-qt',
   'minidump',
   'unity',
 ] as const;


### PR DESCRIPTION
We have Qt:

![image](https://user-images.githubusercontent.com/1633368/114454832-06c0a980-9ba9-11eb-9bb7-9b3afeb7b8b0.png)

Currently documented and easily used on Desktop.
Not yet really ready for the mobile category (sentry-native on mobile).