### PR TITLE
fix(ui): polish alert wizard styles

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -140,7 +140,7 @@ class AlertWizard extends React.Component<Props, State> {
                         </ExternalLink>
                       )}
                     </PanelDescription>
-                    <StyledPlaceholder height="250px" />
+                    <WizardBodyPlaceholder height="250px" />
                     <ExampleHeader>{t('Examples')}</ExampleHeader>
                     <List symbol="bullet">
                       {panelContent.examples.map((example, i) => (
@@ -163,7 +163,7 @@ const StyledPageHeader = styled(PageHeader)`
   margin-bottom: ${space(4)};
 `;
 
-const StyledPlaceholder = styled(Placeholder)`
+const WizardBodyPlaceholder = styled(Placeholder)`
   background-color: ${p => p.theme.border};
   opacity: 0.6;
 `;

--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -186,6 +186,8 @@ const WizardOptions = styled('div')`
 `;
 
 const WizardPanel = styled('div')<{visible?: boolean}>`
+  position: sticky;
+  top: 20px;
   padding: 0;
   flex: 5;
   display: flex;

--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -212,6 +212,7 @@ const WizardPanel = styled('div')<{visible?: boolean}>`
 const WizardPanelBody = styled(PanelBody)`
   margin-bottom: ${space(2)};
   flex: 1;
+  min-width: 100%;
 `;
 
 const PanelDescription = styled('div')`

--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -8,7 +8,7 @@ import ExternalLink from 'app/components/links/externalLink';
 import List from 'app/components/list';
 import ListItem from 'app/components/list/listItem';
 import PageHeading from 'app/components/pageHeading';
-import {Panel, PanelBody} from 'app/components/panels';
+import {PanelBody} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
 import Tag from 'app/components/tag';
@@ -103,14 +103,16 @@ class AlertWizard extends React.Component<Props, State> {
               title={t('Create Alert Rule')}
             />
             <StyledPageHeader>
-              <PageHeading>{t('What should we alert you about?')}</PageHeading>
+              <StyledPageHeading>
+                {t('What should we alert you about?')}
+              </StyledPageHeading>
             </StyledPageHeader>
-            <Heading>{t('Errors')}</Heading>
+            <Styledh2>{t('Errors')}</Styledh2>
             <WizardBody>
               <WizardOptions>
                 {AlertWizardOptions.map(({categoryHeading, options}, i) => (
                   <OptionsWrapper key={categoryHeading}>
-                    {i > 0 && <Heading>{categoryHeading}</Heading>}
+                    {i > 0 && <Styledh2>{categoryHeading}</Styledh2>}
                     <RadioPanelGroup
                       choices={options.map(alertType => {
                         return [
@@ -140,7 +142,7 @@ class AlertWizard extends React.Component<Props, State> {
                         </ExternalLink>
                       )}
                     </PanelDescription>
-                    <Placeholder height="250px" />
+                    <StyledPlaceholder height="250px" />
                     <ExampleHeader>{t('Examples')}</ExampleHeader>
                     <List symbol="bullet">
                       {panelContent.examples.map((example, i) => (
@@ -163,10 +165,13 @@ const StyledPageHeader = styled(PageHeader)`
   margin-bottom: ${space(4)};
 `;
 
-const Heading = styled('h1')`
-  font-size: ${p => p.theme.fontSizeExtraLarge};
-  font-weight: normal;
-  margin-bottom: ${space(1)};
+const StyledPageHeading = styled(PageHeading)`
+  font-weight: bold;
+`;
+
+const StyledPlaceholder = styled(Placeholder)`
+  background-color: ${p => p.theme.border};
+  opacity: 0.6;
 `;
 
 const Styledh2 = styled('h2')`
@@ -181,11 +186,13 @@ const WizardBody = styled('div')`
 
 const WizardOptions = styled('div')`
   flex: 3;
-  margin-right: ${space(4)};
+  margin-right: ${space(3)};
+  border-right: 1px solid ${p => p.theme.innerBorder};
+  padding-right: ${space(3)};
 `;
 
-const WizardPanel = styled(Panel)<{visible?: boolean}>`
-  padding: ${space(3)};
+const WizardPanel = styled('div')<{visible?: boolean}>`
+  padding: 0;
   flex: 5;
   display: flex;
   ${p => !p.visible && 'visibility: hidden'};
@@ -227,6 +234,10 @@ const ExampleItem = styled(ListItem)`
 
 const OptionsWrapper = styled('div')`
   margin-bottom: ${space(4)};
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 `;
 
 export default AlertWizard;

--- a/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/index.tsx
@@ -103,9 +103,7 @@ class AlertWizard extends React.Component<Props, State> {
               title={t('Create Alert Rule')}
             />
             <StyledPageHeader>
-              <StyledPageHeading>
-                {t('What should we alert you about?')}
-              </StyledPageHeading>
+              <PageHeading>{t('What should we alert you about?')}</PageHeading>
             </StyledPageHeader>
             <Styledh2>{t('Errors')}</Styledh2>
             <WizardBody>
@@ -163,10 +161,6 @@ class AlertWizard extends React.Component<Props, State> {
 
 const StyledPageHeader = styled(PageHeader)`
   margin-bottom: ${space(4)};
-`;
-
-const StyledPageHeading = styled(PageHeading)`
-  font-weight: bold;
 `;
 
 const StyledPlaceholder = styled(Placeholder)`

--- a/src/sentry/static/sentry/app/views/alerts/wizard/radioPanelGroup.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/radioPanelGroup.tsx
@@ -78,7 +78,3 @@ export const RadioLineItem = styled('label')<{
 const RadioPanel = styled(Panel)`
   margin: 0;
 `;
-
-const RadioPanelBody = styled(PanelBody)`
-  padding: 0;
-`;

--- a/src/sentry/static/sentry/app/views/alerts/wizard/radioPanelGroup.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/wizard/radioPanelGroup.tsx
@@ -59,16 +59,26 @@ export const RadioLineItem = styled('label')<{
   index: number;
 }>`
   display: grid;
-  grid-gap: 0.25em 0.5em;
+  grid-gap: ${space(0.25)} ${space(1)};
   grid-template-columns: max-content auto max-content;
   align-items: center;
   cursor: pointer;
   outline: none;
   font-weight: normal;
   margin: 0;
+  color: ${p => p.theme.subText};
+  transition: color 0.3s ease-in;
   padding: ${space(1.5)};
+
+  &[aria-checked='true'] {
+    color: ${p => p.theme.textColor};
+  }
 `;
 
 const RadioPanel = styled(Panel)`
   margin: 0;
+`;
+
+const RadioPanelBody = styled(PanelBody)`
+  padding: 0;
 `;

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
@@ -176,7 +176,7 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
             })}
           </StyledPanelBody>
         </Panel>
-        <StyledListItem>{t('Select events')}</StyledListItem>
+        <StyledListItem>{t('Select Events')}</StyledListItem>
         <FormRow>
           <SelectField
             name="environment"

--- a/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/src/sentry/static/sentry/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -700,11 +700,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                       onFilterSearch={this.handleFilterUpdate}
                       allowChangeEventTypes={dataset === Dataset.ERRORS}
                     />
-                    <StyledListItem>
-                      {t('Set actions for when a threshold is met')}
-                    </StyledListItem>
+                    <StyledListItem>{t('Set Thesholds and Actions')}</StyledListItem>
                     {triggerForm(hasAccess)}
-                    <StyledListItem>{t('Add a name and team')}</StyledListItem>
+                    <StyledListItem>{t('Add a Name and Team')}</StyledListItem>
                     {ruleNameOwnerForm(hasAccess)}
                   </List>
                 ) : (


### PR DESCRIPTION
- Fixed styles for alert wizard  
- Updated copy 

## Before

<img width="1380" alt="CleanShot 2021-04-13 at 12 31 01@2x" src="https://user-images.githubusercontent.com/1900676/114609933-35e02500-9c54-11eb-86a8-604845403475.png">

## After 

<img width="1630" alt="CleanShot 2021-04-13 at 12 29 24@2x" src="https://user-images.githubusercontent.com/1900676/114609959-3e386000-9c54-11eb-8fb0-81c60686b7f1.png">
