### PR TITLE
style(js): Use inline eslint-disable-line for all refluxbox imports

### DIFF
--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import {css} from '@emotion/core';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
-// eslint-disable-next-line no-restricted-imports
-import {Box} from 'reflexbox';
+import {Box} from 'reflexbox'; // eslint-disable-line no-restricted-imports
 
 import AssigneeSelector from 'app/components/assigneeSelector';
 import GuideAnchor from 'app/components/assistant/guideAnchor';


### PR DESCRIPTION
Just noticed all other imports of this module disabled eslint on the
same line. This is the only one that didn't :shrug: