### PR TITLE
ref(emotion11): Fix missing props in custom styled components

### DIFF
--- a/static/app/components/group/suggestedOwnerHovercard.tsx
+++ b/static/app/components/group/suggestedOwnerHovercard.tsx
@@ -95,7 +95,10 @@ class SuggestedOwnerHovercard extends React.Component<Props, State> {
                     .map(({message, dateCreated}, i) => (
                       <CommitReasonItem key={i}>
                         <CommitIcon />
-                        <CommitMessage message={message} date={dateCreated} />
+                        <CommitMessage
+                          message={message ?? undefined}
+                          date={dateCreated}
+                        />
                       </CommitReasonItem>
                     ))}
                 </div>
@@ -140,7 +143,7 @@ const tagColors = {
   tag: theme.blue300,
 };
 
-const CommitIcon = styled(p => <IconCommit {...p} />)`
+const CommitIcon = styled(IconCommit)`
   margin-right: ${space(0.5)};
   flex-shrink: 0;
 `;
@@ -194,7 +197,7 @@ const OwnershipTag = styled(({tagType, ...props}) => <div {...props}>{tagType}</
   text-align: center;
 `;
 
-const ViewMoreButton = styled(p => (
+const ViewMoreButton = styled((p: React.ComponentProps<typeof Button>) => (
   <Button {...p} priority="link" size="zero">
     {t('View more')}
   </Button>
@@ -213,7 +216,7 @@ const OwnershipValue = styled('code')`
   line-height: 1.2;
 `;
 
-const EmailAlert = styled(p => <Alert iconSize="16px" {...p} />)`
+const EmailAlert = styled(Alert)`
   margin: 10px -13px -13px;
   border-radius: 0;
   border-color: #ece0b0;

--- a/static/app/components/organizations/headerItem.tsx
+++ b/static/app/components/organizations/headerItem.tsx
@@ -8,6 +8,7 @@ import Tooltip from 'app/components/tooltip';
 import {IconChevron, IconClose, IconInfo, IconLock, IconSettings} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
+import {Theme} from 'app/utils/theme';
 
 type DefaultProps = {
   allowClear: boolean;
@@ -110,7 +111,7 @@ class HeaderItem extends React.Component<Props> {
 }
 
 // Infer props here because of styled/theme
-const getColor = p => {
+const getColor = (p: ColorProps & {theme: Theme}) => {
   if (p.locked) {
     return p.theme.gray300;
   }

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -20,6 +20,7 @@ import space from 'app/styles/space';
 import {Config, Organization, User} from 'app/types';
 import withApi from 'app/utils/withApi';
 
+import SidebarMenuItemLink from '../sidebarMenuItemLink';
 import {CommonSidebarProps} from '../types';
 
 import Divider from './divider.styled';
@@ -169,8 +170,10 @@ const SentryLink = styled(Link)`
   }
 `;
 
-const UserSummary = styled(Link)`
-  ${menuItemStyles}
+const UserSummary = styled(Link)<
+  Omit<React.ComponentProps<typeof SidebarMenuItemLink>, 'children'>
+>`
+  ${p => menuItemStyles(p)}
   padding: 10px 15px;
 `;
 

--- a/static/app/components/sidebar/sidebarMenuItem.tsx
+++ b/static/app/components/sidebar/sidebarMenuItem.tsx
@@ -21,7 +21,7 @@ const SidebarMenuItem = ({to, children, href, ...props}: Props) => {
 };
 
 const menuItemStyles = (
-  p: React.ComponentProps<typeof SidebarMenuItemLink> & {theme: Theme}
+  p: Omit<React.ComponentProps<typeof SidebarMenuItemLink>, 'children'> & {theme: Theme}
 ) => css`
   color: ${p.theme.textColor};
   cursor: pointer;

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -651,7 +651,11 @@ const StyledDropdownList = styled('ul')`
   z-index: ${p => p.theme.zIndex.hovercard};
 `;
 
-const StyledMenuItem = styled(({to, children, ...p}) => (
+type MenuItemProps = React.HTMLProps<HTMLDivElement> & {
+  to?: React.ComponentProps<typeof Link>['to'];
+};
+
+const StyledMenuItem = styled(({to, children, ...p}: MenuItemProps) => (
   <MenuItem noAnchor>
     {to ? (
       // @ts-expect-error allow target _blank for this link to open in new window

--- a/static/app/views/alerts/details/activity/activityPlaceholder.tsx
+++ b/static/app/views/alerts/details/activity/activityPlaceholder.tsx
@@ -4,8 +4,9 @@ import {withTheme} from 'emotion-theming';
 
 import ActivityItem from 'app/components/activity/item';
 import space from 'app/styles/space';
+import {Theme} from 'app/utils/theme';
 
-export default withTheme(function ActivityPlaceholder(props) {
+export default withTheme(function ActivityPlaceholder(props: {theme: Theme}) {
   return (
     <ActivityItem
       bubbleProps={{

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import DocumentTitle from 'react-document-title';
 import {browserHistory, RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
-import {AnimatePresence, motion, useAnimation} from 'framer-motion';
+import {AnimatePresence, motion, MotionProps, useAnimation} from 'framer-motion';
 
 import Button from 'app/components/button';
 import Hook from 'app/components/hook';
@@ -308,7 +308,12 @@ ProgressStatus.defaultProps = {
   transition: testableTransition(),
 };
 
-const Back = styled(({className, animate, ...props}) => (
+type BackProps = Omit<React.ComponentProps<typeof Button>, 'icon' | 'priority'> & {
+  animate: MotionProps['animate'];
+  className?: string;
+};
+
+const Back = styled(({className, animate, ...props}: BackProps) => (
   <motion.div
     className={className}
     animate={animate}


### PR DESCRIPTION
A few `styled(p => ...)` type things that need props for emotion 11 to be happy