### PR TITLE
fix(data-export): Make query a required field

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -51,6 +51,10 @@ class DataExportQuerySerializer(serializers.Serializer):
                 detail = f"You can export up to {MAX_FIELDS} fields at a time. Please delete some and try again."
                 raise serializers.ValidationError(detail)
 
+            if "query" not in query_info:
+                detail = "query is a required to export, please pass an empty string if you don't want to set one"
+                raise serializers.ValidationError(detail)
+
             query_info["field"] = fields
 
             if "project" not in query_info:

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -138,6 +138,19 @@ class DataExportTest(APITestCase):
             ]
         }
 
+    def test_discover_without_query(self):
+        """
+        Ensurse that we handle export requests without a query, and return a 400 status code
+        """
+        payload = self.make_payload("discover", {"field": ["id"]}, overwrite=True)
+        with self.feature("organizations:discover-query"):
+            response = self.get_valid_response(self.org.slug, status_code=400, **payload)
+        assert response.data == {
+            "non_field_errors": [
+                "query is a required to export, please pass an empty string if you don't want to set one"
+            ]
+        }
+
     def test_export_invalid_fields(self):
         """
         Ensures that if too many fields are requested, returns a 400 status code with the


### PR DESCRIPTION
- Fixes SENTRY-PPJ
- This fixes a bug where we would 500 when query wasn't included in the
  payload because the DiscoverProcessor assumes that query will always
  be available
- Could default to empty string, but I think we should ask the user to
  be explicit instead of making that guess for them