### PR TITLE
feat(quick-trace): Add headers to distinguish transactions and errors

### DIFF
--- a/static/app/components/quickTrace/styles.tsx
+++ b/static/app/components/quickTrace/styles.tsx
@@ -71,12 +71,12 @@ export const TraceConnector = styled('div')`
 export const DropdownContainer = styled('span')`
   .dropdown-menu {
     padding: 0;
-    overflow: hidden;
   }
 `;
 
 export const DropdownMenuHeader = styled(MenuHeader)<{first?: boolean}>`
   background: ${p => p.theme.backgroundSecondary};
+  ${p => p.first && 'border-radius: 2px'};
   ${p => !p.first && `border-top: 1px solid ${p.theme.innerBorder};`}
   border-bottom: none;
   padding: ${space(0.5)} ${space(1)};

--- a/static/app/components/quickTrace/styles.tsx
+++ b/static/app/components/quickTrace/styles.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import {LocationDescriptor} from 'history';
 
+import MenuHeader from 'app/components/actions/menuHeader';
 import ExternalLink from 'app/components/links/externalLink';
 import MenuItem from 'app/components/menuItem';
 import Tag, {Background} from 'app/components/tag';
@@ -11,8 +12,8 @@ import {getDuration} from 'app/utils/formatters';
 import {QuickTraceEvent} from 'app/utils/performance/quickTrace/types';
 import {Theme} from 'app/utils/theme';
 
-export const SectionSubtext = styled('div')<{type?: 'error' | 'default'}>`
-  color: ${p => (p.type === 'error' ? p.theme.error : p.theme.subText)};
+export const SectionSubtext = styled('div')`
+  color: ${p => p.theme.subText};
   font-size: ${p => p.theme.fontSizeMedium};
 `;
 
@@ -61,8 +62,28 @@ export const TraceConnector = styled('div')`
   border-top: 1px solid ${p => p.theme.textColor};
 `;
 
-const StyledMenuItem = styled(MenuItem)<{first?: boolean; width: 'small' | 'large'}>`
-  border-top: ${p => (!p.first ? `1px solid ${p.theme.innerBorder}` : null)};
+/**
+ * The DropdownLink component is styled directly with less and the way the
+ * elements are laid out within means we can't apply any styles directly
+ * using emotion. Instead, we wrap it all inside a span and indirectly
+ * style it here.
+ */
+export const DropdownContainer = styled('span')`
+  .dropdown-menu {
+    padding: 0;
+    overflow: hidden;
+  }
+`;
+
+export const DropdownMenuHeader = styled(MenuHeader)<{first?: boolean}>`
+  background: ${p => p.theme.backgroundSecondary};
+  ${p => !p.first && `border-top: 1px solid ${p.theme.innerBorder};`}
+  border-bottom: none;
+  padding: ${space(0.5)} ${space(1)};
+`;
+
+const StyledMenuItem = styled(MenuItem)<{width: 'small' | 'large'}>`
+  border-top: 1px solid ${p => p.theme.innerBorder};
   width: ${p => (p.width === 'large' ? '350px' : '200px')};
 `;
 
@@ -76,19 +97,17 @@ type DropdownItemProps = {
   children: React.ReactNode;
   to?: string | LocationDescriptor;
   onSelect?: (eventKey: any) => void;
-  first?: boolean;
   width?: 'small' | 'large';
 };
 
 export function DropdownItem({
   children,
-  first,
   onSelect,
   to,
   width = 'large',
 }: DropdownItemProps) {
   return (
-    <StyledMenuItem to={to} onSelect={onSelect} first={first} width={width}>
+    <StyledMenuItem to={to} onSelect={onSelect} width={width}>
       <MenuItemContent>{children}</MenuItemContent>
     </StyledMenuItem>
   );

--- a/static/app/components/quickTrace/utils.tsx
+++ b/static/app/components/quickTrace/utils.tsx
@@ -4,13 +4,24 @@ import {getParams} from 'app/components/organizations/globalSelectionHeader/getP
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
 import {OrganizationSummary} from 'app/types';
 import {Event} from 'app/types/event';
+import {defined} from 'app/utils';
 import EventView from 'app/utils/discover/eventView';
 import {eventDetailsRouteWithEventView, generateEventSlug} from 'app/utils/discover/urls';
-import {EventLite, TraceError} from 'app/utils/performance/quickTrace/types';
+import {
+  EventLite,
+  QuickTraceEvent,
+  TraceError,
+} from 'app/utils/performance/quickTrace/types';
 import {getTraceTimeRangeFromEvent} from 'app/utils/performance/quickTrace/utils';
 import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
 import {getTraceDetailsUrl} from 'app/views/performance/traceDetails/utils';
 import {getTransactionDetailsUrl} from 'app/views/performance/utils';
+
+export function isQuickTraceEvent(
+  event: QuickTraceEvent | TraceError
+): event is QuickTraceEvent {
+  return defined((event as QuickTraceEvent)['transaction.duration']);
+}
 
 export type ErrorDestination = 'discover' | 'issue';
 


### PR DESCRIPTION
Within the dropdown in quick trace, errors and transactions are just mixed in.
This is causing some confusion. This change introduces some section headings to
visually separate the errors from the transactions and opts to show errors with
their titles instead.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/115083393-43581200-9ed5-11eb-9190-e04e0f3a6fa6.png)

## After

![image](https://user-images.githubusercontent.com/10239353/115083360-3804e680-9ed5-11eb-9f0d-cf3c164fb4ec.png)
