### PR TITLE
build(ci): Use webpack development mode for acceptance tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "watch-api-docs": "sane 'yarn build-derefed-docs' api-docs",
     "build-css": "NODE_ENV=production yarn webpack --config=config/webpack.css.config.js",
     "build-chartcuterie-config": "NODE_ENV=production yarn webpack --config=config/webpack.chartcuterie.config.js",
-    "build-acceptance": "IS_ACCEPTANCE_TEST=1 yarn build-production",
+    "build-acceptance": "IS_ACCEPTANCE_TEST=1 NODE_ENV=production yarn webpack --mode development",
     "build-production": "NODE_ENV=production yarn webpack --mode production",
     "build": "yarn build-production --output-path=public",
     "validate-api-examples": "yarn install-api-docs && cd api-docs && yarn openapi-examples-validator ./openapi.json --no-additional-properties"


### PR DESCRIPTION
It currently takes CI ~5-6 minutes for webpack to run in production mode, lets use development mode here instead as it will be faster to build.

Note: We have historically used dev mode, e.g. https://github.com/getsentry/sentry/blob/4dcc94b8f9a8ae3adbb2f138ce32f742df0c2e34/.github/workflows/acceptance.yml#L144

but I made a change in https://github.com/getsentry/sentry/pull/24867 that changed it to production mode. This is reverting that change.
