### PR TITLE
fix(quick-trace): Dropdown on narrow view ports should render well

### DIFF
--- a/static/app/components/events/interfaces/spans/filter.tsx
+++ b/static/app/components/events/interfaces/spans/filter.tsx
@@ -191,8 +191,6 @@ const StyledDropdownButton = styled(DropdownButton)<{hasDarkBorderBottomColor?: 
   white-space: nowrap;
   max-width: 200px;
 
-  z-index: ${p => p.theme.zIndex.dropdown};
-
   &:hover,
   &:active {
     ${p =>

--- a/static/app/views/performance/transactionDetails/eventMetas.tsx
+++ b/static/app/views/performance/transactionDetails/eventMetas.tsx
@@ -17,6 +17,7 @@ import {
 } from 'app/utils/performance/quickTrace/types';
 import {isTransaction} from 'app/utils/performance/quickTrace/utils';
 import Projects from 'app/utils/projects';
+import theme from 'app/utils/theme';
 
 import QuickTraceMeta from './quickTraceMeta';
 import {MetaData} from './styles';
@@ -33,83 +34,125 @@ type Props = Pick<
   meta: TraceMeta | null;
 };
 
-function EventMetas({
-  event,
-  organization,
-  projectId,
-  location,
-  quickTrace,
-  meta,
-  errorDest,
-  transactionDest,
-}: Props) {
-  const type = isTransaction(event) ? 'transaction' : 'event';
+type State = {
+  isLargeScreen: boolean;
+};
 
-  const projectBadge = (
-    <Projects orgId={organization.slug} slugs={[projectId]}>
-      {({projects}) => {
-        const project = projects.find(p => p.slug === projectId);
-        return (
-          <ProjectBadge project={project ? project : {slug: projectId}} avatarSize={16} />
-        );
-      }}
-    </Projects>
-  );
+/**
+ * This should match the breakpoint chosen for the `EventDetailHeader` below
+ */
+const BREAKPOINT_MEDIA_QUERY = `(min-width: ${theme.breakpoints[2]})`;
 
-  const timestamp = (
-    <TimeSince date={event.dateCreated || (event.endTimestamp || 0) * 1000} />
-  );
+class EventMetas extends React.Component<Props, State> {
+  state: State = {
+    isLargeScreen: window.matchMedia?.(BREAKPOINT_MEDIA_QUERY)?.matches,
+  };
 
-  const httpStatus = <HttpStatus event={event} />;
+  componentDidMount() {
+    if (this.mq) {
+      this.mq.addListener(this.handleMediaQueryChange);
+    }
+  }
 
-  return (
-    <EventDetailHeader type={type}>
-      <MetaData
-        headingText={t('Event ID')}
-        tooltipText={t('The unique ID assigned to this %s.', type)}
-        bodyText={getShortEventId(event.eventID)}
-        subtext={projectBadge}
-      />
-      {isTransaction(event) ? (
+  componentWillUnmount() {
+    if (this.mq) {
+      this.mq.removeListener(this.handleMediaQueryChange);
+    }
+  }
+
+  mq = window.matchMedia?.(BREAKPOINT_MEDIA_QUERY);
+
+  handleMediaQueryChange = (changed: MediaQueryListEvent) => {
+    this.setState({
+      isLargeScreen: changed.matches,
+    });
+  };
+
+  render() {
+    const {
+      event,
+      organization,
+      projectId,
+      location,
+      quickTrace,
+      meta,
+      errorDest,
+      transactionDest,
+    } = this.props;
+    const {isLargeScreen} = this.state;
+
+    const type = isTransaction(event) ? 'transaction' : 'event';
+
+    const projectBadge = (
+      <Projects orgId={organization.slug} slugs={[projectId]}>
+        {({projects}) => {
+          const project = projects.find(p => p.slug === projectId);
+          return (
+            <ProjectBadge
+              project={project ? project : {slug: projectId}}
+              avatarSize={16}
+            />
+          );
+        }}
+      </Projects>
+    );
+
+    const timestamp = (
+      <TimeSince date={event.dateCreated || (event.endTimestamp || 0) * 1000} />
+    );
+
+    const httpStatus = <HttpStatus event={event} />;
+
+    return (
+      <EventDetailHeader type={type}>
         <MetaData
-          headingText={t('Event Duration')}
-          tooltipText={t(
-            'The time elapsed between the start and end of this transaction.'
-          )}
-          bodyText={getDuration(event.endTimestamp - event.startTimestamp, 2, true)}
-          subtext={timestamp}
+          headingText={t('Event ID')}
+          tooltipText={t('The unique ID assigned to this %s.', type)}
+          bodyText={getShortEventId(event.eventID)}
+          subtext={projectBadge}
         />
-      ) : (
-        <MetaData
-          headingText={t('Created')}
-          tooltipText={t('The time at which this event was created.')}
-          bodyText={timestamp}
-          subtext={<DateTime date={event.dateCreated} />}
-        />
-      )}
-      {isTransaction(event) && (
-        <MetaData
-          headingText={t('Status')}
-          tooltipText={t(
-            'The status of this transaction indicating if it succeeded or otherwise.'
-          )}
-          bodyText={event.contexts?.trace?.status ?? '\u2014'}
-          subtext={httpStatus}
-        />
-      )}
-      <QuickTraceContainer>
-        <QuickTraceMeta
-          event={event}
-          organization={organization}
-          location={location}
-          quickTrace={quickTrace}
-          traceMeta={meta}
-          errorDest={errorDest}
-          transactionDest={transactionDest}
-        />
-      </QuickTraceContainer>
-    </EventDetailHeader>
-  );
+        {isTransaction(event) ? (
+          <MetaData
+            headingText={t('Event Duration')}
+            tooltipText={t(
+              'The time elapsed between the start and end of this transaction.'
+            )}
+            bodyText={getDuration(event.endTimestamp - event.startTimestamp, 2, true)}
+            subtext={timestamp}
+          />
+        ) : (
+          <MetaData
+            headingText={t('Created')}
+            tooltipText={t('The time at which this event was created.')}
+            bodyText={timestamp}
+            subtext={<DateTime date={event.dateCreated} />}
+          />
+        )}
+        {isTransaction(event) && (
+          <MetaData
+            headingText={t('Status')}
+            tooltipText={t(
+              'The status of this transaction indicating if it succeeded or otherwise.'
+            )}
+            bodyText={event.contexts?.trace?.status ?? '\u2014'}
+            subtext={httpStatus}
+          />
+        )}
+        <QuickTraceContainer>
+          <QuickTraceMeta
+            event={event}
+            organization={organization}
+            location={location}
+            quickTrace={quickTrace}
+            traceMeta={meta}
+            anchor={isLargeScreen ? 'right' : 'left'}
+            errorDest={errorDest}
+            transactionDest={transactionDest}
+          />
+        </QuickTraceContainer>
+      </EventDetailHeader>
+    );
+  }
 }
 
 const EventDetailHeader = styled('div')<{type?: 'transaction' | 'event'}>`
@@ -123,6 +166,7 @@ const EventDetailHeader = styled('div')<{type?: 'transaction' | 'event'}>`
     margin-bottom: 0;
   }
 
+  /* This should match the breakpoint chosen for BREAKPOINT_MEDIA_QUERY above. */
   @media (min-width: ${p => p.theme.breakpoints[2]}) {
     ${p =>
       p.type === 'transaction'

--- a/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
+++ b/static/app/views/performance/transactionDetails/quickTraceMeta.tsx
@@ -27,6 +27,7 @@ type Props = Pick<
   organization: OrganizationSummary;
   quickTrace: QuickTraceQueryChildrenProps;
   traceMeta: TraceMeta | null;
+  anchor: 'left' | 'right';
 };
 
 function handleTraceLink(organization: OrganizationSummary) {
@@ -44,6 +45,7 @@ export default function QuickTraceMeta({
   organization,
   quickTrace: {isLoading, error, trace, type},
   traceMeta,
+  anchor,
   errorDest,
   transactionDest,
 }: Props) {
@@ -69,7 +71,7 @@ export default function QuickTraceMeta({
         quickTrace={{type, trace}}
         location={location}
         organization={organization}
-        anchor="right"
+        anchor={anchor}
         errorDest={errorDest}
         transactionDest={transactionDest}
       />


### PR DESCRIPTION
Quick trace dropdown on transaction always anchors on the right and expands to
the left. On smaller view ports, quick trace is rendered on the left so the
dropdown as well as the expansion goes off screen. This change makes it
responsive and changes the direction it anchors itself and expands as needed.