### PR TITLE
py38: upgrade hiredis to 2.0.0

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -74,7 +74,7 @@ kombu==4.6.11
 grpcio==1.35.0
 
 # not directly used, but provides a speedup for redis
-hiredis==0.3.1
+hiredis==2.0.0
 
 # not directly used, but pinned for at least semaphore/symbolic
 cffi==1.12.2; python_version <= '3.8'


### PR DESCRIPTION
hiredis-py isn't directly used, but provides a speedup for redis-py.

Mainly, hiredis-py 1.0.1 ships wheels for Python 3.8, and additionally hiredis-py 2.0.0 includes hiredis (the C version that it wraps) 1.0.0 which supports secure (ssl) redis which would enable [https://github.com/getsentry/sentry/issues/24238#issuecomment-801508326](https://github.com/getsentry/sentry/issues/24238#issuecomment-801508326). There isn't anything interesting for us in between 1 and 2.

The only notable change is strict unicode decode errors which is passed through with default true from redis-py ≥3.3.0 to hiredis-py ≥ 1.0.0, which is a good thing and we'd want that. I'll go through staging and click around a bunch first to make sure this doesn't result in anything huge.
