### PR TITLE
fix(alert): Don't refresh page when editing an alert rule

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/row.tsx
@@ -120,7 +120,7 @@ class RuleListRow extends React.Component<Props, State> {
                   type="button"
                   icon={<IconSettings />}
                   title={t('Edit')}
-                  href={editLink}
+                  to={editLink}
                 />
               </ButtonBar>
             )}


### PR DESCRIPTION
Previously, clicking the settings icon 
![image](https://user-images.githubusercontent.com/9372512/114759540-495ebf00-9d2c-11eb-8108-288b7d7d71ee.png)

would trigger a complete page refresh. Changed `href` to `to` to fix this.