### PR TITLE
dev_env(feat/fix): Report dev env issues to a separate project

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -37,7 +37,8 @@ report_to_sentry() {
     if ! require sentry-cli; then
         curl -sL https://sentry.io/get-cli/ | bash
     fi
-    SENTRY_DSN=${SENTRY_DEVENV_DSN} \
+    # Report to sentry-dev-env
+    SENTRY_DSN="https://9bdb053cb8274ea69231834d1edeec4c@o1.ingest.sentry.io/5723503" \
         sentry-cli send-event -m "$error_message" --logfile "$_SENTRY_LOG_FILE" --level $log_level
     rm "$_SENTRY_LOG_FILE"
 }
@@ -137,7 +138,8 @@ else
     exec > >(tee "$_SENTRY_LOG_FILE")
     exec 2>&1
     info "Development errors will be reported to Sentry.io."$'\n'"        If you wish to opt-out, set SENTRY_DEVENV_NO_REPORT as an env variable."
-    export SENTRY_DEVENV_DSN=https://23670f54c6254bfd9b7de106637808e9@o1.ingest.sentry.io/1492057
+    # This will allow `sentry devservices` errors to be reported
+    export SENTRY_DEVSERVICES_DSN=https://23670f54c6254bfd9b7de106637808e9@o1.ingest.sentry.io/1492057
 fi
 
 ### System ###

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -172,7 +172,7 @@ def main():
         "max_content_width": 100,
     }
     # This variable is *only* set as part of direnv/.envrc, thus, we cannot affect production
-    if os.environ.get("SENTRY_DEVENV_DSN"):
+    if os.environ.get("SENTRY_DEVSERVICES_DSN") and os.environ.get("SENTRY_DEVENV_NO_REPORT"):
         # We do this here because `configure_structlog` executes later
         logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
         logger = logging.getLogger(__name__)
@@ -184,8 +184,8 @@ def main():
         try:
             func(**kwargs)
         except Exception as e:
-            # This reports to the project sentry-dev-env
-            with sentry_sdk.init(dsn=os.environ["SENTRY_DEVENV_DSN"]):
+            # This reports errors sentry-devservices
+            with sentry_sdk.init(dsn=os.environ["SENTRY_DEVSERVICES_DSN"]):
                 if os.environ.get("USER"):
                     sentry_sdk.set_user({"username": os.environ.get("USER")})
                 sentry_sdk.capture_exception(e)

--- a/src/sentry/runner/__init__.py
+++ b/src/sentry/runner/__init__.py
@@ -172,7 +172,7 @@ def main():
         "max_content_width": 100,
     }
     # This variable is *only* set as part of direnv/.envrc, thus, we cannot affect production
-    if os.environ.get("SENTRY_DEVSERVICES_DSN") and os.environ.get("SENTRY_DEVENV_NO_REPORT"):
+    if os.environ.get("SENTRY_DEVSERVICES_DSN"):
         # We do this here because `configure_structlog` executes later
         logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.INFO)
         logger = logging.getLogger(__name__)


### PR DESCRIPTION
Up until now we were reporting dev env issues (shell based) and devservices
issues (Python based) to the same Sentry project.

This change separates both to report to different projects (sentry-dev-env &
sentry-devservices) which will allow different alert rules & proper Github
source code mapping.

This also fixes make targets not reporting to Sentry.io