### PR TITLE
fix: handle relative URL for issueEndpoint

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -635,7 +635,7 @@ class IssueListOverview extends React.Component<Props, State> {
     const links = parseLinkHeader(this.state.pageLinks);
     if (links && !links.previous.results && this.state.realtimeActive) {
       // Remove collapse stats from endpoint before supplying to poller
-      const issueEndpoint = new URL(links.previous.href);
+      const issueEndpoint = new URL(links.previous.href, window.location.origin);
       issueEndpoint.searchParams.delete('collapse');
       this._poller.setEndpoint(decodeURIComponent(issueEndpoint.href));
       this._poller.enable();


### PR DESCRIPTION
This PR fixes a bug where `links.previous.href` is a relative URL instead of a full URL. This is happening with the Sandbox in the deployed environment. I'm not exactly sure why this is happening but it seems like the root cause has to do with `request.path` being a relative URL here instead of a full URL: https://github.com/getsentry/sentry/blob/2829e61be5cec1b9974e34c10021e5d95455221b/src/sentry/api/bases/organization_events.py#L159

My proposed fix is to provide the second optional argument for the base when calling `new URL` instead of trying to modify the backend code that is used to generate the `Link` response header.

Fixes  SENTRY-DEMO-JAVASCRIPT-12