### PR TITLE
fix(ingest): More instrumentation in consumer

### DIFF
--- a/src/sentry/eventstore/processing/base.py
+++ b/src/sentry/eventstore/processing/base.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 from typing import Any, Optional
 
+import sentry_sdk
+
 from sentry.utils.cache import cache_key_for_event
 from sentry.utils.kvstore.abstract import KVStorage
 
@@ -31,20 +33,23 @@ class EventProcessingStore:
         return key + ":u"
 
     def store(self, event: Event, unprocessed: bool = False) -> str:
-        key = cache_key_for_event(event)
-        if unprocessed:
-            key = self.__get_unprocessed_key(key)
-        self.inner.set(key, event, self.timeout)
-        return key
+        with sentry_sdk.start_span(op="eventstore.processing.store"):
+            key = cache_key_for_event(event)
+            if unprocessed:
+                key = self.__get_unprocessed_key(key)
+            self.inner.set(key, event, self.timeout)
+            return key
 
     def get(self, key: str, unprocessed: bool = False) -> Optional[Event]:
-        if unprocessed:
-            key = self.__get_unprocessed_key(key)
-        return self.inner.get(key)
+        with sentry_sdk.start_span(op="eventstore.processing.get"):
+            if unprocessed:
+                key = self.__get_unprocessed_key(key)
+            return self.inner.get(key)
 
     def delete_by_key(self, key: str) -> None:
-        self.inner.delete(key)
-        self.inner.delete(self.__get_unprocessed_key(key))
+        with sentry_sdk.start_span(op="eventstore.processing.delete_by_key"):
+            self.inner.delete(key)
+            self.inner.delete(self.__get_unprocessed_key(key))
 
     def delete(self, event: Event) -> None:
         key = cache_key_for_event(event)

--- a/src/sentry/ingest/ingest_consumer.py
+++ b/src/sentry/ingest/ingest_consumer.py
@@ -143,13 +143,12 @@ def _do_process_event(message, projects):
         logger.error("Project for ingested event does not exist: %s", project_id)
         return
 
-    with sentry_sdk.start_span(op="ingest_consumer.process_event.parse_payload"):
-        # Parse the JSON payload. This is required to compute the cache key and
-        # call process_event. The payload will be put into Kafka raw, to avoid
-        # serializing it again.
-        # XXX: Do not use CanonicalKeyDict here. This may break preprocess_event
-        # which assumes that data passed in is a raw dictionary.
-        data = json.loads(payload)
+    # Parse the JSON payload. This is required to compute the cache key and
+    # call process_event. The payload will be put into Kafka raw, to avoid
+    # serializing it again.
+    # XXX: Do not use CanonicalKeyDict here. This may break preprocess_event
+    # which assumes that data passed in is a raw dictionary.
+    data = json.loads(payload)
 
     if project_id == settings.SENTRY_PROJECT:
         metrics.incr(

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -10,6 +10,7 @@ import uuid
 from enum import Enum
 from typing import Any
 
+import sentry_sdk
 from django.utils.encoding import force_text
 from django.utils.functional import Promise
 from django.utils.safestring import mark_safe
@@ -105,7 +106,8 @@ def load(fp, **kwargs) -> str:
 
 
 def loads(value: str, **kwargs) -> JSONData:
-    return _default_decoder.decode(value)
+    with sentry_sdk.start_span(op="sentry.utils.json.loads"):
+        return _default_decoder.decode(value)
 
 
 def dumps_htmlsafe(value):


### PR DESCRIPTION
* Wrap every json.loads in a span. This has potential to increase CPU usage by a lot, but I think it's worth a try to see if it maybe doesn't. It would improve our traces a lot.
* Wrap some attachment stuff in ingest-consumer additionally
* Wrap eventstore.processing ops in spans