### PR TITLE
fix(ui): Fix role check for superusers

### DIFF
--- a/src/sentry/static/sentry/app/components/acl/role.tsx
+++ b/src/sentry/static/sentry/app/components/acl/role.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import ConfigStore from 'app/stores/configStore';
 import {Organization} from 'app/types';
+import {isActiveSuperuser} from 'app/utils/isActiveSuperuser';
 import {isRenderFunc} from 'app/utils/isRenderFunc';
 import withOrganization from 'app/utils/withOrganization';
 
@@ -41,7 +42,7 @@ class Role extends React.Component<Props> {
       return false;
     }
 
-    if (user.isSuperuser) {
+    if (isActiveSuperuser()) {
       return true;
     }
 

--- a/src/sentry/static/sentry/app/utils/isActiveSuperuser.tsx
+++ b/src/sentry/static/sentry/app/utils/isActiveSuperuser.tsx
@@ -1,0 +1,28 @@
+import Cookies from 'js-cookie';
+
+import ConfigStore from 'app/stores/configStore';
+
+const SUPERUSER_COOKIE_NAME = 'su';
+
+/**
+ * Checking for just isSuperuser on a config object may not be enough as backend often checks for *active* superuser.
+ * We therefore check both isSuperuser flag AND superuser session cookie.
+ */
+export function isActiveSuperuser() {
+  const {isSuperuser} = ConfigStore.get('user') || {};
+
+  if (isSuperuser) {
+    /**
+     * Superuser cookie cannot be checked for existence as it is HttpOnly.
+     * As a workaround, we try to change it to something else and if that fails we can assume that it's being present.
+     * There may be an edgecase where it's present and expired but for current usage it's not a big deal.
+     */
+    Cookies.set(SUPERUSER_COOKIE_NAME, 'test');
+
+    if (Cookies.get(SUPERUSER_COOKIE_NAME) === undefined) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/tests/js/spec/components/acl/role.spec.jsx
+++ b/tests/js/spec/components/acl/role.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Cookies from 'js-cookie';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
 
@@ -57,11 +58,14 @@ describe('Role', function () {
 
     it('gives access to a superuser with unsufficient role', function () {
       ConfigStore.config.user = {isSuperuser: true};
+      Cookies.set = jest.fn();
+
       mountWithTheme(<Role role="owner">{childrenMock}</Role>, routerContext);
 
       expect(childrenMock).toHaveBeenCalledWith({
         hasRole: true,
       });
+      expect(Cookies.set).toHaveBeenCalledWith('su', 'test');
       ConfigStore.config.user = {isSuperuser: false};
     });
 


### PR DESCRIPTION
Checking for just isSuperuser on a config object may not be enough as backend often checks for *active* superuser.
We therefore check both isSuperuser flag AND superuser session cookie.