### PR TITLE
feat(relay): Enable open registration by default

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1957,7 +1957,7 @@ SENTRY_RELAY_WHITELIST_PK = [
 
 # When open registration is not permitted then only relays in the
 # list of explicitly allowed relays can register.
-SENTRY_RELAY_OPEN_REGISTRATION = False
+SENTRY_RELAY_OPEN_REGISTRATION = True
 
 # GeoIP
 # Used for looking up IP addresses.


### PR DESCRIPTION
Allows registration of external managed Relays with Sentry. Receiving access to
an organization still requires adding the Relay's public key in organization
settings.

This has been enabled on Sentry SaaS for several months, and is should be
enabled on ST and onpremise by default. Authorization of Relay's public keys and
validation of DSNs still applies for those Relays.

See also https://github.com/getsentry/relay/issues/976
