### PR TITLE
ref(notifications): Move email code out of notifications module

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -26,7 +26,7 @@ def build_notification_attachment(notification, context):
         "title": notification.get_title(),
         "text": context["text_description"],
         "mrkdwn_in": ["text"],
-        "footer_icon": notification._get_sentry_avatar_url(),
+        "footer_icon": notification.get_sentry_avatar_url(),
         "footer": footer,
         "color": LEVEL_TO_COLOR["info"],
     }

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -1,9 +1,9 @@
 import logging
-from typing import Any, Mapping
+from typing import AbstractSet, Any, Mapping, Tuple
 
 from sentry.integrations.slack.client import SlackClient  # NOQA
 from sentry.integrations.slack.message_builder.notifications import build_notification_attachment
-from sentry.models import ExternalActor, User
+from sentry.models import ExternalActor, Organization, User
 from sentry.notifications.activity.base import ActivityNotification
 from sentry.notifications.notify import register_notification_provider
 from sentry.shared_integrations.exceptions import ApiError
@@ -14,26 +14,70 @@ logger = logging.getLogger("sentry.notifications")
 SLACK_TIMEOUT = 5
 
 
+def get_context(
+    notification, user: User, reason: int, shared_context: Mapping[str, Any]
+) -> Mapping[str, Any]:
+    """ Compose the various levels of context and add slack-specific fields. """
+    return {
+        **shared_context,
+        **notification.get_user_context(user, reason),
+    }
+
+
+def get_integrations_by_user_id(
+    organization: Organization, users: AbstractSet[User]
+) -> Mapping[User, ExternalActor]:
+    actor_mapping = {user.actor_id: user for user in users}
+
+    external_actors = ExternalActor.objects.filter(
+        provider=ExternalProviders.SLACK.value,
+        actor_id__in=[user.actor_id for user in users],
+        organization=organization,
+    ).select_related("integration")
+
+    return {
+        actor_mapping.get(external_actor.actor_id): external_actor
+        for external_actor in external_actors
+    }
+
+
+def get_channel_and_token(
+    external_actors_by_user: Mapping[User, ExternalActor], user: User
+) -> Tuple[str, str]:
+    external_actor = external_actors_by_user.get(user)
+    channel = external_actor.external_id
+    token = external_actor.integration.metadata["access_token"]
+    return channel, token
+
+
 @register_notification_provider(ExternalProviders.SLACK)
 def send_notification_as_slack(
     notification: ActivityNotification,
     users: Mapping[User, int],
     shared_context: Mapping[str, Any],
 ) -> None:
-    external_actors = ExternalActor.objects.filter(
-        provider=ExternalProviders.SLACK.value,
-        actor=user.actor,
-        organization=notification.organization,
-    ).select_related("integration")
+    external_actors_by_user = get_integrations_by_user_id(notification.organization, users.keys())
+
     client = SlackClient()
-    for external_actor in external_actors:
+    for user, reason in users.items():
+        try:
+            channel, token = get_channel_and_token(external_actors_by_user, user)
+        except AttributeError as e:
+            logger.info(
+                "notification.fail.invalid_slack",
+                extra={
+                    "error": str(e),
+                    "notification": notification,
+                    "user": user.id,
+                },
+            )
+            continue
+
+        context = get_context(notification, user, reason, shared_context)
         attachment = [build_notification_attachment(notification, context)]
-        integration = external_actor.integration
-        if integration:
-            token = integration.metadata["access_token"]
         payload = {
             "token": token,
-            "channel": external_actor.external_id,
+            "channel": channel,
             "link_names": 1,
             "attachments": json.dumps(attachment),
         }
@@ -46,11 +90,13 @@ def send_notification_as_slack(
                     "error": str(e),
                     "notification": notification,
                     "user": user.id,
-                    "channel_id": external_actor.external_id,
+                    "channel_id": channel,
                 },
             )
-        metrics.incr(
-            "activity.notifications.sent",
-            instance="slack.activity.notification",
-            skip_internal=False,
-        )
+            continue
+
+    metrics.incr(
+        "activity.notifications.sent",
+        instance="slack.activity.notification",
+        skip_internal=False,
+    )

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -4,7 +4,8 @@ from typing import Any, Mapping
 from sentry.integrations.slack.client import SlackClient  # NOQA
 from sentry.integrations.slack.message_builder.notifications import build_notification_attachment
 from sentry.models import ExternalActor, User
-from sentry.notifications.activity.base import ActivityNotification, register
+from sentry.notifications.activity.base import ActivityNotification
+from sentry.notifications.notify import register_notification_provider
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json, metrics
@@ -13,7 +14,7 @@ logger = logging.getLogger("sentry.notifications")
 SLACK_TIMEOUT = 5
 
 
-@register(ExternalProviders.SLACK)
+@register_notification_provider(ExternalProviders.SLACK)
 def send_notification_as_slack(
     notification: ActivityNotification,
     users: Mapping[User, int],

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -15,7 +15,9 @@ SLACK_TIMEOUT = 5
 
 @register(ExternalProviders.SLACK)
 def send_notification_as_slack(
-    notification: ActivityNotification, user: User, context: Mapping[str, Any]
+    notification: ActivityNotification,
+    users: Mapping[User, int],
+    shared_context: Mapping[str, Any],
 ) -> None:
     external_actors = ExternalActor.objects.filter(
         provider=ExternalProviders.SLACK.value,

--- a/src/sentry/mail/activity.py
+++ b/src/sentry/mail/activity.py
@@ -1,9 +1,72 @@
-from typing import Any, Mapping
+from typing import Any, Mapping, MutableMapping
 
-from sentry.models import User
+from sentry import options
+from sentry.models import ProjectOption, User
 from sentry.notifications.activity.base import ActivityNotification, register
 from sentry.types.integrations import ExternalProviders
-from sentry.utils.email import MessageBuilder
+from sentry.utils import json
+from sentry.utils.email import MessageBuilder, group_id_to_email
+from sentry.utils.linksign import generate_signed_link
+
+
+def get_headers(notification: ActivityNotification) -> Mapping[str, Any]:
+    headers = {
+        "X-Sentry-Project": notification.project.slug,
+        "X-SMTPAPI": json.dumps({"category": notification.get_category()}),
+    }
+
+    if notification.group:
+        headers.update(
+            {
+                "X-Sentry-Logger": notification.group.logger,
+                "X-Sentry-Logger-Level": notification.group.get_level_display(),
+                "X-Sentry-Reply-To": group_id_to_email(notification.group.id),
+            }
+        )
+
+    return headers
+
+
+def get_subject_with_prefix(notification: ActivityNotification) -> bytes:
+    prefix = str(
+        ProjectOption.objects.get_value(project=notification.project, key="mail:subject_prefix")
+        or options.get("mail.subject-prefix")
+    )
+    return f"{prefix}{notification.get_subject()}".encode("utf-8")
+
+
+def get_email_type(notification: ActivityNotification) -> str:
+    return f"notify.activity.{notification.activity.get_type_display()}"
+
+
+def get_unsubscribe_link(user_id: int, group_id: int) -> str:
+    return generate_signed_link(
+        user_id,
+        "sentry-account-email-unsubscribe-issue",
+        kwargs={"issue_id": group_id},
+    )
+
+
+def can_users_unsubscribe(notification: ActivityNotification) -> bool:
+    return bool(notification.group)
+
+
+def get_context(
+    notification, user: User, reason: int, shared_context: MutableMapping[str, Any]
+) -> Mapping[str, Any]:
+    """
+    Compose the various levels of context and add email-specific fields. The
+    generic HTML/text templates only render the unsubscribe link if one is
+    present in the context, so don't automatically add it to every message.
+    """
+    context = {
+        **shared_context,
+        **notification.get_user_context(user, reason),
+    }
+    if can_users_unsubscribe(notification) and notification.group:
+        context.update({"unsubscribe_link": get_unsubscribe_link(user.id, notification.group.id)})
+
+    return context
 
 
 @register(ExternalProviders.EMAIL)

--- a/src/sentry/mail/activity.py
+++ b/src/sentry/mail/activity.py
@@ -1,8 +1,9 @@
-from typing import Any, Mapping, MutableMapping
+from typing import Any, Mapping
 
 from sentry import options
 from sentry.models import ProjectOption, User
-from sentry.notifications.activity.base import ActivityNotification, register
+from sentry.notifications.activity.base import ActivityNotification
+from sentry.notifications.notify import register_notification_provider
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
 from sentry.utils.email import MessageBuilder, group_id_to_email
@@ -52,7 +53,7 @@ def can_users_unsubscribe(notification: ActivityNotification) -> bool:
 
 
 def get_context(
-    notification, user: User, reason: int, shared_context: MutableMapping[str, Any]
+    notification, user: User, reason: int, shared_context: Mapping[str, Any]
 ) -> Mapping[str, Any]:
     """
     Compose the various levels of context and add email-specific fields. The
@@ -69,11 +70,11 @@ def get_context(
     return context
 
 
-@register(ExternalProviders.EMAIL)
+@register_notification_provider(ExternalProviders.EMAIL)
 def send_notification_as_email(
     notification: ActivityNotification,
     users: Mapping[User, int],
-    shared_context: MutableMapping[str, Any],
+    shared_context: Mapping[str, Any],
 ) -> None:
     headers = get_headers(notification)
     subject = get_subject_with_prefix(notification)

--- a/src/sentry/notifications/activity/base.py
+++ b/src/sentry/notifications/activity/base.py
@@ -251,8 +251,4 @@ class ActivityNotification:
         shared_context = self.get_context()
 
         for provider, participants in participants_by_provider.items():
-            for user, reason in participants.items():
-                user_context = self.update_user_context_from_group(
-                    user, reason, shared_context, self.group
-                )
-                fire(provider, self, user, user_context)
+            registry[provider](self, participants, shared_context)

--- a/src/sentry/notifications/activity/base.py
+++ b/src/sentry/notifications/activity/base.py
@@ -210,14 +210,6 @@ class ActivityNotification:
     def get_title(self) -> str:
         return self.get_activity_name()
 
-    def get_dm_links(self):
-        links = {}
-        links["settings_url"] = absolute_uri("/settings/account/notifications/")
-        links["group_url"] = self.group.get_absolute_url()
-        group_context = self.get_group_context()
-        links["short_id"] = group_context["group"].qualified_short_id
-        return links
-
     def send(self) -> None:
         if not self.should_email():
             return

--- a/src/sentry/notifications/activity/base.py
+++ b/src/sentry/notifications/activity/base.py
@@ -174,9 +174,15 @@ class ActivityNotification:
             "html_description": self.description_as_html(description, html_params or params),
         }
 
-    def get_user_context(self, user: User) -> MutableMapping[str, Any]:
-        # use in case context of email changes depending on user
-        return {}
+    def get_user_context(
+        self, user: User, reason: Optional[int] = None
+    ) -> MutableMapping[str, Any]:
+        """ Get user-specific context. Do not call get_context() here. """
+        return {
+            "reason": GroupSubscriptionReason.descriptions.get(
+                reason, "are subscribed to this issue"
+            )
+        }
 
     def get_category(self) -> str:
         raise NotImplementedError

--- a/src/sentry/notifications/activity/base.py
+++ b/src/sentry/notifications/activity/base.py
@@ -148,7 +148,7 @@ class ActivityNotification:
         user = self.activity.user
         if not user:
             return '<img class="avatar" src="{}" width="20px" height="20px" />'.format(
-                escape(self._get_sentry_avatar_url())
+                escape(self.get_sentry_avatar_url())
             )
         avatar_type = user.get_avatar_type()
         if avatar_type == "upload":
@@ -158,7 +158,8 @@ class ActivityNotification:
         else:
             return get_email_avatar(user.get_display_name(), user.get_label(), 20, True)
 
-    def _get_sentry_avatar_url(self) -> str:
+    @staticmethod
+    def get_sentry_avatar_url() -> str:
         url = "/images/sentry-email-avatar.png"
         return str(absolute_uri(get_asset_url("sentry", url)))
 

--- a/src/sentry/notifications/activity/new_processing_issues.py
+++ b/src/sentry/notifications/activity/new_processing_issues.py
@@ -38,6 +38,7 @@ class NewProcessingIssuesActivityNotification(ActivityNotification):
 
     def get_context(self) -> MutableMapping[str, Any]:
         return {
+            **self.get_base_context(),
             "project": self.project,
             "issues": self.issues,
             "reprocessing_active": self.activity.data["reprocessing_active"],

--- a/src/sentry/notifications/activity/note.py
+++ b/src/sentry/notifications/activity/note.py
@@ -6,6 +6,7 @@ from .base import ActivityNotification
 class NoteActivityNotification(ActivityNotification):
     def get_context(self) -> MutableMapping[str, Any]:
         return {
+            **self.get_base_context(),
             "text_description": str(self.activity.data["text"]),
         }
 

--- a/src/sentry/notifications/activity/release.py
+++ b/src/sentry/notifications/activity/release.py
@@ -23,6 +23,7 @@ from sentry.notifications.helpers import (
     get_deploy_values_by_provider,
     transform_to_notification_settings_by_user,
 )
+from sentry.notifications.notify import notification_providers
 from sentry.notifications.types import (
     GroupSubscriptionReason,
     NotificationSettingOptionValues,
@@ -32,7 +33,7 @@ from sentry.types.integrations import ExternalProviders
 from sentry.utils.compat import zip
 from sentry.utils.http import absolute_uri
 
-from .base import ActivityNotification, notification_providers
+from .base import ActivityNotification
 
 
 class ReleaseActivityNotification(ActivityNotification):

--- a/src/sentry/notifications/activity/release.py
+++ b/src/sentry/notifications/activity/release.py
@@ -178,6 +178,7 @@ class ReleaseActivityNotification(ActivityNotification):
         )
 
         return {
+            **self.get_base_context(),
             "commit_count": len(self.commit_list),
             "author_count": len(self.email_list),
             "file_count": file_count,

--- a/src/sentry/notifications/activity/release.py
+++ b/src/sentry/notifications/activity/release.py
@@ -225,9 +225,6 @@ class ReleaseActivityNotification(ActivityNotification):
     def get_title(self) -> str:
         return self.get_subject()
 
-    def get_dm_links(self):
-        return {"settings_url": absolute_uri("/settings/account/notifications/")}
-
     def get_template(self) -> str:
         return "sentry/emails/activity/release.txt"
 

--- a/src/sentry/notifications/activity/release.py
+++ b/src/sentry/notifications/activity/release.py
@@ -190,7 +190,9 @@ class ReleaseActivityNotification(ActivityNotification):
             "text_description": f"Version {self.release.version} was deployed to {self.environment}",
         }
 
-    def get_user_context(self, user: User) -> MutableMapping[str, Any]:
+    def get_user_context(
+        self, user: User, reason: Optional[int] = None
+    ) -> MutableMapping[str, Any]:
         if user.is_superuser or self.organization.flags.allow_joinleave:
             projects = self.projects
         else:
@@ -211,6 +213,7 @@ class ReleaseActivityNotification(ActivityNotification):
 
         resolved_issue_counts = [self.group_counts_by_project.get(p.id, 0) for p in projects]
         return {
+            **super().get_user_context(user, reason),
             "projects": zip(projects, release_links, resolved_issue_counts),
             "project_count": len(projects),
         }

--- a/src/sentry/notifications/notify.py
+++ b/src/sentry/notifications/notify.py
@@ -1,26 +1,40 @@
-from typing import Any, Optional
+from typing import Any, Callable, Iterable, Mapping, MutableMapping
 
-from sentry.notifications.types import NotificationSettingTypes
+from sentry.models import User
 from sentry.types.integrations import ExternalProviders
+
+# Shortcut so that types don't explode.
+Notifiable = Callable[[Any, Mapping[User, int], Mapping[str, Any]], None]
+
+# Global notifier registry.
+registry: MutableMapping[ExternalProviders, Notifiable] = {}
+
+
+def notification_providers() -> Iterable[ExternalProviders]:
+    """ Get a set of providers that can call notify. """
+    return registry.keys()
+
+
+def register_notification_provider(
+    provider: ExternalProviders,
+) -> Callable[[Notifiable], Notifiable]:
+    """
+    A wrapper that adds the wrapped function to the send_notification_registry
+    (see above) for the provider.
+    """
+
+    def wrapped(send_notification: Notifiable) -> Notifiable:
+        registry[provider] = send_notification
+        return send_notification
+
+    return wrapped
 
 
 def notify(
     provider: ExternalProviders,
-    type: NotificationSettingTypes,
-    user: Optional[Any] = None,
-    team: Optional[Any] = None,
-    data: Optional[Any] = None,
-) -> bool:
-    """
-    Something noteworthy has happened. Let the targets know about what
-    happened on their own terms. For each target, check their notification
-    preferences and send them a message (or potentially do nothing and
-    return False if this kind of correspondence is muted.)
-    :param provider: ExternalProviders enum
-    :param type: NotificationSettingTypes enum
-    :param user: (optional) User object
-    :param team: (optional) Team object
-    :param data: The payload depends on the notification type.
-    :returns Was a notification sent?
-    """
-    return False
+    notification: Any,
+    users: Mapping[User, int],
+    shared_context: Mapping[str, Any],
+) -> None:
+    """ Send notifications to these users. """
+    registry[provider](notification, users, shared_context)

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -37,7 +37,7 @@ def send_notification(*args):
 
 
 def get_attachment():
-    assert len(responses.calls) > 1
+    assert len(responses.calls) >= 1
     data = parse_qs(responses.calls[0].request.body)
     assert "attachments" in data
     attachments = json.loads(data["attachments"][0])

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -50,6 +50,12 @@ class SlackActivityNotificationTest(ActivityTestCase):
             NotificationSettingOptionValues.ALWAYS,
             user=self.user,
         )
+        NotificationSetting.objects.update_settings(
+            ExternalProviders.SLACK,
+            NotificationSettingTypes.ISSUE_ALERTS,
+            NotificationSettingOptionValues.ALWAYS,
+            user=self.user,
+        )
         UserOption.objects.create(user=self.user, key="self_notifications", value="1")
         self.integration = Integration.objects.create(
             provider="slack",

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -88,7 +88,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
         return attachments[0]
 
     @responses.activate
-    @mock.patch("sentry.notifications.activity.base.fire", side_effect=send_notification)
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_assignment(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when an issue is assigned
@@ -115,7 +115,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
         )
 
     @responses.activate
-    @mock.patch("sentry.notifications.activity.base.fire", side_effect=send_notification)
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_unassignment(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when an issue is unassigned
@@ -142,7 +142,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
         )
 
     @responses.activate
-    @mock.patch("sentry.notifications.activity.base.fire", side_effect=send_notification)
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_resolved(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when an issue is resolved
@@ -169,7 +169,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
         )
 
     @responses.activate
-    @mock.patch("sentry.notifications.activity.base.fire", side_effect=send_notification)
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_regression(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when an issue regresses
@@ -196,7 +196,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
         )
 
     @responses.activate
-    @mock.patch("sentry.notifications.activity.base.fire", side_effect=send_notification)
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_new_processing_issue(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when an issue is held back in reprocessing
@@ -251,7 +251,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
         )
 
     @responses.activate
-    @mock.patch("sentry.notifications.activity.base.fire", side_effect=send_notification)
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_resolved_in_release(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when an issue is resolved in a release
@@ -281,7 +281,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
         )
 
     @responses.activate
-    @mock.patch("sentry.notifications.activity.base.fire", side_effect=send_notification)
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_note(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when a comment is made on an issue
@@ -308,7 +308,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
         )
 
     @responses.activate
-    @mock.patch("sentry.notifications.activity.base.fire", side_effect=send_notification)
+    @mock.patch("sentry.notifications.notify.notify", side_effect=send_notification)
     def test_deploy(self, mock_func):
         """
         Test that a Slack message is sent with the expected payload when a deploy happens


### PR DESCRIPTION
This refactor cleans up /src/notifications/activity/base.py in three ways:
- Clean up `context` inheritance
- Move Slack/email-specific code to their own files
- Update the notification functions to take a list of users and move the registry to a file

