### PR TITLE
fix(prettyFormString): Fix [object, object] message

### DIFF
--- a/static/app/actionCreators/indicator.tsx
+++ b/static/app/actionCreators/indicator.tsx
@@ -116,7 +116,7 @@ const prettyFormString = (val: ChangeValue, model: FormModel, fieldName: string)
     return PRETTY_VALUES.get(val);
   }
 
-  return val;
+  return typeof val === 'object' ? val : String(val);
 };
 
 // Some fields have objects in them.

--- a/static/app/actionCreators/indicator.tsx
+++ b/static/app/actionCreators/indicator.tsx
@@ -116,7 +116,7 @@ const prettyFormString = (val: ChangeValue, model: FormModel, fieldName: string)
     return PRETTY_VALUES.get(val);
   }
 
-  return `${val}`;
+  return val;
 };
 
 // Some fields have objects in them.


### PR DESCRIPTION
In the inbound filters settings when switching legacy browsers values, a notification is displayed showing something like "Changed [object object] to [object object]. This happens because the ui renders `${object}`. This fixes the issue

ps: At the moment the notifications still look a bit odd but we don't need to worry about it as we will soon be replacing the old inbound filters with  a new version

