### PR TITLE
feat(breakdowns): Lift breakdown ops to URL state

### DIFF
--- a/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
+++ b/src/sentry/static/sentry/app/views/performance/transactionSummary/filter.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from '@emotion/styled';
+import {Location} from 'history';
 
 import DropdownButton from 'app/components/dropdownButton';
 import DropdownControl from 'app/components/dropdownControl';
@@ -10,6 +11,7 @@ import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
 import {OrganizationSummary} from 'app/types';
+import {decodeScalar} from 'app/utils/queryString';
 
 type DropdownButtonProps = React.ComponentProps<typeof DropdownButton>;
 
@@ -251,6 +253,30 @@ export function filterToColour(option: SpanOperationBreakdownFilter) {
       return pickSpanBarColour(option);
     }
   }
+}
+
+export function stringToFilter(option: string) {
+  if (
+    Object.values(SpanOperationBreakdownFilter).includes(
+      option as SpanOperationBreakdownFilter
+    )
+  ) {
+    return option as SpanOperationBreakdownFilter;
+  }
+
+  return SpanOperationBreakdownFilter.None;
+}
+
+export function decodeFilterFromLocation(location: Location) {
+  return stringToFilter(
+    decodeScalar(location.query.breakdown, SpanOperationBreakdownFilter.None)
+  );
+}
+
+export function filterToLocationQuery(option: SpanOperationBreakdownFilter) {
+  return {
+    breakdown: option as string,
+  };
 }
 
 export default Filter;


### PR DESCRIPTION
Span breakdown operation filters can be set in the URL as `?breakdown=http`. Any invalid values for the query string `?breakdown`, or if `?breakdown=none`, then no span breakdown operation filters are applied on the Transaction Summary page. 