### PR TITLE
feat(ui): Move `core-js` to babel-preset-env

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,13 @@
 module.exports = {
   presets: [
     '@babel/preset-react',
-    '@babel/preset-env',
+    [
+      '@babel/preset-env',
+      {
+        useBuiltIns: 'usage',
+        corejs: '3.11',
+      },
+    ],
     '@babel/preset-typescript',
     [
       '@emotion/babel-preset-css-prop',

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "color": "^3.1.3",
     "compression-webpack-plugin": "7.0.0",
     "copy-text-to-clipboard": "2.2.0",
-    "core-js": "^3.10.1",
+    "core-js": "^3.11.0",
     "create-react-class": "^15.6.2",
     "crypto-browserify": "^3.12.0",
     "crypto-js": "4.0.0",

--- a/static/app/index.tsx
+++ b/static/app/index.tsx
@@ -1,7 +1,3 @@
-// These imports (core-js and regenerator-runtime) are replacements for deprecated `@babel/polyfill`
-import 'core-js/stable';
-import 'regenerator-runtime/runtime';
-
 import {Config} from 'app/types';
 
 const BOOTSTRAP_URL = '/api/client-config/';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5387,10 +5387,15 @@ core-js@^2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
   integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
 
-core-js@^3.0.4, core-js@^3.1.2, core-js@^3.10.1, core-js@^3.6.5, core-js@^3.8.2:
+core-js@^3.0.4, core-js@^3.1.2, core-js@^3.6.5, core-js@^3.8.2:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.1.tgz#e683963978b6806dcc6c0a4a8bd4ab0bdaf3f21a"
   integrity sha512-pwCxEXnj27XG47mu7SXAwhLP3L5CrlvCB91ANUkIz40P27kUcvNfSdvyZJ9CLHiVoKSp+TTChMQMSKQEH/IQxA==
+
+core-js@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.11.0.tgz#05dac6aa70c0a4ad842261f8957b961d36eb8926"
+  integrity sha512-bd79DPpx+1Ilh9+30aT5O1sgpQd4Ttg8oqkqi51ZzhedMM1omD2e6IOF48Z/DzDCZ2svp49tN/3vneTK6ZBkXw==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Move core-js usage to babel configuration, specifically `babel-preset-env` plugin. `usage` setting will only load polyfills as needed. See https://babeljs.io/docs/en/babel-preset-env#corejs for more information

The `core-js` chunk size goes from 382KB -> 251KB as it does not include all polyfills.