### PR TITLE
build(ci): Cache webpack builds for acceptance tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -148,9 +148,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{ steps.webpack-cache.outputs.path }}
-          key: ${{ runner.os }}-webpack-cache
+          key: ${{ runner.os }}-webpack-cache-${{ hashFiles('webpack.config.js') }}
           restore-keys: |
-            ${{ runner.os }}-webpack-cache
+            ${{ runner.os }}-webpack-cache-
 
       - name: Install Javascript Dependencies
         run: |

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -107,6 +107,10 @@ jobs:
         run: |
           echo "::set-output name=python-version::$(cat .python-version)"
 
+      - name: Setup webpack cache
+        id: webpack-cache
+        run: echo "::set-output name=path::.webpack_cache"
+
       # Until GH composite actions can use `uses`, we need to setup python here
       - uses: actions/setup-python@v2
         with:
@@ -140,12 +144,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
+      - name: webpack cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.webpack-cache.outputs.path }}
+          key: ${{ runner.os }}-webpack-cache
+          restore-keys: |
+            ${{ runner.os }}-webpack-cache
+
       - name: Install Javascript Dependencies
         run: |
           yarn install --frozen-lockfile
 
       - name: webpack
         env:
+          WEBPACK_CACHE_PATH: ${{ steps.webpack-cache.outputs.path }}
           SENTRY_INSTRUMENTATION: 1
           # this is fine to not have for forks, it shouldn't fail
           SENTRY_WEBPACK_WEBHOOK_SECRET: ${{ secrets.SENTRY_WEBPACK_WEBHOOK_SECRET }}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -578,6 +578,19 @@ if (IS_PRODUCTION) {
   });
 }
 
+// Cache webpack builds
+if (env.WEBPACK_CACHE_PATH) {
+  appConfig.cache = {
+    type: 'filesystem',
+    cacheLocation: path.resolve(__dirname, env.WEBPACK_CACHE_PATH),
+    buildDependencies: {
+      // This makes all dependencies of this file - build dependencies
+      config: [__filename],
+      // By default webpack and loaders are build dependencies
+    },
+  };
+}
+
 if (env.MEASURE) {
   const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
   const smp = new SpeedMeasurePlugin();


### PR DESCRIPTION
Configure webpack to use a filesystem cache - update acceptance workflow to restore webpack cache.
Webpack will hash all `buildDependencies` (e.g. loaders) and invalidate the cache if they change.

Cold run:
![image](https://user-images.githubusercontent.com/79684/115637238-84309c00-a2c4-11eb-8dfb-111a80cf868e.png)

Cached:
![image](https://user-images.githubusercontent.com/79684/115637856-02da0900-a2c6-11eb-8ab1-7cfced9cd0f6.png)

Perf increase (~33% from a sample size of 1), isn't as nice as my local env, but better than nothing