### PR TITLE
feat(demo): hide migrate to saas for demo mode

### DIFF
--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -41,7 +41,7 @@ function Footer({className}: Props) {
         <FooterLink href="https://github.com/getsentry/sentry">
           {t('Contribute')}
         </FooterLink>
-        {config.isOnPremise && (
+        {config.isOnPremise && !config.demoMode && (
           <FooterLink href="/out/">{t('Migrate to SaaS')}</FooterLink>
         )}
       </Links>


### PR DESCRIPTION
Demo mode is run using the onpremise repo so we actually do want to keep certain UI functionality related to it (such as the version of Sentry). However, we don't need to show the `Migrate to SaaS` in demo mode.

![Screen Shot 2021-04-15 at 2 43 57 PM](https://user-images.githubusercontent.com/8533851/114943639-251de380-9dfb-11eb-8e48-0e84db431db2.png)
