### PR TITLE
feat(demo): add option to skip the org buffer

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2159,9 +2159,6 @@ SENTRY_EXTRA_WORKERS = None
 # Enabling this will allow users to create accounts without an email or password.
 DEMO_MODE = False
 
-# if set to true, create demo organizations on-demand instead of using a buffer
-DEMO_NO_ORG_BUFFER = False
-
 # all demo orgs are owned by the user with this email
 DEMO_ORG_OWNER_EMAIL = None
 

--- a/src/sentry/demo/demo_org_manager.py
+++ b/src/sentry/demo/demo_org_manager.py
@@ -94,7 +94,7 @@ def create_demo_org(quick=False) -> Organization:
         return org
 
 
-def assign_demo_org() -> Tuple[Organization, User]:
+def assign_demo_org(skip_buffer=False) -> Tuple[Organization, User]:
     with sentry_sdk.configure_scope() as scope:
         try:
             parent_span_id = scope.span.span_id
@@ -112,9 +112,9 @@ def assign_demo_org() -> Tuple[Organization, User]:
         from .tasks import build_up_org_buffer
 
         demo_org = None
-        # option to skip the buffer when testing things out locally
-        if settings.DEMO_NO_ORG_BUFFER:
-            org = create_demo_org()
+        # option to skip the buffer when testing things out
+        if skip_buffer:
+            org = create_demo_org(quick=True)
         else:
             demo_org = DemoOrganization.objects.filter(status=DemoOrgStatus.PENDING).first()
             # if no org in buffer, make a quick one with fewer events

--- a/src/sentry/demo/demo_start.py
+++ b/src/sentry/demo/demo_start.py
@@ -31,7 +31,10 @@ class DemoStartView(BaseView):
         logger.info("post.start", extra={"cookie_member_id": member_id})
         sentry_sdk.set_tag("member_id", member_id)
 
-        if member_id:
+        skip_buffer = request.POST.get("skip_buffer") == "1"
+        sentry_sdk.set_tag("skip_buffer", skip_buffer)
+
+        if member_id and not skip_buffer:
             try:
                 # only assign them to an active org for a member role
                 member = OrganizationMember.objects.get(
@@ -50,7 +53,7 @@ class DemoStartView(BaseView):
             from .demo_org_manager import assign_demo_org
 
             # assign the demo org and get the user
-            org, user = assign_demo_org()
+            org, user = assign_demo_org(skip_buffer=skip_buffer)
             member = OrganizationMember.objects.get(organization=org, user=user)
 
             logger.info("post.assigned_org", extra={"organization_slug": org.slug})

--- a/tests/sentry/demo/test_demo_start.py
+++ b/tests/sentry/demo/test_demo_start.py
@@ -31,6 +31,7 @@ class DemoStartTeset(TestCase):
         mock_auth_login.assert_called_once_with(mock.ANY, self.user)
         recovered = resp.cookies[MEMBER_ID_COOKIE].value.split(":")[0]
         assert recovered == str(self.member.id)
+        mock_assign_demo_org.assert_called_once_with(skip_buffer=False)
 
     @override_settings(DEMO_MODE=False, ROOT_URLCONF="sentry.demo.urls")
     def test_disabled(self):
@@ -72,3 +73,10 @@ class DemoStartTeset(TestCase):
             partial_url = f"/organizations/{self.org.slug}/{scenario}/"
             assert resp.status_code == 302
             assert partial_url in resp.url
+
+    @mock.patch("sentry.demo.demo_start.auth.login")
+    @mock.patch("sentry.demo.demo_org_manager.assign_demo_org")
+    def test_skip_buffer(self, mock_assign_demo_org, mock_auth_login):
+        mock_assign_demo_org.return_value = (self.org, self.user)
+        self.client.post(self.path, data={"skip_buffer": "1"})
+        mock_assign_demo_org.assert_called_once_with(skip_buffer=True)


### PR DESCRIPTION
This PR adds an option called `skip_buffer` which we can specify in the form data (`"1"` or `"0"`) that will determine if we create an organization without the org buffer (as opposed to pulling an existing org out of the buufffer). The reason behind this change is that in our deployed instance, we might want to test out changes to organization population without clearing out the org buffer to repopulate with orgs with the latest changes. This change replaces the existing `DEMO_NO_ORG_BUFFER` option which only can really be used in a dev environment. 