### PR TITLE
fix(snql) Remove API referrers and add other examples

### DIFF
--- a/src/sentry/utils/snql.py
+++ b/src/sentry/utils/snql.py
@@ -18,7 +18,7 @@ snql_referrers = {
     "outcomes.timeseries",
     "tsdb-modelid:500",
     "incidents.get_incident_aggregates",
-    "tsdb-modelid:502",
+    "tsdb-modelid:501",
     "tsdb-modelid:502",
     "group.filter_by_event_id",
     "alertruleserializer.test_query",

--- a/src/sentry/utils/snql.py
+++ b/src/sentry/utils/snql.py
@@ -15,13 +15,15 @@ snql_referrers = {
     "sessions.release-sessions-time-bounds",
     "sessions.release-stats",
     "sessions.release-stats-details",
-    "api.performance.durationpercentilechart",
-    "api.performance.vital-detail",
     "outcomes.timeseries",
-    "api.dashboards.worldmapwidget",
-    "api.performance.transaction-summary",
     "tsdb-modelid:500",
     "incidents.get_incident_aggregates",
+    "tsdb-modelid:502",
+    "tsdb-modelid:502",
+    "group.filter_by_event_id",
+    "alertruleserializer.test_query",
+    "incidents.get_incident_event_stats",
+    "tagstore.get_tag_value_paginator_for_projects",
 }
 
 


### PR DESCRIPTION
The "api" referrers use discover, which requires an entity to work correctly.
There will have to be a separate PR that specifies an entity for a query if
possible (the performance queries all use transactions for example). Also add
some more referrers for different products.