### PR TITLE
fix(workflow): Disable issues header action wrapping

### DIFF
--- a/src/sentry/static/sentry/app/views/alerts/list/header.tsx
+++ b/src/sentry/static/sentry/app/views/alerts/list/header.tsx
@@ -81,9 +81,9 @@ export default AlertHeader;
 const BorderlessHeader = styled(Layout.Header)`
   border-bottom: 0;
 
-  /* Not enough buttons to change direction for mobile view */
-  @media (max-width: ${p => p.theme.breakpoints[1]}) {
-    flex-direction: row;
+  /* Not enough buttons to change direction for tablet view */
+  @media (min-width: ${p => p.theme.breakpoints[0]}) {
+    grid-template-columns: 1fr auto;
   }
 `;
 

--- a/src/sentry/static/sentry/app/views/issueList/header.tsx
+++ b/src/sentry/static/sentry/app/views/issueList/header.tsx
@@ -178,11 +178,8 @@ const StyledLayoutTitle = styled(Layout.Title)`
 
 const BorderlessHeader = styled(Layout.Header)`
   border-bottom: 0;
-
   /* Not enough buttons to change direction for mobile view */
-  @media (max-width: ${p => p.theme.breakpoints[1]}) {
-    flex-direction: row;
-  }
+  grid-template-columns: 1fr auto;
 `;
 
 const TabLayoutHeader = styled(Layout.Header)`


### PR DESCRIPTION
adjust the breakpoint for actions to wrap on alerts page and disable wrapping for inbox header.

disable wrapping for this one action
![image](https://user-images.githubusercontent.com/1400464/114791879-191f1c80-9d3c-11eb-9f10-9a1b5c2de66c.png)
