### PR TITLE
fix(alerts): Use event types and data source in alert details related issues

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -26,7 +26,6 @@ import space from 'app/styles/space';
 import {Actor, Organization, Project} from 'app/types';
 import Projects from 'app/utils/projects';
 import Timeline from 'app/views/alerts/rules/details/timeline';
-import {DATASET_EVENT_TYPE_FILTERS} from 'app/views/settings/incidentRules/constants';
 import {
   AlertRuleThresholdType,
   Dataset,
@@ -110,7 +109,7 @@ export default class DetailsBody extends React.Component<Props> {
 
     return (
       <Filters>
-        <code>{DATASET_EVENT_TYPE_FILTERS[rule.dataset]}</code>&nbsp;&nbsp;
+        <code>{extractEventTypeFilterFromRule(rule)}</code>&nbsp;&nbsp;
         {rule.query && <code>{rule.query}</code>}
       </Filters>
     );
@@ -382,7 +381,7 @@ export default class DetailsBody extends React.Component<Props> {
                           )}
                           start={timePeriod.start}
                           end={timePeriod.end}
-                          filter={DATASET_EVENT_TYPE_FILTERS[rule.dataset]}
+                          filter={extractEventTypeFilterFromRule(rule)}
                         />
                       )}
                     </ActivityWrapper>

--- a/static/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/details/relatedIssues.tsx
@@ -11,8 +11,8 @@ import {IconInfo} from 'app/icons';
 import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {OrganizationSummary, Project} from 'app/types';
-import {IncidentRule} from 'app/views/settings/incidentRules/types';
 import {DATASET_EVENT_TYPE_FILTERS} from 'app/views/settings/incidentRules/constants';
+import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
 import {TimePeriodType} from './constants';
 
@@ -47,7 +47,12 @@ class RelatedIssues extends React.Component<Props> {
       groupStatsPeriod: 'auto',
       limit: 5,
       sort: rule.aggregate === 'count_unique(user)' ? 'user' : 'freq',
-      query: [rule.query, rule.eventTypes?.length ? `event.type:[${rule.eventTypes.join(`, `)}]` : DATASET_EVENT_TYPE_FILTERS[rule.dataset]],
+      query: [
+        rule.query,
+        rule.eventTypes?.length
+          ? `event.type:[${rule.eventTypes.join(`, `)}]`
+          : DATASET_EVENT_TYPE_FILTERS[rule.dataset],
+      ],
       project: projects.map(project => project.id),
     };
     const issueSearch = {

--- a/static/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/details/relatedIssues.tsx
@@ -12,6 +12,7 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {OrganizationSummary, Project} from 'app/types';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
+import {DATASET_EVENT_TYPE_FILTERS} from 'app/views/settings/incidentRules/constants';
 
 import {TimePeriodType} from './constants';
 
@@ -46,7 +47,7 @@ class RelatedIssues extends React.Component<Props> {
       groupStatsPeriod: 'auto',
       limit: 5,
       sort: rule.aggregate === 'count_unique(user)' ? 'user' : 'freq',
-      query: rule.query,
+      query: [rule.query, rule.eventTypes?.length ? `event.type:[${rule.eventTypes.join(`, `)}]` : DATASET_EVENT_TYPE_FILTERS[rule.dataset]],
       project: projects.map(project => project.id),
     };
     const issueSearch = {


### PR DESCRIPTION
This puts back the event type filter in the query for the related issues request in the alert details page. It was removed in [#25015](https://github.com/getsentry/sentry/pull/25015) but with IN search support, we can put it back.