### PR TITLE
chore(django22): Fix uses of `mark_safe`

### DIFF
--- a/src/sentry/notifications/activity/base.py
+++ b/src/sentry/notifications/activity/base.py
@@ -3,8 +3,8 @@ from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, S
 from urllib.parse import urlparse, urlunparse
 
 from django.core.urlresolvers import reverse
-from django.utils.html import escape, mark_safe
-from django.utils.safestring import SafeString
+from django.utils.html import escape
+from django.utils.safestring import SafeString, mark_safe
 
 from sentry import options
 from sentry.models import (

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
-from django.utils.html import mark_safe
+from django.utils.safestring import mark_safe
 from django.utils.timezone import is_aware
 from simplejson import JSONDecodeError, JSONEncoder, _default_decoder  # NOQA
 

--- a/src/sentry/web/forms/accounts.py
+++ b/src/sentry/web/forms/accounts.py
@@ -4,7 +4,8 @@ import pytz
 from django import forms
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
-from django.utils.text import capfirst, mark_safe
+from django.utils.safestring import mark_safe
+from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
 
 from sentry import newsletter, options


### PR DESCRIPTION
This has always been defined in `django.utils.safestring`, but it was imported in
`django.utils.text` previously. It has now been removed from there, so we should import it from the
right place