### PR TITLE
ref(Notifications): ExternalActor Endpoints

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,13 @@
 [mypy]
 python_version = 3.6
-files = src/sentry/api/endpoints/project_codeowners.py,
+files = src/sentry/api/bases/external_actor.py,
+        src/sentry/api/endpoints/project_codeowners.py,
+        src/sentry/api/endpoints/external_team.py,
+        src/sentry/api/endpoints/external_team_details.py,
+        src/sentry/api/endpoints/external_user.py,
+        src/sentry/api/endpoints/external_user_details.py,
         src/sentry/api/serializers/base.py,
+        src/sentry/api/serializers/models/external_actor.py,
         src/sentry/api/serializers/models/integration.py,
         src/sentry/api/serializers/models/notification_setting.py,
         src/sentry/api/serializers/models/organization_member.py,

--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -1,0 +1,120 @@
+from typing import Any, MutableMapping
+
+from django.db import IntegrityError
+from django.http import Http404
+from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
+
+from sentry import features
+from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
+from sentry.api.validators.integrations import validate_provider
+from sentry.models import ExternalActor, Organization, OrganizationMember, Team, User
+from sentry.types.integrations import EXTERNAL_PROVIDERS
+
+
+class ExternalActorSerializerBase(CamelSnakeModelSerializer):  # type: ignore
+    external_id = serializers.CharField()
+    external_name = serializers.CharField(required=True)
+    provider = serializers.ChoiceField(choices=list(EXTERNAL_PROVIDERS.values()))
+
+    @property
+    def organization(self):
+        return self.context["organization"]
+
+    def get_actor_id(self, validated_data: MutableMapping[str, Any]) -> int:
+        target_option = validated_data.pop(self._actor_key, None)
+
+        if not target_option:
+            raise Exception("Invalid actor")
+
+        return target_option.actor_id
+
+    def get_provider_id(self, validated_data: MutableMapping[str, Any]) -> int:
+        provider_name_option = validated_data.pop("provider", None)
+        return validate_provider(provider_name_option).value
+
+    def create(self, validated_data: MutableMapping[str, Any]) -> ExternalActor:
+        actor_id = self.get_actor_id(validated_data)
+        provider = self.get_provider_id(validated_data)
+
+        return ExternalActor.objects.get_or_create(
+            **validated_data,
+            actor_id=actor_id,
+            provider=provider,
+            organization=self.organization,
+        )
+
+    def update(
+        self, instance: ExternalActor, validated_data: MutableMapping[str, Any]
+    ) -> ExternalActor:
+        # Discard the object ID passed by the API.
+        if "id" in validated_data:
+            validated_data.pop("id")
+
+        for key, value in validated_data.items():
+            setattr(self.instance, key, value)
+        try:
+            self.instance.save()
+            return self.instance
+        except IntegrityError:
+            raise serializers.ValidationError(
+                "There already exists an external user association with this external_name and provider."
+            )
+
+
+class ExternalUserSerializer(ExternalActorSerializerBase):
+    _actor_key = "user_id"
+
+    user_id = serializers.IntegerField(required=True)
+
+    def validate_user_id(self, user_id: int) -> User:
+        """ Ensure that this user exists and that they belong to the organization. """
+
+        organization_members = OrganizationMember.objects.filter(
+            user_id=user_id, organization=self.organization
+        ).select_related("user")
+
+        if not organization_members:
+            raise serializers.ValidationError("This member does not exist.")
+
+        return organization_members[0].user
+
+    class Meta:
+        model = ExternalActor
+        fields = ["user_id", "external_name", "provider"]
+
+
+class ExternalTeamSerializer(ExternalActorSerializerBase):
+    _actor_key = "team_id"
+
+    team_id = serializers.IntegerField(required=True)
+
+    def validate_team_id(self, team_id: int) -> Team:
+        """ Ensure that this team exists and that they belong to the organization. """
+        try:
+            return Team.objects.get(id=team_id, organization=self.organization)
+        except Team.DoesNotExist:
+            raise serializers.ValidationError("This team does not exist.")
+
+    class Meta:
+        model = ExternalActor
+        fields = ["team_id", "external_name", "provider"]
+
+
+class ExternalActorEndpointMixin:
+    @staticmethod
+    def has_feature(request: Any, organization: Organization) -> bool:
+        return bool(
+            features.has("organizations:import-codeowners", organization, actor=request.user)
+        )
+
+    def assert_has_feature(self, request: Any, organization: Organization) -> None:
+        if not self.has_feature(request, organization):
+            raise PermissionDenied
+
+    @staticmethod
+    def get_external_actor_or_404(external_actor_id: int) -> ExternalActor:
+        try:
+            return ExternalActor.objects.get(id=external_actor_id)
+        except ExternalActor.DoesNotExist:
+            raise Http404

--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -58,7 +58,7 @@ class ExternalActorSerializerBase(CamelSnakeModelSerializer):  # type: ignore
             return self.instance
         except IntegrityError:
             raise serializers.ValidationError(
-                "There already exists an external user association with this external_name and provider."
+                "There already exists an external association with this external_name and provider."
             )
 
 

--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -78,14 +78,15 @@ class ExternalUserSerializer(ExternalActorSerializerBase):
     def validate_user_id(self, user_id: int) -> User:
         """ Ensure that this user exists and that they belong to the organization. """
 
-        organization_members = OrganizationMember.objects.filter(
-            user_id=user_id, organization=self.organization
-        ).select_related("user")
-
-        if not organization_members:
+        try:
+            return (
+                OrganizationMember.objects.filter(user_id=user_id, organization=self.organization)
+                .select_related("user")
+                .get()
+                .user
+            )
+        except OrganizationMember.DoesNotExist:
             raise serializers.ValidationError("This member does not exist.")
-
-        return organization_members[0].user
 
     class Meta:
         model = ExternalActor

--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -29,7 +29,7 @@ class ExternalActorSerializerBase(CamelSnakeModelSerializer):  # type: ignore
         return self.context["organization"]
 
     def get_actor_id(self, validated_data: MutableMapping[str, Any]) -> int:
-        return int(validated_data.pop(self._actor_key))
+        return int(validated_data.pop(self._actor_key).actor_id)
 
     def get_provider_id(self, validated_data: MutableMapping[str, Any]) -> int:
         provider_name_option = validated_data.pop("provider", None)

--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -9,7 +9,7 @@ from rest_framework.request import Request  # type: ignore
 from sentry import features
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.validators.integrations import validate_provider
-from sentry.models import ExternalActor, Organization, OrganizationMember, Team, User
+from sentry.models import ExternalActor, Organization, Team, User
 from sentry.types.integrations import ExternalProviders, get_provider_choices
 
 AVAILABLE_PROVIDERS = {
@@ -74,13 +74,10 @@ class ExternalUserSerializer(ExternalActorSerializerBase):
         """ Ensure that this user exists and that they belong to the organization. """
 
         try:
-            return (
-                OrganizationMember.objects.filter(user_id=user_id, organization=self.organization)
-                .select_related("user")
-                .get()
-                .user
+            return User.objects.get(
+                id=user_id, sentry_orgmember_set__organization=self.organization
             )
-        except OrganizationMember.DoesNotExist:
+        except User.DoesNotExist:
             raise serializers.ValidationError("This member does not exist.")
 
     class Meta:

--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -29,12 +29,7 @@ class ExternalActorSerializerBase(CamelSnakeModelSerializer):  # type: ignore
         return self.context["organization"]
 
     def get_actor_id(self, validated_data: MutableMapping[str, Any]) -> int:
-        target_option = validated_data.pop(self._actor_key, None)
-
-        if not target_option:
-            raise Exception("Invalid actor")
-
-        return int(target_option.actor_id)
+        return int(validated_data.pop(self._actor_key))
 
     def get_provider_id(self, validated_data: MutableMapping[str, Any]) -> int:
         provider_name_option = validated_data.pop("provider", None)

--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -1,8 +1,8 @@
 import logging
-from typing import Any
 
-from rest_framework import status
-from rest_framework.response import Response
+from rest_framework import status  # type: ignore
+from rest_framework.request import Request  # type: ignore
+from rest_framework.response import Response  # type: ignore
 
 from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalTeamSerializer
 from sentry.api.bases.team import TeamEndpoint
@@ -12,8 +12,8 @@ from sentry.models import Team
 logger = logging.getLogger(__name__)
 
 
-class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
-    def post(self, request: Any, team: Team) -> Response:
+class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # type: ignore
+    def post(self, request: Request, team: Team) -> Response:
         """
         Create an External Team
         `````````````

--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -1,34 +1,38 @@
 import logging
+from typing import Any, Tuple
 
-from django.http import Http404
 from rest_framework import status
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import ExternalTeam
+from sentry.models import ExternalActor, Team
 
-from .external_team import ExternalTeamMixin, ExternalTeamSerializer
+from .external_team import ExternalActorEndpointMixin, ExternalTeamSerializer
 
 logger = logging.getLogger(__name__)
 
 
-class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalTeamMixin):
-    def convert_args(
-        self, request, organization_slug, team_slug, external_team_id, *args, **kwargs
-    ):
+class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
+    def convert_args(self, request: Any, *args: Any, **kwargs: Any) -> Tuple[Any, Any]:
+        """ A little magic to make types work for convert_args. """
+        return self._convert_args(request, *args, **kwargs)
+
+    def _convert_args(
+        self,
+        request: Any,
+        organization_slug: str,
+        team_slug: str,
+        external_team_id: int,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Tuple[Any, Any]:
         args, kwargs = super().convert_args(request, organization_slug, team_slug, *args, **kwargs)
-        try:
-            kwargs["external_team"] = ExternalTeam.objects.get(
-                id=external_team_id,
-            )
-        except ExternalTeam.DoesNotExist:
-            raise Http404
 
-        return (args, kwargs)
+        kwargs["external_team"] = self.get_external_actor_or_404(external_team_id)
+        return args, kwargs
 
-    def put(self, request, team, external_team):
+    def put(self, request: Any, team: Team, external_team: ExternalActor) -> Response:
         """
         Update an External Team
         `````````````
@@ -41,11 +45,13 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalTeamMixin):
         :param string provider: enum("github","gitlab")
         :auth: required
         """
-        if not self.has_feature(request, team):
-            raise PermissionDenied
+        self.assert_has_feature(request, team.organization)
 
         serializer = ExternalTeamSerializer(
-            instance=external_team, data={**request.data, "team_id": team.id}, partial=True
+            instance=external_team,
+            data={**request.data, "team_id": team.id},
+            partial=True,
+            context={"organization": team.organization},
         )
         if serializer.is_valid():
             updated_external_team = serializer.save()
@@ -56,12 +62,11 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalTeamMixin):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request, team, external_team):
+    def delete(self, request: Any, team: Team, external_team: ExternalActor) -> Response:
         """
         Delete an External Team
         """
-        if not self.has_feature(request, team):
-            raise PermissionDenied
+        self.assert_has_feature(request, team.organization)
 
         external_team.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -1,22 +1,22 @@
 import logging
 from typing import Any, Tuple
 
-from rest_framework import status
-from rest_framework.response import Response
+from rest_framework import status  # type: ignore
+from rest_framework.request import Request  # type: ignore
+from rest_framework.response import Response  # type: ignore
 
+from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalTeamSerializer
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import ExternalActor, Team
 
-from .external_team import ExternalActorEndpointMixin, ExternalTeamSerializer
-
 logger = logging.getLogger(__name__)
 
 
-class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
+class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # type: ignore
     def convert_args(
         self,
-        request: Any,
+        request: Request,
         organization_slug: str,
         team_slug: str,
         external_team_id: int,
@@ -28,7 +28,7 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
         kwargs["external_team"] = self.get_external_actor_or_404(external_team_id)
         return args, kwargs
 
-    def put(self, request: Any, team: Team, external_team: ExternalActor) -> Response:
+    def put(self, request: Request, team: Team, external_team: ExternalActor) -> Response:
         """
         Update an External Team
         `````````````
@@ -58,7 +58,7 @@ class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request: Any, team: Team, external_team: ExternalActor) -> Response:
+    def delete(self, request: Request, team: Team, external_team: ExternalActor) -> Response:
         """
         Delete an External Team
         """

--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -14,11 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):
-    def convert_args(self, request: Any, *args: Any, **kwargs: Any) -> Tuple[Any, Any]:
-        """ A little magic to make types work for convert_args. """
-        return self._convert_args(request, *args, **kwargs)
-
-    def _convert_args(
+    def convert_args(
         self,
         request: Any,
         organization_slug: str,

--- a/src/sentry/api/endpoints/external_user.py
+++ b/src/sentry/api/endpoints/external_user.py
@@ -1,8 +1,8 @@
 import logging
-from typing import Any
 
-from rest_framework import status
-from rest_framework.response import Response
+from rest_framework import status  # type: ignore
+from rest_framework.request import Request  # type: ignore
+from rest_framework.response import Response  # type: ignore
 
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalUserSerializer
@@ -12,8 +12,8 @@ from sentry.models import Organization
 logger = logging.getLogger(__name__)
 
 
-class ExternalUserEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
-    def post(self, request: Any, organization: Organization) -> Response:
+class ExternalUserEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):  # type: ignore
+    def post(self, request: Request, organization: Organization) -> Response:
         """
         Create an External User
         `````````````

--- a/src/sentry/api/endpoints/external_user_details.py
+++ b/src/sentry/api/endpoints/external_user_details.py
@@ -1,50 +1,47 @@
 import logging
+from typing import Any, Tuple
 
-from django.http import Http404
 from rest_framework import status
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
 
+from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalUserSerializer
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
-from sentry.models import ExternalUser
-
-from .external_user import ExternalUserMixin, ExternalUserSerializer
+from sentry.models import ExternalActor, Organization
 
 logger = logging.getLogger(__name__)
 
 
-class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalUserMixin):
-    def convert_args(self, request, organization_slug, external_user_id, *args, **kwargs):
+class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
+    def convert_args(self, request: Any, *args: Any, **kwargs: Any) -> Tuple[Any, Any]:
+        """ A little magic to make types work for convert_args. """
+        return self._convert_args(request, *args, **kwargs)
+
+    def _convert_args(
+        self, request: Any, organization_slug: str, external_user_id: int, *args: Any, **kwargs: Any
+    ) -> Tuple[Any, Any]:
         args, kwargs = super().convert_args(request, organization_slug, *args, **kwargs)
-        try:
-            kwargs["external_user"] = ExternalUser.objects.get(
-                id=external_user_id,
-            )
-        except ExternalUser.DoesNotExist:
-            raise Http404
+        kwargs["external_user"] = self.get_external_actor_or_404(external_user_id)
+        return args, kwargs
 
-        return (args, kwargs)
-
-    def put(self, request, organization, external_user):
+    def put(self, request: Any, organization: Organization, external_user: ExternalActor):
         """
         Update an External User
         `````````````
 
         :pparam string organization_slug: the slug of the organization the
                                           user belongs to.
-        :pparam int user_id: the organization_member id.
+        :pparam int user_id: the User id.
         :pparam string external_user_id: id of external_user object
         :param string external_name: the Github/Gitlab user name.
         :param string provider: enum("github","gitlab")
         :auth: required
         """
-        if not self.has_feature(request, organization):
-            raise PermissionDenied
+        self.assert_has_feature(request, organization)
 
         serializer = ExternalUserSerializer(
-            instance=external_user,
-            data=request.data,
+            external_user,
+            request.data,
             context={"organization": organization},
             partial=True,
         )
@@ -57,12 +54,11 @@ class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalUserMixin):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request, organization, external_user):
+    def delete(self, request: Any, organization: Organization, external_user: ExternalActor):
         """
         Delete an External Team
         """
-        if not self.has_feature(request, organization):
-            raise PermissionDenied
+        self.assert_has_feature(request, organization)
 
         external_user.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/sentry/api/endpoints/external_user_details.py
+++ b/src/sentry/api/endpoints/external_user_details.py
@@ -1,8 +1,9 @@
 import logging
 from typing import Any, Tuple
 
-from rest_framework import status
-from rest_framework.response import Response
+from rest_framework import status  # type: ignore
+from rest_framework.request import Request  # type: ignore
+from rest_framework.response import Response  # type: ignore
 
 from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalUserSerializer
 from sentry.api.bases.organization import OrganizationEndpoint
@@ -12,15 +13,22 @@ from sentry.models import ExternalActor, Organization
 logger = logging.getLogger(__name__)
 
 
-class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
+class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):  # type: ignore
     def convert_args(
-        self, request: Any, organization_slug: str, external_user_id: int, *args: Any, **kwargs: Any
+        self,
+        request: Request,
+        organization_slug: str,
+        external_user_id: int,
+        *args: Any,
+        **kwargs: Any,
     ) -> Tuple[Any, Any]:
         args, kwargs = super().convert_args(request, organization_slug, *args, **kwargs)
         kwargs["external_user"] = self.get_external_actor_or_404(external_user_id)
         return args, kwargs
 
-    def put(self, request: Any, organization: Organization, external_user: ExternalActor):
+    def put(
+        self, request: Request, organization: Organization, external_user: ExternalActor
+    ) -> Response:
         """
         Update an External User
         `````````````
@@ -50,7 +58,9 @@ class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMix
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-    def delete(self, request: Any, organization: Organization, external_user: ExternalActor):
+    def delete(
+        self, request: Request, organization: Organization, external_user: ExternalActor
+    ) -> Response:
         """
         Delete an External Team
         """

--- a/src/sentry/api/endpoints/external_user_details.py
+++ b/src/sentry/api/endpoints/external_user_details.py
@@ -36,8 +36,8 @@ class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMix
         self.assert_has_feature(request, organization)
 
         serializer = ExternalUserSerializer(
-            external_user,
-            request.data,
+            instance=external_user,
+            data=request.data,
             context={"organization": organization},
             partial=True,
         )

--- a/src/sentry/api/endpoints/external_user_details.py
+++ b/src/sentry/api/endpoints/external_user_details.py
@@ -13,11 +13,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):
-    def convert_args(self, request: Any, *args: Any, **kwargs: Any) -> Tuple[Any, Any]:
-        """ A little magic to make types work for convert_args. """
-        return self._convert_args(request, *args, **kwargs)
-
-    def _convert_args(
+    def convert_args(
         self, request: Any, organization_slug: str, external_user_id: int, *args: Any, **kwargs: Any
     ) -> Tuple[Any, Any]:
         args, kwargs = super().convert_args(request, organization_slug, *args, **kwargs)

--- a/src/sentry/api/endpoints/organization_invite_request_details.py
+++ b/src/sentry/api/endpoints/organization_invite_request_details.py
@@ -6,7 +6,8 @@ from rest_framework.response import Response
 from sentry import features, roles
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.exceptions import ResourceDoesNotExist
-from sentry.api.serializers import OrganizationMemberWithTeamsSerializer, serialize
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.organization_member import OrganizationMemberWithTeamsSerializer
 from sentry.models import AuditLogEntryEvent, InviteStatus, OrganizationMember
 from sentry.signals import member_invited
 

--- a/src/sentry/api/endpoints/organization_invite_request_index.py
+++ b/src/sentry/api/endpoints/organization_invite_request_index.py
@@ -5,7 +5,8 @@ from rest_framework.response import Response
 from sentry import roles
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.api.paginator import OffsetPaginator
-from sentry.api.serializers import OrganizationMemberWithTeamsSerializer, serialize
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.organization_member import OrganizationMemberWithTeamsSerializer
 from sentry.app import locks
 from sentry.models import AuditLogEntryEvent, InviteStatus, OrganizationMember
 from sentry.tasks.members import send_invite_request_notification_email

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -13,8 +13,8 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models import projectcodeowners as projectcodeowners_serializers
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.models import (
-    ExternalTeam,
-    ExternalUser,
+    actor_type_to_string,
+    ExternalActor,
     Project,
     ProjectCodeOwners,
     RepositoryProjectPathConfig,
@@ -27,18 +27,18 @@ logger = logging.getLogger(__name__)
 
 
 def validate_association(
-    raw_items: Sequence[Union[UserEmail, ExternalUser, ExternalTeam]],
-    associations: Sequence[Union[UserEmail, ExternalUser, ExternalTeam]],
+    raw_items: Sequence[Union[UserEmail, ExternalActor]],
+    associations: Sequence[Union[UserEmail, ExternalActor]],
     type: str,
 ) -> Sequence[str]:
     if type == "emails":
         # associations are UserEmail objects
         sentry_items = [item.email for item in associations]
     else:
-        # associations can be ExternalUser or ExternalTeam objects
+        # associations are ExternalActor objects
         sentry_items = [item.external_name for item in associations]
 
-    diff = [item for item in raw_items if item not in sentry_items]
+    diff = [str(item) for item in raw_items if item not in sentry_items]
 
     if len(diff):
         return [f'The following {type} do not have an association in Sentry: {", ".join(diff)}.']
@@ -76,38 +76,37 @@ class ProjectCodeOwnerSerializer(CamelSnakeModelSerializer):  # type: ignore
             email__in=emails,
             user__sentry_orgmember_set__organization=self.context["project"].organization,
         )
-        user_emails_diff = validate_association(emails, user_emails, "emails")
 
+        user_emails_diff = validate_association(emails, user_emails, "emails")
         external_association_err.extend(user_emails_diff)
 
         # Check if the usernames have an association
-        external_users = ExternalUser.objects.filter(
+        external_actors = ExternalActor.objects.filter(
             external_name__in=usernames,
-            organizationmember__organization=self.context["project"].organization,
+            organization=self.context["project"].organization,
         )
 
-        external_users_diff = validate_association(usernames, external_users, "usernames")
-
+        external_users_diff = validate_association(usernames, external_actors, "usernames")
         external_association_err.extend(external_users_diff)
 
-        # Check if the team names have an association
-        external_teams = ExternalTeam.objects.filter(
-            external_name__in=teamnames,
-            team__organization=self.context["project"].organization,
-        )
-
-        external_teams_diff = validate_association(teamnames, external_teams, "team names")
-
+        external_teams_diff = validate_association(teamnames, external_actors, "team names")
         external_association_err.extend(external_teams_diff)
 
         if len(external_association_err):
             raise serializers.ValidationError({"raw": "\n".join(external_association_err)})
 
         # Convert CODEOWNERS into IssueOwner syntax
-        users_dict = {
-            user.external_name: user.organizationmember.user.email for user in external_users
-        }
-        teams_dict = {team.external_name: f"#{team.team.slug}" for team in external_teams}
+        users_dict = {}
+        teams_dict = {}
+        for external_actor in external_actors:
+            type = actor_type_to_string(external_actor.actor.type)
+            if type == "user":
+                user = external_actor.actor.resolve().email
+                users_dict[external_actor.external_name] = user.email
+            elif type == "team":
+                team = external_actor.actor.resolve()
+                teams_dict[external_actor.external_name] = f"#{team.slug}"
+
         emails_dict = {email: email for email in emails}
         associations = {**users_dict, **teams_dict, **emails_dict}
 

--- a/src/sentry/api/endpoints/project_codeowners.py
+++ b/src/sentry/api/endpoints/project_codeowners.py
@@ -13,12 +13,12 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models import projectcodeowners as projectcodeowners_serializers
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.models import (
-    actor_type_to_string,
     ExternalActor,
     Project,
     ProjectCodeOwners,
     RepositoryProjectPathConfig,
     UserEmail,
+    actor_type_to_string,
 )
 from sentry.ownership.grammar import convert_codeowners_syntax, parse_code_owners
 from sentry.utils import metrics

--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -1,0 +1,32 @@
+from typing import Any, Mapping
+
+from sentry.api.serializers import Serializer, register
+from sentry.models import ExternalActor
+from sentry.types.integrations import get_provider_string
+
+
+@register(ExternalActor)
+class ExternalActorSerializer(Serializer):
+    def serialize(
+        self, obj: ExternalActor, attrs: Mapping[Any, Any], user: Any, **kwargs
+    ) -> Mapping[str, Any]:
+        provider = get_provider_string(obj.provider)
+        data = {
+            "id": str(obj.id),
+            "provider": provider,
+            "externalName": obj.external_name,
+        }
+
+        if obj.external_id:
+            data["externalId"] = obj.external_id
+
+        # Extra context `key` tells the API how to resolve actor_id.
+        key = kwargs.pop("key", None)
+        if key == "user":
+            data["userId"] = str(obj.actor.resolve().id)
+        elif key == "team":
+            data["teamId"] = str(obj.actor.resolve().id)
+        else:
+            data["actorId"] = str(obj.actor.id)
+
+        return data

--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -1,17 +1,17 @@
 from typing import Any, Mapping, Optional
 
 from sentry.api.serializers import Serializer, register
-from sentry.models import ExternalActor
+from sentry.models import ExternalActor, User
 from sentry.types.integrations import get_provider_string
 
 
 @register(ExternalActor)
-class ExternalActorSerializer(Serializer):
+class ExternalActorSerializer(Serializer):  # type: ignore
     def serialize(
         self,
         obj: ExternalActor,
-        attrs: Mapping[Any, Any],
-        user: Any,
+        attrs: Mapping[str, Any],
+        user: User,
         key: Optional[str] = None,
         **kwargs: Any,
     ) -> Mapping[str, Any]:

--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -1,12 +1,49 @@
-from typing import Any, Mapping, Optional
+from collections import defaultdict
+from typing import Any, List, Mapping, MutableMapping, Optional
 
 from sentry.api.serializers import Serializer, register
-from sentry.models import ExternalActor, User
+from sentry.models import (
+    ACTOR_TYPES,
+    ExternalActor,
+    User,
+    actor_type_to_class,
+    actor_type_to_string,
+)
 from sentry.types.integrations import get_provider_string
 
 
 @register(ExternalActor)
 class ExternalActorSerializer(Serializer):  # type: ignore
+    def get_attrs(
+        self, item_list: List[ExternalActor], user: User, **kwargs: Any
+    ) -> MutableMapping[Any, Any]:
+        external_actors_by_actor_id = {
+            external_actor.actor_id: external_actor for external_actor in item_list
+        }
+
+        actor_ids_by_type = defaultdict(list)
+        for actor_id, external_actor in external_actors_by_actor_id.items():
+            if actor_id is not None:
+                type_str = actor_type_to_string(external_actor.actor.type)
+                actor_ids_by_type[type_str].append(actor_id)
+
+        resolved_actors_by_type: MutableMapping[str, Mapping[int, int]] = defaultdict(dict)
+        for type_str, type_id in ACTOR_TYPES.items():
+            klass = actor_type_to_class(type_id)
+            actor_ids = actor_ids_by_type[type_str]
+
+            resolved_actors = klass.objects.filter(actor_id__in=actor_ids)
+
+            resolved_actors_by_type[type_str] = {model.actor_id: model for model in resolved_actors}
+
+        results: MutableMapping[ExternalActor, MutableMapping[str, Any]] = defaultdict(dict)
+        for type_str, mapping in resolved_actors_by_type.items():
+            for actor_id, model in mapping.items():
+                external_actor = external_actors_by_actor_id[actor_id]
+                results[external_actor][type_str] = model
+
+        return results
+
     def serialize(
         self,
         obj: ExternalActor,
@@ -27,8 +64,8 @@ class ExternalActorSerializer(Serializer):  # type: ignore
 
         # Extra context `key` tells the API how to resolve actor_id.
         if key == "user":
-            data["userId"] = str(obj.actor.resolve().id)
+            data["userId"] = str(attrs[key].id)
         elif key == "team":
-            data["teamId"] = str(obj.actor.resolve().id)
+            data["teamId"] = str(attrs[key].id)
 
         return data

--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -1,4 +1,4 @@
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 
 from sentry.api.serializers import Serializer, register
 from sentry.models import ExternalActor
@@ -8,7 +8,12 @@ from sentry.types.integrations import get_provider_string
 @register(ExternalActor)
 class ExternalActorSerializer(Serializer):
     def serialize(
-        self, obj: ExternalActor, attrs: Mapping[Any, Any], user: Any, **kwargs
+        self,
+        obj: ExternalActor,
+        attrs: Mapping[Any, Any],
+        user: Any,
+        key: Optional[str] = None,
+        **kwargs: Any,
     ) -> Mapping[str, Any]:
         provider = get_provider_string(obj.provider)
         data = {
@@ -21,7 +26,6 @@ class ExternalActorSerializer(Serializer):
             data["externalId"] = obj.external_id
 
         # Extra context `key` tells the API how to resolve actor_id.
-        key = kwargs.pop("key", None)
         if key == "user":
             data["userId"] = str(obj.actor.resolve().id)
         elif key == "team":

--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -30,7 +30,5 @@ class ExternalActorSerializer(Serializer):  # type: ignore
             data["userId"] = str(obj.actor.resolve().id)
         elif key == "team":
             data["teamId"] = str(obj.actor.resolve().id)
-        else:
-            data["actorId"] = str(obj.actor.id)
 
         return data

--- a/src/sentry/api/serializers/models/integration.py
+++ b/src/sentry/api/serializers/models/integration.py
@@ -6,8 +6,6 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.integrations import IntegrationProvider
 from sentry.models import (
     ExternalIssue,
-    ExternalTeam,
-    ExternalUser,
     Group,
     GroupLink,
     Integration,
@@ -15,7 +13,6 @@ from sentry.models import (
     User,
 )
 from sentry.shared_integrations.exceptions import ApiError
-from sentry.types.integrations import get_provider_string
 from sentry.utils.json import JSONData
 
 logger = logging.getLogger(__name__)
@@ -239,31 +236,3 @@ class IntegrationIssueSerializer(IntegrationSerializer):
         data = super().serialize(obj, attrs, user)
         data["externalIssues"] = attrs.get("external_issues", [])
         return data
-
-
-@register(ExternalTeam)
-class ExternalTeamSerializer(Serializer):  # type: ignore
-    def serialize(
-        self, obj: Any, attrs: Mapping[str, Any], user: User, **kwargs: Any
-    ) -> MutableMapping[str, JSONData]:
-        provider = get_provider_string(obj.provider)
-        return {
-            "id": str(obj.id),
-            "teamId": str(obj.team_id),
-            "provider": provider,
-            "externalName": obj.external_name,
-        }
-
-
-@register(ExternalUser)
-class ExternalUserSerializer(Serializer):  # type: ignore
-    def serialize(
-        self, obj: Any, attrs: Mapping[str, Any], user: User, **kwargs: Any
-    ) -> MutableMapping[str, JSONData]:
-        provider = get_provider_string(obj.provider)
-        return {
-            "id": str(obj.id),
-            "memberId": str(obj.organizationmember_id),
-            "provider": provider,
-            "externalName": obj.external_name,
-        }

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -75,19 +75,16 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
 
         if "externalUsers" in self.expand:
             organization_id = get_organization_id(item_list)
-            actor_mapping = {user.actor_id: user for user in users_set}
             external_actors = list(
                 ExternalActor.objects.filter(
-                    actor_id__in=actor_mapping.keys(),
+                    actor_id__in={user.actor_id for user in users_set},
                     organization_id=organization_id,
                 )
             )
 
-            for external_actor in external_actors:
-                serialized = serialize(external_actor, user, key="user")
-                user = actor_mapping.get(external_actor.actor.id)
-                user_id = str(user.id)
-                external_users_map[user_id].append(serialized)
+            serialized_list = serialize(external_actors, user, key="user")
+            for serialized in serialized_list:
+                external_users_map[serialized["userId"]].append(serialized)
 
         attrs: MutableMapping[OrganizationMember, MutableMapping[str, Any]] = {}
         for item in item_list:

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -68,7 +68,7 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             external_actors = list(ExternalActor.objects.filter(actor_id__in=actor_mapping.keys()))
 
             for external_actor in external_actors:
-                serialized = serialize(external_actor, user, key="team")
+                serialized = serialize(external_actor, user, key="user")
                 user = actor_mapping.get(external_actor.actor.id)
                 external_users_map[user["id"]].append(serialized)
 

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -77,9 +77,8 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             user = users_by_id.get(str(item.user_id), None)
             attrs[item] = {
                 "user": user,
-                "externalUsers": external_users_map.get(item.id),
+                "externalUsers": external_users_map.get(user),
             }
-
         return attrs
 
     def serialize(

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -70,14 +70,17 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             for external_actor in external_actors:
                 serialized = serialize(external_actor, user, key="team")
                 user = actor_mapping.get(external_actor.actor.id)
-                external_users_map[user].append(serialized)
+                external_users_map[user["id"]].append(serialized)
 
         attrs: MutableMapping[OrganizationMember, MutableMapping[str, Any]] = {}
         for item in item_list:
             user = users_by_id.get(str(item.user_id), None)
+            external_users = []
+            if user:
+                external_users = external_users_map.get(user.get("id"))
             attrs[item] = {
                 "user": user,
-                "externalUsers": external_users_map.get(user),
+                "externalUsers": external_users,
             }
         return attrs
 

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -43,18 +43,12 @@ def get_team_slugs_by_organization_member_id(
 
 def get_organization_id(organization_members: Sequence[OrganizationMember]) -> int:
     """ Ensure all organization_members have the same organization ID and then return that ID. """
-    organization_id: Optional[int] = None
-
-    for organization_member in organization_members:
-        next_organization_id = organization_member.organization.id
-        if next_organization_id and not organization_id:
-            organization_id = next_organization_id
-        elif not (next_organization_id and organization_id == next_organization_id):
-            raise Exception("Cannot determine organization")
-
-    if not organization_id:
+    organization_ids = {
+        organization_member.organization_id for organization_member in organization_members
+    }
+    if len(organization_ids) != 1:
         raise Exception("Cannot determine organization")
-    return organization_id
+    return int(organization_ids.pop())
 
 
 @register(OrganizationMember)

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -68,7 +68,7 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
             external_actors = list(ExternalActor.objects.filter(actor_id__in=actor_mapping.keys()))
 
             for external_actor in external_actors:
-                serialized = serialize(external_actor, user)
+                serialized = serialize(external_actor, user, key="team")
                 user = actor_mapping.get(external_actor.actor.id)
                 external_users_map[user].append(serialized)
 

--- a/src/sentry/api/serializers/models/organization_member.py
+++ b/src/sentry/api/serializers/models/organization_member.py
@@ -75,9 +75,9 @@ class OrganizationMemberSerializer(Serializer):  # type: ignore
         attrs: MutableMapping[OrganizationMember, MutableMapping[str, Any]] = {}
         for item in item_list:
             user = users_by_id.get(str(item.user_id), None)
-            external_users = []
+            external_users: List[Any] = []
             if user:
-                external_users = external_users_map.get(user.get("id"))
+                external_users = external_users_map.get(user["id"], [])
             attrs[item] = {
                 "user": user,
                 "externalUsers": external_users,

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -8,7 +8,7 @@ from sentry.api.serializers import Serializer, register, serialize
 from sentry.app import env
 from sentry.auth.superuser import is_active_superuser
 from sentry.models import (
-    ExternalTeam,
+    ExternalActor,
     InviteStatus,
     OrganizationAccessRequest,
     OrganizationMember,
@@ -148,7 +148,8 @@ class TeamWithProjectsSerializer(TeamSerializer):
             .select_related("project")
         )
 
-        external_teams = list(ExternalTeam.objects.filter(team__in=item_list))
+        actor_mapping = {team.actor_id: team for team in item_list}
+        external_actors = list(ExternalActor.objects.filter(actor_id__in=actor_mapping.keys()))
 
         # TODO(dcramer): we should query in bulk for ones we're missing here
         orgs = {i.organization_id: i.organization for i in item_list}
@@ -166,9 +167,11 @@ class TeamWithProjectsSerializer(TeamSerializer):
             project_map[project_team.team_id].append(projects_by_id[project_team.project_id])
 
         external_teams_map = defaultdict(list)
-        for external_team in external_teams:
-            serialized = serialize(external_team, user)
-            external_teams_map[external_team.team_id].append(serialized)
+        for external_actor in external_actors:
+            serialized = serialize(external_actor, user)
+            team = actor_mapping.get(external_actor.actor_id)
+            if team:
+                external_teams_map[team.id].append(serialized)
 
         result = super().get_attrs(item_list, user)
         for team in item_list:

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -167,11 +167,9 @@ class TeamWithProjectsSerializer(TeamSerializer):
             project_map[project_team.team_id].append(projects_by_id[project_team.project_id])
 
         external_teams_map = defaultdict(list)
-        for external_actor in external_actors:
-            serialized = serialize(external_actor, user)
-            team = actor_mapping.get(external_actor.actor_id)
-            if team:
-                external_teams_map[team.id].append(serialized)
+        serialized_list = serialize(external_actors, user, key="team")
+        for serialized in serialized_list:
+            external_teams_map[serialized["teamId"]].append(serialized)
 
         result = super().get_attrs(item_list, user)
         for team in item_list:

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1001,12 +1001,12 @@ urlpatterns = [
                     name="sentry-api-0-organization-member-index",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/members/externaluser/$",
+                    r"^(?P<organization_slug>[^\/]+)/external-users/$",
                     ExternalUserEndpoint.as_view(),
                     name="sentry-api-0-organization-external-user",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/members/externaluser/(?P<external_user_id>[^\/]+)/$",
+                    r"^(?P<organization_slug>[^\/]+)/external-users/(?P<external_user_id>[^\/]+)/$",
                     ExternalUserDetailsEndpoint.as_view(),
                     name="sentry-api-0-organization-external-user-details",
                 ),
@@ -1361,12 +1361,12 @@ urlpatterns = [
                     name="sentry-api-0-team-avatar",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/externalteam/$",
+                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/external-teams/$",
                     ExternalTeamEndpoint.as_view(),
                     name="sentry-api-0-external-team",
                 ),
                 url(
-                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/externalteam/(?P<external_team_id>[^\/]+)/$",
+                    r"^(?P<organization_slug>[^\/]+)/(?P<team_slug>[^\/]+)/external-teams/(?P<external_team_id>[^\/]+)/$",
                     ExternalTeamDetailsEndpoint.as_view(),
                     name="sentry-api-0-external-team-details",
                 ),

--- a/src/sentry/api/validators/integrations.py
+++ b/src/sentry/api/validators/integrations.py
@@ -1,0 +1,25 @@
+from typing import List, Optional, Set
+
+from sentry.api.exceptions import ParameterValidationError
+from sentry.types.integrations import ExternalProviders, get_provider_enum
+
+
+def validate_provider(
+    provider: str,
+    available_providers: Optional[Set[ExternalProviders]] = None,
+    context: Optional[List[str]] = None,
+) -> ExternalProviders:
+    provider_option = get_provider_enum(provider)
+    if not provider_option:
+        raise ParameterValidationError(f"Unknown provider: {provider}", context)
+
+    # If not available_providers are provider, assume all are acceptable
+    if available_providers and provider_option not in available_providers:
+        raise ParameterValidationError(
+            f'The provider "{provider}" is not supported. We currently accept {available_providers} identities.'
+        )
+    return provider_option
+
+
+def validate_provider_option(provider: Optional[str]) -> Optional[ExternalProviders]:
+    return validate_provider(provider) if provider else None

--- a/src/sentry/api/validators/notifications.py
+++ b/src/sentry/api/validators/notifications.py
@@ -1,13 +1,14 @@
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
 from sentry.api.exceptions import ParameterValidationError
+from sentry.api.validators.integrations import validate_provider
 from sentry.notifications.helpers import validate as helper_validate
 from sentry.notifications.types import (
     NotificationScopeType,
     NotificationSettingOptionValues,
     NotificationSettingTypes,
 )
-from sentry.types.integrations import ExternalProviders, get_provider_enum
+from sentry.types.integrations import ExternalProviders
 
 
 def intersect_dict_set(d: Dict[int, Any], s: Set[int]) -> Dict[int, Any]:
@@ -64,10 +65,6 @@ def validate_type_option(type: Optional[str]) -> Optional[NotificationSettingTyp
     return validate_type(type) if type else None
 
 
-def validate_provider_option(provider: Optional[str]) -> Optional[ExternalProviders]:
-    return validate_provider(provider) if provider else None
-
-
 def validate_type(type: str, context: Optional[List[str]] = None) -> NotificationSettingTypes:
     try:
         return NotificationSettingTypes(type)
@@ -98,13 +95,6 @@ def validate_scope(
         return int(scope_id)
     except ValueError:
         raise ParameterValidationError(f"Invalid ID: {scope_id}", context)
-
-
-def validate_provider(provider: str, context: Optional[List[str]] = None) -> ExternalProviders:
-    provider_option = get_provider_enum(provider)
-    if provider_option:
-        return provider_option
-    raise ParameterValidationError(f"Unknown provider: {provider}", context)
 
 
 def validate_value(
@@ -171,7 +161,7 @@ def validate(
 
                 context = parent_context + [type_key, scope_type_key, str(scope_id)]
                 for provider_key, value_key in notifications_by_scope_id.items():
-                    provider = validate_provider(provider_key, context)
+                    provider = validate_provider(provider_key, context=context)
                     value = validate_value(type, value_key, context)
 
                     notification_settings_to_update[(type, scope_type, scope_id, provider)] = value

--- a/src/sentry/ownership/grammar.py
+++ b/src/sentry/ownership/grammar.py
@@ -1,5 +1,6 @@
 import re
 from collections import namedtuple
+from typing import List, Tuple
 
 from parsimonious.exceptions import ParseError  # noqa
 from parsimonious.grammar import Grammar, NodeVisitor
@@ -236,7 +237,7 @@ def load_schema(schema):
     return [Rule.load(r) for r in schema["rules"]]
 
 
-def parse_code_owners(data):
+def parse_code_owners(data: str) -> Tuple[List[str], List[str], List[str]]:
     """Parse a CODEOWNERS text and returns the list of team names, list of usernames"""
     teams = []
     usernames = []

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -5,6 +5,7 @@ import warnings
 from binascii import hexlify
 from hashlib import sha1
 from importlib import import_module
+from typing import Any
 from uuid import uuid4
 
 import petname
@@ -46,9 +47,8 @@ from sentry.models import (
     CommitFileChange,
     Environment,
     EventAttachment,
+    ExternalActor,
     ExternalIssue,
-    ExternalTeam,
-    ExternalUser,
     File,
     Group,
     GroupLink,
@@ -954,18 +954,18 @@ class Factories:
         )
 
     @staticmethod
-    def create_external_user(organizationmember, **kwargs):
+    def create_external_user(user: User, **kwargs: Any) -> ExternalActor:
         kwargs.setdefault("provider", ExternalProviders.GITHUB.value)
         kwargs.setdefault("external_name", "")
 
-        return ExternalUser.objects.create(organizationmember=organizationmember, **kwargs)
+        return ExternalActor.objects.create(actor=user.actor, **kwargs)
 
     @staticmethod
-    def create_external_team(team, **kwargs):
+    def create_external_team(team: Team, **kwargs: Any) -> ExternalActor:
         kwargs.setdefault("provider", ExternalProviders.GITHUB.value)
         kwargs.setdefault("external_name", "@getsentry/ecosystem")
 
-        return ExternalTeam.objects.create(team=team, **kwargs)
+        return ExternalActor.objects.create(actor=team.actor, **kwargs)
 
     @staticmethod
     def create_codeowners(project, code_mapping, **kwargs):

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -297,15 +297,14 @@ class Fixtures:
         if not user:
             user = self.user
         if not organization:
-            organization = self.organization
+            organization = self.organization  # Force creation.
 
-        organizationmember = OrganizationMember.objects.get(user=user, organization=organization)
-        return Factories.create_external_user(organizationmember=organizationmember, **kwargs)
+        return Factories.create_external_user(user=user, organization=organization, **kwargs)
 
     def create_external_team(self, team=None, **kwargs):
         if not team:
             team = self.team
-        return Factories.create_external_team(team=team, **kwargs)
+        return Factories.create_external_team(team=team, organization=team.organization, **kwargs)
 
     def create_codeowners(self, project=None, code_mapping=None, **kwargs):
         if not project:

--- a/src/sentry/types/integrations.py
+++ b/src/sentry/types/integrations.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Optional, Sequence, Set
 
 
 class ExternalProviders(Enum):
@@ -34,3 +34,7 @@ def get_provider_string(provider_int: int) -> str:
 
 def get_provider_enum(value: Optional[str]) -> Optional[ExternalProviders]:
     return {v: k for k, v in EXTERNAL_PROVIDERS.items()}.get(value)
+
+
+def get_provider_choices(providers: Set[ExternalProviders]) -> Sequence[str]:
+    return list(EXTERNAL_PROVIDERS.get(i) for i in providers)

--- a/tests/sentry/api/endpoints/test_external_team.py
+++ b/tests/sentry/api/endpoints/test_external_team.py
@@ -1,6 +1,5 @@
-from sentry.models import ExternalTeam
 from sentry.testutils import APITestCase
-from sentry.types.integrations import ExternalProviders, get_provider_string
+from sentry.types.integrations import get_provider_string
 
 
 class ExternalTeamTest(APITestCase):
@@ -55,10 +54,8 @@ class ExternalTeamTest(APITestCase):
         assert response.data == {"provider": ['"git" is not a valid choice.']}
 
     def test_create_existing_association(self):
-        self.external_team = ExternalTeam.objects.create(
-            team_id=str(self.team.id),
-            provider=ExternalProviders.GITHUB.value,
-            external_name="@getsentry/ecosystem",
+        self.external_team = self.create_external_team(
+            self.team, external_name="@getsentry/ecosystem"
         )
         data = {
             "externalName": self.external_team.external_name,
@@ -68,6 +65,6 @@ class ExternalTeamTest(APITestCase):
             response = self.get_success_response(self.organization.slug, self.team.slug, **data)
         assert response.data == {
             "id": str(self.external_team.id),
-            "teamId": str(self.external_team.team_id),
+            "teamId": str(self.team.id),
             **data,
         }

--- a/tests/sentry/api/endpoints/test_external_team_details.py
+++ b/tests/sentry/api/endpoints/test_external_team_details.py
@@ -1,6 +1,5 @@
-from sentry.models import ExternalTeam
+from sentry.models import ExternalActor
 from sentry.testutils import APITestCase
-from sentry.types.integrations import ExternalProviders
 
 
 class ExternalTeamDetailsTest(APITestCase):
@@ -10,10 +9,9 @@ class ExternalTeamDetailsTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(self.user)
-        self.external_team = ExternalTeam.objects.create(
-            team_id=str(self.team.id),
-            provider=ExternalProviders.GITHUB.value,
-            external_name="@getsentry/ecosystem",
+
+        self.external_team = self.create_external_team(
+            self.team, external_name="@NisanthanNanthakumar"
         )
 
     def test_basic_delete(self):
@@ -21,7 +19,7 @@ class ExternalTeamDetailsTest(APITestCase):
             self.get_success_response(
                 self.organization.slug, self.team.slug, self.external_team.id, method="delete"
             )
-        assert not ExternalTeam.objects.filter(id=str(self.external_team.id)).exists()
+        assert not ExternalActor.objects.filter(id=str(self.external_team.id)).exists()
 
     def test_basic_update(self):
         with self.feature({"organizations:import-codeowners": True}):

--- a/tests/sentry/api/endpoints/test_external_team_details.py
+++ b/tests/sentry/api/endpoints/test_external_team_details.py
@@ -11,7 +11,7 @@ class ExternalTeamDetailsTest(APITestCase):
         self.login_as(self.user)
 
         self.external_team = self.create_external_team(
-            self.team, external_name="@NisanthanNanthakumar"
+            self.team, external_name="@getsentry/ecosystem"
         )
 
     def test_basic_delete(self):

--- a/tests/sentry/api/endpoints/test_external_user_details.py
+++ b/tests/sentry/api/endpoints/test_external_user_details.py
@@ -1,4 +1,4 @@
-from sentry.models import ExternalUser
+from sentry.models import ExternalActor
 from sentry.testutils import APITestCase
 
 
@@ -18,7 +18,7 @@ class ExternalUserDetailsTest(APITestCase):
             self.get_success_response(
                 self.organization.slug, self.external_user.id, method="delete"
             )
-        assert not ExternalUser.objects.filter(id=str(self.external_user.id)).exists()
+        assert not ExternalActor.objects.filter(id=str(self.external_user.id)).exists()
 
     def test_basic_update(self):
         with self.feature({"organizations:import-codeowners": True}):

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -477,22 +477,22 @@ class OrganizationMemberListTest(APITestCase):
     def test_user_has_external_user_association(self):
         response = self.get_valid_response(self.org.slug, qs_params={"expand": "externalUsers"})
         assert len(response.data) == 2
-        member = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
-        assert member
-        assert len(member["externalUsers"]) == 1
-        assert member["externalUsers"][0]["id"] == str(self.external_user.id)
-        assert member["externalUsers"][0]["memberId"] == member["id"]
+        user = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
+        assert user
+        assert len(user["externalUsers"]) == 1
+        assert user["externalUsers"][0]["id"] == str(self.external_user.id)
+        assert user["externalUsers"][0]["userId"] == user["id"]
 
     def test_user_has_external_user_associations_across_multiple_orgs(self):
         self.org_2 = self.create_organization(owner=self.user_2)
         self.external_user_2 = self.create_external_user(self.user_2, self.org_2)
         response = self.get_valid_response(self.org.slug, qs_params={"expand": "externalUsers"})
         assert len(response.data) == 2
-        member = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
-        assert member
-        assert len(member["externalUsers"]) == 1
-        assert member["externalUsers"][0]["id"] == str(self.external_user.id)
-        assert member["externalUsers"][0]["memberId"] == member["id"]
+        user = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
+        assert user
+        assert len(user["externalUsers"]) == 1
+        assert user["externalUsers"][0]["id"] == str(self.external_user.id)
+        assert user["externalUsers"][0]["userId"] == user["id"]
 
 
 class OrganizationMemberListPostTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_organization_member_index.py
+++ b/tests/sentry/api/endpoints/test_organization_member_index.py
@@ -475,24 +475,36 @@ class OrganizationMemberListTest(APITestCase):
         assert len(mail.outbox) == 1
 
     def test_user_has_external_user_association(self):
+        print("user.id", self.user.id)
+        print("user2.id", self.user_2.id)
+        print("external_user", self.external_user.id)
+
         response = self.get_valid_response(self.org.slug, qs_params={"expand": "externalUsers"})
         assert len(response.data) == 2
-        user = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
-        assert user
-        assert len(user["externalUsers"]) == 1
-        assert user["externalUsers"][0]["id"] == str(self.external_user.id)
-        assert user["externalUsers"][0]["userId"] == user["id"]
+        organization_member = next(
+            filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data)
+        )
+        assert organization_member
+        assert len(organization_member["externalUsers"]) == 1
+        assert organization_member["externalUsers"][0]["id"] == str(self.external_user.id)
+        assert (
+            organization_member["externalUsers"][0]["userId"] == organization_member["user"]["id"]
+        )
 
     def test_user_has_external_user_associations_across_multiple_orgs(self):
         self.org_2 = self.create_organization(owner=self.user_2)
         self.external_user_2 = self.create_external_user(self.user_2, self.org_2)
         response = self.get_valid_response(self.org.slug, qs_params={"expand": "externalUsers"})
         assert len(response.data) == 2
-        user = next(filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data))
-        assert user
-        assert len(user["externalUsers"]) == 1
-        assert user["externalUsers"][0]["id"] == str(self.external_user.id)
-        assert user["externalUsers"][0]["userId"] == user["id"]
+        organization_member = next(
+            filter(lambda x: x["user"]["id"] == str(self.user_2.id), response.data)
+        )
+        assert organization_member
+        assert len(organization_member["externalUsers"]) == 1
+        assert organization_member["externalUsers"][0]["id"] == str(self.external_user.id)
+        assert (
+            organization_member["externalUsers"][0]["userId"] == organization_member["user"]["id"]
+        )
 
 
 class OrganizationMemberListPostTest(APITestCase):

--- a/tests/sentry/api/serializers/test_external_actor.py
+++ b/tests/sentry/api/serializers/test_external_actor.py
@@ -1,0 +1,47 @@
+from sentry.api.serializers import serialize
+from sentry.models import ExternalActor
+from sentry.testutils import TestCase
+from sentry.types.integrations import ExternalProviders
+
+
+class ExternalActorSerializerTest(TestCase):
+    def test_user(self):
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+
+        external_actor, _ = ExternalActor.objects.get_or_create(
+            actor_id=user.actor_id,
+            organization=organization,
+            integration=None,
+            provider=ExternalProviders.SLACK.value,
+            external_name="Marcos",
+            external_id="Gaeta",
+        )
+
+        result = serialize(external_actor, user, key="user")
+
+        assert result["id"] == str(external_actor.id)
+        assert result["externalName"] == "Marcos"
+        assert result["externalId"] == "Gaeta"
+        assert result["userId"] == user.id
+
+    def test_team(self):
+        user = self.create_user()
+        organization = self.create_organization(owner=user)
+        team = self.create_team(organization=organization, members=[self.user])
+
+        external_actor, _ = ExternalActor.objects.get_or_create(
+            actor_id=team.actor_id,
+            organization=organization,
+            integration=None,
+            provider=ExternalProviders.SLACK.value,
+            external_name="Marcos",
+            external_id="Gaeta",
+        )
+
+        result = serialize(external_actor, user, key="team")
+
+        assert result["id"] == str(external_actor.id)
+        assert result["externalName"] == "Marcos"
+        assert result["externalId"] == "Gaeta"
+        assert result["teamId"] == team.id

--- a/tests/sentry/api/serializers/test_external_actor.py
+++ b/tests/sentry/api/serializers/test_external_actor.py
@@ -23,7 +23,7 @@ class ExternalActorSerializerTest(TestCase):
         assert result["id"] == str(external_actor.id)
         assert result["externalName"] == "Marcos"
         assert result["externalId"] == "Gaeta"
-        assert result["userId"] == user.id
+        assert result["userId"] == str(user.id)
 
     def test_team(self):
         user = self.create_user()
@@ -44,4 +44,4 @@ class ExternalActorSerializerTest(TestCase):
         assert result["id"] == str(external_actor.id)
         assert result["externalName"] == "Marcos"
         assert result["externalId"] == "Gaeta"
-        assert result["teamId"] == team.id
+        assert result["teamId"] == str(team.id)

--- a/tests/sentry/api/serializers/test_external_actor.py
+++ b/tests/sentry/api/serializers/test_external_actor.py
@@ -20,6 +20,7 @@ class ExternalActorSerializerTest(TestCase):
 
         result = serialize(external_actor, user, key="user")
 
+        assert "actorId" not in result
         assert result["id"] == str(external_actor.id)
         assert result["externalName"] == "Marcos"
         assert result["externalId"] == "Gaeta"
@@ -41,6 +42,7 @@ class ExternalActorSerializerTest(TestCase):
 
         result = serialize(external_actor, user, key="team")
 
+        assert "actorId" not in result
         assert result["id"] == str(external_actor.id)
         assert result["externalName"] == "Marcos"
         assert result["externalId"] == "Gaeta"


### PR DESCRIPTION
This PR replaces deprecated usages of `ExternalTeam` and `ExternalUser` with the new `ExternalActor` model while leaving the API mostly intact.

Updated APIs:
 - `/organizations/<slug>/external-users/`
	 - Uses `user_id` rather than `member_id`. 
 - `/organizations/<slug>/external-users/<id>`
	- Uses `user_id` rather than `member_id`.
 - `/teams/<org_slug>/<slug>/external-teams/`
 - `/team/<org_slug>/<slug>/external-teams/<id>`