### PR TITLE
feat(alert): Default wizard selection and removing fcp

### DIFF
--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -51,7 +51,7 @@ class AlertWizard extends React.Component<Props, State> {
   renderCreateAlertButton() {
     const {organization, project, location} = this.props;
     const {alertOption} = this.state;
-    const metricRuleTemplate = alertOption && AlertWizardRuleTemplates[alertOption];
+    const metricRuleTemplate = AlertWizardRuleTemplates[alertOption];
     const disabled =
       !organization.features.includes('performance-view') &&
       metricRuleTemplate?.dataset === Dataset.TRANSACTIONS;
@@ -86,7 +86,7 @@ class AlertWizard extends React.Component<Props, State> {
     } = this.props;
     const {alertOption} = this.state;
     const title = t('Alert Creation Wizard');
-    const panelContent = alertOption && AlertWizardPanelContent[alertOption];
+    const panelContent = AlertWizardPanelContent[alertOption];
     return (
       <React.Fragment>
         <SentryDocumentTitle title={title} projectSlug={projectId} />
@@ -124,28 +124,26 @@ class AlertWizard extends React.Component<Props, State> {
                 </WizardOptions>
                 <WizardPanel visible={!!panelContent && !!alertOption}>
                   <WizardPanelBody>
-                    {panelContent && alertOption && (
-                      <div>
-                        <PanelHeader>{AlertWizardAlertNames[alertOption]}</PanelHeader>
-                        <PanelBody withPadding>
-                          <PanelDescription>
-                            {panelContent.description}{' '}
-                            {panelContent.docsLink && (
-                              <ExternalLink href={panelContent.docsLink}>
-                                {t('Learn more')}
-                              </ExternalLink>
-                            )}
-                          </PanelDescription>
-                          <WizardImage src={panelContent.illustration} />
-                          <ExampleHeader>{t('Examples')}</ExampleHeader>
-                          <ExampleList symbol="bullet">
-                            {panelContent.examples.map((example, i) => (
-                              <ExampleItem key={i}>{example}</ExampleItem>
-                            ))}
-                          </ExampleList>
-                        </PanelBody>
-                      </div>
-                    )}
+                    <div>
+                      <PanelHeader>{AlertWizardAlertNames[alertOption]}</PanelHeader>
+                      <PanelBody withPadding>
+                        <PanelDescription>
+                          {panelContent.description}{' '}
+                          {panelContent.docsLink && (
+                            <ExternalLink href={panelContent.docsLink}>
+                              {t('Learn more')}
+                            </ExternalLink>
+                          )}
+                        </PanelDescription>
+                        <WizardImage src={panelContent.illustration} />
+                        <ExampleHeader>{t('Examples')}</ExampleHeader>
+                        <ExampleList symbol="bullet">
+                          {panelContent.examples.map((example, i) => (
+                            <ExampleItem key={i}>{example}</ExampleItem>
+                          ))}
+                        </ExampleList>
+                      </PanelBody>
+                    </div>
                     <WizardButton>{this.renderCreateAlertButton()}</WizardButton>
                   </WizardPanelBody>
                 </WizardPanel>

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -37,11 +37,11 @@ type Props = RouteComponentProps<RouteParams, {}> & {
 };
 
 type State = {
-  alertOption: AlertType | null;
+  alertOption: AlertType;
 };
 class AlertWizard extends React.Component<Props, State> {
   state: State = {
-    alertOption: null,
+    alertOption: 'issues',
   };
 
   handleChangeAlertOption = (alertOption: AlertType) => {

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -24,7 +24,6 @@ export type AlertType =
   | 'lcp'
   | 'fid'
   | 'cls'
-  | 'fcp'
   | 'custom';
 
 export const WebVitalAlertTypes = new Set(['lcp', 'fid', 'cls', 'fcp']);
@@ -40,7 +39,6 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
   lcp: t('Largest Contentful Paint'),
   fid: t('First Input Delay'),
   cls: t('Cumulative Layout Shift'),
-  fcp: t('First Contentful Paint'),
   custom: t('Custom Metric'),
 };
 
@@ -62,7 +60,6 @@ export const AlertWizardOptions: {
       'lcp',
       'fid',
       'cls',
-      'fcp',
     ],
   },
   {
@@ -174,16 +171,9 @@ export const AlertWizardPanelContent: Record<AlertType, PanelContent> = {
     docsLink: 'https://docs.sentry.io/product/performance/web-vitals',
     illustration: diagramCLS,
   },
-  fcp: {
-    description: t(
-      'First Contentful Paint (FCP), like Largest Contentful Paint (LCP), measures loading performance. It marks the point when content such as text and images can first be seen on a page.'
-    ),
-    examples: [t('When the average FCP of a page is longer than 0.25 seconds.')],
-    docsLink: 'https://docs.sentry.io/product/performance/web-vitals',
-  },
   custom: {
     description: t(
-      'Alert on metrics which are not listed above, such as first paint (FP) and time to first byte (TTFB).'
+      'Alert on metrics which are not listed above, such as first paint (FP), first contentful paint (FCP), and time to first byte (TTFB).'
     ),
     examples: [
       t('When the 95th percentile FP of a page is longer than 250 milliseconds.'),
@@ -248,11 +238,6 @@ export const AlertWizardRuleTemplates: Record<
     dataset: Dataset.TRANSACTIONS,
     eventTypes: EventTypes.TRANSACTION,
   },
-  fcp: {
-    aggregate: 'p95(measurements.fcp)',
-    dataset: Dataset.TRANSACTIONS,
-    eventTypes: EventTypes.TRANSACTION,
-  },
   custom: {
     aggregate: 'p95(measurements.fp)',
     dataset: Dataset.TRANSACTIONS,
@@ -273,5 +258,4 @@ export const hideParameterSelectorSet = new Set<AlertType>([
   'lcp',
   'fid',
   'cls',
-  'fcp',
 ]);

--- a/static/app/views/alerts/wizard/utils.tsx
+++ b/static/app/views/alerts/wizard/utils.tsx
@@ -16,7 +16,6 @@ const alertTypeIdentifiers: Record<Dataset, Partial<Record<AlertType, string>>> 
     lcp: 'measurements.lcp',
     fid: 'measurements.fid',
     cls: 'measurements.cls',
-    fcp: 'measurements.fcp',
   },
 };
 


### PR DESCRIPTION
Previously we removed the default selection (https://github.com/getsentry/sentry/pull/24866/), but the higher powers have spoken and `issues` is back as the default. Also knocking out FCP from the wizard list as it isn't as highly visible in the docs.

