### PR TITLE
Revert "py38: upgrade hiredis to 2.0.0 (#25238)"

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -74,7 +74,7 @@ kombu==4.6.11
 grpcio==1.35.0
 
 # not directly used, but provides a speedup for redis
-hiredis==2.0.0
+hiredis==0.3.1
 
 # not directly used, but pinned for at least semaphore/symbolic
 cffi==1.12.2; python_version <= '3.8'


### PR DESCRIPTION
This reverts commit 6119389deff6bf73aa835c51eab03d2ef22120ba.