### PR TITLE
feat(workflow): Remove dead inbox flags

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -983,10 +983,6 @@ SENTRY_FEATURES = {
     "organizations:usage-stats-graph": False,
     # Enable inbox support in the issue stream
     "organizations:inbox": False,
-    # Set default tab to inbox
-    "organizations:inbox-tab-default": False,
-    # Add `assigned_or_suggested:[me, none]` to inbox tab query
-    "organizations:inbox-owners-query": False,
     # Enable the new alert details ux design
     "organizations:alert-details-redesign": False,
     # Enable the new images loaded design and features

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -77,8 +77,6 @@ default_manager.add("organizations:global-views", OrganizationFeature)  # NOQA
 default_manager.add("organizations:images-loaded-v2", OrganizationFeature)  # NOQA
 default_manager.add("organizations:import-codeowners", OrganizationFeature)  # NOQA
 default_manager.add("organizations:inbox", OrganizationFeature)  # NOQA
-default_manager.add("organizations:inbox-owners-query", OrganizationFeature)  # NOQA
-default_manager.add("organizations:inbox-tab-default", OrganizationFeature)  # NOQA
 default_manager.add("organizations:incidents", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-alert-rule", OrganizationFeature)  # NOQA
 default_manager.add("organizations:integrations-chat-unfurl", OrganizationFeature)  # NOQA

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -285,7 +285,7 @@ class IssueListOverview extends React.Component<Props, State> {
   private _streamManager = new StreamManager(GroupStore);
 
   getQuery(): string {
-    const {savedSearch, organization, location} = this.props;
+    const {savedSearch, location} = this.props;
     if (savedSearch) {
       return savedSearch.query;
     }
@@ -294,13 +294,6 @@ class IssueListOverview extends React.Component<Props, State> {
 
     if (query !== undefined) {
       return query as string;
-    }
-
-    if (
-      organization.features.includes('inbox') &&
-      organization.features.includes('inbox-tab-default')
-    ) {
-      return Query.FOR_REVIEW;
     }
 
     return DEFAULT_QUERY;
@@ -314,15 +307,6 @@ class IssueListOverview extends React.Component<Props, State> {
 
     if (location.query.sort) {
       return location.query.sort as string;
-    }
-
-    const {organization} = this.props;
-    if (
-      organization.features.includes('inbox') &&
-      organization.features.includes('inbox-tab-default') &&
-      this.getQuery() === Query.FOR_REVIEW
-    ) {
-      return IssueSortOptions.INBOX;
     }
 
     return DEFAULT_SORT;


### PR DESCRIPTION
we're no longer using `inbox-owners-query` and `inbox-tab-default`