### PR TITLE
fix(ui): remove link for issue alert rules

### DIFF
--- a/static/app/views/alerts/rules/row.tsx
+++ b/static/app/views/alerts/rules/row.tsx
@@ -159,8 +159,10 @@ class RuleListRow extends React.Component<Props, State> {
     const canEdit = ownerId ? userTeams.has(ownerId) : true;
     const hasAlertOwnership = organization.features.includes('team-alerts-ownership');
     const hasAlertList = organization.features.includes('alert-list');
-    const alertLink = (
-      <TitleLink to={hasRedesign ? detailsLink : editLink}>{rule.name}</TitleLink>
+    const alertLink = hasRedesign ? (
+      <TitleLink to={detailsLink}>{rule.name}</TitleLink>
+    ) : (
+      rule.name
     );
 
     const IssueStatusText: Record<IncidentStatus, string> = {


### PR DESCRIPTION
Removed link for issue alert rules because it's confusing that it leads to edit whilst metric alert leads to a details page