### PR TITLE
refs(search): Remove `me_or_none` syntax from issue search.

### DIFF
--- a/src/sentry/search/snuba/backend.py
+++ b/src/sentry/search/snuba/backend.py
@@ -35,9 +35,6 @@ def assigned_to_filter(actors, projects, field_filter="id"):
     include_none = False
     types_to_actors = defaultdict(list)
     for actor in actors:
-        if isinstance(actor, list) and actor[0] == "me_or_none":
-            include_none = True
-            actor = actor[1]
         if actor is None:
             include_none = True
         types_to_actors[type(actor) if not isinstance(actor, SimpleLazyObject) else User].append(
@@ -177,9 +174,6 @@ def assigned_or_suggested_filter(owners, projects, field_filter="id"):
     types_to_owners = defaultdict(list)
     include_none = False
     for owner in owners:
-        if isinstance(owner, list) and owner[0] == "me_or_none":
-            include_none = True
-            owner = owner[1]
         if owner is None:
             include_none = True
         types_to_owners[type(owner) if not isinstance(owner, SimpleLazyObject) else User].append(

--- a/src/sentry/search/utils.py
+++ b/src/sentry/search/utils.py
@@ -229,8 +229,6 @@ def parse_actor_value(projects, value, user):
 
 
 def parse_actor_or_none_value(projects, value, user):
-    if value == "me_or_none":
-        return ["me_or_none", user]
     if value == "none":
         return None
     return parse_actor_value(projects, value, user)

--- a/tests/sentry/api/test_issue_search.py
+++ b/tests/sentry/api/test_issue_search.py
@@ -198,14 +198,6 @@ class ConvertActorOrNoneValueTest(TestCase):
             ["me"], [self.project], self.user, None
         ) == convert_user_value(["me"], [self.project], self.user, None)
 
-    def test_me_or_none(self):
-        assert convert_actor_or_none_value(["me_or_none"], [self.project], self.user, None) == [
-            [
-                "me_or_none",
-                self.user,
-            ]
-        ]
-
     def test_none(self):
         assert convert_actor_or_none_value(["none"], [self.project], self.user, None) == [None]
 

--- a/tests/sentry/search/test_utils.py
+++ b/tests/sentry/search/test_utils.py
@@ -293,10 +293,6 @@ class ParseQueryTest(TestCase):
         result = self.parse_query("assigned:me")
         assert result == {"assigned_to": self.user, "tags": {}, "query": ""}
 
-    def test_assigned_me_or_none(self):
-        result = self.parse_query("assigned:me_or_none")
-        assert result == {"assigned_to": ["me_or_none", self.user], "tags": {}, "query": ""}
-
     def test_assigned_none(self):
         result = self.parse_query("assigned:none")
         assert result == {"assigned_to": None, "tags": {}, "query": ""}
@@ -531,14 +527,6 @@ class ParseQueryTest(TestCase):
     def test_assigned_or_suggested_me(self):
         result = self.parse_query("assigned_or_suggested:me")
         assert result == {"assigned_or_suggested": self.user, "tags": {}, "query": ""}
-
-    def test_assigned_or_suggested_me_or_none(self):
-        result = self.parse_query("assigned_or_suggested:me_or_none")
-        assert result == {
-            "assigned_or_suggested": ["me_or_none", self.user],
-            "tags": {},
-            "query": "",
-        }
 
     def test_assigned_or_suggested_none(self):
         result = self.parse_query("assigned_or_suggested:none")

--- a/tests/snuba/api/endpoints/test_organization_group_index.py
+++ b/tests/snuba/api/endpoints/test_organization_group_index.py
@@ -743,7 +743,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
 
         assert options.set("snuba.search.hits-sample-size", old_sample_size)
 
-    def test_assigned_me_or_none(self):
+    def test_assigned_me_none(self):
         self.login_as(user=self.user)
         groups = []
         for i in range(5):
@@ -767,7 +767,7 @@ class GroupListTest(APITestCase, SnubaTestCase):
         assert len(response.data) == 5
 
         GroupAssignee.objects.assign(assigned_groups[1], self.create_user("other@user.com"))
-        response = self.get_response(limit=10, query="assigned:[me_or_none]")
+        response = self.get_response(limit=10, query="assigned:[me, none]")
         assert len(response.data) == 4
 
     def test_seen_stats(self):


### PR DESCRIPTION
We can now use `[me, none]` instead, and existing searches have been  backfilled to update any
referenes to `me_or_none`, so this is safe to remove.