### PR TITLE
fix(ui): Fix `/manage/` overview error

### DIFF
--- a/static/app/views/admin/adminOverview/eventChart.tsx
+++ b/static/app/views/admin/adminOverview/eventChart.tsx
@@ -92,7 +92,7 @@ class EventChart extends React.Component<Props, State> {
 
     rawData['events.total'].forEach((point, idx) => {
       const dReceived = point[1];
-      const dRejected = rawData['events.dropped'][idx][1];
+      const dRejected = rawData['events.dropped'][idx]?.[1];
       const ts = point[0];
       if (sReceived[ts] === undefined) {
         sReceived[ts] = dReceived;


### PR DESCRIPTION
This fixes an array access issue when `events.dropped` is empty

Fixes JAVASCRIPT-23WR