### PR TITLE
[Twilio plugin] Adding support for alpha-numeric sender ID

### DIFF
--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -83,10 +83,12 @@ class TwilioConfigurationForm(forms.Form):
 
     def clean_sms_from(self):
         data = self.cleaned_data["sms_from"]
-        if is_sender_alphanumeric_code(data) and not validate_alphanumeric_sender(data):
-            raise forms.ValidationError(f"{data} is not a valid sender ID.")
-        if not validate_phone(data):
-            raise forms.ValidationError(f"{data} is not a valid phone number.")
+        if is_sender_alphanumeric_code(data):
+            if not validate_alphanumeric_sender(data):
+                raise forms.ValidationError(f"{data} is not a valid sender ID.")
+        else:
+            if not validate_phone(data):
+                raise forms.ValidationError(f"{data} is not a valid phone number.")
         return clean_phone(data)
 
     def clean_sms_to(self):

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -34,6 +34,14 @@ def validate_phone(phone):
         return False
     return True
 
+def validate_alphanumeric_sender(code):
+    max_code_length = 11
+    if not code:
+        return False
+    if len(code) > max_code_length:
+        return False
+
+    return True
 
 def clean_phone(phone):
     # This could raise, but should have been checked with validate_phone first
@@ -48,6 +56,8 @@ def clean_phone(phone):
 def split_sms_to(data):
     return set(filter(bool, re.split(r"\s*,\s*|\s+", data)))
 
+def is_sender_alphanumeric_code(data):
+    return data.upper().isupper()
 
 class TwilioConfigurationForm(forms.Form):
     account_sid = forms.CharField(
@@ -73,6 +83,9 @@ class TwilioConfigurationForm(forms.Form):
 
     def clean_sms_from(self):
         data = self.cleaned_data["sms_from"]
+        if is_sender_alphanumeric_code(data):
+            if not validate_alphanumeric_sender(data):
+                raise forms.ValidationError(f"{data} is not a valid sender ID.")
         if not validate_phone(data):
             raise forms.ValidationError(f"{data} is not a valid phone number.")
         return clean_phone(data)

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -14,6 +14,7 @@ from .client import TwilioApiClient
 
 DEFAULT_REGION = "US"
 MAX_SMS_LENGTH = 160
+MAX_SENDER_CODE_length = 11
 
 DESCRIPTION = """
 Get notified of Sentry alerts via SMS.
@@ -35,10 +36,9 @@ def validate_phone(phone):
     return True
 
 def validate_alphanumeric_sender(code):
-    max_code_length = 11
     if not code:
         return False
-    if len(code) > max_code_length:
+    if len(code) > MAX_SENDER_CODE_length:
         return False
 
     return True
@@ -83,9 +83,8 @@ class TwilioConfigurationForm(forms.Form):
 
     def clean_sms_from(self):
         data = self.cleaned_data["sms_from"]
-        if is_sender_alphanumeric_code(data):
-            if not validate_alphanumeric_sender(data):
-                raise forms.ValidationError(f"{data} is not a valid sender ID.")
+        if is_sender_alphanumeric_code(data) and not validate_alphanumeric_sender(data):
+            raise forms.ValidationError(f"{data} is not a valid sender ID.")
         if not validate_phone(data):
             raise forms.ValidationError(f"{data} is not a valid phone number.")
         return clean_phone(data)

--- a/src/sentry_plugins/twilio/plugin.py
+++ b/src/sentry_plugins/twilio/plugin.py
@@ -49,6 +49,9 @@ def clean_phone(phone):
         phonenumbers.parse(phone, DEFAULT_REGION), phonenumbers.PhoneNumberFormat.E164
     )
 
+def clean_alphanumeric_code(data):
+    return data.strip()
+
 
 # XXX: can likely remove the dedupe here after notify_users has test coverage;
 #      in theory only cleaned data would make it to the plugin via the form,
@@ -83,12 +86,16 @@ class TwilioConfigurationForm(forms.Form):
 
     def clean_sms_from(self):
         data = self.cleaned_data["sms_from"]
+
         if is_sender_alphanumeric_code(data):
             if not validate_alphanumeric_sender(data):
                 raise forms.ValidationError(f"{data} is not a valid sender ID.")
-        else:
-            if not validate_phone(data):
-                raise forms.ValidationError(f"{data} is not a valid phone number.")
+
+            return clean_alphanumeric_code(data)
+
+        if not validate_phone(data):
+            raise forms.ValidationError(f"{data} is not a valid phone number.")
+
         return clean_phone(data)
 
     def clean_sms_to(self):


### PR DESCRIPTION
Overview:
Currently the Twilio plugin only allows valid phone numbers as sender ID's and the plugin explicitly validates for phone numbers in the form clean method.

Changes:
This PR adds a check to see if an alpha numeric code is entered and validates the code instead.

Validation:
From the Twilio docs, alpha numeric id's can have max 11 characters.
[Doc Link](https://support.twilio.com/hc/en-us/articles/223133967-Change-the-From-number-or-Sender-ID-for-Sending-SMS-Messages)

This addresses: Issue #25535