### PR TITLE
feat(chart-rendering): Allow custom storage driver

### DIFF
--- a/src/sentry/models/file.py
+++ b/src/sentry/models/file.py
@@ -77,11 +77,16 @@ class AssembleChecksumMismatch(Exception):
     pass
 
 
-def get_storage():
-    from sentry import options
+def get_storage(config=None):
 
-    backend = options.get("filestore.backend")
-    options = options.get("filestore.options")
+    if config is not None:
+        backend = config["backend"]
+        options = config["options"]
+    else:
+        from sentry import options as options_store
+
+        backend = options_store.get("filestore.backend")
+        options = options_store.get("filestore.options")
 
     try:
         backend = settings.SENTRY_FILESTORE_ALIASES[backend]

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -117,6 +117,14 @@ register(
     default={"url": "http://localhost:7901"},
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK,
 )
+# Leaving these empty will usage the same storage driver configured for
+# Filestore
+register(
+    "chart-rendering.storage.backend", default=None, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK
+)
+register(
+    "chart-rendering.storage.options", default=None, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK
+)
 
 # Analytics
 register("analytics.backend", default="noop", flags=FLAG_NOSTORE)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -117,7 +117,7 @@ register(
     default={"url": "http://localhost:7901"},
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK,
 )
-# Leaving these empty will usage the same storage driver configured for
+# Leaving these empty will use the same storage driver configured for
 # Filestore
 register(
     "chart-rendering.storage.backend", default=None, flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK


### PR DESCRIPTION
This adds options for using a different storage driver when uploading
chartcuterie images. We'll need this to use a explicitly public bucket.