### PR TITLE
ref(ui): Remove some jQuery on DOM ready uses

### DIFF
--- a/src/sentry/templates/sentry/account/sudo.html
+++ b/src/sentry/templates/sentry/account/sudo.html
@@ -15,9 +15,9 @@
 
   {% script type="text/javascript" %}
   <script>
-    $(function() {
-      setTimeout(function(){
-          $("#id_password").focus();
+    document.addEventListener('DOMContentLoaded', function() {
+      setTimeout(function() {
+          document.querySelector("#id_password").focus();
       }, 0);
     });
   </script>

--- a/src/sentry/templates/sentry/bases/modal.html
+++ b/src/sentry/templates/sentry/bases/modal.html
@@ -42,10 +42,13 @@
   {{ block.super }}
   {% script %}
   <script>
-    $(function() {
-      $('#sign-out').on('click', function() {
-        document.modalLogoutForm.submit();
-      });
+    document.addEventListener('DOMContentLoaded', function() {
+      const el = document.querySelector('#sign-out');
+      if (el) {
+        el.addEventListener('click', function() {
+          document.modalLogoutForm.submit();
+        });
+      }
     });
   </script>
   {% endscript %}


### PR DESCRIPTION
We will be making a change where jQuery will be loaded async, so `$()` will not be immediately available. Instead we can use `DOMContentLoaded` event which is [well supported](https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event#browser_compatibility).