### PR TITLE
fix(workflow): Adding current time bucket to alert details

### DIFF
--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -405,6 +405,10 @@ class MetricChart extends React.PureComponent<Props, State> {
       )
     );
 
+    const viableEndDate = getUtcDateString(
+      moment.utc(timePeriod.end).add(rule.timeWindow, 'minutes')
+    );
+
     return (
       <EventsRequest
         api={api}
@@ -416,7 +420,7 @@ class MetricChart extends React.PureComponent<Props, State> {
           .map(project => Number(project.id))}
         interval={interval}
         start={viableStartDate}
-        end={timePeriod.end}
+        end={viableEndDate}
         yAxis={rule.aggregate}
         includePrevious={false}
         currentSeriesName={rule.aggregate}


### PR DESCRIPTION
Currently, on the alert details page, we don't show the current bucket we're in. 

i.e. if buckets are 20 minutes, and it is 3:34, the graph will end at 3:20. This change will make the graph end at 3:40. 

Not showing the current bucket meant that new alerts would not show the most recent incident on the chart. This problem could be exacerbated depending on the evaluation time window of the rule. The trade off is the final data point will drop off on the chart, and gradually increase as events come in and we move on to the next bucket.