### PR TITLE
ref(notifications): Create BaseNotification Class

### DIFF
--- a/src/sentry/integrations/slack/message_builder/notifications.py
+++ b/src/sentry/integrations/slack/message_builder/notifications.py
@@ -5,26 +5,26 @@ from urllib.parse import urljoin
 from sentry.integrations.slack.message_builder.issues import build_group_attachment
 from sentry.integrations.slack.utils import LEVEL_TO_COLOR
 from sentry.models import Group, Rule
-from sentry.notifications.activity.base import ActivityNotification
+from sentry.notifications.base import BaseNotification
 from sentry.notifications.utils.avatar import get_sentry_avatar_url
 from sentry.utils.http import absolute_uri
 
 
-def get_referrer_qstring(notification: ActivityNotification) -> str:
+def get_referrer_qstring(notification: BaseNotification) -> str:
     return "?referrer=" + re.sub("Notification$", "Slack", notification.__class__.__name__)
 
 
-def get_settings_url(notification: ActivityNotification) -> str:
+def get_settings_url(notification: BaseNotification) -> str:
     return urljoin(
         absolute_uri("/settings/account/notifications/"), get_referrer_qstring(notification)
     )
 
 
-def get_group_url(notification: ActivityNotification) -> str:
+def get_group_url(notification: BaseNotification) -> str:
     return urljoin(notification.group.get_absolute_url(), get_referrer_qstring(notification))
 
 
-def build_notification_footer(notification: ActivityNotification) -> str:
+def build_notification_footer(notification: BaseNotification) -> str:
     settings_url = get_settings_url(notification)
 
     if not notification.group:
@@ -38,7 +38,7 @@ def build_notification_footer(notification: ActivityNotification) -> str:
 
 
 def build_notification_attachment(
-    notification: ActivityNotification, context: Mapping[str, Any]
+    notification: BaseNotification, context: Mapping[str, Any]
 ) -> Mapping[str, str]:
     footer = build_notification_footer(notification)
     return {

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -68,7 +68,7 @@ def send_notification_as_slack(
     Send an "activity notification" to a Slack user which are workflow and deploy notification types
     """
 
-    external_actors_by_user = get_integrations_by_user_id(notification.organization, users.keys())
+    external_actors_by_user = get_integrations_by_user_id(notification.organization, users)
 
     client = SlackClient()
     for user in users:

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -8,7 +8,7 @@ from sentry.integrations.slack.message_builder.notifications import (
 )
 from sentry.mail.notify import register_issue_notification_provider
 from sentry.models import ExternalActor, Organization, User
-from sentry.notifications.activity.base import ActivityNotification
+from sentry.notifications.base import BaseNotification
 from sentry.notifications.notify import register_notification_provider
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.types.integrations import ExternalProviders
@@ -56,7 +56,7 @@ def get_channel_and_token(
 
 @register_notification_provider(ExternalProviders.SLACK)
 def send_activity_notification_as_slack(
-    notification: ActivityNotification,
+    notification: BaseNotification,
     users: Mapping[User, int],
     shared_context: Mapping[str, Any],
 ) -> None:

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -58,7 +58,7 @@ def get_channel_and_token(
 
 
 @register_notification_provider(ExternalProviders.SLACK)
-def send_activity_notification_as_slack(
+def send_notification_as_slack(
     notification: BaseNotification,
     users: Set[User],
     shared_context: Mapping[str, Any],

--- a/src/sentry/integrations/slack/notifications.py
+++ b/src/sentry/integrations/slack/notifications.py
@@ -1,5 +1,5 @@
 import logging
-from typing import AbstractSet, Any, Mapping, Tuple
+from typing import AbstractSet, Any, Mapping, Set, Tuple
 
 from sentry.integrations.slack.client import SlackClient  # NOQA
 from sentry.integrations.slack.message_builder.notifications import (
@@ -19,12 +19,15 @@ SLACK_TIMEOUT = 5
 
 
 def get_context(
-    notification, user: User, reason: int, shared_context: Mapping[str, Any]
+    notification: BaseNotification,
+    user: User,
+    shared_context: Mapping[str, Any],
+    extra_context: Mapping[str, Any],
 ) -> Mapping[str, Any]:
     """ Compose the various levels of context and add slack-specific fields. """
     return {
         **shared_context,
-        **notification.get_user_context(user, reason),
+        **notification.get_user_context(user, extra_context),
     }
 
 
@@ -57,8 +60,9 @@ def get_channel_and_token(
 @register_notification_provider(ExternalProviders.SLACK)
 def send_activity_notification_as_slack(
     notification: BaseNotification,
-    users: Mapping[User, int],
+    users: Set[User],
     shared_context: Mapping[str, Any],
+    extra_context_by_user_id: Mapping[str, Any],
 ) -> None:
     """
     Send an "activity notification" to a Slack user which are workflow and deploy notification types
@@ -67,7 +71,8 @@ def send_activity_notification_as_slack(
     external_actors_by_user = get_integrations_by_user_id(notification.organization, users.keys())
 
     client = SlackClient()
-    for user, reason in users.items():
+    for user in users:
+        extra_context = (extra_context_by_user_id or {}).get(user.id, {})
         try:
             channel, token = get_channel_and_token(external_actors_by_user, user)
         except AttributeError as e:
@@ -81,7 +86,7 @@ def send_activity_notification_as_slack(
             )
             continue
 
-        context = get_context(notification, user, reason, shared_context)
+        context = get_context(notification, user, shared_context, extra_context)
         attachment = [build_notification_attachment(notification, context)]
         payload = {
             "token": token,

--- a/src/sentry/mail/__init__.py
+++ b/src/sentry/mail/__init__.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 from sentry.utils.imports import import_string
 
-from .activity import *  # NOQA Importing this in __init__ so that @register runs.
+from .notifications import *  # NOQA Importing this in __init__ so that @register runs.
 
 
 def load_mail_adapter():

--- a/src/sentry/mail/notifications.py
+++ b/src/sentry/mail/notifications.py
@@ -1,8 +1,9 @@
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 
 from sentry import options
 from sentry.models import ProjectOption, User
 from sentry.notifications.activity.base import ActivityNotification
+from sentry.notifications.base import BaseNotification
 from sentry.notifications.notify import register_notification_provider
 from sentry.types.integrations import ExternalProviders
 from sentry.utils import json
@@ -10,7 +11,7 @@ from sentry.utils.email import MessageBuilder, group_id_to_email
 from sentry.utils.linksign import generate_signed_link
 
 
-def get_headers(notification: ActivityNotification) -> Mapping[str, Any]:
+def get_headers(notification: BaseNotification) -> Mapping[str, Any]:
     headers = {
         "X-Sentry-Project": notification.project.slug,
         "X-SMTPAPI": json.dumps({"category": notification.get_category()}),
@@ -28,16 +29,21 @@ def get_headers(notification: ActivityNotification) -> Mapping[str, Any]:
     return headers
 
 
-def get_subject_with_prefix(notification: ActivityNotification) -> bytes:
+def get_subject_with_prefix(
+    notification: BaseNotification, mail_option_key: Optional[str] = None
+) -> bytes:
+    key = mail_option_key or "mail:subject_prefix"
     prefix = str(
-        ProjectOption.objects.get_value(project=notification.project, key="mail:subject_prefix")
+        ProjectOption.objects.get_value(notification.project, key)
         or options.get("mail.subject-prefix")
     )
     return f"{prefix}{notification.get_subject()}".encode("utf-8")
 
 
-def get_email_type(notification: ActivityNotification) -> str:
-    return f"notify.activity.{notification.activity.get_type_display()}"
+def get_email_type(notification: BaseNotification) -> str:
+    if isinstance(notification, ActivityNotification):
+        return f"notify.activity.{notification.activity.get_type_display()}"
+    return ""
 
 
 def get_unsubscribe_link(user_id: int, group_id: int) -> str:
@@ -48,7 +54,7 @@ def get_unsubscribe_link(user_id: int, group_id: int) -> str:
     )
 
 
-def can_users_unsubscribe(notification: ActivityNotification) -> bool:
+def can_users_unsubscribe(notification: BaseNotification) -> bool:
     return bool(notification.group)
 
 
@@ -72,7 +78,7 @@ def get_context(
 
 @register_notification_provider(ExternalProviders.EMAIL)
 def send_notification_as_email(
-    notification: ActivityNotification,
+    notification: BaseNotification,
     users: Mapping[User, int],
     shared_context: Mapping[str, Any],
 ) -> None:
@@ -83,13 +89,13 @@ def send_notification_as_email(
     for user, reason in users.items():
         msg = MessageBuilder(
             subject=subject,
+            context=get_context(notification, user, reason, shared_context),
             template=notification.get_template(),
             html_template=notification.get_html_template(),
             headers=headers,
-            type=type,
-            context=get_context(notification, user, reason, shared_context),
-            reference=notification.activity,
+            reference=notification.get_reference(),
             reply_reference=notification.group,
+            type=type,
         )
         msg.add_users([user.id], project=notification.project)
         msg.send_async()

--- a/src/sentry/mail/notify.py
+++ b/src/sentry/mail/notify.py
@@ -1,13 +1,14 @@
-from typing import Any, Callable, Iterable, Mapping, MutableMapping
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Set
 
-from sentry.models import User
 from sentry.types.integrations import ExternalProviders
 
 # Shortcut so that types don't explode.
-Notifiable = Callable[[Any, Mapping[User, int], Mapping[str, Any]], None]
+Notifiable = Callable[[Any, Set[int], Mapping[str, Any]], None]
 
 # Global notifier registry.
 registry: MutableMapping[ExternalProviders, Notifiable] = {}
+
+APPROVED_PROVIDERS = [ExternalProviders.EMAIL, ExternalProviders.SLACK]
 
 
 def notification_providers() -> Iterable[ExternalProviders]:
@@ -33,10 +34,9 @@ def register_issue_notification_provider(
 def notify_participants(
     notification: Any,
     provider: ExternalProviders,
-    users: Mapping[User, int],
+    users: Set[int],
     shared_context: Mapping[str, Any],
 ) -> None:
     """ Send notifications to these users. """
-    APPROVED_PROVIDERS = [ExternalProviders.EMAIL, ExternalProviders.SLACK]
     if provider in APPROVED_PROVIDERS:
         registry[provider](notification, users, shared_context)

--- a/src/sentry/notifications/activity/base.py
+++ b/src/sentry/notifications/activity/base.py
@@ -10,7 +10,10 @@ from sentry.notifications.base import BaseNotification
 from sentry.notifications.notify import notify
 from sentry.notifications.types import GroupSubscriptionReason
 from sentry.notifications.utils.avatar import avatar_as_html
-from sentry.notifications.utils.participants import get_participants_for_group
+from sentry.notifications.utils.participants import (
+    get_participants_for_group,
+    split_participants_and_context,
+)
 from sentry.types.integrations import ExternalProviders
 
 
@@ -143,5 +146,6 @@ class ActivityNotification(BaseNotification):
         # Only calculate shared context once.
         shared_context = self.get_context()
 
-        for provider, participants in participants_by_provider.items():
-            notify(provider, self, participants, shared_context)
+        for provider, participants_with_reasons in participants_by_provider.items():
+            participants, extra_context = split_participants_and_context(participants_with_reasons)
+            notify(provider, self, participants, shared_context, extra_context)

--- a/src/sentry/notifications/activity/base.py
+++ b/src/sentry/notifications/activity/base.py
@@ -24,14 +24,11 @@ class ActivityNotification:
     def should_email(self) -> bool:
         return True
 
-    def get_template(self) -> str:
-        return "sentry/emails/activity/generic.txt"
-
-    def get_html_template(self) -> str:
-        return "sentry/emails/activity/generic.html"
-
     def get_project_link(self) -> str:
         return str(absolute_uri(f"/{self.organization.slug}/{self.project.slug}/"))
+
+    def get_filename(self) -> str:
+        return "activity/generic"
 
     def get_group_link(self) -> str:
         referrer = re.sub("Notification$", "Email", self.__class__.__name__)

--- a/src/sentry/notifications/activity/base.py
+++ b/src/sentry/notifications/activity/base.py
@@ -135,6 +135,9 @@ class ActivityNotification(BaseNotification):
     def get_title(self) -> str:
         return self.get_activity_name()
 
+    def get_reference(self) -> Any:
+        return self.group
+
     def send(self) -> None:
         if not self.should_email():
             return

--- a/src/sentry/notifications/activity/base.py
+++ b/src/sentry/notifications/activity/base.py
@@ -136,7 +136,7 @@ class ActivityNotification(BaseNotification):
         return self.get_activity_name()
 
     def get_reference(self) -> Any:
-        return self.group
+        return self.activity
 
     def send(self) -> None:
         if not self.should_email():

--- a/src/sentry/notifications/activity/new_processing_issues.py
+++ b/src/sentry/notifications/activity/new_processing_issues.py
@@ -41,11 +41,8 @@ class NewProcessingIssuesActivityNotification(ActivityNotification):
     def get_title(self) -> str:
         return self.get_subject()
 
-    def get_template(self) -> str:
-        return "sentry/emails/activity/new_processing_issues.txt"
-
-    def get_html_template(self) -> str:
-        return "sentry/emails/activity/new_processing_issues.html"
+    def get_filename(self) -> str:
+        return "activity/new_processing_issues"
 
     def get_category(self) -> str:
         return "new_processing_issues_activity_email"

--- a/src/sentry/notifications/activity/note.py
+++ b/src/sentry/notifications/activity/note.py
@@ -10,11 +10,8 @@ class NoteActivityNotification(ActivityNotification):
             "text_description": str(self.activity.data["text"]),
         }
 
-    def get_template(self) -> str:
-        return "sentry/emails/activity/note.txt"
-
-    def get_html_template(self) -> str:
-        return "sentry/emails/activity/note.html"
+    def get_filename(self) -> str:
+        return "activity/note"
 
     def get_category(self) -> str:
         return "note_activity_email"

--- a/src/sentry/notifications/activity/release.py
+++ b/src/sentry/notifications/activity/release.py
@@ -81,7 +81,7 @@ class ReleaseActivityNotification(ActivityNotification):
         return get_projects(self.projects, team_ids)
 
     def get_user_context(
-        self, user: User, reason: Optional[int] = None
+        self, user: User, extra_context: Mapping[str, Any]
     ) -> MutableMapping[str, Any]:
         projects = self.get_projects(user)
         release_links = [
@@ -93,7 +93,7 @@ class ReleaseActivityNotification(ActivityNotification):
 
         resolved_issue_counts = [self.group_counts_by_project.get(p.id, 0) for p in projects]
         return {
-            **super().get_user_context(user, reason),
+            **super().get_user_context(user, extra_context),
             "projects": zip(projects, release_links, resolved_issue_counts),
             "project_count": len(projects),
         }

--- a/src/sentry/notifications/activity/release.py
+++ b/src/sentry/notifications/activity/release.py
@@ -104,11 +104,8 @@ class ReleaseActivityNotification(ActivityNotification):
     def get_title(self) -> str:
         return self.get_subject()
 
-    def get_template(self) -> str:
-        return "sentry/emails/activity/release.txt"
-
-    def get_html_template(self) -> str:
-        return "sentry/emails/activity/release.html"
+    def get_filename(self) -> str:
+        return "activity/release"
 
     def get_category(self) -> str:
         return "release_activity_email"

--- a/src/sentry/notifications/base.py
+++ b/src/sentry/notifications/base.py
@@ -33,10 +33,10 @@ class BaseNotification:
         return True
 
     def get_template(self) -> str:
-        return f"sentry/email/{self.get_filename()}.txt"
+        return f"sentry/emails/{self.get_filename()}.txt"
 
     def get_html_template(self) -> str:
-        return f"sentry/email/{self.get_filename()}.html"
+        return f"sentry/emails/{self.get_filename()}.html"
 
     def get_project_link(self) -> str:
         return str(absolute_uri(f"/{self.organization.slug}/{self.project.slug}/"))

--- a/src/sentry/notifications/base.py
+++ b/src/sentry/notifications/base.py
@@ -1,0 +1,47 @@
+from typing import Any, Mapping, MutableMapping, Set
+
+from sentry.models import Group, Project, User
+from sentry.types.integrations import ExternalProviders
+from sentry.utils.http import absolute_uri
+
+
+class BaseNotification:
+    def __init__(self, project: Project, group: Group) -> None:
+        self.project = project
+        self.organization = self.project.organization
+        self.group = group
+
+    def get_filename(self) -> str:
+        raise NotImplementedError
+
+    def get_category(self) -> str:
+        raise NotImplementedError
+
+    def get_title(self) -> str:
+        raise NotImplementedError
+
+    def get_participants(self) -> Mapping[ExternalProviders, Set[int]]:
+        raise NotImplementedError
+
+    def get_subject(self) -> str:
+        raise NotImplementedError
+
+    def get_reference(self) -> Any:
+        raise NotImplementedError
+
+    def should_email(self) -> bool:
+        return True
+
+    def get_template(self) -> str:
+        return f"sentry/email/{self.get_filename()}.txt"
+
+    def get_html_template(self) -> str:
+        return f"sentry/email/{self.get_filename()}.html"
+
+    def get_project_link(self) -> str:
+        return str(absolute_uri(f"/{self.organization.slug}/{self.project.slug}/"))
+
+    def get_user_context(
+        self, user: User, extra_context: Mapping[str, Any]
+    ) -> MutableMapping[str, Any]:
+        return {}

--- a/src/sentry/notifications/notify.py
+++ b/src/sentry/notifications/notify.py
@@ -1,11 +1,12 @@
-from typing import Any, Callable, Iterable, Mapping, MutableMapping
+from typing import Any, Callable, Iterable, Mapping, MutableMapping, Optional, Set
 
 from sentry.models import User
 from sentry.types.integrations import ExternalProviders
 
 # Shortcut so that types don't explode.
-Notifiable = Callable[[Any, Mapping[User, int], Mapping[str, Any]], None]
-
+Notifiable = Callable[
+    [Any, Set[User], Mapping[str, Any], Optional[Mapping[int, Mapping[str, Any]]]], None
+]
 # Global notifier registry.
 registry: MutableMapping[ExternalProviders, Notifiable] = {}
 
@@ -33,8 +34,9 @@ def register_notification_provider(
 def notify(
     provider: ExternalProviders,
     notification: Any,
-    users: Mapping[User, int],
+    users: Set[User],
     shared_context: Mapping[str, Any],
+    extra_context_by_user_id: Optional[Mapping[int, Mapping[str, Any]]] = None,
 ) -> None:
     """ Send notifications to these users. """
-    registry[provider](notification, users, shared_context)
+    registry[provider](notification, users, shared_context, extra_context_by_user_id)

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Iterable, Mapping, MutableMapping, Optional, Set
+from typing import Any, Iterable, Mapping, MutableMapping, Optional, Set, Tuple
 
 from sentry.models import (
     Group,
@@ -110,3 +110,14 @@ def get_participants_for_release(
             if reason_option:
                 users_to_reasons_by_provider[provider][user] = reason_option
     return users_to_reasons_by_provider
+
+
+def split_participants_and_context(
+    participants_with_reasons: Mapping[User, int]
+) -> Tuple[Set[User], Mapping[int, Mapping[str, Any]]]:
+    participants = set()
+    extra_context = {}
+    for user, reason in participants_with_reasons:
+        participants.add(user)
+        extra_context[user.id] = {"reason": reason}
+    return participants, extra_context

--- a/src/sentry/notifications/utils/participants.py
+++ b/src/sentry/notifications/utils/participants.py
@@ -117,7 +117,7 @@ def split_participants_and_context(
 ) -> Tuple[Set[User], Mapping[int, Mapping[str, Any]]]:
     participants = set()
     extra_context = {}
-    for user, reason in participants_with_reasons:
+    for user, reason in participants_with_reasons.items():
         participants.add(user)
         extra_context[user.id] = {"reason": reason}
     return participants, extra_context

--- a/tests/sentry/integrations/slack/test_notifications.py
+++ b/tests/sentry/integrations/slack/test_notifications.py
@@ -5,8 +5,8 @@ from django.utils import timezone
 from exam import fixture
 
 from sentry.integrations.slack.notifications import (
-    send_activity_notification_as_slack,
     send_issue_notification_as_slack,
+    send_notification_as_slack,
 )
 from sentry.mail import mail_adapter
 from sentry.models import (
@@ -39,7 +39,7 @@ from tests.sentry.mail.activity import ActivityTestCase
 
 def send_notification(*args):
     args_list = list(args)[1:]
-    send_activity_notification_as_slack(*args_list)
+    send_notification_as_slack(*args_list)
 
 
 def send_issue_notification(*args):

--- a/tests/sentry/mail/activity/test_release.py
+++ b/tests/sentry/mail/activity/test_release.py
@@ -105,7 +105,7 @@ class ReleaseTestCase(ActivityTestCase):
             (self.commit4, self.user5),
         ]
 
-        user_context = email.get_user_context(self.user1)
+        user_context = email.get_user_context(self.user1, {})
         # make sure this only includes projects user has access to
         assert len(user_context["projects"]) == 1
         assert user_context["projects"][0][0] == self.project
@@ -155,7 +155,7 @@ class ReleaseTestCase(ActivityTestCase):
         assert context["environment"] == "production"
         assert context["repos"] == []
 
-        user_context = email.get_user_context(self.user1)
+        user_context = email.get_user_context(self.user1, {})
         # make sure this only includes projects user has access to
         assert len(user_context["projects"]) == 1
         assert user_context["projects"][0][0] == self.project
@@ -205,7 +205,7 @@ class ReleaseTestCase(ActivityTestCase):
         assert context["environment"] == "production"
         assert context["repos"] == []
 
-        user_context = email.get_user_context(user6)
+        user_context = email.get_user_context(user6, {})
         # make sure this only includes projects user has access to
         assert len(user_context["projects"]) == 1
         assert user_context["projects"][0][0] == self.project


### PR DESCRIPTION
We're trying to move a lot of Notifications responsibility out of the "sentry.mail" module and into the "sentry.notifications" module. This is going to be a pretty large diff so we're splitting the work into ~200 line chunks.

This chunk creates a base class below `ActivityNotification` that will be extended in the next PR. The notify function now expects the `GroupSubscriptionReason` to be passed in an object called `extra_context`.