### PR TITLE
fix(grouping): Group by sole crashing/current thread

### DIFF
--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -612,21 +612,21 @@ def chained_exception_variant_processor(variants, context, **meta):
 
 @strategy(id="threads:v1", interfaces=["threads"], score=1900)
 def threads(threads_interface, context, **meta):
-    rv = _filtered_threads(
+    thread_variants = _filtered_threads(
         [thread for thread in threads_interface.values if thread.get("crashed")], context, meta
     )
-    if rv is not None:
-        return rv
+    if thread_variants is not None:
+        return thread_variants
 
-    rv = _filtered_threads(
+    thread_variants = _filtered_threads(
         [thread for thread in threads_interface.values if thread.get("current")], context, meta
     )
-    if rv is not None:
-        return rv
+    if thread_variants is not None:
+        return thread_variants
 
-    rv = _filtered_threads(threads_interface.values, context, meta)
-    if rv is not None:
-        return rv
+    thread_variants = _filtered_threads(threads_interface.values, context, meta)
+    if thread_variants is not None:
+        return thread_variants
 
     return {
         "app": GroupingComponent(

--- a/src/sentry/grouping/strategies/newstyle.py
+++ b/src/sentry/grouping/strategies/newstyle.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any, Dict, List
 
 from sentry.grouping.component import GroupingComponent
 from sentry.grouping.strategies.base import call_with_variants, strategy
@@ -611,17 +612,40 @@ def chained_exception_variant_processor(variants, context, **meta):
 
 @strategy(id="threads:v1", interfaces=["threads"], score=1900)
 def threads(threads_interface, context, **meta):
-    thread_count = len(threads_interface.values)
-    if thread_count != 1:
-        return {
-            "app": GroupingComponent(
-                id="threads",
-                contributes=False,
-                hint="ignored because contains %d threads" % thread_count,
-            )
-        }
+    rv = _filtered_threads(
+        [thread for thread in threads_interface.values if thread.get("crashed")], context, meta
+    )
+    if rv is not None:
+        return rv
 
-    stacktrace = threads_interface.values[0].get("stacktrace")
+    rv = _filtered_threads(
+        [thread for thread in threads_interface.values if thread.get("current")], context, meta
+    )
+    if rv is not None:
+        return rv
+
+    rv = _filtered_threads(threads_interface.values, context, meta)
+    if rv is not None:
+        return rv
+
+    return {
+        "app": GroupingComponent(
+            id="threads",
+            contributes=False,
+            hint=(
+                "ignored because does not contain exactly one crashing, "
+                "one current or just one thread, instead contains %s threads"
+                % len(threads_interface.values)
+            ),
+        )
+    }
+
+
+def _filtered_threads(threads: List[Dict[str, Any]], context, meta):
+    if len(threads) != 1:
+        return None
+
+    stacktrace = threads[0].get("stacktrace")
     if not stacktrace:
         return {
             "app": GroupingComponent(

--- a/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/similarity/snapshots/test_features/test_similarity_extract_grouping_input/exception_cocoa_nserror.pysnap
@@ -1,8 +1,9 @@
 ---
-created: '2021-02-11T15:54:40.316997Z'
+created: '2021-04-22T15:23:23.995703Z'
 creator: sentry
 source: tests/sentry/grouping/similarity/test_features.py
 ---
+similarity:2020-07-23:stacktrace:frames-pairs: [[["function","main"]],[["function","ViewController.captureError"]]]
 similarity:2020-07-23:type:ident-shingle: "iOS_Swift.SampleError"
 similarity:2020-07-23:value:character-5-shingle: " (iOS"
 similarity:2020-07-23:value:character-5-shingle: " <int"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-08T09:28:25.551608Z'
+created: '2021-04-22T14:32:55.424993Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,4 +15,136 @@ app:
           0
         value (ignored because ns-error info takes precedence)
           "Code=<int> Description=The operation couldn\u2019t be completed. (iOS_Swift.SampleError error <int>.)"
-      threads (ignored because contains 11 threads)
+--------------------------------------------------------------------------
+app-depth-1:
+  hash: null
+  component:
+    app-depth-1 (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+--------------------------------------------------------------------------
+app-depth-2:
+  hash: null
+  component:
+    app-depth-2 (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "__eventFetcherSourceCallback"
+          frame*
+            function*
+              "GSEventRunModal"
+--------------------------------------------------------------------------
+app-depth-3:
+  hash: null
+  component:
+    app-depth-3 (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "__eventFetcherSourceCallback"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "main"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "UIApplicationMain"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame (ignored by stack trace rule (category:indirection -group))
+            function*
+              "CFRunLoopRunSpecific"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopRun"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopDoSources0"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRunLoopDoSource0"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "__eventFetcherSourceCallback"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "__processEventQueue"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIApplication sendEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIWindow sendEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame (ignored by stack trace rule (category:internals -group))
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame* (marked as prefix frame by stack trace rule (category:ui +sentinel +prefix))
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function*
+              "ViewController.captureError"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/mobile@2021_02_12/threads_no_hash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:16.223964Z'
+created: '2021-04-22T14:32:56.284594Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      threads (ignored because contains 2 threads)
+      threads (ignored because does not contain exactly one crashing, one current or just one thread, instead contains 2 threads)
 --------------------------------------------------------------------------
 fallback:
   hash: "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-16T18:30:09.242780Z'
+created: '2021-04-22T14:32:59.613638Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -13,4 +13,150 @@ app:
         ns-error*
           "iOS_Swift.SampleError"
           0
-      threads (ignored because contains 11 threads)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame (non app frame)
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "CFRunLoopRunSpecific"
+          frame (non app frame)
+            function*
+              "__CFRunLoopRun"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoSources0"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoSource0"
+          frame (non app frame)
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame (non app frame)
+            function*
+              "__eventFetcherSourceCallback"
+          frame (non app frame)
+            function*
+              "__processEventQueue"
+          frame (non app frame)
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIApplication sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIWindow sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame (non app frame)
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame (non app frame)
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function* (isolated function)
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function* (isolated function)
+              "ViewController.captureError"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "CFRunLoopRunSpecific"
+          frame*
+            function*
+              "__CFRunLoopRun"
+          frame*
+            function*
+              "__CFRunLoopDoSources0"
+          frame*
+            function*
+              "__CFRunLoopDoSource0"
+          frame*
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame*
+            function*
+              "__eventFetcherSourceCallback"
+          frame*
+            function*
+              "__processEventQueue"
+          frame*
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame*
+            function*
+              "-[UIApplication sendEvent:]"
+          frame*
+            function*
+              "-[UIWindow sendEvent:]"
+          frame*
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame*
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame*
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame*
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame*
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function* (isolated function)
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function* (isolated function)
+              "ViewController.captureError"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_05/threads_no_hash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:19.260162Z'
+created: '2021-04-22T14:33:00.453921Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      threads (ignored because contains 2 threads)
+      threads (ignored because does not contain exactly one crashing, one current or just one thread, instead contains 2 threads)
 --------------------------------------------------------------------------
 fallback:
   hash: "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-16T18:30:11.723221Z'
+created: '2021-04-22T14:33:03.557422Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,4 +15,150 @@ app:
           0
         value (ignored because ns-error info takes precedence)
           "Code=<int> Description=The operation couldn\u2019t be completed. (iOS_Swift.SampleError error <int>.)"
-      threads (ignored because contains 11 threads)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame (non app frame)
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "CFRunLoopRunSpecific"
+          frame (non app frame)
+            function*
+              "__CFRunLoopRun"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoSources0"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoSource0"
+          frame (non app frame)
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame (non app frame)
+            function*
+              "__eventFetcherSourceCallback"
+          frame (non app frame)
+            function*
+              "__processEventQueue"
+          frame (non app frame)
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIApplication sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIWindow sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame (non app frame)
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame (non app frame)
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function*
+              "ViewController.captureError"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "CFRunLoopRunSpecific"
+          frame*
+            function*
+              "__CFRunLoopRun"
+          frame*
+            function*
+              "__CFRunLoopDoSources0"
+          frame*
+            function*
+              "__CFRunLoopDoSource0"
+          frame*
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame*
+            function*
+              "__eventFetcherSourceCallback"
+          frame*
+            function*
+              "__processEventQueue"
+          frame*
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame*
+            function*
+              "-[UIApplication sendEvent:]"
+          frame*
+            function*
+              "-[UIWindow sendEvent:]"
+          frame*
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame*
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame*
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame*
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame*
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function*
+              "ViewController.captureError"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_04_17/threads_no_hash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:21.659447Z'
+created: '2021-04-22T14:33:04.266135Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      threads (ignored because contains 2 threads)
+      threads (ignored because does not contain exactly one crashing, one current or just one thread, instead contains 2 threads)
 --------------------------------------------------------------------------
 fallback:
   hash: "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-16T18:30:00.410596Z'
+created: '2021-04-22T14:32:47.514771Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,4 +15,150 @@ app:
           0
         value (ignored because ns-error info takes precedence)
           "Code=<int> Description=The operation couldn\u2019t be completed. (iOS_Swift.SampleError error <int>.)"
-      threads (ignored because contains 11 threads)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame (non app frame)
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "CFRunLoopRunSpecific"
+          frame (non app frame)
+            function*
+              "__CFRunLoopRun"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoSources0"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoSource0"
+          frame (non app frame)
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame (non app frame)
+            function*
+              "__eventFetcherSourceCallback"
+          frame (non app frame)
+            function*
+              "__processEventQueue"
+          frame (non app frame)
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIApplication sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIWindow sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame (non app frame)
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame (non app frame)
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function*
+              "ViewController.captureError"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "CFRunLoopRunSpecific"
+          frame*
+            function*
+              "__CFRunLoopRun"
+          frame*
+            function*
+              "__CFRunLoopDoSources0"
+          frame*
+            function*
+              "__CFRunLoopDoSource0"
+          frame*
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame*
+            function*
+              "__eventFetcherSourceCallback"
+          frame*
+            function*
+              "__processEventQueue"
+          frame*
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame*
+            function*
+              "-[UIApplication sendEvent:]"
+          frame*
+            function*
+              "-[UIWindow sendEvent:]"
+          frame*
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame*
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame*
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame*
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame*
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function*
+              "ViewController.captureError"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_05_08/threads_no_hash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:11.335660Z'
+created: '2021-04-22T14:32:48.263917Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      threads (ignored because contains 2 threads)
+      threads (ignored because does not contain exactly one crashing, one current or just one thread, instead contains 2 threads)
 --------------------------------------------------------------------------
 fallback:
   hash: "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-16T18:30:03.296542Z'
+created: '2021-04-22T14:32:51.341008Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,4 +15,150 @@ app:
           0
         value (ignored because ns-error info takes precedence)
           "Code=<int> Description=The operation couldn\u2019t be completed. (iOS_Swift.SampleError error <int>.)"
-      threads (ignored because contains 11 threads)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame (non app frame)
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "CFRunLoopRunSpecific"
+          frame (non app frame)
+            function*
+              "__CFRunLoopRun"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoSources0"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoSource0"
+          frame (non app frame)
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame (non app frame)
+            function*
+              "__eventFetcherSourceCallback"
+          frame (non app frame)
+            function*
+              "__processEventQueue"
+          frame (non app frame)
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIApplication sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIWindow sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame (non app frame)
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame (non app frame)
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function*
+              "ViewController.captureError"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "CFRunLoopRunSpecific"
+          frame*
+            function*
+              "__CFRunLoopRun"
+          frame*
+            function*
+              "__CFRunLoopDoSources0"
+          frame*
+            function*
+              "__CFRunLoopDoSource0"
+          frame*
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame*
+            function*
+              "__eventFetcherSourceCallback"
+          frame*
+            function*
+              "__processEventQueue"
+          frame*
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame*
+            function*
+              "-[UIApplication sendEvent:]"
+          frame*
+            function*
+              "-[UIWindow sendEvent:]"
+          frame*
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame*
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame*
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame*
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame*
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function*
+              "ViewController.captureError"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/newstyle@2019_10_29/threads_no_hash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:13.841598Z'
+created: '2021-04-22T14:32:52.011141Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      threads (ignored because contains 2 threads)
+      threads (ignored because does not contain exactly one crashing, one current or just one thread, instead contains 2 threads)
 --------------------------------------------------------------------------
 fallback:
   hash: "d41d8cd98f00b204e9800998ecf8427e"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/exception_cocoa_nserror.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/exception_cocoa_nserror.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-16T18:30:14.253072Z'
+created: '2021-04-22T14:33:07.266298Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -15,4 +15,150 @@ app:
           0
         value (ignored because ns-error info takes precedence)
           "Code=<int> Description=The operation couldn\u2019t be completed. (iOS_Swift.SampleError error <int>.)"
-      threads (ignored because contains 11 threads)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame (non app frame)
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame (non app frame)
+            function*
+              "UIApplicationMain"
+          frame (non app frame)
+            function*
+              "-[UIApplication _run]"
+          frame (non app frame)
+            function*
+              "GSEventRunModal"
+          frame (non app frame)
+            function*
+              "CFRunLoopRunSpecific"
+          frame (non app frame)
+            function*
+              "__CFRunLoopRun"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoSources0"
+          frame (non app frame)
+            function*
+              "__CFRunLoopDoSource0"
+          frame (non app frame)
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame (non app frame)
+            function*
+              "__eventFetcherSourceCallback"
+          frame (non app frame)
+            function*
+              "__processEventQueue"
+          frame (non app frame)
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIApplication sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIWindow sendEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame (non app frame)
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame (non app frame)
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame (non app frame)
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function*
+              "ViewController.captureError"
+--------------------------------------------------------------------------
+system:
+  hash: null
+  component:
+    system (exception of app takes precedence)
+      threads (exception of app takes precedence)
+        stacktrace*
+          frame*
+            function*
+              "start"
+          frame*
+            function*
+              "main"
+          frame*
+            function*
+              "UIApplicationMain"
+          frame*
+            function*
+              "-[UIApplication _run]"
+          frame*
+            function*
+              "GSEventRunModal"
+          frame*
+            function*
+              "CFRunLoopRunSpecific"
+          frame*
+            function*
+              "__CFRunLoopRun"
+          frame*
+            function*
+              "__CFRunLoopDoSources0"
+          frame*
+            function*
+              "__CFRunLoopDoSource0"
+          frame*
+            function*
+              "__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__"
+          frame*
+            function*
+              "__eventFetcherSourceCallback"
+          frame*
+            function*
+              "__processEventQueue"
+          frame*
+            function*
+              "-[UIApplicationAccessibility sendEvent:]"
+          frame*
+            function*
+              "-[UIApplication sendEvent:]"
+          frame*
+            function*
+              "-[UIWindow sendEvent:]"
+          frame*
+            function*
+              "-[UIWindow _sendTouchesForEvent:]"
+          frame*
+            function*
+              "-[UIControl touchesEnded:withEvent:]"
+          frame*
+            function*
+              "-[UIControl _sendActionsForEvents:withEvent:]"
+          frame*
+            function*
+              "-[UIControl sendAction:to:forEvent:]"
+          frame*
+            function*
+              "__44-[SentryBreadcrumbTracker swizzleSendAction]_block_invoke_2"
+          frame*
+            function*
+              "-[UIApplication sendAction:to:from:forEvent:]"
+          frame*
+            function*
+              "ViewController.captureError"
+          frame (ignored due to recursion)
+            function*
+              "ViewController.captureError"

--- a/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/threads_no_hash.pysnap
+++ b/tests/sentry/grouping/snapshots/test_variants/test_event_hash_variant/similarity@2020_07_23/threads_no_hash.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-02-12T22:47:24.101623Z'
+created: '2021-04-22T14:33:08.010809Z'
 creator: sentry
 source: tests/sentry/grouping/test_variants.py
 ---
@@ -7,7 +7,7 @@ app:
   hash: null
   component:
     app
-      threads (ignored because contains 2 threads)
+      threads (ignored because does not contain exactly one crashing, one current or just one thread, instead contains 2 threads)
 --------------------------------------------------------------------------
 fallback:
   hash: "d41d8cd98f00b204e9800998ecf8427e"


### PR DESCRIPTION
Flow:

1. [new] If there is only one crashing thread, use that for grouping.
2. [new] If there is only one current thread, use that.
3. If there's only one thread overall, use that.

We don't really have a transition plan for this but the previous groups were very likely bad quality anyway.

Note that a stacktrace-less exception still is used over the threads interface. But a contraption like this should never be sent in the first place, because if there's stack info relevant to the exception it should be in that same interface.