### PR TITLE
fix: Bump pytest-sentry to 0.1.9

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ openapi-core @ https://github.com/getsentry/openapi-core/archive/master.zip#egg=
 pytest==6.1.0
 pytest-cov==2.11.1
 pytest-django==3.10.0
-pytest-sentry==0.1.8
+pytest-sentry==0.1.9
 pytest-rerunfailures==9.1.1
 responses==0.10.12
 sqlparse==0.2.4


### PR DESCRIPTION
new spicy features include trace correlation between test and fixtures related to the test + tagging of fixture scope