### PR TITLE
ref(issues): Use in-search for me_or_none

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -983,7 +983,7 @@ SENTRY_FEATURES = {
     "organizations:inbox": False,
     # Set default tab to inbox
     "organizations:inbox-tab-default": False,
-    # Add `assigned_or_suggested:me_or_none` to inbox tab query
+    # Add `assigned_or_suggested:[me, none]` to inbox tab query
     "organizations:inbox-owners-query": False,
     # Enable the new alert details ux design
     "organizations:alert-details-redesign": False,

--- a/static/app/utils/withIssueTags.tsx
+++ b/static/app/utils/withIssueTags.tsx
@@ -86,7 +86,7 @@ const withIssueTags = <P extends InjectedTagsProps>(
       const teamnames: string[] = teams
         .filter(team => team.isMember)
         .map(team => `#${team.slug}`);
-      const allAssigned = ['me_or_none', ...usernames.concat(teamnames)];
+      const allAssigned = ['[me, none]', ...usernames.concat(teamnames)];
       allAssigned.unshift('me');
       usernames.unshift('me');
 

--- a/static/app/views/issueList/searchBar.tsx
+++ b/static/app/views/issueList/searchBar.tsx
@@ -34,7 +34,7 @@ const SEARCH_ITEMS: SearchItem[] = [
   {
     title: t('Assigned'),
     desc:
-      'assigned, assigned_or_suggested:[me|me_or_none|user@example.com|#team-example]',
+      'assigned, assigned_or_suggested:[me|[me, none]|user@example.com|#team-example]',
     value: '',
     type: 'default',
   },

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -5,7 +5,7 @@ import {t, tct} from 'app/locale';
 import {Organization} from 'app/types';
 
 export enum Query {
-  FOR_REVIEW = 'is:unresolved is:for_review assigned_or_suggested:me_or_none',
+  FOR_REVIEW = 'is:unresolved is:for_review assigned_or_suggested:[me, none]',
   UNRESOLVED = 'is:unresolved',
   IGNORED = 'is:ignored',
   REPROCESSING = 'is:reprocessing',

--- a/tests/js/spec/components/streamGroup.spec.jsx
+++ b/tests/js/spec/components/streamGroup.spec.jsx
@@ -73,7 +73,7 @@ describe('StreamGroup', function () {
         groupId="groupId"
         lastSeen="2017-07-25T22:56:12Z"
         firstSeen="2017-07-01T02:06:02Z"
-        query="is:unresolved is:for_review assigned_or_suggested:me_or_none"
+        query="is:unresolved is:for_review assigned_or_suggested:[me, none]"
         organization={organization}
         {...routerContext}
       />,
@@ -101,7 +101,7 @@ describe('StreamGroup', function () {
         groupId="groupId"
         lastSeen="2017-07-25T22:56:12Z"
         firstSeen="2017-07-01T02:06:02Z"
-        query="is:unresolved is:for_review assigned_or_suggested:me_or_none"
+        query="is:unresolved is:for_review assigned_or_suggested:[me, none]"
         organization={organization}
         {...routerContext}
       />,

--- a/tests/js/spec/utils/withIssueTags.spec.jsx
+++ b/tests/js/spec/utils/withIssueTags.spec.jsx
@@ -51,10 +51,10 @@ describe('withIssueTags HoC', function () {
 
     let tagsProp = wrapper.find('MyComponent').prop('tags');
     expect(tagsProp.assigned).toBeTruthy();
-    expect(tagsProp.assigned.values).toEqual(['me', 'me_or_none']);
+    expect(tagsProp.assigned.values).toEqual(['me', '[me, none]']);
 
     expect(tagsProp.assigned_or_suggested).toBeTruthy();
-    expect(tagsProp.assigned_or_suggested.values).toEqual(['me', 'me_or_none']);
+    expect(tagsProp.assigned_or_suggested.values).toEqual(['me', '[me, none]']);
 
     const users = [TestStubs.User(), TestStubs.User({username: 'joe@example.com'})];
     TeamStore.loadInitialData([
@@ -66,14 +66,14 @@ describe('withIssueTags HoC', function () {
     tagsProp = wrapper.find('MyComponent').prop('tags');
     expect(tagsProp.assigned.values).toEqual([
       'me',
-      'me_or_none',
+      '[me, none]',
       'foo@example.com',
       'joe@example.com',
       '#best-team-na',
     ]);
     expect(tagsProp.assigned_or_suggested.values).toEqual([
       'me',
-      'me_or_none',
+      '[me, none]',
       'foo@example.com',
       'joe@example.com',
       '#best-team-na',

--- a/tests/js/spec/views/issueList/header.spec.jsx
+++ b/tests/js/spec/views/issueList/header.spec.jsx
@@ -11,7 +11,7 @@ jest.mock('app/utils/analytics', () => ({
 }));
 
 const queryCounts = {
-  'is:unresolved is:for_review assigned_or_suggested:me_or_none': {
+  'is:unresolved is:for_review assigned_or_suggested:[me, none]': {
     count: 22,
     hasMore: false,
   },
@@ -30,7 +30,7 @@ const queryCounts = {
 };
 
 const queryCountsMaxed = {
-  'is:unresolved is:for_review assigned_or_suggested:me_or_none': {
+  'is:unresolved is:for_review assigned_or_suggested:[me, none]': {
     count: 321,
     hasMore: false,
   },
@@ -58,7 +58,7 @@ describe('IssueListHeader', () => {
     const wrapper = mountWithTheme(
       <IssueListHeader
         organization={organization}
-        query="is:unresolved is:for_review assigned_or_suggested:me_or_none"
+        query="is:unresolved is:for_review assigned_or_suggested:[me, none]"
         queryCount={0}
         queryCounts={queryCounts}
         projectIds={[]}
@@ -154,7 +154,7 @@ describe('IssueListHeader', () => {
     expect(wrapper.find('Link').at(1).prop('to')).toEqual({
       pathname,
       query: {
-        query: 'is:unresolved is:for_review assigned_or_suggested:me_or_none',
+        query: 'is:unresolved is:for_review assigned_or_suggested:[me, none]',
         sort: 'inbox',
       },
     });
@@ -184,7 +184,7 @@ describe('IssueListHeader', () => {
     expect(wrapper.find('Link').at(1).prop('to')).toEqual({
       pathname,
       query: {
-        query: 'is:unresolved is:for_review assigned_or_suggested:me_or_none',
+        query: 'is:unresolved is:for_review assigned_or_suggested:[me, none]',
         sort: 'inbox',
       },
     });
@@ -209,7 +209,7 @@ describe('IssueListHeader', () => {
     expect(wrapper.find('Link').at(1).prop('to')).toEqual({
       pathname: '/organizations/org-slug/issues/',
       query: {
-        query: 'is:unresolved is:for_review assigned_or_suggested:me_or_none',
+        query: 'is:unresolved is:for_review assigned_or_suggested:[me, none]',
         sort: 'inbox',
       },
     });


### PR DESCRIPTION
Changes the default inbox query for be [me, none] instead of me_or_none. Also changes relevant comments/tests