### PR TITLE
chore(sdk): Always sample stats endpoints

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -46,6 +46,10 @@ SAMPLED_URL_NAMES = {
     "sentry-api-0-organization-release-details",
     "sentry-api-0-project-releases",
     "sentry-api-0-project-release-details",
+    # stats
+    "sentry-api-0-organization-stats",
+    "sentry-api-0-organization-stats-v2",
+    "sentry-api-0-project-stats",
 }
 
 SAMPLED_TASKS = {


### PR DESCRIPTION
Always sample these stats endpoints so we have an of idea who is using the stats APIs for reporting. (if a request doesn't come from our app, it isn't guaranteed to be traced).