### PR TITLE
feat(ui): Move some initialization inside of main app bundle

### DIFF
--- a/src/sentry/templates/sentry/organization-login.html
+++ b/src/sentry/templates/sentry/organization-login.html
@@ -9,14 +9,12 @@
 
 {% script %}
 <script>
-  SentryApp.passwordStrength.load(function(passwordStrength) {
-    $(function() {
-      passwordStrength.attachTo({
-        input: document.querySelector('#id_registration_password'),
-        element: document.querySelector('.password-strength'),
-      });
-    })
-  })
+  window.__onSentryInit = window.__onSentryInit || [];
+  window.__onSentryInit.push({
+    name: 'passwordStrength',
+    input: '#id_registration_password',
+    element: '.password-strength',
+  });
 </script>
 {% endscript %}
 {% endblock %}

--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -2,26 +2,28 @@
 {% load sentry_assets %}
 
 <div id="blk_alerts" class="messages-container"></div>
+<div id="blk_indicators"></div>
+
 {% script %}
 <script>
-$(function(){
-  ReactDOM.render(React.createFactory(SentryApp.SystemAlerts)({
-     className: "alert-list"
-  }), document.getElementById('blk_alerts'));
-});
+  window.__onSentryInit = window.__onSentryInit || [];
+  window.__onSentryInit.push({
+    name: 'renderSystemAlerts',
+    container: '#blk_alerts',
+    props: {
+      className: 'alert-list',
+    },
+  });
+  window.__onSentryInit.push({
+    name: 'renderIndicators ',
+    container: '#blk_indicators',
+    props: {
+      className: 'indicators-container',
+    },
+  });
 </script>
 {% endscript %}
 
-<div id="blk_indicators"></div>
-{% script %}
-<script>
-$(function(){
-  ReactDOM.render(React.createFactory(SentryApp.Indicators)({
-     className: "indicators-container"
-  }), document.getElementById('blk_indicators'));
-});
-</script>
-{% endscript %}
 {% if messages %}
   <div id="messages" class="messages-container">
     {% for message in messages %}

--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -10,20 +10,6 @@ import Reflux from 'reflux';
 
 import plugins from 'app/plugins';
 
-// The password strength component is very heavyweight as it includes the
-// zxcvbn, a relatively byte-heavy password strength estimation library. Load
-// it on demand.
-async function loadPasswordStrength(callback: Function) {
-  try {
-    const module = await import(
-      /* webpackChunkName: "passwordStrength" */ 'app/components/passwordStrength'
-    );
-    callback(module);
-  } catch (err) {
-    // Ignore if client can't load this, it enhances UX a bit, but is optional
-  }
-}
-
 const globals = {
   // The following globals are used in sentry-plugins webpack externals
   // configuration.
@@ -63,11 +49,8 @@ globals.SentryApp = {
   },
 
   // The following components are used in legacy django HTML views
-  passwordStrength: {load: loadPasswordStrength},
   U2fSign: require('app/components/u2f/u2fsign').default,
   ConfigStore: require('app/stores/configStore').default,
-  SystemAlerts: require('app/views/app/systemAlerts').default,
-  Indicators: require('app/components/indicators').default,
   SetupWizard: require('app/components/setupWizard').default,
   HookStore: require('app/stores/hookStore').default,
   Modal: require('app/actionCreators/modal'),

--- a/static/app/bootstrap/initializeMain.tsx
+++ b/static/app/bootstrap/initializeMain.tsx
@@ -9,6 +9,7 @@ import {metric} from 'app/utils/analytics';
 
 import {commonInitialization} from './commonInitialization';
 import {initializeSdk} from './initializeSdk';
+import {processInitQueue} from './processInitQueue';
 import {renderMain} from './renderMain';
 import {renderOnDomReady} from './renderOnDomReady';
 
@@ -20,4 +21,5 @@ export function initializeMain(config: Config) {
   // bundle was loaded by browser.
   metric.mark({name: 'sentry-app-init'});
   renderOnDomReady(renderMain);
+  processInitQueue();
 }

--- a/static/app/bootstrap/processInitQueue.tsx
+++ b/static/app/bootstrap/processInitQueue.tsx
@@ -1,0 +1,56 @@
+/**
+ * This allows server templates to push "tasks" to be run after application has initialized.
+ * The global `window.__onSentryInit` is used for this.
+ */
+export async function processInitQueue() {
+  if (!Array.isArray(window.__onSentryInit)) {
+    return;
+  }
+
+  await Promise.all(
+    /**
+     * Be careful here as we can not guarantee type safety on `__onSentryInit` as
+     * these will be defined in server rendered templates
+     */
+    window.__onSentryInit.map(async initConfig => {
+      if (initConfig.name === 'passwordStrength') {
+        const {input, element} = initConfig;
+        if (!input || !element) {
+          return;
+        }
+
+        // The password strength component is very heavyweight as it includes the
+        // zxcvbn, a relatively byte-heavy password strength estimation library. Load
+        // it on demand.
+        const passwordStrength = await import(
+          /* webpackChunkName: "passwordStrength" */ 'app/components/passwordStrength'
+        );
+
+        passwordStrength.attachTo({
+          input: document.querySelector(input),
+          element: document.querySelector(element),
+        });
+
+        return;
+      }
+
+      if (initConfig.name === 'renderIndicators') {
+        const {renderIndicators} = await import(
+          /* webpackChunkName: "renderIndicators" */ 'app/bootstrap/renderIndicators'
+        );
+        renderIndicators(initConfig.container, initConfig.props);
+
+        return;
+      }
+
+      if (initConfig.name === 'renderSystemAlerts') {
+        const {renderSystemAlerts} = await import(
+          /* webpackChunkName: "renderSystemAlerts" */ 'app/bootstrap/renderSystemAlerts'
+        );
+        renderSystemAlerts(initConfig.container, initConfig.props);
+
+        return;
+      }
+    })
+  );
+}

--- a/static/app/bootstrap/renderIndicators.tsx
+++ b/static/app/bootstrap/renderIndicators.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Indicators from 'app/components/indicators';
+
+export function renderIndicators(container: string, props?: Record<string, any>) {
+  const rootEl = document.getElementById(container);
+
+  if (!rootEl) {
+    return;
+  }
+
+  ReactDOM.render(<Indicators {...props} />, rootEl);
+}

--- a/static/app/bootstrap/renderSystemAlerts.tsx
+++ b/static/app/bootstrap/renderSystemAlerts.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import SystemAlerts from 'app/views/app/systemAlerts';
+
+export function renderSystemAlerts(container: string, props?: Record<string, any>) {
+  const rootEl = document.getElementById(container);
+
+  if (!rootEl) {
+    return;
+  }
+
+  ReactDOM.render(<SystemAlerts {...props} />, rootEl);
+}

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -21,6 +21,18 @@ import {DynamicSamplingRules} from './dynamicSampling';
 import {Event} from './event';
 import {Mechanism, RawStacktrace, StacktraceType} from './stacktrace';
 
+export type OnSentryInitConfiguration =
+  | {
+      name: 'passwordStrength';
+      input: string;
+      element: string;
+    }
+  | {
+      name: 'renderSystemAlerts' | 'renderIndicators';
+      container: string;
+      props?: Record<string, any>;
+    };
+
 declare global {
   interface Window {
     /**
@@ -36,6 +48,15 @@ declare global {
      * Pipeline
      */
     __pipelineInitialData: PipelineInitialData;
+
+    /**
+     * This allows our server-rendered templates to push configuration that should be
+     * run after we render our main application.
+     *
+     * An example of this is dynamically importing the `passwordStrength` module only
+     * on the organization login page.
+     */
+    __onSentryInit: OnSentryInitConfiguration[];
 
     /**
      * Sentrys version string

--- a/static/app/views/app/systemAlerts.tsx
+++ b/static/app/views/app/systemAlerts.tsx
@@ -12,7 +12,7 @@ type State = {
   alerts: Array<Alert>;
 };
 
-class Alerts extends React.Component<Props, State> {
+class SystemAlerts extends React.Component<Props, State> {
   state = this.getInitialState();
 
   getInitialState(): State {
@@ -42,4 +42,4 @@ class Alerts extends React.Component<Props, State> {
   }
 }
 
-export default Alerts;
+export default SystemAlerts;


### PR DESCRIPTION
This inverts the relationship between inline scripts in templates and our main js app bundle. Previously, the templates assume that certain bundles are loaded synchronously. We also expose certain components in the app bundle via globals (`SentryApp`). This would no longer work if (when) we make our bundles loaded async.

Instead of exposing components through globals, allow templates to queue up predefined tasks (there are some future optimizations here as I do not believe these other django templates that extend from `layout.html` need the main app bundle). After we render the SPA to the DOM, we will iterate through `__onSentryInit` and perform the necessary initializations.