### PR TITLE
fix(trace-view): Discover link should query all event types

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/traceDetails/index.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/index.tsx
@@ -55,10 +55,10 @@ class TraceSummary extends React.Component<Props> {
 
     return EventView.fromSavedQuery({
       id: undefined,
-      name: `Transactions with Trace ID ${traceSlug}`,
+      name: `Events with Trace ID ${traceSlug}`,
       fields: ['title', 'event.type', 'project', 'timestamp'],
       orderby: '-timestamp',
-      query: `event.type:transaction trace:${traceSlug}`,
+      query: `trace:${traceSlug}`,
       projects: [ALL_ACCESS_PROJECTS],
       version: 2,
       start,


### PR DESCRIPTION
The open in discover link in trace view should query all event types, not just
transactions.

The follow-up to #25196