### PR TITLE
feat(alerts): Chart zoom on alert details page

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -291,13 +291,13 @@ export default class DetailsBody extends React.Component<Props> {
         {({initiallyLoaded, projects}) => {
           return initiallyLoaded ? (
             <React.Fragment>
-              {selectedIncident &&
-                selectedIncident.alertRule.status === AlertRuleStatus.SNAPSHOT && (
+                {selectedIncident &&
+                  selectedIncident.alertRule.status === AlertRuleStatus.SNAPSHOT && (
                   <StyledLayoutBody>
                     <StyledAlert type="warning" icon={<IconInfo size="md" />}>
-                      {t(
-                        'Alert Rule settings have been updated since this alert was triggered.'
-                      )}
+                        {t(
+                          'Alert Rule settings have been updated since this alert was triggered.'
+                        )}
                     </StyledAlert>
                   </StyledLayoutBody>
                 )}

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -291,13 +291,13 @@ export default class DetailsBody extends React.Component<Props> {
         {({initiallyLoaded, projects}) => {
           return initiallyLoaded ? (
             <React.Fragment>
-                {selectedIncident &&
-                  selectedIncident.alertRule.status === AlertRuleStatus.SNAPSHOT && (
+              {selectedIncident &&
+                selectedIncident.alertRule.status === AlertRuleStatus.SNAPSHOT && (
                   <StyledLayoutBody>
                     <StyledAlert type="warning" icon={<IconInfo size="md" />}>
-                        {t(
-                          'Alert Rule settings have been updated since this alert was triggered.'
-                        )}
+                      {t(
+                        'Alert Rule settings have been updated since this alert was triggered.'
+                      )}
                     </StyledAlert>
                   </StyledLayoutBody>
                 )}

--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -23,7 +23,7 @@ import {IconCheckmark, IconFire, IconInfo, IconWarning} from 'app/icons';
 import {t, tct} from 'app/locale';
 import overflowEllipsis from 'app/styles/overflowEllipsis';
 import space from 'app/styles/space';
-import {Actor, Organization, Project} from 'app/types';
+import {Actor, DateString, Organization, Project} from 'app/types';
 import Projects from 'app/utils/projects';
 import Timeline from 'app/views/alerts/rules/details/timeline';
 import {
@@ -51,6 +51,7 @@ type Props = {
   organization: Organization;
   location: Location;
   handleTimePeriodChange: (value: string) => void;
+  handleZoom: (start: DateString, end: DateString) => void;
 } & RouteComponentProps<{orgId: string}, {}>;
 
 export default class DetailsBody extends React.Component<Props> {
@@ -275,6 +276,7 @@ export default class DetailsBody extends React.Component<Props> {
       organization,
       timePeriod,
       selectedIncident,
+      handleZoom,
       params: {orgId},
     } = this.props;
 
@@ -358,6 +360,7 @@ export default class DetailsBody extends React.Component<Props> {
                     filter={this.getFilter()}
                     query={queryWithTypeFilter}
                     orgId={orgId}
+                    handleZoom={handleZoom}
                   />
                   <DetailWrapper>
                     <ActivityWrapper>

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -155,10 +155,9 @@ class AlertRuleDetails extends React.Component<Props, State> {
     }
   };
 
-  handleTimePeriodChange = async (value: string) => {
-    const {location} = this.props;
-    await browserHistory.push({
-      pathname: location.pathname,
+  handleTimePeriodChange = (value: string) => {
+    browserHistory.push({
+      pathname: this.props.location.pathname,
       query: {
         period: value,
       },

--- a/static/app/views/alerts/rules/details/index.tsx
+++ b/static/app/views/alerts/rules/details/index.tsx
@@ -8,7 +8,7 @@ import {Client} from 'app/api';
 import Feature from 'app/components/acl/feature';
 import DateTime from 'app/components/dateTime';
 import {t} from 'app/locale';
-import {Organization} from 'app/types';
+import {DateString, Organization} from 'app/types';
 import {getUtcDateString} from 'app/utils/dates';
 import withApi from 'app/utils/withApi';
 import {makeRuleDetailsQuery} from 'app/views/alerts/list/row';
@@ -165,6 +165,17 @@ class AlertRuleDetails extends React.Component<Props, State> {
     });
   };
 
+  handleZoom = async (start: DateString, end: DateString) => {
+    const {location} = this.props;
+    await browserHistory.push({
+      pathname: location.pathname,
+      query: {
+        start,
+        end,
+      },
+    });
+  };
+
   render() {
     const {rule, incidents, hasError, selectedIncident} = this.state;
     const {params, organization} = this.props;
@@ -185,6 +196,7 @@ class AlertRuleDetails extends React.Component<Props, State> {
             timePeriod={timePeriod}
             selectedIncident={selectedIncident}
             handleTimePeriodChange={this.handleTimePeriodChange}
+            handleZoom={this.handleZoom}
           />
         </Feature>
       </React.Fragment>

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -313,7 +313,12 @@ class MetricChart extends React.PureComponent<Props, State> {
     maxThresholdValue: number,
     maxSeriesValue: number
   ) {
-    const {router, interval, handleZoom, timePeriod: {start, end}} = this.props;
+    const {
+      router,
+      interval,
+      handleZoom,
+      timePeriod: {start, end},
+    } = this.props;
     const {dateModified, timeWindow} = this.props.rule || {};
 
     return (
@@ -335,7 +340,9 @@ class MetricChart extends React.PureComponent<Props, State> {
               top: space(2),
               bottom: 0,
             }}
-            yAxis={maxThresholdValue > maxSeriesValue ? {max: maxThresholdValue} : undefined}
+            yAxis={
+              maxThresholdValue > maxSeriesValue ? {max: maxThresholdValue} : undefined
+            }
             series={[...series, ...areaSeries]}
             graphic={Graphic({
               elements: this.getRuleChangeThresholdElements(data),
@@ -348,7 +355,8 @@ class MetricChart extends React.PureComponent<Props, State> {
                   : [seriesParams];
                 const {marker, data: pointData, seriesName} = pointSeries[0];
                 const [pointX, pointY] = pointData as [number, number];
-                const isModified = dateModified && pointX <= new Date(dateModified).getTime();
+                const isModified =
+                  dateModified && pointX <= new Date(dateModified).getTime();
 
                 const startTime = formatTooltipDate(moment(pointX), 'MMM D LT');
                 const {period, periodLength} = parseStatsPeriod(interval) ?? {
@@ -356,7 +364,10 @@ class MetricChart extends React.PureComponent<Props, State> {
                   period: `${timeWindow}`,
                 };
                 const endTime = formatTooltipDate(
-                  moment(pointX).add(parseInt(period, 10), periodLength as StatsPeriodType),
+                  moment(pointX).add(
+                    parseInt(period, 10),
+                    periodLength as StatsPeriodType
+                  ),
                   'MMM D LT'
                 );
                 const title = isModified


### PR DESCRIPTION
This adds a zoom element to the metric chart in the alert details. When user zooms, we change the url and the display.

[WOR-803](https://getsentry.atlassian.net/browse/WOR-803)

Before Zoom:
![Screen Shot 2021-04-30 at 11 40 48 AM](https://user-images.githubusercontent.com/15015880/116739786-f8e09600-a9a8-11eb-90e5-53bd5ecadc99.png)

After Zoom:
![Screen Shot 2021-04-30 at 11 40 58 AM](https://user-images.githubusercontent.com/15015880/116739822-01d16780-a9a9-11eb-9fec-883e8d72bd1d.png)
