### PR TITLE
feat(notifications): Fix ExternalActor Permissions

### DIFF
--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 
 from sentry import features
-from sentry.api.bases import OrganizationPermission
+from sentry.api.bases import OrganizationPermission, TeamPermission
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.validators.integrations import validate_provider
 from sentry.models import ExternalActor, Organization, Team, User
@@ -103,7 +103,12 @@ class ExternalTeamSerializer(ExternalActorSerializerBase):
         fields = ["team_id", "external_name", "provider"]
 
 
-class ExternalActorPermission(OrganizationPermission):
+class ExternalActorTeamPermission(TeamPermission):  # type: ignore
+    def is_not_2fa_compliant(self, request: Request, organization: Organization) -> bool:
+        return False
+
+
+class ExternalActorPermission(OrganizationPermission):  # type: ignore
     def is_not_2fa_compliant(self, request: Request, organization: Organization) -> bool:
         return False
 

--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -7,6 +7,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 
 from sentry import features
+from sentry.api.bases import OrganizationPermission
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.validators.integrations import validate_provider
 from sentry.models import ExternalActor, Organization, Team, User
@@ -100,6 +101,11 @@ class ExternalTeamSerializer(ExternalActorSerializerBase):
     class Meta:
         model = ExternalActor
         fields = ["team_id", "external_name", "provider"]
+
+
+class ExternalActorPermission(OrganizationPermission):
+    def is_not_2fa_compliant(self, request: Request, organization: Organization) -> bool:
+        return False
 
 
 class ExternalActorEndpointMixin:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -1,6 +1,7 @@
 import sentry_sdk
 from django.core.cache import cache
 from rest_framework.exceptions import ParseError, PermissionDenied
+from rest_framework.request import Request
 
 from sentry.api.base import Endpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -35,7 +36,7 @@ class OrganizationPermission(SentryPermission):
         "DELETE": ["org:admin"],
     }
 
-    def is_not_2fa_compliant(self, request, organization):
+    def is_not_2fa_compliant(self, request: Request, organization: Organization) -> bool:
         return (
             organization.flags.require_2fa
             and not Authenticator.objects.user_has_2fa(request.user)

--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -4,7 +4,11 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalTeamSerializer
+from sentry.api.bases.external_actor import (
+    ExternalActorEndpointMixin,
+    ExternalActorPermission,
+    ExternalTeamSerializer,
+)
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import Team
@@ -13,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # type: ignore
+    permission_classes = (ExternalActorPermission,)
+
     def post(self, request: Request, team: Team) -> Response:
         """
         Create an External Team

--- a/src/sentry/api/endpoints/external_team.py
+++ b/src/sentry/api/endpoints/external_team.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.external_actor import (
     ExternalActorEndpointMixin,
-    ExternalActorPermission,
+    ExternalActorTeamPermission,
     ExternalTeamSerializer,
 )
 from sentry.api.bases.team import TeamEndpoint
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExternalTeamEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # type: ignore
-    permission_classes = (ExternalActorPermission,)
+    permission_classes = (ExternalActorTeamPermission,)
 
     def post(self, request: Request, team: Team) -> Response:
         """

--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -5,7 +5,11 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalTeamSerializer
+from sentry.api.bases.external_actor import (
+    ExternalActorEndpointMixin,
+    ExternalActorPermission,
+    ExternalTeamSerializer,
+)
 from sentry.api.bases.team import TeamEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import ExternalActor, Team
@@ -14,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # type: ignore
+    permission_classes = (ExternalActorPermission,)
+
     def convert_args(
         self,
         request: Request,

--- a/src/sentry/api/endpoints/external_team_details.py
+++ b/src/sentry/api/endpoints/external_team_details.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 
 from sentry.api.bases.external_actor import (
     ExternalActorEndpointMixin,
-    ExternalActorPermission,
+    ExternalActorTeamPermission,
     ExternalTeamSerializer,
 )
 from sentry.api.bases.team import TeamEndpoint
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 class ExternalTeamDetailsEndpoint(TeamEndpoint, ExternalActorEndpointMixin):  # type: ignore
-    permission_classes = (ExternalActorPermission,)
+    permission_classes = (ExternalActorTeamPermission,)
 
     def convert_args(
         self,

--- a/src/sentry/api/endpoints/external_user.py
+++ b/src/sentry/api/endpoints/external_user.py
@@ -5,7 +5,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.api.bases import OrganizationEndpoint
-from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalUserSerializer
+from sentry.api.bases.external_actor import (
+    ExternalActorEndpointMixin,
+    ExternalActorPermission,
+    ExternalUserSerializer,
+)
 from sentry.api.serializers import serialize
 from sentry.models import Organization
 
@@ -13,6 +17,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExternalUserEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):  # type: ignore
+    permission_classes = (ExternalActorPermission,)
+
     def post(self, request: Request, organization: Organization) -> Response:
         """
         Create an External User

--- a/src/sentry/api/endpoints/external_user_details.py
+++ b/src/sentry/api/endpoints/external_user_details.py
@@ -5,7 +5,11 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry.api.bases.external_actor import ExternalActorEndpointMixin, ExternalUserSerializer
+from sentry.api.bases.external_actor import (
+    ExternalActorEndpointMixin,
+    ExternalActorPermission,
+    ExternalUserSerializer,
+)
 from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.api.serializers import serialize
 from sentry.models import ExternalActor, Organization
@@ -14,6 +18,8 @@ logger = logging.getLogger(__name__)
 
 
 class ExternalUserDetailsEndpoint(OrganizationEndpoint, ExternalActorEndpointMixin):  # type: ignore
+    permission_classes = (ExternalActorPermission,)
+
     def convert_args(
         self,
         request: Request,

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -1,9 +1,11 @@
 from rest_framework import permissions
+from rest_framework.request import Request
 
 from sentry.api.exceptions import SsoRequired, SuperuserRequired, TwoFactorRequired
 from sentry.auth import access
 from sentry.auth.superuser import is_active_superuser
 from sentry.auth.system import is_system_auth
+from sentry.models import Organization
 from sentry.utils import auth
 
 
@@ -58,7 +60,7 @@ class SuperuserPermission(permissions.BasePermission):
 
 
 class SentryPermission(ScopedPermission):
-    def is_not_2fa_compliant(self, request, organization):
+    def is_not_2fa_compliant(self, request: Request, organization: Organization) -> bool:
         return False
 
     def needs_sso(self, request, organization):

--- a/src/sentry/web/frontend/base.py
+++ b/src/sentry/web/frontend/base.py
@@ -11,6 +11,7 @@ from django.template.context_processors import csrf
 from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
+from rest_framework.request import Request
 from sudo.views import redirect_to_sudo
 
 from sentry import roles
@@ -108,7 +109,7 @@ class OrganizationMixin:
     def _is_org_member(self, user, organization):
         return OrganizationMember.objects.filter(user=user, organization=organization).exists()
 
-    def is_not_2fa_compliant(self, request, organization):
+    def is_not_2fa_compliant(self, request: Request, organization: Organization) -> bool:
         return (
             organization.flags.require_2fa
             and not Authenticator.objects.user_has_2fa(request.user)


### PR DESCRIPTION
We're unable to update ExternalActors in the Sentry organization. This PR removes the 2fa check for updating external actors.
@ceorourke @NisanthanNanthakumar 