### PR TITLE
ref(ui): Update reprocessing wording for stable release

### DIFF
--- a/static/app/components/modals/reprocessEventModal.tsx
+++ b/static/app/components/modals/reprocessEventModal.tsx
@@ -15,11 +15,11 @@ import RadioField from 'app/views/settings/components/forms/radioField';
 
 const impacts = [
   tct(
-    '[strong:Data glitches.] During reprocessing you may observe temporary data inconsistencies across the entire product. Those inconsistencies disappear the moment reprocessing is complete.',
+    "[strong:Quota applies.] Every event you choose to reprocess counts against your plan's quota. Rate limits and spike protection do not apply.",
     {strong: <strong />}
   ),
   tct(
-    '[strong:Attachment storage needs to be enabled.] If your events come from minidumps or unreal crash reports, you must have [link:attachment storage] enabled.',
+    '[strong:Attachment storage required.] If your events come from minidumps or unreal crash reports, you must have [link:attachment storage] enabled.',
     {
       strong: <strong />,
       link: (
@@ -27,13 +27,8 @@ const impacts = [
       ),
     }
   ),
-  tct(
-    "[strong:Quota applies.] Every event you choose to reprocess will count against your plan's quota a second time. Rate limits and spike protection do not apply.",
-    {strong: <strong />}
-  ),
-  t('Please wait one hour before attempting to reprocess missing debug files.'),
   t(
-    'Reprocessed events will not trigger issue alerts, and reprocessed events are not subject to data forwarding.'
+    'Please wait one hour after upload before attempting to reprocess missing debug files.'
   ),
 ];
 
@@ -86,7 +81,7 @@ class ReprocessingEventModal extends React.Component<Props, State> {
         <Body>
           <Introduction>
             {t(
-              'Reprocessing applies any new debug files or grouping configuration to an Issue. Before you give it a try, you should probably consider these impacts:'
+              'Reprocessing applies new debug files and grouping enhancements to this Issue. Please consider these impacts:'
             )}
           </Introduction>
           <StyledList symbol="bullet">
@@ -95,14 +90,11 @@ class ReprocessingEventModal extends React.Component<Props, State> {
             ))}
           </StyledList>
           <Introduction>
-            {tct(
-              'For more information please refer to [link:the documentation on reprocessing.]',
-              {
-                link: (
-                  <ExternalLink href="https://docs.sentry.io/product/error-monitoring/reprocessing/" />
-                ),
-              }
-            )}
+            {tct('For more information, please refer to [link:the documentation.]', {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/error-monitoring/reprocessing/" />
+              ),
+            })}
           </Introduction>
           <Form
             submitLabel={title}

--- a/tests/js/spec/components/modals/reprocessEventModal.spec.tsx
+++ b/tests/js/spec/components/modals/reprocessEventModal.spec.tsx
@@ -51,7 +51,7 @@ describe('ReprocessEventModal', function () {
 
     // Reprocess impacts
     expect(introduction.at(0).text()).toEqual(
-      'Reprocessing applies any new debug files or grouping configuration to an Issue. Before you give it a try, you should probably consider these impacts:'
+      'Reprocessing applies new debug files and grouping enhancements to this Issue. Please consider these impacts:'
     );
     const impacts = wrapper.find('StyledList');
     expect(impacts).toBeTruthy();
@@ -59,7 +59,7 @@ describe('ReprocessEventModal', function () {
 
     // Docs info
     expect(introduction.at(1).text()).toEqual(
-      'For more information please refer to the documentation on reprocessing.'
+      'For more information, please refer to the documentation.'
     );
 
     // Form


### PR DESCRIPTION
- More concise wording, removing empty phrases like "before you give it a try"
- Move quota impact to the top

The following points are removed from the dialog and should be described in docs:

- Data glitches; this is not actionable at this point in the workflow
- Issue alerts; there is no expectation that reprocessing triggers issue alerts
- Data forwarding; it is an advanced concept