### PR TITLE
feat(workflow): Disable mark reviewed when already reviewed

### DIFF
--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -10,6 +10,7 @@ import DropdownLink from 'app/components/dropdownLink';
 import Tooltip from 'app/components/tooltip';
 import {IconEllipsis, IconPause, IconPlay} from 'app/icons';
 import {t} from 'app/locale';
+import GroupStore from 'app/stores/groupStore';
 import space from 'app/styles/space';
 import {Organization, Project, ResolutionStatus} from 'app/types';
 import Projects from 'app/utils/projects';
@@ -60,6 +61,10 @@ function ActionSet({
   // merges require a single project to be active in an org context
   // selectedProjectSlug is null when 0 or >1 projects are selected.
   const mergeDisabled = !(multiSelected && selectedProjectSlug);
+
+  const selectedIssues = [...issues].map(GroupStore.get);
+  const canMarkReviewed =
+    anySelected && (allInQuerySelected || selectedIssues.some(issue => !!issue?.inbox));
 
   return (
     <Wrapper hasInbox={hasInbox}>
@@ -117,7 +122,7 @@ function ActionSet({
       {hasInbox && (
         <GuideAnchor target="inbox_guide_review" position="bottom">
           <div className="hidden-sm hidden-xs">
-            <ReviewAction disabled={!anySelected} onUpdate={onUpdate} />
+            <ReviewAction disabled={!canMarkReviewed} onUpdate={onUpdate} />
           </div>
         </GuideAnchor>
       )}
@@ -159,7 +164,7 @@ function ActionSet({
         {hasInbox && (
           <MenuItemActionLink
             className="hidden-md hidden-lg hidden-xl"
-            disabled={!anySelected}
+            disabled={!canMarkReviewed}
             onAction={() => onUpdate({inbox: false})}
             title={t('Mark Reviewed')}
           >

--- a/tests/js/spec/views/issueList/actions.spec.jsx
+++ b/tests/js/spec/views/issueList/actions.spec.jsx
@@ -5,6 +5,7 @@ import {initializeOrg} from 'sentry-test/initializeOrg';
 import {mountGlobalModal} from 'sentry-test/modal';
 import {selectByLabel} from 'sentry-test/select-new';
 
+import GroupStore from 'app/stores/groupStore';
 import SelectedGroupStore from 'app/stores/selectedGroupStore';
 import {IssueListActions} from 'app/views/issueList/actions';
 
@@ -345,7 +346,9 @@ describe('IssueListActions', function () {
   });
 
   describe('with inbox feature', function () {
+    let issuesApiMock;
     beforeEach(async () => {
+      GroupStore.init();
       SelectedGroupStore.init();
       await tick();
       const {organization} = TestStubs.routerContext().context;
@@ -370,28 +373,53 @@ describe('IssueListActions', function () {
         />,
         TestStubs.routerContext()
       );
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/projects/',
+        body: [TestStubs.Project({slug: 'earth', platform: 'javascript'})],
+      });
+      issuesApiMock = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/issues/',
+        method: 'PUT',
+      });
     });
 
     it('acknowledges group', async function () {
       wrapper.find('IssueListActions').setState({anySelected: true});
       SelectedGroupStore.add(['1', '2', '3']);
       SelectedGroupStore.toggleSelectAll();
+      const inbox = {
+        date_added: '2020-11-24T13:17:42.248751Z',
+        reason: 0,
+        reason_details: null,
+      };
+      GroupStore.loadInitialData([
+        TestStubs.Group({id: '1', inbox}),
+        TestStubs.Group({id: '2', inbox}),
+        TestStubs.Group({id: '2', inbox}),
+      ]);
 
       await tick();
-      wrapper.update();
 
-      const apiMock = MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/issues/',
-        method: 'PUT',
-      });
       wrapper.find('button[aria-label="Mark Reviewed"]').simulate('click');
-
-      expect(apiMock).toHaveBeenCalledWith(
+      expect(issuesApiMock).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
           data: {inbox: false},
         })
       );
+    });
+
+    it('mark reviewed disabled for group that is already reviewed', async function () {
+      wrapper.find('IssueListActions').setState({anySelected: true});
+      SelectedGroupStore.add(['1']);
+      SelectedGroupStore.toggleSelectAll();
+      GroupStore.loadInitialData([TestStubs.Group({id: '1', inbox: null})]);
+
+      await tick();
+
+      expect(
+        wrapper.find('button[aria-label="Mark Reviewed"]').props()['aria-disabled']
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Disables "mark reviewed" when all selected groups have been reviewed. Still allows mark reviewed when selecting the entire query.