### PR TITLE
fix(trace-view): Only add guide anchor to first transaction

### DIFF
--- a/static/app/views/performance/traceDetails/content.tsx
+++ b/static/app/views/performance/traceDetails/content.tsx
@@ -483,7 +483,7 @@ class TraceDetailsContent extends React.Component<Props, State> {
             !isLastTransaction && hasChildren
               ? [{depth: 0, isOrphanDepth: isNextChildOrphaned}]
               : [],
-          hasGuideAnchor: true,
+          hasGuideAnchor: index === 0,
         });
 
         acc.index = result.lastIndex + 1;


### PR DESCRIPTION
This was unintentionally adding a guide anchor to the orphans as well.