### PR TITLE
fix(dashboards): Pass environment for table widgets

### DIFF
--- a/static/app/views/dashboardsV2/utils.tsx
+++ b/static/app/views/dashboardsV2/utils.tsx
@@ -16,7 +16,7 @@ export function eventViewFromWidget(
   selection: GlobalSelection
 ): EventView {
   const {start, end, period: statsPeriod} = selection.datetime;
-  const {projects} = selection;
+  const {projects, environments} = selection;
 
   return EventView.fromSavedQuery({
     id: undefined,
@@ -29,6 +29,6 @@ export function eventViewFromWidget(
     range: statsPeriod,
     start: start ? getUtcDateString(start) : undefined,
     end: end ? getUtcDateString(end) : undefined,
-    environment: selection.environments,
+    environment: environments,
   });
 }

--- a/static/app/views/dashboardsV2/utils.tsx
+++ b/static/app/views/dashboardsV2/utils.tsx
@@ -29,5 +29,6 @@ export function eventViewFromWidget(
     range: statsPeriod,
     start: start ? getUtcDateString(start) : undefined,
     end: end ? getUtcDateString(end) : undefined,
+    environment: selection.environments,
   });
 }

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -229,6 +229,19 @@ describe('Dashboards > WidgetQueries', function () {
     // Child should be rendered and 2 requests should be sent.
     expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
     expect(tableMock).toHaveBeenCalledTimes(1);
+    expect(tableMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/eventsv2/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: 'event.type:error',
+          name: 'SDK',
+          field: ['sdk.name'],
+          statsPeriod: '14d',
+          environment: ['prod'],
+          project: [1],
+        }),
+      })
+    );
     expect(childProps.timeseriesResults).toBeUndefined();
     expect(childProps.tableResults[0].data).toHaveLength(1);
     expect(childProps.tableResults[0].meta).toBeDefined();

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -163,7 +163,12 @@ describe('Dashboards > WidgetQueries', function () {
     expect(errorMock).toHaveBeenCalledWith(
       '/organizations/org-slug/events-stats/',
       expect.objectContaining({
-        query: expect.objectContaining({interval: '4h'}),
+        query: expect.objectContaining({
+          interval: '4h',
+          statsPeriod: '90d',
+          environment: ['prod'],
+          project: [1],
+        }),
       })
     );
   });

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -139,7 +139,7 @@ describe('Dashboards > WidgetQueries', function () {
 
     const longSelection = {
       projects: [1],
-      environments: ['prod'],
+      environments: ['prod', 'dev'],
       datetime: {
         period: '90d',
       },
@@ -166,7 +166,7 @@ describe('Dashboards > WidgetQueries', function () {
         query: expect.objectContaining({
           interval: '4h',
           statsPeriod: '90d',
-          environment: ['prod'],
+          environment: ['prod', 'dev'],
           project: [1],
         }),
       })

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -231,7 +231,7 @@ describe('Dashboards > WidgetQueries', function () {
     await tick();
     await tick();
 
-    // Child should be rendered and 2 requests should be sent.
+    // Child should be rendered and 1 requests should be sent.
     expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
     expect(tableMock).toHaveBeenCalledTimes(1);
     expect(tableMock).toHaveBeenCalledWith(
@@ -352,7 +352,7 @@ describe('Dashboards > WidgetQueries', function () {
     await tick();
     await tick();
 
-    // Child should be rendered and 2 requests should be sent.
+    // Child should be rendered and 1 requests should be sent.
     expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
     expect(tableMock).toHaveBeenCalledTimes(1);
     expect(tableMock).toHaveBeenCalledWith(
@@ -391,7 +391,7 @@ describe('Dashboards > WidgetQueries', function () {
           title: 'SDK',
           interval: '5m',
           displayType: 'world_map',
-          queries: [{conditions: 'event.type:error', fields: ['sdk.name'], name: 'sdk'}],
+          queries: [{conditions: 'event.type:error', fields: ['count()'], name: 'sdk'}],
         }}
         organization={initialData.organization}
         selection={selection}
@@ -406,7 +406,7 @@ describe('Dashboards > WidgetQueries', function () {
     await tick();
     await tick();
 
-    // Child should be rendered and 2 requests should be sent.
+    // Child should be rendered and 1 requests should be sent.
     expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
     expect(tableMock).toHaveBeenCalledTimes(1);
     expect(tableMock).toHaveBeenCalledWith(
@@ -416,7 +416,7 @@ describe('Dashboards > WidgetQueries', function () {
           referrer: 'api.dashboards.worldmapwidget',
           query: 'event.type:error',
           name: 'SDK',
-          field: ['sdk.name'],
+          field: ['count()'],
           statsPeriod: '14d',
           environment: ['prod'],
           project: [1],

--- a/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
+++ b/tests/js/spec/views/dashboardsV2/widgetQueries.spec.jsx
@@ -320,6 +320,114 @@ describe('Dashboards > WidgetQueries', function () {
     expect(childProps.tableResults[1].data[0].title).toBeDefined();
   });
 
+  it('can send big number result queries', async function () {
+    const tableMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/eventsv2/',
+      body: {
+        meta: {'sdk.name': 'string'},
+        data: [{'sdk.name': 'python'}],
+      },
+    });
+
+    let childProps = undefined;
+    const wrapper = mountWithTheme(
+      <WidgetQueries
+        api={api}
+        widget={{
+          title: 'SDK',
+          interval: '5m',
+          displayType: 'big_number',
+          queries: [{conditions: 'event.type:error', fields: ['sdk.name'], name: 'sdk'}],
+        }}
+        organization={initialData.organization}
+        selection={selection}
+      >
+        {props => {
+          childProps = props;
+          return <div data-test-id="child" />;
+        }}
+      </WidgetQueries>,
+      initialData.routerContext
+    );
+    await tick();
+    await tick();
+
+    // Child should be rendered and 2 requests should be sent.
+    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(tableMock).toHaveBeenCalledTimes(1);
+    expect(tableMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/eventsv2/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          referrer: 'api.dashboards.bignumberwidget',
+          query: 'event.type:error',
+          name: 'SDK',
+          field: ['sdk.name'],
+          statsPeriod: '14d',
+          environment: ['prod'],
+          project: [1],
+        }),
+      })
+    );
+    expect(childProps.timeseriesResults).toBeUndefined();
+    expect(childProps.tableResults[0].data).toHaveLength(1);
+    expect(childProps.tableResults[0].meta).toBeDefined();
+  });
+
+  it('can send world map result queries', async function () {
+    const tableMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-geo/',
+      body: {
+        meta: {'sdk.name': 'string'},
+        data: [{'sdk.name': 'python'}],
+      },
+    });
+
+    let childProps = undefined;
+    const wrapper = mountWithTheme(
+      <WidgetQueries
+        api={api}
+        widget={{
+          title: 'SDK',
+          interval: '5m',
+          displayType: 'world_map',
+          queries: [{conditions: 'event.type:error', fields: ['sdk.name'], name: 'sdk'}],
+        }}
+        organization={initialData.organization}
+        selection={selection}
+      >
+        {props => {
+          childProps = props;
+          return <div data-test-id="child" />;
+        }}
+      </WidgetQueries>,
+      initialData.routerContext
+    );
+    await tick();
+    await tick();
+
+    // Child should be rendered and 2 requests should be sent.
+    expect(wrapper.find('[data-test-id="child"]')).toHaveLength(1);
+    expect(tableMock).toHaveBeenCalledTimes(1);
+    expect(tableMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/events-geo/',
+      expect.objectContaining({
+        query: expect.objectContaining({
+          referrer: 'api.dashboards.worldmapwidget',
+          query: 'event.type:error',
+          name: 'SDK',
+          field: ['sdk.name'],
+          statsPeriod: '14d',
+          environment: ['prod'],
+          project: [1],
+        }),
+      })
+    );
+    expect(childProps.timeseriesResults).toBeUndefined();
+    expect(childProps.tableResults[0].data).toHaveLength(1);
+    expect(childProps.tableResults[0].meta).toBeDefined();
+  });
+
   it('stops loading state once all queries finish even if some fail', async function () {
     const firstQuery = MockApiClient.addMockResponse(
       {


### PR DESCRIPTION
I've added tests to ensure the global selection header are appropriately passed for the API endpoints for the timeseries, table, world map, and big number widgets.