### PR TITLE
fix(images-loaded-v2): Fix list height and undefined debugFilename

### DIFF
--- a/static/app/components/events/interfaces/debugMeta-v2/debugImage/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImage/index.tsx
@@ -50,7 +50,7 @@ function DebugImage({image, onOpenImageDetailsModal, style}: Props) {
               <Tooltip title={code_file}>{codeFilename}</Tooltip>
             </FileName>
           )}
-          {codeFilename !== debugFilename && (
+          {codeFilename !== debugFilename && debugFilename && (
             <CodeFilename>{`(${debugFilename})`}</CodeFilename>
           )}
         </div>

--- a/static/app/components/events/interfaces/debugMeta-v2/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/index.tsx
@@ -267,16 +267,6 @@ class DebugMeta extends React.PureComponent<Props, State> {
     this.setState({panelTableHeight});
   }
 
-  getListHeight() {
-    const {panelTableHeight} = this.state;
-
-    if (!panelTableHeight || panelTableHeight > IMAGE_AND_CANDIDATE_LIST_MAX_HEIGHT) {
-      return IMAGE_AND_CANDIDATE_LIST_MAX_HEIGHT;
-    }
-
-    return panelTableHeight;
-  }
-
   getRelevantImages() {
     const {data} = this.props;
     const {images} = data;
@@ -467,7 +457,7 @@ class DebugMeta extends React.PureComponent<Props, State> {
               this.listRef = el;
             }}
             deferredMeasurementCache={cache}
-            height={this.getListHeight()}
+            height={IMAGE_AND_CANDIDATE_LIST_MAX_HEIGHT}
             overscanRowCount={5}
             rowCount={images.length}
             rowHeight={cache.rowHeight}

--- a/static/app/components/events/interfaces/debugMeta/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta/index.tsx
@@ -459,6 +459,9 @@ class DebugMeta extends React.PureComponent<Props, State> {
 export default DebugMeta;
 
 // XXX(ts): Emotion11 has some trouble with List's defaultProps
+
+// It gives the list have a dynamic height; otherwise, in the case of filtered
+// options, a list will be displayed with an empty space
 const StyledList = styled((p: React.ComponentProps<typeof List>) => <List {...p} />)<{
   height: number;
 }>`


### PR DESCRIPTION

_Undefined DebugFileName_

Before:

![image](https://user-images.githubusercontent.com/29228205/115690657-8c88e580-a35d-11eb-92aa-43c3b1fb021a.png)


After:

![image](https://user-images.githubusercontent.com/29228205/115690700-96124d80-a35d-11eb-936e-965efa88d482.png)


_List Height_

The height of the table was not being changed according to the filter