### PR TITLE
fix(django22): Replace imports from `django.core.urlresolvers` with `django.urls`

### DIFF
--- a/src/sentry/api/client.py
+++ b/src/sentry/api/client.py
@@ -1,6 +1,6 @@
 __all__ = ("ApiClient",)
 
-from django.core.urlresolvers import resolve
+from django.urls import resolve
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from sentry.auth.superuser import Superuser

--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.response import Response
 

--- a/src/sentry/api/endpoints/auth_config.py
+++ b/src/sentry/api/endpoints/auth_config.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework.response import Response
 
 from sentry import newsletter

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from urllib.parse import urljoin
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.response import Response
 

--- a/src/sentry/api/endpoints/organization_integration_request.py
+++ b/src/sentry/api/endpoints/organization_integration_request.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.encoding import force_text
 from rest_framework.response import Response
 

--- a/src/sentry/api/endpoints/project_docs_platform.py
+++ b/src/sentry/api/endpoints/project_docs_platform.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint

--- a/src/sentry/api/endpoints/project_plugin_details.py
+++ b/src/sentry/api/endpoints/project_plugin_details.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework import serializers
 from rest_framework.response import Response
 

--- a/src/sentry/api/endpoints/project_releases_token.py
+++ b/src/sentry/api/endpoints/project_releases_token.py
@@ -2,7 +2,7 @@ import hmac
 from hashlib import sha256
 from uuid import uuid1
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework.response import Response
 
 from sentry.api.bases.project import ProjectEndpoint, StrictProjectPermission

--- a/src/sentry/api/endpoints/sentry_app_requests.py
+++ b/src/sentry/api/endpoints/sentry_app_requests.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework.response import Response
 
 from sentry import eventstore

--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.exceptions import APIException
 

--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -1,6 +1,6 @@
 from urllib.parse import parse_qsl, urlencode
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.crypto import constant_time_compare
 
 from sentry.models import (

--- a/src/sentry/auth/authenticators/u2f.py
+++ b/src/sentry/auth/authenticators/u2f.py
@@ -1,7 +1,7 @@
 from time import time
 
 from cryptography.exceptions import InvalidKey, InvalidSignature
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from u2flib_server import u2f
 from u2flib_server.model import DeviceRegistration

--- a/src/sentry/auth/helper.py
+++ b/src/sentry/auth/helper.py
@@ -3,10 +3,10 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.contrib import messages
-from django.core.urlresolvers import reverse
 from django.db import IntegrityError, transaction
 from django.db.models import F
 from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 

--- a/src/sentry/auth/providers/saml2/generic/views.py
+++ b/src/sentry/auth/providers/saml2/generic/views.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.auth.providers.saml2.forms import (
     AttributeMappingForm,

--- a/src/sentry/auth/providers/saml2/provider.py
+++ b/src/sentry/auth/providers/saml2/provider.py
@@ -3,8 +3,8 @@ from urllib.parse import urlparse
 
 from django.contrib import messages
 from django.contrib.auth import logout
-from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseServerError
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext_lazy as _

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -397,7 +397,7 @@ CSRF_COOKIE_NAME = "sc"
 
 # Auth configuration
 
-from django.core.urlresolvers import reverse_lazy
+from django.urls import reverse_lazy
 
 LOGIN_REDIRECT_URL = reverse_lazy("sentry-login-redirect")
 LOGIN_URL = reverse_lazy("sentry-login")

--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -1,8 +1,8 @@
 import logging
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_text
 

--- a/src/sentry/demo/middleware.py
+++ b/src/sentry/demo/middleware.py
@@ -1,6 +1,6 @@
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, JsonResponse
+from django.urls import reverse
 
 from sentry.models import OrganizationMember
 from sentry.utils import auth

--- a/src/sentry/identity/pipeline.py
+++ b/src/sentry/identity/pipeline.py
@@ -1,8 +1,8 @@
 import logging
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 

--- a/src/sentry/incidents/action_handlers.py
+++ b/src/sentry/incidents/action_handlers.py
@@ -1,7 +1,7 @@
 import abc
 
-from django.core.urlresolvers import reverse
 from django.template.defaultfilters import pluralize
+from django.urls import reverse
 
 from sentry.incidents.models import (
     INCIDENT_STATUS,

--- a/src/sentry/incidents/tasks.py
+++ b/src/sentry/incidents/tasks.py
@@ -1,8 +1,8 @@
 import logging
 from urllib.parse import urlencode
 
-from django.core.urlresolvers import reverse
 from django.db import transaction
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry.auth.access import from_user

--- a/src/sentry/integrations/bitbucket/issues.py
+++ b/src/sentry/integrations/bitbucket/issues.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.integrations.issues import IssueBasicMixin
 from sentry.shared_integrations.exceptions import ApiError, IntegrationFormError

--- a/src/sentry/integrations/bitbucket_server/repository.py
+++ b/src/sentry/integrations/bitbucket_server/repository.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry.models.integration import Integration

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.integrations.issues import IssueBasicMixin
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -1,6 +1,6 @@
 from urllib.parse import quote
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.integrations.client import ApiClient
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized

--- a/src/sentry/integrations/gitlab/issues.py
+++ b/src/sentry/integrations/gitlab/issues.py
@@ -1,6 +1,6 @@
 import re
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.integrations.issues import IssueBasicMixin
 from sentry.shared_integrations.exceptions import ApiError, ApiUnauthorized, IntegrationError

--- a/src/sentry/integrations/jira/descriptor.py
+++ b/src/sentry/integrations/jira/descriptor.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.api.base import Endpoint
 from sentry.utils.assets import get_asset_url

--- a/src/sentry/integrations/jira/integration.py
+++ b/src/sentry/integrations/jira/integration.py
@@ -3,7 +3,7 @@ import re
 from operator import attrgetter
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from sentry import features

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -1,7 +1,7 @@
 from urllib.parse import parse_qsl
 
 import jwt
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from oauthlib.oauth1 import SIGNATURE_RSA
 from requests_oauthlib import OAuth1
 

--- a/src/sentry/integrations/jira_server/integration.py
+++ b/src/sentry/integrations/jira_server/integration.py
@@ -4,8 +4,8 @@ from urllib.parse import urlparse
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from django import forms
-from django.core.urlresolvers import reverse
 from django.core.validators import URLValidator
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
 

--- a/src/sentry/integrations/metric_alerts.py
+++ b/src/sentry/integrations/metric_alerts.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL, get_incident_aggregates
 from sentry.incidents.models import INCIDENT_STATUS, IncidentStatus, IncidentTrigger

--- a/src/sentry/integrations/msteams/link_identity.py
+++ b/src/sentry/integrations/msteams/link_identity.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.db import IntegrityError
+from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.cache import never_cache
 

--- a/src/sentry/integrations/msteams/unlink_identity.py
+++ b/src/sentry/integrations/msteams/unlink_identity.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.decorators.cache import never_cache
 
 from sentry.models import Identity

--- a/src/sentry/integrations/slack/link_identity.py
+++ b/src/sentry/integrations/slack/link_identity.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.db import IntegrityError
+from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.cache import never_cache
 

--- a/src/sentry/integrations/slack/unlink_identity.py
+++ b/src/sentry/integrations/slack/unlink_identity.py
@@ -1,6 +1,6 @@
-from django.core.urlresolvers import reverse
 from django.db import IntegrityError
 from django.http import Http404
+from django.urls import reverse
 from django.views.decorators.cache import never_cache
 
 from sentry.models import Identity

--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from mistune import markdown
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 import jsonschema
 import sentry_sdk
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from requests.exceptions import RequestException
 
 from sentry import features, options

--- a/src/sentry/models/lostpasswordhash.py
+++ b/src/sentry/models/lostpasswordhash.py
@@ -1,8 +1,8 @@
 from datetime import timedelta
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr

--- a/src/sentry/models/organization.py
+++ b/src/sentry/models/organization.py
@@ -3,8 +3,8 @@ from datetime import timedelta
 from enum import IntEnum
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db import IntegrityError, models, transaction
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 

--- a/src/sentry/models/organizationaccessrequest.py
+++ b/src/sentry/models/organizationaccessrequest.py
@@ -1,6 +1,6 @@
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db.models import Q
+from django.urls import reverse
 
 from sentry import roles
 from sentry.db.models import FlexibleForeignKey, Model, sane_repr

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -5,8 +5,8 @@ from urllib.parse import urlencode
 from uuid import uuid4
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db import models, transaction
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.encoding import force_bytes
 from django.utils.translation import ugettext_lazy as _

--- a/src/sentry/models/projectkey.py
+++ b/src/sentry/models/projectkey.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 
 import petname
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 

--- a/src/sentry/models/user.py
+++ b/src/sentry/models/user.py
@@ -5,10 +5,10 @@ from typing import Any, Sequence
 from django.contrib.auth.models import AbstractBaseUser
 from django.contrib.auth.models import UserManager as DjangoUserManager
 from django.contrib.auth.signals import user_logged_out
-from django.core.urlresolvers import reverse
 from django.db import IntegrityError, models, transaction
 from django.db.models.query import QuerySet
 from django.dispatch import receiver
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 

--- a/src/sentry/notifications/activity/base.py
+++ b/src/sentry/notifications/activity/base.py
@@ -2,7 +2,7 @@ import re
 from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, Set, Tuple
 from urllib.parse import urlparse, urlunparse
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.html import escape
 from django.utils.safestring import SafeString, mark_safe
 

--- a/src/sentry/plugins/base/configuration.py
+++ b/src/sentry/plugins/base/configuration.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
-from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 

--- a/src/sentry/plugins/base/v1.py
+++ b/src/sentry/plugins/base/v1.py
@@ -3,8 +3,8 @@ __all__ = ("Plugin",)
 import logging
 from threading import local
 
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
+from django.urls import reverse
 
 from sentry.auth import access
 from sentry.plugins import HIDDEN_PLUGINS

--- a/src/sentry/plugins/bases/issue2.py
+++ b/src/sentry/plugins/bases/issue2.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.conf.urls import url
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.html import format_html
 from rest_framework.response import Response
 

--- a/src/sentry/plugins/providers/base.py
+++ b/src/sentry/plugins/providers/base.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework.response import Response
 
 from sentry.exceptions import InvalidIdentity, PluginError

--- a/src/sentry/plugins/providers/repository.py
+++ b/src/sentry/plugins/providers/repository.py
@@ -1,7 +1,7 @@
 from logging import getLogger
 
-from django.core.urlresolvers import reverse
 from django.db import IntegrityError, transaction
+from django.urls import reverse
 from rest_framework.response import Response
 
 from sentry.api.serializers import serialize

--- a/src/sentry/status_checks/warnings.py
+++ b/src/sentry/status_checks/warnings.py
@@ -1,6 +1,6 @@
 from urllib.parse import urljoin
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from .base import Problem, StatusCheck
 

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.exceptions import InvalidIdentity, PluginError
 from sentry.models import (

--- a/src/sentry/tasks/members.py
+++ b/src/sentry/tasks/members.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from structlog import get_logger
 
 from sentry import roles

--- a/src/sentry/tasks/sentry_apps.py
+++ b/src/sentry/tasks/sentry_apps.py
@@ -1,7 +1,7 @@
 import logging
 
 from celery.task import current
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from requests.exceptions import ConnectionError, RequestException, Timeout
 
 from sentry.api.serializers import AppPlatformEvent, serialize

--- a/src/sentry/templatetags/sentry_avatars.py
+++ b/src/sentry/templatetags/sentry_avatars.py
@@ -2,7 +2,7 @@ from urllib.parse import urlencode
 
 from django import template
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 from sentry.models import User, UserAvatar

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -37,11 +37,11 @@ from django.contrib.auth import login
 from django.contrib.auth.models import AnonymousUser
 from django.core import signing
 from django.core.cache import cache
-from django.core.urlresolvers import reverse
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.http import HttpRequest
 from django.test import TestCase, TransactionTestCase, override_settings
 from django.test.utils import CaptureQueriesContext
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from exam import Exam, before, fixture

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -4,7 +4,7 @@ from time import time
 from django.conf import settings
 from django.contrib.auth import login as _login
 from django.contrib.auth.backends import ModelBackend
-from django.core.urlresolvers import resolve, reverse
+from django.urls import resolve, reverse
 from django.utils.http import is_safe_url
 
 from sentry.models import Authenticator, User

--- a/src/sentry/utils/linksign.py
+++ b/src/sentry/utils/linksign.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlencode
 
 from django.core import signing
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry import options
 from sentry.models import User

--- a/src/sentry/web/decorators.py
+++ b/src/sentry/web/decorators.py
@@ -1,8 +1,8 @@
 from functools import wraps
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from sentry_sdk import Hub
 

--- a/src/sentry/web/frontend/account_identity.py
+++ b/src/sentry/web/frontend/account_identity.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.decorators.cache import never_cache
 
 from sentry.identity.pipeline import IdentityProviderPipeline

--- a/src/sentry/web/frontend/accounts.py
+++ b/src/sentry/web/frontend/accounts.py
@@ -4,10 +4,10 @@ from functools import partial, update_wrapper
 from django.contrib import messages
 from django.contrib.auth import authenticate
 from django.contrib.auth import login as login_user
-from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.template.context_processors import csrf
+from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -1,9 +1,9 @@
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import REDIRECT_FIELD_NAME
-from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.cache import never_cache
 

--- a/src/sentry/web/frontend/auth_organization_login.py
+++ b/src/sentry/web/frontend/auth_organization_login.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
-from django.core.urlresolvers import reverse
 from django.db import transaction
+from django.urls import reverse
 from django.views.decorators.cache import never_cache
 
 from sentry.auth.helper import AuthHelper

--- a/src/sentry/web/frontend/auth_provider_login.py
+++ b/src/sentry/web/frontend/auth_provider_login.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.auth.helper import AuthHelper
 from sentry.web.frontend.base import BaseView

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -1,6 +1,5 @@
 import logging
 
-from django.core.urlresolvers import reverse
 from django.http import (
     HttpResponse,
     HttpResponseBadRequest,
@@ -9,6 +8,7 @@ from django.http import (
 )
 from django.middleware.csrf import CsrfViewMiddleware
 from django.template.context_processors import csrf
+from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from sudo.views import redirect_to_sudo

--- a/src/sentry/web/frontend/debug/debug_organization_invite_request.py
+++ b/src/sentry/web/frontend/debug/debug_organization_invite_request.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.generic import View
 
 from sentry.models import Organization, User

--- a/src/sentry/web/frontend/debug/debug_organization_join_request.py
+++ b/src/sentry/web/frontend/debug/debug_organization_join_request.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.generic import View
 
 from sentry.models import Organization

--- a/src/sentry/web/frontend/debug/mail.py
+++ b/src/sentry/web/frontend/debug/mail.py
@@ -6,8 +6,8 @@ import uuid
 from datetime import datetime, timedelta
 from random import Random
 
-from django.core.urlresolvers import reverse
 from django.template.defaultfilters import slugify
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django.views.generic import View

--- a/src/sentry/web/frontend/integration_extension_configuration.py
+++ b/src/sentry/web/frontend/integration_extension_configuration.py
@@ -1,6 +1,6 @@
 from django.core.signing import SignatureExpired
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
+from django.urls import reverse
 from django.utils.http import urlencode
 
 from sentry import features, integrations

--- a/src/sentry/web/frontend/organization_auth_settings.py
+++ b/src/sentry/web/frontend/organization_auth_settings.py
@@ -1,9 +1,9 @@
 from django import forms
 from django.contrib import messages
-from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models import F
 from django.http import HttpResponse, HttpResponseRedirect
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from sentry import features, roles

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.identity.pipeline import IdentityProviderPipeline

--- a/src/sentry/web/frontend/project_event.py
+++ b/src/sentry/web/frontend/project_event.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect
+from django.urls import reverse
 
 from sentry import eventstore
 from sentry.web.frontend.base import ProjectView

--- a/src/sentry/web/frontend/restore_organization.py
+++ b/src/sentry/web/frontend/restore_organization.py
@@ -1,7 +1,7 @@
 import logging
 
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from sentry.api import client

--- a/src/sentry/web/frontend/unsubscribe_incident_notifications.py
+++ b/src/sentry/web/frontend/unsubscribe_incident_notifications.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.http import Http404
+from django.urls import reverse
 
 from sentry.incidents.logic import unsubscribe_from_incident
 from sentry.incidents.models import Incident

--- a/src/sentry_plugins/jira_ac/views.py
+++ b/src/sentry_plugins/jira_ac/views.py
@@ -1,8 +1,8 @@
 from urllib.parse import urlparse
 
-from django.core.urlresolvers import reverse
 from django.forms.utils import ErrorList
 from django.http import HttpResponse
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View

--- a/src/social_auth/backends/visualstudio.py
+++ b/src/social_auth/backends/visualstudio.py
@@ -6,7 +6,7 @@ and put into sentry.conf.py
 
 import requests
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.utils.http import absolute_uri
 from social_auth.backends import BaseOAuth2, OAuthBackend

--- a/src/social_auth/decorators.py
+++ b/src/social_auth/decorators.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from social_auth.backends import get_backend
 from social_auth.exceptions import WrongBackend

--- a/tests/apidocs/endpoints/events/test_project_event_details.py
+++ b/tests/apidocs/endpoints/events/test_project_event_details.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/events/test_project_events.py
+++ b/tests/apidocs/endpoints/events/test_project_events.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/events/test_project_tagkey_values.py
+++ b/tests/apidocs/endpoints/events/test_project_tagkey_values.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/integration-platform/test-sentry-app-external-issue-details.py
+++ b/tests/apidocs/endpoints/integration-platform/test-sentry-app-external-issue-details.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from sentry.models import SentryAppInstallation
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/integration-platform/test-sentry-app-external-issues.py
+++ b/tests/apidocs/endpoints/integration-platform/test-sentry-app-external-issues.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from sentry.models import SentryAppInstallation
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/integration-platform/test-sentry-app-installations.py
+++ b/tests/apidocs/endpoints/integration-platform/test-sentry-app-installations.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from sentry.models import SentryAppInstallation
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/organizations/test-event-id-lookup.py
+++ b/tests/apidocs/endpoints/organizations/test-event-id-lookup.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/organizations/test-org-details.py
+++ b/tests/apidocs/endpoints/organizations/test-org-details.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/organizations/test-org-index.py
+++ b/tests/apidocs/endpoints/organizations/test-org-index.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/organizations/test-org-projects.py
+++ b/tests/apidocs/endpoints/organizations/test-org-projects.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/organizations/test-org-repos.py
+++ b/tests/apidocs/endpoints/organizations/test-org-repos.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/organizations/test-org-stats.py
+++ b/tests/apidocs/endpoints/organizations/test-org-stats.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/organizations/test-org-users.py
+++ b/tests/apidocs/endpoints/organizations/test-org-users.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/organizations/test-repo-commits.py
+++ b/tests/apidocs/endpoints/organizations/test-repo-commits.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/organizations/test-shortid.py
+++ b/tests/apidocs/endpoints/organizations/test-shortid.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/projects/test-details.py
+++ b/tests/apidocs/endpoints/projects/test-details.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/projects/test-dsyms.py
+++ b/tests/apidocs/endpoints/projects/test-dsyms.py
@@ -2,8 +2,8 @@ import zipfile
 from io import BytesIO
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/projects/test-key-details.py
+++ b/tests/apidocs/endpoints/projects/test-key-details.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/projects/test-keys.py
+++ b/tests/apidocs/endpoints/projects/test-keys.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/projects/test-project-index.py
+++ b/tests/apidocs/endpoints/projects/test-project-index.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/projects/test-project-stats.py
+++ b/tests/apidocs/endpoints/projects/test-project-stats.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/projects/test-service-hook-details.py
+++ b/tests/apidocs/endpoints/projects/test-service-hook-details.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/projects/test-service-hooks.py
+++ b/tests/apidocs/endpoints/projects/test-service-hooks.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/projects/test-tag-values.py
+++ b/tests/apidocs/endpoints/projects/test-tag-values.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/projects/test-users.py
+++ b/tests/apidocs/endpoints/projects/test-users.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from sentry.models import EventUser
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/releases/test_deploys.py
+++ b/tests/apidocs/endpoints/releases/test_deploys.py
@@ -1,7 +1,7 @@
 import datetime
 
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from sentry.models import Deploy, Environment
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/releases/test_organization_release_commit_files.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_commit_files.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from sentry.models import Commit, CommitFileChange, ReleaseCommit
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/releases/test_organization_release_commits.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_commits.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from sentry.models import Commit, ReleaseCommit
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/releases/test_organization_release_details.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_details.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/releases/test_organization_release_file_details.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_file_details.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/releases/test_organization_release_files.py
+++ b/tests/apidocs/endpoints/releases/test_organization_release_files.py
@@ -1,6 +1,6 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/releases/test_organization_releases.py
+++ b/tests/apidocs/endpoints/releases/test_organization_releases.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from sentry.models import Release
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/releases/test_organization_sessions.py
+++ b/tests/apidocs/endpoints/releases/test_organization_sessions.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from sentry.testutils import SnubaTestCase
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/releases/test_project_issues_solved_in_release.py
+++ b/tests/apidocs/endpoints/releases/test_project_issues_solved_in_release.py
@@ -1,7 +1,7 @@
 from uuid import uuid1
 
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from sentry.models import Commit, GroupLink, GroupResolution, ReleaseCommit, Repository
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/releases/test_project_release_commits.py
+++ b/tests/apidocs/endpoints/releases/test_project_release_commits.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from sentry.models import Commit, ReleaseCommit
 from tests.apidocs.util import APIDocsTestCase

--- a/tests/apidocs/endpoints/releases/test_project_release_file_details.py
+++ b/tests/apidocs/endpoints/releases/test_project_release_file_details.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/releases/test_project_release_files.py
+++ b/tests/apidocs/endpoints/releases/test_project_release_files.py
@@ -1,6 +1,6 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/teams/test-by-slug.py
+++ b/tests/apidocs/endpoints/teams/test-by-slug.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/teams/test-index.py
+++ b/tests/apidocs/endpoints/teams/test-index.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/teams/test-projects.py
+++ b/tests/apidocs/endpoints/teams/test-projects.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/apidocs/endpoints/teams/test-stats.py
+++ b/tests/apidocs/endpoints/teams/test-stats.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test.client import RequestFactory
+from django.urls import reverse
 
 from tests.apidocs.util import APIDocsTestCase
 

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import AuthIdentity, AuthProvider
 from sentry.testutils import AuthProviderTestCase

--- a/tests/relay_integration/lang/java/test_plugin.py
+++ b/tests/relay_integration/lang/java/test_plugin.py
@@ -2,7 +2,7 @@ import zipfile
 from io import BytesIO
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import RelayStoreHelper, TransactionTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -1,8 +1,8 @@
 from datetime import timedelta
 from urllib.parse import parse_qsl
 
-from django.core.urlresolvers import reverse
 from django.db.models import F
+from django.urls import reverse
 
 from sentry.auth.authenticators import TotpInterface
 from sentry.models import (

--- a/tests/sentry/api/endpoints/test_accept_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_accept_project_transfer.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlencode
 from uuid import uuid4
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Project
 from sentry.testutils import APITestCase, PermissionTestCase

--- a/tests/sentry/api/endpoints/test_api_application_details.py
+++ b/tests/sentry/api/endpoints/test_api_application_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ApiApplication, ApiApplicationStatus
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_api_applications.py
+++ b/tests/sentry/api/endpoints/test_api_applications.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ApiApplication
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_api_tokens.py
+++ b/tests/sentry/api/endpoints/test_api_tokens.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ApiToken
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_assistant.py
+++ b/tests/sentry/api/endpoints/test_assistant.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 from exam import fixture
 

--- a/tests/sentry/api/endpoints/test_auth.py
+++ b/tests/sentry/api/endpoints/test_auth.py
@@ -1,6 +1,6 @@
 import base64
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_auth_login.py
+++ b/tests/sentry/api/endpoints/test_auth_login.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -2,7 +2,7 @@ from hashlib import sha1
 
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry import options
 from sentry.api.endpoints.chunk import (

--- a/tests/sentry/api/endpoints/test_commit_filechange.py
+++ b/tests/sentry/api/endpoints/test_commit_filechange.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Commit, CommitFileChange, Release, ReleaseCommit, Repository
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_debug_files.py
+++ b/tests/sentry/api/endpoints/test_debug_files.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from uuid import uuid4
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import File, ProjectDebugFile, Release, ReleaseFile
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_dif_assemble.py
+++ b/tests/sentry/api/endpoints/test_dif_assemble.py
@@ -1,7 +1,7 @@
 from hashlib import sha1
 
 from django.core.files.base import ContentFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ApiToken, File, FileBlob, FileBlobIndex, FileBlobOwner
 from sentry.models.debugfile import ProjectDebugFile

--- a/tests/sentry/api/endpoints/test_event_committers.py
+++ b/tests/sentry/api/endpoints/test_event_committers.py
@@ -1,6 +1,6 @@
 import copy
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 from sentry.testutils.factories import DEFAULT_EVENT_DATA

--- a/tests/sentry/api/endpoints/test_event_owners.py
+++ b/tests/sentry/api/endpoints/test_event_owners.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ProjectOwnership
 from sentry.ownership.grammar import Matcher, Owner, Rule, dump_schema

--- a/tests/sentry/api/endpoints/test_group_tombstone.py
+++ b/tests/sentry/api/endpoints/test_group_tombstone.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import GroupHash, GroupTombstone
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_group_tombstone_details.py
+++ b/tests/sentry/api/endpoints/test_group_tombstone_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import GroupHash, GroupTombstone
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_index.py
+++ b/tests/sentry/api/endpoints/test_index.py
@@ -1,6 +1,6 @@
 from base64 import b64encode
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ApiKey, ApiToken
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_access_request_details.py
+++ b/tests/sentry/api/endpoints/test_organization_access_request_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import OrganizationAccessRequest, OrganizationMemberTeam
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_access_requests.py
+++ b/tests/sentry/api/endpoints/test_organization_access_requests.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import OrganizationAccessRequest
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_auth_provider_details.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_provider_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import PermissionTestCase
 

--- a/tests/sentry/api/endpoints/test_organization_auth_providers.py
+++ b/tests/sentry/api/endpoints/test_organization_auth_providers.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase, PermissionTestCase
 

--- a/tests/sentry/api/endpoints/test_organization_code_mapping_details.py
+++ b/tests/sentry/api/endpoints/test_organization_code_mapping_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.api.serializers import serialize
 from sentry.models import Integration, Repository, RepositoryProjectPathConfig

--- a/tests/sentry/api/endpoints/test_organization_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_code_mappings.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Integration, Repository, RepositoryProjectPathConfig
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_config_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_config_repositories.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 from sentry.utils.compat import filter

--- a/tests/sentry/api/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import (
     Dashboard,

--- a/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboard_widget_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import OrganizationDashboardWidgetTestCase
 

--- a/tests/sentry/api/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/api/endpoints/test_organization_dashboards.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Dashboard, DashboardTombstone
 from sentry.testutils import OrganizationDashboardWidgetTestCase

--- a/tests/sentry/api/endpoints/test_organization_invite_request_index.py
+++ b/tests/sentry/api/endpoints/test_organization_invite_request_index.py
@@ -1,5 +1,5 @@
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.models import (

--- a/tests/sentry/api/endpoints/test_organization_member_details.py
+++ b/tests/sentry/api/endpoints/test_organization_member_details.py
@@ -1,6 +1,6 @@
 from django.core import mail
-from django.core.urlresolvers import reverse
 from django.db.models import F
+from django.urls import reverse
 
 from sentry.auth.authenticators import RecoveryCodeInterface, TotpInterface
 from sentry.models import (

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -1,5 +1,5 @@
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry import roles
 from sentry.api.endpoints.organization_member_index import OrganizationMemberSerializer

--- a/tests/sentry/api/endpoints/test_organization_member_issues_assigned.py
+++ b/tests/sentry/api/endpoints/test_organization_member_issues_assigned.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry.models import GroupAssignee, ProjectStatus

--- a/tests/sentry/api/endpoints/test_organization_onboarding_tasks.py
+++ b/tests/sentry/api/endpoints/test_organization_onboarding_tasks.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import OnboardingTask, OnboardingTaskStatus, OrganizationOnboardingTask
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_plugins.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_plugins_configs.py
+++ b/tests/sentry/api/endpoints/test_organization_plugins_configs.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
+++ b/tests/sentry/api/endpoints/test_organization_projects_sent_first_event.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_organization_relay_usage.py
+++ b/tests/sentry/api/endpoints/test_organization_relay_usage.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import pytz
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.models import RelayUsage

--- a/tests/sentry/api/endpoints/test_organization_release_assemble.py
+++ b/tests/sentry/api/endpoints/test_organization_release_assemble.py
@@ -1,7 +1,7 @@
 from hashlib import sha1
 
 from django.core.files.base import ContentFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ApiToken, FileBlob, FileBlobOwner
 from sentry.tasks.assemble import ChunkFileState, assemble_artifacts

--- a/tests/sentry/api/endpoints/test_organization_release_commits.py
+++ b/tests/sentry/api/endpoints/test_organization_release_commits.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Commit, Release, ReleaseCommit, Repository
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_release_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_details.py
@@ -2,7 +2,7 @@ import unittest
 from datetime import datetime
 
 import pytz
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.api.endpoints.organization_release_details import OrganizationReleaseSerializer
 from sentry.app import locks

--- a/tests/sentry/api/endpoints/test_organization_release_file_details.py
+++ b/tests/sentry/api/endpoints/test_organization_release_file_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import File, Release, ReleaseFile
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_release_files.py
+++ b/tests/sentry/api/endpoints/test_organization_release_files.py
@@ -1,5 +1,5 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import File, Release, ReleaseFile
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_release_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_release_meta.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import (
     Commit,

--- a/tests/sentry/api/endpoints/test_organization_release_previous_commits.py
+++ b/tests/sentry/api/endpoints/test_organization_release_previous_commits.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Commit, Release, ReleaseCommit, Repository
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -2,7 +2,7 @@ from base64 import b64encode
 from datetime import datetime, timedelta
 
 import pytz
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.api.endpoints.organization_releases import (

--- a/tests/sentry/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/api/endpoints/test_organization_repositories.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.example import ExampleRepositoryProvider

--- a/tests/sentry/api/endpoints/test_organization_repository_commits.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_commits.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Commit, Repository
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_repository_details.py
+++ b/tests/sentry/api/endpoints/test_organization_repository_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.constants import ObjectStatus
 from sentry.models import Commit, Integration, OrganizationOption, Repository

--- a/tests/sentry/api/endpoints/test_organization_sdk_updates.py
+++ b/tests/sentry/api/endpoints/test_organization_sdk_updates.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.sdk_updates import SdkIndexState
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installation_details.py
@@ -1,5 +1,5 @@
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.constants import SentryAppInstallationStatus
 from sentry.mediators.token_exchange import GrantExchanger

--- a/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_app_installations.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import SentryAppInstallation
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_organization_sentry_apps.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 from sentry.utils import json

--- a/tests/sentry/api/endpoints/test_organization_shortid.py
+++ b/tests/sentry/api/endpoints/test_organization_shortid.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_organization_stats.py
+++ b/tests/sentry/api/endpoints/test_organization_stats.py
@@ -1,7 +1,7 @@
 import functools
 import sys
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry import tsdb
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.models import OrganizationMember, OrganizationMemberTeam, Team

--- a/tests/sentry/api/endpoints/test_organization_user_issues.py
+++ b/tests/sentry/api/endpoints/test_organization_user_issues.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import EventUser, OrganizationMemberTeam
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/sentry/api/endpoints/test_organization_user_issues_search.py
+++ b/tests/sentry/api/endpoints/test_organization_user_issues_search.py
@@ -1,6 +1,6 @@
 from urllib.parse import urlencode
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import OrganizationMemberTeam
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/sentry/api/endpoints/test_project_agnostic_rule_conditions.py
+++ b/tests/sentry/api/endpoints/test_project_agnostic_rule_conditions.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_alert_rule_task_details.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.integrations.slack.tasks import RedisRuleStatus
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_avatar.py
+++ b/tests/sentry/api/endpoints/test_project_avatar.py
@@ -1,6 +1,6 @@
 from base64 import b64encode
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ProjectAvatar
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Integration, ProjectCodeOwners
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_codeowners_details.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ProjectCodeOwners
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_create_sample.py
+++ b/tests/sentry/api/endpoints/test_project_create_sample.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models.groupinbox import GroupInbox
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_environment_details.py
+++ b/tests/sentry/api/endpoints/test_project_environment_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Environment, EnvironmentProject
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_environments.py
+++ b/tests/sentry/api/endpoints/test_project_environments.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Environment, EnvironmentProject
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_key_details.py
+++ b/tests/sentry/api/endpoints/test_project_key_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ProjectKey, ProjectKeyStatus
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_keys.py
+++ b/tests/sentry/api/endpoints/test_project_keys.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ProjectKey
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_member_index.py
+++ b/tests/sentry/api/endpoints/test_project_member_index.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_project_ownership.py
+++ b/tests/sentry/api/endpoints/test_project_ownership.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_project_plugin_details.py
+++ b/tests/sentry/api/endpoints/test_project_plugin_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import AuditLogEntry, ProjectOption
 from sentry.plugins.base import plugins

--- a/tests/sentry/api/endpoints/test_project_plugins.py
+++ b/tests/sentry/api/endpoints/test_project_plugins.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.plugins.base import plugins
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_processingissues.py
+++ b/tests/sentry/api/endpoints/test_project_processingissues.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry.models import EventError, EventProcessingIssue, ProcessingIssue, RawEvent

--- a/tests/sentry/api/endpoints/test_project_release_commits.py
+++ b/tests/sentry/api/endpoints/test_project_release_commits.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Commit, Release, ReleaseCommit, Repository
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_release_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_details.py
@@ -2,7 +2,7 @@ import unittest
 from datetime import datetime
 
 import pytz
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.api.endpoints.project_release_details import ReleaseSerializer
 from sentry.constants import MAX_VERSION_LENGTH

--- a/tests/sentry/api/endpoints/test_project_release_file_details.py
+++ b/tests/sentry/api/endpoints/test_project_release_file_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import File, Release, ReleaseFile
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_release_files.py
+++ b/tests/sentry/api/endpoints/test_project_release_files.py
@@ -1,5 +1,5 @@
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import File, Release, ReleaseFile
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_release_setup.py
+++ b/tests/sentry/api/endpoints/test_project_release_setup.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Commit, ReleaseCommit, Repository
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_release_token.py
+++ b/tests/sentry/api/endpoints/test_project_release_token.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ProjectOption
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_releases.py
+++ b/tests/sentry/api/endpoints/test_project_releases.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 import pytz
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 from exam import fixture
 

--- a/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
+++ b/tests/sentry/api/endpoints/test_project_repo_path_parsing.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Integration
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1,5 +1,5 @@
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Environment, Integration, Rule, RuleActivity, RuleActivityType, RuleStatus
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_rule_task_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_task_details.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 from sentry.utils.compat.mock import patch

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Environment, Integration, Rule, RuleActivity, RuleActivityType
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_search_details.py
+++ b/tests/sentry/api/endpoints/test_project_search_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import SavedSearch, SavedSearchUserDefault
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_searches.py
+++ b/tests/sentry/api/endpoints/test_project_searches.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import SavedSearch, SavedSearchUserDefault
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.integrations.example.integration import ExampleIntegration
 from sentry.models import Integration, OrganizationIntegration

--- a/tests/sentry/api/endpoints/test_project_stats.py
+++ b/tests/sentry/api/endpoints/test_project_stats.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry import tsdb
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_project_tagkey_details.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry import tagstore
 from sentry.tagstore import TagKeyStatus

--- a/tests/sentry/api/endpoints/test_project_tagkey_values.py
+++ b/tests/sentry/api/endpoints/test_project_tagkey_values.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/sentry/api/endpoints/test_project_transfer.py
+++ b/tests/sentry/api/endpoints/test_project_transfer.py
@@ -1,5 +1,5 @@
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 from sentry.utils.compat import mock

--- a/tests/sentry/api/endpoints/test_project_user_stats.py
+++ b/tests/sentry/api/endpoints/test_project_user_stats.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry import tsdb

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import EventUser
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_prompts_activity.py
+++ b/tests/sentry/api/endpoints/test_prompts_activity.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_relay_healthcheck.py
+++ b/tests/sentry/api/endpoints/test_relay_healthcheck.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test import Client
+from django.urls import reverse
 
 
 def test_healthcheck_endpoint():

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -2,7 +2,7 @@ import re
 from uuid import uuid4
 
 import pytest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from sentry_relay.auth import generate_key_pair
 
 from sentry import quotas

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -2,7 +2,7 @@ import re
 from uuid import uuid4
 
 import pytest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from sentry_relay.auth import generate_key_pair
 
 from sentry import quotas

--- a/tests/sentry/api/endpoints/test_relay_projectids.py
+++ b/tests/sentry/api/endpoints/test_relay_projectids.py
@@ -1,7 +1,7 @@
 import re
 from uuid import uuid4
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from sentry_relay.auth import generate_key_pair
 
 from sentry.models.relay import Relay

--- a/tests/sentry/api/endpoints/test_relay_publickeys.py
+++ b/tests/sentry/api/endpoints/test_relay_publickeys.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from uuid import uuid4
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from sentry_relay import generate_key_pair
 
 from sentry.models import Relay

--- a/tests/sentry/api/endpoints/test_relay_register.py
+++ b/tests/sentry/api/endpoints/test_relay_register.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 from sentry_relay import generate_key_pair
 

--- a/tests/sentry/api/endpoints/test_release_deploys.py
+++ b/tests/sentry/api/endpoints/test_release_deploys.py
@@ -1,6 +1,6 @@
 import datetime
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Deploy, Environment, Release, ReleaseProjectEnvironment
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_authorizations.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry.models import ApiApplication, ApiToken

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.constants import SentryAppStatus
 from sentry.models import OrganizationMember, SentryApp

--- a/tests/sentry/api/endpoints/test_sentry_app_features.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_features.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import IntegrationFeature
 from sentry.models.integrationfeature import Feature

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_actions.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_issue_actions.py
@@ -1,5 +1,5 @@
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import PlatformExternalIssue
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_issues.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_issues.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import PlatformExternalIssue
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_installation_external_requests.py
@@ -1,5 +1,5 @@
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.http import urlencode
 
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_sentry_app_interaction.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_interaction.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_publish_request.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.constants import SentryAppStatus
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_sentry_app_requests.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_requests.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/sentry/api/endpoints/test_sentry_app_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_stats.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 from sentry.utils.dates import to_timestamp

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -1,6 +1,6 @@
 import re
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.constants import SentryAppStatus
 from sentry.mediators import sentry_apps

--- a/tests/sentry/api/endpoints/test_sentry_apps_stats.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps_stats.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 from sentry.utils import json

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_token_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.mediators.token_exchange import GrantExchanger
 from sentry.models import ApiToken

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import ApiToken
 from sentry.models.sentryapp import MASKED_VALUE

--- a/tests/sentry/api/endpoints/test_setup_wizard.py
+++ b/tests/sentry/api/endpoints/test_setup_wizard.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_sudo.py
+++ b/tests/sentry/api/endpoints/test_sudo.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_system_health.py
+++ b/tests/sentry/api/endpoints/test_system_health.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase
 

--- a/tests/sentry/api/endpoints/test_system_options.py
+++ b/tests/sentry/api/endpoints/test_system_options.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry import options
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_team_avatar.py
+++ b/tests/sentry/api/endpoints/test_team_avatar.py
@@ -1,6 +1,6 @@
 from base64 import b64encode
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import TeamAvatar
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_team_projects.py
+++ b/tests/sentry/api/endpoints/test_team_projects.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Project, Rule
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_team_stats.py
+++ b/tests/sentry/api/endpoints/test_team_stats.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry import tsdb
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_user_authenticator_details.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_details.py
@@ -1,8 +1,8 @@
 import datetime
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db.models import F
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry.auth.authenticators import RecoveryCodeInterface, SmsInterface, TotpInterface

--- a/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_enroll.py
@@ -2,8 +2,8 @@ import os
 from urllib.parse import parse_qsl
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db.models import F
+from django.urls import reverse
 
 from sentry.models import (
     AuditLogEntry,

--- a/tests/sentry/api/endpoints/test_user_authenticator_index.py
+++ b/tests/sentry/api/endpoints/test_user_authenticator_index.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.auth.authenticators import TotpInterface
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_user_authenticators_index.py
+++ b/tests/sentry/api/endpoints/test_user_authenticators_index.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Authenticator
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_user_avatar.py
+++ b/tests/sentry/api/endpoints/test_user_avatar.py
@@ -1,6 +1,6 @@
 from base64 import b64encode
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import UserAvatar
 from sentry.testutils import APITestCase

--- a/tests/sentry/api/endpoints/test_user_emails.py
+++ b/tests/sentry/api/endpoints/test_user_emails.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import User, UserEmail
 from sentry.testutils import APITestCase

--- a/tests/sentry/data_export/test_models.py
+++ b/tests/sentry/data_export/test_models.py
@@ -2,7 +2,7 @@ import tempfile
 from datetime import timedelta
 
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry.data_export.base import DEFAULT_EXPIRATION, ExportQueryType, ExportStatus

--- a/tests/sentry/demo/test_middleware.py
+++ b/tests/sentry/demo/test_middleware.py
@@ -1,6 +1,6 @@
 import pytest
-from django.core.urlresolvers import reverse
 from django.test import override_settings
+from django.urls import reverse
 
 from sentry.demo.settings import MIDDLEWARE_CLASSES
 from sentry.testutils import APITestCase

--- a/tests/sentry/incidents/endpoints/test_organization_incident_seen.py
+++ b/tests/sentry/incidents/endpoints/test_organization_incident_seen.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.incidents.models import IncidentSeen

--- a/tests/sentry/incidents/test_action_handlers.py
+++ b/tests/sentry/incidents/test_action_handlers.py
@@ -3,7 +3,7 @@ from urllib.parse import parse_qs
 
 import responses
 from django.core import mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 from exam import fixture
 from freezegun import freeze_time

--- a/tests/sentry/incidents/test_tasks.py
+++ b/tests/sentry/incidents/test_tasks.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 from exam import fixture, patcher
 from freezegun import freeze_time

--- a/tests/sentry/integrations/bitbucket/test_integration.py
+++ b/tests/sentry/integrations/bitbucket/test_integration.py
@@ -1,7 +1,7 @@
 from urllib.parse import quote, urlencode
 
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Integration
 from sentry.testutils import APITestCase

--- a/tests/sentry/integrations/bitbucket/test_search.py
+++ b/tests/sentry/integrations/bitbucket/test_search.py
@@ -1,5 +1,5 @@
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Integration
 from sentry.testutils import APITestCase

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Identity, IdentityProvider, Integration
 from sentry.testutils import APITestCase

--- a/tests/sentry/integrations/gitlab/test_search.py
+++ b/tests/sentry/integrations/gitlab/test_search.py
@@ -1,7 +1,7 @@
 from urllib.parse import parse_qs
 
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.utils import json
 

--- a/tests/sentry/integrations/jira/test_integration.py
+++ b/tests/sentry/integrations/jira/test_integration.py
@@ -2,8 +2,8 @@ import copy
 
 import pytest
 import responses
-from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
+from django.urls import reverse
 from exam import fixture
 
 from sentry.integrations.jira import JiraIntegrationProvider

--- a/tests/sentry/integrations/jira/test_search_endpoint.py
+++ b/tests/sentry/integrations/jira/test_search_endpoint.py
@@ -1,7 +1,7 @@
 from urllib.parse import parse_qs, urlparse
 
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.models import Integration

--- a/tests/sentry/integrations/jira/test_webhooks.py
+++ b/tests/sentry/integrations/jira/test_webhooks.py
@@ -1,6 +1,6 @@
 import responses
-from django.core.urlresolvers import reverse
 from django.test.utils import override_settings
+from django.urls import reverse
 
 from sentry.integrations.issues import IssueSyncMixin
 from sentry.models import Integration

--- a/tests/sentry/integrations/jira_server/test_search.py
+++ b/tests/sentry/integrations/jira_server/test_search.py
@@ -1,7 +1,7 @@
 from urllib.parse import parse_qs, urlparse
 
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.models import Identity, IdentityProvider, IdentityStatus, Integration

--- a/tests/sentry/integrations/jira_server/test_webhooks.py
+++ b/tests/sentry/integrations/jira_server/test_webhooks.py
@@ -1,6 +1,6 @@
 import jwt
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 from requests.exceptions import ConnectionError
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.incidents.logic import CRITICAL_TRIGGER_LABEL
 from sentry.integrations.slack.message_builder.incidents import build_incident_attachment

--- a/tests/sentry/integrations/test_ticket_rules.py
+++ b/tests/sentry/integrations/test_ticket_rules.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from rest_framework.test import APITestCase as BaseAPITestCase
 
 from sentry.integrations.jira import JiraCreateTicketAction

--- a/tests/sentry/integrations/vsts_extension/test_provider.py
+++ b/tests/sentry/integrations/vsts_extension/test_provider.py
@@ -1,6 +1,6 @@
 from urllib.parse import parse_qs, urlparse
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.integrations.vsts import VstsIntegrationProvider
 from sentry.integrations.vsts_extension import (

--- a/tests/sentry/models/test_debugfile.py
+++ b/tests/sentry/models/test_debugfile.py
@@ -4,7 +4,7 @@ import zipfile
 from io import BytesIO
 
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import DifMeta, File, ProjectDebugFile, debugfile
 from sentry.testutils import APITestCase, TestCase

--- a/tests/sentry/models/tests.py
+++ b/tests/sentry/models/tests.py
@@ -2,8 +2,8 @@ from datetime import timedelta
 
 import pytest
 from django.core import mail
-from django.core.urlresolvers import reverse
 from django.http import HttpRequest
+from django.urls import reverse
 from django.utils import timezone
 from exam import fixture
 

--- a/tests/sentry/tasks/test_sentry_apps.py
+++ b/tests/sentry/tasks/test_sentry_apps.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 import pytest
 from celery import Task
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from requests.exceptions import Timeout
 
 from sentry.api.serializers import serialize

--- a/tests/sentry/utils/auth/tests.py
+++ b/tests/sentry/utils/auth/tests.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import AnonymousUser
-from django.core.urlresolvers import reverse
 from django.http import HttpRequest
+from django.urls import reverse
 
 from sentry.models import User
 from sentry.testutils import TestCase

--- a/tests/sentry/web/api/tests.py
+++ b/tests/sentry/web/api/tests.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_account_identity.py
+++ b/tests/sentry/web/frontend/test_account_identity.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.encoding import force_bytes
 from exam import before
 

--- a/tests/sentry/web/frontend/test_accounts.py
+++ b/tests/sentry/web/frontend/test_accounts.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.models import LostPasswordHash

--- a/tests/sentry/web/frontend/test_auth_close.py
+++ b/tests/sentry/web/frontend/test_auth_close.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.http import urlquote
 from exam import fixture
 

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -1,7 +1,7 @@
 import pytest
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.test import override_settings
+from django.urls import reverse
 from django.utils.http import urlquote
 from exam import fixture
 

--- a/tests/sentry/web/frontend/test_auth_logout.py
+++ b/tests/sentry/web/frontend/test_auth_logout.py
@@ -1,6 +1,6 @@
 from urllib.parse import quote
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_auth_oauth2.py
+++ b/tests/sentry/web/frontend/test_auth_oauth2.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from urllib.parse import parse_qs, urlencode, urlparse
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.auth.providers.oauth2 import OAuth2Callback, OAuth2Login, OAuth2Provider

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test import override_settings
+from django.urls import reverse
 from exam import fixture
 
 from sentry.models import (

--- a/tests/sentry/web/frontend/test_auth_saml2.py
+++ b/tests/sentry/web/frontend/test_auth_saml2.py
@@ -3,8 +3,8 @@ from urllib.parse import parse_qs, urlencode, urlparse
 
 import pytest
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 from exam import fixture
 
 from sentry.auth.authenticators import TotpInterface

--- a/tests/sentry/web/frontend/test_csrf_failure.py
+++ b/tests/sentry/web/frontend/test_csrf_failure.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test import override_settings
+from django.urls import reverse
 
 from sentry.testutils import TestCase
 

--- a/tests/sentry/web/frontend/test_error_404.py
+++ b/tests/sentry/web/frontend/test_error_404.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test import override_settings
+from django.urls import reverse
 
 from sentry.testutils import TestCase
 

--- a/tests/sentry/web/frontend/test_error_500.py
+++ b/tests/sentry/web/frontend/test_error_500.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.test import override_settings
+from django.urls import reverse
 
 from sentry.testutils import TestCase
 

--- a/tests/sentry/web/frontend/test_error_page_embed.py
+++ b/tests/sentry/web/frontend/test_error_page_embed.py
@@ -2,8 +2,8 @@ import logging
 from urllib.parse import quote, urlencode
 from uuid import uuid4
 
-from django.core.urlresolvers import reverse
 from django.test import override_settings
+from django.urls import reverse
 
 from sentry.models import Environment, UserReport
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_home.py
+++ b/tests/sentry/web/frontend/test_home.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_js_sdk_loader.py
+++ b/tests/sentry/web/frontend/test_js_sdk_loader.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
+++ b/tests/sentry/web/frontend/test_mailgun_inbound_webhook.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import TestCase
 from sentry.utils.compat import mock

--- a/tests/sentry/web/frontend/test_organization_auth_settings.py
+++ b/tests/sentry/web/frontend/test_organization_auth_settings.py
@@ -1,5 +1,5 @@
-from django.core.urlresolvers import reverse
 from django.db import models
+from django.urls import reverse
 
 from sentry.auth.authenticators import TotpInterface
 from sentry.auth.exceptions import IdentityNotValid

--- a/tests/sentry/web/frontend/test_organization_avatar.py
+++ b/tests/sentry/web/frontend/test_organization_avatar.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import File, OrganizationAvatar
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_project_avatar.py
+++ b/tests/sentry/web/frontend/test_project_avatar.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import File, ProjectAvatar
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_project_event.py
+++ b/tests/sentry/web/frontend/test_project_event.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/sentry/web/frontend/test_react_page.py
+++ b/tests/sentry/web/frontend/test_react_page.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import TestCase
 

--- a/tests/sentry/web/frontend/test_reactivate_account.py
+++ b/tests/sentry/web/frontend/test_reactivate_account.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_release_webhook.py
+++ b/tests/sentry/web/frontend/test_release_webhook.py
@@ -1,7 +1,7 @@
 import hmac
 from hashlib import sha256
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.models import ProjectOption

--- a/tests/sentry/web/frontend/test_restore_organization.py
+++ b/tests/sentry/web/frontend/test_restore_organization.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import Organization, OrganizationStatus
 from sentry.testutils import PermissionTestCase, TestCase

--- a/tests/sentry/web/frontend/test_setup_wizard.py
+++ b/tests/sentry/web/frontend/test_setup_wizard.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.api.endpoints.setup_wizard import SETUP_WIZARD_CACHE_KEY
 from sentry.cache import default_cache

--- a/tests/sentry/web/frontend/test_team_avatar.py
+++ b/tests/sentry/web/frontend/test_team_avatar.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import File, TeamAvatar
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_user_avatar.py
+++ b/tests/sentry/web/frontend/test_user_avatar.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import File, UserAvatar
 from sentry.testutils import TestCase

--- a/tests/sentry/web/frontend/test_vsts_extension_configuration.py
+++ b/tests/sentry/web/frontend/test_vsts_extension_configuration.py
@@ -1,6 +1,6 @@
 from urllib.parse import parse_qsl, urlparse
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.models import OrganizationMember
 from sentry.testutils import TestCase

--- a/tests/sentry/web/generic/tests.py
+++ b/tests/sentry/web/generic/tests.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import TestCase
 

--- a/tests/sentry_plugins/gitlab/test_plugin.py
+++ b/tests/sentry_plugins/gitlab/test_plugin.py
@@ -1,6 +1,6 @@
 import responses
-from django.core.urlresolvers import reverse
 from django.test import RequestFactory
+from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import PluginTestCase

--- a/tests/sentry_plugins/jira/test_plugin.py
+++ b/tests/sentry_plugins/jira/test_plugin.py
@@ -1,7 +1,7 @@
 import responses
 from django.contrib.auth.models import AnonymousUser
-from django.core.urlresolvers import reverse
 from django.test import RequestFactory
+from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import TestCase

--- a/tests/sentry_plugins/pagerduty/test_plugin.py
+++ b/tests/sentry_plugins/pagerduty/test_plugin.py
@@ -1,5 +1,5 @@
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.models import Rule

--- a/tests/sentry_plugins/pivotal/test_pivotal_plugin.py
+++ b/tests/sentry_plugins/pivotal/test_pivotal_plugin.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import PluginTestCase

--- a/tests/sentry_plugins/pushover/test_plugin.py
+++ b/tests/sentry_plugins/pushover/test_plugin.py
@@ -1,7 +1,7 @@
 from urllib.parse import parse_qs
 
 import responses
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.models import Rule

--- a/tests/snuba/api/endpoints/test_discover_key_transactions.py
+++ b/tests/snuba/api/endpoints/test_discover_key_transactions.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.discover.models import MAX_KEY_TRANSACTIONS, KeyTransaction
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/snuba/api/endpoints/test_discover_query.py
+++ b/tests/snuba/api/endpoints/test_discover_query.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 import pytest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.discover.models import DiscoverSavedQuery
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_query_detail.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse
 
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryProject
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse
 
 from sentry.models import Group
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/snuba/api/endpoints/test_organization_eventid.py
+++ b/tests/snuba/api/endpoints/test_organization_eventid.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/snuba/api/endpoints/test_organization_events_facets.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from uuid import uuid4
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 from pytz import utc
 from rest_framework.exceptions import ParseError

--- a/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
+++ b/tests/snuba/api/endpoints/test_organization_events_facets_performance.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now

--- a/tests/snuba/api/endpoints/test_organization_events_geo.py
+++ b/tests/snuba/api/endpoints/test_organization_events_geo.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/snuba/api/endpoints/test_organization_events_histogram.py
+++ b/tests/snuba/api/endpoints/test_organization_events_histogram.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from datetime import timedelta
 
 import pytest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/snuba/api/endpoints/test_organization_events_meta.py
+++ b/tests/snuba/api/endpoints/test_organization_events_meta.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from pytz import utc
 from rest_framework.exceptions import ParseError
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 from uuid import uuid4
 
 import pytest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from pytz import utc
 
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/snuba/api/endpoints/test_organization_events_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 from uuid import uuid4
 
-from django.core.urlresolvers import NoReverseMatch, reverse
+from django.urls import NoReverseMatch, reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/snuba/api/endpoints/test_organization_events_trends.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trends.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.api.endpoints.organization_events_trends import OrganizationEventsTrendsEndpointBase
 from sentry.api.event_search import get_filter

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1,7 +1,7 @@
 from base64 import b64encode
 
 import pytest
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from pytz import utc
 
 from sentry.discover.models import KeyTransaction

--- a/tests/snuba/api/endpoints/test_organization_events_vitals.py
+++ b/tests/snuba/api/endpoints/test_organization_events_vitals.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 from uuid import uuid4
 
 from dateutil.parser import parse as parse_datetime
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry import options

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -2,7 +2,7 @@ import datetime
 from uuid import uuid4
 
 import pytz
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from freezegun import freeze_time
 
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/snuba/api/endpoints/test_organization_stats_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_stats_v2.py
@@ -2,7 +2,7 @@ import functools
 from datetime import datetime, timedelta
 
 import pytz
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from freezegun import freeze_time
 
 from sentry.constants import DataCategory

--- a/tests/snuba/api/endpoints/test_organization_tagkey_values.py
+++ b/tests/snuba/api/endpoints/test_organization_tagkey_values.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from exam import fixture
 
 from sentry.testutils import APITestCase, SnubaTestCase

--- a/tests/snuba/api/endpoints/test_organization_tags.py
+++ b/tests/snuba/api/endpoints/test_organization_tags.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/snuba/api/endpoints/test_project_event_details.py
+++ b/tests/snuba/api/endpoints/test_project_event_details.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.testutils import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format

--- a/tests/symbolicator/test_minidump_full.py
+++ b/tests/symbolicator/test_minidump_full.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry import eventstore
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -4,7 +4,7 @@ from io import BytesIO
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry import eventstore
 from sentry.models import File, ProjectDebugFile

--- a/tests/symbolicator/test_unreal_full.py
+++ b/tests/symbolicator/test_unreal_full.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 from sentry.models import EventAttachment, File


### PR DESCRIPTION
This was depecated in 1.10:
> Importing from the django.core.urlresolvers module is deprecated in favor of its new location, django.urls.

https://docs.djangoproject.com/en/3.1/releases/1.10/#id3