### PR TITLE
fix(django22): Fix uses of include to not use namespace when importing a list of urls

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -975,7 +975,7 @@ urlpatterns = [
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/(?:issues|groups)/",
-                    include(GROUP_URLS, namespace="sentry-api-0-organization-group"),
+                    include(GROUP_URLS),
                 ),
                 url(
                     r"^(?P<organization_slug>[^\/]+)/integrations/$",
@@ -1787,7 +1787,7 @@ urlpatterns = [
         ),
     ),
     # Groups
-    url(r"^(?:issues|groups)/", include(GROUP_URLS, namespace="sentry-api-0-group")),
+    url(r"^(?:issues|groups)/", include(GROUP_URLS)),
     url(
         r"^issues/(?P<issue_id>[^\/]+)/participants/$",
         GroupParticipantsEndpoint.as_view(),

--- a/src/sentry/django_admin.py
+++ b/src/sentry/django_admin.py
@@ -32,4 +32,4 @@ def make_site():
 
 site = make_site()
 
-urlpatterns = [url(r"^admin/", include(site.urls))]
+urlpatterns = [url(r"^admin/", include(site.urls[:2]))]


### PR DESCRIPTION
Remove `namespace` when we're importing `GROUP_URLS`, since this is an invalid way of passing
namespace. If we did want the namespace, we could include it via
https://docs.djangoproject.com/en/2.2/ref/urls/#include. So we could do `include((GROUP_URLS,
'sentry-api-0-organization-group`))` if we wanted to.

Also fix the way we import the admin urls into `admin/`.