### PR TITLE
ref(feature-flag): Remove app-store-connect feature flag

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -993,8 +993,6 @@ SENTRY_FEATURES = {
     "organizations:team-alerts-ownership": False,
     # Enable the new alert creation wizard
     "organizations:alert-wizard": False,
-    # Enable App Store Connect in debug files settings
-    "projects:app-store-connect": False,
     # Adds additional filters and a new section to issue alert rules.
     "projects:alert-filters": True,
     # Enable functionality to specify custom inbound filters on events.


### PR DESCRIPTION
removing this feature flag as we will be using the one created by Radu called `organizations:app-store-connect`