### PR TITLE
fix(perf): Segment explorer pagination and more

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 
 from sentry import features, tagstore
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
+from sentry.api.paginator import GenericOffsetPaginator
 from sentry.snuba import discover
 
 
@@ -30,30 +31,44 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsV2EndpointBa
         if len(params.get("project_id", [])) > 1:
             raise ParseError(detail="You cannot view facet performance for multiple projects.")
 
-        with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
-            with self.handle_query_errors():
-                facets = discover.get_performance_facets(
-                    query=request.GET.get("query"),
-                    params=params,
-                    referrer="api.organization-events-facets-performance.top-tags",
-                    aggregate_column=aggregate_column,
-                    orderby=orderby,
-                )
+        def data_fn(offset, limit):
+            with sentry_sdk.start_span(op="discover.endpoint", description="discover_query"):
+                with self.handle_query_errors():
+                    facets = discover.get_performance_facets(
+                        query=request.GET.get("query"),
+                        params=params,
+                        referrer="api.organization-events-facets-performance.top-tags",
+                        aggregate_column=aggregate_column,
+                        orderby=orderby,
+                        offset=offset,
+                        limit=limit,
+                    )
+                with sentry_sdk.start_span(
+                    op="discover.endpoint", description="populate_results"
+                ) as span:
+                    span.set_data("facet_count", len(facets or []))
+                    resp = defaultdict(lambda: {"key": "", "value": {}})
+                    for row in facets:
+                        values = resp[row.key]
+                        values["key"] = tagstore.get_standardized_key(row.key)
+                        values["value"] = {
+                            "name": tagstore.get_tag_value_label(row.key, row.value),
+                            "value": row.value,
+                            "count": row.count,
+                            "frequency": row.frequency,
+                            "aggregate": row.performance,
+                            "comparison": row.comparison,
+                            "sumdelta": row.sumdelta,
+                        }
+                return {"data": list(resp.values())}
 
-        with sentry_sdk.start_span(op="discover.endpoint", description="populate_results") as span:
-            span.set_data("facet_count", len(facets or []))
-            resp = defaultdict(lambda: {"key": "", "topValues": []})
-            for row in facets:
-                values = resp[row.key]
-                values["key"] = tagstore.get_standardized_key(row.key)
-                values["topValues"].append(
-                    {
-                        "name": tagstore.get_tag_value_label(row.key, row.value),
-                        "value": row.value,
-                        "count": row.frequency,
-                        "aggregate": row.performance,
-                        "comparison": row.comparison,
-                        "sumdelta": row.sumdelta,
-                    }
-                )
-        return Response(list(resp.values()))
+        with self.handle_query_errors():
+            return self.paginate(
+                request=request,
+                paginator=GenericOffsetPaginator(data_fn=data_fn),
+                on_results=lambda results: self.handle_results_with_meta(
+                    request, organization, params["project_id"], results
+                ),
+                default_per_page=5,
+                max_per_page=5,
+            )

--- a/src/sentry/snuba/discover.py
+++ b/src/sentry/snuba/discover.py
@@ -897,7 +897,7 @@ def get_performance_facets(
                     key=r["tags_key"],
                     value=r["tags_value"],
                     performance=float(r["aggregate"]),
-                    count=float(r["cnt"]),
+                    count=int(r["cnt"]),
                     frequency=float((r["cnt"] / frequency_sample_rate) / transaction_count),
                     comparison=float(r["aggregate"] / transaction_aggregate),
                     sumdelta=float(r["sumdelta"]),

--- a/static/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
+++ b/static/app/utils/performance/segmentExplorer/segmentExplorerQuery.tsx
@@ -11,8 +11,8 @@ import withApi from 'app/utils/withApi';
 type IncomingDataRow = {
   id: string;
   key: string;
-  topValues: TopValue[];
-  [key: string]: string | number | IncomingTopValue[];
+  value: TopValue;
+  [key: string]: string | number | IncomingTopValue;
 };
 
 type IncomingTopValue = {
@@ -20,12 +20,15 @@ type IncomingTopValue = {
   value: string;
   aggregate: number;
   count: number;
+  frequency: number;
   comparison: number;
   sumdelta: number;
   isOther?: boolean;
 };
 
-type IncomingTableData = IncomingDataRow[];
+type IncomingTableData = {
+  data: IncomingDataRow[];
+};
 
 /**
  * An individual row in a Segment explorer result
@@ -33,9 +36,10 @@ type IncomingTableData = IncomingDataRow[];
 export type TableDataRow = IncomingDataRow & {
   aggregate: number;
   tagValue: TagHint;
+  count: number;
   frequency: number;
   comparison: number;
-  otherValues: TopValue[];
+  value: TopValue;
   totalTimeLost: number;
 };
 
@@ -72,6 +76,7 @@ export function getRequestFunction(_props: QueryProps) {
     const {eventView} = props;
     const apiPayload: FacetQuery = eventView.getEventsAPIPayload(props.location);
     apiPayload.aggregateColumn = aggregateColumn;
+    apiPayload.order = '-sumdelta';
     return apiPayload;
   }
   return getTagExplorerRequestPayload;
@@ -82,14 +87,15 @@ function shouldRefetchData(prevProps: QueryProps, nextProps: QueryProps) {
 }
 
 function afterFetch(data: IncomingTableData) {
-  const newData = data as TableData;
+  const newData = data.data as TableData;
   return newData.map(row => {
-    const firstItem = row.topValues[0];
-    row.tagValue = firstItem;
-    row.aggregate = firstItem.aggregate;
-    row.frequency = firstItem.count;
-    row.comparison = firstItem.comparison;
-    row.totalTimeLost = firstItem.sumdelta;
+    const value = row.value;
+    row.tagValue = value;
+    row.aggregate = value.aggregate;
+    row.frequency = value.frequency;
+    row.count = value.count;
+    row.comparison = value.comparison;
+    row.totalTimeLost = value.sumdelta;
     return row;
   });
 }

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -279,6 +279,7 @@ class SummaryContent extends React.Component<Props, State> {
                 location={location}
                 projects={projects}
                 transactionName={transactionName}
+                currentFilter={spanOperationBreakdownFilter}
               />
             </Feature>
             <RelatedIssues

--- a/static/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -1,14 +1,11 @@
 import React from 'react';
 import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
-import {Location} from 'history';
+import {Location, Query} from 'history';
 
-import DropdownButton from 'app/components/dropdownButton';
-import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import GridEditable from 'app/components/gridEditable';
 import Link from 'app/components/links/link';
 import Pagination from 'app/components/pagination';
-import Tooltip from 'app/components/tooltip';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
@@ -23,7 +20,15 @@ import {decodeScalar} from 'app/utils/queryString';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
 import {TableColumn} from 'app/views/eventsV2/table/types';
 
-import {PerformanceDuration} from '../utils';
+import {
+  PerformanceDuration,
+  platformToPerformanceType,
+  PROJECT_PERFORMANCE_TYPE,
+} from '../utils';
+
+import {SpanOperationBreakdownFilter} from './filter';
+
+const TAGS_CURSOR_NAME = 'tags_cursor';
 
 const COLUMN_ORDER = [
   {
@@ -76,32 +81,55 @@ const COLUMN_ORDER = [
   },
 ];
 
-const DURATION_OPTIONS: DropdownOption[] = [
-  {
-    label: 'transaction.duration',
-    value: 'duration',
-  },
-  {
-    label: 'measurements.lcp',
-    value: 'measurements[lcp]',
-  },
-  {
-    label: 'spans.browser',
-    value: 'span_op_breakdowns[ops.browser]',
-  },
-  {
-    label: 'spans.db',
-    value: 'span_op_breakdowns[ops.db]',
-  },
-  {
-    label: 'spans.http',
-    value: 'span_op_breakdowns[ops.http]',
-  },
-  {
-    label: 'spans.resource',
-    value: 'span_op_breakdowns[ops.resource]',
-  },
-];
+const filterToField = {
+  [SpanOperationBreakdownFilter.Browser]: 'span_op_breakdowns[ops.browser]',
+  [SpanOperationBreakdownFilter.Http]: 'span_op_breakdowns[ops.db]',
+  [SpanOperationBreakdownFilter.Db]: 'span_op_breakdowns[ops.http]',
+  [SpanOperationBreakdownFilter.Resource]: 'span_op_breakdowns[ops.resource]',
+};
+
+const getTransactionField = (
+  currentFilter: SpanOperationBreakdownFilter,
+  projects: Project[],
+  projectIds: readonly number[]
+) => {
+  const fieldFromFilter = filterToField[currentFilter];
+  if (fieldFromFilter) {
+    return fieldFromFilter;
+  }
+
+  const performanceType = platformToPerformanceType(projects, projectIds);
+  if (performanceType === PROJECT_PERFORMANCE_TYPE.FRONTEND) {
+    return 'measurements[lcp]';
+  }
+
+  return 'duration';
+};
+
+const getColumnsWithReplacedDuration = (
+  currentFilter: SpanOperationBreakdownFilter,
+  projects: Project[],
+  projectIds: readonly number[]
+) => {
+  const columns = COLUMN_ORDER.map(c => ({...c}));
+  const durationColumn = columns.find(c => c.key === 'aggregate');
+
+  if (!durationColumn) {
+    return columns;
+  }
+
+  const fieldFromFilter = filterToField[currentFilter];
+  if (fieldFromFilter) {
+    durationColumn.name = 'Avg Span Duration';
+  }
+
+  const performanceType = platformToPerformanceType(projects, projectIds);
+  if (performanceType === PROJECT_PERFORMANCE_TYPE.FRONTEND) {
+    durationColumn.name = 'Avg LCP';
+  }
+
+  return columns;
+};
 
 const handleTagValueClick = (location: Location, tagKey: string, tagValue: string) => {
   const queryString = decodeScalar(location.query.query);
@@ -156,11 +184,7 @@ const renderBodyCell = (
       text = `${pct} faster`;
     }
 
-    return (
-      <Tooltip title={PerformanceDuration({milliseconds: dataRow.aggregate})}>
-        {t(text)}
-      </Tooltip>
-    );
+    return t(text);
   }
   if (column.key === 'aggregate') {
     return <PerformanceDuration abbreviation milliseconds={dataRow.aggregate} />;
@@ -194,6 +218,7 @@ type Props = {
   location: Location;
   projects: Project[];
   transactionName: string;
+  currentFilter: SpanOperationBreakdownFilter;
 };
 
 type State = {
@@ -201,10 +226,6 @@ type State = {
 };
 
 class _TagExplorer extends React.Component<Props, State> {
-  state: State = {
-    aggregateColumn: DURATION_OPTIONS[0].value,
-  };
-
   setAggregateColumn(value: string) {
     this.setState({
       aggregateColumn: value,
@@ -212,14 +233,19 @@ class _TagExplorer extends React.Component<Props, State> {
   }
 
   render() {
-    const {eventView, organization, location} = this.props;
-    const {aggregateColumn} = this.state;
-    const handleCursor = () => {};
+    const {eventView, organization, location, currentFilter, projects} = this.props;
+    const aggregateColumn = getTransactionField(
+      currentFilter,
+      projects,
+      eventView.project
+    );
+    const columns = getColumnsWithReplacedDuration(
+      currentFilter,
+      projects,
+      eventView.project
+    );
 
-    const columnDropdownOptions = DURATION_OPTIONS;
-    const selectedColumn =
-      columnDropdownOptions.find(o => o.value === aggregateColumn) ||
-      columnDropdownOptions[0];
+    const cursor = decodeScalar(location.query?.[TAGS_CURSOR_NAME]);
 
     return (
       <SegmentExplorerQuery
@@ -228,29 +254,21 @@ class _TagExplorer extends React.Component<Props, State> {
         location={location}
         aggregateColumn={aggregateColumn}
         limit={5}
+        cursor={cursor}
       >
         {({isLoading, tableData, pageLinks}) => {
           return (
             <React.Fragment>
-              <TagsHeader
-                selectedColumn={selectedColumn}
-                columnOptions={columnDropdownOptions}
-                handleColumnDropdownChange={(v: string) => this.setAggregateColumn(v)}
-              />
+              <TagsHeader pageLinks={pageLinks} />
               <GridEditable
                 isLoading={isLoading}
                 data={tableData ? tableData : []}
-                columnOrder={COLUMN_ORDER}
+                columnOrder={columns}
                 columnSortBy={[]}
                 grid={{
                   renderBodyCell: renderBodyCellWithData(this.props) as any,
                 }}
                 location={location}
-              />
-              <StyledPagination
-                pageLinks={pageLinks}
-                onCursor={handleCursor}
-                size="small"
               />
             </React.Fragment>
           );
@@ -260,46 +278,22 @@ class _TagExplorer extends React.Component<Props, State> {
   }
 }
 
-type DropdownOption = {
-  label: string;
-  value: string;
-};
-
 type HeaderProps = {
-  selectedColumn: DropdownOption;
-  columnOptions: DropdownOption[];
-  handleColumnDropdownChange: (k: string) => void;
+  pageLinks: string | null;
 };
 function TagsHeader(props: HeaderProps) {
-  const {selectedColumn, columnOptions, handleColumnDropdownChange} = props;
+  const {pageLinks} = props;
+  const handleCursor = (cursor: string, pathname: string, query: Query) => {
+    browserHistory.push({
+      pathname,
+      query: {...query, [TAGS_CURSOR_NAME]: cursor},
+    });
+  };
+
   return (
     <Header>
       <SectionHeading>{t('Suspect Tags')}</SectionHeading>
-      <DropdownControl
-        data-test-id="tag-column-performance"
-        button={({isOpen, getActorProps}) => (
-          <StyledDropdownButton
-            {...getActorProps()}
-            isOpen={isOpen}
-            prefix={t('Column')}
-            size="small"
-          >
-            {selectedColumn.label}
-          </StyledDropdownButton>
-        )}
-      >
-        {columnOptions.map(({value, label}) => (
-          <DropdownItem
-            data-test-id={`option-${value}`}
-            key={value}
-            onSelect={handleColumnDropdownChange}
-            eventKey={value}
-            isActive={value === selectedColumn.value}
-          >
-            {label}
-          </DropdownItem>
-        ))}
-      </DropdownControl>
+      <StyledPagination pageLinks={pageLinks} onCursor={handleCursor} size="small" />
     </Header>
   );
 }
@@ -316,16 +310,12 @@ export const SectionHeading = styled('h4')`
 `;
 
 const Header = styled('div')`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin: 0 0 ${space(1)} 0;
-`;
-const StyledDropdownButton = styled(DropdownButton)`
-  min-width: 145px;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  margin-bottom: ${space(1)};
 `;
 const StyledPagination = styled(Pagination)`
-  margin: 0 0 ${space(3)} 0;
+  margin: 0 0 0 ${space(1)};
 `;
 
 export const TagExplorer = _TagExplorer;

--- a/static/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -221,17 +221,7 @@ type Props = {
   currentFilter: SpanOperationBreakdownFilter;
 };
 
-type State = {
-  aggregateColumn: string;
-};
-
-class _TagExplorer extends React.Component<Props, State> {
-  setAggregateColumn(value: string) {
-    this.setState({
-      aggregateColumn: value,
-    });
-  }
-
+class _TagExplorer extends React.Component<Props> {
   render() {
     const {eventView, organization, location, currentFilter, projects} = this.props;
     const aggregateColumn = getTransactionField(

--- a/static/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -175,16 +175,8 @@ const renderBodyCell = (
   if (column.key === 'comparison') {
     const localValue = dataRow.comparison;
 
-    let text = '';
-    if (localValue > 1) {
-      const pct = formatPercentage(localValue - 1, 0);
-      text = `+${pct} slower`;
-    } else {
-      const pct = formatPercentage(localValue - 1, 0);
-      text = `${pct} faster`;
-    }
-
-    return t(text);
+    const pct = formatPercentage(localValue - 1, 0);
+    return localValue > 1 ? t('+%s slower', pct) : t('%s faster', pct);
   }
   if (column.key === 'aggregate') {
     return <PerformanceDuration abbreviation milliseconds={dataRow.aggregate} />;

--- a/static/app/views/performance/utils.tsx
+++ b/static/app/views/performance/utils.tsx
@@ -2,13 +2,59 @@ import React from 'react';
 import {Location, LocationDescriptor, Query} from 'history';
 
 import Duration from 'app/components/duration';
-import {GlobalSelection, OrganizationSummary} from 'app/types';
+import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
+import {backend, frontend} from 'app/data/platformCategories';
+import {GlobalSelection, OrganizationSummary, Project} from 'app/types';
 import {defined} from 'app/utils';
 import {statsPeriodToDays} from 'app/utils/dates';
 import getCurrentSentryReactTransaction from 'app/utils/getCurrentSentryReactTransaction';
 import {decodeScalar} from 'app/utils/queryString';
 
 import {FilterViews} from './landing';
+
+/**
+ * Performance type can used to determine a default view or which specific field should be used by default on pages
+ * where we don't want to wait for transaction data to return to determine how to display aspects of a page.
+ */
+export enum PROJECT_PERFORMANCE_TYPE {
+  ANY = 'any', // Fallback to transaction duration
+  FRONTEND = 'frontend',
+  BACKEND = 'backend',
+}
+
+const FRONTEND_PLATFORMS: string[] = [...frontend];
+const BACKEND_PLATFORMS: string[] = [...backend];
+
+export function platformToPerformanceType(
+  projects: Project[],
+  projectIds: readonly number[]
+) {
+  if (projectIds.length === 0 || projectIds[0] === ALL_ACCESS_PROJECTS) {
+    return PROJECT_PERFORMANCE_TYPE.ANY;
+  }
+  const selectedProjects = projects.filter(p => projectIds.includes(parseInt(p.id, 10)));
+  if (selectedProjects.length === 0 || selectedProjects.some(p => !p.platform)) {
+    return PROJECT_PERFORMANCE_TYPE.ANY;
+  }
+
+  if (
+    selectedProjects.every(project =>
+      FRONTEND_PLATFORMS.includes(project.platform as string)
+    )
+  ) {
+    return PROJECT_PERFORMANCE_TYPE.FRONTEND;
+  }
+
+  if (
+    selectedProjects.every(project =>
+      BACKEND_PLATFORMS.includes(project.platform as string)
+    )
+  ) {
+    return PROJECT_PERFORMANCE_TYPE.BACKEND;
+  }
+
+  return PROJECT_PERFORMANCE_TYPE.ANY;
+}
 
 export function getPerformanceLandingUrl(organization: OrganizationSummary): string {
   return `/organizations/${organization.slug}/performance/`;


### PR DESCRIPTION
### Summary
This PR changes the api to allow for pagination, removes the old topValues array since it's a singular value now, fixes the sorting issues with sumdelta after having removed the previous dropdown, and automatically picks a column based on what you are looking at it.

It also:
- Adds a generic platform to performance type function
- Removes some dead code