### PR TITLE
fix(smart-searchbar): Fix wrong release tag key comparison

### DIFF
--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -636,7 +636,8 @@ class SmartSearchBar extends React.Component<Props, State> {
         Sentry.captureException(err);
         return [];
       }
-      if (tag.key === 'release' && !values.includes('latest')) {
+
+      if (tag.key === 'release:' && !values.includes('latest')) {
         values.unshift('latest');
       }
 


### PR DESCRIPTION
the string must have a colon, otherwise the `release:latest` option still appears in the list