### PR TITLE
feat(alert): Change metric field to hide irrelevant fields from wizard

### DIFF
--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -1,4 +1,9 @@
 import {t} from 'app/locale';
+import {AggregationKey} from 'app/utils/discover/fields';
+import {
+  OptionConfig,
+  transactionFieldConfig,
+} from 'app/views/settings/incidentRules/constants';
 import {Dataset, EventTypes} from 'app/views/settings/incidentRules/types';
 
 export type AlertType =
@@ -231,4 +236,65 @@ export const AlertWizardRuleTemplates: Record<
     dataset: Dataset.TRANSACTIONS,
     eventTypes: EventTypes.TRANSACTION,
   },
+};
+
+const commonAggregations: AggregationKey[] = [
+  'avg',
+  'percentile',
+  'p50',
+  'p75',
+  'p95',
+  'p99',
+  'p100',
+];
+
+export const WizardMetricFieldConfigs: Record<
+  Exclude<AlertType, 'issues'>,
+  OptionConfig
+> = {
+  num_errors: {
+    aggregations: ['count'],
+    fields: [],
+  },
+  users_experiencing_errors: {
+    aggregations: ['count_unique'],
+    fields: ['user'],
+  },
+  throughput: {
+    aggregations: ['count'],
+    fields: [],
+  },
+  trans_duration: {
+    aggregations: commonAggregations,
+    fields: ['transaction.duration'],
+  },
+  apdex: {
+    aggregations: ['apdex'],
+    fields: [],
+  },
+  failure_rate: {
+    aggregations: ['failure_rate'],
+    fields: [],
+  },
+  lcp: {
+    aggregations: commonAggregations,
+    fields: [],
+    measurementKeys: ['measurements.lcp'],
+  },
+  fid: {
+    aggregations: commonAggregations,
+    fields: [],
+    measurementKeys: ['measurements.fid'],
+  },
+  cls: {
+    aggregations: commonAggregations,
+    fields: [],
+    measurementKeys: ['measurements.cls'],
+  },
+  fcp: {
+    aggregations: commonAggregations,
+    fields: [],
+    measurementKeys: ['measurements.fcp'],
+  },
+  custom: transactionFieldConfig,
 };

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -1,9 +1,4 @@
 import {t} from 'app/locale';
-import {AggregationKey} from 'app/utils/discover/fields';
-import {
-  OptionConfig,
-  transactionFieldConfig,
-} from 'app/views/settings/incidentRules/constants';
 import {Dataset, EventTypes} from 'app/views/settings/incidentRules/types';
 
 export type AlertType =
@@ -238,63 +233,18 @@ export const AlertWizardRuleTemplates: Record<
   },
 };
 
-const commonAggregations: AggregationKey[] = [
-  'avg',
-  'percentile',
-  'p50',
-  'p75',
-  'p95',
-  'p99',
-  'p100',
-];
+export const hidePrimarySelectorSet = new Set<AlertType>([
+  'num_errors',
+  'users_experiencing_errors',
+  'throughput',
+  'apdex',
+  'failure_rate',
+]);
 
-export const WizardMetricFieldConfigs: Record<
-  Exclude<AlertType, 'issues'>,
-  OptionConfig
-> = {
-  num_errors: {
-    aggregations: ['count'],
-    fields: [],
-  },
-  users_experiencing_errors: {
-    aggregations: ['count_unique'],
-    fields: ['user'],
-  },
-  throughput: {
-    aggregations: ['count'],
-    fields: [],
-  },
-  trans_duration: {
-    aggregations: commonAggregations,
-    fields: ['transaction.duration'],
-  },
-  apdex: {
-    aggregations: ['apdex'],
-    fields: [],
-  },
-  failure_rate: {
-    aggregations: ['failure_rate'],
-    fields: [],
-  },
-  lcp: {
-    aggregations: commonAggregations,
-    fields: [],
-    measurementKeys: ['measurements.lcp'],
-  },
-  fid: {
-    aggregations: commonAggregations,
-    fields: [],
-    measurementKeys: ['measurements.fid'],
-  },
-  cls: {
-    aggregations: commonAggregations,
-    fields: [],
-    measurementKeys: ['measurements.cls'],
-  },
-  fcp: {
-    aggregations: commonAggregations,
-    fields: [],
-    measurementKeys: ['measurements.fcp'],
-  },
-  custom: transactionFieldConfig,
-};
+export const hideParameterSelectorSet = new Set<AlertType>([
+  'trans_duration',
+  'lcp',
+  'fid',
+  'cls',
+  'fcp',
+]);

--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -72,6 +72,8 @@ type Props = {
   shouldRenderTag?: boolean;
   onChange: (fieldValue: QueryFieldValue) => void;
   disabled?: boolean;
+  hidePrimarySelector?: boolean;
+  hideParameterSelector?: boolean;
 };
 
 // Type for completing generics in react-select
@@ -311,14 +313,19 @@ class QueryField extends React.Component<Props> {
   }
 
   renderParameterInputs(parameters: ParameterDescription[]): React.ReactNode[] {
-    const {disabled, inFieldLabels, filterAggregateParameters} = this.props;
+    const {
+      disabled,
+      inFieldLabels,
+      filterAggregateParameters,
+      hideParameterSelector,
+    } = this.props;
     const inputs = parameters.map((descriptor: ParameterDescription, index: number) => {
       if (descriptor.kind === 'column' && descriptor.options.length > 0) {
         const aggregateParameters = filterAggregateParameters
           ? descriptor.options.filter(filterAggregateParameters)
           : descriptor.options;
 
-        return (
+        return hideParameterSelector ? null : (
           <SelectControl
             key="select"
             name="parameter"
@@ -432,6 +439,8 @@ class QueryField extends React.Component<Props> {
       filterPrimaryOptions,
       inFieldLabels,
       disabled,
+      hidePrimarySelector,
+      gridColumns,
     } = this.props;
     const {field, fieldOptions, parameterDescriptions} = this.getFieldData();
 
@@ -476,25 +485,30 @@ class QueryField extends React.Component<Props> {
     const parameters = this.renderParameterInputs(parameterDescriptions);
 
     return (
-      <Container className={className} gridColumns={parameters.length + 1}>
-        <SelectControl
-          {...selectProps}
-          styles={!inFieldLabels ? styles : undefined}
-          components={{
-            Option: ({label, data, ...props}: OptionProps<OptionType>) => (
-              <components.Option label={label} data={data} {...props}>
-                <span data-test-id="label">{label}</span>
-                {this.renderTag(data.value.kind)}
-              </components.Option>
-            ),
-            SingleValue: ({data, ...props}: SingleValueProps<OptionType>) => (
-              <components.SingleValue data={data} {...props}>
-                <span data-test-id="label">{data.label}</span>
-                {this.renderTag(data.value.kind)}
-              </components.SingleValue>
-            ),
-          }}
-        />
+      <Container
+        className={className}
+        gridColumns={gridColumns ? gridColumns : parameters.length + 1}
+      >
+        {!hidePrimarySelector && (
+          <SelectControl
+            {...selectProps}
+            styles={!inFieldLabels ? styles : undefined}
+            components={{
+              Option: ({label, data, ...props}: OptionProps<OptionType>) => (
+                <components.Option label={label} data={data} {...props}>
+                  <span data-test-id="label">{label}</span>
+                  {this.renderTag(data.value.kind)}
+                </components.Option>
+              ),
+              SingleValue: ({data, ...props}: SingleValueProps<OptionType>) => (
+                <components.SingleValue data={data} {...props}>
+                  <span data-test-id="label">{data.label}</span>
+                  {this.renderTag(data.value.kind)}
+                </components.SingleValue>
+              ),
+            }}
+          />
+        )}
         {parameters}
       </Container>
     );

--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -321,11 +321,14 @@ class QueryField extends React.Component<Props> {
     } = this.props;
     const inputs = parameters.map((descriptor: ParameterDescription, index: number) => {
       if (descriptor.kind === 'column' && descriptor.options.length > 0) {
+        if (hideParameterSelector) {
+          return null;
+        }
         const aggregateParameters = filterAggregateParameters
           ? descriptor.options.filter(filterAggregateParameters)
           : descriptor.options;
 
-        return hideParameterSelector ? null : (
+        return (
           <SelectControl
             key="select"
             name="parameter"

--- a/static/app/views/settings/incidentRules/constants.tsx
+++ b/static/app/views/settings/incidentRules/constants.tsx
@@ -30,7 +30,7 @@ export const DATASOURCE_EVENT_TYPE_FILTERS = {
   [Datasource.TRANSACTION]: 'event.type:transaction',
 } as const;
 
-type OptionConfig = {
+export type OptionConfig = {
   aggregations: AggregationKey[];
   fields: LooseFieldKey[];
   measurementKeys?: string[];

--- a/static/app/views/settings/incidentRules/constants.tsx
+++ b/static/app/views/settings/incidentRules/constants.tsx
@@ -44,22 +44,30 @@ export const errorFieldConfig: OptionConfig = {
   fields: ['user'],
 };
 
+const commonAggregations: AggregationKey[] = [
+  'avg',
+  'percentile',
+  'p50',
+  'p75',
+  'p95',
+  'p99',
+  'p100',
+];
+
+/**
+ * Allowed aggregations for alerts created from wizard
+ */
+export const wizardAlertFieldConfig: OptionConfig = {
+  aggregations: commonAggregations,
+  fields: ['transaction.duration'],
+  measurementKeys: Object.keys(WEB_VITAL_DETAILS),
+};
+
 /**
  * Allowed transaction aggregations for alerts
  */
 export const transactionFieldConfig: OptionConfig = {
-  aggregations: [
-    'avg',
-    'percentile',
-    'failure_rate',
-    'apdex',
-    'count',
-    'p50',
-    'p75',
-    'p95',
-    'p99',
-    'p100',
-  ],
+  aggregations: [...commonAggregations, 'failure_rate', 'apdex', 'count'],
   fields: ['transaction.duration'],
   measurementKeys: Object.keys(WEB_VITAL_DETAILS),
 };

--- a/static/app/views/settings/incidentRules/metricField.tsx
+++ b/static/app/views/settings/incidentRules/metricField.tsx
@@ -51,6 +51,7 @@ const getFieldOptionConfig = ({
   if (organization.features.includes('alert-wizard')) {
     const alertType = getAlertTypeFromAggregateDataset({dataset, aggregate});
     config = WizardMetricFieldConfigs[alertType];
+    // Hide selectors if they only show one option
     hidePrimarySelector = config.aggregations.length === 1;
     hideParameterSelector =
       (config.measurementKeys?.length ? 1 : 0) + config.fields.length === 1;

--- a/static/app/views/settings/incidentRules/metricField.tsx
+++ b/static/app/views/settings/incidentRules/metricField.tsx
@@ -15,7 +15,10 @@ import {
   FIELDS,
   generateFieldAsString,
 } from 'app/utils/discover/fields';
-import {WizardMetricFieldConfigs} from 'app/views/alerts/wizard/options';
+import {
+  hideParameterSelectorSet,
+  hidePrimarySelectorSet,
+} from 'app/views/alerts/wizard/options';
 import {getAlertTypeFromAggregateDataset} from 'app/views/alerts/wizard/utils';
 import {QueryField} from 'app/views/eventsV2/table/queryField';
 import {FieldValueKind} from 'app/views/eventsV2/table/types';
@@ -23,7 +26,12 @@ import {generateFieldOptions} from 'app/views/eventsV2/utils';
 import FormField from 'app/views/settings/components/forms/formField';
 import FormModel from 'app/views/settings/components/forms/model';
 
-import {errorFieldConfig, OptionConfig, transactionFieldConfig} from './constants';
+import {
+  errorFieldConfig,
+  OptionConfig,
+  transactionFieldConfig,
+  wizardAlertFieldConfig,
+} from './constants';
 import {PRESET_AGGREGATES} from './presets';
 import {Dataset} from './types';
 
@@ -50,11 +58,9 @@ const getFieldOptionConfig = ({
   let hideParameterSelector = false;
   if (organization.features.includes('alert-wizard')) {
     const alertType = getAlertTypeFromAggregateDataset({dataset, aggregate});
-    config = WizardMetricFieldConfigs[alertType];
-    // Hide selectors if they only show one option
-    hidePrimarySelector = config.aggregations.length === 1;
-    hideParameterSelector =
-      (config.measurementKeys?.length ? 1 : 0) + config.fields.length === 1;
+    config = wizardAlertFieldConfig;
+    hidePrimarySelector = hidePrimarySelectorSet.has(alertType);
+    hideParameterSelector = hideParameterSelectorSet.has(alertType);
   } else {
     config = dataset === Dataset.ERRORS ? errorFieldConfig : transactionFieldConfig;
   }


### PR DESCRIPTION
**Currently feature flagged under `alert-wizard`**

Coming from the alert wizard the user has already selected their desired aggregate or function. We should only be showing the user drop-downs which are relevant to that type of alert. 
Ex: A user should not be able to change a `measurements.lcp` alert to a `count()` alert unless they go through the wizard. 

- Added new props to `QueryField` to support hiding certain drop-downs and fields
- Added a new section in `wizard/options.tsx` to describe which selectors are hidden based on an alert type

**Before:**
![image](https://user-images.githubusercontent.com/9372512/115273875-180c3780-a10e-11eb-8db3-1eb6d188acbf.png)

**After:**
![image](https://user-images.githubusercontent.com/9372512/115273815-03c83a80-a10e-11eb-807a-8903afb48e1e.png)
