### PR TITLE
fix(ui): Alert details tooltip to use timezone / data interval

### DIFF
--- a/static/app/components/organizations/globalSelectionHeader/getParams.tsx
+++ b/static/app/components/organizations/globalSelectionHeader/getParams.tsx
@@ -4,6 +4,8 @@ import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {IntervalPeriod} from 'app/types';
 import {defined} from 'app/utils';
 
+export type StatsPeriodType = 'h' | 'd' | 's' | 'm' | 'w';
+
 const STATS_PERIOD_PATTERN = '^(\\d+)([hdmsw])?$';
 
 export function parseStatsPeriod(input: string | IntervalPeriod) {

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -290,43 +290,45 @@ export default class DetailsBody extends React.Component<Props> {
               <Layout.Body>
                 <Layout.Main>
                   <HeaderContainer>
-                    <div>
-                      <SidebarHeading noMargin>{t('Display')}</SidebarHeading>
-                      <ChartControls>
-                        <DropdownControl label={timePeriod.display}>
-                          {TIME_OPTIONS.map(({label, value}) => (
-                            <DropdownItem
-                              key={value}
-                              eventKey={value}
-                              onSelect={this.props.handleTimePeriodChange}
-                            >
-                              {label}
-                            </DropdownItem>
-                          ))}
-                        </DropdownControl>
-                      </ChartControls>
-                    </div>
-                    {projects && projects.length && (
+                    <HeaderGrid>
                       <div>
-                        <SidebarHeading noMargin>{t('Project')}</SidebarHeading>
-
-                        <IdBadge avatarSize={16} project={projects[0]} />
+                        <SidebarHeading noMargin>{t('Display')}</SidebarHeading>
+                        <ChartControls>
+                          <DropdownControl label={timePeriod.display}>
+                            {TIME_OPTIONS.map(({label, value}) => (
+                              <DropdownItem
+                                key={value}
+                                eventKey={value}
+                                onSelect={this.props.handleTimePeriodChange}
+                              >
+                                {label}
+                              </DropdownItem>
+                            ))}
+                          </DropdownControl>
+                        </ChartControls>
                       </div>
-                    )}
-                    <div>
-                      <SidebarHeading noMargin>
-                        {t('Time Interval')}
-                        <Tooltip
-                          title={t(
-                            'This is the time period which the metric is evaluated by.'
-                          )}
-                        >
-                          <IconInfo size="xs" />
-                        </Tooltip>
-                      </SidebarHeading>
+                      {projects && projects.length && (
+                        <div>
+                          <SidebarHeading noMargin>{t('Project')}</SidebarHeading>
 
-                      <RuleText>{this.getTimeWindow()}</RuleText>
-                    </div>
+                          <IdBadge avatarSize={16} project={projects[0]} />
+                        </div>
+                      )}
+                      <div>
+                        <SidebarHeading noMargin>
+                          {t('Time Interval')}
+                          <Tooltip
+                            title={t(
+                              'This is the time period which the metric is evaluated by.'
+                            )}
+                          >
+                            <IconInfo size="xs" />
+                          </Tooltip>
+                        </SidebarHeading>
+
+                        <RuleText>{this.getTimeWindow()}</RuleText>
+                      </div>
+                    </HeaderGrid>
                   </HeaderContainer>
 
                   <MetricChart
@@ -398,6 +400,14 @@ const DetailWrapper = styled('div')`
 
 const HeaderContainer = styled('div')`
   display: flex;
+  flex-direction: row;
+  align-content: flex-start;
+`;
+
+const HeaderGrid = styled('div')`
+  display: grid;
+  grid-template-columns: auto auto auto;
+  align-items: center;
   gap: ${space(4)};
 `;
 
@@ -436,10 +446,12 @@ const StatusContainer = styled('div')`
 `;
 
 const SidebarHeading = styled(SectionHeading)<{noMargin?: boolean}>`
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto auto;
+  justify-content: flex-start;
   margin-top: ${p => (p.noMargin ? 0 : space(2))};
   line-height: 1;
+  gap: ${space(1)};
 `;
 
 const ChartControls = styled('div')`

--- a/static/app/views/alerts/rules/details/constants.tsx
+++ b/static/app/views/alerts/rules/details/constants.tsx
@@ -11,8 +11,6 @@ export const TIME_OPTIONS: SelectValue<string>[] = [
   {label: t('Last 7 days'), value: TimePeriod.SEVEN_DAYS},
 ];
 
-export const ALERT_RULE_DETAILS_DEFAULT_PERIOD = TimePeriod.ONE_DAY;
-
 export const TIME_WINDOWS = {
   [TimePeriod.SIX_HOURS]: TimeWindow.ONE_HOUR * 6 * 60 * 1000,
   [TimePeriod.ONE_DAY]: TimeWindow.ONE_DAY * 60 * 1000,

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -12,18 +12,13 @@ import {Organization} from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import withApi from 'app/utils/withApi';
 import {makeRuleDetailsQuery} from 'app/views/alerts/list/row';
-import {IncidentRule} from 'app/views/settings/incidentRules/types';
+import {IncidentRule, TimePeriod, TimeWindow} from 'app/views/settings/incidentRules/types';
 
 import {Incident} from '../../types';
 import {fetchAlertRule, fetchIncident, fetchIncidentsForRule} from '../../utils';
 
 import DetailsBody from './body';
-import {
-  ALERT_RULE_DETAILS_DEFAULT_PERIOD,
-  TIME_OPTIONS,
-  TIME_WINDOWS,
-  TimePeriodType,
-} from './constants';
+import {TIME_OPTIONS, TIME_WINDOWS, TimePeriodType} from './constants';
 import DetailsHeader from './header';
 
 type Props = {
@@ -62,8 +57,10 @@ class AlertRuleDetails extends React.Component<Props, State> {
 
   getTimePeriod(): TimePeriodType {
     const {location} = this.props;
+    const {rule} = this.state;
 
-    const period = location.query.period ?? ALERT_RULE_DETAILS_DEFAULT_PERIOD;
+    const defaultPeriod = rule?.timeWindow && rule?.timeWindow > TimeWindow.ONE_HOUR ? TimePeriod.SEVEN_DAYS : TimePeriod.ONE_DAY;
+    const period = location.query.period ?? defaultPeriod;
 
     if (location.query.start && location.query.end) {
       return {

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -12,7 +12,11 @@ import {Organization} from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import withApi from 'app/utils/withApi';
 import {makeRuleDetailsQuery} from 'app/views/alerts/list/row';
-import {IncidentRule, TimePeriod, TimeWindow} from 'app/views/settings/incidentRules/types';
+import {
+  IncidentRule,
+  TimePeriod,
+  TimeWindow,
+} from 'app/views/settings/incidentRules/types';
 
 import {Incident} from '../../types';
 import {fetchAlertRule, fetchIncident, fetchIncidentsForRule} from '../../utils';
@@ -59,7 +63,10 @@ class AlertRuleDetails extends React.Component<Props, State> {
     const {location} = this.props;
     const {rule} = this.state;
 
-    const defaultPeriod = rule?.timeWindow && rule?.timeWindow > TimeWindow.ONE_HOUR ? TimePeriod.SEVEN_DAYS : TimePeriod.ONE_DAY;
+    const defaultPeriod =
+      rule?.timeWindow && rule?.timeWindow > TimeWindow.ONE_HOUR
+        ? TimePeriod.SEVEN_DAYS
+        : TimePeriod.ONE_DAY;
     const period = location.query.period ?? defaultPeriod;
 
     if (location.query.start && location.query.end) {

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -24,10 +24,11 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {AvatarProject, Organization, Project} from 'app/types';
 import {ReactEchartsRef} from 'app/types/echarts';
-import {getFormattedDate, getUtcDateString} from 'app/utils/dates';
+import {getUtcDateString} from 'app/utils/dates';
 import theme from 'app/utils/theme';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
+import ConfigStore from 'app/stores/configStore';
 
 import {
   AlertRuleStatus,
@@ -61,6 +62,11 @@ type State = {
   width: number;
   height: number;
 };
+
+function formatTooltipDate(date: moment.MomentInput, format: string): string {
+  const {options: {timezone}} = ConfigStore.get('user');
+  return moment.tz(date, timezone).format(format);
+}
 
 function createThresholdSeries(lineColor: string, threshold: number): LineChartSeries {
   return {
@@ -139,7 +145,7 @@ function createIncidentSeries(
     trigger: 'item',
     alwaysShowContent: true,
     formatter: ({value, marker}) => {
-      const time = getFormattedDate(moment(value), 'MMM D, YYYY LT', {local: true});
+      const time = formatTooltipDate(moment(value), 'MMM D, YYYY LT');
       return [
         `<div class="tooltip-series"><div>`,
         `<span class="tooltip-label">${marker} <strong>${t('Alert')} #${
@@ -336,16 +342,12 @@ class MetricChart extends React.PureComponent<Props, State> {
             const [pointX, pointY] = pointData as [number, number];
             const isModified = dateModified && pointX <= new Date(dateModified).getTime();
 
-            const startTime = getFormattedDate(moment(pointX), 'MMM D LT', {local: true});
+            const startTime = formatTooltipDate(moment(pointX), 'MMM D LT');
             const {period, periodLength} = parseStatsPeriod(interval) ?? {
               periodLength: 'm',
               period: `${timeWindow}`,
             };
-            const endTime = getFormattedDate(
-              moment(pointX).add(parseInt(period, 10), periodLength as StatsPeriodType),
-              'MMM D LT',
-              {local: true}
-            );
+            const endTime = formatTooltipDate(moment(pointX).add(parseInt(period, 10), periodLength as StatsPeriodType), 'MMM D LT');
             const title = isModified
               ? `<strong>${t('Alert Rule Modified')}</strong>`
               : `${marker} <strong>${seriesName}</strong>`;

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -21,6 +21,7 @@ import {Panel, PanelBody, PanelFooter} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
 import {IconCheckmark, IconFire, IconWarning} from 'app/icons';
 import {t} from 'app/locale';
+import ConfigStore from 'app/stores/configStore';
 import space from 'app/styles/space';
 import {AvatarProject, Organization, Project} from 'app/types';
 import {ReactEchartsRef} from 'app/types/echarts';
@@ -28,7 +29,6 @@ import {getUtcDateString} from 'app/utils/dates';
 import theme from 'app/utils/theme';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
-import ConfigStore from 'app/stores/configStore';
 
 import {
   AlertRuleStatus,
@@ -64,7 +64,9 @@ type State = {
 };
 
 function formatTooltipDate(date: moment.MomentInput, format: string): string {
-  const {options: {timezone}} = ConfigStore.get('user');
+  const {
+    options: {timezone},
+  } = ConfigStore.get('user');
   return moment.tz(date, timezone).format(format);
 }
 
@@ -76,6 +78,9 @@ function createThresholdSeries(lineColor: string, threshold: number): LineChartS
       silent: true,
       lineStyle: {color: lineColor, type: 'dashed', width: 1},
       data: [{yAxis: threshold} as any],
+      label: {
+        show: false,
+      },
     }),
     data: [],
   };
@@ -323,7 +328,7 @@ class MetricChart extends React.PureComponent<Props, State> {
         forwardedRef={this.handleRef}
         grid={{
           left: 0,
-          right: 0,
+          right: space(2),
           top: space(2),
           bottom: 0,
         }}
@@ -347,7 +352,10 @@ class MetricChart extends React.PureComponent<Props, State> {
               periodLength: 'm',
               period: `${timeWindow}`,
             };
-            const endTime = formatTooltipDate(moment(pointX).add(parseInt(period, 10), periodLength as StatsPeriodType), 'MMM D LT');
+            const endTime = formatTooltipDate(
+              moment(pointX).add(parseInt(period, 10), periodLength as StatsPeriodType),
+              'MMM D LT'
+            );
             const title = isModified
               ? `<strong>${t('Alert Rule Modified')}</strong>`
               : `${marker} <strong>${seriesName}</strong>`;

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -13,7 +13,10 @@ import MarkArea from 'app/components/charts/components/markArea';
 import MarkLine from 'app/components/charts/components/markLine';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import LineChart, {LineChartSeries} from 'app/components/charts/lineChart';
-import {parseStatsPeriod, StatsPeriodType} from 'app/components/organizations/globalSelectionHeader/getParams';
+import {
+  parseStatsPeriod,
+  StatsPeriodType,
+} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel, PanelBody, PanelFooter} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
 import {IconCheckmark, IconFire, IconWarning} from 'app/icons';
@@ -333,16 +336,15 @@ class MetricChart extends React.PureComponent<Props, State> {
             const [pointX, pointY] = pointData as [number, number];
             const isModified = dateModified && pointX <= new Date(dateModified).getTime();
 
-            const startTime = getFormattedDate(
-              moment(pointX),
-              'MMM D LT',
-              {local: true},
-              );
-            const {period, periodLength} = parseStatsPeriod(interval) ?? {periodLength: 'm', period: `${timeWindow}`};
+            const startTime = getFormattedDate(moment(pointX), 'MMM D LT', {local: true});
+            const {period, periodLength} = parseStatsPeriod(interval) ?? {
+              periodLength: 'm',
+              period: `${timeWindow}`,
+            };
             const endTime = getFormattedDate(
               moment(pointX).add(parseInt(period, 10), periodLength as StatsPeriodType),
               'MMM D LT',
-              {local: true},
+              {local: true}
             );
             const title = isModified
               ? `<strong>${t('Alert Rule Modified')}</strong>`

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -13,6 +13,7 @@ import MarkArea from 'app/components/charts/components/markArea';
 import MarkLine from 'app/components/charts/components/markLine';
 import EventsRequest from 'app/components/charts/eventsRequest';
 import LineChart, {LineChartSeries} from 'app/components/charts/lineChart';
+import {parseStatsPeriod, StatsPeriodType} from 'app/components/organizations/globalSelectionHeader/getParams';
 import {Panel, PanelBody, PanelFooter} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
 import {IconCheckmark, IconFire, IconWarning} from 'app/icons';
@@ -135,7 +136,7 @@ function createIncidentSeries(
     trigger: 'item',
     alwaysShowContent: true,
     formatter: ({value, marker}) => {
-      const time = getFormattedDate(value, 'MMM D, YYYY LT');
+      const time = getFormattedDate(moment(value), 'MMM D, YYYY LT', {local: true});
       return [
         `<div class="tooltip-series"><div>`,
         `<span class="tooltip-label">${marker} <strong>${t('Alert')} #${
@@ -304,6 +305,7 @@ class MetricChart extends React.PureComponent<Props, State> {
     maxThresholdValue: number,
     maxSeriesValue: number
   ) {
+    const {interval} = this.props;
     const {dateModified, timeWindow} = this.props.rule || {};
     return (
       <LineChart
@@ -331,10 +333,16 @@ class MetricChart extends React.PureComponent<Props, State> {
             const [pointX, pointY] = pointData as [number, number];
             const isModified = dateModified && pointX <= new Date(dateModified).getTime();
 
-            const startTime = getFormattedDate(new Date(pointX), 'MMM D LT');
+            const startTime = getFormattedDate(
+              moment(pointX),
+              'MMM D LT',
+              {local: true},
+              );
+            const {period, periodLength} = parseStatsPeriod(interval) ?? {periodLength: 'm', period: `${timeWindow}`};
             const endTime = getFormattedDate(
-              moment(new Date(pointX)).add(timeWindow, 'minutes'),
-              'MMM D LT'
+              moment(pointX).add(parseInt(period, 10), periodLength as StatsPeriodType),
+              'MMM D LT',
+              {local: true},
             );
             const title = isModified
               ? `<strong>${t('Alert Rule Modified')}</strong>`


### PR DESCRIPTION
This fixes the alert details tooltip timezone difference with the chart. Changed the default time range of the chart to be based on the alert rule timewindow, for >1h it's 7d now, 1d otherwise. Fixed padding issues in Safari, gap on flex display isn't supported yet in safari, changed it to a gap display.

Display interval: [WOR-842](https://getsentry.atlassian.net/browse/WOR-842)
Tooltip tz: [WOR-843](https://getsentry.atlassian.net/browse/WOR-843)
Safari: [WOR-846](https://getsentry.atlassian.net/browse/WOR-846)