### PR TITLE
fix(trace-view): Remove the dash when there's no txn

### DIFF
--- a/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
+++ b/src/sentry/static/sentry/app/views/organizationGroupDetails/eventToolbar.tsx
@@ -88,9 +88,7 @@ class GroupEventToolbar extends React.Component<Props> {
               <QuickTraceWrapper>
                 {results.isLoading ? (
                   <Placeholder height="24px" />
-                ) : results.error || results.trace === null ? (
-                  '\u2014'
-                ) : (
+                ) : results.error || results.trace === null ? null : (
                   <QuickTrace
                     event={event}
                     quickTrace={results}


### PR DESCRIPTION
- We currently show a emdash even on issues when there's no associated transaction to the event, just removing it entirely instead
  
# Preview
Before:
![image](https://user-images.githubusercontent.com/4205004/114479614-ddb30f80-9bce-11eb-969c-b0928b949e40.png)

After:
![image](https://user-images.githubusercontent.com/4205004/114479572-c96f1280-9bce-11eb-9ceb-96c09d2d0958.png)
