### PR TITLE
ref(tests) Update select field tests for deprecated control removal

### DIFF
--- a/tests/js/spec/components/forms/selectCreatableField.spec.jsx
+++ b/tests/js/spec/components/forms/selectCreatableField.spec.jsx
@@ -1,154 +1,104 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
+import {changeInputValue, openMenu} from 'sentry-test/select-new';
 
 import {Form, SelectCreatableField} from 'app/components/forms';
 
 describe('SelectCreatableField', function () {
-  describe('deprecatedSelectControl', function () {
-    it('can add user input into select field when using options', function () {
-      const wrapper = mountWithTheme(
-        <SelectCreatableField
-          deprecatedSelectControl
-          options={[{value: 'foo', label: 'Foo'}]}
-          name="fieldName"
-        />
-      );
+  it('can add user input into select field when using options', function () {
+    const wrapper = mountWithTheme(
+      <SelectCreatableField options={[{value: 'foo', label: 'Foo'}]} name="fieldName" />
+    );
 
-      wrapper
-        .find('input[id="id-fieldName"]')
-        .simulate('change', {target: {value: 'bar'}})
-        .simulate('keyDown', {keyCode: 13});
-      wrapper.update();
+    const input = wrapper.find('SelectControl input[type="text"]');
+    changeInputValue(input, 'bar');
+    wrapper.update();
 
-      // Is selected
-      expect(wrapper.find('.Select-value-label').text()).toBe('bar');
+    // Text is in input
+    expect(wrapper.find('SelectControl input[type="text"]').props().value).toBe('bar');
 
-      // Is in select menu
-      expect(wrapper.find('Select').prop('options')).toEqual([
-        expect.objectContaining({
-          value: 'bar',
-          label: 'bar',
-        }),
-        {
-          value: 'foo',
-          label: 'Foo',
-        },
-      ]);
-    });
+    // Click on create option
+    openMenu(wrapper, {control: true});
+    wrapper.find('SelectControl Option div').simulate('click');
 
-    it('can add user input into select field when using choices', function () {
-      const wrapper = mountWithTheme(
-        <SelectCreatableField
-          deprecatedSelectControl
-          choices={['foo']}
-          name="fieldName"
-        />
-      );
+    // Is active hidden input value
+    expect(wrapper.find('SelectControl input[type="hidden"]').props().value).toEqual(
+      'bar'
+    );
+  });
 
-      wrapper
-        .find('input[id="id-fieldName"]')
-        .simulate('change', {target: {value: 'bar'}})
-        .simulate('keyDown', {keyCode: 13});
-      wrapper.update();
+  it('can add user input into select field when using choices', function () {
+    const wrapper = mountWithTheme(
+      <SelectCreatableField choices={['foo']} name="fieldName" />
+    );
 
-      // Is selected
-      expect(wrapper.find('.Select-value-label').text()).toBe('bar');
+    const input = wrapper.find('SelectControl input[type="text"]');
+    changeInputValue(input, 'bar');
+    wrapper.update();
 
-      // Is in select menu
-      expect(wrapper.find('Select').prop('options')).toEqual([
-        expect.objectContaining({
-          value: 'bar',
-          label: 'bar',
-        }),
-        {
-          value: 'foo',
-          label: 'foo',
-        },
-      ]);
-    });
+    // Text is in input
+    expect(wrapper.find('SelectControl input[type="text"]').props().value).toBe('bar');
 
-    it('can add user input into select field when using paired choices', function () {
-      const wrapper = mountWithTheme(
-        <SelectCreatableField
-          deprecatedSelectControl
-          choices={[['foo', 'foo']]}
-          name="fieldName"
-        />
-      );
+    // Click on create option
+    openMenu(wrapper, {control: true});
+    wrapper.find('SelectControl Option div').simulate('click');
 
-      wrapper
-        .find('input[id="id-fieldName"]')
-        .simulate('change', {target: {value: 'bar'}})
-        .simulate('keyDown', {keyCode: 13});
-      wrapper.update();
+    // Is active hidden input value
+    expect(wrapper.find('SelectControl input[type="hidden"]').props().value).toEqual(
+      'bar'
+    );
+  });
 
-      // Is selected
-      expect(wrapper.find('.Select-value-label').text()).toBe('bar');
+  it('can add user input into select field when using paired choices', function () {
+    const wrapper = mountWithTheme(
+      <SelectCreatableField choices={[['foo', 'foo']]} name="fieldName" />
+    );
 
-      // Is in select menu
-      expect(wrapper.find('Select').prop('options')).toEqual([
-        expect.objectContaining({
-          value: 'bar',
-          label: 'bar',
-        }),
-        {
-          value: 'foo',
-          label: 'foo',
-        },
-      ]);
-    });
+    const input = wrapper.find('SelectControl input[type="text"]');
+    changeInputValue(input, 'bar');
+    wrapper.update();
 
-    it('with Form context', function () {
-      const submitMock = jest.fn();
-      const wrapper = mountWithTheme(
-        <Form onSubmit={submitMock}>
-          <SelectCreatableField
-            deprecatedSelectControl
-            choices={[['foo', 'foo']]}
-            name="fieldName"
-          />
-        </Form>,
-        {}
-      );
+    // Text is in input
+    expect(wrapper.find('SelectControl input[type="text"]').props().value).toBe('bar');
 
-      wrapper
-        .find('input[id="id-fieldName"]')
-        .simulate('change', {target: {value: 'bar'}})
-        .simulate('keyDown', {keyCode: 13});
-      wrapper.update();
+    // Click on create option
+    openMenu(wrapper, {control: true});
+    wrapper.find('SelectControl Option div').simulate('click');
 
-      // Is selected
-      expect(wrapper.find('.Select-value-label').text()).toBe('bar');
+    // Is active hidden input value
+    expect(wrapper.find('SelectControl input[type="hidden"]').props().value).toEqual(
+      'bar'
+    );
+  });
 
-      // Is in select menu
-      expect(wrapper.find('Select').prop('options')).toEqual([
-        expect.objectContaining({
-          value: 'bar',
-          label: 'bar',
-        }),
-        {
-          value: 'foo',
-          label: 'foo',
-        },
-      ]);
+  it('with Form context', function () {
+    const submitMock = jest.fn();
+    const wrapper = mountWithTheme(
+      <Form onSubmit={submitMock}>
+        <SelectCreatableField choices={[['foo', 'foo']]} name="fieldName" />
+      </Form>,
+      {}
+    );
 
-      // SelectControl should have the value object, not just a simple value
-      expect(wrapper.find('SelectControl').prop('value')).toEqual(
-        expect.objectContaining({
-          value: 'bar',
-          label: 'bar',
-        })
-      );
+    const input = wrapper.find('SelectControl input[type="text"]');
+    changeInputValue(input, 'bar');
+    wrapper.update();
 
-      wrapper.find('Form').simulate('submit');
-      expect(submitMock).toHaveBeenCalledWith(
-        {
-          fieldName: 'bar',
-        },
-        expect.anything(),
-        expect.anything()
-      );
-    });
+    // Text is in input
+    expect(wrapper.find('SelectControl input[type="text"]').props().value).toBe('bar');
+
+    // Click on create option
+    openMenu(wrapper, {control: true});
+    wrapper.find('SelectControl Option div').simulate('click');
+
+    wrapper.find('Form').simulate('submit');
+    expect(submitMock).toHaveBeenCalledWith(
+      {
+        fieldName: 'bar',
+      },
+      expect.anything(),
+      expect.anything()
+    );
   });
 });

--- a/tests/js/spec/components/forms/selectField.spec.jsx
+++ b/tests/js/spec/components/forms/selectField.spec.jsx
@@ -1,79 +1,122 @@
 import React from 'react';
 
 import {mountWithTheme} from 'sentry-test/enzyme';
-import {selectByValue} from 'sentry-test/select';
+import {selectByValue} from 'sentry-test/select-new';
 
 import {Form, SelectField} from 'app/components/forms';
 
 describe('SelectField', function () {
-  describe('deprecatedSelectControl', function () {
-    it('renders without form context', function () {
-      const wrapper = mountWithTheme(
+  it('renders without form context', function () {
+    const wrapper = mountWithTheme(
+      <SelectField
+        options={[
+          {label: 'a', value: 'a'},
+          {label: 'b', value: 'b'},
+        ]}
+        name="fieldName"
+        value="a"
+      />
+    );
+    expect(wrapper).toSnapshot();
+  });
+
+  it('renders with flat choices', function () {
+    const wrapper = mountWithTheme(
+      <SelectField choices={['a', 'b', 'c']} name="fieldName" />,
+      {
+        context: {
+          form: {
+            data: {
+              fieldName: 'fieldValue',
+            },
+            errors: {},
+          },
+        },
+      }
+    );
+    expect(wrapper).toSnapshot();
+  });
+
+  it('renders with paired choices', function () {
+    const wrapper = mountWithTheme(
+      <SelectField
+        choices={[
+          ['a', 'abc'],
+          ['b', 'bcd'],
+          ['c', 'cde'],
+        ]}
+        name="fieldName"
+      />,
+      {
+        context: {
+          form: {
+            data: {
+              fieldName: 'fieldValue',
+            },
+            errors: {},
+          },
+        },
+      }
+    );
+    expect(wrapper).toSnapshot();
+  });
+
+  it('can change value and submit', function () {
+    const mock = jest.fn();
+    const wrapper = mountWithTheme(
+      <Form onSubmit={mock}>
         <SelectField
-          deprecatedSelectControl
           options={[
             {label: 'a', value: 'a'},
             {label: 'b', value: 'b'},
           ]}
           name="fieldName"
-          value="a"
         />
-      );
-      expect(wrapper).toSnapshot();
-    });
+      </Form>
+    );
+    selectByValue(wrapper, 'a', {name: 'fieldName'});
+    wrapper.find('Form').simulate('submit');
+    expect(mock).toHaveBeenCalledWith(
+      {fieldName: 'a'},
+      expect.anything(),
+      expect.anything()
+    );
+  });
 
-    it('renders with flat choices', function () {
-      const wrapper = mountWithTheme(
-        <SelectField
-          deprecatedSelectControl
-          choices={['a', 'b', 'c']}
-          name="fieldName"
-        />,
-        {
-          context: {
-            form: {
-              data: {
-                fieldName: 'fieldValue',
-              },
-              errors: {},
-            },
-          },
-        }
-      );
-      expect(wrapper).toSnapshot();
-    });
+  it('can set the value to empty string via props with no options', function () {
+    const mock = jest.fn();
+    const wrapper = mountWithTheme(
+      <SelectField
+        options={[
+          {label: 'a', value: 'a'},
+          {label: 'b', value: 'b'},
+        ]}
+        name="fieldName"
+        onChange={mock}
+      />
+    );
+    // Select a value so there is an option selected.
+    selectByValue(wrapper, 'a', {name: 'fieldName'});
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenLastCalledWith('a');
 
-    it('renders with paired choices', function () {
-      const wrapper = mountWithTheme(
-        <SelectField
-          deprecatedSelectControl
-          choices={[
-            ['a', 'abc'],
-            ['b', 'bcd'],
-            ['c', 'cde'],
-          ]}
-          name="fieldName"
-        />,
-        {
-          context: {
-            form: {
-              data: {
-                fieldName: 'fieldValue',
-              },
-              errors: {},
-            },
-          },
-        }
-      );
-      expect(wrapper).toSnapshot();
-    });
+    // Update props to remove value and options.
+    wrapper.setProps({value: '', options: []});
+    wrapper.update();
+    expect(wrapper.find('SelectPicker').props().value).toEqual('');
 
-    it('can change value and submit', function () {
+    // second update.
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(mock).toHaveBeenLastCalledWith('');
+  });
+
+  describe('Multiple', function () {
+    it('selects multiple values and submits', function () {
       const mock = jest.fn();
       const wrapper = mountWithTheme(
         <Form onSubmit={mock}>
           <SelectField
-            deprecatedSelectControl
+            multiple
             options={[
               {label: 'a', value: 'a'},
               {label: 'b', value: 'b'},
@@ -85,64 +128,10 @@ describe('SelectField', function () {
       selectByValue(wrapper, 'a', {name: 'fieldName'});
       wrapper.find('Form').simulate('submit');
       expect(mock).toHaveBeenCalledWith(
-        {fieldName: 'a'},
+        {fieldName: ['a']},
         expect.anything(),
         expect.anything()
       );
-    });
-
-    it('can set the value to empty string via props with no options', function () {
-      const mock = jest.fn();
-      const wrapper = mountWithTheme(
-        <SelectField
-          deprecatedSelectControl
-          options={[
-            {label: 'a', value: 'a'},
-            {label: 'b', value: 'b'},
-          ]}
-          name="fieldName"
-          onChange={mock}
-        />
-      );
-      // Select a value so there is an option selected.
-      selectByValue(wrapper, 'a', {name: 'fieldName'});
-      expect(mock).toHaveBeenCalledTimes(1);
-      expect(mock).toHaveBeenLastCalledWith('a');
-
-      // Update props to remove value and options.
-      wrapper.setProps({value: '', options: []});
-      wrapper.update();
-      expect(wrapper.find('SelectPicker').props().value).toEqual('');
-
-      // second update.
-      expect(mock).toHaveBeenCalledTimes(2);
-      expect(mock).toHaveBeenLastCalledWith('');
-    });
-
-    describe('Multiple', function () {
-      it('selects multiple values and submits', function () {
-        const mock = jest.fn();
-        const wrapper = mountWithTheme(
-          <Form onSubmit={mock}>
-            <SelectField
-              deprecatedSelectControl
-              multiple
-              options={[
-                {label: 'a', value: 'a'},
-                {label: 'b', value: 'b'},
-              ]}
-              name="fieldName"
-            />
-          </Form>
-        );
-        selectByValue(wrapper, 'a', {name: 'fieldName'});
-        wrapper.find('Form').simulate('submit');
-        expect(mock).toHaveBeenCalledWith(
-          {fieldName: ['a']},
-          expect.anything(),
-          expect.anything()
-        );
-      });
     });
   });
 });


### PR DESCRIPTION
Update the tests for deprecatedSelectControl to the non-deprecated version. This helps reduce the size of the diff for the control removal.