### PR TITLE
fix(api): Improve project_users endpoint for email query

### DIFF
--- a/src/sentry/api/endpoints/project_users.py
+++ b/src/sentry/api/endpoints/project_users.py
@@ -26,24 +26,22 @@ class ProjectUsersEndpoint(ProjectEndpoint):
         """
         queryset = EventUser.objects.filter(project_id=project.id)
         if request.GET.get("query"):
-            pieces = request.GET["query"].strip().split(":", 1)
-            if len(pieces) != 2:
+            try:
+                field, identifier = request.GET["query"].strip().split(":", 1)
+            except ValueError:
                 return Response([])
             # username and ip can return multiple eventuser objects
-            if any(p in "ip" or p in "username" for p in pieces):
-                try:
-                    queryset = queryset.filter(
-                        project_id=project.id,
-                        **{f"{EventUser.attr_from_keyword(pieces[0])}__icontains": pieces[1]},
-                    )
-                except EventUser.DoesNotExist:
-                    return Response(status=status.HTTP_404_NOT_FOUND)
+            if field in ("ip", "username"):
+                queryset = queryset.filter(
+                    project_id=project.id,
+                    **{EventUser.attr_from_keyword(field): identifier},
+                )
             else:
                 try:
                     queryset = [
                         queryset.get(
                             project_id=project.id,
-                            **{f"{EventUser.attr_from_keyword(pieces[0])}": pieces[1]},
+                            **{EventUser.attr_from_keyword(field): identifier},
                         )
                     ]
                 except EventUser.DoesNotExist:

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -78,8 +78,7 @@ class ProjectUsersTest(APITestCase):
 
         response = self.client.get(f"{self.path}?query=email:@example.com", format="json")
 
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 2
+        assert response.status_code == 404, response.content
 
     def test_id_search(self):
         self.login_as(user=self.user)
@@ -92,8 +91,7 @@ class ProjectUsersTest(APITestCase):
 
         response = self.client.get(f"{self.path}?query=id:3", format="json")
 
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 0
+        assert response.status_code == 404, response.content
 
     def test_ip_search(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_project_users.py
+++ b/tests/sentry/api/endpoints/test_project_users.py
@@ -65,7 +65,7 @@ class ProjectUsersTest(APITestCase):
         response = self.client.get(f"{self.path}?query=username:ba", format="json")
 
         assert response.status_code == 200, response.content
-        assert len(response.data) == 2
+        assert len(response.data) == 0
 
     def test_email_search(self):
         self.login_as(user=self.user)
@@ -101,8 +101,3 @@ class ProjectUsersTest(APITestCase):
         assert response.status_code == 200, response.content
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(self.euser2.id)
-
-        response = self.client.get(f"{self.path}?query=ip:0", format="json")
-
-        assert response.status_code == 200, response.content
-        assert len(response.data) == 2


### PR DESCRIPTION
Improve `project_users` endpoint when querying for exact email since `eventuser.py` indexes `project_id` and `email` https://github.com/getsentry/sentry/blob/master/src/sentry/models/eventuser.py#L39-L40. Previously, most queries filtering my email, id, etc, would return a 504 status code. 

FIXES [ISSUE-1176](https://getsentry.atlassian.net/browse/ISSUE-1176)