### PR TITLE
feat(demo): deep links v2

### DIFF
--- a/src/sentry/demo/demo_start.py
+++ b/src/sentry/demo/demo_start.py
@@ -193,10 +193,11 @@ def get_one_transaction(org: Organization, project_slug: Optional[str]):
 def get_one_discover_query(org: Organization):
     discover_query = DiscoverSavedQuery.objects.filter(organization=org).first()
 
-    return f"organizations/{org.slug}/discover/results/?id={discover_query.id}&statsPeriod=7d"
+    return f"/organizations/{org.slug}/discover/results/?id={discover_query.id}&statsPeriod=7d"
 
 
 def get_one_web_vitals(org: Organization, project_slug: Optional[str]):
+    # project_slug should be specified so we always get a front end project
     project = _get_project(org, project_slug)
     transaction = _get_one_transaction_name(project)
 

--- a/src/sentry/demo/demo_start.py
+++ b/src/sentry/demo/demo_start.py
@@ -1,10 +1,22 @@
 import logging
+from typing import Optional
+from urllib.parse import quote
 
 import sentry_sdk
 from django.conf import settings
 from django.http import Http404
+from sentry_sdk import capture_exception
 
-from sentry.models import OrganizationMember, OrganizationStatus
+from sentry.discover.models import DiscoverSavedQuery
+from sentry.models import (
+    Group,
+    Organization,
+    OrganizationMember,
+    OrganizationStatus,
+    Project,
+    Release,
+)
+from sentry.snuba import discover
 from sentry.utils import auth
 from sentry.web.decorators import transaction_start
 from sentry.web.frontend.base import BaseView
@@ -31,6 +43,7 @@ class DemoStartView(BaseView):
         logger.info("post.start", extra={"cookie_member_id": member_id})
         sentry_sdk.set_tag("member_id", member_id)
 
+        # TODO(steve): switch to camelCase for request field
         skip_buffer = request.POST.get("skip_buffer") == "1"
         sentry_sdk.set_tag("skip_buffer", skip_buffer)
 
@@ -68,6 +81,7 @@ class DemoStartView(BaseView):
         # whether to initialize analytics when accepted_tracking=1
         # 0 means don't show the footer to accept cookies (user already declined)
         # no value means we show the footer to accept cookies (user has neither accepted nor declined)
+        # TODO: switch to camelCase for request field
         accepted_tracking = request.POST.get(ACCEPTED_TRACKING_COOKIE)
         if accepted_tracking in ["0", "1"]:
             resp.set_cookie(ACCEPTED_TRACKING_COOKIE, accepted_tracking)
@@ -80,6 +94,7 @@ class DemoStartView(BaseView):
 def get_redirect_url(request, org):
     # determine the redirect based on the scenario
     scenario = request.POST.get("scenario")
+    # basic scenarios
     if scenario == "performance":
         return f"/organizations/{org.slug}/performance/"
     if scenario == "releases":
@@ -90,8 +105,127 @@ def get_redirect_url(request, org):
         return f"/organizations/{org.slug}/discover/queries/"
     if scenario == "dashboards":
         return f"/organizations/{org.slug}/dashboards/"
-    url = auth.get_login_redirect(request)
-    # user is logged in so will be automatically redirected
-    # after landing on login page
-    url += "?allow_login=1"
-    return url
+    if scenario == "projects":
+        return f"/organizations/{org.slug}/projects/"
+
+    # more complicated scenarios with query lookups
+    try:
+        # no project slug
+        if scenario == "oneRelease":
+            return get_one_release(org)
+        if scenario == "oneDiscoverQuery":
+            return get_one_discover_query(org)
+
+        # with project slug
+        project_slug = request.POST.get("projectSlug")
+
+        # issue details
+        if scenario == "oneIssue":
+            return get_one_issue(org, project_slug)
+        if scenario == "oneBreadcrumb":
+            return get_one_breadcrumb(org, project_slug)
+        if scenario == "oneStackTrace":
+            return get_one_stack_trace(org, project_slug)
+
+        # performance and discover
+        if scenario == "oneTransaction":
+            return get_one_transaction(org, project_slug)
+        if scenario == "oneWebVitals":
+            return get_one_web_vitals(org, project_slug)
+        if scenario == "oneTransactionSummary":
+            return get_one_transaction_summary(org, project_slug)
+    except Exception:
+        # if an error happens and just let the user enter the sandbox
+        # on the default page
+        capture_exception()
+
+    # default is the issues page
+    return f"/organizations/{org.slug}/issues/"
+
+
+def get_one_release(org: Organization):
+    # pick the most recent release
+    release = Release.objects.filter(organization=org).order_by("-date_added").first()
+    project = release.projects.first()
+    version = quote(release.version)
+
+    return f"/organizations/{org.slug}/releases/{version}/?project={project.id}"
+
+
+def get_one_issue(org: Organization, project_slug: Optional[str]):
+    group_query = Group.objects.filter(project__organization=org)
+    if project_slug:
+        group_query = group_query.filter(project__slug=project_slug)
+    group = group_query.first()
+
+    return f"/organizations/{org.slug}/issues/{group.id}/?project={group.project_id}"
+
+
+def get_one_breadcrumb(org: Organization, project_slug: Optional[str]):
+    return get_one_issue(org, project_slug) + "#breadcrumbs"
+
+
+def get_one_stack_trace(org: Organization, project_slug: Optional[str]):
+    return get_one_issue(org, project_slug) + "#exception"
+
+
+def get_one_transaction(org: Organization, project_slug: Optional[str]):
+    project = _get_project(org, project_slug)
+
+    # find the most recent transaction
+    result = discover.query(
+        query="event.type:transaction",
+        orderby="-timestamp",
+        selected_columns=["id", "timestamp"],
+        limit=1,
+        params={
+            "organization_id": org.id,
+            "project_id": [project.id],
+        },
+        referrer="sandbox.demo_start.get_one_transaction",
+    )
+
+    transaction_id = result["data"][0]["id"]
+
+    return f"/organizations/{org.slug}/discover/{project.slug}:{transaction_id}/"
+
+
+def get_one_discover_query(org: Organization):
+    discover_query = DiscoverSavedQuery.objects.filter(organization=org).first()
+
+    return f"organizations/{org.slug}/discover/results/?id={discover_query.id}&statsPeriod=7d"
+
+
+def get_one_web_vitals(org: Organization, project_slug: Optional[str]):
+    project = _get_project(org, project_slug)
+    transaction = _get_one_transaction_name(project)
+
+    return f"/organizations/{org.slug}/performance/summary/vitals/?project={project.id}&statsPeriod=7d&transaction={transaction}"
+
+
+def get_one_transaction_summary(org: Organization, project_slug: Optional[str]):
+    project = _get_project(org, project_slug)
+    transaction = _get_one_transaction_name(project)
+
+    return f"/organizations/{org.slug}/performance/summary/?project={project.id}&statsPeriod=7d&transaction={transaction}"
+
+
+def _get_project(org: Organization, project_slug: Optional[str]):
+    project_query = Project.objects.filter(organization=org)
+    if project_slug:
+        project_query = project_query.filter(slug=project_slug)
+    return project_query.first()
+
+
+def _get_one_transaction_name(project: Project):
+    result = discover.query(
+        query="event.type:transaction",
+        selected_columns=["transaction"],
+        limit=1,
+        params={
+            "organization_id": project.organization_id,
+            "project_id": [project.id],
+        },
+        referrer="sandbox.demo_start._get_one_transaction_name",
+    )
+    return result["data"][0]["transaction"]

--- a/tests/sentry/demo/test_data_population.py
+++ b/tests/sentry/demo/test_data_population.py
@@ -9,7 +9,7 @@ from sentry.utils.compat.mock import patch
 # significantly decrease event volume
 DEMO_DATA_GEN_PARAMS = DEMO_DATA_GEN_PARAMS.copy()
 DEMO_DATA_GEN_PARAMS["MAX_DAYS"] = 1
-DEMO_DATA_GEN_PARAMS["SCALE_FACTOR"] = 0.1
+DEMO_DATA_GEN_PARAMS["SCALE_FACTOR"] = 0.05
 
 
 @override_settings(DEMO_MODE=True, DEMO_DATA_GEN_PARAMS=DEMO_DATA_GEN_PARAMS)

--- a/tests/sentry/demo/test_demo_start.py
+++ b/tests/sentry/demo/test_demo_start.py
@@ -100,7 +100,11 @@ class DemoStartTeset(TestCase):
         org = Organization.objects.get(members__id=member_id)
         group = Group.objects.filter(project__organization=org, project__slug="react").first()
         project = Project.objects.get(slug="react", organization=org)
-        release = Release.objects.filter(organization=org).order_by("-date_added").first()
+        release = (
+            Release.objects.filter(organization=org, projects=project)
+            .order_by("-date_added")
+            .first()
+        )
         version = quote(release.version)
 
         base_issue_url = f"/organizations/{org.slug}/issues/{group.id}/?project={group.project_id}"

--- a/tests/sentry/demo/test_demo_start.py
+++ b/tests/sentry/demo/test_demo_start.py
@@ -94,10 +94,9 @@ class DemoStartTeset(TestCase):
         User.objects.create(email=org_owner_email)
         # gen the org w/o mocks and save the cookie
         resp = self.client.post(self.path)
-        member_id = resp.cookies[MEMBER_ID_COOKIE].value.split(":")[0]
         self.save_cookie(MEMBER_ID_COOKIE, resp.cookies[MEMBER_ID_COOKIE])
 
-        org = Organization.objects.get(members__id=member_id)
+        org = Organization.objects.get(demoorganization__isnull=False)
         project = Project.objects.get(slug="react", organization=org)
         group = Group.objects.filter(project=project).first()
         release = (

--- a/tests/sentry/demo/test_demo_start.py
+++ b/tests/sentry/demo/test_demo_start.py
@@ -1,13 +1,26 @@
+from urllib.parse import quote
+
 from django.core import signing
 from django.test.utils import override_settings
 from exam import fixture
 
 from sentry.demo.demo_start import MEMBER_ID_COOKIE
-from sentry.models import OrganizationStatus
+from sentry.demo.models import DemoOrganization
+from sentry.demo.settings import DEMO_DATA_QUICK_GEN_PARAMS
+from sentry.models import Group, Organization, OrganizationStatus, Project, Release, User
 from sentry.testutils import TestCase
 from sentry.utils.compat import mock
 
 signer = signing.get_cookie_signer(salt=MEMBER_ID_COOKIE)
+
+
+# significantly decrease event volume
+DEMO_DATA_QUICK_GEN_PARAMS = DEMO_DATA_QUICK_GEN_PARAMS.copy()
+DEMO_DATA_QUICK_GEN_PARAMS["MAX_DAYS"] = 1
+DEMO_DATA_QUICK_GEN_PARAMS["SCALE_FACTOR"] = 0.1
+DEMO_DATA_QUICK_GEN_PARAMS["DISABLE_SESSIONS"] = True
+
+org_owner_email = "james@example.com"
 
 
 @override_settings(DEMO_MODE=True, ROOT_URLCONF="sentry.demo.urls")
@@ -65,12 +78,55 @@ class DemoStartTeset(TestCase):
 
     @mock.patch("sentry.demo.demo_start.auth.login")
     @mock.patch("sentry.demo.demo_org_manager.assign_demo_org")
-    def test_redirects(self, mock_assign_demo_org, mock_auth_login):
+    def test_basic_deep_links(self, mock_assign_demo_org, mock_auth_login):
         mock_assign_demo_org.return_value = (self.org, self.user)
 
-        for scenario in ["performance", "releases", "alerts", "discover", "dashboards"]:
+        for scenario in ["performance", "releases", "alerts", "discover", "dashboards", "projects"]:
             resp = self.client.post(self.path, data={"scenario": scenario})
             partial_url = f"/organizations/{self.org.slug}/{scenario}/"
+            assert resp.status_code == 302
+            assert partial_url in resp.url
+
+    @override_settings(
+        DEMO_DATA_QUICK_GEN_PARAMS=DEMO_DATA_QUICK_GEN_PARAMS, DEMO_ORG_OWNER_EMAIL=org_owner_email
+    )
+    def test_advanced_deep_links(self):
+        User.objects.create(email=org_owner_email)
+        # gen the org w/o mocks and save the cookie
+        resp = self.client.post(self.path)
+        member_id = resp.cookies[MEMBER_ID_COOKIE].value.split(":")[0]
+        self.save_cookie(MEMBER_ID_COOKIE, signer.sign(member_id))
+
+        org = Organization.objects.get(members__id=member_id)
+        group = Group.objects.filter(project__organization=org, project__slug="react").first()
+        project = Project.objects.get(slug="react", organization=org)
+        release = Release.objects.filter(organization=org).order_by("-date_added").first()
+        version = quote(release.version)
+
+        base_issue_url = f"/organizations/{org.slug}/issues/{group.id}/?project={group.project_id}"
+
+        scenario_tuples = [
+            ("oneRelease", f"/organizations/{org.slug}/releases/{version}/"),
+            ("oneDiscoverQuery", f"/organizations/{org.slug}/discover/results/"),
+            ("oneIssue", base_issue_url),
+            ("oneBreadcrumb", base_issue_url + "#breadcrumbs"),
+            ("oneStackTrace", base_issue_url + "#exception"),
+            ("oneTransaction", f"/organizations/{org.slug}/discover/"),
+            (
+                "oneWebVitals",
+                f"/organizations/{org.slug}/performance/summary/vitals/?project={project.id}",
+            ),
+            (
+                "oneTransactionSummary",
+                f"/organizations/{org.slug}/performance/summary/?project={project.id}",
+            ),
+        ]
+
+        assert DemoOrganization.objects.filter(organization=org).exists()
+
+        for scenario_tuple in scenario_tuples:
+            (scenario, partial_url) = scenario_tuple
+            resp = self.client.post(self.path, data={"scenario": scenario, "projectSlug": "react"})
             assert resp.status_code == 302
             assert partial_url in resp.url
 

--- a/tests/sentry/demo/test_demo_start.py
+++ b/tests/sentry/demo/test_demo_start.py
@@ -95,11 +95,11 @@ class DemoStartTeset(TestCase):
         # gen the org w/o mocks and save the cookie
         resp = self.client.post(self.path)
         member_id = resp.cookies[MEMBER_ID_COOKIE].value.split(":")[0]
-        self.save_cookie(MEMBER_ID_COOKIE, signer.sign(member_id))
+        self.save_cookie(MEMBER_ID_COOKIE, resp.cookies[MEMBER_ID_COOKIE])
 
         org = Organization.objects.get(members__id=member_id)
-        group = Group.objects.filter(project__organization=org, project__slug="react").first()
         project = Project.objects.get(slug="react", organization=org)
+        group = Group.objects.filter(project=project).first()
         release = (
             Release.objects.filter(organization=org, projects=project)
             .order_by("-date_added")


### PR DESCRIPTION
This PR is a follow up to https://github.com/getsentry/sentry/pull/24941 adds the following deep link scenarios for sandbox/demo mode:

- projects
- oneRelease
- oneDiscoverQuery
- oneIssue
- oneBreadcrumb
- oneStackTrace
- oneTransaction
- oneWebVitals
- oneTransactionSummary

And also adds the post request option `projectSlug` which will narrow down the scenario to that project (if applicable). The prefix `one` implies we are running a query to pick a matching instance of the scenario.

These deep links will be used in marketing and possibly docs later.

I also made a change to the default URL to be the issues page explicitly instead of letting the browser redirect from the login page when the user is logged in.