### PR TITLE
fix(performance): Remove max from performance histogram

### DIFF
--- a/static/app/views/performance/landing/chart/histogramChart.tsx
+++ b/static/app/views/performance/landing/chart/histogramChart.tsx
@@ -102,12 +102,8 @@ export function HistogramChart(props: Props) {
             allSeries.push(series);
           }
 
-          const values = series.data.map(point => point.value);
-          const max = values.length ? Math.max(...values) : undefined;
-
           const yAxis = {
             type: 'value' as const,
-            max,
             axisLabel: {
               color: theme.chartLabel,
             },


### PR DESCRIPTION
This was copied from the web vitals histogram where the max was needed to render
the baseline marker. This isn't necessary for the landing page, and removing it
gives us a better looking y axis.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/10239353/115927225-16b27600-a452-11eb-9aa7-c375db929891.png)

## AFter

![image](https://user-images.githubusercontent.com/10239353/115927232-1a45fd00-a452-11eb-8a71-61b19dbfb621.png)
