### PR TITLE
fix(async-csv): Use event view to generate export payload

### DIFF
--- a/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
+++ b/src/sentry/static/sentry/app/views/eventsV2/table/tableActions.tsx
@@ -68,13 +68,13 @@ function renderBrowserExportButton(canEdit: boolean, {isLoading, ...props}: Prop
 }
 
 function renderAsyncExportButton(canEdit: boolean, props: Props) {
-  const {isLoading, location} = props;
+  const {isLoading, location, eventView} = props;
   const disabled = isLoading || canEdit === false;
   return (
     <DataExport
       payload={{
         queryType: ExportQueryType.Discover,
-        queryInfo: location.query,
+        queryInfo: eventView.getEventsAPIPayload(location),
       }}
       disabled={disabled}
       icon={<IconDownload size="xs" />}


### PR DESCRIPTION
With the change to use short urls for saved discover queries, we cannot directly
use `location.query` anymore. Instead, generate the export payload through the
event view.