### PR TITLE
fix(release-detail): make icon larger

### DIFF
--- a/static/app/views/releases/detail/releaseHeader.tsx
+++ b/static/app/views/releases/detail/releaseHeader.tsx
@@ -92,7 +92,7 @@ const ReleaseHeader = ({
             <IconWrapper>
               <Clipboard value={version}>
                 <Tooltip title={version} containerDisplayMode="flex">
-                  <IconCopy size="xs" />
+                  <IconCopy />
                 </Tooltip>
               </Clipboard>
             </IconWrapper>
@@ -100,7 +100,7 @@ const ReleaseHeader = ({
               <IconWrapper>
                 <Tooltip title={url}>
                   <ExternalLink href={url}>
-                    <IconOpen size="xs" />
+                    <IconOpen />
                   </ExternalLink>
                 </Tooltip>
               </IconWrapper>


### PR DESCRIPTION
**Before:**
<img width="369" alt="Screen Shot 2021-04-26 at 9 02 58 PM" src="https://user-images.githubusercontent.com/4830259/116183489-d150ab80-a6d2-11eb-9db7-277dc4e14d84.png">

**After:**
<img width="378" alt="Screen Shot 2021-04-26 at 9 02 40 PM" src="https://user-images.githubusercontent.com/4830259/116183492-d1e94200-a6d2-11eb-93c1-251bf0cc583b.png">
