### PR TITLE
fix(billing) Fix quota lines missing on subscription view

### DIFF
--- a/static/app/views/usageStats/usageChart/index.tsx
+++ b/static/app/views/usageStats/usageChart/index.tsx
@@ -304,7 +304,7 @@ export class UsageChart extends React.Component<Props, State> {
     const {chartSeries} = this.props;
     const {chartData} = this.chartMetadata;
 
-    const series: EChartOption.Series[] = [
+    let series: EChartOption.Series[] = [
       barSeries({
         name: SeriesTypes.ACCEPTED,
         data: chartData.accepted as any, // TODO(ts)
@@ -329,7 +329,7 @@ export class UsageChart extends React.Component<Props, State> {
 
     // Additional series passed by parent component
     if (chartSeries) {
-      series.concat(chartSeries as EChartOption.Series[]);
+      series = series.concat(chartSeries as EChartOption.Series[]);
     }
 
     return series;


### PR DESCRIPTION
We need to retain the results of concat() to preserve the quota lines defined in getsentry.