### PR TITLE
fix(django22): Replace uses of `_get_val_from_obj` with `value_from_object`

### DIFF
--- a/src/sentry/db/models/fields/gzippeddict.py
+++ b/src/sentry/db/models/fields/gzippeddict.py
@@ -47,5 +47,4 @@ class GzippedDictField(TextField):
         return compress(pickle.dumps(value))
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
-        return self.get_prep_value(value)
+        return self.get_prep_value(self.value_from_object(obj))

--- a/src/sentry/db/models/fields/jsonfield.py
+++ b/src/sentry/db/models/fields/jsonfield.py
@@ -112,7 +112,7 @@ class JSONField(models.TextField):
         return json.dumps(value, default=default, **self.encoder_kwargs)
 
     def value_to_string(self, obj):
-        return self._get_val_from_obj(obj)
+        return self.value_from_object(obj)
 
 
 class NoPrepareMixin:

--- a/src/social_auth/fields.py
+++ b/src/social_auth/fields.py
@@ -53,8 +53,8 @@ class JSONField(TextField):
 
     def value_to_string(self, obj):
         """Return value from object converted to string properly"""
-        return smart_text(self.get_prep_value(self._get_val_from_obj(obj)))
+        return smart_text(self.value_from_object(obj))
 
     def value_from_object(self, obj):
         """Return value dumped to string."""
-        return self.get_prep_value(self._get_val_from_obj(obj))
+        return self.get_prep_value(super().value_from_object(obj))


### PR DESCRIPTION
https://docs.djangoproject.com/en/2.2/releases/1.9/#id1

One of the misc deprecations in 1.9. `_get_val_from_obj` is removed in 2.0, and `value_from_object`
is recommended instead.