### PR TITLE
fix(ui): Use alert wizard's user friendly names over preset names in alert rule details

### DIFF
--- a/static/app/views/alerts/rules/details/body.tsx
+++ b/static/app/views/alerts/rules/details/body.tsx
@@ -353,7 +353,6 @@ export default class DetailsBody extends React.Component<Props> {
                     selectedIncident={selectedIncident}
                     organization={organization}
                     projects={projects}
-                    metricText={this.getMetricText()}
                     interval={this.getInterval()}
                     filter={this.getFilter()}
                     query={queryWithTypeFilter}

--- a/static/app/views/alerts/rules/details/metricChart.tsx
+++ b/static/app/views/alerts/rules/details/metricChart.tsx
@@ -29,11 +29,12 @@ import {ReactEchartsRef} from 'app/types/echarts';
 import {getUtcDateString} from 'app/utils/dates';
 import theme from 'app/utils/theme';
 import {alertDetailsLink} from 'app/views/alerts/details';
+import {AlertWizardAlertNames} from 'app/views/alerts/wizard/options';
+import {getAlertTypeFromAggregateDataset} from 'app/views/alerts/wizard/utils';
 import {makeDefaultCta} from 'app/views/settings/incidentRules/incidentRulePresets';
 import {IncidentRule} from 'app/views/settings/incidentRules/types';
 
 import {Incident, IncidentActivityType, IncidentStatus} from '../../types';
-import {getIncidentRuleMetricPreset} from '../../utils';
 
 import {TimePeriodType} from './constants';
 
@@ -42,13 +43,12 @@ const VERTICAL_PADDING = 22;
 
 type Props = WithRouterProps & {
   api: Client;
-  rule?: IncidentRule;
+  rule: IncidentRule;
   incidents?: Incident[];
   timePeriod: TimePeriodType;
   selectedIncident?: Incident | null;
   organization: Organization;
   projects: Project[] | AvatarProject[];
-  metricText: React.ReactNode;
   interval: string;
   filter: React.ReactNode;
   query: string;
@@ -165,11 +165,6 @@ class MetricChart extends React.PureComponent<Props, State> {
   };
 
   ref: null | ReactEchartsRef = null;
-
-  get metricPreset() {
-    const {rule} = this.props;
-    return rule ? getIncidentRuleMetricPreset(rule) : undefined;
-  }
 
   /**
    * Syncs component state with the chart's width/heights
@@ -296,7 +291,7 @@ class MetricChart extends React.PureComponent<Props, State> {
           </SummaryStats>
         </ChartSummary>
         <Feature features={['discover-basic']}>
-          <Button size="small" disabled={!rule} {...props}>
+          <Button size="small" {...props}>
             {buttonText}
           </Button>
         </Feature>
@@ -393,14 +388,10 @@ class MetricChart extends React.PureComponent<Props, State> {
       selectedIncident,
       projects,
       interval,
-      metricText,
       filter,
       query,
       incidents,
     } = this.props;
-    if (!rule) {
-      return this.renderEmpty();
-    }
 
     const criticalTrigger = rule.triggers.find(({label}) => label === 'critical');
     const warningTrigger = rule.triggers.find(({label}) => label === 'warning');
@@ -609,10 +600,7 @@ class MetricChart extends React.PureComponent<Props, State> {
               <StyledPanelBody withPadding>
                 <ChartHeader>
                   <ChartTitle>
-                    <PresetName>
-                      {this.metricPreset?.name ?? t('Custom metric')}
-                    </PresetName>
-                    {metricText}
+                    {AlertWizardAlertNames[getAlertTypeFromAggregateDataset(rule)]}
                   </ChartTitle>
                   {filter}
                 </ChartHeader>
@@ -646,11 +634,6 @@ const ChartHeader = styled('div')`
 const ChartTitle = styled('header')`
   display: flex;
   flex-direction: row;
-`;
-
-const PresetName = styled('div')`
-  text-transform: capitalize;
-  margin-right: ${space(0.5)};
 `;
 
 const ChartActions = styled(PanelFooter)`


### PR DESCRIPTION
This changes the old metric preset names to the new alert rule preset names from the first step of the metric alert wizard

Before:
![Screen Shot 2021-05-03 at 8 25 50 AM](https://user-images.githubusercontent.com/15015880/116896603-44818280-abe9-11eb-9800-22bd91ff40f4.png)

After:
![Screen Shot 2021-05-03 at 8 22 56 AM](https://user-images.githubusercontent.com/15015880/116896635-4d725400-abe9-11eb-9317-da192a6ce960.png)

Jira: [WOR-864](https://getsentry.atlassian.net/browse/WOR-864)
