### PR TITLE
fix(dashboards): Fix widget intervals

### DIFF
--- a/src/sentry/models/dashboard.py
+++ b/src/sentry/models/dashboard.py
@@ -152,6 +152,7 @@ PREBUILT_DASHBOARDS = {
                 {
                     "title": "Errors by Country",
                     "displayType": "world_map",
+                    "interval": "5m",
                     "queries": [
                         {
                             "name": "Error counts",

--- a/static/app/views/dashboardsV2/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetQueries.tsx
@@ -36,7 +36,11 @@ function getWidgetInterval(
 ): string {
   // Bars charts are daily totals to aligned with discover. It also makes them
   // usefully different from line/area charts until we expose the interval control, or remove it.
-  const interval = widget.displayType === 'bar' ? '1d' : widget.interval;
+  let interval = widget.displayType === 'bar' ? '1d' : widget.interval;
+  if (!interval) {
+    // Default to 5 minutes
+    interval = '5m';
+  }
   const desiredPeriod = parsePeriodToHours(interval);
   const selectedRange = getDiffInMinutes(datetimeObj);
 


### PR DESCRIPTION
- The "Errors by Country" prebuilt widget is missing a default interval value. This can crash the widget card component when change that widget's display type to something other than World Map.
- If the widget's interval is falsey (e.g. empty string or `undefined`) then set the default interval value to be `5m`.


Fixes JAVASCRIPT-249J