### PR TITLE
feat(alerts): Show incident in chart and project in the header

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -10,9 +10,9 @@ import Alert from 'app/components/alert';
 import ActorAvatar from 'app/components/avatar/actorAvatar';
 import {SectionHeading} from 'app/components/charts/styles';
 import {getInterval} from 'app/components/charts/utils';
-import DateTime from 'app/components/dateTime';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import Duration from 'app/components/duration';
+import IdBadge from 'app/components/idBadge';
 import {KeyValueTable, KeyValueTableRow} from 'app/components/keyValueTable';
 import * as Layout from 'app/components/layouts/thirds';
 import {Panel, PanelBody} from 'app/components/panels';
@@ -304,15 +304,17 @@ export default class DetailsBody extends React.Component<Props> {
                             </DropdownItem>
                           ))}
                         </DropdownControl>
-                        {timePeriod.custom && (
-                          <StyledTimeRange>
-                            <DateTime date={moment.utc(timePeriod.start)} timeAndDate />
-                            {' — '}
-                            <DateTime date={moment.utc(timePeriod.end)} timeAndDate />
-                          </StyledTimeRange>
-                        )}
                       </ChartControls>
                     </div>
+                    {projects && projects.length && (
+                      <div>
+                        <SidebarHeading noMargin>
+                          {t('Project')}
+                        </SidebarHeading>
+
+                        <IdBadge avatarSize={16} project={projects[0]} />
+                      </div>
+                    )}
                     <div>
                       <SidebarHeading noMargin>
                         {t('Time Interval')}
@@ -446,10 +448,6 @@ const ChartControls = styled('div')`
   display: flex;
   flex-direction: row;
   align-items: center;
-`;
-
-const StyledTimeRange = styled('div')`
-  margin-left: ${space(2)};
 `;
 
 const ChartPanel = styled(Panel)`

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -293,7 +293,7 @@ export default class DetailsBody extends React.Component<Props> {
                     <div>
                       <SidebarHeading noMargin>{t('Display')}</SidebarHeading>
                       <ChartControls>
-                        <DropdownControl label={timePeriod.label}>
+                        <DropdownControl label={timePeriod.display}>
                           {TIME_OPTIONS.map(({label, value}) => (
                             <DropdownItem
                               key={value}

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -308,9 +308,7 @@ export default class DetailsBody extends React.Component<Props> {
                     </div>
                     {projects && projects.length && (
                       <div>
-                        <SidebarHeading noMargin>
-                          {t('Project')}
-                        </SidebarHeading>
+                        <SidebarHeading noMargin>{t('Project')}</SidebarHeading>
 
                         <IdBadge avatarSize={16} project={projects[0]} />
                       </div>

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -48,6 +48,7 @@ type Props = {
   rule?: IncidentRule;
   incidents?: Incident[];
   timePeriod: TimePeriodType;
+  selectedIncident?: Incident | null;
   organization: Organization;
   location: Location;
   handleTimePeriodChange: (value: string) => void;
@@ -262,6 +263,7 @@ export default class DetailsBody extends React.Component<Props> {
       location,
       organization,
       timePeriod,
+      selectedIncident,
       params: {orgId},
     } = this.props;
 
@@ -332,6 +334,7 @@ export default class DetailsBody extends React.Component<Props> {
                     rule={rule}
                     incidents={incidents}
                     timePeriod={timePeriod}
+                    selectedIncident={selectedIncident}
                     organization={organization}
                     projects={projects}
                     metricText={this.getMetricText()}

--- a/static/app/views/alerts/rules/details/constants.tsx
+++ b/static/app/views/alerts/rules/details/constants.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {t} from 'app/locale';
 import {SelectValue} from 'app/types';
 import {TimePeriod, TimeWindow} from 'app/views/settings/incidentRules/types';
@@ -25,6 +27,6 @@ export type TimePeriodType = {
   start: string;
   end: string;
   period: string;
-  label: string;
+  label: React.ReactNode;
   custom?: boolean;
 };

--- a/static/app/views/alerts/rules/details/constants.tsx
+++ b/static/app/views/alerts/rules/details/constants.tsx
@@ -27,6 +27,7 @@ export type TimePeriodType = {
   start: string;
   end: string;
   period: string;
-  label: React.ReactNode;
+  label: string;
+  display: React.ReactNode;
   custom?: boolean;
 };

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -146,7 +146,7 @@ class AlertRuleDetails extends React.Component<Props, State> {
   };
 
   render() {
-    const {rule, incidents, hasError} = this.state;
+    const {rule, incidents, hasError, selectedIncident} = this.state;
     const {params, organization} = this.props;
     const timePeriod = this.getTimePeriod();
 
@@ -163,6 +163,7 @@ class AlertRuleDetails extends React.Component<Props, State> {
             rule={rule}
             incidents={incidents}
             timePeriod={timePeriod}
+            selectedIncident={selectedIncident}
             handleTimePeriodChange={this.handleTimePeriodChange}
           />
         </Feature>

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -6,7 +6,7 @@ import moment from 'moment';
 import {fetchOrgMembers} from 'app/actionCreators/members';
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
-import {t} from 'app/locale';
+import DateTime from 'app/components/dateTime';
 import {Organization} from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import withApi from 'app/utils/withApi';
@@ -69,7 +69,13 @@ class AlertRuleDetails extends React.Component<Props, State> {
         start: location.query.start,
         end: location.query.end,
         period,
-        label: t('Custom time'),
+        label: (
+          <React.Fragment>
+            <DateTime date={moment.utc(location.query.start)} timeAndDate />
+            {' — '}
+            <DateTime date={moment.utc(location.query.end)} timeAndDate />
+          </React.Fragment>
+        ),
         custom: true,
       };
     }
@@ -80,7 +86,13 @@ class AlertRuleDetails extends React.Component<Props, State> {
         start,
         end,
         period,
-        label: t('Custom time'),
+        label: (
+          <React.Fragment>
+            <DateTime date={moment.utc(start)} timeAndDate />
+            {' — '}
+            <DateTime date={moment.utc(end)} timeAndDate />
+          </React.Fragment>
+        ),
         custom: true,
       };
     }

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -24,6 +24,7 @@ import {
   TimePeriodType,
 } from './constants';
 import DetailsHeader from './header';
+import {t} from 'app/locale';
 
 type Props = {
   api: Client;
@@ -69,7 +70,8 @@ class AlertRuleDetails extends React.Component<Props, State> {
         start: location.query.start,
         end: location.query.end,
         period,
-        label: (
+        label: t('Custom time'),
+        display: (
           <React.Fragment>
             <DateTime date={moment.utc(location.query.start)} timeAndDate />
             {' — '}
@@ -86,7 +88,8 @@ class AlertRuleDetails extends React.Component<Props, State> {
         start,
         end,
         period,
-        label: (
+        label: t('Custom time'),
+        display: (
           <React.Fragment>
             <DateTime date={moment.utc(start)} timeAndDate />
             {' — '}
@@ -109,6 +112,7 @@ class AlertRuleDetails extends React.Component<Props, State> {
       end,
       period,
       label: timeOption.label as string,
+      display: timeOption.label as string,
     };
   }
 

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -7,6 +7,7 @@ import {fetchOrgMembers} from 'app/actionCreators/members';
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import DateTime from 'app/components/dateTime';
+import {t} from 'app/locale';
 import {Organization} from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import withApi from 'app/utils/withApi';
@@ -24,7 +25,6 @@ import {
   TimePeriodType,
 } from './constants';
 import DetailsHeader from './header';
-import {t} from 'app/locale';
 
 type Props = {
   api: Client;

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -24,7 +24,7 @@ import theme from 'app/utils/theme';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
-import {Incident, IncidentActivityType, IncidentStatus} from '../../types';
+import {AlertRuleStatus, Incident, IncidentActivityType, IncidentStatus} from '../../types';
 import {getIncidentRuleMetricPreset} from '../../utils';
 
 import {TimePeriodType} from './constants';
@@ -87,7 +87,7 @@ function createIncidentSeries(
   orgSlug: string,
   lineColor: string,
   incidentTimestamp: number,
-  identifier?: string,
+  incident: Incident,
   dataPoint?: LineChartSeries['data'][0],
   seriesName?: string
 ) {
@@ -102,16 +102,21 @@ function createIncidentSeries(
           xAxis: incidentTimestamp,
           onClick: () => {
             router.push({
-              pathname: `/organizations/${orgSlug}/alerts/${identifier}/`,
-              query: {redirect: false},
+              pathname: `/organizations/${orgSlug}/alerts/rules/details/${
+                incident.alertRule.status === AlertRuleStatus.SNAPSHOT &&
+                incident.alertRule.originalAlertRuleId
+                  ? incident.alertRule.originalAlertRuleId
+                  : incident.alertRule.id
+              }/`,
+              query: {alert: incident.identifier},
             });
           },
         },
       ] as any,
       label: {
-        show: !!identifier,
+        show: incident.identifier,
         position: 'insideEndBottom',
-        formatter: identifier || '-',
+        formatter: incident.identifier,
         color: lineColor,
         fontSize: 10,
         fontFamily: 'Rubik',
@@ -129,7 +134,7 @@ function createIncidentSeries(
         `<div class="tooltip-series"><div>`,
         `<span class="tooltip-label">${marker} <strong>${t(
           'Alert'
-        )} #${identifier}</strong></span>${seriesName} ${dataPoint?.value?.toLocaleString()}`,
+        )} #${incident.identifier}</strong></span>${seriesName} ${dataPoint?.value?.toLocaleString()}`,
         `</div></div>`,
         `<div class="tooltip-date">${time}</div>`,
         `<div class="tooltip-arrow"></div>`,
@@ -484,7 +489,7 @@ class MetricChart extends React.PureComponent<Props, State> {
                     organization.slug,
                     incidentColor,
                     incidentStartDate,
-                    incident.identifier,
+                    incident,
                     incidentStartValue,
                     series[0].seriesName
                   )

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -24,7 +24,12 @@ import theme from 'app/utils/theme';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
-import {AlertRuleStatus, Incident, IncidentActivityType, IncidentStatus} from '../../types';
+import {
+  AlertRuleStatus,
+  Incident,
+  IncidentActivityType,
+  IncidentStatus,
+} from '../../types';
 import {getIncidentRuleMetricPreset} from '../../utils';
 
 import {TimePeriodType} from './constants';
@@ -132,9 +137,9 @@ function createIncidentSeries(
       const time = getFormattedDate(value, 'MMM D, YYYY LT');
       return [
         `<div class="tooltip-series"><div>`,
-        `<span class="tooltip-label">${marker} <strong>${t(
-          'Alert'
-        )} #${incident.identifier}</strong></span>${seriesName} ${dataPoint?.value?.toLocaleString()}`,
+        `<span class="tooltip-label">${marker} <strong>${t('Alert')} #${
+          incident.identifier
+        }</strong></span>${seriesName} ${dataPoint?.value?.toLocaleString()}`,
         `</div></div>`,
         `<div class="tooltip-date">${time}</div>`,
         `<div class="tooltip-arrow"></div>`,
@@ -316,10 +321,7 @@ class MetricChart extends React.PureComponent<Props, State> {
         yAxis={maxThresholdValue > maxSeriesValue ? {max: maxThresholdValue} : undefined}
         series={series}
         graphic={Graphic({
-          elements: [
-            ...graphics,
-            ...this.getRuleChangeThresholdElements(data),
-          ],
+          elements: [...graphics, ...this.getRuleChangeThresholdElements(data)],
         })}
         tooltip={{
           formatter: seriesParams => {
@@ -470,16 +472,17 @@ class MetricChart extends React.PureComponent<Props, State> {
                 const incidentEnd = incident.dateClosed ?? moment().valueOf();
 
                 const timeWindowMs = rule.timeWindow * 60 * 1000;
-                const incidentColor = warningTrigger &&
-                statusChanges &&
-                !statusChanges.find(
-                  ({value}) => value === `${IncidentStatus.CRITICAL}`
-                )
-                  ? theme.yellow300
-                  : theme.red300;
+                const incidentColor =
+                  warningTrigger &&
+                  statusChanges &&
+                  !statusChanges.find(({value}) => value === `${IncidentStatus.CRITICAL}`)
+                    ? theme.yellow300
+                    : theme.red300;
 
                 const incidentStartDate = moment(incident.dateStarted).valueOf();
-                const incidentCloseDate = incident.dateClosed ? moment(incident.dateClosed).valueOf() : lastPoint;
+                const incidentCloseDate = incident.dateClosed
+                  ? moment(incident.dateClosed).valueOf()
+                  : lastPoint;
                 const incidentStartValue = dataArr.find(
                   point => point.name >= incidentStartDate
                 );
@@ -544,8 +547,13 @@ class MetricChart extends React.PureComponent<Props, State> {
 
                 if (selectedIncident && incident.id === selectedIncident.id) {
                   const chartWidth = width - X_AXIS_BOUNDARY_GAP;
-                  const incidentPosition = (chartWidth * (incidentStartDate - firstPoint) / (lastPoint - firstPoint)) + X_AXIS_BOUNDARY_GAP;
-                  const incidentWidth = chartWidth * (incidentCloseDate - incidentStartDate) / (lastPoint - firstPoint);
+                  const incidentPosition =
+                    (chartWidth * (incidentStartDate - firstPoint)) /
+                      (lastPoint - firstPoint) +
+                    X_AXIS_BOUNDARY_GAP;
+                  const incidentWidth =
+                    (chartWidth * (incidentCloseDate - incidentStartDate)) /
+                    (lastPoint - firstPoint);
 
                   graphics.push({
                     type: 'rect',
@@ -558,7 +566,7 @@ class MetricChart extends React.PureComponent<Props, State> {
                     style: {
                       fill: color(incidentColor).alpha(0.42).rgb().string(),
                     },
-                  },)
+                  });
                 }
               });
           }


### PR DESCRIPTION
This adds a colored area for the selected incident and link to alerts page when clicking on an incident in chart. Added project badge to the header and time window to the display dropdown.

Before:
![Screen Shot 2021-04-15 at 3 11 35 PM](https://user-images.githubusercontent.com/15015880/114944686-ed17a000-9dfc-11eb-8ec6-397e6b1dd8e6.png)

After:
![Screen Shot 2021-04-15 at 3 10 53 PM](https://user-images.githubusercontent.com/15015880/114944696-f1dc5400-9dfc-11eb-8d34-759418709af5.png)
