### PR TITLE
feat(mobile-prompt): replace mobile prompt check event

### DIFF
--- a/static/app/components/suggestProjectCTA.tsx
+++ b/static/app/components/suggestProjectCTA.tsx
@@ -124,9 +124,6 @@ class SuggestProjectCTA extends React.Component<Props, State> {
             'growth.show_mobile_prompt_banner',
             {
               matchedUserAgentString,
-              userAgentMatches: !!matchedUserAgentString,
-              hasMobileProject: this.hasMobileProject,
-              snoozedOrDismissed: isDismissed,
               mobileEventBrowserName: mobileEventResult?.browserName || '',
               mobileEventClientOsName: mobileEventResult?.clientOsName || '',
             },

--- a/static/app/components/suggestProjectCTA.tsx
+++ b/static/app/components/suggestProjectCTA.tsx
@@ -118,22 +118,22 @@ class SuggestProjectCTA extends React.Component<Props, State> {
       },
       () => {
         const matchedUserAgentString = this.matchedUserAgentString;
-
-        //now record the results
-        trackAdvancedAnalyticsEvent(
-          'growth.check_show_mobile_prompt_banner',
-          {
-            matchedUserAgentString,
-            userAgentMatches: !!matchedUserAgentString,
-            hasMobileProject: this.hasMobileProject,
-            snoozedOrDismissed: isDismissed,
-            mobileEventBrowserName: mobileEventResult?.browserName || '',
-            mobileEventClientOsName: mobileEventResult?.clientOsName || '',
-            showCTA: this.showCTA,
-          },
-          this.props.organization,
-          {startSession: true}
-        );
+        if (this.showCTA) {
+          //now record the results
+          trackAdvancedAnalyticsEvent(
+            'growth.show_mobile_prompt_banner',
+            {
+              matchedUserAgentString,
+              userAgentMatches: !!matchedUserAgentString,
+              hasMobileProject: this.hasMobileProject,
+              snoozedOrDismissed: isDismissed,
+              mobileEventBrowserName: mobileEventResult?.browserName || '',
+              mobileEventClientOsName: mobileEventResult?.clientOsName || '',
+            },
+            this.props.organization,
+            {startSession: true}
+          );
+        }
       }
     );
   }

--- a/static/app/utils/growthAnalyticsEvents.tsx
+++ b/static/app/utils/growthAnalyticsEvents.tsx
@@ -2,19 +2,18 @@ type MobilePromptBannerParams = {
   matchedUserAgentString: string;
 };
 
-type CheckShowParams = MobilePromptBannerParams & {
+type ShowParams = MobilePromptBannerParams & {
   userAgentMatches: boolean;
   matchedUserAgentString: string;
   hasMobileProject: boolean;
   snoozedOrDismissed: boolean;
   mobileEventBrowserName: string;
   mobileEventClientOsName: string;
-  showCTA: boolean;
 };
 
 //define the event key to payload mappings
 export type GrowthEventParameters = {
-  'growth.check_show_mobile_prompt_banner': CheckShowParams;
+  'growth.show_mobile_prompt_banner': ShowParams;
   'growth.dismissed_mobile_prompt_banner': MobilePromptBannerParams;
   'growth.opened_mobile_project_suggest_modal': MobilePromptBannerParams;
   'growth.clicked_mobile_prompt_setup_project': MobilePromptBannerParams;
@@ -26,7 +25,7 @@ export type GrowthEventParameters = {
 type GrowthAnalyticsKey = keyof GrowthEventParameters;
 
 export const growthEventMap: Record<GrowthAnalyticsKey, string> = {
-  'growth.check_show_mobile_prompt_banner': 'Growth: Check Show Mobile Prompt Banner',
+  'growth.show_mobile_prompt_banner': 'Growth: Show Mobile Prompt Banner',
   'growth.dismissed_mobile_prompt_banner': 'Growth: Dismissed Mobile Prompt Banner',
   'growth.opened_mobile_project_suggest_modal':
     'Growth: Open Mobile Project Suggest Modal',

--- a/static/app/utils/growthAnalyticsEvents.tsx
+++ b/static/app/utils/growthAnalyticsEvents.tsx
@@ -3,10 +3,7 @@ type MobilePromptBannerParams = {
 };
 
 type ShowParams = MobilePromptBannerParams & {
-  userAgentMatches: boolean;
   matchedUserAgentString: string;
-  hasMobileProject: boolean;
-  snoozedOrDismissed: boolean;
   mobileEventBrowserName: string;
   mobileEventClientOsName: string;
 };


### PR DESCRIPTION
The event for checking if we show the mobile prompt CTA banner is happening very frequently and we had to disable it in Amplitude. Instead, we should only emit an event if we actually show the CTA banner. We can also remove some boolean params from the event because if we show the CTA banner, we already know the value of those of the booleans.