### PR TITLE
fix(trace-view): Correctly add parent event ids for orphans

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -446,7 +446,10 @@ class OrganizationEventsTraceEndpoint(OrganizationEventsTraceEndpointBase):
                         )
                     # We need to connect back to an existing orphan trace
                     if has_orphans and child["span_id"] in results_map:
-                        previous_event["children"].extend(results_map.pop(child["span_id"]))
+                        orphan_subtraces = results_map.pop(child["span_id"])
+                        for orphan_subtrace in orphan_subtraces:
+                            orphan_subtrace["parent_event_id"] = previous_event["event_id"]
+                        previous_event["children"].extend(orphan_subtraces)
                     if child["span_id"] not in parent_map:
                         continue
                     # Avoid potential span loops by popping, so we don't traverse the same nodes twice


### PR DESCRIPTION
- This fixes a bug where orphans might not have the parent span id if
  the event loop encountered the child first, since when this happened
  we werent setting this association