### PR TITLE
ci: Bump tini & gosu and move to static hash verification

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,38 +11,25 @@ LABEL org.opencontainers.image.authors="oss@sentry.io"
 # add our user and group first to make sure their IDs get assigned consistently
 RUN groupadd -r sentry && useradd -r -m -g sentry sentry
 
-ENV GOSU_VERSION=1.11 \
-  TINI_VERSION=0.18.0
+ENV GOSU_VERSION=1.12 \
+  GOSU_SHA256=0f25a21cf64e58078057adc78f38705163c1d564a959ff30a891c31917011a54 \
+  TINI_VERSION=0.19.0 \
+  TINI_SHA256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
+
 
 RUN set -x \
   && buildDeps=" \
-  dirmngr \
-  gnupg \
   wget \
   " \
   && apt-get update && apt-get install -y --no-install-recommends $buildDeps \
   && rm -rf /var/lib/apt/lists/* \
-  # Fetch trusted keys
-  && for key in \
-  # gosu
-  B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-  # tini
-  595E85A6B1B4779EA4DAAEC70B588DFF0527A9B7 \
-  ; do \
-  # TODO(byk): Replace the keyserver below w/ something owned by Sentry
-  gpg --batch --keyserver hkps://mattrobenolt-keyserver.global.ssl.fastly.net:443 --recv-keys "$key"; \
-  done \
   # grab gosu for easy step-down from root
-  && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
-  && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
-  && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-  && rm -r /usr/local/bin/gosu.asc \
+  && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-amd64" \
+  && echo "$GOSU_SHA256 /usr/local/bin/gosu" | sha256sum --check --status \
   && chmod +x /usr/local/bin/gosu \
   # grab tini for signal processing and zombie killing
-  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini" \
-  && wget -O /usr/local/bin/tini.asc "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini.asc" \
-  && gpg --batch --verify /usr/local/bin/tini.asc /usr/local/bin/tini \
-  && rm /usr/local/bin/tini.asc \
+  && wget -O /usr/local/bin/tini "https://github.com/krallin/tini/releases/download/v$TINI_VERSION/tini-amd64" \
+  && echo "$TINI_SHA256 /usr/local/bin/tini" | sha256sum --check --status \
   && chmod +x /usr/local/bin/tini \
   && apt-get purge -y --auto-remove $buildDeps
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN groupadd -r sentry && useradd -r -m -g sentry sentry
 ENV GOSU_VERSION=1.12 \
   GOSU_SHA256=0f25a21cf64e58078057adc78f38705163c1d564a959ff30a891c31917011a54 \
   TINI_VERSION=0.19.0 \
-  TINI_SHA256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82b
+  TINI_SHA256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
 
 
 RUN set -x \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN groupadd -r sentry && useradd -r -m -g sentry sentry
 ENV GOSU_VERSION=1.12 \
   GOSU_SHA256=0f25a21cf64e58078057adc78f38705163c1d564a959ff30a891c31917011a54 \
   TINI_VERSION=0.19.0 \
-  TINI_SHA256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82c
+  TINI_SHA256=93dcc18adc78c65a028a84799ecf8ad40c936fdfc5f2a57b1acda5a8117fa82b
 
 
 RUN set -x \


### PR DESCRIPTION
The keyserver concept seems to be on the decline and the existing keyservers are quite slow and unreliable. We used to use a personally-owned keyserver proxy to alleviate for these issues but turns out we can simply rely on GitHub and a static signature with equal (or maybe more) reassurance.