### PR TITLE
fix(alerts): Contain project name to column

### DIFF
--- a/static/app/views/alerts/rules/row.tsx
+++ b/static/app/views/alerts/rules/row.tsx
@@ -190,10 +190,12 @@ class RuleListRow extends React.Component<Props, State> {
         )}
 
         <FlexCenter>
-          <ProjectBadge
-            avatarSize={18}
-            project={!projectsLoaded ? {slug} : this.getProject(slug, projects)}
-          />
+          <ProjectBadgeContainer>
+            <ProjectBadge
+              avatarSize={18}
+              project={!projectsLoaded ? {slug} : this.getProject(slug, projects)}
+            />
+          </ProjectBadgeContainer>
         </FlexCenter>
         {hasAlertOwnership && (
           <FlexCenter>
@@ -340,6 +342,10 @@ const AlertNameAndStatus = styled('div')`
 
 const AlertName = styled('div')`
   font-size: ${p => p.theme.fontSizeLarge};
+`;
+
+const ProjectBadgeContainer = styled('div')`
+  width: 100%;
 `;
 
 const ProjectBadge = styled(IdBadge)`


### PR DESCRIPTION
fixes the project badge getting too close to the next div. project badge already has ellipsis

![image](https://user-images.githubusercontent.com/1400464/115631790-5c890600-a2bb-11eb-9a57-25cbc1f6edda.png)
