### PR TITLE
feat(org-stats): Allow absolute date selection

### DIFF
--- a/static/app/views/usageStats/index.tsx
+++ b/static/app/views/usageStats/index.tsx
@@ -4,33 +4,39 @@ import styled from '@emotion/styled';
 import {LocationDescriptorObject} from 'history';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
+import moment from 'moment';
 
 import {DateTimeObject} from 'app/components/charts/utils';
 import DropdownControl, {DropdownItem} from 'app/components/dropdownControl';
 import ErrorBoundary from 'app/components/errorBoundary';
+import {getParams} from 'app/components/organizations/globalSelectionHeader/getParams';
+import TimeRangeSelector, {
+  ChangeData,
+} from 'app/components/organizations/timeRangeSelector';
 import PageHeading from 'app/components/pageHeading';
+import {Panel} from 'app/components/panels';
 import SentryDocumentTitle from 'app/components/sentryDocumentTitle';
-import {DEFAULT_RELATIVE_PERIODS, DEFAULT_STATS_PERIOD} from 'app/constants';
+import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {t} from 'app/locale';
 import {PageContent, PageHeader} from 'app/styles/organization';
 import space from 'app/styles/space';
 import {
   DataCategory,
   DataCategoryName,
+  DateString,
   Organization,
   Project,
   RelativePeriod,
 } from 'app/types';
-import {parsePeriodToHours} from 'app/utils/dates';
 
 import {CHART_OPTIONS_DATACATEGORY, ChartDataTransform} from './usageChart';
 import UsageStatsOrg from './usageStatsOrg';
 import UsageStatsProjects from './usageStatsProjects';
 
 const PAGE_QUERY_PARAMS = [
+  'pageStatsPeriod',
   'pageStart',
   'pageEnd',
-  'pagePeriod',
   'pageUtc',
   'dataCategory',
   'transform',
@@ -43,7 +49,15 @@ type Props = {
   organization: Organization;
 } & RouteComponentProps<{orgId: string}, {}>;
 
-class OrganizationStats extends React.Component<Props> {
+type State = {
+  isCalendarOpen: boolean;
+};
+
+class OrganizationStats extends React.Component<Props, State> {
+  state = {
+    isCalendarOpen: false,
+  };
+
   get dataCategory(): DataCategory {
     const dataCategory = this.props.location?.query?.dataCategory;
 
@@ -62,21 +76,40 @@ class OrganizationStats extends React.Component<Props> {
     return DataCategoryName[dataCategory] ?? t('Unknown Data Category');
   }
 
-  get dataPeriod(): DateTimeObject {
-    const {pagePeriod, pageStart, pageEnd} = this.props.location?.query ?? {};
-    if (!pagePeriod && !pageStart && !pageEnd) {
+  get dataDatetime(): DateTimeObject {
+    const query = this.props.location?.query ?? {};
+
+    const {start, end, statsPeriod, utc: utcString} = getParams(query, {
+      allowEmptyPeriod: true,
+      allowAbsoluteDatetime: true,
+      allowAbsolutePageDatetime: true,
+    });
+
+    if (!statsPeriod && !start && !end) {
       return {period: DEFAULT_STATS_PERIOD};
     }
 
-    // Absolute date range is more specific than period
-    if (pageStart && pageEnd) {
-      return {start: pageStart, end: pageEnd};
+    // Following getParams, statsPeriod will take priority over start/end
+    if (statsPeriod) {
+      return {period: statsPeriod};
     }
 
-    const keys = Object.keys(DEFAULT_RELATIVE_PERIODS);
-    return pagePeriod && keys.includes(pagePeriod)
-      ? {period: pagePeriod}
-      : {period: DEFAULT_STATS_PERIOD};
+    const utc = utcString === 'true';
+    if (start && end) {
+      return utc
+        ? {
+            start: moment.utc(start).format(),
+            end: moment.utc(end).format(),
+            utc,
+          }
+        : {
+            start: moment(start).utc().format(),
+            end: moment(end).utc().format(),
+            utc,
+          };
+    }
+
+    return {period: DEFAULT_STATS_PERIOD};
   }
 
   // Validation and type-casting should be handled by chart
@@ -129,6 +162,28 @@ class OrganizationStats extends React.Component<Props> {
     };
   };
 
+  handleUpdateDatetime = (datetime: ChangeData): LocationDescriptorObject => {
+    const {start, end, relative, utc} = datetime;
+
+    if (start && end) {
+      const parser = utc ? moment.utc : moment;
+
+      return this.setStateOnUrl({
+        pageStatsPeriod: undefined,
+        pageStart: parser(start).format(),
+        pageEnd: parser(end).format(),
+        pageUtc: utc ?? undefined,
+      });
+    }
+
+    return this.setStateOnUrl({
+      pageStatsPeriod: (relative as RelativePeriod) || undefined,
+      pageStart: undefined,
+      pageEnd: undefined,
+      pageUtc: undefined,
+    });
+  };
+
   /**
    * TODO: Enable user to set dateStart/dateEnd
    *
@@ -137,7 +192,10 @@ class OrganizationStats extends React.Component<Props> {
   setStateOnUrl = (
     nextState: {
       dataCategory?: DataCategory;
-      pagePeriod?: RelativePeriod;
+      pageStatsPeriod?: RelativePeriod;
+      pageStart?: DateString;
+      pageEnd?: DateString;
+      pageUtc?: boolean | null;
       transform?: ChartDataTransform;
       sort?: string;
       query?: string;
@@ -167,20 +225,29 @@ class OrganizationStats extends React.Component<Props> {
     return nextLocation;
   };
 
-  renderPageControl() {
-    const {period} = this.dataPeriod;
+  renderPageControl = () => {
+    const {organization} = this.props;
+    const {isCalendarOpen} = this.state;
 
-    // Remove options for relative periods shorter than 1 week
-    const relativePeriods = Object.keys(DEFAULT_RELATIVE_PERIODS).reduce((acc, key) => {
-      const periodDays = parsePeriodToHours(key) / 24;
-      if (periodDays >= 7) {
-        acc[key] = DEFAULT_RELATIVE_PERIODS[key];
-      }
-      return acc;
-    }, {});
+    const {start, end, period, utc} = this.dataDatetime;
 
     return (
       <React.Fragment>
+        <DropdownDate isCalendarOpen={isCalendarOpen}>
+          <TimeRangeSelector
+            relative={period ?? ''}
+            start={start ?? null}
+            end={end ?? null}
+            utc={utc ?? null}
+            label={<DropdownLabel>Date range:</DropdownLabel>}
+            onChange={() => {}}
+            onUpdate={this.handleUpdateDatetime}
+            onToggleSelector={isOpen => this.setState({isCalendarOpen: isOpen})}
+            organization={organization}
+            defaultPeriod="14d"
+          />
+        </DropdownDate>
+
         <DropdownDataCategory
           label={
             <DropdownLabel>
@@ -201,29 +268,9 @@ class OrganizationStats extends React.Component<Props> {
             </DropdownItem>
           ))}
         </DropdownDataCategory>
-        <DropdownDate
-          label={
-            <DropdownLabel>
-              <span>{t('Date Range: ')}</span>
-              <span>{DEFAULT_RELATIVE_PERIODS[period || DEFAULT_STATS_PERIOD]}</span>
-            </DropdownLabel>
-          }
-        >
-          {Object.keys(relativePeriods).map(key => (
-            <DropdownItem
-              key={key}
-              eventKey={key}
-              onSelect={(val: string) =>
-                this.setStateOnUrl({pagePeriod: val as RelativePeriod})
-              }
-            >
-              {DEFAULT_RELATIVE_PERIODS[key]}
-            </DropdownItem>
-          ))}
-        </DropdownDate>
       </React.Fragment>
     );
-  }
+  };
 
   render() {
     const {organization} = this.props;
@@ -249,7 +296,7 @@ class OrganizationStats extends React.Component<Props> {
                 organization={organization}
                 dataCategory={this.dataCategory}
                 dataCategoryName={this.dataCategoryName}
-                dataDatetime={this.dataPeriod}
+                dataDatetime={this.dataDatetime}
                 chartTransform={this.chartTransform}
                 handleChangeState={this.setStateOnUrl}
               />
@@ -259,7 +306,7 @@ class OrganizationStats extends React.Component<Props> {
                 organization={organization}
                 dataCategory={this.dataCategory}
                 dataCategoryName={this.dataCategoryName}
-                dataDatetime={this.dataPeriod}
+                dataDatetime={this.dataDatetime}
                 tableSort={this.tableSort}
                 tableQuery={this.tableQuery}
                 tableCursor={this.tableCursor}
@@ -289,9 +336,15 @@ const PageGrid = styled('div')`
   }
 `;
 
-const StyledDropdown = styled(DropdownControl)`
+const DropdownDataCategory = styled(DropdownControl)`
+  height: 42px;
+  grid-column: auto / span 1;
+  justify-self: stretch;
+  align-self: stretch;
+
   button {
     width: 100%;
+    height: 100%;
 
     > span {
       display: flex;
@@ -299,20 +352,42 @@ const StyledDropdown = styled(DropdownControl)`
     }
   }
 `;
-const DropdownDataCategory = styled(StyledDropdown)`
-  grid-column: auto / span 1;
+
+const DropdownDate = styled(Panel)<{isCalendarOpen: boolean}>`
+  grid-column: auto / span 3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 42px;
+
+  background: ${p => p.theme.background};
+  border: 1px solid ${p => p.theme.border};
+  border-radius: ${p =>
+    p.isCalendarOpen
+      ? `${p.theme.borderRadius} ${p.theme.borderRadius} 0 0`
+      : p.theme.borderRadius};
+  padding: 0;
+  margin: 0;
+  font-size: ${p => p.theme.fontSizeMedium};
+  color: ${p => p.theme.textColor};
+
+  > div {
+    flex-grow: 1;
+  }
+
+  > div > div:first-child {
+    padding: ${space(1)} ${space(2)};
+  }
 
   @media (min-width: ${p => p.theme.breakpoints[2]}) {
     grid-column: auto / span 3;
   }
 `;
-const DropdownDate = styled(StyledDropdown)`
-  grid-column: auto / span 1;
-`;
 
 const DropdownLabel = styled('span')`
-  min-width: 100px;
   text-align: left;
+  font-weight: 600;
+  color: ${p => p.theme.textColor};
 
   > span:last-child {
     font-weight: 400;

--- a/static/app/views/usageStats/index.tsx
+++ b/static/app/views/usageStats/index.tsx
@@ -244,7 +244,7 @@ class OrganizationStats extends React.Component<Props, State> {
             onUpdate={this.handleUpdateDatetime}
             onToggleSelector={isOpen => this.setState({isCalendarOpen: isOpen})}
             organization={organization}
-            defaultPeriod="14d"
+            defaultPeriod={DEFAULT_STATS_PERIOD}
           />
         </DropdownDate>
 

--- a/static/app/views/usageStats/usageChart/index.tsx
+++ b/static/app/views/usageStats/usageChart/index.tsx
@@ -80,6 +80,11 @@ export enum SeriesTypes {
 
 type DefaultProps = {
   /**
+   * Display datetime in UTC
+   */
+  usageDateShowUtc: boolean;
+
+  /**
    * Intervals between the x-axis values
    */
   usageDateInterval: IntervalPeriod;
@@ -111,6 +116,10 @@ type Props = DefaultProps & {
 
   usageDateStart: string;
   usageDateEnd: string;
+
+  /**
+   * Usage data to draw on chart
+   */
   usageStats: ChartStats;
 
   /**
@@ -136,6 +145,7 @@ export type ChartStats = {
 
 export class UsageChart extends React.Component<Props, State> {
   static defaultProps: DefaultProps = {
+    usageDateShowUtc: true,
     usageDateInterval: '1d',
     handleDataTransformation: (stats, transform) => {
       const chartData: ChartStats = {
@@ -175,11 +185,16 @@ export class UsageChart extends React.Component<Props, State> {
    * either covers day 16-30 or may not be available at all.
    */
   static getDerivedStateFromProps(nextProps: Readonly<Props>, prevState: State): State {
-    const {usageDateStart, usageDateEnd, usageDateInterval} = nextProps;
+    const {usageDateStart, usageDateEnd, usageDateShowUtc, usageDateInterval} = nextProps;
 
     return {
       ...prevState,
-      xAxisDates: getXAxisDates(usageDateStart, usageDateEnd, usageDateInterval),
+      xAxisDates: getXAxisDates(
+        usageDateStart,
+        usageDateEnd,
+        usageDateShowUtc,
+        usageDateInterval
+      ),
     };
   }
 

--- a/static/app/views/usageStats/usageStatsOrg.tsx
+++ b/static/app/views/usageStats/usageStatsOrg.tsx
@@ -13,6 +13,7 @@ import {DEFAULT_STATS_PERIOD} from 'app/constants';
 import {t, tct} from 'app/locale';
 import space from 'app/styles/space';
 import {DataCategory, IntervalPeriod, Organization, RelativePeriod} from 'app/types';
+import {parsePeriodToHours} from 'app/utils/dates';
 
 import {
   FORMAT_DATETIME_DAILY,
@@ -26,7 +27,7 @@ import UsageChart, {
   ChartStats,
 } from './usageChart';
 import UsageStatsPerMin from './usageStatsPerMin';
-import {formatUsageWithUnits, getFormatUsageOptions} from './utils';
+import {formatUsageWithUnits, getFormatUsageOptions, isDisplayUtc} from './utils';
 
 type Props = {
   organization: Organization;
@@ -53,7 +54,8 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
     if (
       prevDateTime.start !== currDateTime.start ||
       prevDateTime.end !== currDateTime.end ||
-      prevDateTime.period !== currDateTime.period
+      prevDateTime.period !== currDateTime.period ||
+      prevDateTime.utc !== currDateTime.utc
     ) {
       this.reloadData();
     }
@@ -71,9 +73,19 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
   get endpointQuery() {
     const {dataDatetime} = this.props;
 
-    // TODO: Enable user to use dateStart/dateEnd
+    const queryDatetime =
+      dataDatetime.start && dataDatetime.end
+        ? {
+            start: dataDatetime.start,
+            end: dataDatetime.end,
+            utc: dataDatetime.utc,
+          }
+        : {
+            statsPeriod: dataDatetime.period || DEFAULT_STATS_PERIOD,
+          };
+
     return {
-      statsPeriod: dataDatetime?.period || DEFAULT_STATS_PERIOD,
+      ...queryDatetime,
       interval: getInterval(dataDatetime),
       groupBy: ['category', 'outcome'],
       field: ['sum(quantity)'],
@@ -92,8 +104,10 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
     chartDateInterval: IntervalPeriod;
     chartDateStart: string;
     chartDateEnd: string;
+    chartDateUtc: boolean;
     chartDateStartDisplay: string;
     chartDateEndDisplay: string;
+    chartDateTimezoneDisplay: string;
     chartTransform: ChartDataTransform;
   } {
     const {orgStats} = this.state;
@@ -121,55 +135,59 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
     chartDateInterval: IntervalPeriod;
     chartDateStart: string;
     chartDateEnd: string;
+    chartDateUtc: boolean;
     chartDateStartDisplay: string;
     chartDateEndDisplay: string;
+    chartDateTimezoneDisplay: string;
   } {
     const {orgStats} = this.state;
+    const {dataDatetime} = this.props;
+
+    const interval = getInterval(dataDatetime);
 
     // Use fillers as loading/error states will not display datetime at all
     if (!orgStats || !orgStats.intervals || orgStats.intervals.length < 2) {
-      const {dataDatetime} = this.props;
-
       return {
-        chartDateInterval: getInterval(dataDatetime),
+        chartDateInterval: interval,
         chartDateStart: '',
         chartDateEnd: '',
+        chartDateUtc: true,
         chartDateStartDisplay: '',
         chartDateEndDisplay: '',
+        chartDateTimezoneDisplay: '',
       };
     }
 
-    // Calculate intervals using API data
     const {intervals} = orgStats;
-    const startTime = moment(intervals[0]);
-    const endTime = moment(intervals[intervals.length - 1]);
-    const intervalMinutes = moment(endTime).diff(startTime, 'm') / (intervals.length - 1);
+    const intervalHours = parsePeriodToHours(interval);
+
+    // Keep datetime in UTC until we want to display it to users
+    const startTime = moment(intervals[0]).utc();
+    const endTime = moment(intervals[intervals.length - 1]).utc();
+    const useUtc = isDisplayUtc(dataDatetime);
 
     // If interval is a day or more, use UTC to format date. Otherwise, the date
     // may shift ahead/behind when converting to the user's local time.
-    const isPerDay = intervalMinutes >= 24 * 60;
-    const FORMAT_DATETIME = isPerDay ? FORMAT_DATETIME_DAILY : FORMAT_DATETIME_HOURLY;
+    const FORMAT_DATETIME =
+      intervalHours >= 24 ? FORMAT_DATETIME_DAILY : FORMAT_DATETIME_HOURLY;
 
     const xAxisStart = moment(startTime);
     const xAxisEnd = moment(endTime);
-    const displayStart = isPerDay ? moment(startTime).utc() : moment(startTime).local();
-    const displayEnd = isPerDay
-      ? moment(endTime).utc()
-      : moment(endTime).local().add(intervalMinutes, 'm');
+    const displayStart = useUtc ? moment(startTime).utc() : moment(startTime).local();
+    const displayEnd = useUtc ? moment(endTime).utc() : moment(endTime).local();
 
-    const intervalString =
-      intervalMinutes < 60
-        ? `${intervalMinutes}m`
-        : intervalMinutes < 60 * 24
-        ? `${intervalMinutes / 60}h`
-        : `${intervalMinutes / (60 * 24)}d`;
+    if (intervalHours < 24) {
+      displayEnd.add(intervalHours, 'h');
+    }
 
     return {
-      chartDateInterval: intervalString as IntervalPeriod,
+      chartDateInterval: interval,
       chartDateStart: xAxisStart.format(),
       chartDateEnd: xAxisEnd.format(),
+      chartDateUtc: useUtc,
       chartDateStartDisplay: displayStart.format(FORMAT_DATETIME),
       chartDateEndDisplay: displayEnd.format(FORMAT_DATETIME),
+      chartDateTimezoneDisplay: displayStart.format('Z'),
     };
   }
 
@@ -203,13 +221,13 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
 
     try {
       const {dataCategory} = this.props;
-      const {chartDateInterval} = this.chartDateRange;
+      const {chartDateInterval, chartDateUtc} = this.chartDateRange;
 
       const usageStats: UsageStat[] = orgStats.intervals.map(interval => {
         const dateTime = moment(interval);
 
         return {
-          date: getDateFromMoment(dateTime, chartDateInterval),
+          date: getDateFromMoment(dateTime, chartDateInterval, chartDateUtc),
           total: 0,
           accepted: 0,
           filtered: 0,
@@ -359,6 +377,7 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
       chartDateInterval,
       chartDateStart,
       chartDateEnd,
+      chartDateUtc,
       chartTransform,
     } = this.chartData;
 
@@ -376,6 +395,7 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
         dataTransform={chartTransform}
         usageDateStart={chartDateStart}
         usageDateEnd={chartDateEnd}
+        usageDateShowUtc={chartDateUtc}
         usageDateInterval={chartDateInterval}
         usageStats={chartStats}
       />
@@ -384,12 +404,13 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
 
   renderChartFooter = () => {
     const {handleChangeState} = this.props;
-    const {loading} = this.state;
+    const {loading, error} = this.state;
     const {
       chartDateInterval,
       chartTransform,
       chartDateStartDisplay,
       chartDateEndDisplay,
+      chartDateTimezoneDisplay,
     } = this.chartData;
 
     return (
@@ -398,12 +419,13 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
           <FooterDate>
             <SectionHeading>{t('Date Range')}</SectionHeading>
             <span>
-              {loading ? (
+              {loading || error ? (
                 <NotAvailable />
               ) : (
-                tct('[start] — [end] ([interval] interval)', {
+                tct('[start] — [end] ([timezone] UTC, [interval] interval)', {
                   start: chartDateStartDisplay,
                   end: chartDateEndDisplay,
+                  timezone: chartDateTimezoneDisplay,
                   interval: chartDateInterval,
                 })
               )}

--- a/static/app/views/usageStats/usageStatsProjects.tsx
+++ b/static/app/views/usageStats/usageStatsProjects.tsx
@@ -63,6 +63,7 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
       prevDateTime.start !== currDateTime.start ||
       prevDateTime.end !== currDateTime.end ||
       prevDateTime.period !== currDateTime.period ||
+      prevDateTime.utc !== currDateTime.utc ||
       currDataCategory !== prevDataCategory
     ) {
       this.reloadData();
@@ -80,9 +81,21 @@ class UsageStatsProjects extends AsyncComponent<Props, State> {
 
   get endpointQuery() {
     const {dataDatetime, dataCategory} = this.props;
+
+    const queryDatetime =
+      dataDatetime.start && dataDatetime.end
+        ? {
+            start: dataDatetime.start,
+            end: dataDatetime.end,
+            utc: dataDatetime.utc,
+          }
+        : {
+            statsPeriod: dataDatetime.period || DEFAULT_STATS_PERIOD,
+          };
+
     // We do not need more granularity in the data so interval is '1d'
     return {
-      statsPeriod: dataDatetime?.period || DEFAULT_STATS_PERIOD,
+      ...queryDatetime,
       interval: '1d',
       groupBy: ['outcome', 'project'],
       field: ['sum(quantity)'],

--- a/static/app/views/usageStats/utils.tsx
+++ b/static/app/views/usageStats/utils.tsx
@@ -1,5 +1,7 @@
+import {DateTimeObject, getInterval} from 'app/components/charts/utils';
 import {DataCategory} from 'app/types';
 import {formatBytesBase10} from 'app/utils';
+import {parsePeriodToHours} from 'app/utils/dates';
 
 export const MILLION = 10 ** 6;
 export const BILLION = 10 ** 9;
@@ -79,4 +81,24 @@ export function abbreviateUsageNumber(n: number) {
 
   // Do not show decimals
   return n.toFixed().toLocaleString();
+}
+
+/**
+ * We want to display datetime in UTC in the following situations:
+ *
+ * 1) The user selected an absolute date range with UTC
+ * 2) The user selected a wide date range with 1d interval
+ *
+ * When the interval is 1d, we need to use UTC because the 24 hour range might
+ * shift forward/backward depending on the user's timezone, or it might be
+ * displayed as a day earlier/later
+ */
+export function isDisplayUtc(datetime: DateTimeObject): boolean {
+  if (datetime.utc) {
+    return true;
+  }
+
+  const interval = getInterval(datetime);
+  const hours = parsePeriodToHours(interval);
+  return hours >= 24;
 }

--- a/tests/js/spec/views/usageStats/index.spec.jsx
+++ b/tests/js/spec/views/usageStats/index.spec.jsx
@@ -141,7 +141,7 @@ describe('UsageStats', function () {
         organization={organization}
         location={{
           query: {
-            pagePeriod: ninetyDays,
+            pageStatsPeriod: ninetyDays,
             dataCategory: DataCategory.TRANSACTIONS,
             transform: CHART_OPTIONS_DATA_TRANSFORM[1].value,
             sort: '-project',
@@ -221,7 +221,7 @@ describe('UsageStats', function () {
         organization={organization}
         location={{
           query: {
-            pagePeriod: ninetyDays,
+            pageStatsPeriod: ninetyDays,
             dataCategory: DataCategory.ERRORS,
             transform: CHART_OPTIONS_DATA_TRANSFORM[0].value,
             sort: '-project',
@@ -237,11 +237,22 @@ describe('UsageStats', function () {
     await tick();
     wrapper.update();
 
-    const optionPagePeriod = wrapper.find(`DropdownItem[eventKey="30d"]`);
-    optionPagePeriod.props().onSelect('30d');
+    const optionpagePeriod = wrapper.find(`TimeRangeSelector`);
+    optionpagePeriod.props().onUpdate({relative: '30d'});
     expect(router.push).toHaveBeenCalledWith({
       query: expect.objectContaining({
-        pagePeriod: '30d',
+        pageStatsPeriod: '30d',
+      }),
+    });
+
+    optionpagePeriod
+      .props()
+      .onUpdate({start: '2021-01-01', end: '2021-01-31', utc: true});
+    expect(router.push).toHaveBeenCalledWith({
+      query: expect.objectContaining({
+        pageStart: '2021-01-01T00:00:00Z',
+        pageEnd: '2021-01-31T00:00:00Z',
+        pageUtc: true,
       }),
     });
 
@@ -282,7 +293,7 @@ describe('UsageStats', function () {
           query: {
             pageStart: '2021-01-01T00:00:00Z',
             pageEnd: '2021-01-07T00:00:00Z',
-            pagePeriod: ninetyDays,
+            pageStatsPeriod: ninetyDays,
             pageUtc: true,
             dataCategory: DataCategory.TRANSACTIONS,
             transform: CHART_OPTIONS_DATA_TRANSFORM[1].value,

--- a/tests/js/spec/views/usageStats/usageChart/utils.spec.jsx
+++ b/tests/js/spec/views/usageStats/usageChart/utils.spec.jsx
@@ -1,20 +1,33 @@
 import {getDateFromMoment, getXAxisDates} from 'app/views/usageStats/usageChart/utils';
 
-const TS_START = 1531094400000; // 2018 July 9 UTC
-const TS_END = 1531180800000; // 2018 July 10 UTC
+const TS_START = 1531094400000; // 2018 July 9, 12am UTC
+const TS_END = 1531180800000; // 2018 July 10, 12am UTC
 
 describe('getDateFromMoment', () => {
   // Ensure date remains in UTC
-  it('shows the date if interval is 1 day or more', () => {
+  it('shows the date if interval is >= 24h', () => {
     expect(getDateFromMoment(TS_START)).toBe('Jul 9');
     expect(getDateFromMoment(TS_START, '7d')).toBe('Jul 9');
   });
 
   // Ensure datetime is shifted to localtime
-  it('shows the date amd time if interval is less than a day', () => {
-    expect(getDateFromMoment(TS_START, '6h')).toBe('Jul 8 8:00 PM - 2:00 AM');
-    expect(getDateFromMoment(TS_START, '1h')).toBe('Jul 8 8:00 PM - 9:00 PM');
-    expect(getDateFromMoment(TS_START, '5m')).toBe('Jul 8 8:00 PM - 8:05 PM');
+  it('shows the date and time if interval is <24h', () => {
+    expect(getDateFromMoment(TS_START, '6h')).toBe('Jul 8 8:00 PM - 2:00 AM (-04:00)');
+    expect(getDateFromMoment(TS_START, '1h')).toBe('Jul 8 8:00 PM - 9:00 PM (-04:00)');
+    expect(getDateFromMoment(TS_START, '5m')).toBe('Jul 8 8:00 PM - 8:05 PM (-04:00)');
+  });
+
+  // Ensure datetime is shifted to localtime
+  it('coerces date and time into UTC', () => {
+    expect(getDateFromMoment(TS_START, '6h', true)).toBe(
+      'Jul 9 12:00 AM - 6:00 AM (+00:00)'
+    );
+    expect(getDateFromMoment(TS_START, '1h', true)).toBe(
+      'Jul 9 12:00 AM - 1:00 AM (+00:00)'
+    );
+    expect(getDateFromMoment(TS_START, '5m', true)).toBe(
+      'Jul 9 12:00 AM - 12:05 AM (+00:00)'
+    );
   });
 });
 
@@ -25,49 +38,63 @@ describe('getXAxisDates', () => {
     expect(dates).toEqual(['Jul 9', 'Jul 10']);
   });
 
-  // Ensure datetime is shifted to localtime
-  it('calculates 4h intervals', () => {
-    const dates = getXAxisDates(TS_START, TS_END, '4h');
+  // Datetime remains in UTC
+  it('calculates 4h intervals in UTC', () => {
+    const dates = getXAxisDates(TS_START, TS_END, true, '4h');
     expect(dates).toEqual([
-      'Jul 8 8:00 PM - 12:00 AM',
-      'Jul 9 12:00 AM - 4:00 AM',
-      'Jul 9 4:00 AM - 8:00 AM',
-      'Jul 9 8:00 AM - 12:00 PM',
-      'Jul 9 12:00 PM - 4:00 PM',
-      'Jul 9 4:00 PM - 8:00 PM',
-      'Jul 9 8:00 PM - 12:00 AM',
+      'Jul 9 12:00 AM - 4:00 AM (+00:00)',
+      'Jul 9 4:00 AM - 8:00 AM (+00:00)',
+      'Jul 9 8:00 AM - 12:00 PM (+00:00)',
+      'Jul 9 12:00 PM - 4:00 PM (+00:00)',
+      'Jul 9 4:00 PM - 8:00 PM (+00:00)',
+      'Jul 9 8:00 PM - 12:00 AM (+00:00)',
+      'Jul 10 12:00 AM - 4:00 AM (+00:00)',
     ]);
   });
 
-  // Ensure datetime is shifted to localtime
-  it('calculates 1h intervals', () => {
-    const dates = getXAxisDates(TS_START, TS_END, '1h');
+  // Datetime is shifted to localtime
+  it('calculates 4h intervals', () => {
+    const dates = getXAxisDates(TS_START, TS_END, false, '4h');
     expect(dates).toEqual([
-      'Jul 8 8:00 PM - 9:00 PM',
-      'Jul 8 9:00 PM - 10:00 PM',
-      'Jul 8 10:00 PM - 11:00 PM',
-      'Jul 8 11:00 PM - 12:00 AM',
-      'Jul 9 12:00 AM - 1:00 AM',
-      'Jul 9 1:00 AM - 2:00 AM',
-      'Jul 9 2:00 AM - 3:00 AM',
-      'Jul 9 3:00 AM - 4:00 AM',
-      'Jul 9 4:00 AM - 5:00 AM',
-      'Jul 9 5:00 AM - 6:00 AM',
-      'Jul 9 6:00 AM - 7:00 AM',
-      'Jul 9 7:00 AM - 8:00 AM',
-      'Jul 9 8:00 AM - 9:00 AM',
-      'Jul 9 9:00 AM - 10:00 AM',
-      'Jul 9 10:00 AM - 11:00 AM',
-      'Jul 9 11:00 AM - 12:00 PM',
-      'Jul 9 12:00 PM - 1:00 PM',
-      'Jul 9 1:00 PM - 2:00 PM',
-      'Jul 9 2:00 PM - 3:00 PM',
-      'Jul 9 3:00 PM - 4:00 PM',
-      'Jul 9 4:00 PM - 5:00 PM',
-      'Jul 9 5:00 PM - 6:00 PM',
-      'Jul 9 6:00 PM - 7:00 PM',
-      'Jul 9 7:00 PM - 8:00 PM',
-      'Jul 9 8:00 PM - 9:00 PM',
+      'Jul 8 8:00 PM - 12:00 AM (-04:00)',
+      'Jul 9 12:00 AM - 4:00 AM (-04:00)',
+      'Jul 9 4:00 AM - 8:00 AM (-04:00)',
+      'Jul 9 8:00 AM - 12:00 PM (-04:00)',
+      'Jul 9 12:00 PM - 4:00 PM (-04:00)',
+      'Jul 9 4:00 PM - 8:00 PM (-04:00)',
+      'Jul 9 8:00 PM - 12:00 AM (-04:00)',
+    ]);
+  });
+
+  // Datetime is shifted to localtime
+  it('calculates 1h intervals', () => {
+    const dates = getXAxisDates(TS_START, TS_END, false, '1h');
+    expect(dates).toEqual([
+      'Jul 8 8:00 PM - 9:00 PM (-04:00)',
+      'Jul 8 9:00 PM - 10:00 PM (-04:00)',
+      'Jul 8 10:00 PM - 11:00 PM (-04:00)',
+      'Jul 8 11:00 PM - 12:00 AM (-04:00)',
+      'Jul 9 12:00 AM - 1:00 AM (-04:00)',
+      'Jul 9 1:00 AM - 2:00 AM (-04:00)',
+      'Jul 9 2:00 AM - 3:00 AM (-04:00)',
+      'Jul 9 3:00 AM - 4:00 AM (-04:00)',
+      'Jul 9 4:00 AM - 5:00 AM (-04:00)',
+      'Jul 9 5:00 AM - 6:00 AM (-04:00)',
+      'Jul 9 6:00 AM - 7:00 AM (-04:00)',
+      'Jul 9 7:00 AM - 8:00 AM (-04:00)',
+      'Jul 9 8:00 AM - 9:00 AM (-04:00)',
+      'Jul 9 9:00 AM - 10:00 AM (-04:00)',
+      'Jul 9 10:00 AM - 11:00 AM (-04:00)',
+      'Jul 9 11:00 AM - 12:00 PM (-04:00)',
+      'Jul 9 12:00 PM - 1:00 PM (-04:00)',
+      'Jul 9 1:00 PM - 2:00 PM (-04:00)',
+      'Jul 9 2:00 PM - 3:00 PM (-04:00)',
+      'Jul 9 3:00 PM - 4:00 PM (-04:00)',
+      'Jul 9 4:00 PM - 5:00 PM (-04:00)',
+      'Jul 9 5:00 PM - 6:00 PM (-04:00)',
+      'Jul 9 6:00 PM - 7:00 PM (-04:00)',
+      'Jul 9 7:00 PM - 8:00 PM (-04:00)',
+      'Jul 9 8:00 PM - 9:00 PM (-04:00)',
     ]);
   });
 


### PR DESCRIPTION
When selecting the date range by...
* relative periods (e.g. "last 14 days"), we will display datetime
  * in local timezone if interval is <24h
  * in UTC if interval is >= 24h (otherwise the 24 hour range for a date will vary in different timezones)
* in absolute date ranges (e.g. "Apr 1 - Apr 31"), we will display datetime
  * in local timezone if UTC is not selected
  * in UTC if UTC is selected
  * override to UTC if interval >= 24h

I've ensured that date strings being passed between components are always in UTC, otherwise doing add/subtract on them will cause weird behaviours on DST dates.

---

![image](https://user-images.githubusercontent.com/1748388/116210962-38348b80-a6f8-11eb-85ff-c2bc8d1fbdd8.png)

![image](https://user-images.githubusercontent.com/1748388/116210979-3a96e580-a6f8-11eb-874b-6b680a32a32a.png)

![image](https://user-images.githubusercontent.com/1748388/116210999-3ec30300-a6f8-11eb-9007-9943ecd89e1b.png)
