### PR TITLE
fix(ui): Remove extra commit avatar padding for non-users

### DIFF
--- a/docs-ui/components/commitRow.stories.js
+++ b/docs-ui/components/commitRow.stories.js
@@ -1,0 +1,84 @@
+import React from 'react';
+
+import CommitRow from 'app/components/commitRow';
+
+export default {
+  title: 'UI/CommitRow',
+  component: CommitRow,
+};
+
+export const Default = () => {
+  const commit = {
+    dateCreated: '2018-11-30T18:46:31Z',
+    message:
+      '(improve) Add Links to Spike-Protection Email (#2408)\n\n* (improve) Add Links to Spike-Protection Email\r\n\r\nUsers now have access to useful links from the blogs and docs on Spike-protection.\r\n\r\n* fixed wording',
+    id: 'f7f395d14b2fe29a4e253bf1d3094d61e6ad4434',
+    author: {
+      username: 'example@sentry.io',
+      lastLogin: '2018-11-30T21:18:09.812Z',
+      isSuperuser: true,
+      isManaged: false,
+      lastActive: '2018-11-30T21:25:15.222Z',
+      id: '224288',
+      isActive: true,
+      has2fa: false,
+      name: 'Foo Bar',
+      avatarUrl: 'https://example.com/avatar.png',
+      dateJoined: '2018-02-26T23:57:43.766Z',
+      emails: [
+        {
+          is_verified: true,
+          id: '231605',
+          email: 'example@sentry.io',
+        },
+      ],
+      avatar: {
+        avatarUuid: null,
+        avatarType: 'letter_avatar',
+      },
+      hasPasswordAuth: true,
+      email: 'example@sentry.io',
+    },
+    repository: {
+      id: '4',
+      name: 'example/repo-name',
+      provider: 'github',
+      url: 'https://github.com/example/repo-name',
+      status: 'active',
+      externalSlug: 'example/repo-name',
+    },
+  };
+  const nonuserCommit = {
+    ...commit,
+    dateCreated: '2018-11-30T18:46:31Z',
+    author: {
+      username: 'example@sentry.io',
+      isActive: true,
+      has2fa: false,
+      name: 'Foo Bar',
+      avatarUrl: 'https://example.com/avatar.png',
+      dateJoined: '2018-02-26T23:57:43.766Z',
+      emails: [
+        {
+          is_verified: true,
+          id: '231605',
+          email: 'example@sentry.io',
+        },
+      ],
+      avatar: {
+        avatarUuid: null,
+        avatarType: 'letter_avatar',
+      },
+      hasPasswordAuth: true,
+      email: 'example@sentry.io',
+    },
+  };
+  return (
+    <div>
+      <CommitRow commit={commit} />
+      <CommitRow commit={nonuserCommit} />
+    </div>
+  );
+};
+
+Default.storyName = 'CommitRow';

--- a/static/app/components/commitRow.tsx
+++ b/static/app/components/commitRow.tsx
@@ -12,7 +12,7 @@ import TimeSince from 'app/components/timeSince';
 import {IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
-import {Commit} from 'app/types';
+import {Commit, User} from 'app/types';
 
 type Props = {
   commit: Commit;
@@ -30,7 +30,7 @@ class CommitRow extends React.Component<Props> {
     return firstLine;
   }
 
-  renderHovercardBody(author) {
+  renderHovercardBody(author: User) {
     return (
       <EmailWarning>
         {tct(
@@ -70,7 +70,7 @@ class CommitRow extends React.Component<Props> {
           customAvatar
         ) : nonMemberEmail ? (
           <AvatarWrapper>
-            <Hovercard body={this.renderHovercardBody(author)}>
+            <Hovercard body={this.renderHovercardBody(author!)}>
               <UserAvatar size={36} user={author} />
               <EmailWarningIcon>
                 <IconWarning size="xs" />
@@ -102,6 +102,7 @@ class CommitRow extends React.Component<Props> {
 }
 
 const AvatarWrapper = styled('div')`
+  position: relative;
   align-self: flex-start;
   margin-right: ${space(2)};
 `;
@@ -122,10 +123,9 @@ const StyledLink = styled(Link)`
 `;
 
 const EmailWarningIcon = styled('span')`
-  position: relative;
-  top: 15px;
-  left: -11px;
-  display: inline-block;
+  position: absolute;
+  bottom: -6px;
+  right: -7px;
   line-height: 12px;
   border-radius: 50%;
   border: 1px solid ${p => p.theme.white};


### PR DESCRIPTION
Add stories for commitRow

Fixes the odd padding on non-user rows seen here (the ones with the warning icon)
<img width="422" alt="Screen Shot 2021-04-19 at 1 32 11 PM" src="https://user-images.githubusercontent.com/1400464/115299642-e4341080-a113-11eb-85fd-e6ba0e961f55.png">
