### PR TITLE
fix(bitbucket) Fix a bug to display correctly organisation name and url

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -171,11 +171,14 @@ class BitbucketIntegrationProvider(IntegrationProvider):
             principal_data = state["principal"]
 
             domain = principal_data["links"]["html"]["href"].replace("https://", "").rstrip("/")
+            if "nickname" in principal_data:
+                split_domain = domain.split("/")
+                domain = "/".join([split_domain[0], principal_data["nickname"]])
 
             return {
                 "provider": self.key,
                 "external_id": state["clientKey"],
-                "name": principal_data.get("username", principal_data["uuid"]),
+                "name": principal_data.get("nickname", principal_data["uuid"]),
                 "metadata": {
                     "public_key": state["publicKey"],
                     "shared_secret": state["sharedSecret"],


### PR DESCRIPTION
This PR fixes issue: #24333

The username in bitbucket API response was removed since April 2019 and replaced with nickname, hence the org name and URL was not showing up correctly.

More details: https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/
