### PR TITLE
fix(notifications): Wrong actor_id

### DIFF
--- a/src/sentry/api/endpoints/user_notification_settings_details.py
+++ b/src/sentry/api/endpoints/user_notification_settings_details.py
@@ -90,6 +90,6 @@ class UserNotificationSettingsDetailsEndpoint(UserEndpoint):
         validate_has_feature(user)
 
         notification_settings = validate(request.data, user=user)
-        NotificationSetting.objects.update_settings_bulk(notification_settings, target_id=user.id)
+        NotificationSetting.objects.update_settings_bulk(notification_settings, user.actor_id)
 
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
In the previous PR we set the `actor_id` as the current user's `user_id` when updating notification settings.