### PR TITLE
ref(email): Log organization ID

### DIFF
--- a/src/sentry/notifications/activity/base.py
+++ b/src/sentry/notifications/activity/base.py
@@ -57,6 +57,7 @@ class ActivityNotification(BaseNotification):
         activity_link = urlunparse(parts)
 
         return {
+            "organization": self.group.project.organization,
             "group": self.group,
             "link": group_link,
             "activity_link": activity_link,


### PR DESCRIPTION
This is an action item from a post mortem - it'd be easier to trace down workflow notification logs if we had the organization ID - currently we only log the project ID. `send_async` pulls out context with an `id` attribute and adds it to the log (code [here](https://github.com/getsentry/sentry/blob/master/src/sentry/utils/email.py#L383-L404)).