### PR TITLE
feat(trace-view): Improve the trace view performance

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -82,7 +82,7 @@ def query_trace_data(trace_id, params):
             orderby=snuba_filter.orderby,
             limit=MAX_TRACE_SIZE,
         )
-        for dataset, snuba_filter in [transaction_query.filter, error_query.filter]
+        for snuba_filter in [transaction_query.filter, error_query.filter]
     ]
     results = bulk_raw_query(
         snuba_params,

--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -47,7 +47,7 @@ def query_trace_data(trace_id, params):
         ],
         # We want to guarantee at least getting the root, and hopefully events near it with timestamp
         # id is just for consistent results
-        orderby=["-root", "-timestamp", "id"],
+        orderby=["-root", "timestamp", "id"],
         params=params,
         query=f"event.type:transaction trace:{trace_id}",
     )

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -553,7 +553,7 @@ def top_events_timeseries(
         op="discover.discover", description="top_events.transform_results"
     ) as span:
         span.set_data("result_count", len(result.get("data", [])))
-        result = transform_data(result, translated_columns, snuba_filter, selected_columns)
+        result = transform_data(result, translated_columns, snuba_filter)
 
         if "project" in selected_columns:
             translated_columns["project_id"] = "project"

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -115,10 +115,8 @@ def zerofill(data, start, end, rollup, orderby):
     return rv
 
 
-def transform_results(
-    results, function_alias_map, translated_columns, snuba_filter, selected_columns=None
-):
-    results = transform_data(results, translated_columns, snuba_filter, selected_columns)
+def transform_results(results, function_alias_map, translated_columns, snuba_filter):
+    results = transform_data(results, translated_columns, snuba_filter)
     results["meta"] = transform_meta(results, function_alias_map)
     return results
 
@@ -138,16 +136,13 @@ def transform_meta(results, function_alias_map):
     return meta
 
 
-def transform_data(result, translated_columns, snuba_filter, selected_columns=None):
+def transform_data(result, translated_columns, snuba_filter):
     """
     Transform internal names back to the public schema ones.
 
     When getting timeseries results via rollup, this function will
     zerofill the output results.
     """
-    if selected_columns is None:
-        selected_columns = []
-
     for col in result["meta"]:
         # Translate back column names that were converted to snuba format
         col["name"] = translated_columns.get(col["name"], col["name"])
@@ -260,7 +255,6 @@ def query(
             snuba_query.fields["functions"],
             snuba_query.columns,
             snuba_filter,
-            selected_columns,
         )
 
 

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -40,6 +40,7 @@ __all__ = (
     "PaginationResult",
     "InvalidSearchQuery",
     "query",
+    "prepare_discover_query",
     "timeseries_query",
     "top_events_timeseries",
     "get_facets",
@@ -52,6 +53,7 @@ __all__ = (
 
 logger = logging.getLogger(__name__)
 
+PreparedQuery = namedtuple("query", ["filter", "columns", "fields"])
 PaginationResult = namedtuple("PaginationResult", ["next", "previous", "oldest", "latest"])
 FacetResult = namedtuple("FacetResult", ["key", "value", "count"])
 PerformanceFacetResult = namedtuple(
@@ -219,6 +221,60 @@ def query(
     # We clobber this value throughout this code, so copy the value
     selected_columns = selected_columns[:]
 
+    snuba_query = prepare_discover_query(
+        selected_columns,
+        query,
+        params,
+        orderby,
+        auto_fields,
+        auto_aggregations,
+        use_aggregate_conditions,
+        conditions,
+        functions_acl,
+    )
+    snuba_filter = snuba_query.filter
+
+    with sentry_sdk.start_span(op="discover.discover", description="query.snuba_query"):
+        result = raw_query(
+            start=snuba_filter.start,
+            end=snuba_filter.end,
+            groupby=snuba_filter.groupby,
+            conditions=snuba_filter.conditions,
+            aggregations=snuba_filter.aggregations,
+            selected_columns=snuba_filter.selected_columns,
+            filter_keys=snuba_filter.filter_keys,
+            having=snuba_filter.having,
+            orderby=snuba_filter.orderby,
+            dataset=Dataset.Discover,
+            limit=limit,
+            offset=offset,
+            referrer=referrer,
+        )
+
+    with sentry_sdk.start_span(
+        op="discover.discover", description="query.transform_results"
+    ) as span:
+        span.set_data("result_count", len(result.get("data", [])))
+        return transform_results(
+            result,
+            snuba_query.fields["functions"],
+            snuba_query.columns,
+            snuba_filter,
+            selected_columns,
+        )
+
+
+def prepare_discover_query(
+    selected_columns,
+    query,
+    params,
+    orderby=None,
+    auto_fields=False,
+    auto_aggregations=False,
+    use_aggregate_conditions=False,
+    conditions=None,
+    functions_acl=None,
+):
     with sentry_sdk.start_span(
         op="discover.discover", description="query.filter_transform"
     ) as span:
@@ -230,8 +286,6 @@ def query(
                 not auto_aggregations
             ), "Auto aggregations cannot be used without enabling aggregate conditions"
             snuba_filter.having = []
-
-    function_translations = {}
 
     with sentry_sdk.start_span(op="discover.discover", description="query.field_translations"):
         if orderby is not None:
@@ -249,9 +303,7 @@ def query(
         snuba_filter.update_with(resolved_fields)
 
         # Resolve the public aliases into the discover dataset names.
-        snuba_filter, translated_columns = resolve_discover_aliases(
-            snuba_filter, function_translations
-        )
+        snuba_filter, translated_columns = resolve_discover_aliases(snuba_filter)
 
         # Make sure that any aggregate conditions are also in the selected columns
         for having_clause in snuba_filter.having:
@@ -298,30 +350,7 @@ def query(
         if conditions is not None:
             snuba_filter.conditions.extend(conditions)
 
-    with sentry_sdk.start_span(op="discover.discover", description="query.snuba_query"):
-        result = raw_query(
-            start=snuba_filter.start,
-            end=snuba_filter.end,
-            groupby=snuba_filter.groupby,
-            conditions=snuba_filter.conditions,
-            aggregations=snuba_filter.aggregations,
-            selected_columns=snuba_filter.selected_columns,
-            filter_keys=snuba_filter.filter_keys,
-            having=snuba_filter.having,
-            orderby=snuba_filter.orderby,
-            dataset=Dataset.Discover,
-            limit=limit,
-            offset=offset,
-            referrer=referrer,
-        )
-
-    with sentry_sdk.start_span(
-        op="discover.discover", description="query.transform_results"
-    ) as span:
-        span.set_data("result_count", len(result.get("data", [])))
-        return transform_results(
-            result, resolved_fields["functions"], translated_columns, snuba_filter, selected_columns
-        )
+    return PreparedQuery(snuba_filter, translated_columns, resolved_fields)
 
 
 def get_timeseries_snuba_filter(selected_columns, query, params, rollup, default_count=True):

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -598,6 +598,7 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         assert response.status_code == 200, response.content
         self.assert_trace_data(response.data[0])
         # We shouldn't have detailed fields here
+        assert "transaction.status" not in response.data[0]
         assert "tags" not in response.data[0]
         assert "measurements" not in response.data[0]
 

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -598,7 +598,6 @@ class OrganizationEventsTraceEndpointTest(OrganizationEventsTraceEndpointBase):
         assert response.status_code == 200, response.content
         self.assert_trace_data(response.data[0])
         # We shouldn't have detailed fields here
-        assert "transaction.status" not in response.data[0]
         assert "tags" not in response.data[0]
         assert "measurements" not in response.data[0]
 


### PR DESCRIPTION
- This improves the trace view performance significantly by
  parallelizing the transaction and error queries
- This also pulls the preparation of discover queries into a helper
  function so that it can be re-used for this purpose
- Some minor optimizations
    - Realized that changing columns based on detailed or not likely
      meant that we couldn't take advantage of snuba's caching cause the
      columns changed
    - Removed the orderby timestamp, most of the time the trace view
      only looks at 24h of data, so I think we might see some speed up
      by avoiding snuba's optimization

### Preview
Before (225ms):
![image](https://user-images.githubusercontent.com/4205004/115091058-79e95900-9ee4-11eb-9b7c-398e8847b196.png)

After (138ms):
![image](https://user-images.githubusercontent.com/4205004/115091068-8077d080-9ee4-11eb-9858-ae86deaacd17.png)
