### PR TITLE
fix(org-stats): Fix for edge-case when statsPeriod == interval

### DIFF
--- a/static/app/views/usageStats/usageChart/index.tsx
+++ b/static/app/views/usageStats/usageChart/index.tsx
@@ -260,7 +260,7 @@ export class UsageChart extends React.Component<Props, State> {
     // Use hours as common units
     const dataPeriod = statsPeriodToDays(undefined, usageDateStart, usageDateEnd) * 24;
     const barPeriod = parsePeriodToHours(usageDateInterval);
-    if (dataPeriod === 0 || barPeriod === -1) {
+    if (dataPeriod < 0 || barPeriod < 0) {
       throw new Error('UsageChart: Unable to parse data time period');
     }
 

--- a/static/app/views/usageStats/usageStatsOrg.tsx
+++ b/static/app/views/usageStats/usageStatsOrg.tsx
@@ -146,7 +146,7 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
     const interval = getSeriesApiInterval(dataDatetime);
 
     // Use fillers as loading/error states will not display datetime at all
-    if (!orgStats || !orgStats.intervals || orgStats.intervals.length < 2) {
+    if (!orgStats || !orgStats.intervals) {
       return {
         chartDateInterval: interval,
         chartDateStart: '',
@@ -163,7 +163,10 @@ class UsageStatsOrganization extends AsyncComponent<Props, State> {
 
     // Keep datetime in UTC until we want to display it to users
     const startTime = moment(intervals[0]).utc();
-    const endTime = moment(intervals[intervals.length - 1]).utc();
+    const endTime =
+      intervals.length < 2
+        ? moment(startTime) // when statsPeriod and interval is the same value
+        : moment(intervals[intervals.length - 1]).utc();
     const useUtc = isDisplayUtc(dataDatetime);
 
     // If interval is a day or more, use UTC to format date. Otherwise, the date


### PR DESCRIPTION
Happens when the user select `statsPeriod` of `1h` on Org Stats, or when `billingPeriodStart` and `billingPeriodEnd` is on the same day.

#### Org Stats (period 1h, interval 1h)
<img width="1120" alt="Screen Shot 2021-04-28 at 3 46 29 PM" src="https://user-images.githubusercontent.com/1748388/116481888-f3643e00-a838-11eb-829d-cbde4ad505d0.png">

#### Billing (period 1d, interval 1d)
<img width="1184" alt="Screen Shot 2021-04-28 at 3 45 59 PM" src="https://user-images.githubusercontent.com/1748388/116481915-feb76980-a838-11eb-940f-b135f1ceb6cc.png">

fixes JAVASCRIPT-24FK 
fixes JAVASCRIPT-24FM 