### PR TITLE
feat(alert): Log a transaction when saving alert rules

### DIFF
--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react';
+import {Transaction} from '@sentry/types';
 
 import HookStore from 'app/stores/hookStore';
 import {Hooks} from 'app/types/hooks';
@@ -128,7 +129,7 @@ type RecordMetric = Hooks['metrics:event'] & {
      * Optional op code
      */
     op?: string;
-  }) => void;
+  }) => Transaction;
 
   endTransaction: (opts: {
     /**
@@ -236,6 +237,7 @@ metric.startTransaction = ({name, traceId, op}) => {
   }
   const transaction = Sentry.startTransaction({name, op, traceId});
   transactionDataStore[name] = transaction;
+  return transaction;
 };
 
 metric.endTransaction = ({name}) => {

--- a/static/app/views/settings/incidentRules/create.tsx
+++ b/static/app/views/settings/incidentRules/create.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import {Organization, Project, Team} from 'app/types';
+import {metric} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
 import withTeams from 'app/utils/withTeams';
 import {WizardRuleTemplate} from 'app/views/alerts/wizard/options';
@@ -36,6 +37,7 @@ class IncidentRulesCreate extends React.Component<Props> {
     const {router} = this.props;
     const {orgId} = this.props.params;
 
+    metric.endTransaction({name: 'saveAlertRule'});
     router.push(`/organizations/${orgId}/alerts/rules/`);
   };
 

--- a/static/app/views/settings/incidentRules/details.tsx
+++ b/static/app/views/settings/incidentRules/details.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import {Organization, Project, Team} from 'app/types';
+import {metric} from 'app/utils/analytics';
 import withTeams from 'app/utils/withTeams';
 import AsyncView from 'app/views/asyncView';
 import RuleForm from 'app/views/settings/incidentRules/ruleForm';
@@ -49,6 +50,7 @@ class IncidentRulesDetails extends AsyncView<Props, State> {
     const {router} = this.props;
     const {orgId} = this.props.params;
 
+    metric.endTransaction({name: 'saveAlertRule'});
     router.push(`/organizations/${orgId}/alerts/rules/`);
   };
 

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -4,7 +4,18 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import GlobalModal from 'app/components/globalModal';
+import {metric} from 'app/utils/analytics';
 import IncidentRulesDetails from 'app/views/settings/incidentRules/details';
+
+jest.mock('app/utils/analytics', () => ({
+  metric: {
+    startTransaction: jest.fn(() => ({
+      setTag: jest.fn(),
+      setData: jest.fn(),
+    })),
+    endTransaction: jest.fn(),
+  },
+}));
 
 describe('Incident Rules Details', function () {
   beforeAll(function () {
@@ -109,6 +120,7 @@ describe('Incident Rules Details', function () {
     // Save Trigger
     wrapper.find('button[aria-label="Save Rule"]').simulate('submit');
 
+    expect(metric.startTransaction).toHaveBeenCalledWith({name: 'saveAlertRule'});
     expect(editRule).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/ruleForm.spec.jsx
@@ -4,10 +4,20 @@ import {mountWithTheme} from 'sentry-test/enzyme';
 import {initializeOrg} from 'sentry-test/initializeOrg';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
+import {metric} from 'app/utils/analytics';
 import FormModel from 'app/views/settings/components/forms/model';
 import RuleFormContainer from 'app/views/settings/incidentRules/ruleForm';
 
 jest.mock('app/actionCreators/indicator');
+jest.mock('app/utils/analytics', () => ({
+  metric: {
+    startTransaction: jest.fn(() => ({
+      setTag: jest.fn(),
+      setData: jest.fn(),
+    })),
+    endTransaction: jest.fn(),
+  },
+}));
 
 describe('Incident Rules Form', function () {
   const {organization, project, routerContext} = initializeOrg();
@@ -64,6 +74,7 @@ describe('Incident Rules Form', function () {
         url: '/projects/org-slug/project-slug/alert-rules/',
         method: 'POST',
       });
+      metric.startTransaction.mockClear();
     });
 
     /**
@@ -95,6 +106,7 @@ describe('Incident Rules Form', function () {
           }),
         })
       );
+      expect(metric.startTransaction).toHaveBeenCalledWith({name: 'saveAlertRule'});
     });
     describe('Slack async lookup', () => {
       const uuid = 'xxxx-xxxx-xxxx';


### PR DESCRIPTION
Sends a transaction to sentry when alert rules are saved
**Example:**
![image](https://user-images.githubusercontent.com/9372512/114756103-64c7cb00-9d28-11eb-97f4-e2aef70a60fe.png)

Because issue alerts and metric alerts treat actions a little differently the tags they have are a bit different.

**Example metric alert tags:**
![image](https://user-images.githubusercontent.com/9372512/114756467-c25c1780-9d28-11eb-9f61-38a1cdf4a0e4.png)

**Example issue alert tags:**
![image](https://user-images.githubusercontent.com/9372512/114756670-fe8f7800-9d28-11eb-8fc0-df49b1428ca6.png)
