### PR TITLE
fix(perf): Various histogram fixes

### DIFF
--- a/static/app/views/performance/transactionSummary/charts.tsx
+++ b/static/app/views/performance/transactionSummary/charts.tsx
@@ -15,6 +15,7 @@ import Placeholder from 'app/components/placeholder';
 import {t} from 'app/locale';
 import {OrganizationSummary, SelectValue} from 'app/types';
 import EventView from 'app/utils/discover/eventView';
+import {removeHistogramQueryStrings} from 'app/utils/performance/histogram';
 import {decodeScalar} from 'app/utils/queryString';
 import {TransactionsListOption} from 'app/views/releases/detail/overview';
 import {YAxis} from 'app/views/releases/detail/overview/chart/releaseChartControls';
@@ -29,7 +30,7 @@ import {
 import DurationChart from './durationChart';
 import DurationPercentileChart from './durationPercentileChart';
 import {SpanOperationBreakdownFilter} from './filter';
-import LatencyChart, {LatencyChartControls} from './latencyChart';
+import LatencyChart, {LatencyChartControls, ZOOM_END, ZOOM_START} from './latencyChart';
 import TrendChart from './trendChart';
 import VitalsChart from './vitalsChart';
 
@@ -91,7 +92,10 @@ class TransactionSummaryCharts extends React.Component<Props> {
     const {location} = this.props;
     browserHistory.push({
       pathname: location.pathname,
-      query: {...location.query, display: value},
+      query: {
+        ...removeHistogramQueryStrings(location, [ZOOM_START, ZOOM_END]),
+        display: value,
+      },
     });
   };
 

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -177,7 +177,8 @@ class SummaryContent extends React.Component<Props, State> {
     const totalCount = totalValues === null ? null : totalValues.count;
 
     const spanOperationBreakdownConditions = filterToSearchConditions(
-      spanOperationBreakdownFilter
+      spanOperationBreakdownFilter,
+      location
     );
 
     if (spanOperationBreakdownConditions) {

--- a/static/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/static/app/views/performance/transactionSummary/latencyChart.tsx
@@ -209,19 +209,7 @@ class LatencyChart extends React.Component<Props, State> {
       location
     );
 
-    let min: number | undefined = undefined;
-    let max: number | undefined = undefined;
-
-    if (ZOOM_START in location.query) {
-      min = decodeInteger(location.query[ZOOM_START], 0);
-    }
-
-    if (ZOOM_END in location.query) {
-      const decodedMax = decodeInteger(location.query[ZOOM_END]);
-      if (typeof decodedMax === 'number') {
-        max = decodedMax;
-      }
-    }
+    const {min, max} = decodeHistogramZoom(location);
 
     const field = filterToField(currentFilter) ?? 'transaction.duration';
 
@@ -293,6 +281,24 @@ export function LatencyChartControls(props: {location: Location}) {
       }}
     </Histogram>
   );
+}
+
+export function decodeHistogramZoom(location: Location) {
+  let min: number | undefined = undefined;
+  let max: number | undefined = undefined;
+
+  if (ZOOM_START in location.query) {
+    min = decodeInteger(location.query[ZOOM_START], 0);
+  }
+
+  if (ZOOM_END in location.query) {
+    const decodedMax = decodeInteger(location.query[ZOOM_END]);
+    if (typeof decodedMax === 'number') {
+      max = decodedMax;
+    }
+  }
+
+  return {min, max};
 }
 
 export default LatencyChart;


### PR DESCRIPTION
Histogram query strings (i.e. `startDuration` and `endDuration`) should implicitly be applied to various queries on the Performance Summary page. In other words, is the user selects a range of 200ms to 400ms range from the histogram, then `transaction.duration:>200ms transaction.duration:<400ms` are implicitly added to the search conditions. This also applies for span op breakdown filters.

https://user-images.githubusercontent.com/139499/115475364-6eac6b00-a20d-11eb-9d72-79c8b766a340.mp4

In addition, histogram query strings are removed when switching Display chart modes from the "Duration Distribution" chart.
