### PR TITLE
ref(feature-flag): Enable images-loaded-v2 by default - GA

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -986,7 +986,7 @@ SENTRY_FEATURES = {
     # Enable the new alert details ux design
     "organizations:alert-details-redesign": False,
     # Enable the new images loaded design and features
-    "organizations:images-loaded-v2": False,
+    "organizations:images-loaded-v2": True,
     # Enable teams to have ownership of alert rules
     "organizations:team-alerts-ownership": False,
     # Enable the new alert creation wizard

--- a/tests/sentry/api/serializers/test_organization.py
+++ b/tests/sentry/api/serializers/test_organization.py
@@ -27,6 +27,7 @@ class OrganizationSerializerTest(TestCase):
             "discover-query",
             "event-attachments",
             "event-attachments-viewer",
+            "images-loaded-v2",
             "integrations-alert-rule",
             "integrations-chat-unfurl",
             "integrations-event-hooks",

--- a/tests/symbolicator/test_payload_full.py
+++ b/tests/symbolicator/test_payload_full.py
@@ -104,7 +104,8 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
         assert response.status_code == 201, response.content
         assert len(response.data) == 1
 
-        event = self.post_and_retrieve_event(REAL_RESOLVING_EVENT_DATA)
+        with self.feature({"organizations:images-loaded-v2": False}):
+            event = self.post_and_retrieve_event(REAL_RESOLVING_EVENT_DATA)
 
         assert event.data["culprit"] == "main"
         insta_snapshot_stacktrace_data(self, event.data)
@@ -163,14 +164,16 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
             "timestamp": iso_format(before_now(seconds=1)),
         }
 
-        event = self.post_and_retrieve_event(event_data)
+        with self.feature({"organizations:images-loaded-v2": False}):
+            event = self.post_and_retrieve_event(event_data)
         assert event.data["culprit"] == "main"
         insta_snapshot_stacktrace_data(self, event.data)
 
     def test_missing_dsym(self):
         self.login_as(user=self.user)
 
-        event = self.post_and_retrieve_event(REAL_RESOLVING_EVENT_DATA)
+        with self.feature({"organizations:images-loaded-v2": False}):
+            event = self.post_and_retrieve_event(REAL_RESOLVING_EVENT_DATA)
         assert event.data["culprit"] == "unknown"
         insta_snapshot_stacktrace_data(self, event.data)
 
@@ -180,7 +183,8 @@ class SymbolicatorResolvingIntegrationTest(RelayStoreHelper, TransactionTestCase
         payload = dict(project=self.project.id, **REAL_RESOLVING_EVENT_DATA)
         del payload["debug_meta"]
 
-        event = self.post_and_retrieve_event(payload)
+        with self.feature({"organizations:images-loaded-v2": False}):
+            event = self.post_and_retrieve_event(payload)
         assert event.data["culprit"] == "unknown"
         insta_snapshot_stacktrace_data(self, event.data)
 


### PR DESCRIPTION
This sets the `images-loaded-v2` feature flag to true for all users for the ga release