### PR TITLE
feat(breakdowns): Show relative ops breakdown when there is no applied ops filter

### DIFF
--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -549,6 +549,10 @@ const spanOperationRelativeBreakdownRenderer = (
   return (
     <RelativeOpsBreakdown>
       {SPAN_OP_BREAKDOWN_FIELDS.map(field => {
+        if (!isDurationValue(data, field)) {
+          return null;
+        }
+
         const operationName = getSpanOperationName(field) ?? 'op';
         const spanOpDuration = data[field];
         const widthPercentage = spanOpDuration / cumulativeSpanOpBreakdown;

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -535,14 +535,15 @@ const spanOperationRelativeBreakdownRenderer = (
   data: EventData,
   {location}: RenderFunctionBaggage
 ): React.ReactNode => {
+  const cumulativeSpanOpBreakdown = data['spans.total.time'];
+
   if (
     !isDurationValue(data, 'spans.total.time') ||
-    SPAN_OP_BREAKDOWN_FIELDS.every(field => !isDurationValue(data, field))
+    SPAN_OP_BREAKDOWN_FIELDS.every(field => !isDurationValue(data, field)) ||
+    cumulativeSpanOpBreakdown === 0
   ) {
     return FIELD_FORMATTERS.duration.renderFunc(SPAN_OP_RELATIVE_BREAKDOWN_FIELD, data);
   }
-
-  const cumulativeSpanOpBreakdown = data['spans.total.time'];
 
   let otherPercentage = 1;
 
@@ -554,7 +555,7 @@ const spanOperationRelativeBreakdownRenderer = (
         }
 
         const operationName = getSpanOperationName(field) ?? 'op';
-        const spanOpDuration = data[field];
+        const spanOpDuration: number = data[field];
         const widthPercentage = spanOpDuration / cumulativeSpanOpBreakdown;
         otherPercentage = otherPercentage - widthPercentage;
         if (widthPercentage === 0) {

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 import partial from 'lodash/partial';
@@ -33,6 +34,11 @@ import {getShortEventId} from 'app/utils/events';
 import {formatFloat, formatPercentage} from 'app/utils/formatters';
 import getDynamicText from 'app/utils/getDynamicText';
 import Projects from 'app/utils/projects';
+import {
+  filterToLocationQuery,
+  SpanOperationBreakdownFilter,
+  stringToFilter,
+} from 'app/views/performance/transactionSummary/filter';
 
 import ArrayValue from './arrayValue';
 import {EventData, MetaType} from './eventView';
@@ -525,7 +531,10 @@ const spanOperationBreakdownRenderer = (field: string) => (
   );
 };
 
-const spanOperationRelativeBreakdownRenderer = (data: EventData): React.ReactNode => {
+const spanOperationRelativeBreakdownRenderer = (
+  data: EventData,
+  {location}: RenderFunctionBaggage
+): React.ReactNode => {
   if (
     !isDurationValue(data, 'spans.total.time') ||
     SPAN_OP_BREAKDOWN_FIELDS.every(field => !isDurationValue(data, field))
@@ -554,6 +563,21 @@ const spanOperationRelativeBreakdownRenderer = (data: EventData): React.ReactNod
                 spanBarHatch={false}
                 style={{
                   backgroundColor: pickBarColour(operationName),
+                  cursor: 'pointer',
+                }}
+                onClick={event => {
+                  event.stopPropagation();
+                  const filter = stringToFilter(operationName);
+                  if (filter === SpanOperationBreakdownFilter.None) {
+                    return;
+                  }
+                  browserHistory.push({
+                    pathname: location.pathname,
+                    query: {
+                      ...location.query,
+                      ...filterToLocationQuery(filter),
+                    },
+                  });
                 }}
               />
             </Tooltip>

--- a/static/app/utils/discover/fields.tsx
+++ b/static/app/utils/discover/fields.tsx
@@ -824,6 +824,19 @@ export function isSpanOperationBreakdownField(field: string) {
   return field.startsWith('spans.');
 }
 
+export const SPAN_OP_RELATIVE_BREAKDOWN_FIELD = 'span_ops_breakdown.relative';
+
+export function isRelativeSpanOperationBreakdownField(field: string) {
+  return field === SPAN_OP_RELATIVE_BREAKDOWN_FIELD;
+}
+
+export const SPAN_OP_BREAKDOWN_FIELDS = [
+  'spans.http',
+  'spans.db',
+  'spans.browser',
+  'spans.resource',
+];
+
 export function getSpanOperationName(field: string): string | null {
   const results = field.match(SPAN_OP_BREAKDOWN_PATTERN);
   if (results && results.length >= 2) {

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -9,7 +9,10 @@ import {IconEllipsis} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {TableDataRow} from 'app/utils/discover/discoverQuery';
-import {getAggregateAlias} from 'app/utils/discover/fields';
+import {
+  getAggregateAlias,
+  isRelativeSpanOperationBreakdownField,
+} from 'app/utils/discover/fields';
 import {getDuration} from 'app/utils/formatters';
 import {QueryResults} from 'app/utils/tokenizeSearch';
 
@@ -190,6 +193,12 @@ class CellAction extends React.Component<Props, State> {
 
   renderMenuButtons() {
     const {dataRow, column, handleCellAction, allowActions} = this.props;
+
+    // Do not render context menu buttons for the span op breakdown field.
+    if (isRelativeSpanOperationBreakdownField(column.name)) {
+      return null;
+    }
+
     const fieldAlias = getAggregateAlias(column.name);
 
     let value = dataRow[fieldAlias];

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -19,7 +19,11 @@ import {generateQueryWithTag} from 'app/utils';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
 import {TableDataRow} from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
-import {getAggregateAlias} from 'app/utils/discover/fields';
+import {
+  getAggregateAlias,
+  SPAN_OP_BREAKDOWN_FIELDS,
+  SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
+} from 'app/utils/discover/fields';
 import {generateEventSlug} from 'app/utils/discover/urls';
 import {decodeScalar} from 'app/utils/queryString';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
@@ -176,16 +180,6 @@ class SummaryContent extends React.Component<Props, State> {
     const query = decodeScalar(location.query.query, '');
     const totalCount = totalValues === null ? null : totalValues.count;
 
-    const spanOperationBreakdownConditions = filterToSearchConditions(
-      spanOperationBreakdownFilter,
-      location
-    );
-
-    if (spanOperationBreakdownConditions) {
-      eventView = eventView.clone();
-      eventView.query = `${eventView.query} ${spanOperationBreakdownConditions}`.trim();
-    }
-
     // NOTE: This is not a robust check for whether or not a transaction is a front end
     // transaction, however it will suffice for now.
     const hasWebVitals =
@@ -197,10 +191,62 @@ class SummaryContent extends React.Component<Props, State> {
         })
       );
 
-    const durationTableTitle =
-      spanOperationBreakdownFilter === SpanOperationBreakdownFilter.None
-        ? t('total duration')
-        : `${spanOperationBreakdownFilter} duration`;
+    const transactionsListTitles = organization.features.includes('trace-view-summary')
+      ? [t('event id'), t('user'), t('total duration'), t('trace id'), t('timestamp')]
+      : [t('event id'), t('user'), t('total duration'), t('timestamp')];
+
+    let transactionsListEventView = eventView.clone();
+
+    if (organization.features.includes('performance-ops-breakdown')) {
+      // update search conditions
+
+      const spanOperationBreakdownConditions = filterToSearchConditions(
+        spanOperationBreakdownFilter,
+        location
+      );
+
+      if (spanOperationBreakdownConditions) {
+        eventView = eventView.clone();
+        eventView.query = `${eventView.query} ${spanOperationBreakdownConditions}`.trim();
+        transactionsListEventView = eventView.clone();
+      }
+
+      // update header titles of transactions list
+
+      const operationDurationTableTitle =
+        spanOperationBreakdownFilter === SpanOperationBreakdownFilter.None
+          ? t('operation duration')
+          : `${spanOperationBreakdownFilter} duration`;
+
+      // add ops breakdown duration column as the 3rd column
+      transactionsListTitles.splice(2, 0, operationDurationTableTitle);
+
+      // span_ops_breakdown.relative is a preserved name and a marker for the associated
+      // field renderer to be used to generate the relative ops breakdown
+      let durationField = SPAN_OP_RELATIVE_BREAKDOWN_FIELD;
+
+      if (spanOperationBreakdownFilter !== SpanOperationBreakdownFilter.None) {
+        durationField = filterToField(spanOperationBreakdownFilter)!;
+      }
+
+      const fields = [...transactionsListEventView.fields];
+
+      // add ops breakdown duration column as the 3rd column
+      fields.splice(2, 0, {field: durationField});
+
+      if (spanOperationBreakdownFilter === SpanOperationBreakdownFilter.None) {
+        // Add spans.total.time field so that the span op breakdown can be compared against it.
+        // This is used to generate the relative
+        fields.push({field: 'spans.total.time'});
+        fields.push(
+          ...SPAN_OP_BREAKDOWN_FIELDS.map(field => {
+            return {field};
+          })
+        );
+      }
+
+      transactionsListEventView.fields = fields;
+    }
 
     return (
       <React.Fragment>
@@ -245,18 +291,8 @@ class SummaryContent extends React.Component<Props, State> {
             <TransactionsList
               location={location}
               organization={organization}
-              eventView={eventView}
-              titles={
-                organization.features.includes('trace-view-summary')
-                  ? [
-                      t('event id'),
-                      t('user'),
-                      durationTableTitle,
-                      t('trace id'),
-                      t('timestamp'),
-                    ]
-                  : [t('event id'), t('user'), durationTableTitle, t('timestamp')]
-              }
+              eventView={transactionsListEventView}
+              titles={transactionsListTitles}
               handleDropdownChange={this.handleTransactionsListSortChange}
               generateLink={{
                 id: generateTransactionLink(transactionName),

--- a/static/app/views/performance/transactionSummary/index.tsx
+++ b/static/app/views/performance/transactionSummary/index.tsx
@@ -33,7 +33,6 @@ import {addRoutePerformanceContext, getTransactionName} from '../utils';
 import SummaryContent from './content';
 import {
   decodeFilterFromLocation,
-  filterToField,
   filterToLocationQuery,
   SpanOperationBreakdownFilter,
 } from './filter';
@@ -277,26 +276,13 @@ function generateSummaryEventView(
     .setTagValues('event.type', ['transaction'])
     .setTagValues('transaction', [transactionName]);
 
-  const spanOperationBreakdownFilter = decodeFilterFromLocation(location);
-
   Object.keys(conditions.tagValues).forEach(field => {
     if (isAggregateField(field)) conditions.removeTag(field);
   });
 
-  let durationField = 'transaction.duration';
-
-  if (spanOperationBreakdownFilter !== SpanOperationBreakdownFilter.None) {
-    durationField = filterToField(spanOperationBreakdownFilter)!;
-  }
-
   const fields = organization.features.includes('trace-view-summary')
-    ? ['id', 'user.display', durationField, 'trace', 'timestamp']
-    : ['id', 'user.display', durationField, 'timestamp'];
-
-  if (spanOperationBreakdownFilter !== SpanOperationBreakdownFilter.None) {
-    // Add transaction.duration field so that the span op breakdown can be compared against it.
-    fields.push('transaction.duration');
-  }
+    ? ['id', 'user.display', 'transaction.duration', 'trace', 'timestamp']
+    : ['id', 'user.display', 'transaction.duration', 'timestamp'];
 
   return EventView.fromNewQueryWithLocation(
     {


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/25590

An additional column,  exclusively for span operation breakdowns, is inserted as the third column. This column will render operation breakdowns depending on the current filters:
- If there is no filter, then the proportionality of the operation breakdowns are shown. An other category is implicitly derived.
- If there is a filter, then only that operation breakdown is shown.

This column is only inserted if the org has the feature `performance-ops-breakdown`.

The transaction duration (i.e. "Total Duration") column is preserved.

https://user-images.githubusercontent.com/139499/116158053-fede2a80-a6bb-11eb-8b18-a4477c9c8024.mp4

