### PR TITLE
fix(ui): Force group list to not tint row for alert details

### DIFF
--- a/static/app/components/issues/groupList.tsx
+++ b/static/app/components/issues/groupList.tsx
@@ -29,6 +29,7 @@ const defaultProps = {
   withChart: true,
   withPagination: true,
   useFilteredStats: true,
+  useTintRow: true,
 };
 
 type Props = WithRouterProps & {
@@ -192,6 +193,7 @@ class GroupList extends React.Component<Props, State> {
       renderEmptyMessage,
       withPagination,
       useFilteredStats,
+      useTintRow,
       customStatsPeriod,
       queryParams,
     } = this.props;
@@ -243,6 +245,7 @@ class GroupList extends React.Component<Props, State> {
                   withChart={withChart}
                   memberList={members}
                   useFilteredStats={useFilteredStats}
+                  useTintRow={useTintRow}
                   customStatsPeriod={customStatsPeriod}
                   statsPeriod={statsPeriod}
                 />

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -65,6 +65,7 @@ const defaultProps = {
   canSelect: true,
   withChart: true,
   useFilteredStats: false,
+  useTintRow: true,
 };
 
 type Props = {
@@ -145,7 +146,7 @@ class StreamGroup extends React.Component<Props, State> {
       return;
     }
 
-    const actionTaken = this.state.data.status === 'unresolved' ? false : true;
+    const actionTaken = this.state.data.status !== 'unresolved';
     const data = GroupStore.get(id) as Group;
     this.setState(state => {
       // When searching is:for_review and the inbox reason is removed
@@ -346,6 +347,7 @@ class StreamGroup extends React.Component<Props, State> {
       displayReprocessingLayout,
       showInboxTime,
       useFilteredStats,
+      useTintRow,
       customStatsPeriod,
     } = this.props;
 
@@ -379,6 +381,7 @@ class StreamGroup extends React.Component<Props, State> {
         hasInbox={hasInbox}
         unresolved={unresolved}
         actionTaken={actionTaken}
+        useTintRow={useTintRow ?? true}
       >
         {canSelect && (
           <GroupCheckBoxWrapper>
@@ -570,6 +573,7 @@ const Wrapper = styled(PanelItem)<{
   hasInbox: boolean;
   unresolved: boolean;
   actionTaken: boolean;
+  useTintRow: boolean;
 }>`
   position: relative;
   padding: ${p => (p.hasInbox ? `${space(1.5)} 0` : `${space(1)} 0`)};
@@ -578,6 +582,7 @@ const Wrapper = styled(PanelItem)<{
   ${p => (p.hasInbox ? p.theme.textColor : p.theme.subText)};
 
   ${p =>
+    p.useTintRow &&
     (p.reviewed || !p.unresolved) &&
     !p.actionTaken &&
     css`

--- a/static/app/views/alerts/rules/details/relatedIssues.tsx
+++ b/static/app/views/alerts/rules/details/relatedIssues.tsx
@@ -86,6 +86,7 @@ class RelatedIssues extends React.Component<Props> {
             withPagination={false}
             useFilteredStats
             customStatsPeriod={timePeriod}
+            useTintRow={false}
           />
         </TableWrapper>
       </React.Fragment>


### PR DESCRIPTION
This adds a parameter to stream group to force not show the action taken/reviewed ui where it grays out the rows. This is distracting in the alert details page, this removes it.

Before:
![Screen Shot 2021-05-03 at 8 29 19 AM](https://user-images.githubusercontent.com/15015880/116897246-e608d400-abe9-11eb-8855-14248ad7b672.png)

After:
![Screen Shot 2021-05-03 at 8 29 33 AM](https://user-images.githubusercontent.com/15015880/116897280-ef923c00-abe9-11eb-9c70-31c446b29945.png)

Jira: [WOR-840](https://getsentry.atlassian.net/browse/WOR-840)
