### PR TITLE
fix(monitoring): Log when we timeout on creating short_id

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -977,6 +977,7 @@ def _save_aggregate2(event, flat_hashes, hierarchical_hashes, release, **kwargs)
                         "next_short_id.timeout",
                         tags={"platform": event.platform or "unknown"},
                     )
+                    sentry_sdk.capture_message("short_id.timeout")
                     raise HashDiscarded("Timeout when getting next_short_id")
 
                 # it's possible the release was deleted between


### PR DESCRIPTION
We want to gain visibility into which projects are most affected when short_id incr is contending. We have a metric for this but cannot use high-cardinality tags there. Since this is happening rarely enough (observable via metric), we can afford sending a message to Sentry. The project is tagged for the entire task.

All of those messages should group together so we only need to go through group creation once. That said if save_event is _really really_ down we will not benefit from this.