### PR TITLE
feat(alerts): Link to alert details with incident id

### DIFF
--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -21,8 +21,8 @@ import {Group} from 'app/types';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import StreamManager from 'app/utils/streamManager';
 import withApi from 'app/utils/withApi';
+import {TimePeriodType} from 'app/views/alerts/rules/details/constants';
 
-import {TimePeriodType} from './constants';
 import GroupListHeader from './groupListHeader';
 
 

--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -21,9 +21,10 @@ import {Group} from 'app/types';
 import {callIfFunction} from 'app/utils/callIfFunction';
 import StreamManager from 'app/utils/streamManager';
 import withApi from 'app/utils/withApi';
-import {TimePeriodType} from 'app/views/alerts/rules/details/body';
 
+import {TimePeriodType} from './constants';
 import GroupListHeader from './groupListHeader';
+
 
 const defaultProps = {
   canSelectGroups: true,

--- a/src/sentry/static/sentry/app/components/issues/groupList.tsx
+++ b/src/sentry/static/sentry/app/components/issues/groupList.tsx
@@ -25,7 +25,6 @@ import {TimePeriodType} from 'app/views/alerts/rules/details/constants';
 
 import GroupListHeader from './groupListHeader';
 
-
 const defaultProps = {
   canSelectGroups: true,
   withChart: true,

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -41,8 +41,9 @@ import EventView from 'app/utils/discover/eventView';
 import {queryToObj} from 'app/utils/stream';
 import withGlobalSelection from 'app/utils/withGlobalSelection';
 import withOrganization from 'app/utils/withOrganization';
-import {TimePeriodType} from 'app/views/alerts/rules/details/body';
+import {TimePeriodType} from 'app/views/alerts/rules/details/constants';
 import {getTabs, isForReviewQuery, Query} from 'app/views/issueList/utils';
+
 
 const DiscoveryExclusionFields: string[] = [
   'query',

--- a/src/sentry/static/sentry/app/components/stream/group.tsx
+++ b/src/sentry/static/sentry/app/components/stream/group.tsx
@@ -44,7 +44,6 @@ import withOrganization from 'app/utils/withOrganization';
 import {TimePeriodType} from 'app/views/alerts/rules/details/constants';
 import {getTabs, isForReviewQuery, Query} from 'app/views/issueList/utils';
 
-
 const DiscoveryExclusionFields: string[] = [
   'query',
   'status',

--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -11,7 +11,6 @@ import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import withApi from 'app/utils/withApi';
-import {makeRuleDetailsQuery} from 'app/views/alerts/list/row';
 
 import {AlertRuleStatus, Incident, IncidentStats, IncidentStatus} from '../types';
 import {

--- a/src/sentry/static/sentry/app/views/alerts/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/details/index.tsx
@@ -81,7 +81,7 @@ class IncidentDetails extends React.Component<Props, State> {
                 ? incident.alertRule.originalAlertRuleId
                 : incident.alertRule.id
             }/`,
-            query: makeRuleDetailsQuery(incident),
+            query: {alert: incident.identifier},
           });
         }
 

--- a/src/sentry/static/sentry/app/views/alerts/list/row.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/row.tsx
@@ -152,7 +152,7 @@ class AlertListRow extends AsyncComponent<Props, State> {
               ? incident.alertRule.originalAlertRuleId
               : incident.alertRule.id
           }/`,
-          query: makeRuleDetailsQuery(incident),
+          query: {alert: incident.identifier},
         }
       : {
           pathname: `/organizations/${orgId}/alerts/${incident.identifier}/`,

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/body.tsx
@@ -38,18 +38,10 @@ import {extractEventTypeFilterFromRule} from 'app/views/settings/incidentRules/u
 
 import {Incident, IncidentStatus} from '../../types';
 
-import {API_INTERVAL_POINTS_LIMIT, TIME_OPTIONS} from './constants';
+import {API_INTERVAL_POINTS_LIMIT, TIME_OPTIONS, TimePeriodType} from './constants';
 import MetricChart from './metricChart';
 import RelatedIssues from './relatedIssues';
 import RelatedTransactions from './relatedTransactions';
-
-export type TimePeriodType = {
-  start: string;
-  end: string;
-  period: string;
-  label: string;
-  custom?: boolean;
-};
 
 type Props = {
   api: Client;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/constants.tsx
@@ -20,3 +20,11 @@ export const TIME_WINDOWS = {
 
 export const API_INTERVAL_POINTS_LIMIT = 10000;
 export const API_INTERVAL_POINTS_MIN = 150;
+
+export type TimePeriodType = {
+  start: string;
+  end: string;
+  period: string;
+  label: string;
+  custom?: boolean;
+};

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -17,7 +17,12 @@ import {Incident} from '../../types';
 import {fetchAlertRule, fetchIncident, fetchIncidentsForRule} from '../../utils';
 
 import DetailsBody from './body';
-import {ALERT_RULE_DETAILS_DEFAULT_PERIOD, TIME_OPTIONS, TIME_WINDOWS, TimePeriodType} from './constants';
+import {
+  ALERT_RULE_DETAILS_DEFAULT_PERIOD,
+  TIME_OPTIONS,
+  TIME_WINDOWS,
+  TimePeriodType,
+} from './constants';
 import DetailsHeader from './header';
 
 type Props = {
@@ -77,7 +82,7 @@ class AlertRuleDetails extends React.Component<Props, State> {
         period,
         label: t('Custom time'),
         custom: true,
-      }
+      };
     }
 
     const timeOption =
@@ -96,7 +101,11 @@ class AlertRuleDetails extends React.Component<Props, State> {
   }
 
   fetchData = async () => {
-    const {api, params: {orgId, ruleId}, location} = this.props;
+    const {
+      api,
+      params: {orgId, ruleId},
+      location,
+    } = this.props;
 
     this.setState({isLoading: true, hasError: false});
 
@@ -105,7 +114,7 @@ class AlertRuleDetails extends React.Component<Props, State> {
     if (location.query.alert) {
       await fetchIncident(api, orgId, location.query.alert)
         .then(incident => this.setState({selectedIncident: incident}))
-        .catch(() => this.setState({selectedIncident: null}))
+        .catch(() => this.setState({selectedIncident: null}));
     }
 
     const timePeriod = this.getTimePeriod();

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -109,8 +109,6 @@ class AlertRuleDetails extends React.Component<Props, State> {
 
     this.setState({isLoading: true, hasError: false});
 
-    fetchOrgMembers(api, orgId);
-
     if (location.query.alert) {
       await fetchIncident(api, orgId, location.query.alert)
         .then(incident => this.setState({selectedIncident: incident}))

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/index.tsx
@@ -10,13 +10,14 @@ import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import withApi from 'app/utils/withApi';
+import {makeRuleDetailsQuery} from 'app/views/alerts/list/row';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
 import {Incident} from '../../types';
-import {fetchAlertRule, fetchIncidentsForRule} from '../../utils';
+import {fetchAlertRule, fetchIncident, fetchIncidentsForRule} from '../../utils';
 
 import DetailsBody from './body';
-import {ALERT_RULE_DETAILS_DEFAULT_PERIOD, TIME_OPTIONS, TIME_WINDOWS} from './constants';
+import {ALERT_RULE_DETAILS_DEFAULT_PERIOD, TIME_OPTIONS, TIME_WINDOWS, TimePeriodType} from './constants';
 import DetailsHeader from './header';
 
 type Props = {
@@ -30,6 +31,7 @@ type State = {
   hasError: boolean;
   rule?: IncidentRule;
   incidents?: Incident[];
+  selectedIncident?: Incident | null;
 };
 
 class AlertRuleDetails extends React.Component<Props, State> {
@@ -52,23 +54,34 @@ class AlertRuleDetails extends React.Component<Props, State> {
     }
   }
 
-  getTimePeriod() {
+  getTimePeriod(): TimePeriodType {
     const {location} = this.props;
 
-    const timePeriod = location.query.period ?? ALERT_RULE_DETAILS_DEFAULT_PERIOD;
+    const period = location.query.period ?? ALERT_RULE_DETAILS_DEFAULT_PERIOD;
 
     if (location.query.start && location.query.end) {
       return {
         start: location.query.start,
         end: location.query.end,
-        period: timePeriod,
+        period,
         label: t('Custom time'),
         custom: true,
       };
     }
 
+    if (location.query.alert && this.state.selectedIncident) {
+      const {start, end} = makeRuleDetailsQuery(this.state.selectedIncident);
+      return {
+        start,
+        end,
+        period,
+        label: t('Custom time'),
+        custom: true,
+      }
+    }
+
     const timeOption =
-      TIME_OPTIONS.find(item => item.value === timePeriod) ?? TIME_OPTIONS[1];
+      TIME_OPTIONS.find(item => item.value === period) ?? TIME_OPTIONS[1];
     const start = getUtcDateString(
       moment(moment.utc().diff(TIME_WINDOWS[timeOption.value]))
     );
@@ -77,16 +90,23 @@ class AlertRuleDetails extends React.Component<Props, State> {
     return {
       start,
       end,
+      period,
       label: timeOption.label as string,
-      period: timePeriod,
     };
   }
 
   fetchData = async () => {
+    const {api, params: {orgId, ruleId}, location} = this.props;
+
     this.setState({isLoading: true, hasError: false});
-    const {
-      params: {orgId, ruleId},
-    } = this.props;
+
+    fetchOrgMembers(api, orgId);
+
+    if (location.query.alert) {
+      await fetchIncident(api, orgId, location.query.alert)
+        .then(incident => this.setState({selectedIncident: incident}))
+        .catch(() => this.setState({selectedIncident: null}))
+    }
 
     const timePeriod = this.getTimePeriod();
     const {start, end} = timePeriod;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -401,7 +401,6 @@ class MetricChart extends React.PureComponent<Props, State> {
         environment={rule.environment ? [rule.environment] : undefined}
         project={(projects as Project[])
           .filter(p => p && p.slug)
-          .filter(p => p && p.slug)
           .map(project => Number(project.id))}
         interval={interval}
         start={viableStartDate}

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -26,6 +26,7 @@ import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
 import {Incident, IncidentActivityType, IncidentStatus} from '../../types';
 import {getIncidentRuleMetricPreset} from '../../utils';
+
 import {TimePeriodType} from './constants';
 
 const X_AXIS_BOUNDARY_GAP = 20;
@@ -399,7 +400,8 @@ class MetricChart extends React.PureComponent<Props, State> {
         query={query}
         environment={rule.environment ? [rule.environment] : undefined}
         project={(projects as Project[])
-          .filter(p => p && p.slug).filter(p => p && p.slug)
+          .filter(p => p && p.slug)
+          .filter(p => p && p.slug)
           .map(project => Number(project.id))}
         interval={interval}
         start={viableStartDate}

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/metricChart.tsx
@@ -21,12 +21,12 @@ import {AvatarProject, Organization, Project} from 'app/types';
 import {ReactEchartsRef} from 'app/types/echarts';
 import {getFormattedDate, getUtcDateString} from 'app/utils/dates';
 import theme from 'app/utils/theme';
-import {TimePeriodType} from 'app/views/alerts/rules/details/body';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
 import {Incident, IncidentActivityType, IncidentStatus} from '../../types';
 import {getIncidentRuleMetricPreset} from '../../utils';
+import {TimePeriodType} from './constants';
 
 const X_AXIS_BOUNDARY_GAP = 20;
 const VERTICAL_PADDING = 22;
@@ -399,7 +399,7 @@ class MetricChart extends React.PureComponent<Props, State> {
         query={query}
         environment={rule.environment ? [rule.environment] : undefined}
         project={(projects as Project[])
-          .filter(p => p && p.slug)
+          .filter(p => p && p.slug).filter(p => p && p.slug)
           .map(project => Number(project.id))}
         interval={interval}
         start={viableStartDate}
@@ -415,7 +415,6 @@ class MetricChart extends React.PureComponent<Props, State> {
           }
 
           const series: LineChartSeries[] = [...timeseriesData];
-
           // Ensure series data appears above incident lines
           series[0].z = 100;
           const dataArr = timeseriesData[0].data;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
@@ -11,8 +11,10 @@ import {IconInfo} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {OrganizationSummary, Project} from 'app/types';
-import {TimePeriodType} from 'app/views/alerts/rules/details/body';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
+
+import {TimePeriodType} from './constants';
+
 
 type Props = {
   organization: OrganizationSummary;

--- a/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/rules/details/relatedIssues.tsx
@@ -15,7 +15,6 @@ import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
 import {TimePeriodType} from './constants';
 
-
 type Props = {
   organization: OrganizationSummary;
   rule: IncidentRule;


### PR DESCRIPTION
This allows to link to the alert details page with query `alert=incident.identifier` rather than the time range. Time range is calculated after the page loads instead.

[WOR-729](https://getsentry.atlassian.net/browse/WOR-729)