### PR TITLE
fix(emotion11): ReactVirtualizedList emotion11 type incompatibility

### DIFF
--- a/static/app/components/dropdownAutoComplete/list.tsx
+++ b/static/app/components/dropdownAutoComplete/list.tsx
@@ -117,6 +117,9 @@ const List = ({
 
 export default List;
 
-const StyledList = styled(ReactVirtualizedList)`
+// XXX(ts): Emotion11 has some trouble with List's defaultProps
+const StyledList = styled((p: React.ComponentProps<typeof ReactVirtualizedList>) => (
+  <ReactVirtualizedList {...p} />
+))`
   outline: none;
 `;

--- a/static/app/components/events/interfaces/breadcrumbs/list.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/list.tsx
@@ -160,8 +160,13 @@ const Wrapper = styled('div')`
   ${aroundContentStyle}
 `;
 
-// it makes the list have a dynamic height; otherwise, in the case of filtered options, a list will be displayed with an empty space
-const StyledList = styled(List)<{height: number}>`
+// XXX(ts): Emotion11 has some trouble with List's defaultProps
+//
+// It gives the list have a dynamic height; otherwise, in the case of filtered
+// options, a list will be displayed with an empty space
+const StyledList = styled((p: React.ComponentProps<typeof List>) => <List {...p} />)<{
+  height: number;
+}>`
   height: auto !important;
   max-height: ${p => p.height}px;
   overflow-y: auto !important;

--- a/static/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -624,7 +624,10 @@ const Title = styled('h3')`
   height: 14px;
 `;
 
-const StyledList = styled(List)<{height: number}>`
+// XXX(ts): Emotion11 has some trouble with List's defaultProps
+const StyledList = styled((p: React.ComponentProps<typeof List>) => <List {...p} />)<{
+  height: number;
+}>`
   height: auto !important;
   max-height: ${p => p.height}px;
   overflow-y: auto !important;

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -458,7 +458,10 @@ class DebugMeta extends React.PureComponent<Props, State> {
 
 export default DebugMeta;
 
-const StyledList = styled(List)<{height: number}>`
+// XXX(ts): Emotion11 has some trouble with List's defaultProps
+const StyledList = styled((p: React.ComponentProps<typeof List>) => <List {...p} />)<{
+  height: number;
+}>`
   height: auto !important;
   max-height: ${p => p.height}px;
   outline: none;


### PR DESCRIPTION
Emotion 11 doesn't like the defaultProps assigned.. Maybe there's a better way to fix this, but it was easier to just avoid the defaultProps by wrapping this all together