### PR TITLE
fix(workflow): Use global selection w/ alerts

### DIFF
--- a/static/app/components/sidebar/index.tsx
+++ b/static/app/components/sidebar/index.tsx
@@ -171,6 +171,8 @@ class Sidebar extends React.Component<Props, State> {
     evt: React.MouseEvent<HTMLAnchorElement>
   ) => {
     const globalSelectionRoutes = [
+      'alerts',
+      'alerts/rules',
       'dashboards',
       'issues',
       'releases',

--- a/static/app/views/alerts/rules/index.tsx
+++ b/static/app/views/alerts/rules/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import {RouteComponentProps} from 'react-router';
 import styled from '@emotion/styled';
 import flatten from 'lodash/flatten';
-import isEqual from 'lodash/isEqual';
 
 import {addErrorMessage} from 'app/actionCreators/indicator';
 import AsyncComponent from 'app/components/asyncComponent';
@@ -54,6 +53,14 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
       query.expand = ['latestIncident'];
     }
 
+    if (organization.features.includes('team-alerts-ownership')) {
+      query.team = this.getTeamQuery();
+    }
+
+    if (organization.features.includes('alert-details-redesign') && !query.sort) {
+      query.sort = ['incident_status', 'date_triggered'];
+    }
+
     return [
       [
         'ruleList',
@@ -63,6 +70,25 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
         },
       ],
     ];
+  }
+
+  getTeamQuery(): string[] {
+    const {
+      location: {query},
+    } = this.props;
+    if (query.team === undefined) {
+      return ALERT_LIST_QUERY_DEFAULT_TEAMS;
+    }
+
+    if (query.team === '') {
+      return [];
+    }
+
+    if (Array.isArray(query.team)) {
+      return query.team;
+    }
+
+    return [query.team];
   }
 
   tryRenderEmpty() {
@@ -90,11 +116,12 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
   handleChangeFilter = (activeFilters: Set<string>) => {
     const {router, location} = this.props;
     const {cursor: _cursor, page: _page, ...currentQuery} = location.query;
+    const teams = [...activeFilters];
     router.push({
       pathname: location.pathname,
       query: {
         ...currentQuery,
-        team: [...activeFilters],
+        team: teams.length ? teams : '',
       },
     });
   };
@@ -135,9 +162,7 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
 
   renderFilterBar() {
     const {teams, location} = this.props;
-    const teamQuery = location.query?.team;
-    const filteredTeams: Set<string> =
-      typeof teamQuery === 'string' ? new Set([teamQuery]) : new Set(teamQuery);
+    const filteredTeams = new Set(this.getTeamQuery());
     const additionalOptions = [
       {label: t('My Teams'), value: 'myteams'},
       {label: t('Unassigned'), value: 'unassigned'},
@@ -345,45 +370,13 @@ class AlertRulesList extends AsyncComponent<Props, State & AsyncComponent['state
 
 class AlertRulesListContainer extends React.Component<Props> {
   componentDidMount() {
-    const {organization, router, location, selection} = this.props;
-    const query: Record<string, string | number | string[] | number[]> = {
-      project: selection.projects,
-      // TODO(workflow): Support environments from global selection header
-      // environment: selection.environments,
-    };
-
-    if (organization.features.includes('team-alerts-ownership')) {
-      query.team = ALERT_LIST_QUERY_DEFAULT_TEAMS;
-    }
-
-    if (organization.features.includes('alert-details-redesign') && !query.sort) {
-      query.sort = ['incident_status', 'date_triggered'];
-    }
-
-    router.replace({
-      pathname: location.pathname,
-      query: {
-        ...query,
-        ...location.query,
-      },
-    });
     this.trackView();
   }
 
   componentDidUpdate(prevProps: Props) {
-    const {router, location, selection} = this.props;
+    const {location} = this.props;
     if (prevProps.location.query?.sort !== location.query?.sort) {
       this.trackView();
-    }
-
-    if (!isEqual(prevProps.selection.projects, selection.projects)) {
-      router.replace({
-        pathname: location.pathname,
-        query: {
-          ...location.query,
-          project: selection.projects,
-        },
-      });
     }
   }
 

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -196,6 +196,31 @@ describe('OrganizationRuleList', () => {
     );
   });
 
+  it('uses empty team query parameter when removing all teams', async () => {
+    const ownershipOrg = {
+      ...organization,
+      features: ['team-alerts-ownership'],
+    };
+    const wrapper = await createWrapper({organization: ownershipOrg});
+
+    wrapper.setProps({
+      location: {query: {team: 'myteams'}, search: '?team=myteams`'},
+    });
+    wrapper.find('Button[data-test-id="filter-button"]').simulate('click');
+    // Uncheck myteams
+    const myTeamsItem = wrapper.find('Filter').find('ListItem').at(0);
+    expect(myTeamsItem.text()).toBe('My Teams');
+    myTeamsItem.simulate('click');
+
+    expect(router.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: {
+          team: '',
+        },
+      })
+    );
+  });
+
   it('displays alert status', async () => {
     const ownershipOrg = {
       ...organization,

--- a/tests/js/spec/views/alerts/rules/index.spec.jsx
+++ b/tests/js/spec/views/alerts/rules/index.spec.jsx
@@ -190,6 +190,7 @@ describe('OrganizationRuleList', () => {
       expect.objectContaining({
         query: {
           name: testQuery,
+          team: ['myteams', 'unassigned'],
         },
       })
     );
@@ -218,12 +219,13 @@ describe('OrganizationRuleList', () => {
     };
     await createWrapper({organization: ownershipOrg});
 
-    expect(router.replace).toHaveBeenCalledWith(
+    expect(rulesMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/combined-rules/',
       expect.objectContaining({
-        query: expect.objectContaining({
+        query: {
           expand: ['latestIncident'],
           sort: ['incident_status', 'date_triggered'],
-        }),
+        },
       })
     );
   });


### PR DESCRIPTION
Before: Clicking alerts in the sidebar twice removed all query parameters, including project.
Now: Clicking twice keeps at least the global selection header project

Removes setting query parameters on load fixing a possible redirect loop.