### PR TITLE
ref(counter): Option to use pg 9.5+ upsert for short_id counters (option only)

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -300,3 +300,6 @@ register("store.load-shed-group-creation-projects", type=Sequence, default=[])
 
 # Killswitch for dropping events in ingest consumer or really anywhere
 register("store.load-shed-pipeline-projects", type=Sequence, default=[])
+
+# Switch for more performant project counter incr
+register("store.projectcounter-modern-upsert-sample-rate", default=0.0)


### PR DESCRIPTION
Introduce option for https://github.com/getsentry/sentry/pull/25182