### PR TITLE
fix(symbolication): Correct aliased source names

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -171,8 +171,6 @@ class Symbolicator:
                 metrics.timing(
                     "events.symbolicator.response.completed.size", len(json.dumps(json_response))
                 )
-                reverse_source_aliases(json_response)
-                redact_internal_sources(json_response)
                 return json_response
 
     def process_minidump(self, minidump):
@@ -191,114 +189,6 @@ class Symbolicator:
             ),
             "symbolicate_stacktraces",
         )
-
-
-def reverse_source_aliases(response, builtin_sources=None):
-    """Reverses internal source aliases from a response.
-
-    When an internal source was an alias this reverses the alias in the DIF candidates,
-    exposing it again like the user configured this.  This is only done for internal sources
-    since other sources do not support aliases.
-    """
-    if builtin_sources is None:
-        builtin_sources = settings.SENTRY_BUILTIN_SOURCES
-    reverse_aliases = reverse_aliases_map(builtin_sources)
-
-    for module in response.get("modules", []):
-        for candidate in module.get("candidates", []):
-            source_id = candidate["source"]
-            if source_id in reverse_aliases:
-                candidate["source"] = reverse_aliases.get(source_id)
-
-
-def reverse_aliases_map(builtin_sources):
-    """Returns a map of source IDs to their original un-aliased source ID.
-
-    :param builtin_sources: The value of `settings.SENTRY_BUILTIN_SOURCES`.
-    """
-    reverse_aliases = dict()
-    for key, source in builtin_sources.items():
-        if source.get("type") != "alias":
-            continue
-        try:
-            self_id = source["id"]
-        except KeyError:
-            continue
-        for aliased_source in source.get("sources", []):
-            try:
-                aliased_source = builtin_sources[aliased_source]
-                aliased_id = aliased_source["id"]
-            except KeyError:
-                continue
-            reverse_aliases[aliased_id] = self_id
-    return reverse_aliases
-
-
-def redact_internal_sources(response):
-    """Redacts information about internal sources from a response.
-
-    Symbolicator responses can contain a section about DIF object file candidates where were
-    attempted to be downloaded from the sources.  This includes a full URI of where the
-    download was attempted from.  For internal sources we want to redact this in order to
-    not leak any internal details.
-
-    Note that this modifies the argument passed in, thus redacting in-place.  It still
-    returns the modified response.
-    """
-    for module in response.get("modules", []):
-        redact_internal_sources_from_module(module)
-
-
-def redact_internal_sources_from_module(module):
-    """Redacts information about internal sources from a single module.
-
-    This in-place redacts candidates from only a single module of the symbolicator response.
-
-    The strategy here is for each internal source to replace the location with the DebugID.
-    Furthermore if there are any "notfound" entries collapse them into a single entry and
-    only show this entry if there are no entries with another status.
-    """
-    sources_notfound = set()
-    sources_other = set()
-    new_candidates = []
-
-    for candidate in module.get("candidates", []):
-        source_id = candidate["source"]
-        if is_internal_source_id(source_id):
-
-            # Only keep location for sentry:project.
-            if source_id != "sentry:project":
-                candidate.pop("location", None)
-
-            # Collapse nofound statuses, collect info on sources which both have a notfound
-            # as well as other statusses.  This allows us to later filter the notfound ones.
-            try:
-                status = candidate.get("download", {})["status"]
-            except KeyError:
-                pass
-            else:
-                if status == "notfound":
-                    candidate.pop("location", None)  # This location is bogus, remove it.
-                    if source_id in sources_notfound:
-                        continue
-                    else:
-                        sources_notfound.add(source_id)
-                else:
-                    sources_other.add(source_id)
-        new_candidates.append(candidate)
-
-    def should_keep(candidate):
-        """Returns `False` if the candidate should be kept in the list of candidates.
-
-        This removes the candidates with a status of ``notfound`` *if* they also have
-        another status.
-        """
-        source_id = candidate["source"]
-        status = candidate.get("download", {}).get("status")
-        return status != "notfound" or source_id not in sources_other
-
-    if "candidates" in module:
-        module["candidates"] = [c for c in new_candidates if should_keep(c)]
 
 
 class TaskIdNotFound(Exception):
@@ -480,6 +370,18 @@ class SymbolicatorSession:
         self.timeout = timeout
         self.session = None
 
+        # Build some maps for use in ._process_response()
+        self.reverse_source_aliases = reverse_aliases_map(settings.SENTRY_BUILTIN_SOURCES)
+        self.source_names = {source["id"]: source.get("name", "unknown") for source in self.sources}
+
+        # Add a name for the special "sentry:project" source.
+        self.source_names[INTERNAL_SOURCE_NAME] = "Sentry"
+
+        # Add names for aliased sources.
+        for source in settings.SENTRY_BUILTIN_SOURCES.values():
+            if source.get("type") == "alias":
+                self.source_names[source["id"]] = source.get("name", "unknown")
+
     def __enter__(self):
         self.open()
         return self
@@ -501,14 +403,23 @@ class SymbolicatorSession:
             raise RuntimeError("Session not opened")
 
     def _process_response(self, json):
-        source_names = {source["id"]: source.get("name") for source in self.sources}
-        source_names[INTERNAL_SOURCE_NAME] = "Sentry"
+        """Post-processes the JSON repsonse.
 
+        This modifies the candidates list from Symbolicator responses to undo aliased
+        sources, hide information about unknown sources and add names to sources rather then
+        just have their IDs.
+        """
         for module in json.get("modules") or ():
             for candidate in module.get("candidates") or ():
-                if candidate.get("source"):
-                    candidate["source_name"] = source_names.get(candidate["source"])
+                # Reverse internal source aliases from the response.
+                source_id = candidate["source"]
+                if source_id in self.reverse_source_aliases:
+                    candidate["source"] = source_id = self.reverse_source_aliases[source_id]
 
+                # Add a "source_name" field to save the UI a lookup.
+                candidate["source_name"] = self.source_names.get(candidate["source"], "unknown")
+
+        redact_internal_sources(json)
         return json
 
     def _request(self, method, path, **kwargs):
@@ -623,3 +534,93 @@ class SymbolicatorSession:
 
     def healthcheck(self):
         return self._request("get", "healthcheck")
+
+
+def reverse_aliases_map(builtin_sources):
+    """Returns a map of source IDs to their original un-aliased source ID.
+
+    :param builtin_sources: The value of `settings.SENTRY_BUILTIN_SOURCES`.
+    """
+    reverse_aliases = dict()
+    for key, source in builtin_sources.items():
+        if source.get("type") != "alias":
+            continue
+        try:
+            self_id = source["id"]
+        except KeyError:
+            continue
+        for aliased_source in source.get("sources", []):
+            try:
+                aliased_source = builtin_sources[aliased_source]
+                aliased_id = aliased_source["id"]
+            except KeyError:
+                continue
+            reverse_aliases[aliased_id] = self_id
+    return reverse_aliases
+
+
+def redact_internal_sources(response):
+    """Redacts information about internal sources from a response.
+
+    Symbolicator responses can contain a section about DIF object file candidates where were
+    attempted to be downloaded from the sources.  This includes a full URI of where the
+    download was attempted from.  For internal sources we want to redact this in order to
+    not leak any internal details.
+
+    Note that this modifies the argument passed in, thus redacting in-place.  It still
+    returns the modified response.
+    """
+    for module in response.get("modules", []):
+        redact_internal_sources_from_module(module)
+
+
+def redact_internal_sources_from_module(module):
+    """Redacts information about internal sources from a single module.
+
+    This in-place redacts candidates from only a single module of the symbolicator response.
+
+    The strategy here is for each internal source to replace the location with the DebugID.
+    Furthermore if there are any "notfound" entries collapse them into a single entry and
+    only show this entry if there are no entries with another status.
+    """
+    sources_notfound = set()
+    sources_other = set()
+    new_candidates = []
+
+    for candidate in module.get("candidates", []):
+        source_id = candidate["source"]
+        if is_internal_source_id(source_id):
+
+            # Only keep location for sentry:project.
+            if source_id != "sentry:project":
+                candidate.pop("location", None)
+
+            # Collapse nofound statuses, collect info on sources which both have a notfound
+            # as well as other statusses.  This allows us to later filter the notfound ones.
+            try:
+                status = candidate.get("download", {})["status"]
+            except KeyError:
+                pass
+            else:
+                if status == "notfound":
+                    candidate.pop("location", None)  # This location is bogus, remove it.
+                    if source_id in sources_notfound:
+                        continue
+                    else:
+                        sources_notfound.add(source_id)
+                else:
+                    sources_other.add(source_id)
+        new_candidates.append(candidate)
+
+    def should_keep(candidate):
+        """Returns `False` if the candidate should be kept in the list of candidates.
+
+        This removes the candidates with a status of ``notfound`` *if* they also have
+        another status.
+        """
+        source_id = candidate["source"]
+        status = candidate.get("download", {}).get("status")
+        return status != "notfound" or source_id not in sources_other
+
+    if "candidates" in module:
+        module["candidates"] = [c for c in new_candidates if should_keep(c)]

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -413,11 +413,13 @@ class SymbolicatorSession:
             for candidate in module.get("candidates") or ():
                 # Reverse internal source aliases from the response.
                 source_id = candidate["source"]
-                if source_id in self.reverse_source_aliases:
-                    candidate["source"] = source_id = self.reverse_source_aliases[source_id]
+                original_source_id = self.reverse_source_aliases.get(source_id)
+                if original_source_id is not None:
+                    candidate["source"] = original_source_id
+                    source_id = original_source_id
 
                 # Add a "source_name" field to save the UI a lookup.
-                candidate["source_name"] = self.source_names.get(candidate["source"], "unknown")
+                candidate["source_name"] = self.source_names.get(source_id, "unknown")
 
         redact_internal_sources(json)
         return json

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -265,37 +265,3 @@ class TestAliasReversion:
         reverse_aliases = symbolicator.reverse_aliases_map(builtin_sources)
         expected = {"sentry:ios-source": "sentry:ios", "sentry:tvos-source": "sentry:ios"}
         assert reverse_aliases == expected
-
-    def test_merge_candidates(self, builtin_sources):
-        event = {
-            "modules": [
-                {
-                    "candidates": [
-                        {
-                            "source": "sentry:ios-source",
-                            "location": "http://example.com/prefix/path0",
-                            "download": {"status": "notfound"},
-                        },
-                        {
-                            "source": "sentry:tvos-source",
-                            "location": "http://example.com/prefix/path1",
-                            "download": {"status": "ok"},
-                        },
-                    ]
-                }
-            ]
-        }
-        candidates = [
-            {
-                "source": "sentry:ios",
-                "location": "http://example.com/prefix/path0",
-                "download": {"status": "notfound"},
-            },
-            {
-                "source": "sentry:ios",
-                "location": "http://example.com/prefix/path1",
-                "download": {"status": "ok"},
-            },
-        ]
-        symbolicator.reverse_source_aliases(event, builtin_sources)
-        assert event["modules"][0]["candidates"] == candidates


### PR DESCRIPTION
When we had aliased sources the source names were added before the
aliasing was undone.  This resulted in some random name from before
the alias showing up.

This instead consolidates all the candidates post-processing to one
location and makes sure the alias reversing happens before the names
are added as well as that aliased source have their name present.