### PR TITLE
fix(notifications platform): Account for empty get_send_to result

### DIFF
--- a/src/sentry/mail/adapter.py
+++ b/src/sentry/mail/adapter.py
@@ -474,9 +474,10 @@ class MailAdapter:
 
     def notify_digest(self, project, digest, target_type, target_identifier=None):
         metrics.incr("mail_adapter.notify_digest")
-        user_ids = self.get_send_to(project, target_type, target_identifier)[
+        user_ids = self.get_send_to(project, target_type, target_identifier).get(
             ExternalProviders.EMAIL
-        ]
+        )
+
         logger.info(
             "mail.adapter.notify_digest",
             extra={


### PR DESCRIPTION
Fixes and adds a test for the case where an alert rule with an action to send to a member who no longer exists fires and it is digested. 

Fixes [SENTRY-PVT](https://sentry.io/organizations/sentry/issues/2359359309/?environment=prod&project=1&referrer=alert_email)