### PR TITLE
ref(outcomes): Make QueryDefinition less request specific

### DIFF
--- a/src/sentry/api/endpoints/organization_stats_v2.py
+++ b/src/sentry/api/endpoints/organization_stats_v2.py
@@ -32,7 +32,7 @@ class OrganizationStatsEndpointV2(OrganizationEventsEndpointBase):
         except NoProjects:
             raise NoProjects("No projects available")
 
-        return QueryDefinition(
+        return QueryDefinition.from_query_dict(
             request.GET,
             params,
         )

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -15,7 +15,7 @@ DATE_TRUNC_GROUPERS = {"date": "day", "hour": "hour", "minute": "minute"}
 epoch = datetime(1970, 1, 1, tzinfo=pytz.utc)
 
 
-def to_timestamp(value):
+def to_timestamp(value: datetime):
     """
     Convert a time zone aware datetime to a POSIX timestamp (with fractional
     component.)

--- a/src/sentry/utils/outcomes.py
+++ b/src/sentry/utils/outcomes.py
@@ -22,8 +22,8 @@ class Outcome(IntEnum):
     def api_name(self) -> str:
         return self.name.lower()
 
-    @classmethod
-    def parse(cls, name: str) -> "Outcome":
+    @staticmethod
+    def parse(name: str) -> "Outcome":
         return Outcome[name.upper()]
 
 

--- a/tests/sentry/snuba/test_outcomes.py
+++ b/tests/sentry/snuba/test_outcomes.py
@@ -9,7 +9,7 @@ from sentry.utils.outcomes import Outcome
 
 
 def _make_query(qs, allow_minute_resolution=True):
-    return QueryDefinition(QueryDict(qs), {}, allow_minute_resolution)
+    return QueryDefinition.from_query_dict(QueryDict(qs), {}, allow_minute_resolution)
 
 
 class OutcomesQueryDefinitionTests(TestCase):


### PR DESCRIPTION
Wanting to use QueryDefinition without haveing a QueryDict :)