### PR TITLE
fix(alert): Add list to non-wizard rule form

### DIFF
--- a/static/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -735,8 +735,10 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                       thresholdChart={chart}
                       onFilterSearch={this.handleFilterUpdate}
                     />
-                    {triggerForm(hasAccess)}
-                    {ruleNameOwnerForm(hasAccess)}
+                    <List symbol="colored-numeric" initialCounterValue={2}>
+                      {triggerForm(hasAccess)}
+                      {ruleNameOwnerForm(hasAccess)}
+                    </List>
                   </React.Fragment>
                 )
               }


### PR DESCRIPTION
Adds the `<List>` component to the non-wizard builder form to fix this styling issue. Kinda weird to have another list just for this, but this will be only necessary until the alert wizard GA's

**Before:**
![image](https://user-images.githubusercontent.com/9372512/115610048-56dcf180-a2b6-11eb-894a-01032cf4af31.png)


**After:**
![image](https://user-images.githubusercontent.com/9372512/115610029-4f1d4d00-a2b6-11eb-8142-7f7c3502c8e8.png)
