### PR TITLE
ref(span-view): Change view span to view transaction

### DIFF
--- a/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
+++ b/src/sentry/static/sentry/app/components/events/interfaces/spans/spanDetail.tsx
@@ -230,7 +230,7 @@ class SpanDetail extends React.Component<Props, State> {
               size="xsmall"
               to={to}
             >
-              {t('View Span')}
+              {t('View Transaction')}
             </StyledDiscoverButton>
           );
         }}
@@ -240,8 +240,8 @@ class SpanDetail extends React.Component<Props, State> {
     const results = this.state.transactionResults[0];
 
     return (
-      <Row title="Child Span" extra={viewChildButton}>
-        {`${results['trace.span']} - ${results.transaction} (${results['project.name']})`}
+      <Row title="Child Transaction" extra={viewChildButton}>
+        {`${results.transaction} (${results['project.name']})`}
       </Row>
     );
   }


### PR DESCRIPTION
- This is so we're more consistent with the trace view where we call
  these child links viewing transaction
  - I also thinks this is clearer as to what this row is for