### PR TITLE
fix(django22): Update old migrations to specify `on_delete` param

### DIFF
--- a/src/sentry/migrations/0002_912_to_recent.py
+++ b/src/sentry/migrations/0002_912_to_recent.py
@@ -1,13 +1,14 @@
+import django.db.models.deletion
+import django.utils.timezone
+from django.conf import settings
 from django.db import migrations, models
+
+import sentry.db.models.fields.array
 import sentry.db.models.fields.bounded
+import sentry.db.models.fields.encrypted
+import sentry.db.models.fields.foreignkey
 import sentry.db.models.fields.jsonfield
 import sentry.db.models.fields.uuid
-import sentry.db.models.fields.array
-import django.utils.timezone
-import sentry.db.models.fields.foreignkey
-import django.db.models.deletion
-from django.conf import settings
-import sentry.db.models.fields.encrypted
 
 
 class Migration(migrations.Migration):
@@ -846,7 +847,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="incidentsnapshot",
             name="incident",
-            field=models.OneToOneField(to="sentry.Incident"),
+            field=models.OneToOneField(to="sentry.Incident", on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name="incidentgroup",

--- a/src/social_auth/migrations/0001_initial.py
+++ b/src/social_auth/migrations/0001_initial.py
@@ -1,5 +1,6 @@
-from django.db import migrations, models
 from django.conf import settings
+from django.db import migrations, models
+
 import social_auth.fields
 
 
@@ -22,7 +23,11 @@ class Migration(migrations.Migration):
                 ("extra_data", social_auth.fields.JSONField(default="{}")),
                 (
                     "user",
-                    models.ForeignKey(related_name="social_auth", to=settings.AUTH_USER_MODEL),
+                    models.ForeignKey(
+                        related_name="social_auth",
+                        to=settings.AUTH_USER_MODEL,
+                        on_delete=models.CASCADE,
+                    ),
                 ),
             ],
         ),


### PR DESCRIPTION
This is required in modern versions of Django, and old migrations that don't specify what to do on
`on_delete` end up erroring.