### PR TITLE
feat(perf-cleanup): spacing and labels

### DIFF
--- a/static/app/views/performance/landing/content.tsx
+++ b/static/app/views/performance/landing/content.tsx
@@ -119,7 +119,7 @@ class LandingContent extends React.Component<Props, State> {
     return (
       <React.Fragment>
         <SearchContainer>
-          <StyledSearchBar
+          <SearchBar
             organization={organization}
             projectIds={eventView.project}
             query={filterString}
@@ -131,24 +131,22 @@ class LandingContent extends React.Component<Props, State> {
             onSearch={handleSearch}
             maxQueryLength={MAX_QUERY_LENGTH}
           />
-          <ProjectTypeDropdown>
-            <DropdownControl
-              buttonProps={{prefix: t('Display')}}
-              label={currentLandingDisplay.label}
-            >
-              {LANDING_DISPLAYS.map(({label, field}) => (
-                <DropdownItem
-                  key={field}
-                  onSelect={this.handleLandingDisplayChange}
-                  eventKey={field}
-                  data-test-id={field}
-                  isActive={field === currentLandingDisplay.field}
-                >
-                  {label}
-                </DropdownItem>
-              ))}
-            </DropdownControl>
-          </ProjectTypeDropdown>
+          <DropdownControl
+            buttonProps={{prefix: t('Display')}}
+            label={currentLandingDisplay.label}
+          >
+            {LANDING_DISPLAYS.map(({label, field}) => (
+              <DropdownItem
+                key={field}
+                onSelect={this.handleLandingDisplayChange}
+                eventKey={field}
+                data-test-id={field}
+                isActive={field === currentLandingDisplay.field}
+              >
+                {label}
+              </DropdownItem>
+            ))}
+          </DropdownControl>
         </SearchContainer>
         {this.renderSelectedDisplay(currentLandingDisplay.field)}
       </React.Fragment>
@@ -288,7 +286,7 @@ class LandingContent extends React.Component<Props, State> {
 
     return (
       <React.Fragment>
-        <StyledSearchBar
+        <SearchBar
           organization={organization}
           projectIds={eventView.project}
           query={filterString}
@@ -345,14 +343,7 @@ class LandingContent extends React.Component<Props, State> {
 const SearchContainer = styled('div')`
   display: grid;
   grid-template-columns: 1fr min-content;
-`;
-
-const ProjectTypeDropdown = styled('div')`
-  margin-left: ${space(1)};
-`;
-
-const StyledSearchBar = styled(SearchBar)`
-  flex-grow: 1;
+  grid-gap: ${space(2)};
   margin-bottom: ${space(2)};
 `;
 

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -199,7 +199,7 @@ class SummaryContent extends React.Component<Props, State> {
 
     const durationTableTitle =
       spanOperationBreakdownFilter === SpanOperationBreakdownFilter.None
-        ? t('duration')
+        ? t('total duration')
         : `${spanOperationBreakdownFilter} duration`;
 
     return (

--- a/static/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -28,7 +28,7 @@ import {PerformanceDuration} from '../utils';
 const COLUMN_ORDER = [
   {
     key: 'key',
-    name: 'Key',
+    name: 'Tag Key',
     width: -1,
     column: {
       kind: 'field',
@@ -60,7 +60,7 @@ const COLUMN_ORDER = [
   },
   {
     key: 'comparison',
-    name: 'Comparison To Avg',
+    name: 'Compared To Avg',
     width: -1,
     column: {
       kind: 'field',

--- a/static/app/views/performance/vitalDetail/colorBar.tsx
+++ b/static/app/views/performance/vitalDetail/colorBar.tsx
@@ -36,7 +36,7 @@ const VitalBar = styled('div')<VitalBarProps>`
   display: grid;
   grid-template-columns: ${p => p.fractions.map(f => `${f}fr`).join(' ')};
   margin-bottom: ${space(1)};
-  border-radius: ${p => p.theme.borderRadius};
+  border-radius: 2px;
 `;
 
 type ColorProps = {


### PR DESCRIPTION
- Refactored for more even spacing next to display
![Screen Shot 2021-04-22 at 12 52 20 PM](https://user-images.githubusercontent.com/4830259/115776979-9adcfe80-a369-11eb-8a15-cc5065309afd.png)

- Change duration to total duration
![Screen Shot 2021-04-22 at 12 52 43 PM](https://user-images.githubusercontent.com/4830259/115777010-a6302a00-a369-11eb-990f-88711bdfd9a4.png)

- Less rounded web vital bar
![Screen Shot 2021-04-22 at 12 53 08 PM](https://user-images.githubusercontent.com/4830259/115777112-c2cc6200-a369-11eb-8fde-c33d1aaba095.png)

- Added Tag to Key and changed Comparison to Compared
![Screen Shot 2021-04-22 at 12 53 30 PM](https://user-images.githubusercontent.com/4830259/115777122-c5c75280-a369-11eb-9eda-565548beaf06.png)
