### PR TITLE
feat(demo): adds more org members

### DIFF
--- a/src/sentry/demo/demo_org_manager.py
+++ b/src/sentry/demo/demo_org_manager.py
@@ -21,7 +21,7 @@ from sentry.models import (
 from sentry.tasks.deletion import delete_organization
 from sentry.utils.email import create_fake_email
 
-from .data_population import handle_react_python_scenario
+from .data_population import handle_react_python_scenario, populate_org_members
 from .models import DemoOrganization, DemoOrgStatus, DemoUser
 from .utils import generate_random_name
 
@@ -57,6 +57,8 @@ def create_demo_org(quick=False) -> Organization:
                 name="React", organization=org, platform="javascript-react"
             )
             react_project.add_team(team)
+
+            populate_org_members(org, team)
 
             # we'll be adding transactions later
             Project.objects.filter(organization=org).update(

--- a/src/sentry/demo/middleware.py
+++ b/src/sentry/demo/middleware.py
@@ -66,7 +66,7 @@ class DemoMiddleware:
 
         # find a member in the target org
         member = OrganizationMember.objects.filter(
-            organization__slug=org_slug, role="member"
+            organization__slug=org_slug, user__demouser__isnull=False, role="member"
         ).first()
         # if no member, can't login
         if not member or not member.user:

--- a/tests/sentry/demo/test_data_population.py
+++ b/tests/sentry/demo/test_data_population.py
@@ -18,6 +18,7 @@ class DataPopulationTest(TestCase):
         super().setUp()
         self.react_project = self.create_project(organization=self.organization, platform="react")
         self.python_project = self.create_project(organization=self.organization, platform="python")
+        self.create_member(organization=self.organization, user=self.create_user())
 
     @patch.object(DataPopulation, "send_session")
     def test_basic(self, mock_send_session):

--- a/tests/sentry/demo/test_middleware.py
+++ b/tests/sentry/demo/test_middleware.py
@@ -2,6 +2,7 @@ import pytest
 from django.test import override_settings
 from django.urls import reverse
 
+from sentry.demo.models import DemoUser
 from sentry.demo.settings import MIDDLEWARE_CLASSES
 from sentry.testutils import APITestCase
 from sentry.utils import auth
@@ -15,9 +16,15 @@ class DemoMiddlewareTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.organization2 = self.create_organization()
+        # non demo user
         self.user2 = self.create_user()
         self.om2 = self.create_member(
             organization=self.organization2, user=self.user2, role="member"
+        )
+        # demo user
+        self.demo_user = DemoUser.create_user()
+        self.demo_om = self.create_member(
+            organization=self.organization2, user=self.demo_user, role="member"
         )
         self.url = reverse(
             "sentry-organization-issue-list",
@@ -34,11 +41,11 @@ class DemoMiddlewareTest(APITestCase):
     def test_switch_to_logged_in(self, mock_auth_login):
         response = self.client.get(self.url)
         assert response.status_code == 200, response.content
-        mock_auth_login.assert_called_once_with(mock.ANY, self.user2)
+        mock_auth_login.assert_called_once_with(mock.ANY, self.demo_user)
 
     @mock.patch("sentry.demo.middleware.auth.login", side_effect=orig_login)
     def test_keep_logged_in(self, mock_auth_login):
-        self.login_as(self.user2)
+        self.login_as(self.demo_user)
         response = self.client.get(self.url)
         assert response.status_code == 200, response.content
         assert mock_auth_login.call_count == 0


### PR DESCRIPTION
This PR creates three dummy org members for the demo org corresponding to the real members on the team

![Screen Shot 2021-04-20 at 9 06 07 AM](https://user-images.githubusercontent.com/8533851/115429166-00898900-a1b8-11eb-9c43-6b1b86ca7f7b.png)

We also attribute commits and assign issues to these dummy users. Note, these are _not_ Demo users and thus one cannot log in as them nor are they deleted.

![Screen Shot 2021-04-20 at 9 03 32 AM](https://user-images.githubusercontent.com/8533851/115429396-3a5a8f80-a1b8-11eb-92f1-0cc9c952e049.png)
