### PR TITLE
fix(api): Get sessions bounds only for required project

### DIFF
--- a/src/sentry/api/endpoints/organization_release_meta.py
+++ b/src/sentry/api/endpoints/organization_release_meta.py
@@ -13,7 +13,6 @@ from sentry.models import (
     ReleaseFile,
     ReleaseProject,
 )
-from sentry.snuba.sessions import get_release_sessions_time_bounds
 
 
 class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
@@ -65,8 +64,6 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
         for project_id, platform in platforms:
             platforms_by_project[project_id].append(platform)
 
-        environments = set(request.GET.getlist("environment")) or None
-
         # This must match what is returned from the `Release` serializer
         projects = [
             {
@@ -76,12 +73,6 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
                 "newGroups": pr["new_groups"],
                 "platform": pr["project__platform"],
                 "platforms": platforms_by_project.get(pr["project__id"]) or [],
-                **get_release_sessions_time_bounds(
-                    project_id=pr["project__id"],
-                    release=release.version,
-                    org_id=organization.id,
-                    environments=environments,
-                ),
             }
             for pr in project_releases
         ]

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -448,6 +448,14 @@ class ReleaseSerializer(Serializer):
                 rv["healthData"] = expose_health_data(project["health_data"])
             return rv
 
+        def expose_current_project_meta(current_project_meta):
+            rv = {}
+            if "sessions_lower_bound" in current_project_meta:
+                rv["sessionsLowerBound"] = current_project_meta["sessions_lower_bound"]
+            if "sessions_upper_bound" in current_project_meta:
+                rv["sessionsUpperBound"] = current_project_meta["sessions_upper_bound"]
+            return rv
+
         d = {
             "version": obj.version,
             "status": ReleaseStatus.to_string(obj.status),
@@ -468,5 +476,8 @@ class ReleaseSerializer(Serializer):
             "projects": [expose_project(p) for p in attrs.get("projects", [])],
             "firstEvent": attrs.get("first_seen"),
             "lastEvent": attrs.get("last_seen"),
+            "currentProjectMeta": expose_current_project_meta(
+                kwargs.get("current_project_meta", {})
+            ),
         }
         return d

--- a/tests/sentry/api/endpoints/test_organization_release_meta.py
+++ b/tests/sentry/api/endpoints/test_organization_release_meta.py
@@ -84,5 +84,3 @@ class ReleaseMetaTest(APITestCase):
         assert data["commitFilesChanged"] == 2
         assert data["releaseFileCount"] == 1
         assert len(data["projects"]) == 2
-        assert data["projects"][0]["sessions_upper_bound"] is None
-        assert data["projects"][0]["sessions_lower_bound"] is None


### PR DESCRIPTION
This PR,
- Moves the functionality of fetching sessions time bound from OrganizationReleaseMetaEndpoint to OrganizationReleaseDetailsEndpoint to prevent fetching sessions time bounds for all projects, when they are only required for a specific project in the release endpoint 

Ref: https://app.asana.com/0/1199560214229133/1200233951975053