### PR TITLE
chore(deps): Do not explicitly install @webpack/serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
     "@storybook/react": "^6.2.9",
     "@storybook/theming": "^6.2.9",
     "@visual-snapshot/jest": "^2.0.2",
-    "@webpack-cli/serve": "^1.3.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.1",
     "babel-eslint": "^10.1.0",
     "babel-gettext-extractor": "^4.1.3",


### PR DESCRIPTION
The package says right on the tin:

> This package is used by webpack-cli under-the-hood and is not intended for installation as of v0.2.0