### PR TITLE
fix(ui): Always show open in discover button in alert details

### DIFF
--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -248,7 +248,6 @@ class MetricChart extends React.PureComponent<Props, State> {
     warningDuration: number
   ) {
     const {rule, orgId, projects, timePeriod} = this.props;
-    const preset = this.metricPreset;
     const ctaOpts = {
       orgSlug: orgId,
       projects: projects as Project[],
@@ -257,9 +256,7 @@ class MetricChart extends React.PureComponent<Props, State> {
       end: timePeriod.end,
     };
 
-    const {buttonText, ...props} = preset
-      ? preset.makeCtaParams(ctaOpts)
-      : makeDefaultCta(ctaOpts);
+    const {buttonText, ...props} = makeDefaultCta(ctaOpts);
 
     const resolvedPercent = (
       (100 * Math.max(totalDuration - criticalDuration - warningDuration, 0)) /

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -542,14 +542,14 @@ class MetricChart extends React.PureComponent<Props, State> {
                 });
 
                 if (selectedIncident && incident.id === selectedIncident.id) {
-                  const areaColor = incidentColor === theme.yellow300 ? theme.yellow100 : theme.red100;
+                  const selectedIncidentColor = incidentColor === theme.yellow300 ? theme.yellow100 : theme.red100;
 
                   areaSeries.push({
                     type: 'line',
                     markArea: MarkArea({
                       silent: true,
                       itemStyle: {
-                        color: color(areaColor).alpha(0.42).rgb().string(),
+                        color: color(selectedIncidentColor).alpha(0.42).rgb().string(),
                       },
                       data: [
                         [{xAxis: incidentStartDate}, {xAxis: incidentCloseDate}],

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -542,12 +542,14 @@ class MetricChart extends React.PureComponent<Props, State> {
                 });
 
                 if (selectedIncident && incident.id === selectedIncident.id) {
+                  const areaColor = incidentColor === theme.yellow300 ? theme.yellow100 : theme.red100;
+
                   areaSeries.push({
                     type: 'line',
                     markArea: MarkArea({
                       silent: true,
                       itemStyle: {
-                        color: color(incidentColor).alpha(0.42).rgb().string(),
+                        color: color(areaColor).alpha(0.42).rgb().string(),
                       },
                       data: [
                         [{xAxis: incidentStartDate}, {xAxis: incidentCloseDate}],

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -542,7 +542,8 @@ class MetricChart extends React.PureComponent<Props, State> {
                 });
 
                 if (selectedIncident && incident.id === selectedIncident.id) {
-                  const selectedIncidentColor = incidentColor === theme.yellow300 ? theme.yellow100 : theme.red100;
+                  const selectedIncidentColor =
+                    incidentColor === theme.yellow300 ? theme.yellow100 : theme.red100;
 
                   areaSeries.push({
                     type: 'line',


### PR DESCRIPTION
This changes the button text on the alert details chart to open in discover, instead on transaction summary. Also changed the alert details selected incident area color to red100/yellow100.