### PR TITLE
fix(perf): Tag explorer ops breakdown

### DIFF
--- a/static/app/views/performance/transactionSummary/tagExplorer.tsx
+++ b/static/app/views/performance/transactionSummary/tagExplorer.tsx
@@ -83,8 +83,8 @@ const COLUMN_ORDER = [
 
 const filterToField = {
   [SpanOperationBreakdownFilter.Browser]: 'span_op_breakdowns[ops.browser]',
-  [SpanOperationBreakdownFilter.Http]: 'span_op_breakdowns[ops.db]',
-  [SpanOperationBreakdownFilter.Db]: 'span_op_breakdowns[ops.http]',
+  [SpanOperationBreakdownFilter.Http]: 'span_op_breakdowns[ops.http]',
+  [SpanOperationBreakdownFilter.Db]: 'span_op_breakdowns[ops.db]',
   [SpanOperationBreakdownFilter.Resource]: 'span_op_breakdowns[ops.resource]',
 };
 
@@ -121,6 +121,7 @@ const getColumnsWithReplacedDuration = (
   const fieldFromFilter = filterToField[currentFilter];
   if (fieldFromFilter) {
     durationColumn.name = 'Avg Span Duration';
+    return columns;
   }
 
   const performanceType = platformToPerformanceType(projects, projectIds);


### PR DESCRIPTION
### Summary
The map for ops breakdown to field/column had http and db switched around, as well as the title not being correct for frontend events.