### PR TITLE
fix(snuba): Fix session and user double error count

### DIFF
--- a/src/sentry/snuba/sessions_v2.py
+++ b/src/sentry/snuba/sessions_v2.py
@@ -93,13 +93,17 @@ class SessionsField:
         if status is None:
             return row["sessions"]
         if status == "healthy":
-            return row["sessions"] - row["sessions_errored"]
+            healthy_sessions = row["sessions"] - row["sessions_errored"]
+            return max(healthy_sessions, 0)
         if status == "abnormal":
             return row["sessions_abnormal"]
         if status == "crashed":
             return row["sessions_crashed"]
         if status == "errored":
-            return row["sessions_errored"]
+            errored_sessions = (
+                row["sessions_errored"] - row["sessions_crashed"] - row["sessions_abnormal"]
+            )
+            return max(errored_sessions, 0)
         return 0
 
 
@@ -116,13 +120,15 @@ class UsersField:
         if status is None:
             return row["users"]
         if status == "healthy":
-            return row["users"] - row["users_errored"]
+            healthy_users = row["users"] - row["users_errored"]
+            return max(healthy_users, 0)
         if status == "abnormal":
             return row["users_abnormal"]
         if status == "crashed":
             return row["users_crashed"]
         if status == "errored":
-            return row["users_errored"]
+            errored_users = row["users_errored"] - row["users_crashed"] - row["users_abnormal"]
+            return max(errored_users, 0)
         return 0
 
 

--- a/tests/snuba/api/endpoints/test_organization_sessions.py
+++ b/tests/snuba/api/endpoints/test_organization_sessions.py
@@ -488,8 +488,8 @@ class OrganizationSessionsEndpointTest(APITestCase, SnubaTestCase):
             },
             {
                 "by": {"session.status": "errored"},
-                "series": {"sum(session)": [3]},
-                "totals": {"sum(session)": 3},
+                "series": {"sum(session)": [2]},
+                "totals": {"sum(session)": 2},
             },
             {
                 "by": {"session.status": "healthy"},

--- a/tests/snuba/sessions/test_sessions_v2.py
+++ b/tests/snuba/sessions/test_sessions_v2.py
@@ -416,16 +416,38 @@ def test_massage_virtual_groupby_timeseries():
         {
             "users": 1,
             "users_crashed": 1,
-            "sessions": 6,
-            "sessions_errored": 1,
+            "sessions": 31,
+            "sessions_errored": 15,
             "users_errored": 1,
-            "sessions_abnormal": 0,
-            "sessions_crashed": 1,
+            "sessions_abnormal": 6,
+            "sessions_crashed": 8,
             "users_abnormal": 0,
         }
     ]
     # snuba returns the datetimes as strings for now
     result_timeseries = [
+        {
+            "sessions_errored": 4,
+            "users": 1,
+            "users_crashed": 0,
+            "sessions_abnormal": 4,
+            "sessions": 10,
+            "users_errored": 0,
+            "users_abnormal": 0,
+            "sessions_crashed": 3,
+            "bucketed_started": "2020-12-17T18:00:00+00:00",
+        },
+        {
+            "sessions_errored": 10,
+            "users": 1,
+            "users_crashed": 0,
+            "sessions_abnormal": 2,
+            "sessions": 15,
+            "users_errored": 0,
+            "users_abnormal": 0,
+            "sessions_crashed": 4,
+            "bucketed_started": "2020-12-18T00:00:00+00:00",
+        },
         {
             "sessions_errored": 1,
             "users": 1,
@@ -463,32 +485,99 @@ def test_massage_virtual_groupby_timeseries():
         "groups": [
             {
                 "by": {"session.status": "abnormal"},
-                "series": {"count_unique(user)": [0, 0, 0, 0], "sum(session)": [0, 0, 0, 0]},
-                "totals": {"count_unique(user)": 0, "sum(session)": 0},
+                "series": {"count_unique(user)": [0, 0, 0, 0], "sum(session)": [4, 2, 0, 0]},
+                "totals": {"count_unique(user)": 0, "sum(session)": 6},
             },
             {
                 "by": {"session.status": "crashed"},
-                "series": {"count_unique(user)": [0, 0, 0, 1], "sum(session)": [0, 0, 0, 1]},
-                "totals": {"count_unique(user)": 1, "sum(session)": 1},
+                "series": {"count_unique(user)": [0, 0, 0, 1], "sum(session)": [3, 4, 0, 1]},
+                "totals": {"count_unique(user)": 1, "sum(session)": 8},
             },
             {
                 "by": {"session.status": "errored"},
-                "series": {"count_unique(user)": [0, 0, 0, 1], "sum(session)": [0, 0, 0, 1]},
-                "totals": {"count_unique(user)": 1, "sum(session)": 1},
+                "series": {"count_unique(user)": [0, 0, 0, 0], "sum(session)": [0, 4, 0, 0]},
+                "totals": {"count_unique(user)": 0, "sum(session)": 1},
             },
             {
                 "by": {"session.status": "healthy"},
-                "series": {"count_unique(user)": [0, 0, 1, 0], "sum(session)": [0, 0, 3, 2]},
+                "series": {"count_unique(user)": [1, 1, 1, 0], "sum(session)": [6, 5, 3, 2]},
                 # while in one of the time slots, we have a healthy user, it is
                 # the *same* user as the one experiencing a crash later on,
                 # so in the *whole* time window, that one user is not counted as healthy,
                 # so the `0` here is expected, as thats an example of the `count_unique` behavior.
-                "totals": {"count_unique(user)": 0, "sum(session)": 5},
+                "totals": {"count_unique(user)": 0, "sum(session)": 16},
             },
         ],
     }
 
     actual_result = result_sorted(massage_sessions_result(query, result_totals, result_timeseries))
+
+    assert actual_result == expected_result
+
+
+@freeze_time("2020-12-18T13:25:15.769Z")
+def test_clamping_in_massage_sessions_results_with_groupby_timeseries():
+    query = _make_query(
+        "statsPeriod=12h&interval=6h&field=sum(session)&field=count_unique(user)&groupBy=session.status"
+    )
+    # snuba returns the datetimes as strings for now
+    result_timeseries = [
+        {
+            "sessions": 5,
+            "sessions_errored": 10,
+            "sessions_crashed": 0,
+            "sessions_abnormal": 0,
+            "users": 5,
+            "users_errored": 10,
+            "users_crashed": 0,
+            "users_abnormal": 0,
+            "bucketed_started": "2020-12-18T06:00:00+00:00",
+        },
+        {
+            "sessions": 7,
+            "sessions_errored": 3,
+            "sessions_crashed": 2,
+            "sessions_abnormal": 2,
+            "users": 7,
+            "users_errored": 3,
+            "users_crashed": 2,
+            "users_abnormal": 2,
+            "bucketed_started": "2020-12-18T12:00:00+00:00",
+        },
+    ]
+    expected_result = {
+        "start": "2020-12-18T06:00:00Z",
+        "end": "2020-12-18T13:26:00Z",
+        "query": "",
+        "intervals": [
+            "2020-12-18T06:00:00Z",
+            "2020-12-18T12:00:00Z",
+        ],
+        "groups": [
+            {
+                "by": {"session.status": "abnormal"},
+                "series": {"count_unique(user)": [0, 2], "sum(session)": [0, 2]},
+                "totals": {"count_unique(user)": 0, "sum(session)": 0},
+            },
+            {
+                "by": {"session.status": "crashed"},
+                "series": {"count_unique(user)": [0, 2], "sum(session)": [0, 2]},
+                "totals": {"count_unique(user)": 0, "sum(session)": 0},
+            },
+            {
+                "by": {"session.status": "errored"},
+                "series": {"count_unique(user)": [10, 0], "sum(session)": [10, 0]},
+                "totals": {"count_unique(user)": 0, "sum(session)": 0},
+            },
+            {
+                "by": {"session.status": "healthy"},
+                "series": {"count_unique(user)": [0, 4], "sum(session)": [0, 4]},
+                "totals": {"count_unique(user)": 0, "sum(session)": 0},
+            },
+        ],
+    }
+
+    actual_result = result_sorted(massage_sessions_result(query, [], result_timeseries))
 
     assert actual_result == expected_result
 


### PR DESCRIPTION
This PR:
 - Subtracts `crashed` and `abnormal` count from `errored` count for both `users` and `sessions` to
prevent double count in errors. 
- Clamp `errored` and `healthy` values for `sessions` and `users` to zero so we don't end up with negative values (due to subtraction of materialized views)
