### PR TITLE
fix(workflow): Use incidents+perf flag for alert wizard

### DIFF
--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -16,6 +16,7 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import BuilderBreadCrumbs from 'app/views/alerts/builder/builderBreadCrumbs';
+import {Dataset} from 'app/views/settings/incidentRules/types';
 
 import {
   AlertType,
@@ -53,7 +54,8 @@ class AlertWizard extends React.Component<Props, State> {
     const {organization, project, location} = this.props;
     const {alertOption} = this.state;
     const metricRuleTemplate = AlertWizardRuleTemplates[alertOption];
-    const isMetricAlert = !!metricRuleTemplate?.dataset;
+    const isMetricAlert = !!metricRuleTemplate;
+    const isTransactionDataset = metricRuleTemplate?.dataset === Dataset.TRANSACTIONS;
 
     const to = {
       pathname: `/organizations/${organization.slug}/alerts/${project.slug}/new/`,
@@ -82,7 +84,13 @@ class AlertWizard extends React.Component<Props, State> {
 
     return (
       <Feature
-        features={isMetricAlert ? ['incidents'] : []}
+        features={
+          isTransactionDataset
+            ? ['incidents', 'performance-view']
+            : isMetricAlert
+            ? ['incidents']
+            : []
+        }
         requireAll
         organization={organization}
         hookName="feature-disabled:alert-wizard-performance"

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -53,7 +53,7 @@ class AlertWizard extends React.Component<Props, State> {
     const {organization, project, location} = this.props;
     const {alertOption} = this.state;
     const metricRuleTemplate = AlertWizardRuleTemplates[alertOption];
-    const isTransactionDataset = alertOption !== 'issues';
+    const isMetricAlert = !!metricRuleTemplate?.dataset;
 
     const to = {
       pathname: `/organizations/${organization.slug}/alerts/${project.slug}/new/`,
@@ -82,7 +82,7 @@ class AlertWizard extends React.Component<Props, State> {
 
     return (
       <Feature
-        features={isTransactionDataset ? ['incidents'] : []}
+        features={isMetricAlert ? ['incidents'] : []}
         requireAll
         organization={organization}
         hookName="feature-disabled:alert-wizard-performance"

--- a/static/app/views/alerts/wizard/index.tsx
+++ b/static/app/views/alerts/wizard/index.tsx
@@ -16,7 +16,6 @@ import {t} from 'app/locale';
 import space from 'app/styles/space';
 import {Organization, Project} from 'app/types';
 import BuilderBreadCrumbs from 'app/views/alerts/builder/builderBreadCrumbs';
-import {Dataset} from 'app/views/settings/incidentRules/types';
 
 import {
   AlertType,
@@ -54,7 +53,7 @@ class AlertWizard extends React.Component<Props, State> {
     const {organization, project, location} = this.props;
     const {alertOption} = this.state;
     const metricRuleTemplate = AlertWizardRuleTemplates[alertOption];
-    const isTransactionDataset = metricRuleTemplate?.dataset === Dataset.TRANSACTIONS;
+    const isTransactionDataset = alertOption !== 'issues';
 
     const to = {
       pathname: `/organizations/${organization.slug}/alerts/${project.slug}/new/`,
@@ -65,7 +64,7 @@ class AlertWizard extends React.Component<Props, State> {
       },
     };
 
-    const noFeatureMessage = t('Requires performance feature.');
+    const noFeatureMessage = t('Requires incidents feature.');
     const renderNoAccess = p => (
       <Hovercard
         body={
@@ -83,7 +82,8 @@ class AlertWizard extends React.Component<Props, State> {
 
     return (
       <Feature
-        features={isTransactionDataset ? ['performance-view'] : []}
+        features={isTransactionDataset ? ['incidents'] : []}
+        requireAll
         organization={organization}
         hookName="feature-disabled:alert-wizard-performance"
         renderDisabled={renderNoAccess}


### PR DESCRIPTION
disable everything except issues for users without the `incidents` flag

![image](https://user-images.githubusercontent.com/1400464/116484296-9fa82380-a83d-11eb-890c-b6c475e0252a.png)
