### PR TITLE
fix(snql) get_next_or_prev_event_id uses discover dataset

### DIFF
--- a/src/sentry/utils/snql.py
+++ b/src/sentry/utils/snql.py
@@ -9,6 +9,7 @@ referrer_blacklist = {
     "tsdb-modelid:200",
     "tsdb-modelid:202",
     "tsdb-modelid:100",
+    "eventstore.get_next_or_prev_event_id",
 }
 referrers_by_entity = {
     "api.performance.durationpercentilechart": "discover_transactions",


### PR DESCRIPTION
Discover isn't supported right now, blacklist this referrer for now.