### PR TITLE
fix: Only query select the hash anchor link within the data section's subtree

### DIFF
--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -31,11 +31,12 @@ class EventDataSection extends React.Component<Props> {
   static defaultProps = defaultProps;
 
   componentDidMount() {
-    if (location.hash) {
+    const dataSectionDOM = this.dataSectionDOMRef.current;
+    if (location.hash && dataSectionDOM) {
       const [, hash] = location.hash.split('#');
 
       try {
-        const anchorElement = hash && document.querySelector('div#' + hash);
+        const anchorElement = hash && dataSectionDOM.querySelector('div#' + hash);
         if (anchorElement) {
           anchorElement.scrollIntoView();
         }
@@ -49,6 +50,8 @@ class EventDataSection extends React.Component<Props> {
       }
     }
   }
+
+  dataSectionDOMRef = React.createRef<HTMLDivElement>();
 
   render() {
     const {
@@ -67,7 +70,7 @@ class EventDataSection extends React.Component<Props> {
     const titleNode = wrapTitle ? <h3>{title}</h3> : title;
 
     return (
-      <DataSection className={className || ''}>
+      <DataSection ref={this.dataSectionDOMRef} className={className || ''}>
         {title && (
           <SectionHeader id={type} isCentered={isCentered}>
             <Title>


### PR DESCRIPTION
This borrows the same approach in https://github.com/getsentry/sentry/pull/25760

When viewing an event details page with a location hash (https://developer.mozilla.org/en-US/docs/Web/API/Location/hash) present in the URL, then the `<EventDataSection />` component will attempt find an element with a matched hash name and scroll to that element.

If a match occurs, then `anchorElement.scrollIntoView()` is called for each `<EventDataSection />` component that's present on the page. This PR adjusts the scope of the anchor search to only within the `<EventDataSection />`'s component subtree rather than the entire `document` tree. 