### PR TITLE
fix(aws-lambda): Handle aws rate limiting error

### DIFF
--- a/src/sentry/integrations/aws_lambda/utils.py
+++ b/src/sentry/integrations/aws_lambda/utils.py
@@ -23,6 +23,7 @@ SUPPORTED_RUNTIMES = [
 
 INVALID_LAYER_TEXT = "Invalid existing layer %s"
 MISSING_ROLE_TEXT = "Invalid role associated with the lambda function"
+TOO_MANY_REQUESTS_TEXT = "Something went wrong! Please enable function manually after installation"
 
 DEFAULT_NUM_RETRIES = 3
 
@@ -313,6 +314,15 @@ def get_invalid_layer_name(err_message):
     return None
 
 
+def get_too_many_requests_error_message(err_message):
+    """
+    Check to see if an error is a TooManyRequestsException
+    :param err_message: error string
+    :return boolean value if the error matches the too many requests error
+    """
+    return "TooManyRequestsException" in err_message
+
+
 def get_missing_role_error(err_message):
     """
     Check to see if an error matches the missing role text
@@ -338,9 +348,10 @@ def get_sentry_err_message(err_message):
     invalid_layer = get_invalid_layer_name(err_message)
     if invalid_layer:
         return True, (INVALID_LAYER_TEXT % invalid_layer)
-    missing_role = get_missing_role_error(err_message)
-    if missing_role:
+    if get_missing_role_error(err_message):
         return True, MISSING_ROLE_TEXT
+    if get_too_many_requests_error_message(err_message):
+        return True, TOO_MANY_REQUESTS_TEXT
     return False, err_message
 
 

--- a/tests/sentry/integrations/aws_lambda/test_integration.py
+++ b/tests/sentry/integrations/aws_lambda/test_integration.py
@@ -393,3 +393,65 @@ class AwsLambdaIntegrationTest(IntegrationTestCase):
         mock_react_view.assert_called_with(
             ANY, "awsLambdaFailureDetails", {"lambdaFunctionFailures": failures, "successCount": 0}
         )
+
+    @patch("sentry.integrations.aws_lambda.integration.get_supported_functions")
+    @patch("sentry.integrations.aws_lambda.integration.gen_aws_client")
+    @patch.object(PipelineView, "render_react_view", return_value=HttpResponse())
+    def test_lambda_setup_layer_too_many_requests_exception(
+        self, mock_react_view, mock_gen_aws_client, mock_get_supported_functions
+    ):
+        class MockException(Exception):
+            pass
+
+        too_many_requests_err = (
+            "An error occurred (TooManyRequestsException) when calling the "
+            "UpdateFunctionConfiguration operation (reached max retries: 4): "
+            "Rate exceeded"
+        )
+        mock_client = Mock()
+        mock_gen_aws_client.return_value = mock_client
+        mock_client.update_function_configuration = MagicMock(
+            side_effect=Exception(too_many_requests_err)
+        )
+        mock_client.describe_account = MagicMock(return_value={"Account": {"Name": "my_name"}})
+        mock_client.exceptions = MagicMock()
+        mock_client.exceptions.ResourceConflictException = MockException
+
+        mock_get_supported_functions.return_value = [
+            {
+                "FunctionName": "lambdaB",
+                "Runtime": "nodejs10.x",
+                "FunctionArn": "arn:aws:lambda:us-east-2:599817902985:function:lambdaB",
+            },
+        ]
+
+        aws_external_id = "12-323"
+        self.pipeline.state.step_index = 2
+        self.pipeline.state.data = {
+            "region": region,
+            "account_number": account_number,
+            "aws_external_id": aws_external_id,
+            "project_id": self.projectA.id,
+        }
+
+        resp = self.client.post(
+            self.setup_path,
+            {"lambdaB": True},
+            format="json",
+            HTTP_ACCEPT="application/json",
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+
+        assert resp.status_code == 200
+        assert not Integration.objects.filter(provider=self.provider.key).exists()
+
+        failures = [
+            {
+                "name": "lambdaB",
+                "error": "Something went wrong! Please enable function manually after installation",
+            }
+        ]
+
+        mock_react_view.assert_called_with(
+            ANY, "awsLambdaFailureDetails", {"lambdaFunctionFailures": failures, "successCount": 0}
+        )


### PR DESCRIPTION
This PR:
- Replace `Unknown Error`  shown to user when trying to batch enable many lambda functions at once (due to TooManyRequestsException from AWS) with a more useful error message