### PR TITLE
fix(perf): Clamp sample rate for facets query

### DIFF
--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -836,7 +836,7 @@ def get_performance_facets(
     target_sample = 50000 * (math.log(transaction_count, 10) - 3)
 
     dynamic_sample_rate = 0 if transaction_count <= 0 else (target_sample / transaction_count)
-    sample_rate = math.min(math.max(dynamic_sample_rate, 0), 1) if sampling_enabled else None
+    sample_rate = min(max(dynamic_sample_rate, 0), 1) if sampling_enabled else None
     frequency_sample_rate = sample_rate if sample_rate else 1
 
     excluded_tags = [

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -836,7 +836,7 @@ def get_performance_facets(
     target_sample = 50000 * (math.log(transaction_count, 10) - 3)
 
     dynamic_sample_rate = 0 if transaction_count <= 0 else (target_sample / transaction_count)
-    sample_rate = dynamic_sample_rate if sampling_enabled else None
+    sample_rate = math.min(math.max(dynamic_sample_rate, 0), 1) if sampling_enabled else None
     frequency_sample_rate = sample_rate if sample_rate else 1
 
     excluded_tags = [


### PR DESCRIPTION
### Summary
We were receiving errors which indicated that the sample rate wasn't being properly clamped to [0,1] when sending the query to Snuba.

Refs SENTRY-PSB