### PR TITLE
feat(issue_search): Add `none` keyword for assignment related searches.

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -37,6 +37,8 @@ def assigned_to_filter(actors, projects, field_filter="id"):
         if isinstance(actor, list) and actor[0] == "me_or_none":
             include_none = True
             actor = actor[1]
+        if actor is None:
+            include_none = True
         types_to_actors[type(actor) if not isinstance(actor, SimpleLazyObject) else User].append(
             actor
         )
@@ -177,6 +179,8 @@ def assigned_or_suggested_filter(owners, projects, field_filter="id"):
         if isinstance(owner, list) and owner[0] == "me_or_none":
             include_none = True
             owner = owner[1]
+        if owner is None:
+            include_none = True
         types_to_owners[type(owner) if not isinstance(owner, SimpleLazyObject) else User].append(
             owner
         )

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -231,6 +231,8 @@ def parse_actor_value(projects, value, user):
 def parse_actor_or_none_value(projects, value, user):
     if value == "me_or_none":
         return ["me_or_none", user]
+    if value == "none":
+        return None
     return parse_actor_value(projects, value, user)
 
 

--- a/tests/acceptance/test_organization_group_index.py
+++ b/tests/acceptance/test_organization_group_index.py
@@ -118,7 +118,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
         with self.feature("organizations:inbox"):
             self.page.visit_issue_list(
                 self.org.slug,
-                query="?query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3Ame_or_none",
+                query="?query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A[me, none]",
             )
             self.page.wait_for_stream()
             self.browser.snapshot("organization issues inbox results")
@@ -130,7 +130,7 @@ class OrganizationGroupIndexTest(AcceptanceTestCase, SnubaTestCase):
 
             self.page.visit_issue_list(
                 self.org.slug,
-                query="?query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3Ame_or_none",
+                query="?query=is%3Aunresolved+is%3Afor_review+assigned_or_suggested%3A[me, none]",
             )
             self.page.wait_for_stream()
             groups = self.browser.elements('[data-test-id="event-issue-header"]')

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -206,6 +206,9 @@ class ConvertActorOrNoneValueTest(TestCase):
             ]
         ]
 
+    def test_none(self):
+        assert convert_actor_or_none_value(["none"], [self.project], self.user, None) == [None]
+
     def test_team(self):
         assert convert_actor_or_none_value(
             [f"#{self.team.slug}"], [self.project], self.user, None

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -293,6 +293,10 @@ class ParseQueryTest(TestCase):
         result = self.parse_query("assigned:me")
         assert result == {"assigned_to": self.user, "tags": {}, "query": ""}
 
+    def test_assigned_me_or_none(self):
+        result = self.parse_query("assigned:me_or_none")
+        assert result == {"assigned_to": ["me_or_none", self.user], "tags": {}, "query": ""}
+
     def test_assigned_none(self):
         result = self.parse_query("assigned:none")
         assert result == {"assigned_to": None, "tags": {}, "query": ""}
@@ -527,6 +531,14 @@ class ParseQueryTest(TestCase):
     def test_assigned_or_suggested_me(self):
         result = self.parse_query("assigned_or_suggested:me")
         assert result == {"assigned_or_suggested": self.user, "tags": {}, "query": ""}
+
+    def test_assigned_or_suggested_me_or_none(self):
+        result = self.parse_query("assigned_or_suggested:me_or_none")
+        assert result == {
+            "assigned_or_suggested": ["me_or_none", self.user],
+            "tags": {},
+            "query": "",
+        }
 
     def test_assigned_or_suggested_none(self):
         result = self.parse_query("assigned_or_suggested:none")

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -293,9 +293,9 @@ class ParseQueryTest(TestCase):
         result = self.parse_query("assigned:me")
         assert result == {"assigned_to": self.user, "tags": {}, "query": ""}
 
-    def test_assigned_me_or_none(self):
-        result = self.parse_query("assigned:me_or_none")
-        assert result == {"assigned_to": ["me_or_none", self.user], "tags": {}, "query": ""}
+    def test_assigned_none(self):
+        result = self.parse_query("assigned:none")
+        assert result == {"assigned_to": None, "tags": {}, "query": ""}
 
     def test_assigned_email(self):
         result = self.parse_query(f"assigned:{self.user.email}")
@@ -528,10 +528,10 @@ class ParseQueryTest(TestCase):
         result = self.parse_query("assigned_or_suggested:me")
         assert result == {"assigned_or_suggested": self.user, "tags": {}, "query": ""}
 
-    def test_assigned_or_suggested_me_or_none(self):
-        result = self.parse_query("assigned_or_suggested:me_or_none")
+    def test_assigned_or_suggested_none(self):
+        result = self.parse_query("assigned_or_suggested:none")
         assert result == {
-            "assigned_or_suggested": ["me_or_none", self.user],
+            "assigned_or_suggested": None,
             "tags": {},
             "query": "",
         }

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -252,7 +252,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         self.login_as(user=self.user)
         response = self.get_valid_response(
             sort="inbox",
-            query="is:unresolved is:for_review assigned_or_suggested:me_or_none",
+            query="is:unresolved is:for_review assigned_or_suggested:[me, none]",
             limit=10,
         )
         assert [item["id"] for item in response.data] == [str(group_1.id), str(group_2.id)]
@@ -763,11 +763,11 @@ class GroupListTest(APITestCase, SnubaTestCase):
         response = self.get_response(limit=10, query="assigned:me")
         assert [row["id"] for row in response.data] == [str(g.id) for g in assigned_groups]
 
-        response = self.get_response(limit=10, query="assigned:me_or_none")
+        response = self.get_response(limit=10, query="assigned:[me, none]")
         assert len(response.data) == 5
 
         GroupAssignee.objects.assign(assigned_groups[1], self.create_user("other@user.com"))
-        response = self.get_response(limit=10, query="assigned:me_or_none")
+        response = self.get_response(limit=10, query="assigned:[me_or_none]")
         assert len(response.data) == 4
 
     def test_seen_stats(self):
@@ -1043,7 +1043,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert int(response.data[0]["id"]) == event.group.id
 
         response = self.get_response(
-            sort_by="date", limit=10, query="assigned_or_suggested:me_or_none"
+            sort_by="date", limit=10, query="assigned_or_suggested:[me, none]"
         )
         assert response.status_code == 200
         assert len(response.data) == 4
@@ -1062,7 +1062,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
             user_id=not_me.id,
         )
         response = self.get_response(
-            sort_by="date", limit=10, query="assigned_or_suggested:me_or_none"
+            sort_by="date", limit=10, query="assigned_or_suggested:[me, none]"
         )
         assert response.status_code == 200
         assert len(response.data) == 3
@@ -1080,7 +1080,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         )
         # Should now include event2 as it has shared ownership.
         response = self.get_response(
-            sort_by="date", limit=10, query="assigned_or_suggested:me_or_none"
+            sort_by="date", limit=10, query="assigned_or_suggested:[me, none]"
         )
         assert response.status_code == 200
         assert len(response.data) == 4

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -1016,7 +1016,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         )
 
         self.run_test_query_in_syntax(
-            f"assigned:[me_or_none, {other_user.username}]",
+            f"assigned:[me, none, {other_user.username}]",
             [self.group1, self.group2, group_3],
             [],
         )
@@ -1128,7 +1128,7 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
         )
 
         self.run_test_query_in_syntax(
-            "assigned_or_suggested:[me_or_none]",
+            "assigned_or_suggested:[me, none]",
             [group, group1, group2, assigned_group],
             [assigned_to_other_group],
         )
@@ -1143,18 +1143,18 @@ class EventsSnubaSearchTest(TestCase, SnubaTestCase):
             user_id=not_me.id,
         )
         self.run_test_query_in_syntax(
-            "assigned_or_suggested:[me_or_none]",
+            "assigned_or_suggested:[me, none]",
             [group, group1, assigned_group],
             [assigned_to_other_group, group2],
         )
         GroupOwner.objects.filter(group=group, user=self.user).delete()
         self.run_test_query_in_syntax(
-            f"assigned_or_suggested:[me_or_none, #{self.team.slug}]",
+            f"assigned_or_suggested:[me, none, #{self.team.slug}]",
             [group, group1, assigned_group],
             [assigned_to_other_group, group2],
         )
         self.run_test_query_in_syntax(
-            f"assigned_or_suggested:[me_or_none, #{self.team.slug}, {not_me.email}]",
+            f"assigned_or_suggested:[me, none, #{self.team.slug}, {not_me.email}]",
             [group, group1, assigned_group, group2],
             [assigned_to_other_group],
         )


### PR DESCRIPTION
So that we can implement `assigned:[me, none]` searches. Also can be used independently.

Will remove this syntax one the frontend is no longer sending and we've backfilled existing saved searches