### PR TITLE
feat(sidebar): Add link to marketing homepage inside product

### DIFF
--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -89,7 +89,7 @@ const SidebarDropdown = ({api, org, orientation, collapsed, config, user}: Props
           </SidebarDropdownActor>
 
           {isOpen && (
-            <OrgAndUserMenu {...getMenuProps({})}>
+            <OrgUserAndMarketingMenu {...getMenuProps({})}>
               {hasOrganization && (
                 <React.Fragment>
                   <SidebarOrgSummary organization={org} />
@@ -153,7 +153,13 @@ const SidebarDropdown = ({api, org, orientation, collapsed, config, user}: Props
                   </React.Fragment>
                 )}
               </DemoModeGate>
-            </OrgAndUserMenu>
+
+              <Divider />
+
+              <SidebarMenuItem href="https://sentry.io/welcome/">
+                {t('Homepage')}
+              </SidebarMenuItem>
+            </OrgUserAndMarketingMenu>
           )}
         </SidebarDropdownRoot>
       )}
@@ -231,11 +237,11 @@ const StyledAvatar = styled(Avatar)<{collapsed: boolean}>`
   border-radius: 6px; /* Fixes background bleeding on corners */
 `;
 
-const OrgAndUserMenu = styled('div')`
+const OrgUserAndMarketingMenu = styled('div')`
   ${SidebarDropdownMenu};
   top: 42px;
   min-width: 180px;
-  z-index: ${p => p.theme.zIndex.orgAndUserMenu};
+  z-index: ${p => p.theme.zIndex.orgUserAndMarketingMenu};
 `;
 
 const StyledIconChevron = styled(IconChevron)`

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -448,7 +448,7 @@ const commonTheme = {
     settingsSidebarNav: 1018,
     sidebarPanel: 1019,
     sidebar: 1020,
-    orgAndUserMenu: 1030,
+    orgUserAndMarketingMenu: 1030,
 
     // Sentry user feedback modal
     sentryErrorEmbed: 1090,

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -122,7 +122,7 @@ describe('Sidebar', function () {
     it('can open Sidebar org/name dropdown menu', function () {
       wrapper = createWrapper();
       wrapper.find('SidebarDropdownActor').simulate('click');
-      expect(wrapper.find('OrgAndUserMenu')).toHaveLength(1);
+      expect(wrapper.find('OrgUserAndMarketingMenu')).toHaveLength(1);
       expect(wrapper).toSnapshot();
     });
 
@@ -137,7 +137,7 @@ describe('Sidebar', function () {
         organization: org,
       });
       wrapper.find('SidebarDropdownActor').simulate('click');
-      expect(wrapper.find('OrgAndUserMenu')).toHaveLength(1);
+      expect(wrapper.find('OrgUserAndMarketingMenu')).toHaveLength(1);
       expect(
         wrapper.find('SidebarMenuItem[to="/settings/org-slug/members/"]')
       ).toHaveLength(1);


### PR DESCRIPTION
Closes #25670.

@ckj This implements your first suggestion (from private Slack):

> I can think of two paths forward at this point 1) add a link to the user/org dropdown. 'Visit Sentry.io' or 2) add a link to the footer saying the same

The footer felt way too distant. Lots of scrolling to discover that there are even links down there (does anyone ever click on those? genuinely interested). Also, "Visit Sentry.io" felt weird because the user is already _on_ https://sentry.io/. 🙈

Choice of "Homepage" and "Pricing" is based on @chriswiggins' [input](https://github.com/getsentry/sentry/issues/25670#issuecomment-827864852):

> The issue with "Its in the product" is that 9/10 I just want to see your pricing plan options on your marketing screen, because to me this is a much better way of viewing it.

... and also my own experience as a Sentry champion at my last workplace prior to joining Sentry, where I was in the same boat as @chriswiggins (roughly: wtf why am I not on https://app.sentry.io/ can I please get to the pricing page without logging out oh well I guess I'll open an incognito window 🙄). Also, this gives a nice nudge to self-hosted users who have no other persistent reminder in-app right now that SaaS exists. "Homepage" by itself felt alone, more than two items seemed excessive, adding "Pricing" felt like it gives helpful context without being overwhelming.

Checked, menu still works fine on a small phone.

You okay with this approach?

(**Technical reviewer note:** I'm not sure about the logic around `<Divider />` ... is it possible to have neither a user nor an organization? 🤔)

# Screenshots

<img width="1231" alt="desktop" src="https://user-images.githubusercontent.com/134455/116311599-6ad29880-a779-11eb-8a93-cf26d979cfe9.png">

<img width="448" alt="mobile" src="https://user-images.githubusercontent.com/134455/116311608-6d34f280-a779-11eb-8190-ee94c87d9851.png">