### PR TITLE
fix(search): Fix bug with search values that look like short ids

### DIFF
--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -200,7 +200,7 @@ class GroupManager(BaseManager):
 
     def by_qualified_short_id_bulk(self, organization_id: int, short_ids: List[str]):
         short_ids = [parse_short_id(short_id) for short_id in short_ids]
-        if not short_ids or any(short_id for short_id in short_ids if short_id is None):
+        if not short_ids or any(short_id is None for short_id in short_ids):
             raise Group.DoesNotExist()
 
         project_short_id_lookup = defaultdict(list)

--- a/tests/sentry/models/test_group.py
+++ b/tests/sentry/models/test_group.py
@@ -164,6 +164,11 @@ class GroupTest(TestCase, SnubaTestCase):
 
         assert group2 == group
 
+        with self.assertRaises(Group.DoesNotExist):
+            Group.objects.by_qualified_short_id(
+                group.organization.id, "server_name:my-server-with-dashes-0ac14dadda3b428cf"
+            )
+
         group.update(status=GroupStatus.PENDING_DELETION)
         with self.assertRaises(Group.DoesNotExist):
             Group.objects.by_qualified_short_id(group.organization.id, short_id)


### PR DESCRIPTION
This fixes an issue with `by_qualified_short_id_bulk` that causes an error when fields look like a
short-id.

Fixes SENTRY-PNP, SENTRY-PNQ, SENTRY-PNR