### PR TITLE
fix(django22): Replace uses of `assignment_tag` with `simple_tag`

### DIFF
--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -280,7 +280,7 @@ def soft_break(value, length):
     )
 
 
-@register.assignment_tag
+@register.simple_tag
 def random_int(a, b=None):
     if b is None:
         a, b = 0, a


### PR DESCRIPTION
`assignment_tag` was deprecated in 1.9, and should be replaced with `simple_tag`, as per
https://docs.djangoproject.com/en/3.1/releases/1.9/#assignment-tag