### PR TITLE
fix(analytics): update analytics function signature to include organization_id

### DIFF
--- a/static/app/components/globalSdkUpdateAlert.tsx
+++ b/static/app/components/globalSdkUpdateAlert.tsx
@@ -45,21 +45,21 @@ const recordAnalyticsSeen = ({organization}: AnalyticsOpts) =>
   trackAnalyticsEvent({
     eventKey: 'sdk_updates.seen',
     eventName: 'SDK Updates: Seen',
-    organizationId: organization.id,
+    organization_id: organization.id,
   });
 
 const recordAnalyticsSnoozed = ({organization}: AnalyticsOpts) =>
   trackAnalyticsEvent({
     eventKey: 'sdk_updates.snoozed',
     eventName: 'SDK Updates: Snoozed',
-    organizationId: organization.id,
+    organization_id: organization.id,
   });
 
 const recordAnalyticsClicked = ({organization}: AnalyticsOpts) =>
   trackAnalyticsEvent({
     eventKey: 'sdk_updates.clicked',
     eventName: 'SDK Updates: Clicked',
-    organizationId: organization.id,
+    organization_id: organization.id,
   });
 
 const flattenSuggestions = (list: ProjectSdkUpdates[]) =>

--- a/static/app/components/numberDragControl.tsx
+++ b/static/app/components/numberDragControl.tsx
@@ -47,6 +47,7 @@ class NumberDragControl extends React.Component<Props, State> {
           trackAnalyticsEvent({
             eventName: 'Number Drag Control: Clicked',
             eventKey: 'number_drag_control.clicked',
+            organization_id: null,
           });
 
           event.currentTarget.requestPointerLock();

--- a/static/app/components/search/index.tsx
+++ b/static/app/components/search/index.tsx
@@ -112,6 +112,7 @@ class Search extends React.Component<Props> {
     trackAnalyticsEvent({
       eventKey: `${this.props.entryPoint}.open`,
       eventName: `${this.props.entryPoint} Open`,
+      organization_id: null,
     });
   }
 
@@ -126,6 +127,7 @@ class Search extends React.Component<Props> {
       query: state && state.inputValue,
       result_type: item.resultType,
       source_type: item.sourceType,
+      organization_id: null,
     });
 
     const {to, action} = item;
@@ -169,6 +171,7 @@ class Search extends React.Component<Props> {
       eventKey: `${this.props.entryPoint}.query`,
       eventName: `${this.props.entryPoint} Query`,
       query,
+      organization_id: null,
     });
   }, 200);
 

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -215,6 +215,7 @@ type AnalyticsTrackEvent = (opts: {
    * The English string used as the name of the event.
    */
   eventName: string;
+  organization_id: string | number | null;
   /**
    * Arbitrary data to track
    */

--- a/static/app/views/performance/transactionSummary/keyTransactionButton.tsx
+++ b/static/app/views/performance/transactionSummary/keyTransactionButton.tsx
@@ -104,7 +104,7 @@ class KeyTransactionButton extends React.Component<Props, State> {
     trackAnalyticsEvent({
       eventName: 'Performance Views: Key Transaction toggle',
       eventKey: 'performance_views.key_transaction.toggle',
-      orgId: parseInt(organization.id, 10),
+      organization_id: organization.id,
       action: isKeyTransaction ? 'remove' : 'add',
     });
 

--- a/static/app/views/projectsDashboard/resources.tsx
+++ b/static/app/views/projectsDashboard/resources.tsx
@@ -22,7 +22,7 @@ class Resources extends React.Component<Props> {
     trackAnalyticsEvent({
       eventKey: 'orgdash.resources_shown',
       eventName: 'Projects Dashboard: Resources Shown',
-      organization: organization.id,
+      organization_id: organization.id,
     });
   }
 

--- a/static/app/views/settings/components/settingsNavigationGroup.tsx
+++ b/static/app/views/settings/components/settingsNavigationGroup.tsx
@@ -29,7 +29,7 @@ const SettingsNavigationGroup = (props: NavigationGroupProps) => {
           //only call the analytics event if the URL is changing
           if (recordAnalytics && to !== window.location.pathname) {
             trackAnalyticsEvent({
-              organization_id: organization && organization.id,
+              organization_id: organization ? organization.id : null,
               project_id: project && project.id,
               eventName: 'Sidebar Item Clicked',
               eventKey: 'sidebar.item_clicked',


### PR DESCRIPTION
This PR explicitly requires all analytics events to have `organization_id` of `string | number | null`. This is to prevent the frequent bugs where we pass in `organization_id=undefined` which means [we don't record the analytics event](https://github.com/getsentry/getsentry/blob/e4e77129fc2e04ad9fdf93b496ba98bb852c750b/static/getsentry/gsApp/utils/trackAnalyticsEvent.tsx#L81-L83). If we don't care about the `organization_id`, just pass in `null`.

After this is merged, I'll make a getsentry PR to make typing stricter there as well.