### PR TITLE
feat(symbolication): Option comparing stackwalkers (sentry option)

### DIFF
--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -326,12 +326,11 @@ def parse_sources(config):
 
 
 def get_options_for_project(project):
-    rate = options.get("symbolicator.compare_stackwalking_methods_rate")
-    compare_stackwalking = True if random.random() < rate else False
+    compare_rate = options.get("symbolicator.compare_stackwalking_methods_rate")
     return {
         # Symbolicators who do not support options will ignore this field entirely.
         "dif_candidates": features.has("organizations:images-loaded-v2", project.organization),
-        "compare_stackwalking_methods": compare_stackwalking,
+        "compare_stackwalking_methods": random.random() < compare_rate,
     }
 
 

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -1,5 +1,6 @@
 import base64
 import logging
+import random
 import sys
 import time
 from urllib.parse import urljoin
@@ -325,10 +326,12 @@ def parse_sources(config):
 
 
 def get_options_for_project(project):
+    rate = options.get("symbolicator.compare_stackwalking_methods_rate")
+    compare_stackwalking = True if random.random() < rate else False
     return {
         # Symbolicators who do not support options will ignore this field entirely.
         "dif_candidates": features.has("organizations:images-loaded-v2", project.organization),
-        "compare_stackwalking_methods": features.has("symbolicator:compare-stackwalking-methods"),
+        "compare_stackwalking_methods": compare_stackwalking,
     }
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -109,6 +109,7 @@ register(
     default={"url": "http://localhost:3021"},
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK,
 )
+register("symbolicator.compare_stackwalking_methods_rate", default=0.0)
 
 # The ratio of requests for which the new stackwalking method should be compared against the old one
 register("symbolicator.compare_stackwalking_methods_rate", default=0.0)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -109,7 +109,6 @@ register(
     default={"url": "http://localhost:3021"},
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK,
 )
-register("symbolicator.compare_stackwalking_methods_rate", default=0.0)
 
 # The ratio of requests for which the new stackwalking method should be compared against the old one
 register("symbolicator.compare_stackwalking_methods_rate", default=0.0)


### PR DESCRIPTION
Symbolicator has a new per-request option to test a new stackwalker,
this sentry option allows us to turn this on for a small ratio of
the requests so we can assess the performance and quality impacts
without impacting normal production.

----

See also the version using flagr: https://github.com/getsentry/sentry/pull/25812