### PR TITLE
build(webpack): Ignore "pipeline" entry point for local UI dev

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -544,6 +544,7 @@ if (IS_UI_DEV_ONLY || IS_DEPLOY_PREVIEW) {
       favicon: path.resolve(staticPrefix, 'images', 'favicon_dev.png'),
       template: path.resolve(staticPrefix, 'index.ejs'),
       mobile: true,
+      excludeChunks: ['pipeline'],
       title: 'Sentry',
     })
   );


### PR DESCRIPTION
Ignore the pipeline entry for local UI dev.

This regressed from https://github.com/getsentry/sentry/pull/25174 - the HTMLWebpackPlugin auto injects all entrypoints.