### PR TITLE
fix(orgstats): filter category instead of groupBy

### DIFF
--- a/static/app/views/usageStats/types.tsx
+++ b/static/app/views/usageStats/types.tsx
@@ -5,6 +5,7 @@ export enum Outcome {
   FILTERED = 'filtered',
   INVALID = 'invalid',
   DROPPED = 'dropped',
+  RATE_LIMITED = 'rate_limited',
 }
 
 /**

--- a/static/app/views/usageStats/usageStatsOrg.tsx
+++ b/static/app/views/usageStats/usageStatsOrg.tsx
@@ -218,11 +218,11 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
         dropped: 0,
         invalid: 0,
         filtered: 0,
+        rate_limited: 0,
       };
 
       orgStats.groups.forEach(group => {
         const {outcome, category} = group.by;
-
         // HACK: The backend enum are singular, but the frontend enums are plural
         if (!dataCategory.includes(`${category}`)) {
           return;
@@ -232,7 +232,7 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
         count[outcome] += group.totals['sum(quantity)'];
 
         group.series['sum(quantity)'].forEach((stat, i) => {
-          if (outcome === Outcome.DROPPED || outcome === Outcome.INVALID) {
+          if (outcome === Outcome.RATE_LIMITED || outcome === Outcome.INVALID) {
             usageStats[i].dropped.total += stat;
           }
 
@@ -240,9 +240,11 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
         });
       });
 
-      // Invalid data is dropped
+      // Invalid and rate_limited data is dropped
       count.dropped += count.invalid;
+      count.dropped += count.rate_limited;
       delete count.invalid;
+      delete count.rate_limited;
 
       usageStats.forEach(stat => {
         stat.total = stat.accepted + stat.filtered + stat.dropped.total;

--- a/tests/js/spec/views/usageStats/index.spec.jsx
+++ b/tests/js/spec/views/usageStats/index.spec.jsx
@@ -49,10 +49,10 @@ describe('UsageStats', function () {
     expect(orgAsync.props().dataDatetime.period).toEqual(DEFAULT_STATS_PERIOD);
     expect(orgAsync.props().dataCategory).toEqual(DataCategory.ERRORS);
     expect(orgAsync.props().chartTransform).toEqual(undefined);
-    expect(orgAsync.text()).toContain('Total Errors49');
+    expect(orgAsync.text()).toContain('Total Errors64');
     expect(orgAsync.text()).toContain('Accepted28');
     expect(orgAsync.text()).toContain('Filtered7');
-    expect(orgAsync.text()).toContain('Dropped14');
+    expect(orgAsync.text()).toContain('Dropped29');
 
     const orgChart = wrapper.find('UsageChart');
     expect(orgChart.props().dataCategory).toEqual(DataCategory.ERRORS);
@@ -368,13 +368,25 @@ function getMockResponse() {
         {
           by: {
             category: 'error',
-            outcome: 'dropped',
+            outcome: 'rate_limited',
           },
           totals: {
             'sum(quantity)': 14,
           },
           series: {
             'sum(quantity)': [2, 2, 2, 2, 2, 2, 2],
+          },
+        },
+        {
+          by: {
+            category: 'error',
+            outcome: 'invalid',
+          },
+          totals: {
+            'sum(quantity)': 15,
+          },
+          series: {
+            'sum(quantity)': [2, 2, 2, 2, 2, 2, 3],
           },
         },
       ],

--- a/tests/js/spec/views/usageStats/index.spec.jsx
+++ b/tests/js/spec/views/usageStats/index.spec.jsx
@@ -107,8 +107,9 @@ describe('UsageStats', function () {
         query: {
           statsPeriod: DEFAULT_STATS_PERIOD,
           interval: '1d',
-          groupBy: ['category', 'outcome', 'project'],
+          groupBy: ['outcome', 'project'],
           field: ['sum(quantity)'],
+          category: 'error',
         },
       })
     );
@@ -205,7 +206,8 @@ describe('UsageStats', function () {
         query: {
           statsPeriod: ninetyDays,
           interval: '1d',
-          groupBy: ['category', 'outcome', 'project'],
+          groupBy: ['outcome', 'project'],
+          category: 'transaction',
           field: ['sum(quantity)'],
         },
       })


### PR DESCRIPTION
Filter by category instead of grouping by category and make a new call when category is switched for the projects tables.
This is done so we do not drop rows on very large orgs. this will satisfy requirements until a proper endpoint with pagination can be built.  (this increases it so max limit from ~600 active projects to ~2500 until rows start to drop).

bonus: also include rate_limited outcomes in "Dropped"