### PR TITLE
fix(trends): Add confidence as a queryable field

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trends.py
+++ b/src/sentry/api/endpoints/organization_events_trends.py
@@ -74,11 +74,24 @@ class OrganizationEventsTrendsEndpointBase(OrganizationEventsV2EndpointBase):
                 ],
                 ["minus", "transaction.duration"],
             ),
+            # TODO(wmak): remove this once we don't use this on the frontend
             "t_test()": Alias(
                 lambda aggregate_filter: [
                     "t_test",
                     aggregate_filter.operator,
                     aggregate_filter.value.value,
+                ],
+                None,
+            ),
+            "confidence()": Alias(
+                lambda aggregate_filter: [
+                    "t_test",
+                    CORRESPONDENCE_MAP[aggregate_filter.operator]
+                    if trend_type == REGRESSION
+                    else aggregate_filter.operator,
+                    -1 * aggregate_filter.value.value
+                    if trend_type == IMPROVED
+                    else aggregate_filter.value.value,
                 ],
                 None,
             ),

--- a/static/app/views/performance/landing.tsx
+++ b/static/app/views/performance/landing.tsx
@@ -232,6 +232,7 @@ class PerformanceLanding extends React.Component<Props, State> {
     if (isNavigatingAwayFromTrends) {
       // This stops errors from occurring when navigating to other views since we are appending aggregates to the trends view
       conditions.removeTag('tpm()');
+      conditions.removeTag('confidence()');
       conditions.removeTag('transaction.duration');
 
       newQuery.query = stringifyQueryObject(conditions);

--- a/static/app/views/performance/trends/utils.tsx
+++ b/static/app/views/performance/trends/utils.tsx
@@ -204,7 +204,7 @@ export function modifyTrendView(
       trendParameter.column
     );
   }
-  trendView.query = getLimitTransactionItems(trendView.query, trendsType);
+  trendView.query = getLimitTransactionItems(trendView.query);
 
   trendView.interval = getQueryInterval(location, trendView);
 
@@ -291,7 +291,7 @@ export function movingAverage(data, index, size) {
 /**
  * This function applies defaults for trend and count percentage, and adds the confidence limit to the query
  */
-function getLimitTransactionItems(query: string, trendChangeType: TrendChangeType) {
+function getLimitTransactionItems(query: string) {
   const limitQuery = tokenizeSearch(query);
   if (!limitQuery.hasTag('count_percentage()')) {
     limitQuery.addTagValues('count_percentage()', ['>0.25', '<4']);
@@ -299,14 +299,8 @@ function getLimitTransactionItems(query: string, trendChangeType: TrendChangeTyp
   if (!limitQuery.hasTag('trend_percentage()')) {
     limitQuery.addTagValues('trend_percentage()', ['>0%']);
   }
-  if (!limitQuery.hasTag('t_test()')) {
-    const tagValues: string[] = [];
-    if (trendChangeType === TrendChangeType.REGRESSION) {
-      tagValues.push(`<-6`);
-    } else {
-      tagValues.push(`>6`);
-    }
-    limitQuery.addTagValues('t_test()', tagValues);
+  if (!limitQuery.hasTag('confidence()')) {
+    limitQuery.addTagValues('confidence()', ['>6']);
   }
   return limitQuery.formatString();
 }


### PR DESCRIPTION
- This allows queries like `confidence():>0` for low confidence trends
- Gonna follow up with:
  - fully hiding the t_test field, which is currently being used by the frontend
  - Docs update to explain how to use this confidence filter