### PR TITLE
chore(discover): Adding a tag to see stats v1 usage

### DIFF
--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -20,6 +20,7 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsV2EndpointBase):
             span.set_data("organization", organization)
             if not self.has_feature(organization, request):
                 span.set_data("using_v1_results", True)
+                sentry_sdk.set_tag("stats.using_v1", organization.slug)
                 return self.get_v1_results(request, organization)
 
             top_events = 0


### PR DESCRIPTION
- I want to figure out all the places where this v1 functionality is
  still being used, to determine if we should look into removing it
  entirely, or supporting it better