### PR TITLE
fix(performace): Format duration chart yaxis

### DIFF
--- a/static/app/views/performance/charts/chart.tsx
+++ b/static/app/views/performance/charts/chart.tsx
@@ -94,7 +94,16 @@ class Chart extends React.Component<Props> {
         ];
 
     const yAxes = disableMultiAxis
-      ? undefined
+      ? [
+          {
+            axisLabel: {
+              color: theme.chartLabel,
+              formatter(value: number) {
+                return axisLabelFormatter(value, data[0].seriesName);
+              },
+            },
+          },
+        ]
       : [
           {
             gridIndex: 0,


### PR DESCRIPTION
Duration based charts on performance landing are not using the axis formatted.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/115904555-ec9d8b80-a432-11eb-81fa-764e716bed91.png)

## After

![image](https://user-images.githubusercontent.com/10239353/115904572-f1fad600-a432-11eb-8e25-9558efebc102.png)
