### PR TITLE
feat(codeowners): ExternalActorSerializerBase should require integration_id

### DIFF
--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -27,13 +27,13 @@ class ExternalActorSerializerBase(CamelSnakeModelSerializer):  # type: ignore
     external_id = serializers.CharField(required=False, allow_null=True)
     external_name = serializers.CharField(required=True)
     provider = serializers.ChoiceField(choices=get_provider_choices(AVAILABLE_PROVIDERS))
-    integration_id = serializers.IntegerField(required=False, allow_null=True)
+    integration_id = serializers.IntegerField(required=True)
 
     @property
     def organization(self) -> Organization:
         return self.context["organization"]
 
-    def validate_integration_id(self, integration_id: str) -> Optional[str]:
+    def validate_integration_id(self, integration_id: str) -> str:
         return validate_integration_id_option(integration_id, self.organization)
 
     def validate_external_id(self, external_id: str) -> Optional[str]:

--- a/src/sentry/api/bases/external_actor.py
+++ b/src/sentry/api/bases/external_actor.py
@@ -10,7 +10,7 @@ from sentry import features
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
 from sentry.api.validators.external_actor import (
     validate_external_id_option,
-    validate_integration_id_option,
+    validate_integration_id,
 )
 from sentry.api.validators.integrations import validate_provider
 from sentry.models import ExternalActor, Organization, Team, User
@@ -34,7 +34,7 @@ class ExternalActorSerializerBase(CamelSnakeModelSerializer):  # type: ignore
         return self.context["organization"]
 
     def validate_integration_id(self, integration_id: str) -> str:
-        return validate_integration_id_option(integration_id, self.organization)
+        return validate_integration_id(integration_id, self.organization)
 
     def validate_external_id(self, external_id: str) -> Optional[str]:
         return validate_external_id_option(external_id)

--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -56,6 +56,7 @@ class ExternalActorSerializer(Serializer):  # type: ignore
             "id": str(obj.id),
             "provider": provider,
             "externalName": obj.external_name,
+            "integrationId": obj.integration_id,
         }
 
         if obj.external_id:

--- a/src/sentry/api/serializers/models/external_actor.py
+++ b/src/sentry/api/serializers/models/external_actor.py
@@ -56,7 +56,7 @@ class ExternalActorSerializer(Serializer):  # type: ignore
             "id": str(obj.id),
             "provider": provider,
             "externalName": obj.external_name,
-            "integrationId": obj.integration_id,
+            "integrationId": str(obj.integration_id),
         }
 
         if obj.external_id:

--- a/src/sentry/api/validators/external_actor.py
+++ b/src/sentry/api/validators/external_actor.py
@@ -29,9 +29,7 @@ def validate_external_id_option(external_id: Optional[str]) -> Optional[str]:
     return external_id
 
 
-def validate_integration_id_option(
-    integration_id: Optional[str], organization: Organization
-) -> str:
+def validate_integration_id_option(integration_id: str, organization: Organization) -> str:
 
     integration_query = OrganizationIntegration.objects.filter(
         organization=organization, integration_id=integration_id

--- a/src/sentry/api/validators/external_actor.py
+++ b/src/sentry/api/validators/external_actor.py
@@ -29,7 +29,7 @@ def validate_external_id_option(external_id: Optional[str]) -> Optional[str]:
     return external_id
 
 
-def validate_integration_id_option(integration_id: str, organization: Organization) -> str:
+def validate_integration_id(integration_id: str, organization: Organization) -> str:
 
     integration_query = OrganizationIntegration.objects.filter(
         organization=organization, integration_id=integration_id

--- a/src/sentry/api/validators/external_actor.py
+++ b/src/sentry/api/validators/external_actor.py
@@ -31,9 +31,7 @@ def validate_external_id_option(external_id: Optional[str]) -> Optional[str]:
 
 def validate_integration_id_option(
     integration_id: Optional[str], organization: Organization
-) -> Optional[str]:
-    if not integration_id:
-        return None
+) -> str:
 
     integration_query = OrganizationIntegration.objects.filter(
         organization=organization, integration_id=integration_id

--- a/tests/sentry/api/endpoints/test_external_team.py
+++ b/tests/sentry/api/endpoints/test_external_team.py
@@ -10,73 +10,19 @@ class ExternalTeamTest(APITestCase):
     def setUp(self):
         super().setUp()
         self.login_as(self.user)
-
-    def test_basic_post(self):
-        data = {"externalName": "@getsentry/ecosystem", "provider": "github"}
-        with self.feature({"organizations:import-codeowners": True}):
-            response = self.get_success_response(
-                self.organization.slug, self.team.slug, status_code=201, **data
-            )
-        assert response.data == {
-            "id": str(response.data["id"]),
-            "teamId": str(self.team.id),
-            **data,
-        }
-
-    def test_without_feature_flag(self):
-        data = {"externalName": "@getsentry/ecosystem", "provider": "github"}
-        response = self.get_error_response(
-            self.organization.slug, self.team.slug, status_code=403, **data
-        )
-        assert response.data == {"detail": "You do not have permission to perform this action."}
-
-    def test_missing_provider(self):
-        data = {"externalName": "@getsentry/ecosystem"}
-        with self.feature({"organizations:import-codeowners": True}):
-            response = self.get_error_response(
-                self.organization.slug, self.team.slug, status_code=400, **data
-            )
-        assert response.data == {"provider": ["This field is required."]}
-
-    def test_missing_externalName(self):
-        data = {"provider": "gitlab"}
-        with self.feature({"organizations:import-codeowners": True}):
-            response = self.get_error_response(
-                self.organization.slug, self.team.slug, status_code=400, **data
-            )
-        assert response.data == {"externalName": ["This field is required."]}
-
-    def test_invalid_provider(self):
-        data = {"externalName": "@getsentry/ecosystem", "provider": "git"}
-        with self.feature({"organizations:import-codeowners": True}):
-            response = self.get_error_response(
-                self.organization.slug, self.team.slug, status_code=400, **data
-            )
-        assert response.data == {"provider": ['"git" is not a valid choice.']}
-
-    def test_create_existing_association(self):
-        self.external_team = self.create_external_team(
-            self.team, external_name="@getsentry/ecosystem"
-        )
-        data = {
-            "externalName": self.external_team.external_name,
-            "provider": get_provider_string(self.external_team.provider),
-        }
-        with self.feature({"organizations:import-codeowners": True}):
-            response = self.get_success_response(self.organization.slug, self.team.slug, **data)
-        assert response.data == {
-            "id": str(self.external_team.id),
-            "teamId": str(self.team.id),
-            **data,
-        }
-
-    def test_create_with_integration(self):
         self.integration = Integration.objects.create(
-            provider="gitlab", name="Gitlab", external_id="gitlab:1"
+            provider="github", name="GitHub", external_id="github:1"
         )
 
         self.integration.add_organization(self.organization, self.user)
 
+        self.slack_integration = Integration.objects.create(
+            provider="slack", name="Slack", external_id="slack:2"
+        )
+
+        self.slack_integration.add_organization(self.organization, self.user)
+
+    def test_basic_post(self):
         data = {
             "externalName": "@getsentry/ecosystem",
             "provider": "github",
@@ -89,12 +35,84 @@ class ExternalTeamTest(APITestCase):
         assert response.data == {
             "id": str(response.data["id"]),
             "teamId": str(self.team.id),
-            "externalName": data["externalName"],
-            "provider": data["provider"],
+            **data,
         }
-        assert (
-            ExternalActor.objects.get(id=response.data["id"]).integration_id == self.integration.id
+
+    def test_without_feature_flag(self):
+        data = {
+            "externalName": "@getsentry/ecosystem",
+            "provider": "github",
+            "integrationId": self.integration.id,
+        }
+        response = self.get_error_response(
+            self.organization.slug, self.team.slug, status_code=403, **data
         )
+        assert response.data == {"detail": "You do not have permission to perform this action."}
+
+    def test_missing_provider(self):
+        data = {
+            "externalName": "@getsentry/ecosystem",
+            "integrationId": self.integration.id,
+        }
+        with self.feature({"organizations:import-codeowners": True}):
+            response = self.get_error_response(
+                self.organization.slug, self.team.slug, status_code=400, **data
+            )
+        assert response.data == {"provider": ["This field is required."]}
+
+    def test_missing_externalName(self):
+        data = {
+            "provider": "github",
+            "integrationId": self.integration.id,
+        }
+        with self.feature({"organizations:import-codeowners": True}):
+            response = self.get_error_response(
+                self.organization.slug, self.team.slug, status_code=400, **data
+            )
+        assert response.data == {"externalName": ["This field is required."]}
+
+    def test_missing_integrationId(self):
+        data = {
+            "externalName": "@getsentry/ecosystem",
+            "provider": "github",
+        }
+        with self.feature({"organizations:import-codeowners": True}):
+            response = self.get_error_response(
+                self.organization.slug, self.team.slug, status_code=400, **data
+            )
+        assert response.data == {"integrationId": ["This field is required."]}
+
+    def test_invalid_provider(self):
+        data = {
+            "externalName": "@getsentry/ecosystem",
+            "provider": "git",
+            "integrationId": self.integration.id,
+        }
+        with self.feature({"organizations:import-codeowners": True}):
+            response = self.get_error_response(
+                self.organization.slug, self.team.slug, status_code=400, **data
+            )
+        assert response.data == {"provider": ['"git" is not a valid choice.']}
+
+    def test_create_existing_association(self):
+        self.external_team = self.create_external_team(
+            self.team, external_name="@getsentry/ecosystem", integration=self.integration
+        )
+
+        data = {
+            "externalName": self.external_team.external_name,
+            "provider": get_provider_string(self.external_team.provider),
+            "integrationId": self.integration.id,
+        }
+        with self.feature({"organizations:import-codeowners": True}):
+            response = self.get_success_response(
+                self.organization.slug, self.team.slug, status_code=200, **data
+            )
+        assert response.data == {
+            "id": str(self.external_team.id),
+            "teamId": str(self.team.id),
+            **data,
+        }
 
     def test_create_with_invalid_integration_id(self):
         self.org2 = self.create_organization(owner=self.user, name="org2")
@@ -122,15 +140,14 @@ class ExternalTeamTest(APITestCase):
             "externalId": "YU287RFO30",
             "externalName": "@getsentry/ecosystem",
             "provider": "slack",
+            "integrationId": self.slack_integration.id,
         }
         with self.feature({"organizations:import-codeowners": True}):
             response = self.get_success_response(self.organization.slug, self.team.slug, **data)
         assert response.data == {
             "id": str(response.data["id"]),
             "teamId": str(self.team.id),
-            "externalName": data["externalName"],
-            "externalId": data["externalId"],
-            "provider": data["provider"],
+            **data,
         }
         assert ExternalActor.objects.get(id=response.data["id"]).external_id == "YU287RFO30"
 
@@ -139,6 +156,7 @@ class ExternalTeamTest(APITestCase):
             "externalId": "",
             "externalName": "@getsentry/ecosystem",
             "provider": "slack",
+            "integrationId": self.slack_integration.id,
         }
         with self.feature({"organizations:import-codeowners": True}):
             self.get_error_response(self.organization.slug, self.team.slug, **data)

--- a/tests/sentry/api/endpoints/test_external_team.py
+++ b/tests/sentry/api/endpoints/test_external_team.py
@@ -33,9 +33,10 @@ class ExternalTeamTest(APITestCase):
                 self.organization.slug, self.team.slug, status_code=201, **data
             )
         assert response.data == {
+            **data,
             "id": str(response.data["id"]),
             "teamId": str(self.team.id),
-            **data,
+            "integrationId": str(self.integration.id),
         }
 
     def test_without_feature_flag(self):
@@ -109,9 +110,10 @@ class ExternalTeamTest(APITestCase):
                 self.organization.slug, self.team.slug, status_code=200, **data
             )
         assert response.data == {
+            **data,
             "id": str(self.external_team.id),
             "teamId": str(self.team.id),
-            **data,
+            "integrationId": str(self.integration.id),
         }
 
     def test_create_with_invalid_integration_id(self):
@@ -145,9 +147,10 @@ class ExternalTeamTest(APITestCase):
         with self.feature({"organizations:import-codeowners": True}):
             response = self.get_success_response(self.organization.slug, self.team.slug, **data)
         assert response.data == {
+            **data,
             "id": str(response.data["id"]),
             "teamId": str(self.team.id),
-            **data,
+            "integrationId": str(self.slack_integration.id),
         }
         assert ExternalActor.objects.get(id=response.data["id"]).external_id == "YU287RFO30"
 

--- a/tests/sentry/api/endpoints/test_external_user.py
+++ b/tests/sentry/api/endpoints/test_external_user.py
@@ -1,3 +1,4 @@
+from sentry.models import Integration
 from sentry.testutils import APITestCase
 
 
@@ -10,10 +11,16 @@ class ExternalUserTest(APITestCase):
         self.login_as(self.user)
 
         self.org_slug = self.organization.slug  # force creation
+        self.integration = Integration.objects.create(
+            provider="github", name="GitHub", external_id="github:1"
+        )
+
+        self.integration.add_organization(self.organization, self.user)
         self.data = {
             "externalName": "@NisanthanNanthakumar",
             "provider": "github",
             "userId": self.user.id,
+            "integrationId": self.integration.id,
         }
 
     def test_basic_post(self):
@@ -47,6 +54,12 @@ class ExternalUserTest(APITestCase):
             response = self.get_error_response(self.org_slug, status_code=400, **self.data)
         assert response.data == {"userId": ["This field is required."]}
 
+    def test_missing_integrationId(self):
+        self.data.pop("integrationId")
+        with self.feature({"organizations:import-codeowners": True}):
+            response = self.get_error_response(self.org_slug, status_code=400, **self.data)
+        assert response.data == {"integrationId": ["This field is required."]}
+
     def test_invalid_provider(self):
         self.data.update(provider="unknown")
         with self.feature({"organizations:import-codeowners": True}):
@@ -55,11 +68,11 @@ class ExternalUserTest(APITestCase):
 
     def test_create_existing_association(self):
         self.external_user = self.create_external_user(
-            self.user, self.organization, external_name=self.data["externalName"]
+            self.user, self.organization, self.integration, external_name=self.data["externalName"]
         )
 
         with self.feature({"organizations:import-codeowners": True}):
-            response = self.get_success_response(self.org_slug, **self.data)
+            response = self.get_success_response(self.org_slug, status_code=200, **self.data)
         assert response.data == {
             **self.data,
             "id": str(self.external_user.id),

--- a/tests/sentry/api/endpoints/test_external_user.py
+++ b/tests/sentry/api/endpoints/test_external_user.py
@@ -30,6 +30,7 @@ class ExternalUserTest(APITestCase):
             **self.data,
             "id": str(response.data["id"]),
             "userId": str(self.user.id),
+            "integrationId": str(self.integration.id),
         }
 
     def test_without_feature_flag(self):
@@ -77,4 +78,5 @@ class ExternalUserTest(APITestCase):
             **self.data,
             "id": str(self.external_user.id),
             "userId": str(self.user.id),
+            "integrationId": str(self.integration.id),
         }

--- a/tests/sentry/api/endpoints/test_organization_teams.py
+++ b/tests/sentry/api/endpoints/test_organization_teams.py
@@ -105,6 +105,7 @@ class OrganizationTeamsListTest(APITestCase):
         assert len(response.data[0]["externalTeams"]) == 1
         assert response.data[0]["externalTeams"][0] == {
             "id": str(self.external_team.id),
+            "integrationId": str(self.external_team.integration.id),
             "provider": get_provider_string(self.external_team.provider),
             "externalName": self.external_team.external_name,
             "teamId": str(self.team.id),

--- a/tests/sentry/api/endpoints/test_project_codeowners.py
+++ b/tests/sentry/api/endpoints/test_project_codeowners.py
@@ -9,6 +9,12 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
         self.user = self.create_user("admin@sentry.io", is_superuser=True)
 
         self.login_as(user=self.user)
+
+        self.integration = Integration.objects.create(
+            provider="github", name="GitHub", external_id="github:1"
+        )
+        self.integration.add_organization(self.organization, self.user)
+
         self.team = self.create_team(
             organization=self.organization, slug="tiger-team", members=[self.user]
         )
@@ -17,8 +23,10 @@ class ProjectCodeOwnersEndpointTestCase(APITestCase):
             organization=self.organization, teams=[self.team], slug="bengal"
         )
         self.code_mapping = self.create_code_mapping(project=self.project)
-        self.external_user = self.create_external_user(external_name="@NisanthanNanthakumar")
-        self.external_team = self.create_external_team()
+        self.external_user = self.create_external_user(
+            external_name="@NisanthanNanthakumar", integration=self.integration
+        )
+        self.external_team = self.create_external_team(integration=self.integration)
         self.url = reverse(
             "sentry-api-0-project-codeowners",
             kwargs={"organization_slug": self.organization.slug, "project_slug": self.project.slug},


### PR DESCRIPTION
## Objective:
We are transitioning towards making the `integration_id` column in `sentry_externalactor` a NOT NULL column.
This PR implements a django validation when saving records to `sentry_externalactor` and raises the appropriate errors.

There will be a follow up PR to implement the NOT NULL migration.

## Tests:
Refactored associated tests.