### PR TITLE
feat(alert): New label style for query field and height prop

### DIFF
--- a/static/app/views/settings/incidentRules/metricField.tsx
+++ b/static/app/views/settings/incidentRules/metricField.tsx
@@ -42,6 +42,8 @@ type Props = Omit<FormField['props'], 'children'> & {
    */
   columnWidth?: number;
   inFieldLabels?: boolean;
+  inLineLabels?: boolean;
+  height?: number;
 };
 
 const getFieldOptionConfig = ({
@@ -126,7 +128,14 @@ const help = ({name, model}: {name: string; model: FormModel}) => {
   );
 };
 
-const MetricField = ({organization, columnWidth, inFieldLabels, ...props}: Props) => (
+const MetricField = ({
+  organization,
+  columnWidth,
+  inFieldLabels,
+  inLineLabels,
+  height,
+  ...props
+}: Props) => (
   <FormField help={help} {...props}>
     {({onChange, value, model, disabled}) => {
       const dataset = model.getValue('dataset');
@@ -160,7 +169,7 @@ const MetricField = ({organization, columnWidth, inFieldLabels, ...props}: Props
 
       return (
         <React.Fragment>
-          {!inFieldLabels && (
+          {!inFieldLabels && !inLineLabels && (
             <AggregateHeader>
               <div>{t('Function')}</div>
               {numParameters > 0 && <div>{t('Parameter')}</div>}
@@ -175,10 +184,12 @@ const MetricField = ({organization, columnWidth, inFieldLabels, ...props}: Props
             columnWidth={columnWidth}
             gridColumns={parameterColumns + 1}
             inFieldLabels={inFieldLabels}
+            inLineLabels={inLineLabels}
             shouldRenderTag={false}
             disabled={disabled}
             hideParameterSelector={hideParameterSelector}
             hidePrimarySelector={hidePrimarySelector}
+            height={height}
           />
         </React.Fragment>
       );

--- a/static/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
+++ b/static/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import {Client} from 'app/api';
+import {SectionHeading} from 'app/components/charts/styles';
 import SearchBar from 'app/components/events/searchBar';
 import SelectControl from 'app/components/forms/selectControl';
 import ListItem from 'app/components/list/listItem';
@@ -145,8 +146,9 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
                     }}
                     inline={false}
                     flexibleControlStateSize
-                    columnWidth={200}
-                    inFieldLabels
+                    columnWidth={225}
+                    inLineLabels
+                    height={32}
                     required
                   />
                   <FormRowText>{t('Time Interval')}</FormRowText>
@@ -161,6 +163,13 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
                         ...formElemBaseStyle,
                         flex: 1,
                         minWidth: 130,
+                      }}
+                      styles={{
+                        control: provided => ({
+                          ...provided,
+                          minHeight: '32px',
+                          height: '32px',
+                        }),
                       }}
                       choices={Object.entries(TIME_WINDOW_MAP)}
                       required
@@ -336,7 +345,7 @@ const StyledListItem = styled(ListItem)`
 const FormRow = styled('div')`
   display: flex;
   flex-direction: row;
-  align-items: flex-end;
+  align-items: center;
   flex-wrap: wrap;
   margin-bottom: ${space(2)};
 `;
@@ -345,10 +354,8 @@ const ChartFooter = styled(FormRow)`
   margin: 0;
 `;
 
-const FormRowText = styled('div')`
-  padding: ${space(0.5)};
-  /* Match the height of the select controls */
-  line-height: 36px;
+const FormRowText = styled(SectionHeading)`
+  margin: ${space(1)};
 `;
 
 export default RuleConditionsFormForWizard;

--- a/static/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
+++ b/static/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
@@ -319,7 +319,6 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
 
 const ChartPanel = styled(Panel)`
   margin-bottom: ${space(4)};
-  min-height: 335px;
 `;
 
 const StyledPanelBody = styled(PanelBody)`


### PR DESCRIPTION
- Add a new label style for the query field: `inLineLabels` which will have a label in line with each field. 
- Add a height prop to control the height of the fields in the `QueryField` 
     - This is used to match the height of these alert builder controls to the height of the discover chart controls.

**Before:**
![image](https://user-images.githubusercontent.com/9372512/115598856-de236880-a2a8-11eb-86f4-68b6339d2dc0.png)

**After:**
![image](https://user-images.githubusercontent.com/9372512/115598661-a4eaf880-a2a8-11eb-930f-d168d399cb2a.png)
