### PR TITLE
ref(editable-text): Add disabled option

### DIFF
--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -17,9 +17,17 @@ type Props = {
   name?: string;
   errorMessage?: React.ReactNode;
   successMessage?: React.ReactNode;
+  isDisabled?: boolean;
 };
 
-function EditableText({value, onChange, name, errorMessage, successMessage}: Props) {
+function EditableText({
+  value,
+  onChange,
+  name,
+  errorMessage,
+  successMessage,
+  isDisabled = false,
+}: Props) {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState(value);
 
@@ -119,7 +127,7 @@ function EditableText({value, onChange, name, errorMessage, successMessage}: Pro
   }
 
   return (
-    <Wrapper>
+    <Wrapper isDisabled={isDisabled}>
       {isEditing ? (
         <InputWrapper
           ref={inputWrapper}
@@ -138,7 +146,7 @@ function EditableText({value, onChange, name, errorMessage, successMessage}: Pro
         </InputWrapper>
       ) : (
         <Content
-          onClick={handleContentClick}
+          onClick={isDisabled ? undefined : handleContentClick}
           ref={contentRef}
           data-test-id="editable-text-label"
         >
@@ -189,21 +197,34 @@ const StyledIconEdit = styled(IconEdit)`
   cursor: pointer;
 `;
 
-const Wrapper = styled('div')`
+const Wrapper = styled('div')<{isDisabled: boolean}>`
   display: flex;
   justify-content: flex-start;
   height: 40px;
-  :hover {
-    ${StyledIconEdit} {
-      opacity: 1;
-    }
-    ${Label} {
-      border-color: ${p => p.theme.gray300};
-    }
-    ${InnerLabel} {
-      border-bottom-color: transparent;
-    }
-  }
+  ${p =>
+    p.isDisabled
+      ? `
+          ${StyledIconEdit} {
+            cursor: default;
+          }
+
+          ${InnerLabel} {
+            border-bottom-color: transparent;
+          }
+        `
+      : `
+          :hover {
+            ${StyledIconEdit} {
+              opacity: 1;
+            }
+            ${Label} {
+              border-color: ${p.theme.gray300};
+            }
+            ${InnerLabel} {
+              border-bottom-color: transparent;
+            }
+          }
+        `}
 `;
 
 const InputWrapper = styled('div')<{isEmpty: boolean}>`

--- a/static/app/views/dashboardsV2/detail.tsx
+++ b/static/app/views/dashboardsV2/detail.tsx
@@ -321,6 +321,7 @@ class DashboardDetail extends React.Component<Props, State> {
                   <DashboardTitle
                     dashboard={modifiedDashboard || dashboard}
                     onUpdate={this.setModifiedDashboard}
+                    isEditing={isEditing}
                   />
                   <Controls
                     organization={organization}

--- a/static/app/views/dashboardsV2/title.tsx
+++ b/static/app/views/dashboardsV2/title.tsx
@@ -10,20 +10,22 @@ import {DashboardDetails} from './types';
 
 type Props = {
   dashboard: DashboardDetails | null;
+  isEditing: boolean;
   onUpdate: (dashboard: DashboardDetails) => void;
 };
 
-function DashboardTitle({dashboard, onUpdate}: Props) {
+function DashboardTitle({dashboard, isEditing, onUpdate}: Props) {
   return (
     <Container>
       {!dashboard ? (
         t('Dashboards')
       ) : (
         <StyledEditableText
+          isDisabled={!isEditing}
           value={dashboard.title}
           onChange={newTitle => onUpdate({...dashboard, title: newTitle})}
           errorMessage={t('Please set a title for this dashboard')}
-          successMessage={t('Dashboard title saved successfully')}
+          successMessage={t('Dashboard title updated successfully')}
         />
       )}
     </Container>


### PR DESCRIPTION
The dashboard title should only be displayed as "editable" if the dashboard is in "edit mode", otherwise, it should be displayed differently.

This PR adds the "isDisabled" prop in the editableText component, fixing the issue.