### PR TITLE
fix(alert): Move header outside of placeholder

### DIFF
--- a/static/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/static/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -258,21 +258,19 @@ class TriggersChart extends React.PureComponent<Props, State> {
 
                 const chart = (
                   <React.Fragment>
+                    {header}
+                    <TransparentLoadingMask visible={reloading} />
                     {loading || reloading ? (
                       <ChartPlaceholder />
                     ) : (
-                      <React.Fragment>
-                        {header}
-                        <TransparentLoadingMask visible={reloading} />
-                        <ThresholdsChart
-                          period={statsPeriod}
-                          maxValue={maxValue ? maxValue.value : maxValue}
-                          data={timeseriesData}
-                          triggers={triggers}
-                          resolveThreshold={resolveThreshold}
-                          thresholdType={thresholdType}
-                        />
-                      </React.Fragment>
+                      <ThresholdsChart
+                        period={statsPeriod}
+                        maxValue={maxValue ? maxValue.value : maxValue}
+                        data={timeseriesData}
+                        triggers={triggers}
+                        resolveThreshold={resolveThreshold}
+                        thresholdType={thresholdType}
+                      />
                     )}
                     <ChartControls>
                       <InlineContainer>


### PR DESCRIPTION
**Header now shows before chart is loaded**
![Kapture 2021-04-19 at 18 40 43](https://user-images.githubusercontent.com/9372512/115312134-c9c35c80-a13e-11eb-9716-2efe6909d023.gif)
