### PR TITLE
ref: Refactor transaction post processing

### DIFF
--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -53,6 +53,9 @@ buffer_incr_complete = BetterSignal(providing_args=["model", "columns", "extra",
 pending_delete = BetterSignal(providing_args=["instance", "actor"])
 event_processed = BetterSignal(providing_args=["project", "event"])
 
+# Should eventually be removed as transactions should not be post processed
+transaction_processed = BetterSignal(providing_args=["project", "event"])
+
 # DEPRECATED
 event_received = BetterSignal(providing_args=["ip", "project"])
 event_accepted = BetterSignal(providing_args=["ip", "data", "project"])

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -53,9 +53,6 @@ buffer_incr_complete = BetterSignal(providing_args=["model", "columns", "extra",
 pending_delete = BetterSignal(providing_args=["instance", "actor"])
 event_processed = BetterSignal(providing_args=["project", "event"])
 
-# Should eventually be removed as transactions should not be post processed
-transaction_processed = BetterSignal(providing_args=["project", "event"])
-
 # DEPRECATED
 event_received = BetterSignal(providing_args=["ip", "project"])
 event_accepted = BetterSignal(providing_args=["ip", "data", "project"])

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -3,7 +3,7 @@ import logging
 from sentry import analytics, features
 from sentry.app import locks
 from sentry.exceptions import PluginError
-from sentry.signals import event_processed, issue_unignored, transaction_processed
+from sentry.signals import event_processed, issue_unignored
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.cache import cache
@@ -223,7 +223,7 @@ def post_process_group(
         # This should eventually be completely removed and transactions
         # will not go through any post processing.
         if is_transaction_event:
-            transaction_processed.send_robust(
+            event_processed.send_robust(
                 sender=post_process_group,
                 project=event.project,
                 event=event,

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -227,7 +227,6 @@ def post_process_group(
                 sender=post_process_group,
                 project=event.project,
                 event=event,
-                # primary_hash=kwargs.get("primary_hash"),
             )
 
             event_processing_store.delete_by_key(cache_key)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -54,7 +54,7 @@ def _should_send_error_created_hooks(project):
 
 def _capture_stats(event, is_new):
     # TODO(dcramer): limit platforms to... something?
-    platform = event.group.platform if event.group else event.platform
+    platform = event.group.platform
     if not platform:
         return
     platform = platform.split("-", 1)[0].split("_", 1)[0]
@@ -204,6 +204,36 @@ def post_process_group(
 
         set_current_event_project(event.project_id)
 
+        is_transaction_event = not bool(event.group_id)
+
+        # Simplified post processing for transaction events.
+        # This should eventually be completely removed and transactions
+        # will not go through any post processing.
+        if is_transaction_event:
+            from sentry.models import EventDict, Organization, Project
+
+            # Re-bind node data to avoid renormalization. We only want to
+            # renormalize when loading old data from the database.
+            event.data = EventDict(event.data, skip_renormalization=True)
+
+            # Re-bind Project and Org since we're reading the Event object
+            # from cache which may contain stale parent models.
+            event.project = Project.objects.get_from_cache(id=event.project_id)
+            event.project._organization_cache = Organization.objects.get_from_cache(
+                id=event.project.organization_id
+            )
+
+            event_processed.send_robust(
+                sender=post_process_group,
+                project=event.project,
+                event=event,
+                # primary_hash=kwargs.get("primary_hash"),
+            )
+
+            event_processing_store.delete_by_key(cache_key)
+
+            return
+
         is_reprocessed = is_reprocessed_event(event.data)
 
         # NOTE: we must pass through the full Event object, and not an
@@ -227,23 +257,22 @@ def post_process_group(
             id=event.project.organization_id
         )
 
-        if event.group_id:
-            # Re-bind Group since we're reading the Event object
-            # from cache, which may contain a stale group and project
-            event.group, _ = get_group_with_redirect(event.group_id)
-            event.group_id = event.group.id
+        # Re-bind Group since we're reading the Event object
+        # from cache, which may contain a stale group and project
+        event.group, _ = get_group_with_redirect(event.group_id)
+        event.group_id = event.group.id
 
-            event.group.project = event.project
-            event.group.project._organization_cache = event.project._organization_cache
+        event.group.project = event.project
+        event.group.project._organization_cache = event.project._organization_cache
 
         bind_organization_context(event.project.organization)
 
         _capture_stats(event, is_new)
 
-        if event.group_id and is_reprocessed and is_new:
+        if is_reprocessed and is_new:
             add_group_to_inbox(event.group, GroupInboxReason.REPROCESSED)
 
-        if event.group_id and not is_reprocessed:
+        if not is_reprocessed:
             # we process snoozes before rules as it might create a regression
             # but not if it's new because you can't immediately snooze a new group
             has_reappeared = False if is_new else process_snoozes(event.group)
@@ -337,9 +366,8 @@ def post_process_group(
 
             safe_execute(similarity.record, event.project, [event], _with_transaction=False)
 
-        if event.group_id:
-            # Patch attachments that were ingested on the standalone path.
-            update_existing_attachments(event)
+        # Patch attachments that were ingested on the standalone path.
+        update_existing_attachments(event)
 
         if not is_reprocessed:
             event_processed.send_robust(


### PR DESCRIPTION
This is the first step towards removing transactions from
post processing entirely. It simply groups the post
processing transaction code so it can be more easily refactored
later.

The only functional change included here is that the metric
`events.processed` is no longer inclusive of transactions.