### PR TITLE
ci: Avoid copying node_modules into workspace during build

### DIFF
--- a/docker/builder.dockerfile
+++ b/docker/builder.dockerfile
@@ -39,10 +39,10 @@ RUN export YARN_CACHE_FOLDER="$(mktemp -d)" \
   && yarn install --frozen-lockfile --production --quiet \
   && rm -r "$YARN_CACHE_FOLDER"
 
-WORKDIR /workspace
-VOLUME ["/workspace/node_modules", "/workspace/build"]
 COPY docker/builder.sh /builder.sh
 ENTRYPOINT [ "/builder.sh" ]
+
+WORKDIR /js/workspace
 
 ARG SOURCE_COMMIT
 ENV SENTRY_BUILD=${SOURCE_COMMIT:-unknown}

--- a/docker/builder.sh
+++ b/docker/builder.sh
@@ -2,14 +2,15 @@
 
 set -e
 
+mount --bind /workspace /js/workspace
+cd /js/workspace
+echo '--modules-folder=/js/node_modules' >> .yarnrc
+echo '--install.offline=true' >> .yarnrc
+
 if [[ ! -f setup.py ]]; then
     >&2 echo "Cannot find setup.py, make sure you have mounted your source dir to /workspace"
     exit 1
 fi
-
-mkdir -p ./node_modules
-echo "Populating node_modules cache..."
-cp -ur /js/node_modules/* ./node_modules/
 
 export YARN_CACHE_FOLDER="$(mktemp -d)"
 python setup.py bdist_wheel --build-number 0


### PR DESCRIPTION
During the build step, we were copying the `node_modules` folder cached in the builder image into the workspace directory. This was both tedious and error prone (copying a lot of files and preserving their attributes) and it also clobbered the working directory.

This new approach mounts the workspace directory under the cache `/js` directory to preserve `node_modules` resolution order (`tsc` always goes up to the parent directory for `node_modules`) and it also instructs `yarn` to use the parent `node_modules` as its modules directory. It still "clobbers" the workspace by modifying the `.yarnrc` file for this but that's on a much smaller scale.

I expected to see some speed improvements with this too due to avoiding the huge copy operation but it didn't happen. 🤷🏻‍♂️ 