### PR TITLE
feat(demo): adds retry logic for IntegrityError creating the demo user

### DIFF
--- a/src/sentry/demo/models.py
+++ b/src/sentry/demo/models.py
@@ -55,6 +55,10 @@ class DemoOrganization(DefaultFieldsModel):
         self.date_assigned = timezone.now()
         self.save()
 
+    @classmethod
+    def get_one_pending_org(cls):
+        return cls.objects.filter(status=DemoOrgStatus.PENDING).first()
+
 
 class DemoUser(DefaultFieldsModel):
     __core__ = False


### PR DESCRIPTION
This PR fixes a bug from a race condition where two people get assigned the same organization at the same time from `assign_demo_org`. We try to make two users of the same email address which produces a `IntegrityError`. When that happens, just call `assign_demo_org` again but only up to 3 times. I thought about using a lock here, but that might be problematic since we shouldn't have to worry about an `IntegrityError` if we are creating an org on-demand instead of pulling it out of a buffer. 

Fixes: SENTRY-DEMO-R