### PR TITLE
feat(codeowners): Fix up Add Codeowners modal states

### DIFF
--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -30,7 +30,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
     users can go from the file in the stack trace to the
     provider of their choice.
 
-    `filepath`: The file path from the strack trace
+    `filepath` (optional): The file path from the strack trace
     `commitId` (optional): The commit_id for the last commit of the
                            release associated to the stack trace's event
 

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -39,8 +39,6 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
     def get(self, request, project):
         # should probably feature gate
         filepath = request.GET.get("file")
-        if not filepath:
-            return Response({"detail": "Filepath is required"}, status=400)
 
         commitId = request.GET.get("commitId")
         platform = request.GET.get("platform")
@@ -55,6 +53,10 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                 lambda i: i.has_feature(IntegrationFeatures.STACKTRACE_LINK), integrations
             )
         ]
+
+        # If the query does not have file, skip the remaining logic.
+        if not filepath:
+            return Response(result)
 
         # xxx(meredith): if there are ever any changes to this query, make
         # sure that we are still ordering by `id` because we want to make sure

--- a/src/sentry/api/endpoints/project_stacktrace_link.py
+++ b/src/sentry/api/endpoints/project_stacktrace_link.py
@@ -30,7 +30,7 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
     users can go from the file in the stack trace to the
     provider of their choice.
 
-    `filepath` (optional): The file path from the strack trace
+    `filepath`: The file path from the strack trace
     `commitId` (optional): The commit_id for the last commit of the
                            release associated to the stack trace's event
 
@@ -39,6 +39,8 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
     def get(self, request, project):
         # should probably feature gate
         filepath = request.GET.get("file")
+        if not filepath:
+            return Response({"detail": "Filepath is required"}, status=400)
 
         commitId = request.GET.get("commitId")
         platform = request.GET.get("platform")
@@ -53,10 +55,6 @@ class ProjectStacktraceLinkEndpoint(ProjectEndpoint):
                 lambda i: i.has_feature(IntegrationFeatures.STACKTRACE_LINK), integrations
             )
         ]
-
-        # If the query does not have file, skip the remaining logic.
-        if not filepath:
-            return Response(result)
 
         # xxx(meredith): if there are ever any changes to this query, make
         # sure that we are still ordering by `id` because we want to make sure

--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -95,6 +95,7 @@ class IntegrationFeatures(Enum):
     SERVERLESS = "serverless"
     TICKET_RULES = "ticket-rules"
     STACKTRACE_LINK = "stacktrace-link"
+    CODEOWNERS = "codeowners"
 
     # features currently only existing on plugins:
     DATA_FORWARDING = "data-forwarding"

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -172,6 +172,7 @@ class GitHubIntegrationProvider(IntegrationProvider):
             IntegrationFeatures.COMMITS,
             IntegrationFeatures.ISSUE_BASIC,
             IntegrationFeatures.STACKTRACE_LINK,
+            IntegrationFeatures.CODEOWNERS,
         ]
     )
 

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -273,6 +273,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
             IntegrationFeatures.ISSUE_BASIC,
             IntegrationFeatures.COMMITS,
             IntegrationFeatures.STACKTRACE_LINK,
+            IntegrationFeatures.CODEOWNERS,
         ]
     )
 

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -54,7 +54,11 @@ class ConfigureIntegration extends AsyncView<Props, State> {
 
   componentDidMount() {
     const {location} = this.props;
-    const value = location.query.tab === 'codeMappings' ? 'codeMappings' : 'repos';
+    const value =
+      (['codeMappings', 'userMappings', 'teamMappings'] as const).find(
+        tab => tab === location.query.tab
+      ) || 'repos';
+
     // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({tab: value});
   }

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
@@ -189,7 +189,7 @@ class AddCodeOwnerModal extends Component<Props, State> {
         <Header closeButton>{t('Add Code Owner File')}</Header>
         <Body>
           {!codeMappings.length && (
-            <React.Fragment>
+            <Fragment>
               <div>
                 {t(
                   "Configure code mapping to add your CODEOWNERS file. Select the integration you'd like to use for mapping:"
@@ -207,7 +207,7 @@ class AddCodeOwnerModal extends Component<Props, State> {
                   </Button>
                 ))}
               </IntegrationsList>
-            </React.Fragment>
+            </Fragment>
           )}
           {codeMappings.length > 0 && (
             <Form

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
@@ -132,7 +132,7 @@ class AddCodeOwnerModal extends Component<Props, State> {
         {codeMapping && (
           <p>
             {tct(
-              'Add the missing [userMappingsLink:User Mappings] and [teamMappingsLink:Team Mappings].',
+              'Configure [userMappingsLink:User Mappings] or[teamMappingsLink:Team Mappings] for any missing associations.',
               {
                 userMappingsLink: (
                   <Link

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -8,7 +8,13 @@ import Button from 'app/components/button';
 import ExternalLink from 'app/components/links/externalLink';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
-import {CodeOwners, Organization, Project, RepositoryProjectPathConfig} from 'app/types';
+import {
+  CodeOwners,
+  Integration,
+  Organization,
+  Project,
+  RepositoryProjectPathConfig,
+} from 'app/types';
 import routeTitleGen from 'app/utils/routeTitle';
 import AsyncView from 'app/views/asyncView';
 import Form from 'app/views/settings/components/forms/form';
@@ -28,6 +34,7 @@ type State = {
   ownership: null | any;
   codeMappings: RepositoryProjectPathConfig[];
   codeowners?: CodeOwners[];
+  integrations: Integration[];
 } & AsyncView['state'];
 
 class ProjectOwnership extends AsyncView<Props, State> {
@@ -44,26 +51,31 @@ class ProjectOwnership extends AsyncView<Props, State> {
         'codeMappings',
         `/organizations/${organization.slug}/code-mappings/?projectId=${project.id}`,
       ],
-      ['stacktrace', `/projects/${organization.slug}/${project.slug}/stacktrace-link/`],
+      [
+        'integrations',
+        `/organizations/${organization.slug}/integrations/`,
+        {query: {features: ['codeowners']}},
+      ],
     ];
     if (organization.features.includes('import-codeowners')) {
       endpoints.push([
         'codeowners',
-        `/projects/${organization.slug}/${project.slug}/codeowners/?expand=codeMapping`,
+        `/projects/${organization.slug}/${project.slug}/codeowners/`,
+        {query: {expand: ['codeMapping']}},
       ]);
     }
     return endpoints;
   }
 
   handleAddCodeOwner = () => {
-    const {codeMappings, stacktrace} = this.state;
+    const {codeMappings, integrations} = this.state;
     openModal(modalProps => (
       <AddCodeOwnerModal
         {...modalProps}
         organization={this.props.organization}
         project={this.props.project}
         codeMappings={codeMappings}
-        integrations={stacktrace.integrations}
+        integrations={integrations}
         onSave={this.handleCodeownerAdded}
       />
     ));

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -49,7 +49,8 @@ class ProjectOwnership extends AsyncView<Props, State> {
       ['ownership', `/projects/${organization.slug}/${project.slug}/ownership/`],
       [
         'codeMappings',
-        `/organizations/${organization.slug}/code-mappings/?projectId=${project.id}`,
+        `/organizations/${organization.slug}/code-mappings/`,
+        {query: {projectId: project.id}},
       ],
       [
         'integrations',

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -44,6 +44,7 @@ class ProjectOwnership extends AsyncView<Props, State> {
         'codeMappings',
         `/organizations/${organization.slug}/code-mappings/?projectId=${project.id}`,
       ],
+      ['stacktrace', `/projects/${organization.slug}/${project.slug}/stacktrace-link/`],
     ];
     if (organization.features.includes('import-codeowners')) {
       endpoints.push([
@@ -55,13 +56,14 @@ class ProjectOwnership extends AsyncView<Props, State> {
   }
 
   handleAddCodeOwner = () => {
-    const {codeMappings} = this.state;
+    const {codeMappings, stacktrace} = this.state;
     openModal(modalProps => (
       <AddCodeOwnerModal
         {...modalProps}
         organization={this.props.organization}
         project={this.props.project}
         codeMappings={codeMappings}
+        integrations={stacktrace.integrations}
         onSave={this.handleCodeownerAdded}
       />
     ));

--- a/tests/js/sentry-test/fixtures/integrationListDirectory.js
+++ b/tests/js/sentry-test/fixtures/integrationListDirectory.js
@@ -33,29 +33,49 @@ export function ProviderList() {
   };
 }
 
-export function IntegrationConfig() {
-  return [
-    {
-      accountType: null,
-      configData: {},
-      configOrganization: [],
-      domainName: 'bitbucket.org/%7Bfb715533-bbd7-4666-aa57-01dc93dd9cc0%7D',
-      icon:
-        'https://secure.gravatar.com/avatar/8b4cb68e40b74c90427d8262256bd1c8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNN-0.png',
-      id: '4',
-      name: '{fb715533-bbd7-4666-aa57-01dc93dd9cc0}',
-      provider: {
-        aspects: {},
-        canAdd: true,
-        canDisable: false,
-        features: ['commits', 'issue-basic'],
-        key: 'bitbucket',
-        name: 'Bitbucket',
-        slug: 'bitbucket',
-      },
-      status: 'active',
+export function BitbucketIntegrationConfig() {
+  return {
+    accountType: null,
+    configData: {},
+    configOrganization: [],
+    domainName: 'bitbucket.org/%7Bfb715533-bbd7-4666-aa57-01dc93dd9cc0%7D',
+    icon:
+      'https://secure.gravatar.com/avatar/8b4cb68e40b74c90427d8262256bd1c8?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FNN-0.png',
+    id: '4',
+    name: '{fb715533-bbd7-4666-aa57-01dc93dd9cc0}',
+    provider: {
+      aspects: {},
+      canAdd: true,
+      canDisable: false,
+      features: ['commits', 'issue-basic'],
+      key: 'bitbucket',
+      name: 'Bitbucket',
+      slug: 'bitbucket',
     },
-  ];
+    status: 'active',
+  };
+}
+
+export function GithubIntegrationConfig() {
+  return {
+    accountType: null,
+    configData: {},
+    configOrganization: [],
+    domainName: 'github.com',
+    icon: 'https://secure.gravatar.com/avatar/8b4cb68e40b74c90427d8262256bd1c8',
+    id: '5',
+    name: 'NisanthanNanthakumar',
+    provider: {
+      aspects: {},
+      canAdd: true,
+      canDisable: false,
+      features: ['commits', 'issue-basic'],
+      key: 'github',
+      name: 'Github',
+      slug: 'github',
+    },
+    status: 'active',
+  };
 }
 
 export function OrgOwnedApps() {

--- a/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
+++ b/tests/js/spec/views/organizationIntegrations/integrationListDirectory.spec.jsx
@@ -25,7 +25,10 @@ describe('IntegrationListDirectory', function () {
     beforeEach(() => {
       mockResponse([
         [`/organizations/${org.slug}/config/integrations/`, TestStubs.ProviderList()],
-        [`/organizations/${org.slug}/integrations/`, TestStubs.IntegrationConfig()],
+        [
+          `/organizations/${org.slug}/integrations/`,
+          [TestStubs.BitbucketIntegrationConfig()],
+        ],
         [`/organizations/${org.slug}/sentry-apps/`, TestStubs.OrgOwnedApps()],
         ['/sentry-apps/', TestStubs.PublishedApps()],
         [

--- a/tests/js/spec/views/projectOwnership.spec.jsx
+++ b/tests/js/spec/views/projectOwnership.spec.jsx
@@ -82,6 +82,11 @@ describe('Add Codeowner File', function () {
       method: 'GET',
       body: [],
     });
+    Client.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/stacktrace-link/`,
+      method: 'GET',
+      body: [],
+    });
   });
 
   describe('codeowner action button', function () {

--- a/tests/sentry/api/endpoints/test_organization_code_mappings.py
+++ b/tests/sentry/api/endpoints/test_organization_code_mappings.py
@@ -66,7 +66,7 @@ class OrganizationCodeMappingsTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["commits", "issue-basic", "stacktrace-link"],
+                "features": ["codeowners", "commits", "issue-basic", "stacktrace-link"],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",
@@ -87,7 +87,7 @@ class OrganizationCodeMappingsTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["commits", "issue-basic", "stacktrace-link"],
+                "features": ["codeowners", "commits", "issue-basic", "stacktrace-link"],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",
@@ -123,7 +123,7 @@ class OrganizationCodeMappingsTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["commits", "issue-basic", "stacktrace-link"],
+                "features": ["codeowners", "commits", "issue-basic", "stacktrace-link"],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",
@@ -185,7 +185,7 @@ class OrganizationCodeMappingsTest(APITestCase):
             "repoName": self.repo1.name,
             "provider": {
                 "aspects": {},
-                "features": ["commits", "issue-basic", "stacktrace-link"],
+                "features": ["codeowners", "commits", "issue-basic", "stacktrace-link"],
                 "name": "GitHub",
                 "canDisable": False,
                 "key": "github",

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -46,12 +46,8 @@ class ProjectStacktraceLinkTest(APITestCase):
         self.login_as(user=self.user)
 
         response = self.client.get(self.url, format="json")
-        assert response.status_code == 200, response.content
-        assert response.data == {
-            "config": None,
-            "sourceUrl": None,
-            "integrations": [self._serialized_integration()],
-        }
+        assert response.status_code == 400, response.content
+        assert response.data == {"detail": "Filepath is required"}
 
     def test_no_configs(self):
         self.login_as(user=self.user)

--- a/tests/sentry/api/endpoints/test_project_stacktrace_link.py
+++ b/tests/sentry/api/endpoints/test_project_stacktrace_link.py
@@ -46,7 +46,12 @@ class ProjectStacktraceLinkTest(APITestCase):
         self.login_as(user=self.user)
 
         response = self.client.get(self.url, format="json")
-        assert response.status_code == 400, response.content
+        assert response.status_code == 200, response.content
+        assert response.data == {
+            "config": None,
+            "sourceUrl": None,
+            "integrations": [self._serialized_integration()],
+        }
 
     def test_no_configs(self):
         self.login_as(user=self.user)


### PR DESCRIPTION
## Objective
This PR has some UI cleanup for a nicer UX. 
 - Preview file should open in new tab, not in current tab
 - There should be an empty state screen for users who click Add CodeOwners and have a source code integration. This is to let users setup a Code Mapping.
## UI
![Screen Shot 2021-04-26 at 4 53 11 PM](https://user-images.githubusercontent.com/10491193/116166872-c8041680-a6b3-11eb-98c7-a99d2bad5b13.png)
![Screen Shot 2021-04-28 at 10 33 20 AM](https://user-images.githubusercontent.com/10491193/116447788-35778a80-a80d-11eb-9001-efb9835d17e5.png)

