### PR TITLE
feat: Generate custom event view for "Open in Discover" from transaction summary page

### DIFF
--- a/static/app/components/discover/transactionsList.tsx
+++ b/static/app/components/discover/transactionsList.tsx
@@ -132,6 +132,11 @@ type Props = {
    * Show a loading indicator instead of the table, used for transaction summary p95.
    */
   forceLoading?: boolean;
+  /**
+   * Optional callback function to generate an alternative EventView object to be used
+   * for generating the Discover query.
+   */
+  generateDiscoverEventView?: () => EventView;
 };
 
 class TransactionsList extends React.Component<Props> {
@@ -159,6 +164,14 @@ class TransactionsList extends React.Component<Props> {
     }
 
     return sortedEventView;
+  }
+
+  generateDiscoverEventView(): EventView {
+    const {generateDiscoverEventView} = this.props;
+    if (typeof generateDiscoverEventView === 'function') {
+      return generateDiscoverEventView();
+    }
+    return this.getEventView();
   }
 
   renderHeader(): React.ReactNode {
@@ -203,7 +216,9 @@ class TransactionsList extends React.Component<Props> {
           <GuideAnchor target="release_transactions_open_in_discover">
             <DiscoverButton
               onClick={handleOpenInDiscoverClick}
-              to={this.getEventView().getResultsViewUrlTarget(organization.slug)}
+              to={this.generateDiscoverEventView().getResultsViewUrlTarget(
+                organization.slug
+              )}
               size="small"
               data-test-id="discover-open"
             >

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -21,6 +21,7 @@ import {TableDataRow} from 'app/utils/discover/discoverQuery';
 import EventView from 'app/utils/discover/eventView';
 import {
   getAggregateAlias,
+  isRelativeSpanOperationBreakdownField,
   SPAN_OP_BREAKDOWN_FIELDS,
   SPAN_OP_RELATIVE_BREAKDOWN_FIELD,
 } from 'app/utils/discover/fields';
@@ -306,9 +307,11 @@ class SummaryContent extends React.Component<Props, State> {
                     // Remove the extra field columns
                     ...sortedEventView.fields.slice(0, transactionsListTitles.length),
                   ];
+
                   // omit "Operation Duration" column
-                  fields.splice(2, 1);
-                  sortedEventView.fields = fields;
+                  sortedEventView.fields = fields.filter(({field}) => {
+                    return !isRelativeSpanOperationBreakdownField(field);
+                  });
                 }
                 return sortedEventView;
               }}

--- a/static/app/views/performance/transactionSummary/content.tsx
+++ b/static/app/views/performance/transactionSummary/content.tsx
@@ -292,6 +292,26 @@ class SummaryContent extends React.Component<Props, State> {
               location={location}
               organization={organization}
               eventView={transactionsListEventView}
+              generateDiscoverEventView={() => {
+                const {selected} = getTransactionsListSort(location, {
+                  p95: totalValues?.p95 ?? 0,
+                  spanOperationBreakdownFilter,
+                });
+                const sortedEventView = transactionsListEventView.withSorts([
+                  selected.sort,
+                ]);
+
+                if (spanOperationBreakdownFilter === SpanOperationBreakdownFilter.None) {
+                  const fields = [
+                    // Remove the extra field columns
+                    ...sortedEventView.fields.slice(0, transactionsListTitles.length),
+                  ];
+                  // omit "Operation Duration" column
+                  fields.splice(2, 1);
+                  sortedEventView.fields = fields;
+                }
+                return sortedEventView;
+              }}
               titles={transactionsListTitles}
               handleDropdownChange={this.handleTransactionsListSortChange}
               generateLink={{


### PR DESCRIPTION
We include custom columns for the Transactions list on the Transaction Summary page. We prefer to not include some of them (e.g. `span_ops_breakdown.relative` column), as they may not render well in Discover.

We do this by being able to pass a callback function to generate the EventView object used for generating the Discover URL for the "Open in Discover" CTA.