### PR TITLE
fix(perf-view): Update column width for User Misery on Performance

### DIFF
--- a/src/sentry/static/sentry/app/components/gridEditable/index.tsx
+++ b/src/sentry/static/sentry/app/components/gridEditable/index.tsx
@@ -248,20 +248,23 @@ class GridEditable<
 
     const prependColumns = this.props.grid.prependColumnWidths || [];
     const prepend = prependColumns.join(' ');
-    const widths = columnOrder.map(item => {
+    const widths = columnOrder.map((item, index) => {
       if (item.width === COL_WIDTH_UNDEFINED) {
         return `minmax(${COL_WIDTH_MINIMUM}px, auto)`;
       } else if (typeof item.width === 'number' && item.width > COL_WIDTH_MINIMUM) {
+        if (index === columnOrder.length - 1) {
+          return `minmax(${item.width}px, auto)`;
+        }
         return `${item.width}px`;
+      }
+      if (index === columnOrder.length - 1) {
+        return `minmax(${COL_WIDTH_MINIMUM}px, auto)`;
       }
       return `${COL_WIDTH_MINIMUM}px`;
     });
 
     // The last column has no resizer and should always be a flexible column
     // to prevent underflows.
-    if (widths.length > 0) {
-      widths[widths.length - 1] = `minmax(${COL_WIDTH_MINIMUM}px, auto)`;
-    }
 
     grid.style.gridTemplateColumns = `${prepend} ${widths.join(' ')}`;
   }

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -1,5 +1,6 @@
 import {Location} from 'history';
 
+import {COL_WIDTH_UNDEFINED} from 'app/components/gridEditable';
 import {t} from 'app/locale';
 import {LightWeightOrganization, NewQuery, SelectValue} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
@@ -281,9 +282,12 @@ function generateGenericPerformanceEventView(
       `count_miserable(user,${organization.apdexThreshold})`,
       `user_misery(${organization.apdexThreshold})`,
     ],
-    widths: ['-1', '-1', '-1', '-1', '-1', '-1', '-1', '-1', '-1', '-1', '110'],
     version: 2,
   };
+
+  const widths = Array(savedQuery.fields.length).fill(COL_WIDTH_UNDEFINED);
+  widths[savedQuery.fields.length - 1] = '110';
+  savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
     savedQuery.range = DEFAULT_STATS_PERIOD;
@@ -340,6 +344,10 @@ function generateBackendPerformanceEventView(
     version: 2,
   };
 
+  const widths = Array(savedQuery.fields.length).fill(COL_WIDTH_UNDEFINED);
+  widths[savedQuery.fields.length - 1] = '110';
+  savedQuery.widths = widths;
+
   if (!query.statsPeriod && !hasStartAndEnd) {
     savedQuery.range = DEFAULT_STATS_PERIOD;
   }
@@ -393,6 +401,10 @@ function generateFrontendPageloadPerformanceEventView(
     ],
     version: 2,
   };
+
+  const widths = Array(savedQuery.fields.length).fill(COL_WIDTH_UNDEFINED);
+  widths[savedQuery.fields.length - 1] = '110';
+  savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
     savedQuery.range = DEFAULT_STATS_PERIOD;
@@ -449,6 +461,10 @@ function generateFrontendOtherPerformanceEventView(
     ],
     version: 2,
   };
+
+  const widths = Array(savedQuery.fields.length).fill(COL_WIDTH_UNDEFINED);
+  widths[savedQuery.fields.length - 1] = '110';
+  savedQuery.widths = widths;
 
   if (!query.statsPeriod && !hasStartAndEnd) {
     savedQuery.range = DEFAULT_STATS_PERIOD;

--- a/src/sentry/static/sentry/app/views/performance/data.tsx
+++ b/src/sentry/static/sentry/app/views/performance/data.tsx
@@ -281,6 +281,7 @@ function generateGenericPerformanceEventView(
       `count_miserable(user,${organization.apdexThreshold})`,
       `user_misery(${organization.apdexThreshold})`,
     ],
+    widths: ['-1', '-1', '-1', '-1', '-1', '-1', '-1', '-1', '-1', '-1', '110'],
     version: 2,
   };
 


### PR DESCRIPTION
The User Misery column does not have sufficient padding
in Performance when the screen is smaller.

Screenshots:
Before
![Screen Shot 2021-04-13 at 1 54 01 PM](https://user-images.githubusercontent.com/63818634/114598556-09caa100-9c60-11eb-9c7b-6ecf4b34892b.png)

After
![Screen Shot 2021-04-13 at 1 49 35 PM](https://user-images.githubusercontent.com/63818634/114598573-0d5e2800-9c60-11eb-9aa8-a4968465330b.png)

 