### PR TITLE
ref(issues): Collapse release details on issue details page

### DIFF
--- a/static/app/components/group/sidebar.tsx
+++ b/static/app/components/group/sidebar.tsx
@@ -74,7 +74,10 @@ class GroupSidebar extends React.Component<Props, State> {
     // Fetch group data for all environments since the one passed in props is filtered for the selected environment
     // The charts rely on having all environment data as well as the data for the selected env
     try {
-      const allEnvironmentsGroupData = await api.requestPromise(`/issues/${group.id}/`);
+      const query = {collapse: 'release'};
+      const allEnvironmentsGroupData = await api.requestPromise(`/issues/${group.id}/`, {
+        query,
+      });
       // eslint-disable-next-line react/no-did-mount-set-state
       this.setState({allEnvironmentsGroupData});
     } catch {

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -5,7 +5,14 @@ import Reflux from 'reflux';
 import GroupActions from 'app/actions/groupActions';
 import {t} from 'app/locale';
 import IndicatorStore from 'app/stores/indicatorStore';
-import {Activity, BaseGroup, Group, GroupStats} from 'app/types';
+import {
+  Activity,
+  BaseGroup,
+  Group,
+  GroupCollapseRelease,
+  GroupRelease,
+  GroupStats,
+} from 'app/types';
 
 function showAlert(msg, type) {
   IndicatorStore.addMessage(msg, type, {
@@ -52,15 +59,15 @@ type Internals = {
 type GroupStoreInterface = Reflux.StoreDefinition & {
   init: () => void;
   reset: () => void;
-  loadInitialData: (items: BaseGroup[] | Group[]) => void;
-  add: (items: BaseGroup[] | Group[]) => void;
+  loadInitialData: (items: BaseGroup[] | Group[] | GroupCollapseRelease[]) => void;
+  add: (items: BaseGroup[] | Group[] | GroupCollapseRelease[]) => void;
   remove: (itemIds: string[]) => void;
   addStatus: (id: string, status: string) => void;
   clearStatus: (id: string, status: string) => void;
   hasStatus: (id: string, status: string) => boolean;
-  get: (id: string) => BaseGroup | Group | undefined;
+  get: (id: string) => BaseGroup | Group | GroupCollapseRelease | undefined;
   getAllItemIds: () => string[];
-  getAllItems: () => BaseGroup[] | Group[];
+  getAllItems: () => BaseGroup[] | Group[] | GroupCollapseRelease[];
   onAssignTo: (changeId: string, itemId: string, data: any) => void;
   onAssignToError: (changeId: string, itemId: string, error: Error) => void;
   onAssignToSuccess: (changeId: string, itemId: string, response: any) => void;
@@ -86,6 +93,7 @@ type GroupStoreInterface = Reflux.StoreDefinition & {
     silent: boolean
   ) => void;
   onPopulateStats: (itemIds: string[], response: GroupStats[]) => void;
+  onPopulateReleases: (itemId: string, releaseData: GroupRelease) => void;
 };
 
 type GroupStore = Reflux.Store & GroupStoreInterface;
@@ -490,6 +498,18 @@ const storeConfig: Reflux.StoreDefinition & Internals & GroupStoreInterface = {
       }
     });
     this.trigger(new Set(this.items.map(item => item.id)));
+  },
+
+  onPopulateReleases(itemId: string, releaseData: GroupRelease) {
+    this.items.forEach((item, idx) => {
+      if (item.id === itemId) {
+        this.items[idx] = {
+          ...item,
+          ...releaseData,
+        };
+      }
+    });
+    this.trigger(new Set([itemId]));
   },
 };
 

--- a/static/app/types/index.tsx
+++ b/static/app/types/index.tsx
@@ -967,6 +967,11 @@ type BaseGroupStatusResolution = {
   statusDetails: ResolutionStatusDetails;
 };
 
+export type GroupRelease = {
+  firstRelease: Release;
+  lastRelease: Release;
+};
+
 // TODO(ts): incomplete
 export type BaseGroup = {
   id: string;
@@ -975,14 +980,12 @@ export type BaseGroup = {
   annotations: string[];
   assignedTo: Actor;
   culprit: string;
-  firstRelease: Release;
   firstSeen: string;
   hasSeen: boolean;
   isBookmarked: boolean;
   isUnhandled: boolean;
   isPublic: boolean;
   isSubscribed: boolean;
-  lastRelease: Release;
   lastSeen: string;
   level: Level;
   logger: string;
@@ -1005,11 +1008,13 @@ export type BaseGroup = {
   subscriptionDetails: {disabled?: boolean; reason?: string} | null;
   inbox?: InboxDetails | null | false;
   owners?: SuggestedOwner[] | null;
-};
+} & GroupRelease;
 
 export type GroupReprocessing = BaseGroup & GroupStats & BaseGroupStatusReprocessing;
 export type GroupResolution = BaseGroup & GroupStats & BaseGroupStatusResolution;
 export type Group = GroupResolution | GroupReprocessing;
+export type GroupCollapseRelease = Omit<Group, keyof GroupRelease> &
+  Partial<GroupRelease>;
 
 export type GroupTombstone = {
   id: string;

--- a/static/app/views/organizationGroupDetails/groupDetails.tsx
+++ b/static/app/views/organizationGroupDetails/groupDetails.tsx
@@ -125,6 +125,10 @@ class GroupDetails extends React.Component<Props, State> {
     return `/issues/${this.props.params.groupId}/`;
   }
 
+  get groupReleaseEndpoint() {
+    return `/issues/${this.props.params.groupId}/first-last-release/`;
+  }
+
   async getEvent(group?: Group) {
     if (group) {
       this.setState({loadingEvent: true, eventError: false});
@@ -252,6 +256,7 @@ class GroupDetails extends React.Component<Props, State> {
     if (organization?.features?.includes('inbox')) {
       query.expand = 'inbox';
     }
+    query.collapse = 'release';
 
     return query;
   }
@@ -318,6 +323,12 @@ class GroupDetails extends React.Component<Props, State> {
     }
   };
 
+  async fetchGroupReleases() {
+    const {api} = this.props;
+    const releases = await api.requestPromise(this.groupReleaseEndpoint);
+    GroupStore.onPopulateReleases(this.props.params.groupId, releases);
+  }
+
   async fetchData() {
     const {api, isGlobalSelectionReady, params} = this.props;
 
@@ -336,6 +347,7 @@ class GroupDetails extends React.Component<Props, State> {
       });
 
       const [data] = await Promise.all([groupPromise, eventPromise]);
+      this.fetchGroupReleases();
 
       const reprocessingNewRoute = this.getReprocessingNewRoute(data);
 

--- a/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
+++ b/tests/js/spec/views/organizationGroupDetails/groupDetails.spec.jsx
@@ -95,6 +95,10 @@ describe('groupDetails', function () {
       url: '/organizations/org-slug/users/',
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/issues/${group.id}/first-last-release/`,
+      body: {firstRelease: group.firstRelease, lastRelease: group.lastRelease},
+    });
   });
   afterEach(async function () {
     if (wrapper) {
@@ -219,6 +223,7 @@ describe('groupDetails', function () {
       expect.objectContaining({
         query: {
           environment: ['staging'],
+          collapse: 'release',
         },
       })
     );


### PR DESCRIPTION
The FE component to https://github.com/getsentry/sentry/pull/25186

This PR collapses `release` on the IssueDetails page and fetches release separately via `issues/${group.id}/first-last-release/`. This information is then used in the `sidebar.tsx` to show the first seen and last seen information.