### PR TITLE
ref(native): Current instead of crashed threads in minidumps

### DIFF
--- a/src/sentry/lang/native/processing.py
+++ b/src/sentry/lang/native/processing.py
@@ -222,7 +222,12 @@ def _merge_full_response(data, response):
         is_requesting = complete_stacktrace.get("is_requesting")
         thread_id = complete_stacktrace.get("thread_id")
 
-        data_thread = {"id": thread_id, "crashed": is_requesting}
+        data_thread = {"id": thread_id}
+        if is_requesting:
+            if response.get("crashed"):
+                data_thread["crashed"] = True
+            else:
+                data_thread["current"] = True
         data_threads.append(data_thread)
 
         if is_requesting:

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_full_minidump.pysnap
@@ -333,8 +333,7 @@ threads:
     id: 1636
     raw_stacktrace: null
     stacktrace: null
-  - crashed: false
-    id: 3580
+  - id: 3580
     raw_stacktrace: null
     stacktrace:
       frames:
@@ -389,8 +388,7 @@ threads:
         eip: '0x771e016c'
         esi: '0x13b4930'
         esp: '0x159f900'
-  - crashed: false
-    id: 2600
+  - id: 2600
     raw_stacktrace: null
     stacktrace:
       frames:
@@ -445,8 +443,7 @@ threads:
         eip: '0x771e016c'
         esi: '0x13b7a68'
         esp: '0x169f9f4'
-  - crashed: false
-    id: 2920
+  - id: 2920
     raw_stacktrace: null
     stacktrace:
       frames:

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_missing_dsym.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_missing_dsym.pysnap
@@ -386,8 +386,7 @@ threads:
     id: 1636
     raw_stacktrace: null
     stacktrace: null
-  - crashed: false
-    id: 3580
+  - id: 3580
     raw_stacktrace: null
     stacktrace:
       frames:
@@ -442,8 +441,7 @@ threads:
         eip: '0x771e016c'
         esi: '0x13b4930'
         esp: '0x159f900'
-  - crashed: false
-    id: 2600
+  - id: 2600
     raw_stacktrace: null
     stacktrace:
       frames:
@@ -498,8 +496,7 @@ threads:
         eip: '0x771e016c'
         esi: '0x13b7a68'
         esp: '0x169f9f4'
-  - crashed: false
-    id: 2920
+  - id: 2920
     raw_stacktrace: null
     stacktrace:
       frames:

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_raw_minidump.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_raw_minidump.pysnap
@@ -336,8 +336,7 @@ threads:
     id: 1636
     raw_stacktrace: null
     stacktrace: null
-  - crashed: false
-    id: 3580
+  - id: 3580
     raw_stacktrace: null
     stacktrace:
       frames:
@@ -392,8 +391,7 @@ threads:
         eip: '0x771e016c'
         esi: '0x13b4930'
         esp: '0x159f900'
-  - crashed: false
-    id: 2600
+  - id: 2600
     raw_stacktrace: null
     stacktrace:
       frames:
@@ -448,8 +446,7 @@ threads:
         eip: '0x771e016c'
         esi: '0x13b7a68'
         esp: '0x169f9f4'
-  - crashed: false
-    id: 2920
+  - id: 2920
     raw_stacktrace: null
     stacktrace:
       frames:

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_initial.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_initial.pysnap
@@ -386,8 +386,7 @@ threads:
     id: 1636
     raw_stacktrace: null
     stacktrace: null
-  - crashed: false
-    id: 3580
+  - id: 3580
     raw_stacktrace: null
     stacktrace:
       frames:
@@ -442,8 +441,7 @@ threads:
         eip: '0x771e016c'
         esi: '0x13b4930'
         esp: '0x159f900'
-  - crashed: false
-    id: 2600
+  - id: 2600
     raw_stacktrace: null
     stacktrace:
       frames:
@@ -498,8 +496,7 @@ threads:
         eip: '0x771e016c'
         esi: '0x13b7a68'
         esp: '0x169f9f4'
-  - crashed: false
-    id: 2920
+  - id: 2920
     raw_stacktrace: null
     stacktrace:
       frames:

--- a/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_reprocessed.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorMinidumpIntegrationTest/test_reprocessing_reprocessed.pysnap
@@ -333,8 +333,7 @@ threads:
     id: 1636
     raw_stacktrace: null
     stacktrace: null
-  - crashed: false
-    id: 3580
+  - id: 3580
     raw_stacktrace: null
     stacktrace:
       frames:
@@ -389,8 +388,7 @@ threads:
         eip: '0x771e016c'
         esi: '0x13b4930'
         esp: '0x159f900'
-  - crashed: false
-    id: 2600
+  - id: 2600
     raw_stacktrace: null
     stacktrace:
       frames:
@@ -445,8 +443,7 @@ threads:
         eip: '0x771e016c'
         esi: '0x13b7a68'
         esp: '0x169f9f4'
-  - crashed: false
-    id: 2920
+  - id: 2920
     raw_stacktrace: null
     stacktrace:
       frames:

--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_apple_crash_with_attachments.pysnap
@@ -280,8 +280,7 @@ sdk:
 stacktrace: null
 threads:
   values:
-  - crashed: false
-    id: 0
+  - id: 0
     stacktrace:
       frames:
       - data:
@@ -362,8 +361,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bc6c2a'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 1
+  - id: 1
     stacktrace:
       frames:
       - data:
@@ -383,8 +381,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bc85be'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 2
+  - id: 2
     stacktrace:
       frames:
       - data:
@@ -404,8 +401,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bc85be'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 3
+  - id: 3
     stacktrace:
       frames:
       - data:
@@ -420,8 +416,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bc85be'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 4
+  - id: 4
     stacktrace:
       frames:
       - data:
@@ -443,8 +438,7 @@ threads:
         package: /usr/lib/system/libsystem_kernel.dylib
   - crashed: true
     id: 5
-  - crashed: false
-    id: 6
+  - id: 6
     stacktrace:
       frames:
       - data:
@@ -495,8 +489,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bc6c2a'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 7
+  - id: 7
     stacktrace:
       frames:
       - data:
@@ -559,8 +552,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 8
+  - id: 8
     stacktrace:
       frames:
       - data:
@@ -623,8 +615,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 9
+  - id: 9
     stacktrace:
       frames:
       - data:
@@ -687,8 +678,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 10
+  - id: 10
     stacktrace:
       frames:
       - data:
@@ -751,8 +741,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 11
+  - id: 11
     stacktrace:
       frames:
       - data:
@@ -815,8 +804,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 12
+  - id: 12
     stacktrace:
       frames:
       - data:
@@ -879,8 +867,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 13
+  - id: 13
     stacktrace:
       frames:
       - data:
@@ -943,8 +930,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 14
+  - id: 14
     stacktrace:
       frames:
       - data:
@@ -1007,8 +993,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 15
+  - id: 15
     stacktrace:
       frames:
       - data:
@@ -1071,8 +1056,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 16
+  - id: 16
     stacktrace:
       frames:
       - data:
@@ -1141,8 +1125,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 17
+  - id: 17
     stacktrace:
       frames:
       - data:
@@ -1193,8 +1176,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 18
+  - id: 18
     stacktrace:
       frames:
       - data:
@@ -1245,8 +1227,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 19
+  - id: 19
     stacktrace:
       frames:
       - data:
@@ -1297,8 +1278,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 20
+  - id: 20
     stacktrace:
       frames:
       - data:
@@ -1349,8 +1329,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 21
+  - id: 21
     stacktrace:
       frames:
       - data:
@@ -1401,8 +1380,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 22
+  - id: 22
     stacktrace:
       frames:
       - data:
@@ -1422,8 +1400,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bc85be'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 23
+  - id: 23
     stacktrace:
       frames:
       - data:
@@ -1443,8 +1420,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bc85be'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 24
+  - id: 24
     stacktrace:
       frames:
       - data:
@@ -1464,8 +1440,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bc85be'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 25
+  - id: 25
     stacktrace:
       frames:
       - data:
@@ -1485,8 +1460,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bc85be'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 26
+  - id: 26
     stacktrace:
       frames:
       - data:
@@ -1537,8 +1511,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca876'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 27
+  - id: 27
     stacktrace:
       frames:
       - data:
@@ -1589,8 +1562,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 28
+  - id: 28
     stacktrace:
       frames:
       - data:
@@ -1641,8 +1613,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 29
+  - id: 29
     stacktrace:
       frames:
       - data:
@@ -1693,8 +1664,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 30
+  - id: 30
     stacktrace:
       frames:
       - data:
@@ -1745,8 +1715,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 31
+  - id: 31
     stacktrace:
       frames:
       - data:
@@ -1797,8 +1766,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 32
+  - id: 32
     stacktrace:
       frames:
       - data:
@@ -1849,8 +1817,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 33
+  - id: 33
     stacktrace:
       frames:
       - data:
@@ -1919,8 +1886,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 34
+  - id: 34
     stacktrace:
       frames:
       - data:
@@ -2031,8 +1997,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61c74969'
         package: /usr/lib/system/libsystem_platform.dylib
-  - crashed: false
-    id: 35
+  - id: 35
     stacktrace:
       frames:
       - data:
@@ -2089,8 +2054,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca876'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 36
+  - id: 36
     stacktrace:
       frames:
       - data:
@@ -2141,8 +2105,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 37
+  - id: 37
     stacktrace:
       frames:
       - data:
@@ -2193,8 +2156,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 38
+  - id: 38
     stacktrace:
       frames:
       - data:
@@ -2245,8 +2207,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 39
+  - id: 39
     stacktrace:
       frames:
       - data:
@@ -2297,8 +2258,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 40
+  - id: 40
     stacktrace:
       frames:
       - data:
@@ -2349,8 +2309,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 41
+  - id: 41
     stacktrace:
       frames:
       - data:
@@ -2401,8 +2360,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 42
+  - id: 42
     stacktrace:
       frames:
       - data:
@@ -2453,8 +2411,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 43
+  - id: 43
     stacktrace:
       frames:
       - data:
@@ -2505,8 +2462,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 44
+  - id: 44
     stacktrace:
       frames:
       - data:
@@ -2557,8 +2513,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 45
+  - id: 45
     stacktrace:
       frames:
       - data:
@@ -2609,8 +2564,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 46
+  - id: 46
     stacktrace:
       frames:
       - data:
@@ -2661,8 +2615,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 47
+  - id: 47
     stacktrace:
       frames:
       - data:
@@ -2713,8 +2666,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 48
+  - id: 48
     stacktrace:
       frames:
       - data:
@@ -2765,8 +2717,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 49
+  - id: 49
     stacktrace:
       frames:
       - data:
@@ -2817,8 +2768,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 50
+  - id: 50
     stacktrace:
       frames:
       - data:
@@ -2869,8 +2819,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 51
+  - id: 51
     stacktrace:
       frames:
       - data:
@@ -2921,8 +2870,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bca1b2'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 52
+  - id: 52
     stacktrace:
       frames:
       - data:
@@ -2961,8 +2909,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bc6c7e'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 53
+  - id: 53
     stacktrace:
       frames:
       - data:
@@ -3019,8 +2966,7 @@ threads:
         in_app: false
         instruction_addr: '0x7fff61bc6c2a'
         package: /usr/lib/system/libsystem_kernel.dylib
-  - crashed: false
-    id: 54
+  - id: 54
     stacktrace:
       frames:
       - data:

--- a/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
+++ b/tests/symbolicator/snapshots/SymbolicatorUnrealIntegrationTest/test_unreal_crash_with_attachments.pysnap
@@ -164,8 +164,7 @@ sdk:
 stacktrace: null
 threads:
   values:
-  - crashed: false
-    id: 248
+  - id: 248
     stacktrace:
       frames:
       - data:
@@ -221,8 +220,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c3f2cc448'
         rsp: '0x8c3f2cc418'
-  - crashed: false
-    id: 9772
+  - id: 9772
     stacktrace:
       frames:
       - data:
@@ -264,8 +262,7 @@ threads:
         rip: '0x7ffe100fd854'
         rsi: '0x7ffe10083140'
         rsp: '0x8c3f79fb48'
-  - crashed: false
-    id: 8188
+  - id: 8188
     stacktrace:
       frames:
       - data:
@@ -307,8 +304,7 @@ threads:
         rip: '0x7ffe100fd854'
         rsi: '0x7ffe10083140'
         rsp: '0x8c3fc6f838'
-  - crashed: false
-    id: 10188
+  - id: 10188
     stacktrace:
       frames:
       - data:
@@ -352,8 +348,7 @@ threads:
         rsp: '0x8c4013f6b8'
   - crashed: true
     id: 6900
-  - crashed: false
-    id: 5200
+  - id: 5200
     stacktrace:
       frames:
       - data:
@@ -409,8 +404,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c3ebbf438'
-  - crashed: false
-    id: 9648
+  - id: 9648
     stacktrace:
       frames:
       - data:
@@ -466,8 +460,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c4068f738'
-  - crashed: false
-    id: 4372
+  - id: 4372
     stacktrace:
       frames:
       - data:
@@ -523,8 +516,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c4070f778'
-  - crashed: false
-    id: 10628
+  - id: 10628
     stacktrace:
       frames:
       - data:
@@ -573,8 +565,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c4078f858'
-  - crashed: false
-    id: 11280
+  - id: 11280
     stacktrace:
       frames:
       - data:
@@ -637,8 +628,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c4080f468'
-  - crashed: false
-    id: 2432
+  - id: 2432
     stacktrace:
       frames:
       - data:
@@ -694,8 +684,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c4088f808'
-  - crashed: false
-    id: 6680
+  - id: 6680
     stacktrace:
       frames:
       - data:
@@ -758,8 +747,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c4090f958'
-  - crashed: false
-    id: 6492
+  - id: 6492
     stacktrace:
       frames:
       - data:
@@ -822,8 +810,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c4098fa68'
-  - crashed: false
-    id: 6080
+  - id: 6080
     stacktrace:
       frames:
       - data:
@@ -886,8 +873,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c40a0f2f8'
-  - crashed: false
-    id: 6984
+  - id: 6984
     stacktrace:
       frames:
       - data:
@@ -950,8 +936,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c40a8f868'
-  - crashed: false
-    id: 10192
+  - id: 10192
     stacktrace:
       frames:
       - data:
@@ -993,8 +978,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c40b0f5c8'
-  - crashed: false
-    id: 11120
+  - id: 11120
     stacktrace:
       frames:
       - data:
@@ -1036,8 +1020,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c40b8fa78'
-  - crashed: false
-    id: 4872
+  - id: 4872
     stacktrace:
       frames:
       - data:
@@ -1072,8 +1055,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c40c0fa78'
-  - crashed: false
-    id: 4160
+  - id: 4160
     stacktrace:
       frames:
       - data:
@@ -1115,8 +1097,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c40c8f838'
-  - crashed: false
-    id: 11048
+  - id: 11048
     stacktrace:
       frames:
       - data:
@@ -1158,8 +1139,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c40d0f8a8'
-  - crashed: false
-    id: 7512
+  - id: 7512
     stacktrace:
       frames:
       - data:
@@ -1215,8 +1195,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c40d8f9f8'
-  - crashed: false
-    id: 8684
+  - id: 8684
     stacktrace:
       frames:
       - data:
@@ -1265,8 +1244,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c3ebdfab8'
         rsp: '0x8c3ebdfa88'
-  - crashed: false
-    id: 5444
+  - id: 5444
     stacktrace:
       frames:
       - data:
@@ -1315,8 +1293,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c3ebff488'
         rsp: '0x8c3ebff458'
-  - crashed: false
-    id: 12064
+  - id: 12064
     stacktrace:
       frames:
       - data:
@@ -1365,8 +1342,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c40dafb28'
         rsp: '0x8c40dafaf8'
-  - crashed: false
-    id: 468
+  - id: 468
     stacktrace:
       frames:
       - data:
@@ -1415,8 +1391,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c40dcf6c8'
         rsp: '0x8c40dcf698'
-  - crashed: false
-    id: 8276
+  - id: 8276
     stacktrace:
       frames:
       - data:
@@ -1465,8 +1440,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c40def448'
         rsp: '0x8c40def418'
-  - crashed: false
-    id: 7604
+  - id: 7604
     stacktrace:
       frames:
       - data:
@@ -1515,8 +1489,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c40e0f588'
         rsp: '0x8c40e0f558'
-  - crashed: false
-    id: 8056
+  - id: 8056
     stacktrace:
       frames:
       - data:
@@ -1565,8 +1538,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c40e2f868'
         rsp: '0x8c40e2f838'
-  - crashed: false
-    id: 7540
+  - id: 7540
     stacktrace:
       frames:
       - data:
@@ -1615,8 +1587,7 @@ threads:
         rip: '0x7ffe100fa584'
         rsi: '0x0'
         rsp: '0x8c412ff828'
-  - crashed: false
-    id: 9920
+  - id: 9920
     stacktrace:
       frames:
       - data:
@@ -1665,8 +1636,7 @@ threads:
         rip: '0x7ffe100fa584'
         rsi: '0x0'
         rsp: '0x8c4131fd08'
-  - crashed: false
-    id: 4264
+  - id: 4264
     stacktrace:
       frames:
       - data:
@@ -1715,8 +1685,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c4133f728'
         rsp: '0x8c4133f6f8'
-  - crashed: false
-    id: 2548
+  - id: 2548
     stacktrace:
       frames:
       - data:
@@ -1765,8 +1734,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c4135fb98'
         rsp: '0x8c4135fb68'
-  - crashed: false
-    id: 3060
+  - id: 3060
     stacktrace:
       frames:
       - data:
@@ -1815,8 +1783,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c4137fa18'
         rsp: '0x8c4137f9e8'
-  - crashed: false
-    id: 664
+  - id: 664
     stacktrace:
       frames:
       - data:
@@ -1865,8 +1832,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c4139fa38'
         rsp: '0x8c4139fa08'
-  - crashed: false
-    id: 3028
+  - id: 3028
     stacktrace:
       frames:
       - data:
@@ -1915,8 +1881,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c413bf8f8'
         rsp: '0x8c413bf8c8'
-  - crashed: false
-    id: 964
+  - id: 964
     stacktrace:
       frames:
       - data:
@@ -1951,8 +1916,7 @@ threads:
         rip: '0x7ffe100fd854'
         rsi: '0x7ffe10083140'
         rsp: '0x8c4223f9f8'
-  - crashed: false
-    id: 9124
+  - id: 9124
     stacktrace:
       frames:
       - data:
@@ -2001,8 +1965,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c418bfc08'
         rsp: '0x8c418bfbd8'
-  - crashed: false
-    id: 9264
+  - id: 9264
     stacktrace:
       frames:
       - data:
@@ -2051,8 +2014,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c4270fa48'
         rsp: '0x8c4270fa18'
-  - crashed: false
-    id: 7528
+  - id: 7528
     stacktrace:
       frames:
       - data:
@@ -2094,8 +2056,7 @@ threads:
         rip: '0x7ffe100fd854'
         rsi: '0x7ffe10083140'
         rsp: '0x8c42bdfa78'
-  - crashed: false
-    id: 4136
+  - id: 4136
     stacktrace:
       frames:
       - data:
@@ -2319,8 +2280,7 @@ threads:
         rip: '0x7ffe100faa54'
         rsi: '0x0'
         rsp: '0x8c430af608'
-  - crashed: false
-    id: 10520
+  - id: 10520
     stacktrace:
       frames:
       - data:
@@ -2369,8 +2329,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c418df688'
         rsp: '0x8c418df658'
-  - crashed: false
-    id: 10828
+  - id: 10828
     stacktrace:
       frames:
       - data:
@@ -2419,8 +2378,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c418ff998'
         rsp: '0x8c418ff968'
-  - crashed: false
-    id: 6428
+  - id: 6428
     stacktrace:
       frames:
       - data:
@@ -2469,8 +2427,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c4191f678'
         rsp: '0x8c4191f648'
-  - crashed: false
-    id: 11276
+  - id: 11276
     stacktrace:
       frames:
       - data:
@@ -2519,8 +2476,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c4193f7b8'
         rsp: '0x8c4193f788'
-  - crashed: false
-    id: 11076
+  - id: 11076
     stacktrace:
       frames:
       - data:
@@ -2569,8 +2525,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c4195f738'
         rsp: '0x8c4195f708'
-  - crashed: false
-    id: 9748
+  - id: 9748
     stacktrace:
       frames:
       - data:
@@ -2619,8 +2574,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c4197f9f8'
         rsp: '0x8c4197f9c8'
-  - crashed: false
-    id: 6820
+  - id: 6820
     stacktrace:
       frames:
       - data:
@@ -2669,8 +2623,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c4199fac8'
         rsp: '0x8c4199fa98'
-  - crashed: false
-    id: 5932
+  - id: 5932
     stacktrace:
       frames:
       - data:
@@ -2719,8 +2672,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c419bf6d8'
         rsp: '0x8c419bf6a8'
-  - crashed: false
-    id: 10672
+  - id: 10672
     stacktrace:
       frames:
       - data:
@@ -2755,8 +2707,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x8c419df628'
         rsp: '0x8c419df5f8'
-  - crashed: false
-    id: 3096
+  - id: 3096
     stacktrace:
       frames:
       - data:
@@ -2805,8 +2756,7 @@ threads:
         rip: '0x7ffe100fa584'
         rsi: '0x0'
         rsp: '0x8c419efb58'
-  - crashed: false
-    id: 10944
+  - id: 10944
     stacktrace:
       frames:
       - data:
@@ -2946,8 +2896,7 @@ threads:
         rip: '0x7ffe100faa54'
         rsi: '0x0'
         rsp: '0x8c4357f4f8'
-  - crashed: false
-    id: 7648
+  - id: 7648
     stacktrace:
       frames:
       - data:
@@ -2982,8 +2931,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c43a4f4d8'
-  - crashed: false
-    id: 612
+  - id: 612
     stacktrace:
       frames:
       - data:
@@ -3032,8 +2980,7 @@ threads:
         rip: '0x7ffe100f9f84'
         rsi: '0x0'
         rsp: '0x8c4188f7a8'
-  - crashed: false
-    id: 10900
+  - id: 10900
     stacktrace:
       frames:
       - data:


### PR DESCRIPTION
Minidumps from processes that have not crashed have still been marked with
`crashed` in the threads interface. This PR changes so that the requesting
thread is instead marked as `current`.

