### PR TITLE
fix(quick-trace): Link quick trace dropdown to trace view

### DIFF
--- a/static/app/utils/performance/quickTrace/types.tsx
+++ b/static/app/utils/performance/quickTrace/types.tsx
@@ -26,7 +26,6 @@ export type TraceError = {
   issue_id: number;
   event_id: string;
   span: string;
-  transaction: string;
   project_id: number;
   project_slug: string;
   title: string;


### PR DESCRIPTION
The quick trace dropdown currently links to a discover query that ORs together
the event ids. This can error when there are too many. Instead, this change
links it to trace view.