### PR TITLE
fix: Measure spans for grouping components

### DIFF
--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -1,5 +1,7 @@
 import inspect
 
+import sentry_sdk
+
 from sentry import projectoptions
 from sentry.grouping.enhancer import Enhancements
 
@@ -77,7 +79,10 @@ class GroupingContext:
             raise RuntimeError(f"failed to dispatch interface {path} to strategy")
 
         kwargs["context"] = self
-        rv = strategy(interface, *args, **kwargs)
+        with sentry_sdk.start_span(
+            op="sentry.grouping.GroupingContext.get_grouping_component", description=interface.path
+        ):
+            rv = strategy(interface, *args, **kwargs)
         assert isinstance(rv, dict)
 
         if self["variant"] is not None:

--- a/src/sentry/grouping/strategies/base.py
+++ b/src/sentry/grouping/strategies/base.py
@@ -80,7 +80,7 @@ class GroupingContext:
 
         kwargs["context"] = self
         with sentry_sdk.start_span(
-            op="sentry.grouping.GroupingContext.get_grouping_component", description=interface.path
+            op="sentry.grouping.GroupingContext.get_grouping_component", description=path
         ):
             rv = strategy(interface, *args, **kwargs)
         assert isinstance(rv, dict)


### PR DESCRIPTION
We have some massive minidump events reaching 20MB in size, and we want to figure out if the slowdown happens in exception interface or threads interface, or perhaps inbetween from just passing around such a massive piece of data.