### PR TITLE
fix(ui): Fix alert details status area calculations

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -407,7 +407,7 @@ const HeaderContainer = styled('div')`
 const HeaderGrid = styled('div')`
   display: grid;
   grid-template-columns: auto auto auto;
-  align-items: center;
+  align-items: start;
   gap: ${space(4)};
 `;
 

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -528,11 +528,14 @@ class MetricChart extends React.PureComponent<Props, State> {
                   lastPoint
                 );
                 const areaColor = warningTrigger ? theme.yellow300 : theme.red300;
-                series.push(createStatusAreaSeries(areaColor, areaStart, areaEnd));
-                if (areaColor === theme.yellow300) {
-                  warningDuration += areaEnd - areaStart;
-                } else {
-                  criticalDuration += areaEnd - areaStart;
+                if (areaEnd > areaStart) {
+                  series.push(createStatusAreaSeries(areaColor, areaStart, areaEnd));
+
+                  if (areaColor === theme.yellow300) {
+                    warningDuration += Math.abs(areaEnd - areaStart);
+                  } else {
+                    criticalDuration += Math.abs(areaEnd - areaStart);
+                  }
                 }
 
                 statusChanges?.forEach((activity, idx) => {
@@ -551,17 +554,19 @@ class MetricChart extends React.PureComponent<Props, State> {
                     activity.value === `${IncidentStatus.CRITICAL}`
                       ? theme.red300
                       : theme.yellow300;
-                  series.push(
-                    createStatusAreaSeries(
-                      statusAreaColor,
-                      statusAreaStart,
-                      statusAreaEnd
-                    )
-                  );
-                  if (statusAreaColor === theme.yellow300) {
-                    warningDuration += statusAreaEnd - statusAreaStart;
-                  } else {
-                    criticalDuration += statusAreaEnd - statusAreaStart;
+                  if (statusAreaEnd > statusAreaStart) {
+                    series.push(
+                      createStatusAreaSeries(
+                        statusAreaColor,
+                        statusAreaStart,
+                        statusAreaEnd
+                      )
+                    );
+                    if (statusAreaColor === theme.yellow300) {
+                      warningDuration += Math.abs(statusAreaEnd - statusAreaStart);
+                    } else {
+                      criticalDuration += Math.abs(statusAreaEnd - statusAreaStart);
+                    }
                   }
                 });
 


### PR DESCRIPTION
This fixes an issue where some status changes were not changed until after the incident was closed. Added a guard for these cases. The status percentage calculations seem to align to the bar better with this guard.
Also fixed the header vertical alignment.

Before:
![Screen Shot 2021-04-20 at 5 57 17 PM](https://user-images.githubusercontent.com/15015880/115481950-70246600-a202-11eb-8bc2-512a897f5210.png)

After:
![Screen Shot 2021-04-20 at 5 58 02 PM](https://user-images.githubusercontent.com/15015880/115481960-77e40a80-a202-11eb-9756-892f8d86d8cb.png)

