### PR TITLE
fix(pre-commit): Proper error when executing pre-commit outside of virtualenv

### DIFF
--- a/config/hooks/pre-commit
+++ b/config/hooks/pre-commit
@@ -13,7 +13,15 @@ if "VIRTUAL_ENV" in os.environ:
 
 
 def main():
-    from sentry.lint.engine import get_modified_files, run
+    try:
+        from sentry.lint.engine import get_modified_files, run
+    except ModuleNotFoundError as e:
+        if "VIRTUAL_ENV" not in os.environ:
+            sys.stderr.write(
+                "ERROR: You're executing outside of the venv. Try this command: direnv allow\n"
+            )
+            sys.exit(1)
+        raise (e)
 
     files_modified = [text_type(f) for f in get_modified_files(os.getcwd()) if os.path.exists(f)]
 


### PR DESCRIPTION
If anything happens that requires you to execute `direnv allow`, you won't have an activated virtualenv (to be improved in #25676).

If you're not within a virtualenv, you don't have `sentry` installed via `SENTRY_LIGHT_BUILD=1 pip install -e '.[dev]'`, thus, when you execute `git commit` you won't have the Sentry linters available to be imported.

If we need to keep this legacy pre-commit, we should at least help developers know that they need to run `direnv allow` to get the virtualenv.