### PR TITLE
fix(templates) Fix date template filter to handle date

### DIFF
--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -1,7 +1,7 @@
 import functools
 import os.path
 from collections import namedtuple
-from datetime import timedelta
+from datetime import datetime, timedelta
 from random import randint
 from urllib.parse import quote
 
@@ -235,7 +235,7 @@ def duration(value):
 def date(dt, arg=None):
     from django.template.defaultfilters import date
 
-    if not timezone.is_aware(dt):
+    if isinstance(dt, datetime) and not timezone.is_aware(dt):
         dt = dt.replace(tzinfo=timezone.utc)
     return date(dt, arg)
 

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from django.template import engines
 
@@ -60,3 +62,25 @@ def test_absolute_uri(input, output):
         .strip()
     )
     assert result == output
+
+
+def test_date_handle_date_and_datetime():
+    result = (
+        engines["django"]
+        .from_string(
+            """
+{% load sentry_helpers %}
+{{ date_obj|date:"Y-m-d" }}
+{{ datetime_obj|date:"Y-m-d" }}
+            """
+        )
+        .render(
+            context={
+                "date_obj": datetime.date(2021, 4, 16),
+                "datetime_obj": datetime.datetime(2021, 4, 17, 12, 13, 14),
+            }
+        )
+        .strip()
+    )
+
+    assert result == "\n".join(["2021-04-16", "2021-04-17"])


### PR DESCRIPTION
Date instances do not have timezones and raise errors when passed to `timezone.is_aware()`.

Fixes SENTRY-PQ9