### PR TITLE
ref(ui) Replace more contextTypes with HOCs

### DIFF
--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import {browserHistory} from 'react-router';
+import {browserHistory, withRouter, WithRouterProps} from 'react-router';
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
-import PropTypes from 'prop-types';
 import * as qs from 'query-string';
 
 import {fetchOrgMembers, indexMembersByProject} from 'app/actionCreators/members';
@@ -32,7 +31,7 @@ const defaultProps = {
   useFilteredStats: true,
 };
 
-type Props = {
+type Props = WithRouterProps & {
   api: Client;
   query: string;
   orgId: string;
@@ -60,10 +59,6 @@ type State = {
 };
 
 class GroupList extends React.Component<Props, State> {
-  static contextTypes = {
-    location: PropTypes.object,
-  };
-
   static defaultProps = defaultProps;
 
   state: State = {
@@ -147,9 +142,9 @@ class GroupList extends React.Component<Props, State> {
   }
 
   getQueryParams() {
-    const {query} = this.props;
+    const {location, query} = this.props;
 
-    const queryParams = this.context.location.query;
+    const queryParams = location.query;
     queryParams.limit = 50;
     queryParams.sort = 'new';
     queryParams.query = query;
@@ -265,4 +260,4 @@ class GroupList extends React.Component<Props, State> {
 
 export {GroupList};
 
-export default withApi(GroupList);
+export default withApi(withRouter(GroupList));

--- a/static/app/components/smartSearchBar/index.tsx
+++ b/static/app/components/smartSearchBar/index.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import {browserHistory} from 'react-router';
+import {browserHistory, withRouter, WithRouterProps} from 'react-router';
 import {ClassNames, withTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import createReactClass from 'create-react-class';
 import debounce from 'lodash/debounce';
-import PropTypes from 'prop-types';
 import Reflux from 'reflux';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
@@ -139,7 +138,7 @@ const ThemedCreateSavedSearchButton = withTheme(
   )
 );
 
-type Props = {
+type Props = WithRouterProps & {
   api: Client;
   organization: LightWeightOrganization;
   dropdownClassName?: string;
@@ -303,10 +302,6 @@ class SmartSearchBar extends React.Component<Props, State> {
    */
   static getQueryTerms = (query: string, cursor: number) =>
     query.slice(0, cursor).match(/\S+:"[^"]*"?|\S+/g);
-
-  static contextTypes = {
-    router: PropTypes.object,
-  };
 
   static defaultProps = {
     defaultQuery: '',
@@ -621,7 +616,7 @@ class SmartSearchBar extends React.Component<Props, State> {
         return [];
       }
 
-      const {location} = this.context.router;
+      const {location} = this.props;
       const endpointParams = getParams(location.query);
 
       this.setState({loading: true});
@@ -746,8 +741,7 @@ class SmartSearchBar extends React.Component<Props, State> {
    * if an error is encountered.
    */
   fetchReleases = async (releaseVersion: string): Promise<any[]> => {
-    const {api, organization} = this.props;
-    const {location} = this.context.router;
+    const {api, location, organization} = this.props;
 
     const project = location && location.query ? location.query.projectId : undefined;
 
@@ -947,14 +941,13 @@ class SmartSearchBar extends React.Component<Props, State> {
   onTogglePinnedSearch = async (evt: React.MouseEvent) => {
     const {
       api,
+      location,
       organization,
       savedSearchType,
       hasPinnedSearch,
       pinnedSearch,
       sort,
     } = this.props;
-
-    const {router} = this.context;
 
     evt.preventDefault();
     evt.stopPropagation();
@@ -964,7 +957,7 @@ class SmartSearchBar extends React.Component<Props, State> {
     }
 
     // eslint-disable-next-line no-unused-vars
-    const {cursor: _cursor, page: _page, ...currentQuery} = router.location.query;
+    const {cursor: _cursor, page: _page, ...currentQuery} = location.query;
 
     trackAnalyticsEvent({
       eventKey: 'search.pin',
@@ -978,7 +971,7 @@ class SmartSearchBar extends React.Component<Props, State> {
     if (!!pinnedSearch) {
       unpinSearch(api, organization.slug, savedSearchType, pinnedSearch).then(() => {
         browserHistory.push({
-          ...router.location,
+          ...location,
           pathname: `/organizations/${organization.slug}/issues/`,
           query: {
             ...currentQuery,
@@ -1003,7 +996,7 @@ class SmartSearchBar extends React.Component<Props, State> {
     }
 
     browserHistory.push({
-      ...router.location,
+      ...location,
       pathname: `/organizations/${organization.slug}/issues/searches/${resp.id}/`,
       query: currentQuery,
     });
@@ -1079,7 +1072,7 @@ class SmartSearchBar extends React.Component<Props, State> {
         this.searchInput.current.focus();
       }
 
-      // then update the autocomplete box with new contextTypes
+      // then update the autocomplete box with new items
       this.updateAutoCompleteItems();
       this.props.onChange?.(newQuery, new MouseEvent('click') as any);
     });
@@ -1304,7 +1297,7 @@ const SmartSearchBarContainer = createReactClass<Props>({
   },
 });
 
-export default withApi(withOrganization(SmartSearchBarContainer));
+export default withApi(withRouter(withOrganization(SmartSearchBarContainer)));
 export {SmartSearchBar};
 
 const Container = styled('div')<{isOpen: boolean}>`

--- a/tests/js/spec/components/smartSearchBar.spec.jsx
+++ b/tests/js/spec/components/smartSearchBar.spec.jsx
@@ -36,7 +36,7 @@ describe('removeSpace()', function () {
 });
 
 describe('SmartSearchBar', function () {
-  let options, organization, supportedTags;
+  let location, options, organization, supportedTags;
   let environmentTagValuesMock;
   const tagValuesMock = jest.fn(() => Promise.resolve([]));
 
@@ -51,7 +51,7 @@ describe('SmartSearchBar', function () {
     };
     organization = TestStubs.Organization({id: '123'});
 
-    const location = {
+    location = {
       pathname: '/organizations/org-slug/recent-searches/',
       query: {
         projectId: '0',
@@ -91,6 +91,7 @@ describe('SmartSearchBar', function () {
       orgId: 'org-slug',
       projectId: '0',
       query: '',
+      location,
       organization,
       supportedTags,
       onGetTagValues: getTagValuesMock,
@@ -125,6 +126,7 @@ describe('SmartSearchBar', function () {
       orgId: 'org-slug',
       projectId: '0',
       query: '',
+      location,
       organization,
       supportedTags,
       onGetTagValues: getTagValuesMock,
@@ -159,6 +161,7 @@ describe('SmartSearchBar', function () {
       orgId: 'org-slug',
       projectId: '0',
       query: '',
+      location,
       organization,
       supportedTags,
       onGetTagValues: getTagValuesMock,
@@ -191,6 +194,7 @@ describe('SmartSearchBar', function () {
       orgId: 'org-slug',
       projectId: '0',
       query: '',
+      location,
       organization,
       supportedTags,
       onGetTagValues: getTagValuesMock,
@@ -227,6 +231,7 @@ describe('SmartSearchBar', function () {
       const searchBar = mountWithTheme(
         <SmartSearchBar
           organization={organization}
+          location={location}
           supportedTags={supportedTags}
           query="one"
         />,
@@ -240,6 +245,7 @@ describe('SmartSearchBar', function () {
       const searchBar = mountWithTheme(
         <SmartSearchBar
           organization={organization}
+          location={location}
           supportedTags={supportedTags}
           query="one"
         />,
@@ -255,6 +261,7 @@ describe('SmartSearchBar', function () {
       const searchBar = mountWithTheme(
         <SmartSearchBar
           organization={organization}
+          location={location}
           supportedTags={supportedTags}
           query="one"
         />,
@@ -271,6 +278,7 @@ describe('SmartSearchBar', function () {
       const searchBar = mountWithTheme(
         <SmartSearchBar
           organization={organization}
+          location={location}
           supportedTags={supportedTags}
           query="one"
         />,
@@ -319,6 +327,7 @@ describe('SmartSearchBar', function () {
     it('clears the query', function () {
       const props = {
         organization,
+        location,
         query: 'is:unresolved ruby',
         defaultQuery: 'is:unresolved',
         supportedTags,
@@ -333,6 +342,7 @@ describe('SmartSearchBar', function () {
     it('calls onSearch()', async function () {
       const props = {
         organization,
+        location,
         query: 'is:unresolved ruby',
         defaultQuery: 'is:unresolved',
         supportedTags,
@@ -350,6 +360,7 @@ describe('SmartSearchBar', function () {
       const searchBar = mountWithTheme(
         <SmartSearchBar
           organization={organization}
+          location={location}
           supportedTags={supportedTags}
           onGetTagValues={tagValuesMock}
         />,
@@ -366,6 +377,7 @@ describe('SmartSearchBar', function () {
       const searchBar = mountWithTheme(
         <SmartSearchBar
           organization={organization}
+          location={location}
           supportedTags={supportedTags}
           onGetTagValues={tagValuesMock}
           hasPinnedSearch
@@ -383,7 +395,11 @@ describe('SmartSearchBar', function () {
   describe('onQueryBlur()', function () {
     it('hides the drop down', function () {
       const searchBar = mountWithTheme(
-        <SmartSearchBar organization={organization} supportedTags={supportedTags} />,
+        <SmartSearchBar
+          organization={organization}
+          location={location}
+          supportedTags={supportedTags}
+        />,
         options
       ).instance();
       searchBar.state.dropdownVisible = true;
@@ -400,7 +416,11 @@ describe('SmartSearchBar', function () {
     describe('escape', function () {
       it('blurs the input', function () {
         const wrapper = mountWithTheme(
-          <SmartSearchBar organization={organization} supportedTags={supportedTags} />,
+          <SmartSearchBar
+            organization={organization}
+            location={location}
+            supportedTags={supportedTags}
+          />,
           options
         );
         wrapper.setState({dropdownVisible: true});
@@ -422,6 +442,7 @@ describe('SmartSearchBar', function () {
         <SmartSearchBar
           onSearch={stubbedOnSearch}
           organization={organization}
+          location={location}
           query="is:unresolved"
           supportedTags={supportedTags}
         />,
@@ -439,6 +460,7 @@ describe('SmartSearchBar', function () {
       jest.useRealTimers();
       const props = {
         organization,
+        location,
         query: 'is:unresolved',
         supportedTags,
         onSearch: jest.fn(),
@@ -458,6 +480,7 @@ describe('SmartSearchBar', function () {
           onSearch={stubbedOnSearch}
           organization={organization}
           query="is:unresolved"
+          location={location}
           supportedTags={supportedTags}
           hasPinnedSearch
         />,
@@ -475,6 +498,7 @@ describe('SmartSearchBar', function () {
       query: '',
       defaultQuery: 'is:unresolved',
       organization,
+      location,
       supportedTags,
     };
     const wrapper = mountWithTheme(<SmartSearchBar {...props} />, options);
@@ -489,6 +513,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: '',
         organization,
+        location,
         supportedTags,
       };
       const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
@@ -502,6 +527,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: 'fu',
         organization,
+        location,
         supportedTags,
       };
       jest.useRealTimers();
@@ -521,6 +547,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: '!fu',
         organization,
+        location,
         supportedTags,
       };
       jest.useRealTimers();
@@ -540,6 +567,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: 'is:unresolved fu',
         organization,
+        location,
         supportedTags,
       };
       jest.useRealTimers();
@@ -560,6 +588,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: 'environment:production',
         excludeEnvironment: true,
+        location,
         organization,
         supportedTags,
       };
@@ -598,6 +627,7 @@ describe('SmartSearchBar', function () {
         orgId: 'org-slug',
         projectId: '0',
         query: 'firstRelease:',
+        location,
         organization,
         supportedTags,
       };
@@ -627,6 +657,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: 'event.type:error ',
         organization,
+        location,
         supportedTags,
       };
       const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
@@ -638,6 +669,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: 'id: event.type:error ',
         organization,
+        location,
         supportedTags,
       };
       const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
@@ -650,6 +682,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: 'event.type:error id:',
         organization,
+        location,
         supportedTags,
       };
       const searchBar = mountWithTheme(<SmartSearchBar {...props} />, options).instance();
@@ -663,6 +696,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: 'event.type:error id:',
         organization,
+        location,
         supportedTags,
       };
       const searchBar = mountWithTheme(
@@ -681,6 +715,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: '',
         organization,
+        location,
         supportedTags,
       };
       const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
@@ -698,6 +733,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: '',
         organization,
+        location,
         supportedTags,
       };
       const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
@@ -723,6 +759,7 @@ describe('SmartSearchBar', function () {
       const props = {
         query: '',
         organization,
+        location,
         supportedTags,
       };
       const smartSearchBar = mountWithTheme(<SmartSearchBar {...props} />, options);
@@ -770,6 +807,7 @@ describe('SmartSearchBar', function () {
           query=""
           supportedTags={supportedTags}
           savedSearchType={0}
+          location={location}
           hasPinnedSearch
         />,
         options
@@ -788,6 +826,7 @@ describe('SmartSearchBar', function () {
           query="is:unresolved"
           supportedTags={supportedTags}
           savedSearchType={0}
+          location={location}
           hasPinnedSearch
         />,
         options
@@ -808,6 +847,7 @@ describe('SmartSearchBar', function () {
           query="is:unresolved"
           supportedTags={supportedTags}
           savedSearchType={0}
+          location={location}
           pinnedSearch={pinnedSearch}
           hasPinnedSearch
         />,


### PR DESCRIPTION
Replace a few more instances of `contextTypes` with HoCs. Working towards not using the legacy context APIs anymore.