### PR TITLE
ref(styls): Fix very subtle selector bug

### DIFF
--- a/static/app/components/events/interfaces/crashHeader/crashActions.tsx
+++ b/static/app/components/events/interfaces/crashHeader/crashActions.tsx
@@ -127,7 +127,7 @@ const ButtonGroupWrapper = styled('div')`
   > * {
     padding: ${space(0.5)} 0;
   }
-  > * :not(:last-child) {
+  > *:not(:last-child) {
     margin-right: ${space(1)};
   }
 `;


### PR DESCRIPTION
This caused 2nd level nested elements to be selected, not the *
elements.