### PR TITLE
fix(ui): alert list tidy

### DIFF
--- a/static/app/views/alerts/rules/index.tsx
+++ b/static/app/views/alerts/rules/index.tsx
@@ -470,7 +470,7 @@ const StyledPanelTable = styled(PanelTable)<{
     `svg:not([data-test-id='icon-check-mark']) {
     display: none;`}
   & > * {
-    padding: ${p => (p.hasAlertList ? `${space(1.5)} ${space(2)}` : space(2))};
+    padding: ${p => (p.hasAlertList ? `${space(2)} ${space(2)}` : space(2))};
   }
 `;
 

--- a/static/app/views/alerts/rules/row.tsx
+++ b/static/app/views/alerts/rules/row.tsx
@@ -176,7 +176,7 @@ class RuleListRow extends React.Component<Props, State> {
                 />
               </FlexCenter>
               <AlertNameAndStatus>
-                <div>{alertLink}</div>
+                <AlertName>{alertLink}</AlertName>
                 {!isIssueAlert(rule) && this.renderLastIncidentDate()}
               </AlertNameAndStatus>
             </AlertNameWrapper>
@@ -280,7 +280,11 @@ const AlertNameWrapper = styled(FlexCenter)<{isIncident?: boolean}>`
 
 const AlertNameAndStatus = styled('div')`
   margin-left: ${space(1.5)};
-  line-height: 1.4;
+  line-height: 1.35;
+`;
+
+const AlertName = styled('div')`
+  font-size: ${p => p.theme.fontSizeLarge};
 `;
 
 const ProjectBadge = styled(IdBadge)`


### PR DESCRIPTION
Added a bit more spacing between rows and bumped font-size of alert rule link 

<img width="1476" alt="CleanShot 2021-04-19 at 12 53 18@2x" src="https://user-images.githubusercontent.com/1900676/115295346-8224dc80-a10e-11eb-9fcc-a038966ad145.png">
