### PR TITLE
fix(trace-view): Orphan continuing depths should be dashed

### DIFF
--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -380,7 +380,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
         const result = this.renderTransaction(child, {
           continuingDepths:
             !isLastChild && hasChildren
-              ? [...continuingDepths, {depth: generation, isOrphanDepth: false}]
+              ? [...continuingDepths, {depth: generation, isOrphanDepth: isOrphan}]
               : continuingDepths,
           isOrphan,
           isLast: isLastChild,


### PR DESCRIPTION
When there is a continuing depth connector bar, it should respect whether or not
the parent event is an orphan or the descendant of an orphan. Previously, all
continuing depths were hard coded to be not orphans resulting in a solid line
where a dashed line is expected.

# Screenshot

## Before

![image](https://user-images.githubusercontent.com/10239353/115050408-b8aded80-9ea9-11eb-91fd-4e05944de9b0.png)

## After

![image](https://user-images.githubusercontent.com/10239353/115050448-c2375580-9ea9-11eb-89b6-4aa94062ae69.png)
