### PR TITLE
fix(bootstrap): Docker initialization does not work after updating Docker

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -40,7 +40,7 @@ sudo-askpass() {
 init-docker() {
     # Need to start docker if it was freshly installed or updated
     # You will know that Docker is ready for devservices when the icon on the menu bar stops flashing
-    if [ ! -f /Library/PrivilegedHelperTools/com.docker.vmnetd ]; then
+    if query-mac && [ ! -f /Library/PrivilegedHelperTools/com.docker.vmnetd ]; then
         echo "Making some changes to complete Docker initialization"
         # allow the app to run without confirmation
         xattr -d -r com.apple.quarantine /Applications/Docker.app

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -38,8 +38,9 @@ sudo-askpass() {
 # After using homebrew to install docker, we need to do some magic to remove the need to interact with the GUI
 # See: https://github.com/docker/for-mac/issues/2359#issuecomment-607154849 for why we need to do things below
 init-docker() {
-    # Need to start docker if it was freshly installed (docker server is not running)
-    if query-mac && ! require docker && [ -d "/Applications/Docker.app" ]; then
+    # Need to start docker if it was freshly installed or updated
+    # You will know that Docker is ready for devservices when the icon on the menu bar stops flashing
+    if [ ! -f /Library/PrivilegedHelperTools/com.docker.vmnetd ]; then
         echo "Making some changes to complete Docker initialization"
         # allow the app to run without confirmation
         xattr -d -r com.apple.quarantine /Applications/Docker.app


### PR DESCRIPTION
When Docker Desktop updates, it removes certain files from disk and
undoing what `init-docker` accomplishes.

In order for this to work without UI interaction we simply check for the file
that gets removed.

This issue only affects anyone trying to call `./scripts/do.sh init-docker` after
a Docker Desktop update, thus, a very small number of people.