### PR TITLE
feat(trace-view): Improve rendering of errors

### DIFF
--- a/src/sentry/static/sentry/app/components/eventOrGroupHeader.tsx
+++ b/src/sentry/static/sentry/app/components/eventOrGroupHeader.tsx
@@ -209,22 +209,7 @@ const GroupLevel = styled('div')<{level: Level}>`
   height: 15px;
   border-radius: 0 3px 3px 0;
 
-  background-color: ${p => {
-    switch (p.level) {
-      case 'sample':
-        return p.theme.purple300;
-      case 'info':
-        return p.theme.blue300;
-      case 'warning':
-        return p.theme.yellow300;
-      case 'error':
-        return p.theme.orange400;
-      case 'fatal':
-        return p.theme.red300;
-      default:
-        return p.theme.gray300;
-    }
-  }};
+  background-color: ${p => p.theme.level[p.level] ?? p.theme.level.default};
 
   & span {
     display: block;

--- a/src/sentry/static/sentry/app/components/quickTrace/utils.tsx
+++ b/src/sentry/static/sentry/app/components/quickTrace/utils.tsx
@@ -16,7 +16,7 @@ export type ErrorDestination = 'discover' | 'issue';
 
 export type TransactionDestination = 'discover' | 'performance';
 
-function generateIssueEventTarget(
+export function generateIssueEventTarget(
   event: TraceError,
   organization: OrganizationSummary
 ): LocationDescriptor {

--- a/src/sentry/static/sentry/app/utils/performance/quickTrace/types.tsx
+++ b/src/sentry/static/sentry/app/utils/performance/quickTrace/types.tsx
@@ -3,6 +3,7 @@ import {
   DiscoverQueryProps,
   GenericChildrenProps,
 } from 'app/utils/discover/genericDiscoverQuery';
+import {Theme} from 'app/utils/theme';
 
 /**
  * `EventLite` represents the type of a simplified event from
@@ -28,6 +29,8 @@ export type TraceError = {
   transaction: string;
   project_id: number;
   project_slug: string;
+  title: string;
+  level: keyof Theme['level'];
 };
 
 export type TraceLite = EventLite[];

--- a/src/sentry/static/sentry/app/utils/theme.tsx
+++ b/src/sentry/static/sentry/app/utils/theme.tsx
@@ -305,6 +305,15 @@ const tag = {
   },
 };
 
+const level = {
+  sample: colors.purple300,
+  info: colors.blue300,
+  warning: colors.yellow300,
+  error: colors.orange400,
+  fatal: colors.red300,
+  default: colors.gray300,
+};
+
 const generateButtonTheme = alias => ({
   borderRadius: '3px',
 
@@ -504,6 +513,8 @@ const commonTheme = {
   },
 
   tag,
+
+  level,
 
   charts: {
     colors: CHART_PALETTE[CHART_PALETTE.length - 1],

--- a/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
+++ b/src/sentry/static/sentry/app/views/performance/traceDetails/styles.tsx
@@ -10,11 +10,13 @@ import {Panel} from 'app/components/panels';
 import Pills from 'app/components/pills';
 import SearchBar from 'app/components/searchBar';
 import {IconChevron, IconFire} from 'app/icons';
+import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {defined} from 'app/utils';
 import {TraceFullDetailed} from 'app/utils/performance/quickTrace/types';
 import {appendTagCondition} from 'app/utils/queryString';
+import {Theme} from 'app/utils/theme';
 import {transactionSummaryRouteWithQuery} from 'app/views/performance/transactionSummary/utils';
 
 export {
@@ -137,6 +139,38 @@ export function ErrorBadge({showDetail}: {showDetail: boolean}) {
     </BadgeBorder>
   );
 }
+
+export const ErrorMessageTitle = styled('div')`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const ErrorMessageContent = styled('div')`
+  display: grid;
+  align-items: center;
+  grid-template-columns: 16px 72px auto;
+  grid-gap: ${space(0.75)};
+  margin-top: ${space(0.75)};
+`;
+
+export const ErrorDot = styled('div')<{level: keyof Theme['level']}>`
+  background-color: ${p => p.theme.level[p.level]};
+  content: '';
+  width: ${space(1)};
+  min-width: ${space(1)};
+  height: ${space(1)};
+  margin-right: ${space(1)};
+  border-radius: 100%;
+  flex: 1;
+`;
+
+export const ErrorLevel = styled('span')`
+  width: 80px;
+`;
+
+export const ErrorTitle = styled('span')`
+  ${overflowEllipsis};
+`;
 
 const StyledPills = styled(Pills)`
   padding-top: ${space(1.5)};


### PR DESCRIPTION
Errors in trace view are currently being linked to a discover query. This change
renders the list of errors and links each one to the corresponding event in
issues.

# Screenshots

![image](https://user-images.githubusercontent.com/10239353/114608800-135a0600-9c6c-11eb-9865-4951a6c26e09.png)

![image](https://user-images.githubusercontent.com/10239353/114608775-0a693480-9c6c-11eb-96ec-4796af528290.png)
