### PR TITLE
fix(ui): more alert details polish

### DIFF
--- a/src/sentry/api/serializers/models/incident.py
+++ b/src/sentry/api/serializers/models/incident.py
@@ -93,9 +93,11 @@ class IncidentSerializer(Serializer):
 class DetailedIncidentSerializer(IncidentSerializer):
     def __init__(self, expand=None):
         if expand is None:
-            expand = ["seen_by"]
-        elif "seen_by" not in expand:
+            expand = []
+        if "seen_by" not in expand:
             expand.append("seen_by")
+        if "original_alert_rule" not in expand:
+            expand.append("original_alert_rule")
         super().__init__(expand=expand)
 
     def get_attrs(self, item_list, user, **kwargs):

--- a/static/app/views/alerts/details/body.tsx
+++ b/static/app/views/alerts/details/body.tsx
@@ -36,6 +36,7 @@ import {DATA_SOURCE_LABELS, getIncidentMetricPreset, isIssueAlert} from '../util
 
 import Activity from './activity';
 import Chart from './chart';
+import {alertDetailsLink} from 'app/views/alerts/details/index';
 
 type Props = {
   incident?: Incident;
@@ -211,13 +212,8 @@ export default class DetailsBody extends React.Component<Props> {
       incident?.alertRule &&
       !isIssueAlert(incident?.alertRule) &&
       organization.features.includes('alert-details-redesign');
-    const alertRuleLink = hasRedesign
-      ? `/organizations/${organization.slug}/alerts/rules/details/${
-          incident?.alertRule.status === AlertRuleStatus.SNAPSHOT &&
-          incident?.alertRule.originalAlertRuleId
-            ? incident?.alertRule.originalAlertRuleId
-            : incident?.alertRule.id
-        }/`
+    const alertRuleLink = hasRedesign && incident
+      ? alertDetailsLink(organization, incident)
       : `/organizations/${params.orgId}/alerts/metric-rules/${incident?.projects[0]}/${incident?.alertRule?.id}/`;
 
     return (

--- a/static/app/views/alerts/details/body.tsx
+++ b/static/app/views/alerts/details/body.tsx
@@ -21,6 +21,7 @@ import {Organization, Project} from 'app/types';
 import {defined} from 'app/utils';
 import Projects from 'app/utils/projects';
 import theme from 'app/utils/theme';
+import {alertDetailsLink} from 'app/views/alerts/details/index';
 import {DATASET_EVENT_TYPE_FILTERS} from 'app/views/settings/incidentRules/constants';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/presets';
 import {AlertRuleThresholdType} from 'app/views/settings/incidentRules/types';
@@ -36,7 +37,6 @@ import {DATA_SOURCE_LABELS, getIncidentMetricPreset, isIssueAlert} from '../util
 
 import Activity from './activity';
 import Chart from './chart';
-import {alertDetailsLink} from 'app/views/alerts/details/index';
 
 type Props = {
   incident?: Incident;
@@ -212,9 +212,10 @@ export default class DetailsBody extends React.Component<Props> {
       incident?.alertRule &&
       !isIssueAlert(incident?.alertRule) &&
       organization.features.includes('alert-details-redesign');
-    const alertRuleLink = hasRedesign && incident
-      ? alertDetailsLink(organization, incident)
-      : `/organizations/${params.orgId}/alerts/metric-rules/${incident?.projects[0]}/${incident?.alertRule?.id}/`;
+    const alertRuleLink =
+      hasRedesign && incident
+        ? alertDetailsLink(organization, incident)
+        : `/organizations/${params.orgId}/alerts/metric-rules/${incident?.projects[0]}/${incident?.alertRule?.id}/`;
 
     return (
       <StyledPageContent>

--- a/static/app/views/alerts/details/index.tsx
+++ b/static/app/views/alerts/details/index.tsx
@@ -37,12 +37,13 @@ type State = {
   stats?: IncidentStats;
 };
 
-export const alertDetailsLink = (organization: Organization, incident: Incident) => `/organizations/${organization.slug}/alerts/rules/details/${
-  incident?.alertRule.status === AlertRuleStatus.SNAPSHOT &&
-  incident?.alertRule.originalAlertRuleId
-    ? incident?.alertRule.originalAlertRuleId
-    : incident?.alertRule.id
-}/`
+export const alertDetailsLink = (organization: Organization, incident: Incident) =>
+  `/organizations/${organization.slug}/alerts/rules/details/${
+    incident?.alertRule.status === AlertRuleStatus.SNAPSHOT &&
+    incident?.alertRule.originalAlertRuleId
+      ? incident?.alertRule.originalAlertRuleId
+      : incident?.alertRule.id
+  }/`;
 
 class IncidentDetails extends React.Component<Props, State> {
   state: State = {isLoading: false, hasError: false};

--- a/static/app/views/alerts/details/index.tsx
+++ b/static/app/views/alerts/details/index.tsx
@@ -37,6 +37,13 @@ type State = {
   stats?: IncidentStats;
 };
 
+export const alertDetailsLink = (organization: Organization, incident: Incident) => `/organizations/${organization.slug}/alerts/rules/details/${
+  incident?.alertRule.status === AlertRuleStatus.SNAPSHOT &&
+  incident?.alertRule.originalAlertRuleId
+    ? incident?.alertRule.originalAlertRuleId
+    : incident?.alertRule.id
+}/`
+
 class IncidentDetails extends React.Component<Props, State> {
   state: State = {isLoading: false, hasError: false};
 
@@ -61,6 +68,7 @@ class IncidentDetails extends React.Component<Props, State> {
     const {
       api,
       location,
+      organization,
       params: {orgId, alertId},
     } = this.props;
 
@@ -74,12 +82,7 @@ class IncidentDetails extends React.Component<Props, State> {
           location && location.query && location.query.redirect === 'false';
         if (hasRedesign && !stopRedirect) {
           browserHistory.replace({
-            pathname: `/organizations/${orgId}/alerts/rules/details/${
-              incident.alertRule.status === AlertRuleStatus.SNAPSHOT &&
-              incident.alertRule.originalAlertRuleId
-                ? incident.alertRule.originalAlertRuleId
-                : incident.alertRule.id
-            }/`,
+            pathname: alertDetailsLink(organization, incident),
             query: {alert: incident.identifier},
           });
         }

--- a/static/app/views/alerts/list/row.tsx
+++ b/static/app/views/alerts/list/row.tsx
@@ -19,12 +19,13 @@ import {Organization, Project} from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import getDynamicText from 'app/utils/getDynamicText';
 import theme from 'app/utils/theme';
+import {alertDetailsLink} from 'app/views/alerts/details';
 
 import {
   API_INTERVAL_POINTS_LIMIT,
   API_INTERVAL_POINTS_MIN,
 } from '../rules/details/constants';
-import {AlertRuleStatus, Incident, IncidentStats, IncidentStatus} from '../types';
+import {Incident, IncidentStats, IncidentStatus} from '../types';
 import {getIncidentMetricPreset, isIssueAlert} from '../utils';
 
 import SparkLine from './sparkLine';
@@ -146,12 +147,7 @@ class AlertListRow extends AsyncComponent<Props, State> {
 
     const alertLink = hasRedesign
       ? {
-          pathname: `/organizations/${orgId}/alerts/rules/details/${
-            incident.alertRule.status === AlertRuleStatus.SNAPSHOT &&
-            incident.alertRule.originalAlertRuleId
-              ? incident.alertRule.originalAlertRuleId
-              : incident.alertRule.id
-          }/`,
+          pathname: alertDetailsLink(organization, incident),
           query: {alert: incident.identifier},
         }
       : {

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -293,11 +293,14 @@ export default class DetailsBody extends React.Component<Props> {
           return initiallyLoaded ? (
             <React.Fragment>
               <StyledLayoutBody>
-                {selectedIncident && selectedIncident.alertRule.status === AlertRuleStatus.SNAPSHOT && <StyledAlert type="warning" icon={<IconInfo size="md" />}>
-                  {t(
-                    'Alert Rule settings have been updated since this alert was triggered.'
+                {selectedIncident &&
+                  selectedIncident.alertRule.status === AlertRuleStatus.SNAPSHOT && (
+                    <StyledAlert type="warning" icon={<IconInfo size="md" />}>
+                      {t(
+                        'Alert Rule settings have been updated since this alert was triggered.'
+                      )}
+                    </StyledAlert>
                   )}
-                </StyledAlert>}
               </StyledLayoutBody>
               <StyledLayoutBodyWrapper>
                 <Layout.Main>

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -18,7 +18,7 @@ import {Panel, PanelBody} from 'app/components/panels';
 import Placeholder from 'app/components/placeholder';
 import TimeSince from 'app/components/timeSince';
 import Tooltip from 'app/components/tooltip';
-import {IconCheckmark, IconFire, IconInfo, IconUser, IconWarning} from 'app/icons';
+import {IconCheckmark, IconFire, IconInfo, IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
@@ -122,21 +122,27 @@ export default class DetailsBody extends React.Component<Props> {
       return null;
     }
 
-    const icon =
+    const status =
       trigger.label === 'critical' ? (
-        <IconFire color="red300" size="sm" />
+        <StatusWrapper>
+          <IconFire color="red300" size="sm" /> Critical
+        </StatusWrapper>
       ) : trigger.label === 'warning' ? (
-        <IconWarning color="yellow300" size="sm" />
+        <StatusWrapper>
+          <IconWarning color="yellow300" size="sm" /> Warning
+        </StatusWrapper>
       ) : (
-        <IconCheckmark color="green300" size="sm" isCircled />
+        <StatusWrapper>
+          <IconCheckmark color="green300" size="sm" isCircled /> Resolved
+        </StatusWrapper>
       );
 
     const thresholdTypeText =
-      rule.thresholdType === AlertRuleThresholdType.ABOVE ? t('Above') : t('Below');
+      rule.thresholdType === AlertRuleThresholdType.ABOVE ? t('above') : t('below');
 
     return (
       <TriggerCondition>
-        {icon}
+        {status}
         <TriggerText>{`${thresholdTypeText} ${trigger.alertThreshold}`}</TriggerText>
       </TriggerCondition>
     );
@@ -185,11 +191,7 @@ export default class DetailsBody extends React.Component<Props> {
               <KeyValueTableRow
                 keyName={t('Team')}
                 value={
-                  teamActor ? (
-                    <ActorAvatar actor={teamActor} size={24} />
-                  ) : (
-                    <IconUser size="20px" color="gray400" />
-                  )
+                  teamActor ? <ActorAvatar actor={teamActor} size={24} /> : 'Unassigned'
                 }
               />
             </Feature>
@@ -324,7 +326,7 @@ export default class DetailsBody extends React.Component<Props> {
                               'This is the time period which the metric is evaluated by.'
                             )}
                           >
-                            <IconInfo size="xs" />
+                            <IconInfo size="xs" color="gray200" />
                           </Tooltip>
                         </SidebarHeading>
 
@@ -404,6 +406,12 @@ const DetailWrapper = styled('div')`
   }
 `;
 
+const StatusWrapper = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${space(0.5)};
+`;
+
 const HeaderContainer = styled('div')`
   display: flex;
   flex-direction: row;
@@ -413,7 +421,7 @@ const HeaderContainer = styled('div')`
 const HeaderGrid = styled('div')`
   display: grid;
   grid-template-columns: auto auto auto;
-  align-items: start;
+  align-items: flex-start;
   gap: ${space(4)};
 `;
 
@@ -448,6 +456,7 @@ const SidebarHeading = styled(SectionHeading)<{noMargin?: boolean}>`
   grid-template-columns: auto auto;
   justify-content: flex-start;
   margin-top: ${p => (p.noMargin ? 0 : space(2))};
+  margin-bottom: ${space(0.5)};
   line-height: 1;
   gap: ${space(1)};
 `;
@@ -479,7 +488,7 @@ const TriggerCondition = styled('div')`
 `;
 
 const TriggerText = styled('div')`
-  margin-left: ${space(1)};
+  margin-left: ${space(0.5)};
   white-space: nowrap;
 `;
 

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -6,6 +6,7 @@ import moment from 'moment';
 
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
+import Alert from 'app/components/alert';
 import ActorAvatar from 'app/components/avatar/actorAvatar';
 import {SectionHeading} from 'app/components/charts/styles';
 import {getInterval} from 'app/components/charts/utils';
@@ -35,7 +36,7 @@ import {
 import {extractEventTypeFilterFromRule} from 'app/views/settings/incidentRules/utils/getEventTypeFilter';
 
 import AlertBadge from '../../alertBadge';
-import {Incident, IncidentStatus} from '../../types';
+import {AlertRuleStatus, Incident, IncidentStatus} from '../../types';
 
 import {API_INTERVAL_POINTS_LIMIT, TIME_OPTIONS, TimePeriodType} from './constants';
 import MetricChart from './metricChart';
@@ -291,6 +292,13 @@ export default class DetailsBody extends React.Component<Props> {
         {({initiallyLoaded, projects}) => {
           return initiallyLoaded ? (
             <React.Fragment>
+              <StyledLayoutBody>
+                {selectedIncident && selectedIncident.alertRule.status === AlertRuleStatus.SNAPSHOT && <StyledAlert type="warning" icon={<IconInfo size="md" />}>
+                  {t(
+                    'Alert Rule settings have been updated since this alert was triggered.'
+                  )}
+                </StyledAlert>}
+              </StyledLayoutBody>
               <StyledLayoutBodyWrapper>
                 <Layout.Main>
                   <HeaderContainer>
@@ -427,8 +435,20 @@ const HeaderGrid = styled('div')`
   gap: ${space(4)};
 `;
 
+const StyledLayoutBody = styled(Layout.Body)`
+  flex-grow: 0;
+  padding-bottom: 0 !important;
+  @media (min-width: ${p => p.theme.breakpoints[1]}) {
+    grid-template-columns: auto;
+  }
+`;
+
 const StyledLayoutBodyWrapper = styled(Layout.Body)`
   margin-bottom: -${space(3)};
+`;
+
+const StyledAlert = styled(Alert)`
+  margin: 0;
 `;
 
 const ActivityWrapper = styled('div')`

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -409,7 +409,9 @@ const DetailWrapper = styled('div')`
 const StatusWrapper = styled('div')`
   display: flex;
   align-items: center;
-  gap: ${space(0.5)};
+  svg {
+    margin-right: ${space(0.5)};
+  }
 `;
 
 const HeaderContainer = styled('div')`

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -6,7 +6,6 @@ import moment from 'moment';
 
 import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
-import Alert from 'app/components/alert';
 import ActorAvatar from 'app/components/avatar/actorAvatar';
 import {SectionHeading} from 'app/components/charts/styles';
 import {getInterval} from 'app/components/charts/utils';
@@ -290,13 +289,6 @@ export default class DetailsBody extends React.Component<Props> {
         {({initiallyLoaded, projects}) => {
           return initiallyLoaded ? (
             <React.Fragment>
-              <StyledLayoutBody>
-                <StyledAlert type="info" icon={<IconInfo size="md" />}>
-                  {t(
-                    'You’re viewing the new alert details page. To view the old experience, select an alert on the chart or in the history.'
-                  )}
-                </StyledAlert>
-              </StyledLayoutBody>
               <StyledLayoutBodyWrapper>
                 <Layout.Main>
                   <HeaderContainer>
@@ -425,20 +417,8 @@ const HeaderGrid = styled('div')`
   gap: ${space(4)};
 `;
 
-const StyledLayoutBody = styled(Layout.Body)`
-  flex-grow: 0;
-  padding-bottom: 0 !important;
-  @media (min-width: ${p => p.theme.breakpoints[1]}) {
-    grid-template-columns: auto;
-  }
-`;
-
 const StyledLayoutBodyWrapper = styled(Layout.Body)`
   margin-bottom: -${space(3)};
-`;
-
-const StyledAlert = styled(Alert)`
-  margin: 0;
 `;
 
 const ActivityWrapper = styled('div')`

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -27,15 +27,11 @@ import {AvatarProject, Organization, Project} from 'app/types';
 import {ReactEchartsRef} from 'app/types/echarts';
 import {getUtcDateString} from 'app/utils/dates';
 import theme from 'app/utils/theme';
+import {alertDetailsLink} from 'app/views/alerts/details';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
-import {
-  AlertRuleStatus,
-  Incident,
-  IncidentActivityType,
-  IncidentStatus,
-} from '../../types';
+import {Incident, IncidentActivityType, IncidentStatus} from '../../types';
 import {getIncidentRuleMetricPreset} from '../../utils';
 
 import {TimePeriodType} from './constants';
@@ -105,7 +101,7 @@ function createStatusAreaSeries(
 
 function createIncidentSeries(
   router: Props['router'],
-  orgSlug: string,
+  organization: Organization,
   lineColor: string,
   incidentTimestamp: number,
   incident: Incident,
@@ -123,12 +119,7 @@ function createIncidentSeries(
           xAxis: incidentTimestamp,
           onClick: () => {
             router.push({
-              pathname: `/organizations/${orgSlug}/alerts/rules/details/${
-                incident.alertRule.status === AlertRuleStatus.SNAPSHOT &&
-                incident.alertRule.originalAlertRuleId
-                  ? incident.alertRule.originalAlertRuleId
-                  : incident.alertRule.id
-              }/`,
+              pathname: alertDetailsLink(organization, incident),
               query: {alert: incident.identifier},
             });
           },
@@ -509,7 +500,7 @@ class MetricChart extends React.PureComponent<Props, State> {
                 series.push(
                   createIncidentSeries(
                     router,
-                    organization.slug,
+                    organization,
                     incidentColor,
                     incidentStartDate,
                     incident,

--- a/static/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/details/relatedIssues.tsx
@@ -57,12 +57,12 @@ class RelatedIssues extends React.Component<Props> {
     return (
       <React.Fragment>
         <ControlsWrapper>
-          <SectionHeading>
+          <StyledSectionHeading>
             {t('Related Issues')}
             <Tooltip title={t('Top issues containing events matching the metric.')}>
-              <IconInfo size="xs" />
+              <IconInfo size="xs" color="gray200" />
             </Tooltip>
-          </SectionHeading>
+          </StyledSectionHeading>
           <Button data-test-id="issues-open" size="small" to={issueSearch}>
             {t('Open in Issues')}
           </Button>
@@ -86,6 +86,11 @@ class RelatedIssues extends React.Component<Props> {
     );
   }
 }
+
+const StyledSectionHeading = styled(SectionHeading)`
+  display: flex;
+  align-items: center;
+`;
 
 const ControlsWrapper = styled('div')`
   display: flex;

--- a/static/app/views/alerts/rules/row.tsx
+++ b/static/app/views/alerts/rules/row.tsx
@@ -28,6 +28,7 @@ import {AlertRuleThresholdType} from 'app/views/settings/incidentRules/types';
 import AlertBadge from '../alertBadge';
 import {CombinedMetricIssueAlerts, IncidentStatus} from '../types';
 import {isIssueAlert} from '../utils';
+import {alertDetailsLink} from 'app/views/alerts/details';
 
 type Props = {
   rule: CombinedMetricIssueAlerts;

--- a/static/app/views/alerts/rules/row.tsx
+++ b/static/app/views/alerts/rules/row.tsx
@@ -28,7 +28,6 @@ import {AlertRuleThresholdType} from 'app/views/settings/incidentRules/types';
 import AlertBadge from '../alertBadge';
 import {CombinedMetricIssueAlerts, IncidentStatus} from '../types';
 import {isIssueAlert} from '../utils';
-import {alertDetailsLink} from 'app/views/alerts/details';
 
 type Props = {
   rule: CombinedMetricIssueAlerts;


### PR DESCRIPTION
- Tidied up Conditions copy
- Fixed spacing/padding issues for the sidebar
- Correct tooltip icon colors
- Replaced Team Icon in table with "Unassigned" copy
- Removed Alert at the top of the page
---
- Added alert rule changed banner for snapshot incidents
- Created a function for alert details link instead of repeating the logic
- In the alert rule details serializer need to return the original alert rule to redirect old links to the correct rule, added a default expand