### PR TITLE
fix(alerts): Set projects from global selection on change

### DIFF
--- a/static/app/views/alerts/rules/index.tsx
+++ b/static/app/views/alerts/rules/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import flatten from 'lodash/flatten';
+import isEqual from 'lodash/isEqual';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -369,9 +370,20 @@ class AlertRulesListContainer extends React.Component<Props> {
     this.trackView();
   }
 
-  componentDidUpdate(nextProps: Props) {
-    if (nextProps.location.query?.sort !== this.props.location.query?.sort) {
+  componentDidUpdate(prevProps: Props) {
+    if (prevProps.location.query?.sort !== this.props.location.query?.sort) {
       this.trackView();
+    }
+
+    const {router, location, selection} = this.props;
+    if (!isEqual(prevProps.selection.projects, this.props.selection.projects)) {
+      router.replace({
+        pathname: location.pathname,
+        query: {
+          ...location.query,
+          project: selection.projects,
+        },
+      });
     }
   }
 

--- a/static/app/views/alerts/rules/index.tsx
+++ b/static/app/views/alerts/rules/index.tsx
@@ -371,12 +371,12 @@ class AlertRulesListContainer extends React.Component<Props> {
   }
 
   componentDidUpdate(prevProps: Props) {
-    if (prevProps.location.query?.sort !== this.props.location.query?.sort) {
+    const {router, location, selection} = this.props;
+    if (prevProps.location.query?.sort !== location.query?.sort) {
       this.trackView();
     }
 
-    const {router, location, selection} = this.props;
-    if (!isEqual(prevProps.selection.projects, this.props.selection.projects)) {
+    if (!isEqual(prevProps.selection.projects, selection.projects)) {
       router.replace({
         pathname: location.pathname,
         query: {

--- a/static/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -703,7 +703,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                 </Confirm>
               ) : null
             }
-            submitLabel={t('Create Rule')}
+            submitLabel={t('Save Rule')}
           >
             <Feature organization={organization} features={['alert-wizard']}>
               {({hasFeature}) =>

--- a/tests/js/spec/views/settings/incidentRules/details.spec.jsx
+++ b/tests/js/spec/views/settings/incidentRules/details.spec.jsx
@@ -118,7 +118,7 @@ describe('Incident Rules Details', function () {
     wrapper.find('button[aria-label="Add Action"]').simulate('click');
 
     // Save Trigger
-    wrapper.find('button[aria-label="Create Rule"]').simulate('submit');
+    wrapper.find('button[aria-label="Save Rule"]').simulate('submit');
 
     expect(metric.startTransaction).toHaveBeenCalledWith({name: 'saveAlertRule'});
     expect(editRule).toHaveBeenCalledWith(
@@ -180,7 +180,7 @@ describe('Incident Rules Details', function () {
       .simulate('change', {target: {value: ''}});
 
     // Save Trigger
-    wrapper.find('button[aria-label="Create Rule"]').simulate('submit');
+    wrapper.find('button[aria-label="Save Rule"]').simulate('submit');
 
     expect(editRule).toHaveBeenCalledWith(
       expect.anything(),


### PR DESCRIPTION
fixes an issue when selected projects are set after the component has mounted.
also made a text change, editing a project said "create rule" but we want both issues and metric alerts to say "save rule" during edit and create.