### PR TITLE
feat(workflow): Add alert wizard performance hook

### DIFF
--- a/static/app/stores/hookStore.tsx
+++ b/static/app/stores/hookStore.tsx
@@ -17,6 +17,7 @@ const validHookNames = new Set<HookName>([
   'component:header-date-range',
   'component:header-selector-items',
   'feature-disabled:alerts-page',
+  'feature-disabled:alert-wizard-performance',
   'feature-disabled:custom-inbound-filters',
   'feature-disabled:custom-symbol-sources',
   'feature-disabled:data-forwarding',

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -114,6 +114,7 @@ export type FeatureDisabledHooks = {
   'feature-disabled:sso-rippling': FeatureDisabledHook;
   'feature-disabled:sso-saml2': FeatureDisabledHook;
   'feature-disabled:trace-view-link': FeatureDisabledHook;
+  'feature-disabled:alert-wizard-performance': FeatureDisabledHook;
 };
 
 /**


### PR DESCRIPTION
### "set conditions" Button is now right aligned
<img width="1154" alt="Screen Shot 2021-04-27 at 4 25 39 PM" src="https://user-images.githubusercontent.com/1400464/116327543-d87fc400-a77b-11eb-8da1-bad81ad8a1fe.png">

### Disabled on-premise
<img width="1171" alt="Screen Shot 2021-04-27 at 4 25 52 PM" src="https://user-images.githubusercontent.com/1400464/116327547-db7ab480-a77b-11eb-8500-b390484c6d6c.png">

### Disabled sentry.io
<img width="1141" alt="Screen Shot 2021-04-27 at 4 31 00 PM" src="https://user-images.githubusercontent.com/1400464/116327630-111f9d80-a77c-11eb-92ad-0a54d987541c.png">

### Clicking "learn more"
<img width="1151" alt="Screen Shot 2021-04-27 at 4 33 53 PM" src="https://user-images.githubusercontent.com/1400464/116327650-1ed52300-a77c-11eb-8161-1fd92b1a01c3.png">

