### PR TITLE
fix(django22): Make sure all foreign keys define `on_delete`.

### DIFF
--- a/src/social_auth/models.py
+++ b/src/social_auth/models.py
@@ -22,7 +22,7 @@ CLEAN_USERNAME_REGEX = re.compile(r"[^\w.@+-_]+", re.UNICODE)
 class UserSocialAuth(models.Model):
     """Social Auth association model"""
 
-    user = models.ForeignKey(AUTH_USER_MODEL, related_name="social_auth")
+    user = models.ForeignKey(AUTH_USER_MODEL, related_name="social_auth", on_delete=models.CASCADE)
     provider = models.CharField(max_length=32)
     uid = models.CharField(max_length=UID_LENGTH)
     extra_data = JSONField(default="{}")


### PR DESCRIPTION
Django now requires all foreign keys to define `on_delete`. We already do this in our base class,
but we missed it for the `UserSocialAuth` model