### PR TITLE
ref(emotion11): Avoid withTheme for only chart colors

### DIFF
--- a/static/app/components/charts/baseChart.tsx
+++ b/static/app/components/charts/baseChart.tsx
@@ -71,9 +71,10 @@ type Props = {
    */
   series?: EChartOption.Series[];
   /**
-   * Array of color codes to use in charts
+   * Array of color codes to use in charts. May also take a function which is
+   * provided with the current theme
    */
-  colors?: string[];
+  colors?: string[] | ((theme: Theme) => string[]);
   /**
    * Must be explicitly `null` to disable xAxis
    *
@@ -355,8 +356,11 @@ function BaseChartUnwrapped({
         })
       : undefined;
 
+  const resolveColors =
+    colors !== undefined ? (Array.isArray(colors) ? colors : colors(theme)) : null;
+
   const color =
-    colors ||
+    resolveColors ||
     (series.length ? theme.charts.getColorPalette(series.length) : theme.charts.colors);
 
   const chartOption = {

--- a/static/app/views/projectDetail/charts/projectErrorsBasicChart.tsx
+++ b/static/app/views/projectDetail/charts/projectErrorsBasicChart.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {browserHistory} from 'react-router';
-import {withTheme} from 'emotion-theming';
 import {Location} from 'history';
 
 import AsyncComponent from 'app/components/asyncComponent';
@@ -12,14 +11,12 @@ import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {t} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import getDynamicText from 'app/utils/getDynamicText';
-import {Theme} from 'app/utils/theme';
 
 const ALLOWED_TIME_PERIODS = ['1h', '24h', '7d', '14d', '30d'];
 
 type Props = AsyncComponent['props'] & {
   organization: Organization;
   location: Location;
-  theme: Theme;
   onTotalValuesChange: (value: number | null) => void;
   projectId?: string;
 };
@@ -109,7 +106,6 @@ class ProjectErrorsBasicChart extends AsyncComponent<Props, State> {
   }
 
   renderBody() {
-    const {theme} = this.props;
     const {loading, reloading} = this.state;
 
     return getDynamicText({
@@ -123,7 +119,7 @@ class ProjectErrorsBasicChart extends AsyncComponent<Props, State> {
             series={this.getSeries()}
             isGroupedByDate
             showTimeInTooltip
-            colors={[theme.purple300, theme.purple200]}
+            colors={theme => [theme.purple300, theme.purple200]}
             grid={{left: '10px', right: '10px', top: '40px', bottom: '0px'}}
           />
         </TransitionChart>
@@ -133,4 +129,4 @@ class ProjectErrorsBasicChart extends AsyncComponent<Props, State> {
   }
 }
 
-export default withTheme(ProjectErrorsBasicChart);
+export default ProjectErrorsBasicChart;


### PR DESCRIPTION
I'm removing withTheme's like this 1) to simplify components where possible, and 2) since there are some cases where emotion11's withTheme isn't happy and I don't fully understand why yet