### PR TITLE
fix(outcomes): bump up query limit to max of 10k

### DIFF
--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -1,3 +1,4 @@
+import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple
@@ -16,6 +17,8 @@ from sentry.utils.outcomes import Outcome
 from sentry.utils.snuba import raw_query
 
 from .dataset import Dataset
+
+logger = logging.getLogger(__name__)
 
 """
 The new Outcomes API defines a "metrics"-like interface which is can be used in
@@ -279,6 +282,7 @@ def run_outcomes_query(query: QueryDefinition) -> Tuple[ResultSet, ResultSet]:
         conditions=query.conditions,
         selected_columns=query.query_columns,
         referrer="outcomes.totals",
+        limit=10000,
     )
     result_timeseries = raw_query(
         dataset=query.dataset,
@@ -291,6 +295,7 @@ def run_outcomes_query(query: QueryDefinition) -> Tuple[ResultSet, ResultSet]:
         end=query.end,
         rollup=query.rollup,
         referrer="outcomes.timeseries",
+        limit=10000,
     )
 
     result_totals = _format_rows(result["data"], query)

--- a/src/sentry/snuba/outcomes.py
+++ b/src/sentry/snuba/outcomes.py
@@ -1,4 +1,3 @@
-import logging
 from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple
@@ -17,8 +16,6 @@ from sentry.utils.outcomes import Outcome
 from sentry.utils.snuba import raw_query
 
 from .dataset import Dataset
-
-logger = logging.getLogger(__name__)
 
 """
 The new Outcomes API defines a "metrics"-like interface which is can be used in


### PR DESCRIPTION
We started missing data when our # of intervals became large (primarily on 14d view) due to default snuba row limit being 1000. 

This increases limit to max of 10,000 which will make overall orgstats queries work. For orgs with large # of active projects (> ~600) still need to modify things a bit for the project queries. math on this:


- the theoretical maximum amount of rows per time interval of datacategory+outcome is 24 (6 x 4).
10000 / 24 = 416
- so maximum # of projects is limited to ~416, and in practice, probably like 600 since it's a theoretical max and not every hour of every combo will be filled in. This still isn't great as our largest users have over 1000 projects.

solutions for solving project table problem:
- re-query when DataCategory is changed on the page, and this increases # of projects we can display from 416 to 625 (still have 4 seperate categories as errors technically have 4).
- if we do an optimization query side to combine row categories as ERROR, we can increase that number from 625 to 2500
- when client-side pagination is implemented, could fetch new project totals when page changes