### PR TITLE
feat(deps): Enable dependabot for most npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      # Going to start with a high interval, and then tone it back
+      interval: daily
+      time: 12:00pm
+      timezone: America/Los_Angeles
+    reviewers:
+      - @getsentry/owners-js-build
+    ignore:
+      # These are packages we're "stuck" on for now
+      - dependecy-name: jquery
+      - dependecy-name: bootstrap
+      - dependecy-name: react-bootstrap
+      - dependecy-name: reflux
+      - dependecy-name: react-router
+      - dependecy-name: react-select
+      - dependecy-name: react-select-legacy


### PR DESCRIPTION
I disabled the obvious ones that we can't upgrade yet, but there's probably some more we'll have to add I think