### PR TITLE
fix(alerts): Pad metric alert id in incident chart

### DIFF
--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -66,6 +66,9 @@ function createThresholdSeries(lineColor: string, threshold: number): LineChartS
       silent: true,
       lineStyle: {color: lineColor, type: 'dashed', width: 1},
       data: [{yAxis: threshold} as any],
+      label: {
+        show: false,
+      },
     }),
     data: [],
   };
@@ -312,7 +315,7 @@ class MetricChart extends React.PureComponent<Props, State> {
         forwardedRef={this.handleRef}
         grid={{
           left: 0,
-          right: 0,
+          right: space(2),
           top: space(2),
           bottom: 0,
         }}


### PR DESCRIPTION
disable critical/warning threshold labels