### PR TITLE
fix(alert): Save less tags when recording saveAlertRule transaction

### DIFF
--- a/static/app/views/settings/incidentRules/ruleForm/index.tsx
+++ b/static/app/views/settings/incidentRules/ruleForm/index.tsx
@@ -448,9 +448,11 @@ class RuleFormContainer extends AsyncComponent<Props, State> {
       transaction.setTag('operation', !rule.id ? 'create' : 'edit');
       for (const trigger of sanitizedTriggers) {
         for (const action of trigger.actions) {
-          transaction.setTag(action.type, true);
-          if (action.integrationId) {
-            transaction.setTag(`integrationId:${action.integrationId}`, true);
+          if (action.type === 'slack') {
+            transaction.setTag(action.type, true);
+            if (action.integrationId) {
+              transaction.setTag(`integrationId:${action.integrationId}`, true);
+            }
           }
         }
       }

--- a/static/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
+++ b/static/app/views/settings/projectAlerts/issueRuleEditor/index.tsx
@@ -269,7 +269,7 @@ class IssueRuleEditor extends AsyncView<Props, State> {
           // Grab the last part of something like 'sentry.mail.actions.NotifyEmailAction'
           const splitActionId = action.id.split('.');
           const actionName = splitActionId[splitActionId.length - 1];
-          if (actionName) {
+          if (actionName === 'SlackNotifyServiceAction') {
             transaction.setTag(actionName, true);
           }
         }


### PR DESCRIPTION
Previously this transaction saved all actions that the alert rule was being saved with, but this is a little too cluttered and a lot of these tags are not important to know for performance reasons. It seems the most important tag to capture is whether the user is saving a slack rule. 

This PR removes all other action/integration tags except the slack one.