### PR TITLE
test(pytest): Give suggestion when chromedriver does not match Chrome version

### DIFF
--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -11,7 +11,11 @@ from urllib.parse import urlparse
 import pytest
 from django.utils.text import slugify
 from selenium import webdriver
-from selenium.common.exceptions import NoSuchElementException, WebDriverException
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    SessionNotCreatedException,
+    WebDriverException,
+)
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.support import expected_conditions
 from selenium.webdriver.support.ui import WebDriverWait
@@ -453,7 +457,16 @@ def pytest_configure(config):
 
 @TimedRetryPolicy.wrap(timeout=15, exceptions=(WebDriverException,), log_original_error=True)
 def start_chrome(**chrome_args):
-    return webdriver.Chrome(**chrome_args)
+    try:
+        return webdriver.Chrome(**chrome_args)
+    except SessionNotCreatedException as e:
+        if "This version of ChromeDriver only supports Chrome version" in e.msg:
+            raise Exception(
+                """ChromeDriver version does not match Chrome version, update ChromeDriver (e.g. if you use `homebrew`):
+
+    brew cask upgrade chromedriver
+    """
+            )
 
 
 @pytest.fixture(scope="function")

--- a/src/sentry/utils/pytest/selenium.py
+++ b/src/sentry/utils/pytest/selenium.py
@@ -464,7 +464,7 @@ def start_chrome(**chrome_args):
             raise Exception(
                 """ChromeDriver version does not match Chrome version, update ChromeDriver (e.g. if you use `homebrew`):
 
-    brew cask upgrade chromedriver
+    brew upgrade --cask chromedriver
     """
             )
 


### PR DESCRIPTION
ChromeDriver version needs to be in sync with the users local Chrome browser version when running acceptance tests. Give the user an example command to run to upgrade their ChromeDriver. This is not exactly cross-platform friendly, but it is a step in the right direction.