### PR TITLE
fix(ui): Fix potential bug where SPA fails to render

### DIFF
--- a/static/app/bootstrap/renderOnDomReady.tsx
+++ b/static/app/bootstrap/renderOnDomReady.tsx
@@ -1,5 +1,5 @@
 export function renderOnDomReady(renderFn: () => void) {
-  if (document.readyState === 'complete') {
+  if (document.readyState !== 'loading') {
     renderFn();
   } else {
     document.addEventListener('DOMContentLoaded', renderFn);


### PR DESCRIPTION
There is a potential bug here where `document.readyState` is not `complete` and not `loading` (it is `interactive`), and so will never call `renderFn` as `DOMContentLoaded` has already fired.

[`interactive` means](https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState):
> The document has finished loading and the document has been parsed but sub-resources such as scripts, images, stylesheets and frames are still loading.

So we should be safe to render at this state as our vendor scripts should have finished before we get to this render.


This was introduced in https://github.com/getsentry/sentry/pull/25174 - Impact does not look widespread as I do not see anything unusual in Discover.