### PR TITLE
fix(django22): Rename uses of `RegexURL*` to `URL*`

### DIFF
--- a/src/sentry/plugins/base/group_api_urls.py
+++ b/src/sentry/plugins/base/group_api_urls.py
@@ -1,7 +1,13 @@
 import logging
 import re
 
-from django.conf.urls import RegexURLPattern, RegexURLResolver, include, url
+from django.conf.urls import include, url
+
+try:
+    from django.urls import URLPattern, URLResolver
+except ImportError:
+    # TODO(django22): Remove once we've upgraded
+    from django.conf.urls import RegexURLPattern as URLPattern, RegexURLResolver as URLResolver
 
 from sentry.plugins.base import plugins
 
@@ -18,10 +24,11 @@ def load_plugin_urls(plugins):
             # a plugin's get_group_urls should return an iterable of url()'s,
             # which can either be RegexURLResolver or RegexURLPattern
             for u in urls:
-                if not isinstance(u, (RegexURLResolver, RegexURLPattern)):
+                if not isinstance(u, (URLResolver, URLPattern)):
                     raise TypeError(
-                        "url must be RegexURLResolver or RegexURLPattern, not %r: %r"
-                        % (type(u).__name__, u)
+                        "url must be URLResolver or URLPattern, not {!r}: {!r}".format(
+                            type(u).__name__, u
+                        )
                     )
         except Exception:
             logger.exception("routes.failed", extra={"plugin": type(plugin).__name__})

--- a/src/sentry/plugins/base/project_api_urls.py
+++ b/src/sentry/plugins/base/project_api_urls.py
@@ -1,7 +1,13 @@
 import logging
 import re
 
-from django.conf.urls import RegexURLPattern, RegexURLResolver, include, url
+from django.conf.urls import include, url
+
+try:
+    from django.urls import URLPattern, URLResolver
+except ImportError:
+    # TODO(django22): Remove once we've upgraded
+    from django.conf.urls import RegexURLPattern as URLPattern, RegexURLResolver as URLResolver
 
 from sentry.plugins.base import plugins
 
@@ -16,12 +22,13 @@ def load_plugin_urls(plugins):
             continue
         try:
             # a plugin's get_project_urls should return an iterable of url()'s,
-            # which can either be RegexURLResolver or RegexURLPattern
+            # which can either be URLResolver or URLPattern
             for u in urls:
-                if not isinstance(u, (RegexURLResolver, RegexURLPattern)):
+                if not isinstance(u, (URLResolver, URLPattern)):
                     raise TypeError(
-                        "url must be RegexURLResolver or RegexURLPattern, not %r: %r"
-                        % (type(u).__name__, u)
+                        "url must be URLResolver or URLPattern, not {!r}: {!r}".format(
+                            type(u).__name__, u
+                        )
                     )
         except Exception:
             logger.exception("routes.failed", extra={"plugin": type(plugin).__name__})


### PR DESCRIPTION
`RegexURLPattern` and `RegexURLResolver` have been renamed and moved to `django.urls`. Adding in a
compatibility shim for importing these.

I'm not sure that this code is used at all in plugins - at least, our supported ones don't ever
return anything here. But don't want to risk breaking any custom plugins people have built.