### PR TITLE
fix(ui): Adjust position of form error indicator

### DIFF
--- a/src/sentry/static/sentry/app/views/settings/components/forms/field/controlState.tsx
+++ b/src/sentry/static/sentry/app/views/settings/components/forms/field/controlState.tsx
@@ -48,6 +48,7 @@ const ControlState = ({isSaving, isSaved, error}: Props) => (
 );
 
 const ControlStateWrapper = styled('div')`
+  line-height: 0;
   padding: 0 8px;
 `;
 


### PR DESCRIPTION
before
<img width="1006" alt="Screen Shot 2021-04-14 at 5 04 02 PM" src="https://user-images.githubusercontent.com/1400464/114795531-9ef29600-9d43-11eb-8c2c-e34a173ed36e.png">

after
<img width="1087" alt="Screen Shot 2021-04-14 at 5 04 19 PM" src="https://user-images.githubusercontent.com/1400464/114795530-9e59ff80-9d43-11eb-9e40-ec4f44d70346.png">
