### PR TITLE
fix(ui): Filter project list when creating alert

### DIFF
--- a/static/app/actionCreators/navigation.tsx
+++ b/static/app/actionCreators/navigation.tsx
@@ -5,6 +5,7 @@ import {Location} from 'history';
 import {openModal} from 'app/actionCreators/modal';
 import NavigationActions from 'app/actions/navigationActions';
 import ContextPickerModal from 'app/components/contextPickerModal';
+import ProjectsStore from 'app/stores/projectsStore';
 
 // TODO(ts): figure out better typing for react-router here
 export function navigateTo(to: string, router: InjectedRouter & {location?: Location}) {
@@ -12,8 +13,11 @@ export function navigateTo(to: string, router: InjectedRouter & {location?: Loca
   const needOrg = to.indexOf(':orgId') > -1;
   const needProject = to.indexOf(':projectId') > -1;
   const comingFromProjectId = router?.location?.query?.project;
+  const needProjectId = !comingFromProjectId;
 
-  if (needOrg || needProject) {
+  const projectById = ProjectsStore.getById(comingFromProjectId);
+
+  if (needOrg || (needProject && needProjectId)) {
     openModal(
       modalProps => (
         <ContextPickerModal
@@ -33,7 +37,9 @@ export function navigateTo(to: string, router: InjectedRouter & {location?: Loca
       {}
     );
   } else {
-    router.push(to);
+    projectById
+      ? router.push(to.replace(':projectId', projectById.slug))
+      : router.push(to);
   }
 }
 

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -253,6 +253,12 @@ class ContextPickerModal extends React.Component<Props> {
 
   renderProjectSelectOrMessage() {
     const {organization, projects} = this.props;
+    // only show projects the user is a part of
+    const memberProjects: Project[] = [];
+    projects.forEach(project => project.isMember && memberProjects.push(project));
+
+    const projectOptions = memberProjects.map(({slug}) => ({label: slug, value: slug}));
+
     if (!projects.length) {
       return (
         <div>
@@ -272,7 +278,7 @@ class ContextPickerModal extends React.Component<Props> {
         }}
         placeholder={t('Select a Project to continue')}
         name="project"
-        options={projects.map(({slug}) => ({label: slug, value: slug}))}
+        options={projectOptions}
         onChange={this.handleSelectProject}
         onMenuOpen={this.onProjectMenuOpen}
         components={{Option: this.customOptionProject, DropdownIndicator: null}}

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -254,8 +254,7 @@ class ContextPickerModal extends React.Component<Props> {
   renderProjectSelectOrMessage() {
     const {organization, projects} = this.props;
     // only show projects the user is a part of
-    const memberProjects: Project[] = [];
-    projects.forEach(project => project.isMember && memberProjects.push(project));
+    const memberProjects = projects.filter(project => project.isMember);
 
     const projectOptions = memberProjects.map(({slug}) => ({label: slug, value: slug}));
 


### PR DESCRIPTION
Filter the project list when creating an alert to only show the projects the user is a part of. Also, if a project is selected in the Global Header, go directly to that project's create alert page.

FIXES [WOR-826](https://getsentry.atlassian.net/browse/WOR-826)

### Before
You would see all projects, regardless if a project was selected in the global header or if you were a part of that project or not.

<img width="886" alt="Screen Shot 2021-04-16 at 3 43 01 AM" src="https://user-images.githubusercontent.com/20312973/115013566-115b9700-9e66-11eb-9916-3745a8382471.png">

### After

Only projects you're a part of will be displayed. If a project is selected in the global header, clicking on the "Create Alert Rule" button will directly take you to the create alert page for that project.

<img width="852" alt="Screen Shot 2021-04-16 at 2 04 51 AM" src="https://user-images.githubusercontent.com/20312973/115013892-7c0cd280-9e66-11eb-8c57-b2a8111a6b63.png">

![create-alert-rule](https://user-images.githubusercontent.com/20312973/115014366-166d1600-9e67-11eb-835e-9abae1620c16.gif)