### PR TITLE
ref(integration-platform): limit app management to managers/owners

### DIFF
--- a/src/sentry/api/bases/sentryapps.py
+++ b/src/sentry/api/bases/sentryapps.py
@@ -73,7 +73,7 @@ class SentryAppsPermission(SentryPermission):
             "member:read",
             "team:read",
         ),
-        "POST": ("org:read", "org:integrations", "org:write", "org:admin"),
+        "POST": ("org:write", "org:admin"),
     }
 
     def has_object_permission(self, request, view, organization):
@@ -168,7 +168,7 @@ class SentryAppsBaseEndpoint(IntegrationPlatformEndpoint):
 class SentryAppPermission(SentryPermission):
     unpublished_scope_map = {
         "GET": ("org:read", "org:integrations", "org:write", "org:admin"),
-        "PUT": ("org:read", "org:integrations", "org:write", "org:admin"),
+        "PUT": ("org:write", "org:admin"),
         "POST": ("org:write", "org:admin"),  # used for publishing an app
         "DELETE": ("org:write", "org:admin"),
     }
@@ -379,8 +379,8 @@ class SentryAppAuthorizationsBaseEndpoint(SentryAppInstallationBaseEndpoint):
 
 class SentryInternalAppTokenPermission(SentryPermission):
     scope_map = {
-        "GET": ("org:read", "org:integrations", "org:write", "org:admin"),
-        "POST": ("org:read", "org:integrations", "org:write", "org:admin"),
+        "GET": ("org:write", "org:admin"),
+        "POST": ("org:write", "org:admin"),
         "DELETE": ("org:write", "org:admin"),
     }
 

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -71,7 +71,7 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
     );
 
     const action = (
-      <Access organization={organization} access={['org:integrations']}>
+      <Access organization={organization} access={['org:write']}>
         {({hasAccess}) => (
           <Button
             priority="primary"
@@ -117,7 +117,7 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
     );
 
     const action = (
-      <Access organization={organization} access={['org:integrations']}>
+      <Access organization={organization} access={['org:write']}>
         {({hasAccess}) => (
           <Button
             priority="primary"

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router';
 
 import {removeSentryApp} from 'app/actionCreators/sentryApps';
+import Access from 'app/components/acl/access';
 import AlertLink from 'app/components/alertLink';
 import Button from 'app/components/button';
 import {Panel, PanelBody, PanelHeader} from 'app/components/panels';
@@ -59,20 +60,31 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
 
   renderInternalIntegrations() {
     const {orgId} = this.props.params;
+    const {organization} = this.props;
     const integrations = this.state.applications.filter(
       (app: SentryApp) => app.status === 'internal'
     );
     const isEmpty = integrations.length === 0;
 
+    const permissionTooltipText = t(
+      'Manager or Owner permissions required to add an internal integration.'
+    );
+
     const action = (
-      <Button
-        priority="primary"
-        size="small"
-        to={`/settings/${orgId}/developer-settings/new-internal/`}
-        icon={<IconAdd size="xs" isCircled />}
-      >
-        {t('New Internal Integration')}
-      </Button>
+      <Access organization={organization} access={['org:integrations']}>
+        {({hasAccess}) => (
+          <Button
+            priority="primary"
+            disabled={!hasAccess}
+            title={!hasAccess ? permissionTooltipText : undefined}
+            size="small"
+            to={`/settings/${orgId}/developer-settings/new-internal/`}
+            icon={<IconAdd size="xs" isCircled />}
+          >
+            {t('New Internal Integration')}
+          </Button>
+        )}
+      </Access>
     );
 
     return (
@@ -96,18 +108,29 @@ class OrganizationDeveloperSettings extends AsyncView<Props, State> {
 
   renderExernalIntegrations() {
     const {orgId} = this.props.params;
+    const {organization} = this.props;
     const integrations = this.state.applications.filter(app => app.status !== 'internal');
     const isEmpty = integrations.length === 0;
 
+    const permissionTooltipText = t(
+      'Manager or Owner permissions required to add a public integration.'
+    );
+
     const action = (
-      <Button
-        priority="primary"
-        size="small"
-        to={`/settings/${orgId}/developer-settings/new-public/`}
-        icon={<IconAdd size="xs" isCircled />}
-      >
-        {t('New Public Integration')}
-      </Button>
+      <Access organization={organization} access={['org:integrations']}>
+        {({hasAccess}) => (
+          <Button
+            priority="primary"
+            disabled={!hasAccess}
+            title={!hasAccess ? permissionTooltipText : undefined}
+            size="small"
+            to={`/settings/${orgId}/developer-settings/new-public/`}
+            icon={<IconAdd size="xs" isCircled />}
+          >
+            {t('New Public Integration')}
+          </Button>
+        )}
+      </Access>
     );
 
     return (

--- a/tests/sentry/api/endpoints/test_sentry_app_components.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_components.py
@@ -83,28 +83,29 @@ class OrganizationSentryAppComponentsTest(APITestCase):
         response = self.get_valid_response(self.org.slug, qs_params={"projectId": self.project.id})
 
         assert self.component3.uuid not in [d["uuid"] for d in response.data]
-        assert response.data == [
-            {
-                "uuid": str(self.component1.uuid),
-                "type": "issue-link",
-                "schema": self.component1.schema,
-                "sentryApp": {
-                    "uuid": self.sentry_app1.uuid,
-                    "slug": self.sentry_app1.slug,
-                    "name": self.sentry_app1.name,
-                },
+        components = {d["uuid"]: d for d in response.data}
+
+        assert components[str(self.component1.uuid)] == {
+            "uuid": str(self.component1.uuid),
+            "type": "issue-link",
+            "schema": self.component1.schema,
+            "sentryApp": {
+                "uuid": self.sentry_app1.uuid,
+                "slug": self.sentry_app1.slug,
+                "name": self.sentry_app1.name,
             },
-            {
-                "uuid": str(self.component2.uuid),
-                "type": "issue-link",
-                "schema": self.component2.schema,
-                "sentryApp": {
-                    "uuid": self.sentry_app2.uuid,
-                    "slug": self.sentry_app2.slug,
-                    "name": self.sentry_app2.name,
-                },
+        }
+
+        assert components[str(self.component2.uuid)] == {
+            "uuid": str(self.component2.uuid),
+            "type": "issue-link",
+            "schema": self.component2.schema,
+            "sentryApp": {
+                "uuid": self.sentry_app2.uuid,
+                "slug": self.sentry_app2.slug,
+                "name": self.sentry_app2.name,
             },
-        ]
+        }
 
     @patch("sentry.mediators.sentry_app_components.Preparer.run")
     def test_project_not_owned_by_org(self, run):

--- a/tests/sentry/api/endpoints/test_sentry_app_details.py
+++ b/tests/sentry/api/endpoints/test_sentry_app_details.py
@@ -330,21 +330,27 @@ class UpdateSentryAppDetailsTest(SentryAppDetailsTest):
         assert response.status_code == 400
         assert response.data == {"allowedOrigins": ["'*' not allowed in origin"]}
 
-    def test_create_integration_exceeding_scopes(self):
+    def test_members_cant_update(self):
         member_om = OrganizationMember.objects.get(user=self.user, organization=self.org)
         member_om.role = "member"
         member_om.save()
         self.login_as(user=self.user)
         url = reverse("sentry-api-0-sentry-app-details", args=[self.unpublished_app.slug])
-        response = self.client.put(
-            url, data={"scopes": ["member:read", "member:write", "member:admin"]}
-        )
+        response = self.client.put(url, data={"scopes": ["member:read"]})
+        assert response.status_code == 403
+
+    def test_create_integration_exceeding_scopes(self):
+        member_om = OrganizationMember.objects.get(user=self.user, organization=self.org)
+        member_om.role = "manager"
+        member_om.save()
+        self.login_as(user=self.user)
+        url = reverse("sentry-api-0-sentry-app-details", args=[self.unpublished_app.slug])
+        response = self.client.put(url, data={"scopes": ["org:read", "org:write", "org:admin"]})
 
         assert response.status_code == 400
         assert response.data == {
             "scopes": [
-                "Requested permission of member:write exceeds requester's permission. Please contact an administrator to make the requested change.",
-                "Requested permission of member:admin exceeds requester's permission. Please contact an administrator to make the requested change.",
+                "Requested permission of org:admin exceeds requester's permission. Please contact an administrator to make the requested change.",
             ]
         }
 

--- a/tests/sentry/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/api/endpoints/test_sentry_apps.py
@@ -669,18 +669,25 @@ class PostSentryAppsTest(SentryAppsTest):
         )
         assert response.status_code == 400
 
-    def test_create_integration_exceeding_scopes(self):
+    def test_members_cant_create(self):
         member_om = OrganizationMember.objects.get(user=self.user, organization=self.org)
         member_om.role = "member"
         member_om.save()
         self.login_as(user=self.user)
-        response = self._post(events=(), scopes=("member:read", "member:write", "member:admin"))
+        response = self._post()
+        assert response.status_code == 403
+
+    def test_create_integration_exceeding_scopes(self):
+        member_om = OrganizationMember.objects.get(user=self.user, organization=self.org)
+        member_om.role = "manager"
+        member_om.save()
+        self.login_as(user=self.user)
+        response = self._post(events=(), scopes=("org:read", "org:write", "org:admin"))
 
         assert response.status_code == 400
         assert response.data == {
             "scopes": [
-                "Requested permission of member:write exceeds requester's permission. Please contact an administrator to make the requested change.",
-                "Requested permission of member:admin exceeds requester's permission. Please contact an administrator to make the requested change.",
+                "Requested permission of org:admin exceeds requester's permission. Please contact an administrator to make the requested change.",
             ]
         }
 

--- a/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
+++ b/tests/sentry/api/endpoints/test_sentry_internal_app_tokens.py
@@ -81,12 +81,20 @@ class GetSentryInternalAppTokenTest(SentryInternalAppTokenTest):
         assert response_content[0]["id"] == str(token.id)
         assert response_content[0]["token"] == token.token
 
-    def test_token_is_masked(self):
+    def no_access_for_members(self):
         user = self.create_user(email="meep@example.com")
         self.create_member(organization=self.org, user=user)
+        self.login_as(user)
+
+        response = self.client.get(self.url, format="json")
+        assert response.status_code == 403
+
+    def test_token_is_masked(self):
+        user = self.create_user(email="meep@example.com")
+        self.create_member(organization=self.org, user=user, role="manager")
         # create an app with scopes higher than what a member role has
         sentry_app = self.create_internal_integration(
-            name="AnothaOne", organization=self.org, scopes=("project:write",)
+            name="AnothaOne", organization=self.org, scopes=("org:admin",)
         )
 
         self.login_as(user)


### PR DESCRIPTION
Reduces scopes for creating and updating sentry apps (either public or internal) to `Managers` or `Owners`. Because sentry apps either have access to all projects or none, `Members` and `Admins` can create integrations that have `project:read` or `event:read` scopes and can access issue data that belongs to projects they are not apart of. This is fine for organizations with open membership (as any member can choose to join any team and therefore get access), however this is a security concern for closed membership organizations.

**UI Tooltips:**
Same tooltip for both the Public and Internal integration buttons, just with slightly different text: 

![Screen Shot 2021-04-20 at 11 25 48 AM](https://user-images.githubusercontent.com/15368179/115448176-405b6b00-a1ce-11eb-8d1a-a7007e2bf7e6.png)
