### PR TITLE
fix(guides): only provide href to dismiss button if assistant is in hash

### DIFF
--- a/static/app/components/assistant/guideAnchor.tsx
+++ b/static/app/components/assistant/guideAnchor.tsx
@@ -132,10 +132,13 @@ export const GuideAnchor = createReactClass<Props, State>({
     const lastStep = currentStepCount === totalStepCount;
     const hasManySteps = totalStepCount > 1;
 
+    // to clear `#assistant` from the url
+    const href = window.location.hash === '#assistant' ? '#' : '';
+
     const dismissButton = (
       <DismissButton
         size="small"
-        href="#" // to clear `#assistant` from the url
+        href={href}
         onClick={this.handleDismiss}
         priority="link"
       >


### PR DESCRIPTION
Changing the hash can sometimes cause the browser to refresh the page which is not what we want when a user dismisses a guide. We may have to that with the `#assistant` in the query param to clear it, but if that's not there we don't need to change the hash URL.