### PR TITLE
fix(alert): Fix custom metric to retain all alerting options

### DIFF
--- a/static/app/views/settings/incidentRules/create.tsx
+++ b/static/app/views/settings/incidentRules/create.tsx
@@ -24,9 +24,10 @@ type Props = {
   organization: Organization;
   project: Project;
   eventView: EventView | undefined;
+  teams: Team[];
   wizardTemplate?: WizardRuleTemplate;
   sessionId?: string;
-  teams: Team[];
+  isCustomMetric?: boolean;
 } & RouteComponentProps<RouteParams, {}>;
 
 /**

--- a/static/app/views/settings/incidentRules/metricField.tsx
+++ b/static/app/views/settings/incidentRules/metricField.tsx
@@ -15,10 +15,10 @@ import {
   generateFieldAsString,
 } from 'app/utils/discover/fields';
 import {
+  AlertType,
   hideParameterSelectorSet,
   hidePrimarySelectorSet,
 } from 'app/views/alerts/wizard/options';
-import {getAlertTypeFromAggregateDataset} from 'app/views/alerts/wizard/utils';
 import {QueryField} from 'app/views/eventsV2/table/queryField';
 import {FieldValueKind} from 'app/views/eventsV2/table/types';
 import {generateFieldOptions} from 'app/views/eventsV2/utils';
@@ -41,22 +41,22 @@ type Props = Omit<FormField['props'], 'children'> & {
    */
   columnWidth?: number;
   inFieldLabels?: boolean;
+  alertType?: AlertType;
 };
 
 const getFieldOptionConfig = ({
   dataset,
-  aggregate,
   organization,
+  alertType,
 }: {
   dataset: Dataset;
-  aggregate: string;
   organization: Organization;
+  alertType?: AlertType;
 }) => {
   let config: OptionConfig;
   let hidePrimarySelector = false;
   let hideParameterSelector = false;
-  if (organization.features.includes('alert-wizard')) {
-    const alertType = getAlertTypeFromAggregateDataset({dataset, aggregate});
+  if (organization.features.includes('alert-wizard') && alertType) {
     config = getWizardAlertFieldConfig(alertType);
     hidePrimarySelector = hidePrimarySelectorSet.has(alertType);
     hideParameterSelector = hideParameterSelectorSet.has(alertType);
@@ -125,11 +125,16 @@ const help = ({name, model}: {name: string; model: FormModel}) => {
   );
 };
 
-const MetricField = ({organization, columnWidth, inFieldLabels, ...props}: Props) => (
+const MetricField = ({
+  organization,
+  columnWidth,
+  inFieldLabels,
+  alertType,
+  ...props
+}: Props) => (
   <FormField help={help} {...props}>
     {({onChange, value, model, disabled}) => {
       const dataset = model.getValue('dataset');
-      const aggregate = model.getValue('aggregate');
 
       const {
         fieldOptionsConfig,
@@ -137,8 +142,8 @@ const MetricField = ({organization, columnWidth, inFieldLabels, ...props}: Props
         hideParameterSelector,
       } = getFieldOptionConfig({
         dataset: dataset as Dataset,
-        aggregate,
         organization,
+        alertType,
       });
       const fieldOptions = generateFieldOptions({organization, ...fieldOptionsConfig});
       const fieldValue = explodeFieldString(value ?? '');

--- a/static/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
+++ b/static/app/views/settings/incidentRules/ruleConditionsFormForWizard.tsx
@@ -296,6 +296,7 @@ class RuleConditionsFormForWizard extends React.PureComponent<Props, State> {
               inline={false}
               flexibleControlStateSize
               columnWidth={200}
+              alertType={alertType}
               required
             />
           )}

--- a/static/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -63,6 +63,7 @@ type Props = {
   userTeamIds: Set<string>;
   ruleId?: string;
   sessionId?: string;
+  isCustomMetric?: boolean;
 } & RouteComponentProps<{orgId: string; projectId: string; ruleId?: string}, {}> & {
     onSubmitSuccess?: Form['props']['onSubmitSuccess'];
   } & AsyncComponent['props'];
@@ -588,6 +589,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       onSubmitSuccess,
       project,
       userTeamIds,
+      isCustomMetric,
     } = this.props;
     const {
       query,
@@ -716,7 +718,7 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
                       thresholdChart={wizardBuilderChart}
                       onFilterSearch={this.handleFilterUpdate}
                       allowChangeEventTypes={dataset === Dataset.ERRORS}
-                      alertType={alertType}
+                      alertType={isCustomMetric ? 'custom' : alertType}
                     />
                     <AlertListItem>{t('Set thresholds to trigger alert')}</AlertListItem>
                     {triggerForm(hasAccess)}

--- a/static/app/views/settings/projectAlerts/create.tsx
+++ b/static/app/views/settings/projectAlerts/create.tsx
@@ -158,6 +158,7 @@ class Create extends React.Component<Props, State> {
                 wizardTemplate={wizardTemplate}
                 sessionId={this.sessionId}
                 project={project}
+                isCustomMetric={wizardAlertType === 'custom'}
               />
             )}
           </Layout.Main>


### PR DESCRIPTION
Previously, when you go to the alert builder after selecting **custom** metric you will initially be presented with all the alert builder options, but once you make a selection that coincides with a known alert type e.g. `Throughput`, `Largest Contentful Paint`, etc... it would lock you into that alert type.

Changed to now maintain the custom metric status, but still have the rest of the page act the same. So the graph will show a nice name for the alert type, but you can switch between all the different alert types e.g. Duration --> Apdex

**Before:**
![Kapture 2021-04-26 at 17 17 06](https://user-images.githubusercontent.com/9372512/116151978-54faa000-a6b3-11eb-8fa3-1ce2778aed49.gif)

**After:**
![Kapture 2021-04-26 at 17 15 44](https://user-images.githubusercontent.com/9372512/116151955-4ca26500-a6b3-11eb-8e6b-8a9c1d5db359.gif)
