### PR TITLE
pre-commit(fix): Change the way shellcheck-py gets installed in pre-c…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,19 +51,18 @@ repos:
       # We can't change this mock to unittest.mock until Python 3.8,
       # refer to the comment in this file.
       exclude: 'src/sentry/utils/compat/mock.py'
+    - id: shellcheck
+      name: shellcheck
+      entry: shellcheck
+      language: system
+      exclude: 'src/sentry/templates/sentry/reprocessing-script.sh'
+      types: [shell]
 
 -   repo: https://github.com/sirosen/check-jsonschema
     rev: 0.3.0
     hooks:
     - id: check-github-actions
     - id: check-github-workflows
-
--   repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.7.1.1
-    hooks:
-    - id: shellcheck
-      exclude: 'src/sentry/templates/sentry/reprocessing-script.sh'
-      types: [shell]
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/requirements-pre-commit.txt
+++ b/requirements-pre-commit.txt
@@ -3,3 +3,4 @@ black==20.8b1
 sentry-flake8==1.0.0
 pyupgrade==2.10.0
 isort==5.8.0
+shellcheck-py==0.7.1.1


### PR DESCRIPTION
…ommit

Unfortunately, the way pre-commit installed the package directly from the repository started failing.