### PR TITLE
feat(notifications platform): Send Slack messages for Issue Alerts

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -133,27 +133,52 @@ def build_action_text(group: Group, identity: Identity, action):
 def build_rule_url(rule: Rule, group: Group, project: Project):
     org_slug = group.organization.slug
     project_slug = project.slug
+    if type(rule) == tuple:
+        return absolute_uri(rule[1])
     rule_url = f"/organizations/{org_slug}/alerts/rules/{project_slug}/{rule.id}/"
     return absolute_uri(rule_url)
 
 
-def build_group_attachment(
-    group: Group,
-    event=None,
-    tags: Mapping[str, str] = None,
-    identity: Identity = None,
-    actions=None,
-    rules: List[Rule] = None,
-    link_to_event: bool = False,
-):
-    # XXX(dcramer): options are limited to 100 choices, even when nested
-    status = group.get_status()
+def build_footer(group, issue_alert, project, rules=None):
+    footer = f"{group.qualified_short_id}"
 
+    if rules:
+        rule_url = build_rule_url(rules[0], group, project)
+        if issue_alert:
+            footer += f" via <{rule_url}|{rules[0][0]}>"
+        else:
+            footer += f" via <{rule_url}|{rules[0].label}>"
+
+        if len(rules) > 1:
+            footer += f" (+{len(rules) - 1} other)"
+
+    return footer
+
+
+def build_tag_fields(event_for_tags, tags=None):
+    fields = []
+    if tags:
+        event_tags = event_for_tags.tags if event_for_tags else []
+        for key, value in event_tags:
+            std_key = tagstore.get_standardized_key(key)
+            if std_key not in tags:
+                continue
+
+            labeled_value = tagstore.get_tag_value_label(key, value)
+            fields.append(
+                {
+                    "title": std_key.encode("utf-8"),
+                    "value": labeled_value.encode("utf-8"),
+                    "short": True,
+                }
+            )
+    return fields
+
+
+def build_actions(group, project, text, color, actions=None, identity=None):
+    status = group.get_status()
     members = get_member_assignees(group)
     teams = get_team_assignees(group)
-
-    logo_url = absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
-    text = build_attachment_text(group, event) or ""
 
     if actions is None:
         actions = []
@@ -168,8 +193,6 @@ def build_group_attachment(
     }
 
     ignore_button = {"name": "status", "value": "ignored", "type": "button", "text": "Ignore"}
-
-    project = Project.objects.get_from_cache(id=group.project_id)
 
     cache_key = "has_releases:2:%s" % (project.id)
     has_releases = cache.get(cache_key)
@@ -209,6 +232,31 @@ def build_group_attachment(
         },
     ]
 
+    if actions:
+        action_texts = [_f for _f in [build_action_text(group, identity, a) for a in actions] if _f]
+        text += "\n" + "\n".join(action_texts)
+
+        color = ACTIONED_ISSUE_COLOR
+        payload_actions = []
+
+    return payload_actions, text, color
+
+
+def build_group_attachment(
+    group: Group,
+    event=None,
+    tags: Mapping[str, str] = None,
+    identity: Identity = None,
+    actions=None,
+    rules: List[Rule] = None,
+    link_to_event: bool = False,
+    issue_alert: bool = False,
+):
+    # XXX(dcramer): options are limited to 100 choices, even when nested
+    logo_url = absolute_uri(get_asset_url("sentry", "images/sentry-email-avatar.png"))
+    text = build_attachment_text(group, event) or ""
+    project = Project.objects.get_from_cache(id=group.project_id)
+
     # If an event is unspecified, use the tags of the latest event (if one exists).
     event_for_tags = event if event else group.get_latest_event()
 
@@ -219,29 +267,7 @@ def build_group_attachment(
         else fallback_color
     )
 
-    fields = []
-    if tags:
-        event_tags = event_for_tags.tags if event_for_tags else []
-        for key, value in event_tags:
-            std_key = tagstore.get_standardized_key(key)
-            if std_key not in tags:
-                continue
-
-            labeled_value = tagstore.get_tag_value_label(key, value)
-            fields.append(
-                {
-                    "title": std_key.encode("utf-8"),
-                    "value": labeled_value.encode("utf-8"),
-                    "short": True,
-                }
-            )
-
-    if actions:
-        action_texts = [_f for _f in [build_action_text(group, identity, a) for a in actions] if _f]
-        text += "\n" + "\n".join(action_texts)
-
-        color = ACTIONED_ISSUE_COLOR
-        payload_actions = []
+    fields = build_tag_fields(event_for_tags, tags)
 
     ts = group.last_seen
 
@@ -249,20 +275,20 @@ def build_group_attachment(
         event_ts = event.datetime
         ts = max(ts, event_ts)
 
-    footer = f"{group.qualified_short_id}"
-
-    if rules:
-        rule_url = build_rule_url(rules[0], group, project)
-        footer += f" via <{rule_url}|{rules[0].label}>"
-
-        if len(rules) > 1:
-            footer += f" (+{len(rules) - 1} other)"
+    footer = build_footer(group, issue_alert, project, rules)
 
     obj = event if event is not None else group
     if event and link_to_event:
         title_link = group.get_absolute_url(params={"referrer": "slack"}, event_id=event.event_id)
+    elif issue_alert:
+        title_link = group.get_absolute_url(params={"referrer": "IssueAlertSlack"})
     else:
         title_link = group.get_absolute_url(params={"referrer": "slack"})
+
+    if not issue_alert:
+        payload_actions, text, color = build_actions(group, project, text, color, actions, identity)
+    else:
+        payload_actions = []
 
     return {
         "fallback": f"[{project.slug}] {obj.title}",

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -176,6 +176,9 @@ def build_tag_fields(event_for_tags, tags=None):
 
 
 def build_actions(group, project, text, color, actions=None, identity=None):
+    """
+    Having actions means a button will be shown on the Slack message e.g. ignore, resolve, assign
+    """
     status = group.get_status()
     members = get_member_assignees(group)
     teams = get_team_assignees(group)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -6,6 +6,7 @@ from sentry import tagstore
 from sentry.integrations.slack.utils import ACTIONED_ISSUE_COLOR, LEVEL_TO_COLOR
 from sentry.models import (
     ActorTuple,
+    Event,
     Group,
     GroupAssignee,
     GroupStatus,
@@ -139,7 +140,7 @@ def build_rule_url(rule: Rule, group: Group, project: Project):
     return absolute_uri(rule_url)
 
 
-def build_footer(group, issue_alert, project, rules=None):
+def build_footer(group: Group, issue_alert: bool, project: Project, rules=None):
     footer = f"{group.qualified_short_id}"
 
     if rules:
@@ -155,7 +156,7 @@ def build_footer(group, issue_alert, project, rules=None):
     return footer
 
 
-def build_tag_fields(event_for_tags, tags=None):
+def build_tag_fields(event_for_tags: Event, tags: Mapping[str, str] = None):
     fields = []
     if tags:
         event_tags = event_for_tags.tags if event_for_tags else []
@@ -175,7 +176,9 @@ def build_tag_fields(event_for_tags, tags=None):
     return fields
 
 
-def build_actions(group, project, text, color, actions=None, identity=None):
+def build_actions(
+    group: Group, project: Project, text: str, color: str, actions=None, identity: Identity = None
+):
     """
     Having actions means a button will be shown on the Slack message e.g. ignore, resolve, assign
     """
@@ -247,7 +250,7 @@ def build_actions(group, project, text, color, actions=None, identity=None):
 
 def build_group_attachment(
     group: Group,
-    event=None,
+    event: Event = None,
     tags: Mapping[str, str] = None,
     identity: Identity = None,
     actions=None,

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -6,7 +6,6 @@ from sentry import tagstore
 from sentry.integrations.slack.utils import ACTIONED_ISSUE_COLOR, LEVEL_TO_COLOR
 from sentry.models import (
     ActorTuple,
-    Event,
     Group,
     GroupAssignee,
     GroupStatus,
@@ -156,7 +155,7 @@ def build_footer(group: Group, issue_alert: bool, project: Project, rules=None):
     return footer
 
 
-def build_tag_fields(event_for_tags: Event, tags: Mapping[str, str] = None):
+def build_tag_fields(event_for_tags, tags: Mapping[str, str] = None):
     fields = []
     if tags:
         event_tags = event_for_tags.tags if event_for_tags else []
@@ -250,7 +249,7 @@ def build_actions(
 
 def build_group_attachment(
     group: Group,
-    event: Event = None,
+    event=None,
     tags: Mapping[str, str] = None,
     identity: Identity = None,
     actions=None,

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -131,10 +131,10 @@ def build_action_text(group: Group, identity: Identity, action):
     )
 
 
-def build_rule_url(rule: Rule, group: Group, project: Project):
+def build_rule_url(rule: Rule, group: Group, project: Project, issue_alert: bool):
     org_slug = group.organization.slug
     project_slug = project.slug
-    if type(rule) == tuple:
+    if issue_alert:
         return absolute_uri(rule[1])
     rule_url = f"/organizations/{org_slug}/alerts/rules/{project_slug}/{rule.id}/"
     return absolute_uri(rule_url)
@@ -144,7 +144,7 @@ def build_footer(group: Group, issue_alert: bool, project: Project, rules=None):
     footer = f"{group.qualified_short_id}"
 
     if rules:
-        rule_url = build_rule_url(rules[0], group, project)
+        rule_url = build_rule_url(rules[0], group, project, issue_alert)
         if issue_alert:
             footer += f" via <{rule_url}|{rules[0][0]}>"
         else:

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 
 from sentry.integrations.slack.message_builder.issues import build_group_attachment
 from sentry.integrations.slack.utils import LEVEL_TO_COLOR
-from sentry.models import Event, Group, Rule
+from sentry.models import Group, Rule
 from sentry.notifications.activity.base import ActivityNotification
 from sentry.utils.http import absolute_uri
 
@@ -52,7 +52,7 @@ def build_notification_attachment(
 
 def build_issue_notification_attachment(
     group: Group,
-    event: Event = None,
+    event=None,
     tags: Mapping[str, str] = None,
     rules: List[Rule] = None,
 ):

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -1,10 +1,12 @@
 import re
-from typing import Any, Mapping
+from typing import Any, List, Mapping
 from urllib.parse import urljoin
 
+from sentry.integrations.slack.message_builder.issues import build_group_attachment
 from sentry.integrations.slack.utils import LEVEL_TO_COLOR
 from sentry.notifications.activity.base import ActivityNotification
 from sentry.utils.http import absolute_uri
+from sentry.models import Group, Rule
 
 
 def get_referrer_qstring(notification: ActivityNotification) -> str:
@@ -46,3 +48,13 @@ def build_notification_attachment(
         "footer": footer,
         "color": LEVEL_TO_COLOR["info"],
     }
+
+
+def build_issue_notification_attachment(
+    group: Group,
+    event=None,
+    tags: Mapping[str, str] = None,
+    rules: List[Rule] = None,
+):
+
+    return build_group_attachment(group, event, tags, rules, issue_alert=True)

--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -4,9 +4,9 @@ from urllib.parse import urljoin
 
 from sentry.integrations.slack.message_builder.issues import build_group_attachment
 from sentry.integrations.slack.utils import LEVEL_TO_COLOR
+from sentry.models import Event, Group, Rule
 from sentry.notifications.activity.base import ActivityNotification
 from sentry.utils.http import absolute_uri
-from sentry.models import Group, Rule
 
 
 def get_referrer_qstring(notification: ActivityNotification) -> str:
@@ -52,7 +52,7 @@ def build_notification_attachment(
 
 def build_issue_notification_attachment(
     group: Group,
-    event=None,
+    event: Event = None,
     tags: Mapping[str, str] = None,
     rules: List[Rule] = None,
 ):

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -6,7 +6,7 @@ from sentry.integrations.slack.message_builder.notifications import (
     build_issue_notification_attachment,
     build_notification_attachment,
 )
-from sentry.models import ExternalActor, Organization, User
+from sentry.models import ExternalActor, Organization, Project, User
 from sentry.notifications.activity.base import ActivityNotification
 from sentry.notifications.notify import register_notification_provider
 from sentry.shared_integrations.exceptions import ApiError
@@ -110,9 +110,9 @@ def send_activity_notification_as_slack(
 
 
 def send_issue_notification_as_slack(
-    user_id: Any,
-    context: Any,
-    project: Any,
+    user_id: int,
+    context: Mapping[str, Any],
+    project: Project,
 ) -> None:
     """
     Send an "issue notification" to a Slack user which are project level issue alerts

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -1,7 +1,8 @@
 import itertools
 import logging
+from collections import defaultdict
 from enum import Enum
-from typing import Set
+from typing import Mapping, Set
 
 from django.utils import dateformat
 from django.utils.encoding import force_text
@@ -11,6 +12,7 @@ from sentry import digests, options
 from sentry.digests import get_option_key as get_digest_option_key
 from sentry.digests.notifications import event_to_record, unsplit_key
 from sentry.digests.utilities import get_digest_metadata, get_personalized_digests
+from sentry.mail.notify import notify_participants, register_issue_notification_provider
 from sentry.models import (
     Commit,
     Group,
@@ -25,7 +27,10 @@ from sentry.models import (
     User,
 )
 from sentry.notifications.activity import EMAIL_CLASSES_BY_TYPE
-from sentry.notifications.helpers import transform_to_notification_settings_by_user
+from sentry.notifications.helpers import (
+    get_settings_by_provider,
+    transform_to_notification_settings_by_user,
+)
 from sentry.notifications.types import (
     GroupSubscriptionReason,
     NotificationScopeType,
@@ -35,7 +40,7 @@ from sentry.notifications.types import (
 from sentry.plugins.base import plugins
 from sentry.plugins.base.structs import Notification
 from sentry.tasks.digests import deliver_digest
-from sentry.types.integrations import ExternalProviders
+from sentry.types.integrations import EXTERNAL_PROVIDERS, ExternalProviders
 from sentry.utils import json, metrics
 from sentry.utils.cache import cache
 from sentry.utils.committers import get_serialized_event_file_committers
@@ -188,52 +193,22 @@ class MailAdapter:
             logger.debug("Tried to send notification to invalid project: %r", project)
             return set()
 
-        send_to = []
         if target_type == ActionTargetType.ISSUE_OWNERS:
             if not event:
-                send_to = self.get_send_to_all_in_project(project)
+                return self.get_send_to_all_in_project(project)
             else:
-                send_to = self.get_send_to_owners(event, project)
+                return self.get_send_to_owners(event, project)
         elif target_type == ActionTargetType.MEMBER:
-            send_to = self.get_send_to_member(project, target_identifier)
+            # CEO: this is set to just email for now, but when we update the alert rule UI
+            # to allow you to choose "notification" rather than "email" this will need to change
+            return {ExternalProviders.EMAIL: self.get_send_to_member(project, target_identifier)}
         elif target_type == ActionTargetType.TEAM:
-            send_to = self.get_send_to_team(project, target_identifier)
-        return set(send_to)
+            return {ExternalProviders.EMAIL: self.get_send_to_team(project, target_identifier)}
+        return {}
 
     def get_send_to_owners(self, event, project):
         owners, _ = ProjectOwnership.get_owners(project.id, event.data)
-        if owners != ProjectOwnership.Everyone:
-            if not owners:
-                metrics.incr(
-                    "features.owners.send_to",
-                    tags={"organization": project.organization_id, "outcome": "empty"},
-                    skip_internal=True,
-                )
-                return set()
-
-            metrics.incr(
-                "features.owners.send_to",
-                tags={"organization": project.organization_id, "outcome": "match"},
-                skip_internal=True,
-            )
-            send_to = set()
-            teams_to_resolve = set()
-            for owner in owners:
-                if owner.type == User:
-                    send_to.add(owner.id)
-                else:
-                    teams_to_resolve.add(owner.id)
-
-            # get all users in teams
-            if teams_to_resolve:
-                send_to |= set(
-                    User.objects.filter(
-                        is_active=True,
-                        sentry_orgmember_set__organizationmemberteam__team__id__in=teams_to_resolve,
-                    ).values_list("id", flat=True)
-                )
-            return send_to - self.disabled_users_from_project(project)
-        else:
+        if owners == ProjectOwnership.Everyone:
             metrics.incr(
                 "features.owners.send_to",
                 tags={"organization": project.organization_id, "outcome": "everyone"},
@@ -241,8 +216,46 @@ class MailAdapter:
             )
             return self.get_send_to_all_in_project(project)
 
+        if not owners:
+            metrics.incr(
+                "features.owners.send_to",
+                tags={"organization": project.organization_id, "outcome": "empty"},
+                skip_internal=True,
+            )
+            return {}
+
+        metrics.incr(
+            "features.owners.send_to",
+            tags={"organization": project.organization_id, "outcome": "match"},
+            skip_internal=True,
+        )
+        all_possible_user_ids = set()
+        teams_to_resolve = set()
+        for owner in owners:
+            if owner.type == User:
+                all_possible_user_ids.add(owner.id)
+            else:
+                teams_to_resolve.add(owner.id)
+
+        # get all users in teams
+        if teams_to_resolve:
+            all_possible_user_ids |= self.get_user_ids_for_teams_to_resolve(teams_to_resolve)
+
+        output = defaultdict(set)
+        disabled_users = self.disabled_users_from_project(project)
+
+        for provider in EXTERNAL_PROVIDERS.keys():
+            output[provider] = all_possible_user_ids - disabled_users[provider]
+        return output
+
+    def get_user_ids_for_teams_to_resolve(teams_to_resolve):
+        return User.objects.filter(
+            is_active=True,
+            sentry_orgmember_set__organizationmemberteam__team__id__in=teams_to_resolve,
+        ).values_list("id", flat=True)
+
     @staticmethod
-    def disabled_users_from_project(project: Project) -> Set[int]:
+    def disabled_users_from_project(project: Project) -> Mapping[ExternalProviders, Set[int]]:
         """ Get a set of users that have disabled Issue Alert notifications for a given project. """
         user_ids = project.member_set.values_list("user", flat=True)
         users = User.objects.filter(id__in=user_ids)
@@ -254,23 +267,20 @@ class MailAdapter:
         notification_settings_by_user = transform_to_notification_settings_by_user(
             notification_settings, users
         )
-
         # Although this can be done with dict comprehension, looping for clarity.
-        output = set()
+        output = defaultdict(set)
         for user in users:
             settings = notification_settings_by_user.get(user)
             if settings:
-                # Check per-project settings first, fallback to project-independent settings.
-                project_setting = settings.get(NotificationScopeType.PROJECT)
-                if project_setting:
-                    project_setting = project_setting[ExternalProviders.EMAIL]
-                user_setting = settings.get(NotificationScopeType.USER)
-                if user_setting:
-                    user_setting = user_setting[ExternalProviders.EMAIL]
-                if project_setting == NotificationSettingOptionValues.NEVER or (
-                    not project_setting and user_setting == NotificationSettingOptionValues.NEVER
-                ):
-                    output.add(user.id)
+                settings_by_provider = get_settings_by_provider(settings)
+                for provider, settings_value_by_scope in settings_by_provider.items():
+                    project_setting = settings_value_by_scope.get(NotificationScopeType.PROJECT)
+                    user_setting = settings_value_by_scope.get(NotificationScopeType.USER)
+                    if project_setting == NotificationSettingOptionValues.NEVER or (
+                        not project_setting
+                        and user_setting == NotificationSettingOptionValues.NEVER
+                    ):
+                        output[provider].add(user.id)
         return output
 
     def get_send_to_team(self, project, target_identifier):
@@ -280,9 +290,10 @@ class MailAdapter:
             team = Team.objects.get(id=int(target_identifier), projectteam__project=project)
         except Team.DoesNotExist:
             return set()
-        return set(
-            team.member_set.values_list("user_id", flat=True)
-        ) - self.disabled_users_from_project(project)
+        return (
+            set(team.member_set.values_list("user_id", flat=True))
+            - self.disabled_users_from_project(project)[ExternalProviders.EMAIL]
+        )
 
     def get_send_to_member(self, project, target_identifier):
         """
@@ -308,13 +319,16 @@ class MailAdapter:
 
     def get_send_to_all_in_project(self, project):
         cache_key = f"mail:send_to:{project.pk}"
-        send_to_list = cache.get(cache_key)
-        if send_to_list is None:
-            users = self.get_sendable_user_objects(project)
-            send_to_list = [user.id for user in users if user]
-            cache.set(cache_key, send_to_list, 60)  # 1 minute cache
+        send_to_mapping = cache.get(cache_key)
+        if send_to_mapping is None:
+            users_by_provider = NotificationSetting.objects.get_notification_recipients(project)
+            send_to_mapping = {
+                provider: {user.id for user in users if user}
+                for provider, users in users_by_provider.items()
+            }
+            cache.set(cache_key, send_to_mapping, 60)  # 1 minute cache
 
-        return send_to_list
+        return send_to_mapping
 
     def add_unsubscribe_link(self, context, user_id, project, referrer):
         context["unsubscribe_link"] = generate_signed_link(
@@ -382,6 +396,10 @@ class MailAdapter:
         has_integrations = bool(project_plugins or organization_integrations)
 
         context = {
+            "subject": subject,
+            "template": template,
+            "html_template": html_template,
+            "project": project,
             "project_label": project.get_full_name(),
             "group": group,
             "event": event,
@@ -406,45 +424,50 @@ class MailAdapter:
 
             context.update({"tags": event.tags, "interfaces": interface_list})
 
-        headers = {
+        context["headers"] = {
             "X-Sentry-Logger": group.logger,
             "X-Sentry-Logger-Level": group.get_level_display(),
             "X-Sentry-Project": project.slug,
             "X-Sentry-Reply-To": group_id_to_email(group.id),
             "X-SMTPAPI": json.dumps({"category": "issue_alert_email"}),
         }
+        context["target_type"] = target_type
+        context["target_identifier"] = target_identifier
 
-        for user_id in self.get_send_to(
+        participants_by_provider = self.get_send_to(
             project=project,
             target_type=target_type,
             target_identifier=target_identifier,
             event=event,
-        ):
+        )
+
+        for provider, participants in participants_by_provider.items():
+            notify_participants(self, provider, participants, context)
+
+    @register_issue_notification_provider(ExternalProviders.EMAIL)
+    def notify_by_email(self, users, context):
+        for user in users:
             logger.info(
                 "mail.adapter.notify.mail_user",
                 extra={
-                    "target_type": target_type,
-                    "target_identifier": target_identifier,
-                    "group": group.id,
-                    "project_id": project.id,
-                    "user_id": user_id,
+                    "target_type": context["target_type"],
+                    "target_identifier": context["target_identifier"],
+                    "group": context["group"].id,
+                    "project_id": context["project"].id,
+                    "user_id": user,
                 },
             )
-            from sentry.integrations.slack.notifications import send_issue_notification_as_slack
-
-            send_issue_notification_as_slack(user_id, context, project)
-
-            self.add_unsubscribe_link(context, user_id, project, "alert_email")
+            self.add_unsubscribe_link(context, user, context["project"], "alert_email")
             self._send_mail(
-                subject=subject,
-                template=template,
-                html_template=html_template,
-                project=project,
-                reference=group,
-                headers=headers,
+                subject=context["subject"],
+                template=context["template"],
+                html_template=context["html_template"],
+                project=context["project"],
+                reference=context["group"],
+                headers=context["headers"],
                 type="notify.error",
                 context=context,
-                send_to=[user_id],
+                send_to=[user],
             )
 
     def get_digest_subject(self, group, counts, date):

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -199,7 +199,7 @@ class MailAdapter:
             else:
                 return self.get_send_to_owners(event, project)
         elif target_type == ActionTargetType.MEMBER:
-            # CEO: this is set to just email for now, but when we update the alert rule UI
+            # TODO(ceo): this is set to just email for now, but when we update the alert rule UI
             # to allow you to choose "notification" rather than "email" this will need to change
             return {ExternalProviders.EMAIL: self.get_send_to_member(project, target_identifier)}
         elif target_type == ActionTargetType.TEAM:

--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -81,7 +81,7 @@ class MailAdapter:
 
         project = event.group.project
         extra["project_id"] = project.id
-        if digests.enabled(project):
+        if not digests.enabled(project):  # CEO TODO rm not
 
             def get_digest_option(key):
                 return ProjectOption.objects.get_value(project, get_digest_option_key("mail", key))
@@ -430,6 +430,9 @@ class MailAdapter:
                     "user_id": user_id,
                 },
             )
+            from sentry.integrations.slack.notifications import send_issue_notification_as_slack
+
+            send_issue_notification_as_slack(user_id, context, project)
 
             self.add_unsubscribe_link(context, user_id, project, "alert_email")
             self._send_mail(

--- a/src/sentry/mail/notify.py
+++ b/src/sentry/mail/notify.py
@@ -1,0 +1,41 @@
+from typing import Any, Callable, Iterable, Mapping, MutableMapping
+
+from sentry.models import User
+from sentry.types.integrations import ExternalProviders
+
+# Shortcut so that types don't explode.
+Notifiable = Callable[[Any, Mapping[User, int], Mapping[str, Any]], None]
+
+# Global notifier registry.
+registry: MutableMapping[ExternalProviders, Notifiable] = {}
+
+
+def notification_providers() -> Iterable[ExternalProviders]:
+    """ Get a set of providers that can call notify. """
+    return registry.keys()
+
+
+def register_issue_notification_provider(
+    provider: ExternalProviders,
+) -> Callable[[Notifiable], Notifiable]:
+    """
+    A wrapper that adds the wrapped function to the send_notification_registry
+    (see above) for the provider.
+    """
+
+    def wrapped(send_notification: Notifiable) -> Notifiable:
+        registry[provider] = send_notification
+        return send_notification
+
+    return wrapped
+
+
+def notify_participants(
+    notification: Any,
+    provider: ExternalProviders,
+    users: Mapping[User, int],
+    shared_context: Mapping[str, Any],
+    # project: Project,
+) -> None:
+    """ Send notifications to these users. """
+    registry[provider](notification, users, shared_context)

--- a/src/sentry/mail/notify.py
+++ b/src/sentry/mail/notify.py
@@ -38,4 +38,6 @@ def notify_participants(
     # project: Project,
 ) -> None:
     """ Send notifications to these users. """
-    registry[provider](notification, users, shared_context)
+    APPROVED_PROVIDERS = [ExternalProviders.EMAIL, ExternalProviders.SLACK]
+    if provider in APPROVED_PROVIDERS:
+        registry[provider](notification, users, shared_context)

--- a/src/sentry/mail/notify.py
+++ b/src/sentry/mail/notify.py
@@ -35,7 +35,6 @@ def notify_participants(
     provider: ExternalProviders,
     users: Mapping[User, int],
     shared_context: Mapping[str, Any],
-    # project: Project,
 ) -> None:
     """ Send notifications to these users. """
     APPROVED_PROVIDERS = [ExternalProviders.EMAIL, ExternalProviders.SLACK]

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -305,3 +305,18 @@ def get_user_subscriptions_for_groups(
             results[group.id] = (is_disabled, is_active, subscription)
 
     return results
+
+
+def get_settings_by_provider(
+    settings: Mapping[
+        NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]
+    ]
+) -> Mapping[ExternalProviders, Mapping[NotificationScopeType, NotificationSettingOptionValues]]:
+
+    output = defaultdict(dict)
+
+    for scope_type in settings:
+        for provider, value in settings[scope_type].items():
+            output[provider][scope_type] = value
+
+    return output

--- a/src/sentry/notifications/helpers.py
+++ b/src/sentry/notifications/helpers.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple, Union
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Set, Tuple, Union
 
 from sentry.notifications.types import (
     NOTIFICATION_SETTING_DEFAULTS,
@@ -311,9 +311,13 @@ def get_settings_by_provider(
     settings: Mapping[
         NotificationScopeType, Mapping[ExternalProviders, NotificationSettingOptionValues]
     ]
-) -> Mapping[ExternalProviders, Mapping[NotificationScopeType, NotificationSettingOptionValues]]:
+) -> MutableMapping[
+    ExternalProviders, MutableMapping[NotificationScopeType, NotificationSettingOptionValues]
+]:
 
-    output = defaultdict(dict)
+    output: MutableMapping[
+        ExternalProviders, MutableMapping[NotificationScopeType, NotificationSettingOptionValues]
+    ] = defaultdict(dict)
 
     for scope_type in settings:
         for provider, value in settings[scope_type].items():

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -233,6 +233,10 @@ class BuildIncidentAttachmentTest(TestCase):
             "footer_icon": "http://testserver/_static/{version}/sentry/images/sentry-email-avatar.png",
         }
 
+    def test_build_group_attachment_issue_alert(self):
+        issue_alert_group = self.create_group(project=self.project)
+        assert build_group_attachment(issue_alert_group, issue_alert=True)["actions"] == []
+
     def test_build_group_attachment_color_no_event_error_fallback(self):
         group_with_no_events = self.create_group(project=self.project)
         assert build_group_attachment(group_with_no_events)["color"] == "#E03E2F"

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -3,7 +3,7 @@ from urllib.parse import parse_qs
 import responses
 from django.utils import timezone
 
-from sentry.integrations.slack.notifications import send_notification_as_slack
+from sentry.integrations.slack.notifications import send_activity_notification_as_slack
 from sentry.models import (
     Activity,
     Deploy,
@@ -33,7 +33,7 @@ from tests.sentry.mail.activity import ActivityTestCase
 
 def send_notification(*args):
     args_list = list(args)[1:]
-    send_notification_as_slack(*args_list)
+    send_activity_notification_as_slack(*args_list)
 
 
 def get_attachment():

--- a/tests/sentry/mail/test_adapter.py
+++ b/tests/sentry/mail/test_adapter.py
@@ -80,7 +80,9 @@ class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
     def test_get_send_to_with_team_owners(self):
         event = self.store_event(data=self.make_event_data("foo.py"), project_id=self.project.id)
         assert sorted({self.user.pk, self.user2.pk}) == sorted(
-            self.adapter.get_send_to(self.project, ActionTargetType.ISSUE_OWNERS, event=event.data)
+            self.adapter.get_send_to(self.project, ActionTargetType.ISSUE_OWNERS, event=event.data)[
+                ExternalProviders.EMAIL
+            ]
         )
 
         # Make sure that disabling mail alerts works as expected
@@ -93,12 +95,14 @@ class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
         )
         assert {self.user.pk} == self.adapter.get_send_to(
             self.project, ActionTargetType.ISSUE_OWNERS, event=event.data
-        )
+        )[ExternalProviders.EMAIL]
 
     def test_get_send_to_with_user_owners(self):
         event = self.store_event(data=self.make_event_data("foo.cbl"), project_id=self.project.id)
         assert sorted({self.user.pk, self.user2.pk}) == sorted(
-            self.adapter.get_send_to(self.project, ActionTargetType.ISSUE_OWNERS, event=event.data)
+            self.adapter.get_send_to(self.project, ActionTargetType.ISSUE_OWNERS, event=event.data)[
+                ExternalProviders.EMAIL
+            ]
         )
 
         # Make sure that disabling mail alerts works as expected
@@ -111,25 +115,25 @@ class MailAdapterGetSendToTest(BaseMailAdapterTest, TestCase):
         )
         assert {self.user.pk} == self.adapter.get_send_to(
             self.project, ActionTargetType.ISSUE_OWNERS, event=event.data
-        )
+        )[ExternalProviders.EMAIL]
 
     def test_get_send_to_with_user_owner(self):
         event = self.store_event(data=self.make_event_data("foo.jx"), project_id=self.project.id)
         assert {self.user2.pk} == self.adapter.get_send_to(
             self.project, ActionTargetType.ISSUE_OWNERS, event=event.data
-        )
+        )[ExternalProviders.EMAIL]
 
     def test_get_send_to_with_fallthrough(self):
         event = self.store_event(data=self.make_event_data("foo.cpp"), project_id=self.project.id)
-        assert {self.user.pk, self.user2.pk} == set(
-            self.adapter.get_send_to(self.project, ActionTargetType.ISSUE_OWNERS, event=event.data)
-        )
+        assert {self.user.pk, self.user2.pk} == self.adapter.get_send_to(
+            self.project, ActionTargetType.ISSUE_OWNERS, event=event.data
+        )[ExternalProviders.EMAIL]
 
     def test_get_send_to_without_fallthrough(self):
         ProjectOwnership.objects.get(project_id=self.project.id).update(fallthrough=False)
         event = self.store_event(data=self.make_event_data("foo.cpp"), project_id=self.project.id)
-        assert set() == self.adapter.get_send_to(
-            self.project, ActionTargetType.ISSUE_OWNERS, event=event.data
+        assert set() == set(
+            self.adapter.get_send_to(self.project, ActionTargetType.ISSUE_OWNERS, event=event.data)
         )
 
 
@@ -640,7 +644,9 @@ class MailAdapterGetSendToOwnersTest(BaseMailAdapterTest, TestCase):
         event_all_users = self.store_event(
             data=self.make_event_data("foo.cbl"), project_id=self.project.id
         )
-        assert self.adapter.get_send_to_owners(event_all_users, self.project) == {
+        assert self.adapter.get_send_to_owners(event_all_users, self.project)[
+            ExternalProviders.EMAIL
+        ] == {
             self.user.id,
             self.user2.id,
             self.user3.id,
@@ -650,7 +656,9 @@ class MailAdapterGetSendToOwnersTest(BaseMailAdapterTest, TestCase):
         event_team = self.store_event(
             data=self.make_event_data("foo.py"), project_id=self.project.id
         )
-        assert self.adapter.get_send_to_owners(event_team, self.project) == {
+        assert self.adapter.get_send_to_owners(event_team, self.project)[
+            ExternalProviders.EMAIL
+        ] == {
             self.user2.id,
             self.user3.id,
         }
@@ -659,7 +667,9 @@ class MailAdapterGetSendToOwnersTest(BaseMailAdapterTest, TestCase):
         event_single_user = self.store_event(
             data=self.make_event_data("foo.jx"), project_id=self.project.id
         )
-        assert self.adapter.get_send_to_owners(event_single_user, self.project) == {self.user2.id}
+        assert self.adapter.get_send_to_owners(event_single_user, self.project)[
+            ExternalProviders.EMAIL
+        ] == {self.user2.id}
 
     def test_disable_alerts_user_scope(self):
         event_all_users = self.store_event(


### PR DESCRIPTION
This PR creates the backend for sending issue alerts to a Slack user. This isn't possible to use yet as we haven't implemented the UI (e.g. when creating an alert rule and selecting the action "send an email to <Member> <colleen@sentry.io>", we'll change "email" to "notification" and it will follow the user's preferences) which is why the test is skipped for now, but I wanted to ensure the alert sends when enabled and it does pass when Slack is hard coded as the provider.

The alert itself looks the same as existing alert rule Slack alerts but without the buttons. It doesn't make sense for users to be able to perform actions on these as multiple users will be sent the same ones and we'd run into race conditions easily (e.g. user A and user B receive the same notification, user B hits resolve and user A hits ignore). 
<img width="375" alt="Screen Shot 2021-04-21 at 5 01 06 PM" src="https://user-images.githubusercontent.com/29959063/115638843-04a4cc00-a2c8-11eb-895b-2a39ce97f054.png">
