### PR TITLE
feat(processing): Add `BigtableEventProcessingStore`

### DIFF
--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -10,7 +10,7 @@ DEFAULT_TIMEOUT = 60 * 60 * 24
 Event = Any
 
 
-class BaseEventProcessingStore:
+class EventProcessingStore:
     """
     Store for event blobs during processing
 

--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -23,9 +23,9 @@ class EventProcessingStore:
     implementations.
     """
 
-    def __init__(self, inner: KVStorage[str, Event], timeout: int = DEFAULT_TIMEOUT):
+    def __init__(self, inner: KVStorage[str, Event]):
         self.inner = inner
-        self.timeout = timedelta(seconds=timeout)
+        self.timeout = timedelta(seconds=DEFAULT_TIMEOUT)
 
     def __get_unprocessed_key(self, key: str) -> str:
         return key + ":u"

--- a/src/sentry/eventstore/processing/bigtable.py
+++ b/src/sentry/eventstore/processing/bigtable.py
@@ -19,6 +19,6 @@ def BigtableEventProcessingStore(
     return EventProcessingStore(
         KVStorageCodecWrapper(
             BigtableKVStorage(instance, table_name, compression=compression),
-            JSONCodec() | BytesCodec(),
+            JSONCodec() | BytesCodec(),  # maintains functional parity with cache backend
         )
     )

--- a/src/sentry/eventstore/processing/bigtable.py
+++ b/src/sentry/eventstore/processing/bigtable.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from sentry.utils.codecs import BytesCodec, JSONCodec
 from sentry.utils.kvstore.bigtable import BigtableKVStorage
 from sentry.utils.kvstore.encoding import KVStorageCodecWrapper
@@ -7,18 +5,16 @@ from sentry.utils.kvstore.encoding import KVStorageCodecWrapper
 from .base import EventProcessingStore
 
 
-def BigtableEventProcessingStore(
-    instance: str,
-    table_name: str,
-    compression: Optional[str] = None,
-) -> EventProcessingStore:
+def BigtableEventProcessingStore(**options) -> EventProcessingStore:
     """
     Creates an instance of the processing store which uses Bigtable as its
     backend.
+
+    Keyword argument are forwarded to the ``BigtableKVStorage`` constructor.
     """
     return EventProcessingStore(
         KVStorageCodecWrapper(
-            BigtableKVStorage(instance, table_name, compression=compression),
+            BigtableKVStorage(**options),
             JSONCodec() | BytesCodec(),  # maintains functional parity with cache backend
         )
     )

--- a/src/sentry/eventstore/processing/bigtable.py
+++ b/src/sentry/eventstore/processing/bigtable.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+from sentry.utils.codecs import BytesCodec, JSONCodec
+from sentry.utils.kvstore.bigtable import BigtableKVStorage
+from sentry.utils.kvstore.encoding import KVStorageCodecWrapper
+
+from .base import EventProcessingStore
+
+
+def BigtableEventProcessingStore(
+    instance: str,
+    table_name: str,
+    compression: Optional[str] = None,
+) -> EventProcessingStore:
+    """
+    Creates an instance of the processing store which uses Bigtable as its
+    backend.
+    """
+    return EventProcessingStore(
+        KVStorageCodecWrapper(
+            BigtableKVStorage(instance, table_name, compression=compression),
+            JSONCodec() | BytesCodec(),
+        )
+    )

--- a/src/sentry/eventstore/processing/default.py
+++ b/src/sentry/eventstore/processing/default.py
@@ -4,11 +4,9 @@ from sentry.utils.kvstore.cache import CacheKVStorage
 from .base import EventProcessingStore
 
 
-class DefaultEventProcessingStore(EventProcessingStore):
+def DefaultEventProcessingStore(**options) -> EventProcessingStore:
     """
-    Default implementation of processing store which uses the `default_cache`
-    as backend.
+    Creates an instance of the processing store which uses the
+    ``default_cache`` as its backend.
     """
-
-    def __init__(self, **options) -> None:
-        super().__init__(inner=CacheKVStorage(default_cache), **options)
+    return EventProcessingStore(CacheKVStorage(default_cache), **options)

--- a/src/sentry/eventstore/processing/default.py
+++ b/src/sentry/eventstore/processing/default.py
@@ -4,9 +4,9 @@ from sentry.utils.kvstore.cache import CacheKVStorage
 from .base import EventProcessingStore
 
 
-def DefaultEventProcessingStore(**options) -> EventProcessingStore:
+def DefaultEventProcessingStore() -> EventProcessingStore:
     """
     Creates an instance of the processing store which uses the
     ``default_cache`` as its backend.
     """
-    return EventProcessingStore(CacheKVStorage(default_cache), **options)
+    return EventProcessingStore(CacheKVStorage(default_cache))

--- a/src/sentry/eventstore/processing/default.py
+++ b/src/sentry/eventstore/processing/default.py
@@ -1,10 +1,10 @@
 from sentry.cache import default_cache
 from sentry.utils.kvstore.cache import CacheKVStorage
 
-from .base import BaseEventProcessingStore
+from .base import EventProcessingStore
 
 
-class DefaultEventProcessingStore(BaseEventProcessingStore):
+class DefaultEventProcessingStore(EventProcessingStore):
     """
     Default implementation of processing store which uses the `default_cache`
     as backend.

--- a/src/sentry/eventstore/processing/redis.py
+++ b/src/sentry/eventstore/processing/redis.py
@@ -1,10 +1,10 @@
 from sentry.cache.redis import RedisClusterCache
 from sentry.utils.kvstore.cache import CacheKVStorage
 
-from .base import BaseEventProcessingStore
+from .base import EventProcessingStore
 
 
-class RedisClusterEventProcessingStore(BaseEventProcessingStore):
+class RedisClusterEventProcessingStore(EventProcessingStore):
     """
     Processing store implementation using the redis cluster cache as a backend.
     """

--- a/src/sentry/eventstore/processing/redis.py
+++ b/src/sentry/eventstore/processing/redis.py
@@ -8,5 +8,7 @@ def RedisClusterEventProcessingStore(**options) -> EventProcessingStore:
     """
     Creates an instance of the processing store which uses the Redis Cluster
     cache as its backend.
+
+    Keyword argument are forwarded to the ``RedisClusterCache`` constructor.
     """
     return EventProcessingStore(CacheKVStorage(RedisClusterCache(**options)))

--- a/src/sentry/eventstore/processing/redis.py
+++ b/src/sentry/eventstore/processing/redis.py
@@ -4,10 +4,9 @@ from sentry.utils.kvstore.cache import CacheKVStorage
 from .base import EventProcessingStore
 
 
-class RedisClusterEventProcessingStore(EventProcessingStore):
+def RedisClusterEventProcessingStore(**options) -> EventProcessingStore:
     """
-    Processing store implementation using the redis cluster cache as a backend.
+    Creates an instance of the processing store which uses the Redis Cluster
+    cache as its backend.
     """
-
-    def __init__(self, **options) -> None:
-        super().__init__(inner=CacheKVStorage(RedisClusterCache(**options)))
+    return EventProcessingStore(CacheKVStorage(RedisClusterCache(**options)))

--- a/src/sentry/utils/kvstore/bigtable.py
+++ b/src/sentry/utils/kvstore/bigtable.py
@@ -65,6 +65,7 @@ class BigtableKVStorage(KVStorage[str, bytes]):
         client_options: Optional[Mapping[Any, Any]] = None,
         default_ttl: Optional[timedelta] = None,
         compression: Optional[str] = None,
+        app_profile: Optional[str] = None,
     ) -> None:
         client_options = client_options if client_options is not None else {}
         if "admin" in client_options:
@@ -79,6 +80,7 @@ class BigtableKVStorage(KVStorage[str, bytes]):
         self.client_options = client_options
         self.default_ttl = default_ttl
         self.compression = compression
+        self.app_profile = app_profile
 
         self.__table: Table
         self.__table_lock = Lock()
@@ -88,7 +90,7 @@ class BigtableKVStorage(KVStorage[str, bytes]):
             return (
                 bigtable.Client(project=self.project, admin=True, **self.client_options)
                 .instance(self.instance)
-                .table(self.table_name)
+                .table(self.table_name, app_profile_id=self.app_profile)
             )
 
         try:
@@ -106,7 +108,7 @@ class BigtableKVStorage(KVStorage[str, bytes]):
                     table = self.__table = (
                         bigtable.Client(project=self.project, **self.client_options)
                         .instance(self.instance)
-                        .table(self.table_name)
+                        .table(self.table_name, app_profile_id=self.app_profile)
                     )
             return table
 


### PR DESCRIPTION
This pieces together all of the various building blocks initiated by #24644 to enable using Google Cloud Bigtable as an event processing store backend. This creates a more explicit separation between the "event processing store" (an application level construct, what is stored) and the storage backend (a storage level construct, how things are stored) as `BaseEventProcessingStore` is no longer intended to be subclassed.

This also adds the ability for `BigtableKVStorage` to be provided a non-default [app profile](https://cloud.google.com/bigtable/docs/app-profiles) for specifying the replicated instance routing strategy, enabling cluster failover, etc.