### PR TITLE
feat(symbolicator): Option comparing stackwalkers (flagr)

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1018,6 +1018,8 @@ SENTRY_FEATURES = {
     "projects:servicehooks": False,
     # Use Kafka (instead of Celery) for ingestion pipeline.
     "projects:kafka-ingest": False,
+    # Enable stackwalking comparison
+    "symbolicator:compare-stackwalking-methods": False,
     # Don't add feature defaults down here! Please add them in their associated
     # group sorted alphabetically.
 }

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -150,6 +150,9 @@ default_manager.add("projects:similarity-view-v2", ProjectFeature)  # NOQA
 # Project plugin features
 default_manager.add("projects:plugins", ProjectPluginFeature)  # NOQA
 
+# Globally scoped features
+default_manager.add("symbolicator:compare-stackwalking-methods", Feature)  # NOQA
+
 # This is a gross hardcoded list, but there's no
 # other sensible way to manage this right now without augmenting
 # features themselves in the manager with detections like this.

--- a/src/sentry/features/__init__.py
+++ b/src/sentry/features/__init__.py
@@ -151,7 +151,7 @@ default_manager.add("projects:similarity-view-v2", ProjectFeature)  # NOQA
 default_manager.add("projects:plugins", ProjectPluginFeature)  # NOQA
 
 # Globally scoped features
-default_manager.add("symbolicator:compare-stackwalking-methods", Feature)  # NOQA
+default_manager.add("symbolicator:compare-stackwalking-methods", Feature, True)  # NOQA
 
 # This is a gross hardcoded list, but there's no
 # other sensible way to manage this right now without augmenting

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -292,7 +292,8 @@ def parse_sources(config):
 def get_options_for_project(project):
     return {
         # Symbolicators who do not support options will ignore this field entirely.
-        "dif_candidates": features.has("organizations:images-loaded-v2", project.organization)
+        "dif_candidates": features.has("organizations:images-loaded-v2", project.organization),
+        "compare_stackwalking_methods": features.has("symbolicator:compare-stackwalking-methods"),
     }
 
 


### PR DESCRIPTION
Symbolicator has a new per-request option to test a new stackwalker,
this sentry option allows us to turn this on for a small ratio of
the requests so we can assess the performance and quality impacts
without impacting normal production.

This version relies on Flagr only enabling this for a percentage
of the requests, see the flag on flagr:
https://flagr.getsentry.net/#/flags/67

----

See also the alternative without flagr: https://github.com/getsentry/sentry/pull/25807

This also needs a PR in getsentry and needs the feature to land in symbolicator (PRs to be linked here when they exist)