### PR TITLE
fix(discover): Quote and escape text searches as needed

### DIFF
--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -1173,7 +1173,7 @@ class EventView {
 
   getQueryWithAdditionalConditions() {
     const {query} = this;
-    if (!this.additionalConditions) {
+    if (this.additionalConditions.isEmpty()) {
       return query;
     }
     const conditions = tokenizeSearch(query);

--- a/static/app/utils/tokenizeSearch.tsx
+++ b/static/app/utils/tokenizeSearch.tsx
@@ -107,6 +107,13 @@ export class QueryResults {
             formattedTokens.push(`${token.key}:${token.value}`);
           }
           break;
+        case TokenType.QUERY:
+          if (/[\s\(\)\\"]/g.test(token.value)) {
+            formattedTokens.push(`"${escapeDoubleQuotes(token.value)}"`);
+          } else {
+            formattedTokens.push(token.value);
+          }
+          break;
         default:
           formattedTokens.push(token.value);
       }
@@ -270,6 +277,10 @@ export class QueryResults {
     q.tagValues = {...this.tagValues};
     q.tokens = [...this.tokens];
     return q;
+  }
+
+  isEmpty() {
+    return this.tokens.length === 0;
   }
 }
 

--- a/tests/js/spec/utils/tokenizeSearch.spec.jsx
+++ b/tests/js/spec/utils/tokenizeSearch.spec.jsx
@@ -245,6 +245,16 @@ describe('utils/tokenizeSearch', function () {
       results.query = ['x', 'y'];
       expect(results.formatString()).toEqual('a:a d:d x y');
       expect(results.query).toEqual(['x', 'y']);
+
+      results.query = ['a b c'];
+      expect(results.formatString()).toEqual('a:a d:d "a b c"');
+      expect(results.query).toEqual(['a b c']);
+
+      results.query = ['invalid literal for int() with base'];
+      expect(results.formatString()).toEqual(
+        'a:a d:d "invalid literal for int() with base"'
+      );
+      expect(results.query).toEqual(['invalid literal for int() with base']);
     });
 
     it('add ops to query object', function () {


### PR DESCRIPTION
Text searches can contain spaces, quotes and parentheses. These text searches
need to be escaped and quoted.