### PR TITLE
feat(ui): Sort release issues by frequency

### DIFF
--- a/static/app/views/releases/detail/overview/issues.tsx
+++ b/static/app/views/releases/detail/overview/issues.tsx
@@ -102,7 +102,7 @@ class Issues extends React.Component<Props, State> {
         defaultStatsPeriod,
       }),
       limit: 10,
-      sort: 'new',
+      sort: 'freq',
     };
 
     switch (issuesType) {

--- a/static/app/views/releases/detail/overview/issues.tsx
+++ b/static/app/views/releases/detail/overview/issues.tsx
@@ -19,6 +19,7 @@ import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {GlobalSelection} from 'app/types';
 import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {IssueSortOptions} from 'app/views/issueList/utils';
 
 import EmptyState from '../emptyState';
 
@@ -102,7 +103,7 @@ class Issues extends React.Component<Props, State> {
         defaultStatsPeriod,
       }),
       limit: 10,
-      sort: 'freq',
+      sort: IssueSortOptions.FREQ,
     };
 
     switch (issuesType) {

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -54,6 +54,7 @@ export const getReleaseNewIssuesUrl = (
       start: undefined,
       end: undefined,
       query: stringifyQueryObject(new QueryResults([`firstRelease:${version}`])),
+      sort: 'freq',
     },
   };
 };

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -72,6 +72,7 @@ export const getReleaseUnhandledIssuesUrl = (
       query: stringifyQueryObject(
         new QueryResults([`release:${version}`, 'error.unhandled:true'])
       ),
+      sort: IssueSortOptions.FREQ,
     },
   };
 };

--- a/static/app/views/releases/utils/index.tsx
+++ b/static/app/views/releases/utils/index.tsx
@@ -3,6 +3,7 @@ import round from 'lodash/round';
 import {tn} from 'app/locale';
 import {Release, ReleaseStatus} from 'app/types';
 import {QueryResults, stringifyQueryObject} from 'app/utils/tokenizeSearch';
+import {IssueSortOptions} from 'app/views/issueList/utils';
 
 import {DisplayOption} from '../list/utils';
 
@@ -54,7 +55,7 @@ export const getReleaseNewIssuesUrl = (
       start: undefined,
       end: undefined,
       query: stringifyQueryObject(new QueryResults([`firstRelease:${version}`])),
-      sort: 'freq',
+      sort: IssueSortOptions.FREQ,
     },
   };
 };

--- a/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
+++ b/tests/js/spec/views/releases/detail/overview/issues.spec.jsx
@@ -27,22 +27,22 @@ describe('Release Issues', function () {
     });
 
     newIssuesEndpoint = MockApiClient.addMockResponse({
-      url: `/organizations/${props.orgId}/issues/?limit=10&query=first-release%3A1.0.0&sort=new&statsPeriod=14d`,
+      url: `/organizations/${props.orgId}/issues/?limit=10&query=first-release%3A1.0.0&sort=freq&statsPeriod=14d`,
       body: [],
     });
     resolvedIssuesEndpoint = MockApiClient.addMockResponse({
       url:
-        '/organizations/org/releases/1.0.0/resolved/?limit=10&query=&sort=new&statsPeriod=14d',
+        '/organizations/org/releases/1.0.0/resolved/?limit=10&query=&sort=freq&statsPeriod=14d',
       body: [],
     });
     unhandledIssuesEndpoint = MockApiClient.addMockResponse({
       url:
-        '/organizations/org/issues/?limit=10&query=release%3A1.0.0%20error.handled%3A0&sort=new&statsPeriod=14d',
+        '/organizations/org/issues/?limit=10&query=release%3A1.0.0%20error.handled%3A0&sort=freq&statsPeriod=14d',
       body: [],
     });
     allIssuesEndpoint = MockApiClient.addMockResponse({
       url:
-        '/organizations/org/issues/?limit=10&query=release%3A1.0.0&sort=new&statsPeriod=14d',
+        '/organizations/org/issues/?limit=10&query=release%3A1.0.0&sort=freq&statsPeriod=14d',
       body: [],
     });
   });
@@ -147,7 +147,7 @@ describe('Release Issues', function () {
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
       query: {
-        sort: 'new',
+        sort: 'freq',
         query: 'firstRelease:1.0.0',
         cursor: undefined,
         limit: undefined,
@@ -159,7 +159,7 @@ describe('Release Issues', function () {
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
       query: {
-        sort: 'new',
+        sort: 'freq',
         query: 'release:1.0.0',
         cursor: undefined,
         limit: undefined,
@@ -171,7 +171,7 @@ describe('Release Issues', function () {
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
       query: {
-        sort: 'new',
+        sort: 'freq',
         query: 'release:1.0.0 error.handled:0',
         cursor: undefined,
         limit: undefined,
@@ -183,7 +183,7 @@ describe('Release Issues', function () {
     expect(wrapper.find('Link[data-test-id="issues-button"]').prop('to')).toEqual({
       pathname: '/organizations/org/issues/',
       query: {
-        sort: 'new',
+        sort: 'freq',
         query: 'release:1.0.0',
         cursor: undefined,
         limit: undefined,


### PR DESCRIPTION
Changing the default sort of issues (and links to Issues stream) on Releases pages to sort by frequency (the number of events).