### PR TITLE
build(ci): Split frontend tests into 2 instances

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -18,8 +18,12 @@ jobs:
     name: frontend tests
     runs-on: ubuntu-20.04
     timeout-minutes: 20
+    strategy:
+      matrix:
+        instance: [0, 1]
 
     env:
+      CI_NODE_TOTAL: ${{ strategy.job-total }}
       VISUAL_HTML_ENABLE: 1
     steps:
       - uses: actions/checkout@v2
@@ -49,9 +53,11 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: jest
+        env:
+          CI_NODE_INDEX: ${{ matrix.instance }}
         run: |
           NODE_ENV=production yarn build-css
-          yarn test-ci --forceExit
+          JEST_TESTS=$(jest --listTests --json) yarn test-ci --forceExit
 
       - name: Save HTML artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -57,7 +57,7 @@ jobs:
           CI_NODE_INDEX: ${{ matrix.instance }}
         run: |
           NODE_ENV=production yarn build-css
-          JEST_TESTS=$(jest --listTests --json) yarn test-ci --forceExit
+          JEST_TESTS=$(yarn jest --listTests --json) yarn test-ci --forceExit
 
       - name: Save HTML artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -51,13 +51,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Build CSS
+        run: NODE_ENV=production yarn build-css
+
       - name: jest
-        env:
-          CI_NODE_TOTAL: ${{ strategy.job-total }}
-          CI_NODE_INDEX: ${{ matrix.instance }}
         run: |
-          NODE_ENV=production yarn build-css
-          JEST_TESTS=$(yarn jest --listTests --json) yarn test-ci --forceExit
+          CI_NODE_TOTAL=${{ strategy.job-total }} CI_NODE_INDEX=${{ matrix.instance }} JEST_TESTS=$(yarn jest --listTests --json) yarn test-ci --forceExit
 
       - name: Save HTML artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: jest
         run: |
-          CI_NODE_TOTAL=${{ strategy.job-total }} CI_NODE_INDEX=${{ matrix.instance }} JEST_TESTS=$(yarn jest --listTests --json) yarn test-ci --forceExit
+          CI_NODE_TOTAL=${{ strategy.job-total }} CI_NODE_INDEX=${{ matrix.instance }} JEST_TESTS=$(yarn -s jest --listTests --json) yarn test-ci --forceExit
 
       - name: Save HTML artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -23,7 +23,6 @@ jobs:
         instance: [0, 1]
 
     env:
-      CI_NODE_TOTAL: ${{ strategy.job-total }}
       VISUAL_HTML_ENABLE: 1
     steps:
       - uses: actions/checkout@v2
@@ -54,6 +53,7 @@ jobs:
 
       - name: jest
         env:
+          CI_NODE_TOTAL: ${{ strategy.job-total }}
           CI_NODE_INDEX: ${{ matrix.instance }}
         run: |
           NODE_ENV=production yarn build-css

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ const path = require('path'); // eslint-disable-line
 
 let testMatch;
 
+const {JEST_TESTS, CI_NODE_TOTAL, CI_NODE_INDEX} = process.env;
 /**
  * In CI we may need to shard our jest tests so that we can parellize the test runs
  *
@@ -10,23 +11,23 @@ let testMatch;
  * Then we split up the tests based on the total number of CI instances that will
  * be running the tests.
  */
-if (process.env.CI && process.env.JEST_TESTS) {
-  const {CI_NODE_TOTAL, CI_NODE_INDEX} = process.env;
-
+if (
+  JEST_TESTS &&
+  typeof CI_NODE_TOTAL !== 'undefined' &&
+  typeof CI_NODE_INDEX !== 'undefined'
+) {
   // Taken from https://github.com/facebook/jest/issues/6270#issue-326653779
   const tests = JSON.parse(process.env.JEST_TESTS).sort((a, b) => {
     return b.localeCompare(a);
   });
 
-  if (typeof CI_NODE_TOTAL !== 'undefined' && typeof CI_NODE_INDEX !== 'undefined') {
-    const length = tests.length;
-    const size = Math.floor(length / CI_NODE_TOTAL);
-    const remainder = length % CI_NODE_TOTAL;
-    const offset = Math.min(CI_NODE_INDEX, remainder) + CI_NODE_INDEX * size;
-    const chunk = size + (CI_NODE_INDEX < remainder ? 1 : 0);
+  const length = tests.length;
+  const size = Math.floor(length / CI_NODE_TOTAL);
+  const remainder = length % CI_NODE_TOTAL;
+  const offset = Math.min(CI_NODE_INDEX, remainder) + CI_NODE_INDEX * size;
+  const chunk = size + (CI_NODE_INDEX < remainder ? 1 : 0);
 
-    testMatch = tests.slice(offset, offset + chunk);
-  }
+  testMatch = tests.slice(offset, offset + chunk);
 }
 
 module.exports = {


### PR DESCRIPTION
Frontend test duration has been creeping up and failing. There are some optimizations we could do, but I think this needs to be split for now.

Took the logic from this post https://github.com/facebook/jest/issues/6270#issue-326653779 and applied it here. 