### PR TITLE
fix(tests): Fix flakey visual snapshot from async loading

### DIFF
--- a/tests/acceptance/test_project_ownership.py
+++ b/tests/acceptance/test_project_ownership.py
@@ -19,4 +19,5 @@ class ProjectOwnershipTest(AcceptanceTestCase):
         self.browser.wait_until_test_id("issueowners-panel")
         self.browser.click('[aria-label="Edit"]')
         self.browser.wait_until(".modal-dialog")
+        self.browser.wait_until_not("div[class$='loadingIndicator']")
         self.browser.snapshot("project ownership modal")


### PR DESCRIPTION
## Objective:
The visual snapshots were failing for unrelated changes.
https://storage.googleapis.com/sentry-visual-snapshots/getsentry/sentry/1d0d35c09027d0c22d891abb4bb84f08cf6eef1e/index.html

![image (8)](https://user-images.githubusercontent.com/10491193/115603234-c17d3580-a294-11eb-932f-e45033dcc365.png)

This PR will make this acceptance test more consistent by waiting until the select box loading indicators disappears before snapshotting.