### PR TITLE
fix(tests): Add an option to disable the sdk on tests

### DIFF
--- a/src/sentry/utils/pytest/sentry.py
+++ b/src/sentry/utils/pytest/sentry.py
@@ -123,6 +123,9 @@ def pytest_configure(config):
         settings.SENTRY_TSDB = "sentry.tsdb.redissnuba.RedisSnubaTSDB"
         settings.SENTRY_EVENTSTREAM = "sentry.eventstream.snuba.SnubaEventStream"
 
+    if os.environ.get("DISABLE_TEST_SDK", False):
+        settings.SENTRY_SDK_CONFIG = {}
+
     if not hasattr(settings, "SENTRY_OPTIONS"):
         settings.SENTRY_OPTIONS = {}
 


### PR DESCRIPTION
- Right now locally if there's an error in tests, the sentry_sdk is very
  noisy cause its trying to send the error and the sdk's debug is on by
  default. Using an option to disable it as an easy way to remove this
  noise
eg. 
<img width="1364" alt="image" src="https://user-images.githubusercontent.com/4205004/115898856-09829080-a42c-11eb-8a1a-bad70513f723.png">
