### PR TITLE
 feat(breakdowns): Expose spans.total.time field

### DIFF
--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -1642,7 +1642,7 @@ def is_duration_measurement(key):
 
 
 def is_span_op_breakdown(key):
-    return isinstance(key, str) and SPAN_OP_BREAKDOWNS_FIELD_RE.match(key)
+    return isinstance(key, str) and get_span_op_breakdown_name(key) is not None
 
 
 def get_measurement_name(measurement):
@@ -1652,7 +1652,12 @@ def get_measurement_name(measurement):
 
 def get_span_op_breakdown_name(breakdown):
     match = SPAN_OP_BREAKDOWNS_FIELD_RE.match(breakdown)
-    return f"ops.{match.group(1).lower()}" if match else None
+    if match:
+        breakdown_key = match.group(1).lower()
+        if breakdown_key == "total.time":
+            return breakdown_key
+        return f"ops.{breakdown_key}"
+    return None
 
 
 def get_array_column_alias(array_column):

--- a/tests/sentry/search/events/test_fields.py
+++ b/tests/sentry/search/events/test_fields.py
@@ -94,6 +94,18 @@ def test_get_json_meta_type():
         )
         == "duration"
     )
+    assert (
+        get_json_meta_type(
+            "percentile_spans_total_time_0_5",
+            "Nullable(Float64)",
+            FunctionDetails(
+                "percentile(spans.total.time, 0.5)",
+                FUNCTIONS["percentile"],
+                {"column": "spans.total.time", "percentile": 0.5},
+            ),
+        )
+        == "duration"
+    )
 
 
 def test_parse_function():
@@ -111,6 +123,11 @@ def test_parse_function():
     assert parse_function("p75(spans.http)") == (
         "p75",
         ["spans.http"],
+        None,
+    )
+    assert parse_function("p75(spans.total.time)") == (
+        "p75",
+        ["spans.total.time"],
         None,
     )
     assert parse_function("apdex(300)") == ("apdex", ["300"], None)

--- a/tests/sentry/snuba/test_discover.py
+++ b/tests/sentry/snuba/test_discover.py
@@ -609,6 +609,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
                 "spans.db",
                 "spans.resource",
                 "spans.browser",
+                "spans.total.time",
                 "spans.does_not_exist",
             ],
             query="event.type:transaction",
@@ -622,6 +623,7 @@ class QueryIntegrationTest(SnubaTestCase, TestCase):
         assert data[0]["spans.db"] == span_ops["ops.db"]["value"]
         assert data[0]["spans.resource"] == span_ops["ops.resource"]["value"]
         assert data[0]["spans.browser"] == span_ops["ops.browser"]["value"]
+        assert data[0]["spans.total.time"] == span_ops["total.time"]["value"]
         assert data[0]["spans.does_not_exist"] is None
 
 

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -209,6 +209,10 @@ class SnubaUtilsTest(TestCase):
             get_snuba_column_name("spans.key", Dataset.Transactions)
             == "span_op_breakdowns[ops.key]"
         )
+        assert (
+            get_snuba_column_name("spans.total.time", Dataset.Transactions)
+            == "span_op_breakdowns[total.time]"
+        )
         assert get_snuba_column_name("spans.KEY", Dataset.Discover) == "span_op_breakdowns[ops.key]"
         assert (
             get_snuba_column_name("spans.KEY", Dataset.Transactions)


### PR DESCRIPTION
Expose `spans.total.time` field so that we can query for them from the frontend. We do not plan to expose the  `spans.total.time` field to the Discover column builder. 

This field will be used to generate segmented bars for operation breakdowns relative to each other as shown below:

<img width="311" alt="Screen Shot 2021-04-23 at 4 35 02 PM" src="https://user-images.githubusercontent.com/139499/115927078-e1a62380-a451-11eb-9ea2-bf1551c9a580.png">
