### PR TITLE
ref(emotion): In emotion 11 shouldForwardProp arg is not always a string

### DIFF
--- a/static/app/components/button.tsx
+++ b/static/app/components/button.tsx
@@ -254,7 +254,7 @@ const StyledButton = styled(
     shouldForwardProp: prop =>
       prop === 'forwardRef' ||
       prop === 'external' ||
-      (isPropValid(prop) && prop !== 'disabled'),
+      (typeof prop === 'string' && isPropValid(prop) && prop !== 'disabled'),
   }
 )<Props>`
   display: inline-block;
@@ -306,7 +306,8 @@ const buttonLabelPropKeys = ['size', 'priority', 'borderless', 'align'];
 type ButtonLabelProps = Pick<ButtonProps, 'size' | 'priority' | 'borderless' | 'align'>;
 
 const ButtonLabel = styled('span', {
-  shouldForwardProp: prop => isPropValid(prop) && !buttonLabelPropKeys.includes(prop),
+  shouldForwardProp: prop =>
+    typeof prop === 'string' && isPropValid(prop) && !buttonLabelPropKeys.includes(prop),
 })<ButtonLabelProps>`
   display: grid;
   grid-auto-flow: column;

--- a/static/app/components/issueDiff/index.tsx
+++ b/static/app/components/issueDiff/index.tsx
@@ -161,7 +161,7 @@ export default withApi(IssueDiff);
 export {IssueDiff};
 
 const StyledIssueDiff = styled('div', {
-  shouldForwardProp: p => isPropValid(p) && p !== 'loading',
+  shouldForwardProp: p => typeof p === 'string' && isPropValid(p) && p !== 'loading',
 })<Pick<State, 'loading'>>`
   background-color: ${p => p.theme.backgroundSecondary};
   overflow: auto;

--- a/static/app/components/links/link.tsx
+++ b/static/app/components/links/link.tsx
@@ -48,7 +48,8 @@ class Link extends React.Component<Props> {
 export default withRouter(Link);
 
 const Anchor = styled('a', {
-  shouldForwardProp: prop => isPropValid(prop) && prop !== 'disabled',
+  shouldForwardProp: prop =>
+    typeof prop === 'string' && isPropValid(prop) && prop !== 'disabled',
 })<{disabled?: boolean}>`
   ${p =>
     p.disabled &&

--- a/static/app/components/menuItem.tsx
+++ b/static/app/components/menuItem.tsx
@@ -207,7 +207,8 @@ function getChildStyles(props: MenuListItemProps & {theme: Theme}) {
 }
 
 const MenuAnchor = styled('a', {
-  shouldForwardProp: p => ['isActive', 'disabled'].includes(p) === false,
+  shouldForwardProp: p =>
+    typeof p === 'string' && ['isActive', 'disabled'].includes(p) === false,
 })<MenuListItemProps>`
   ${getListItemStyles}
 `;
@@ -241,7 +242,8 @@ const MenuTarget = styled('span')<MenuListItemProps>`
 `;
 
 const MenuLink = styled(Link, {
-  shouldForwardProp: p => ['isActive', 'disabled'].includes(p) === false,
+  shouldForwardProp: p =>
+    typeof p === 'string' && ['isActive', 'disabled'].includes(p) === false,
 })<MenuListItemProps>`
   ${getListItemStyles}
 `;

--- a/static/app/components/organizations/headerItem.tsx
+++ b/static/app/components/organizations/headerItem.tsx
@@ -124,7 +124,7 @@ type ColorProps = {
 };
 
 const StyledHeaderItem = styled('div', {
-  shouldForwardProp: p => isPropValid(p) && p !== 'loading',
+  shouldForwardProp: p => typeof p === 'string' && isPropValid(p) && p !== 'loading',
 })<
   ColorProps & {
     loading: boolean;

--- a/static/app/components/panels/panelTable.tsx
+++ b/static/app/components/panels/panelTable.tsx
@@ -131,7 +131,7 @@ const LoadingWrapper = styled('div')``;
 const TableEmptyStateWarning = styled(EmptyStateWarning)``;
 
 const Wrapper = styled(Panel, {
-  shouldForwardProp: p => isPropValid(p) && p !== 'columns',
+  shouldForwardProp: p => typeof p === 'string' && isPropValid(p) && p !== 'columns',
 })<WrapperProps>`
   display: grid;
   grid-template-columns: repeat(${p => p.columns}, auto);

--- a/static/app/views/alerts/details/header.tsx
+++ b/static/app/views/alerts/details/header.tsx
@@ -203,7 +203,7 @@ const Controls = styled('div')`
 `;
 
 const Details = styled(PageHeader, {
-  shouldForwardProp: p => isPropValid(p) && p !== 'columns',
+  shouldForwardProp: p => typeof p === 'string' && isPropValid(p) && p !== 'columns',
 })<{columns: 3 | 5}>`
   margin-bottom: 0;
   padding: ${space(1.5)} ${space(4)} ${space(2)};
@@ -228,7 +228,7 @@ const StyledLoadingError = styled(LoadingError)`
 `;
 
 const GroupedHeaderItems = styled('div', {
-  shouldForwardProp: p => isPropValid(p) && p !== 'columns',
+  shouldForwardProp: p => typeof p === 'string' && isPropValid(p) && p !== 'columns',
 })<{columns: 3 | 5}>`
   display: grid;
   grid-template-columns: repeat(${p => p.columns}, max-content);
@@ -257,14 +257,14 @@ const ItemValue = styled('div')`
 `;
 
 const IncidentTitle = styled(PageHeading, {
-  shouldForwardProp: p => isPropValid(p) && p !== 'loading',
+  shouldForwardProp: p => typeof p === 'string' && isPropValid(p) && p !== 'loading',
 })<{loading: boolean}>`
   ${p => p.loading && 'opacity: 0'};
   line-height: 1.5;
 `;
 
 const IncidentSubTitle = styled('div', {
-  shouldForwardProp: p => isPropValid(p) && p !== 'loading',
+  shouldForwardProp: p => typeof p === 'string' && isPropValid(p) && p !== 'loading',
 })<{loading: boolean}>`
   ${p => p.loading && 'opacity: 0'};
   font-size: ${p => p.theme.fontSizeLarge};

--- a/static/app/views/alerts/rules/details/header.tsx
+++ b/static/app/views/alerts/rules/details/header.tsx
@@ -97,7 +97,7 @@ const Details = styled(PageHeader)`
 `;
 
 const RuleTitle = styled(PageHeading, {
-  shouldForwardProp: p => isPropValid(p) && p !== 'loading',
+  shouldForwardProp: p => typeof p === 'string' && isPropValid(p) && p !== 'loading',
 })<{loading: boolean}>`
   ${p => p.loading && 'opacity: 0'};
   line-height: 1.5;

--- a/static/app/views/settings/components/forms/controls/input.tsx
+++ b/static/app/views/settings/components/forms/controls/input.tsx
@@ -9,7 +9,8 @@ type Props = Omit<Parameters<typeof inputStyles>[0], 'theme'>;
  * Do not forward required to `input` to avoid default browser behavior
  */
 const Input = styled('input', {
-  shouldForwardProp: prop => isPropValid(prop) && prop !== 'required',
+  shouldForwardProp: prop =>
+    typeof prop === 'string' && isPropValid(prop) && prop !== 'required',
 })<Props>`
   ${inputStyles};
 `;


### PR DESCRIPTION
This is part of me trying to get us to emotion 11, the prop name changes to PropKey which can also be a number or undefined