### PR TITLE
feat(transaction-summary): Make status breakdown clickable

### DIFF
--- a/static/app/components/charts/breakdownBars.tsx
+++ b/static/app/components/charts/breakdownBars.tsx
@@ -7,6 +7,7 @@ import {formatPercentage} from 'app/utils/formatters';
 type Point = {
   label: string;
   value: number;
+  onClick?: () => void;
 };
 
 type Props = {
@@ -24,7 +25,11 @@ function BreakdownBars({data}: Props) {
       {data.map((point, i) => (
         <React.Fragment key={`${i}:${point.label}`}>
           <Percentage>{formatPercentage(point.value / total, 0)}</Percentage>
-          <BarContainer>
+          <BarContainer
+            data-test-id={`status-${point.label}`}
+            cursor={point.onClick ? 'pointer' : 'default'}
+            onClick={point.onClick}
+          >
             <Bar style={{width: `${((point.value / total) * 100).toFixed(2)}%`}} />
             <Label>{point.label}</Label>
           </BarContainer>
@@ -48,10 +53,11 @@ const Percentage = styled('div')`
   text-align: right;
 `;
 
-const BarContainer = styled('div')`
+const BarContainer = styled('div')<{cursor: 'pointer' | 'default'}>`
   padding-left: ${space(1)};
   padding-right: ${space(1)};
   position: relative;
+  cursor: ${p => p.cursor};
 `;
 
 const Label = styled('span')`

--- a/static/app/views/performance/transactionSummary/statusBreakdown.tsx
+++ b/static/app/views/performance/transactionSummary/statusBreakdown.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {browserHistory} from 'react-router';
 import styled from '@emotion/styled';
 import {Location} from 'history';
 
@@ -13,6 +14,7 @@ import {t} from 'app/locale';
 import {LightWeightOrganization} from 'app/types';
 import DiscoverQuery from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
+import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
 import {getTermHelp, PERFORMANCE_TERM} from 'app/views/performance/data';
 
 type Props = {
@@ -64,6 +66,20 @@ function StatusBreakdown({eventView, location, organization}: Props) {
           const points = tableData.data.map(row => ({
             label: String(row['transaction.status']),
             value: parseInt(String(row.count), 10),
+            onClick: () => {
+              const query = tokenizeSearch(eventView.query);
+              query
+                .removeTag('!transaction.status')
+                .setTagValues('transaction.status', [row['transaction.status']]);
+              browserHistory.push({
+                pathname: location.pathname,
+                query: {
+                  ...location.query,
+                  cursor: undefined,
+                  query: stringifyQueryObject(query),
+                },
+              });
+            },
           }));
           return <BreakdownBars data={points} />;
         }}

--- a/tests/js/spec/views/performance/transactionSummary.spec.jsx
+++ b/tests/js/spec/views/performance/transactionSummary.spec.jsx
@@ -232,6 +232,7 @@ describe('Performance > TransactionSummary', function () {
   afterEach(function () {
     MockApiClient.clearMockResponses();
     ProjectsStore.reset();
+    jest.clearAllMocks();
   });
 
   it('renders basic UI elements', async function () {
@@ -267,6 +268,9 @@ describe('Performance > TransactionSummary', function () {
 
     // Ensure create alert from discover is hidden without metric alert
     expect(wrapper.find('CreateAlertFromViewButton')).toHaveLength(0);
+
+    // Ensure status breakdown exists
+    expect(wrapper.find('StatusBreakdown')).toHaveLength(1);
   });
 
   it('renders feature flagged UI elements', async function () {
@@ -454,5 +458,31 @@ describe('Performance > TransactionSummary', function () {
     wrapper.update();
 
     expect(issueGet).toHaveBeenCalled();
+  });
+
+  it('adds search condition on transaction status when clicking on status breakdown', async function () {
+    const initialData = initializeData();
+    const wrapper = mountWithTheme(
+      <TransactionSummary
+        organization={initialData.organization}
+        location={initialData.router.location}
+      />,
+      initialData.routerContext
+    );
+    await tick();
+    wrapper.update();
+
+    wrapper.find('BarContainer[data-test-id="status-ok"]').at(0).simulate('click');
+    await tick();
+    wrapper.update();
+
+    expect(browserHistory.push).toHaveBeenCalledTimes(1);
+    expect(browserHistory.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({
+          query: expect.stringContaining('transaction.status:ok'),
+        }),
+      })
+    );
   });
 });


### PR DESCRIPTION
Currently, the status breakdown on transaction summary is not clickable so it cannot be used as a means to drilldown on the data. This change makes it so that when clicking on a transaction status, a filter for that status is added to the search terms.