### PR TITLE
ref(ts): Minor type corrections

### DIFF
--- a/static/app/components/passwordStrength.tsx
+++ b/static/app/components/passwordStrength.tsx
@@ -55,7 +55,6 @@ const PasswordStrength = ({
   const styles = css`
     background: ${colors[score]};
     width: ${percent}%;
-    height: 100%;
   `;
 
   return (
@@ -66,7 +65,7 @@ const PasswordStrength = ({
         aria-valuemin={0}
         aria-valuemax={100}
       >
-        <div css={styles} />
+        <StrengthProgressBar css={styles} />
       </StrengthProgress>
       <StrengthLabel>
         {tct('Strength: [textScore]', {
@@ -82,6 +81,10 @@ const StrengthProgress = styled('div')`
   height: 8px;
   border-radius: 2px;
   overflow: hidden;
+`;
+
+const StrengthProgressBar = styled('div')`
+  height: 100%;
 `;
 
 const StrengthLabel = styled('div')`

--- a/static/app/views/settings/account/accountSecurity/components/recoveryCodes.tsx
+++ b/static/app/views/settings/account/accountSecurity/components/recoveryCodes.tsx
@@ -88,7 +88,7 @@ const RecoveryCodes = ({
           <EmptyMessage>{t('You have no more recovery codes to use')}</EmptyMessage>
         )}
       </PanelBody>
-      <iframe name="printable" css={{display: 'none'}} />
+      <iframe name="printable" style={{display: 'none'}} />
     </CodeContainer>
   );
 };


### PR DESCRIPTION
Just some trivail things.

 * Use `style` for these type of styles in the iframe
 * Use a styled component for `css`. This isn't strictly required I think, but in react 17 there may be some type mismatch w/ emotion handling this css prop on intrinsic elements. This is the only instance of `css` on an intrinsic element though, so just make it a styled component.