### PR TITLE
fix(django22): Always pass choices as a keyword arg to `forms.ChoiceField`

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -51,8 +51,8 @@ ATTR_CHOICES = [
 
 
 class EventAttributeForm(forms.Form):
-    attribute = forms.ChoiceField((a, a) for a in ATTR_CHOICES)
-    match = forms.ChoiceField(list(MATCH_CHOICES.items()))
+    attribute = forms.ChoiceField(choices=[(a, a) for a in ATTR_CHOICES])
+    match = forms.ChoiceField(choices=list(MATCH_CHOICES.items()))
     value = forms.CharField(widget=forms.TextInput(), required=False)
 
 

--- a/src/sentry/rules/conditions/tagged_event.py
+++ b/src/sentry/rules/conditions/tagged_event.py
@@ -33,7 +33,7 @@ MATCH_CHOICES = OrderedDict(
 
 class TaggedEventForm(forms.Form):
     key = forms.CharField(widget=forms.TextInput())
-    match = forms.ChoiceField(list(MATCH_CHOICES.items()), widget=forms.Select())
+    match = forms.ChoiceField(choices=list(MATCH_CHOICES.items()), widget=forms.Select())
     value = forms.CharField(widget=forms.TextInput(), required=False)
 
     def clean(self):


### PR DESCRIPTION
If choices is passed as an arg it will tend to conflict with `widget` when it's passed as a kwarg,
so just make sure we're explicitly passing it as `choices`