### PR TITLE
feat(alert): Moved metric field to second step of builder

### DIFF
--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -259,3 +259,24 @@ export const hideParameterSelectorSet = new Set<AlertType>([
   'fid',
   'cls',
 ]);
+
+export function getFunctionHelpText(
+  alertType: AlertType
+): {labelText: string; timeWindowText?: string} {
+  const timeWindowText = t('over');
+  if (alertType === 'apdex') {
+    return {
+      labelText: t('Select apdex value and time interval'),
+      timeWindowText,
+    };
+  } else if (hidePrimarySelectorSet.has(alertType)) {
+    return {
+      labelText: t('Select time interval'),
+    };
+  } else {
+    return {
+      labelText: t('Select function and time interval'),
+      timeWindowText,
+    };
+  }
+}

--- a/static/app/views/settings/incidentRules/constants.tsx
+++ b/static/app/views/settings/incidentRules/constants.tsx
@@ -5,7 +5,7 @@ import {
   DATA_SOURCE_TO_SET_AND_EVENT_TYPES,
   getQueryDatasource,
 } from 'app/views/alerts/utils';
-import {WizardRuleTemplate} from 'app/views/alerts/wizard/options';
+import {AlertType, WizardRuleTemplate} from 'app/views/alerts/wizard/options';
 import {
   AlertRuleThresholdType,
   Dataset,
@@ -54,6 +54,26 @@ const commonAggregations: AggregationKey[] = [
   'p100',
 ];
 
+const allAggregations: AggregationKey[] = [
+  ...commonAggregations,
+  'failure_rate',
+  'apdex',
+  'count',
+];
+
+export function getWizardAlertFieldConfig(alertType: AlertType): OptionConfig {
+  // If user selected apdex we must include that in the OptionConfig as it has a user specified column
+  const aggregations =
+    alertType === 'apdex' || alertType === 'custom'
+      ? allAggregations
+      : commonAggregations;
+  return {
+    aggregations,
+    fields: ['transaction.duration'],
+    measurementKeys: Object.keys(WEB_VITAL_DETAILS),
+  };
+}
+
 /**
  * Allowed aggregations for alerts created from wizard
  */
@@ -67,7 +87,7 @@ export const wizardAlertFieldConfig: OptionConfig = {
  * Allowed transaction aggregations for alerts
  */
 export const transactionFieldConfig: OptionConfig = {
-  aggregations: [...commonAggregations, 'failure_rate', 'apdex', 'count'],
+  aggregations: allAggregations,
   fields: ['transaction.duration'],
   measurementKeys: Object.keys(WEB_VITAL_DETAILS),
 };

--- a/static/app/views/settings/incidentRules/metricField.tsx
+++ b/static/app/views/settings/incidentRules/metricField.tsx
@@ -5,7 +5,6 @@ import styled from '@emotion/styled';
 import Button from 'app/components/button';
 import Tooltip from 'app/components/tooltip';
 import {t, tct} from 'app/locale';
-import space from 'app/styles/space';
 import {Organization} from 'app/types';
 import {
   Aggregation,
@@ -28,9 +27,9 @@ import FormModel from 'app/views/settings/components/forms/model';
 
 import {
   errorFieldConfig,
+  getWizardAlertFieldConfig,
   OptionConfig,
   transactionFieldConfig,
-  wizardAlertFieldConfig,
 } from './constants';
 import {PRESET_AGGREGATES} from './presets';
 import {Dataset} from './types';
@@ -58,7 +57,7 @@ const getFieldOptionConfig = ({
   let hideParameterSelector = false;
   if (organization.features.includes('alert-wizard')) {
     const alertType = getAlertTypeFromAggregateDataset({dataset, aggregate});
-    config = wizardAlertFieldConfig;
+    config = getWizardAlertFieldConfig(alertType);
     hidePrimarySelector = hidePrimarySelectorSet.has(alertType);
     hideParameterSelector = hideParameterSelectorSet.has(alertType);
   } else {
@@ -160,13 +159,6 @@ const MetricField = ({organization, columnWidth, inFieldLabels, ...props}: Props
 
       return (
         <React.Fragment>
-          {!inFieldLabels && (
-            <AggregateHeader>
-              <div>{t('Function')}</div>
-              {numParameters > 0 && <div>{t('Parameter')}</div>}
-              {numParameters > 1 && <div>{t('Value')}</div>}
-            </AggregateHeader>
-          )}
           <StyledQueryField
             filterPrimaryOptions={option => option.value.kind === FieldValueKind.FUNCTION}
             fieldOptions={fieldOptions}
@@ -192,18 +184,6 @@ const StyledQueryField = styled(QueryField)<{gridColumns: number; columnWidth?: 
     css`
       width: ${p.gridColumns * p.columnWidth}px;
     `}
-`;
-
-const AggregateHeader = styled('div')`
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: 1fr;
-  grid-gap: ${space(1)};
-  text-transform: uppercase;
-  font-size: ${p => p.theme.fontSizeSmall};
-  color: ${p => p.theme.gray300};
-  font-weight: bold;
-  margin-bottom: ${space(1)};
 `;
 
 const PresetButton = styled(Button)<{disabled: boolean}>`

--- a/static/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
+++ b/static/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
@@ -19,6 +19,7 @@ import {
   DATA_SOURCE_LABELS,
   DATA_SOURCE_TO_SET_AND_EVENT_TYPES,
 } from 'app/views/alerts/utils';
+import {AlertType, getFunctionHelpText} from 'app/views/alerts/wizard/options';
 import FormField from 'app/views/settings/components/forms/formField';
 import SelectField from 'app/views/settings/components/forms/selectField';
 
@@ -43,8 +44,9 @@ type Props = {
   organization: Organization;
   projectSlug: string;
   disabled: boolean;
-  thresholdChart: (props: {footer: React.ReactNode}) => React.ReactElement;
+  thresholdChart: React.ReactElement;
   onFilterSearch: (query: string) => void;
+  alertType: AlertType;
   allowChangeEventTypes?: boolean;
 };
 
@@ -80,7 +82,13 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {organization, disabled, onFilterSearch, allowChangeEventTypes} = this.props;
+    const {
+      organization,
+      disabled,
+      onFilterSearch,
+      allowChangeEventTypes,
+      alertType,
+    } = this.props;
     const {environments} = this.state;
 
     const environmentOptions: SelectValue<string | null>[] =
@@ -129,31 +137,12 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
       border: 'none',
     };
 
+    const {labelText: intervalLabelText, timeWindowText} = getFunctionHelpText(alertType);
+
     return (
       <React.Fragment>
         <ChartPanel>
-          <StyledPanelBody>
-            {this.props.thresholdChart({
-              footer: (
-                <ChartFooter>
-                  <MetricField
-                    name="aggregate"
-                    help={null}
-                    organization={organization}
-                    disabled={disabled}
-                    style={{
-                      ...formElemBaseStyle,
-                    }}
-                    inline={false}
-                    flexibleControlStateSize
-                    columnWidth={200}
-                    inFieldLabels
-                    required
-                  />
-                </ChartFooter>
-              ),
-            })}
-          </StyledPanelBody>
+          <StyledPanelBody>{this.props.thresholdChart}</StyledPanelBody>
         </ChartPanel>
         <StyledListItem>{t('Filter events')}</StyledListItem>
         <FormRow>
@@ -284,7 +273,7 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
         </FormRow>
         <StyledListItem>
           <StyledListTitle>
-            <div>{t('Select time interval')}</div>
+            <div>{intervalLabelText}</div>
             <Tooltip
               title={t(
                 'Time window over which the metric is evaluated. Alerts are evaluated every minute regardless of this value.'
@@ -294,23 +283,40 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
             </Tooltip>
           </StyledListTitle>
         </StyledListItem>
-        <ThresholdSelectField
-          name="timeWindow"
-          style={{
-            ...formElemBaseStyle,
-            flex: '0 150px 0',
-            minWidth: 130,
-            maxWidth: 300,
-            marginBottom: 20,
-          }}
-          choices={Object.entries(TIME_WINDOW_MAP)}
-          required
-          isDisabled={disabled}
-          getValue={value => Number(value)}
-          setValue={value => `${value}`}
-          inline={false}
-          flexibleControlStateSize
-        />
+        <FormRow>
+          {timeWindowText && (
+            <MetricField
+              name="aggregate"
+              help={null}
+              organization={organization}
+              disabled={disabled}
+              style={{
+                ...formElemBaseStyle,
+              }}
+              inline={false}
+              flexibleControlStateSize
+              columnWidth={200}
+              required
+            />
+          )}
+          {timeWindowText && <FormRowText>{timeWindowText}</FormRowText>}
+          <SelectField
+            name="timeWindow"
+            style={{
+              ...formElemBaseStyle,
+              flex: '0 150px 0',
+              minWidth: 130,
+              maxWidth: 300,
+            }}
+            choices={Object.entries(TIME_WINDOW_MAP)}
+            required
+            isDisabled={disabled}
+            getValue={value => Number(value)}
+            setValue={value => `${value}`}
+            inline={false}
+            flexibleControlStateSize
+          />
+        </FormRow>
       </React.Fragment>
     );
   }
@@ -325,12 +331,6 @@ const StyledListTitle = styled('div')`
 
 const ChartPanel = styled(Panel)`
   margin-bottom: ${space(4)};
-  min-height: 335px;
-`;
-
-const ThresholdSelectField = styled(SelectField)`
-  margin-bottom: ${space(2)} !important;
-  padding-top: 0 !important;
 `;
 
 const StyledPanelBody = styled(PanelBody)`
@@ -357,13 +357,13 @@ const StyledListItem = styled(ListItem)`
 const FormRow = styled('div')`
   display: flex;
   flex-direction: row;
-  align-items: flex-end;
+  align-items: center;
   flex-wrap: wrap;
   margin-bottom: ${space(4)};
 `;
 
-const ChartFooter = styled(FormRow)`
-  margin: 0;
+const FormRowText = styled('div')`
+  margin: ${space(1)};
 `;
 
 export default RuleConditionsFormForWizard;

--- a/static/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -617,7 +617,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       thresholdType,
     };
     const alertType = getAlertTypeFromAggregateDataset({aggregate, dataset});
-    const wizardBuilderChart = ({footer}) => (
+    const wizardBuilderChart = (
       <TriggersChart
         {...chartProps}
         header={
@@ -628,7 +628,6 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
             </AlertInfo>
           </ChartHeader>
         }
-        footer={footer}
       />
     );
     const chart = <TriggersChart {...chartProps} />;
@@ -717,10 +716,9 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                       thresholdChart={wizardBuilderChart}
                       onFilterSearch={this.handleFilterUpdate}
                       allowChangeEventTypes={dataset === Dataset.ERRORS}
+                      alertType={alertType}
                     />
-                    <StyledListItem>
-                      {t('Set thresholds to trigger alert')}
-                    </StyledListItem>
+                    <AlertListItem>{t('Set thresholds to trigger alert')}</AlertListItem>
                     {triggerForm(hasAccess)}
                     <StyledListItem>{t('Add a rule name and team')}</StyledListItem>
                     {ruleNameOwnerForm(hasAccess)}
@@ -753,6 +751,10 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
 const StyledListItem = styled(ListItem)`
   margin: ${space(2)} 0 ${space(1)} 0;
   font-size: ${p => p.theme.fontSizeExtraLarge};
+`;
+
+const AlertListItem = styled(StyledListItem)`
+  margin-top: 0;
 `;
 
 const ChartHeader = styled('div')`

--- a/static/app/views/settings/incidentRules/triggers/chart/index.tsx
+++ b/static/app/views/settings/incidentRules/triggers/chart/index.tsx
@@ -39,7 +39,6 @@ type Props = {
   resolveThreshold: IncidentRule['resolveThreshold'];
   thresholdType: IncidentRule['thresholdType'];
   header?: React.ReactNode;
-  footer?: React.ReactNode;
 };
 
 const TIME_PERIOD_MAP: Record<TimePeriod, string> = {
@@ -195,7 +194,6 @@ class TriggersChart extends React.PureComponent<Props, State> {
       thresholdType,
       environment,
       header,
-      footer,
     } = this.props;
     const {statsPeriod, totalEvents} = this.state;
 
@@ -274,18 +272,14 @@ class TriggersChart extends React.PureComponent<Props, State> {
                     )}
                     <ChartControls>
                       <InlineContainer>
-                        {footer ? (
-                          footer
-                        ) : (
-                          <React.Fragment>
-                            <SectionHeading>{t('Total Events')}</SectionHeading>
-                            {totalEvents !== null ? (
-                              <SectionValue>{totalEvents.toLocaleString()}</SectionValue>
-                            ) : (
-                              <SectionValue>&mdash;</SectionValue>
-                            )}
-                          </React.Fragment>
-                        )}
+                        <React.Fragment>
+                          <SectionHeading>{t('Total Events')}</SectionHeading>
+                          {totalEvents !== null ? (
+                            <SectionValue>{totalEvents.toLocaleString()}</SectionValue>
+                          ) : (
+                            <SectionValue>&mdash;</SectionValue>
+                          )}
+                        </React.Fragment>
                       </InlineContainer>
                       <InlineContainer>
                         <SectionHeading>{t('Display')}</SectionHeading>
@@ -294,8 +288,8 @@ class TriggersChart extends React.PureComponent<Props, State> {
                           styles={{
                             control: provided => ({
                               ...provided,
-                              minHeight: '25px',
-                              height: '25px',
+                              minHeight: '32px',
+                              height: '32px',
                             }),
                           }}
                           isSearchable={false}
@@ -344,5 +338,5 @@ const PeriodSelectControl = styled(SelectControl)`
   font-weight: normal;
   text-transform: none;
   border: 0;
-  margin-right: ${space(2)};
+  margin-right: ${space(0.5)};
 `;


### PR DESCRIPTION
- Moves the metric field to the time interval step
- Removes the footer from the alert wizard and replaces it with event count
- Makes the time display dropdown 32px height to match discover
- Fixes a bug with apdex where you cannot select a value

**Before:**
![image](https://user-images.githubusercontent.com/9372512/116113918-ee5f8d00-a686-11eb-963e-b6dac50244d1.png)

**After:**
![image](https://user-images.githubusercontent.com/9372512/116113677-b2c4c300-a686-11eb-8417-63c689954eb6.png)
