### PR TITLE
feat(perf): Add latency chart controls

### DIFF
--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -79,7 +79,27 @@ export function decodeList(value: string[] | string | undefined | null): string[
   return Array.isArray(value) ? value : isString(value) ? [value] : [];
 }
 
+export function decodeInteger(value: QueryValue, fallback?: number): number | undefined {
+  const unwrapped =
+    Array.isArray(value) && value.length > 0
+      ? value[0]
+      : isString(value)
+      ? value
+      : undefined;
+
+  if (unwrapped === undefined) {
+    return fallback;
+  }
+
+  const parsed = parseInt(unwrapped, 10);
+  if (isFinite(parsed)) {
+    return parsed;
+  }
+  return fallback;
+}
+
 export default {
+  decodeInteger,
   decodeList,
   decodeScalar,
   formatQueryString,

--- a/static/app/utils/queryString.tsx
+++ b/static/app/utils/queryString.tsx
@@ -80,12 +80,7 @@ export function decodeList(value: string[] | string | undefined | null): string[
 }
 
 export function decodeInteger(value: QueryValue, fallback?: number): number | undefined {
-  const unwrapped =
-    Array.isArray(value) && value.length > 0
-      ? value[0]
-      : isString(value)
-      ? value
-      : undefined;
+  const unwrapped = decodeScalar(value);
 
   if (unwrapped === undefined) {
     return fallback;

--- a/static/app/views/performance/transactionSummary/charts.tsx
+++ b/static/app/views/performance/transactionSummary/charts.tsx
@@ -29,7 +29,7 @@ import {
 import DurationChart from './durationChart';
 import DurationPercentileChart from './durationPercentileChart';
 import {SpanOperationBreakdownFilter} from './filter';
-import LatencyChart from './latencyChart';
+import LatencyChart, {LatencyChartControls} from './latencyChart';
 import TrendChart from './trendChart';
 import VitalsChart from './vitalsChart';
 
@@ -239,6 +239,9 @@ class TransactionSummaryCharts extends React.Component<Props> {
                 options={TREND_PARAMETERS_OPTIONS}
                 onChange={this.handleTrendColumnChange}
               />
+            )}
+            {display === DisplayModes.LATENCY && (
+              <LatencyChartControls location={location} />
             )}
             <OptionSelector
               title={t('Display')}

--- a/static/app/views/performance/transactionSummary/index.tsx
+++ b/static/app/views/performance/transactionSummary/index.tsx
@@ -16,6 +16,7 @@ import {GlobalSelection, Organization, Project} from 'app/types';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
 import {Column, isAggregateField, WebVital} from 'app/utils/discover/fields';
+import {removeHistogramQueryStrings} from 'app/utils/performance/histogram';
 import {decodeScalar} from 'app/utils/queryString';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
 import withApi from 'app/utils/withApi';
@@ -36,6 +37,7 @@ import {
   filterToLocationQuery,
   SpanOperationBreakdownFilter,
 } from './filter';
+import {ZOOM_END, ZOOM_START} from './latencyChart';
 
 type Props = {
   api: Client;
@@ -100,7 +102,7 @@ class TransactionSummary extends React.Component<Props, State> {
     const {location} = this.props;
 
     const nextQuery: Location['query'] = {
-      ...location.query,
+      ...removeHistogramQueryStrings(location, [ZOOM_START, ZOOM_END]),
       ...filterToLocationQuery(newFilter),
     };
 

--- a/static/app/views/performance/transactionSummary/index.tsx
+++ b/static/app/views/performance/transactionSummary/index.tsx
@@ -281,19 +281,6 @@ function generateSummaryEventView(
     if (isAggregateField(field)) conditions.removeTag(field);
   });
 
-  // Handle duration filters from the latency chart
-  if (location.query.startDuration || location.query.endDuration) {
-    conditions.setTagValues(
-      'transaction.duration',
-      [
-        decodeScalar(location.query.startDuration),
-        decodeScalar(location.query.endDuration),
-      ]
-        .filter(item => item)
-        .map((item, index) => (index === 0 ? `>${item}` : `<${item}`))
-    );
-  }
-
   let durationField = 'transaction.duration';
 
   if (spanOperationBreakdownFilter !== SpanOperationBreakdownFilter.None) {

--- a/static/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/static/app/views/performance/transactionSummary/latencyChart.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import {Location} from 'history';
 
-import Button from 'app/components/button';
 import BarChart from 'app/components/charts/barChart';
 import BarChartZoom from 'app/components/charts/barChartZoom';
 import ErrorPanel from 'app/components/charts/errorPanel';
 import LoadingPanel from 'app/components/charts/loadingPanel';
 import OptionSelector from 'app/components/charts/optionSelector';
-import {HeaderTitleLegend, InlineContainer} from 'app/components/charts/styles';
+import {HeaderTitleLegend} from 'app/components/charts/styles';
 import QuestionTooltip from 'app/components/questionTooltip';
 import {IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';

--- a/static/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/static/app/views/performance/transactionSummary/latencyChart.tsx
@@ -277,7 +277,7 @@ export function LatencyChartControls(props: {location: Location}) {
 
   return (
     <Histogram location={location} zoomKeys={[ZOOM_START, ZOOM_END]}>
-      {({isZoomed, filterOptions, handleResetView, handleFilterChange, activeFilter}) => {
+      {({filterOptions, handleFilterChange, activeFilter}) => {
         return (
           <React.Fragment>
             <OptionSelector
@@ -286,16 +286,6 @@ export function LatencyChartControls(props: {location: Location}) {
               options={filterOptions}
               onChange={handleFilterChange}
             />
-            <InlineContainer>
-              <Button
-                onClick={handleResetView}
-                disabled={!isZoomed}
-                data-test-id="reset-view"
-                size="small"
-              >
-                {t('Reset View')}
-              </Button>
-            </InlineContainer>
           </React.Fragment>
         );
       }}

--- a/static/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/static/app/views/performance/transactionSummary/latencyChart.tsx
@@ -17,7 +17,7 @@ import Histogram from 'app/utils/performance/histogram';
 import HistogramQuery from 'app/utils/performance/histogram/histogramQuery';
 import {HistogramData} from 'app/utils/performance/histogram/types';
 import {computeBuckets, formatHistogramData} from 'app/utils/performance/histogram/utils';
-import {decodeScalar} from 'app/utils/queryString';
+import {decodeInteger, decodeScalar} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 
 import {filterToColour, filterToField, SpanOperationBreakdownFilter} from './filter';
@@ -213,11 +213,14 @@ class LatencyChart extends React.Component<Props, State> {
     let max: number | undefined = undefined;
 
     if (ZOOM_START in location.query) {
-      min = Math.abs(parseInt(decodeScalar(location.query[ZOOM_START], '0'), 10));
+      min = decodeInteger(location.query[ZOOM_START], 0);
     }
 
     if (ZOOM_END in location.query) {
-      max = Math.abs(parseInt(decodeScalar(location.query[ZOOM_END], '0'), 10));
+      const decodedMax = decodeInteger(location.query[ZOOM_END]);
+      if (typeof decodedMax === 'number') {
+        max = decodedMax;
+      }
     }
 
     const field = filterToField(currentFilter) ?? 'transaction.duration';

--- a/static/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/static/app/views/performance/transactionSummary/latencyChart.tsx
@@ -17,7 +17,7 @@ import Histogram from 'app/utils/performance/histogram';
 import HistogramQuery from 'app/utils/performance/histogram/histogramQuery';
 import {HistogramData} from 'app/utils/performance/histogram/types';
 import {computeBuckets, formatHistogramData} from 'app/utils/performance/histogram/utils';
-import {decodeInteger, decodeScalar} from 'app/utils/queryString';
+import {decodeInteger} from 'app/utils/queryString';
 import theme from 'app/utils/theme';
 
 import {filterToColour, filterToField, SpanOperationBreakdownFilter} from './filter';

--- a/tests/js/spec/utils/queryString.spec.js
+++ b/tests/js/spec/utils/queryString.spec.js
@@ -115,3 +115,27 @@ describe('decodeList()', function () {
     expect(utils.decodeList('')).toEqual([]);
   });
 });
+
+describe('decodeInteger()', function () {
+  it('handles integer strings', function () {
+    expect(utils.decodeInteger('1')).toEqual(1);
+    expect(utils.decodeInteger('1.2')).toEqual(1);
+    expect(utils.decodeInteger('1.9')).toEqual(1);
+    expect(utils.decodeInteger('foo')).toEqual(undefined);
+    expect(utils.decodeInteger('foo', 2020)).toEqual(2020);
+  });
+
+  it('handles arrays', function () {
+    expect(utils.decodeInteger(['1', 'foo'])).toEqual(1);
+    expect(utils.decodeInteger(['1.2', 'foo'])).toEqual(1);
+    expect(utils.decodeInteger(['1.9', 'foo'])).toEqual(1);
+    expect(utils.decodeInteger(['foo', '1'])).toEqual(undefined);
+    expect(utils.decodeInteger(['foo'], 2020)).toEqual(2020);
+  });
+
+  it('handles falsey values', function () {
+    expect(utils.decodeInteger(undefined, 2020)).toEqual(2020);
+    expect(utils.decodeInteger(false, 2020)).toEqual(2020);
+    expect(utils.decodeInteger('', 2020)).toEqual(2020);
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/25260

Add latency chart controls to the Transaction Summary page to control inclusion and exclusion of outliers, and as well as resetting the zoom level. 

Certain inconsistencies and bugs were addressed, such as:

- `max` parameter for the histogram endpoint was not properly set
- Certain hacks like https://github.com/getsentry/sentry/pull/17841 are now outdated since the introduction of the histogram endpoint by @Zylphrex .
- Filtering span op breakdown distribution graph when clicking and dragging over it was not working. This PR aims to fix that.

-----

<img width="1303" alt="Screen Shot 2021-04-14 at 1 26 54 PM" src="https://user-images.githubusercontent.com/139499/114753195-2bda2700-9d25-11eb-822d-bb7359136d49.png">

<img width="1301" alt="Screen Shot 2021-04-14 at 1 26 39 PM" src="https://user-images.githubusercontent.com/139499/114753201-2d0b5400-9d25-11eb-97b0-13e866c2220f.png">


https://user-images.githubusercontent.com/139499/114754569-b66f5600-9d26-11eb-93df-4370efe27d93.mp4


