### PR TITLE
fix(auth): better org login redirect logic

### DIFF
--- a/src/sentry/api/endpoints/auth_login.py
+++ b/src/sentry/api/endpoints/auth_login.py
@@ -56,11 +56,9 @@ class AuthLoginEndpoint(Endpoint, OrganizationMixin):
             )
 
         active_org = self.get_active_organization(request)
-        redirect_url = auth.get_org_redirect_url(request, active_org)
-
         return Response(
             {
-                "nextUri": auth.get_login_redirect(request, redirect_url),
+                "nextUri": auth.get_login_redirect(request, active_org),
                 "user": serialize(user, user, DetailedUserSerializer()),
             }
         )

--- a/src/sentry/utils/auth.py
+++ b/src/sentry/utils/auth.py
@@ -92,9 +92,11 @@ def get_org_redirect_url(request, active_organization):
     return "/organizations/new/"
 
 
-def get_login_redirect(request, default=None):
-    if default is None:
+def get_login_redirect(request, active_organization=None):
+    if active_organization is None:
         default = get_login_url()
+    else:
+        default = get_org_redirect_url(request, active_organization)
 
     # If there is a pending 2fa authentication bound to the session then
     # we need to go to the 2fa dialog.

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -160,7 +160,7 @@ class AuthLoginView(BaseView):
 
                 return response
 
-            return self.redirect(auth.get_login_redirect(request))
+            return self.redirect(auth.get_login_redirect(request, organization))
 
         elif request.method == "POST":
             from sentry.app import ratelimiter
@@ -199,7 +199,7 @@ class AuthLoginView(BaseView):
                             organization=organization, email=user.email
                         )
                     except OrganizationMember.DoesNotExist:
-                        pass
+                        return self.redirect(auth.get_login_url())
                     else:
                         # XXX(jferge): if user is in 2fa removed state,
                         # dont redirect to org login page instead redirect to general login where
@@ -207,7 +207,7 @@ class AuthLoginView(BaseView):
                         if om.user is None:
                             return self.redirect(auth.get_login_url())
 
-                return self.redirect(auth.get_login_redirect(request))
+                return self.redirect(auth.get_login_redirect(request, organization))
             else:
                 metrics.incr(
                     "login.attempt", instance="failure", skip_internal=True, sample_rate=1.0

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -193,12 +193,14 @@ class AuthLoginView(BaseView):
 
                 if not user.is_active:
                     return self.redirect(reverse("sentry-reactivate-account"))
-                if organization and settings.SENTRY_SINGLE_ORGANIZATION:
+                if organization:
                     try:
                         om = OrganizationMember.objects.get(
                             organization=organization, email=user.email
                         )
                     except OrganizationMember.DoesNotExist:
+                        # if they succesfully login but aren't a member of org
+                        # redirect back to main auth page
                         return self.redirect(auth.get_login_url())
                     else:
                         # XXX(jferge): if user is in 2fa removed state,

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -676,7 +676,9 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         user = self.create_user("foor@example.com")
         self.create_member(organization=self.organization, user=user)
         member = OrganizationMember.objects.get(organization=self.organization, user=user)
+        member.email = "foor@example.com"
         member.save()
+
         self.session["_next"] = reverse(
             "sentry-organization-settings", args=[self.organization.slug]
         )

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -76,7 +76,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         ):
             resp = self.client.post(path, {"op": "newuser"}, follow=True)
             assert resp.redirect_chain == [
-                (reverse("sentry-login"), 302),
                 ("/organizations/foo/issues/", 302),
             ]
 
@@ -114,7 +113,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         resp = self.client.post(path, {"op": "confirm"}, follow=True)
         assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
             ("/organizations/foo/issues/", 302),
         ]
 
@@ -140,7 +138,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         path = reverse("sentry-auth-sso")
         resp = self.client.post(path, {"email": "foo@example.com"}, follow=True)
         assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
             ("/organizations/foo/issues/", 302),
         ]
 
@@ -165,7 +162,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         resp = self.client.post(path, {"op": "newuser"}, follow=True)
         assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
             ("/organizations/foo/issues/", 302),
         ]
 
@@ -257,10 +253,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.status_code == 200
 
         resp = self.client.post(path, {"op": "confirm"}, follow=True)
-        assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
-            ("/organizations/foo/issues/", 302),
-        ]
+        assert resp.redirect_chain == [("/organizations/foo/issues/", 302)]
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
         new_user = auth_identity.user
@@ -300,7 +293,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         resp = self.client.post(path, {"op": "confirm"}, follow=True)
         assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
             ("/organizations/foo/issues/", 302),
         ]
 
@@ -346,10 +338,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.status_code == 200
 
         resp = self.client.post(path, {"op": "confirm"}, follow=True)
-        assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
-            ("/organizations/foo/issues/", 302),
-        ]
+        assert resp.redirect_chain == [("/organizations/foo/issues/", 302)]
 
         auth_identity = AuthIdentity.objects.get(id=auth_identity.id)
 
@@ -394,7 +383,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
 
         resp = self.client.post(path, {"op": "newuser"}, follow=True)
         assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
             ("/organizations/foo/issues/", 302),
         ]
 
@@ -449,7 +437,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
             path, {"email": "bar@example.com", "id": "123", "email_verified": "1"}, follow=True
         )
         assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
             ("/organizations/foo/issues/", 302),
             ("/auth/login/foo/", 302),
         ]
@@ -607,7 +594,6 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         # updated to be something else)
         resp = self.client.post(path, {"email": "adfadsf@example.com"}, follow=True)
         assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
             ("/organizations/foo/issues/", 302),
             ("/auth/login/foo/", 302),
         ]
@@ -646,10 +632,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         resp = self.client.post(
             path, {"email": "foo@new-domain.com", "legacy_email": "foo@example.com"}, follow=True
         )
-        assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
-            ("/organizations/foo/issues/", 302),
-        ]
+        assert resp.redirect_chain == [("/organizations/foo/issues/", 302)]
 
         # Ensure the ident was migrated from the legacy identity
         updated_ident = AuthIdentity.objects.get(id=user_ident.id)

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -211,10 +211,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.status_code == 200
 
         resp = self.client.post(path, {"op": "confirm"}, follow=True)
-        assert resp.redirect_chain == [
-            (reverse("sentry-login"), 302),
-            ("/organizations/foo/issues/", 302),
-        ]
+        assert resp.redirect_chain == [("/organizations/foo/issues/", 302)]
         auth_identity = AuthIdentity.objects.get(auth_provider=auth_provider)
 
         new_user = auth_identity.user

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -666,7 +666,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         member.user = None
         member.save()
         resp = self.client.post(
-            self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
+            self.path, {"username": user.username, "password": "admin", "op": "login"}, follow=True
         )
         assert resp.redirect_chain == [("/auth/login/", 302), ("/organizations/new/", 302)]
 
@@ -677,14 +677,12 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.create_member(organization=self.organization, user=user)
         member = OrganizationMember.objects.get(organization=self.organization, user=user)
         member.save()
-
         self.session["_next"] = reverse(
             "sentry-organization-settings", args=[self.organization.slug]
         )
         self.save_session()
-
         resp = self.client.post(
-            self.path, {"username": self.user, "password": "admin", "op": "login"}, follow=True
+            self.path, {"username": user.username, "password": "admin", "op": "login"}, follow=True
         )
         assert resp.redirect_chain == [
             (reverse("sentry-organization-settings", args=[self.organization.slug]), 302),


### PR DESCRIPTION
### Summary

If you:

- have multiple org memberships
-  do not have a url in session var `_next` (you navigated to the login page directly instead of being redirected),

You can be taken to the wrong org after logging in. 

This is because in `get_login_redirect` we set the default redirect to `/auth/login`, 
which for an authenticated user will pull in the first org listed by [Organizations.objects.get_for_user](https://github.com/getsentry/sentry/blob/83875f7e8c433b942278332404f313f939e67da0/src/sentry/web/frontend/base.py#L96)

In SSO and basic auth, we'll supply a default of the org url which should make for better UX.

The other option considered for fixing was to set the `activeorg` session variable, but this seems cleaner (and makes for 1 less redirect). Unless we had a good reason for always redirecting back to `/auth/login/`, this seems ideal.

Would like review of approach before polishing and adding more tests.

### TODO:

- [ ] play with SSO case more (are there fail cases in auth helper where we don't want to redirect back to the org?)
- [ ] confirm this doesn't break any sudo functionality redirects
- [ ] add test for fixed scenario (multiple org, wrong redirect)

