### PR TITLE
ref: monkeypatch DRF JSONRenderer to use our simplejson encoder

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -826,6 +826,8 @@ LOGGING = {
 # django-rest-framework
 
 REST_FRAMEWORK = {
+    # NOTE: We patch DRF's JSONRenderer to use our simplejson encoder,
+    #       search for monkeypatch_drf_jsonrenderer_encoder_class.
     "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer"],
     "DEFAULT_PARSER_CLASSES": [
         "rest_framework.parsers.JSONParser",

--- a/src/sentry/runner/initializer.py
+++ b/src/sentry/runner/initializer.py
@@ -485,9 +485,9 @@ def monkeypatch_drf_jsonrenderer_encoder_class():
     # if STRICT_JSON=True.
     from rest_framework.renderers import JSONRenderer
 
-    from sentry.utils.json import _default_encoder
+    from sentry.utils.json import DefaultJSONEncoder
 
-    JSONRenderer.encoder_class = _default_encoder
+    JSONRenderer.encoder_class = DefaultJSONEncoder
 
 
 def monkeypatch_drf_listfield_serializer_errors():

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -52,15 +52,14 @@ def better_default_encoder(o):
 
 class DefaultJSONEncoder(JSONEncoder):
     def __init__(self, *args, **kwargs):
-        super().__init__(
-            # upstream: (', ', ': ')
-            # Ours eliminates whitespace.
-            separators=(",", ":"),
-            # upstream: False
-            # True makes nan, inf, -inf serialize as null in compliance with ECMA-262.
-            ignore_nan=True,
-            default=better_default_encoder,
-        )
+        # upstream: (', ', ': ')
+        # Ours eliminates whitespace.
+        kwargs["separators"] = (",", ":")
+        # upstream: False
+        # True makes nan, inf, -inf serialize as null in compliance with ECMA-262.
+        kwargs["ignore_nan"] = True
+        kwargs["default"] = better_default_encoder
+        super().__init__(*args, **kwargs)
 
 
 class JSONEncoderForHTML(JSONEncoder):

--- a/src/sentry/utils/json.py
+++ b/src/sentry/utils/json.py
@@ -50,6 +50,19 @@ def better_default_encoder(o):
     raise TypeError(repr(o) + " is not JSON serializable")
 
 
+class DefaultJSONEncoder(JSONEncoder):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            # upstream: (', ', ': ')
+            # Ours eliminates whitespace.
+            separators=(",", ":"),
+            # upstream: False
+            # True makes nan, inf, -inf serialize as null in compliance with ECMA-262.
+            ignore_nan=True,
+            default=better_default_encoder,
+        )
+
+
 class JSONEncoderForHTML(JSONEncoder):
     # Our variant of JSONEncoderForHTML that also accounts for apostrophes
     # See: https://github.com/simplejson/simplejson/blob/master/simplejson/encoder.py
@@ -69,15 +82,7 @@ class JSONEncoderForHTML(JSONEncoder):
             yield chunk
 
 
-_default_encoder = JSONEncoder(
-    # upstream: (', ', ': ')
-    # Ours eliminates whitespace.
-    separators=(",", ":"),
-    # upstream: False
-    # True makes nan, inf, -inf serialize as null in compliance with ECMA-262.
-    ignore_nan=True,
-    default=better_default_encoder,
-)
+_default_encoder = DefaultJSONEncoder()
 
 _default_escaped_encoder = JSONEncoderForHTML(
     separators=(",", ":"),


### PR DESCRIPTION
Fixes SENTRY-Q2M.

Following https://github.com/getsentry/sentry/pull/24550, STRICT_JSON defaults to True which is desirable.

https://sentry.io/organizations/sentry/issues/2378549472/activity/?project=1 shows some nan not being transformed before it hits DRF json response rendering. You can experience this by like, saying `apdex(300): ` and providing no value: https://staging.getsentry.net/organizations/sentry/performance/?environment=staging&project=1&query=transaction.duration%3A%3C15m+apdex%28300%29%3A&sort=apdex_300&statsPeriod=24h

Previously without STRICT_JSON, those nans would just passthrough to frontend. The visual result is the same I think.

We'd like to keep STRICT_JSON (it also applies to parsing request.data), but avoid this error and also give the frontend `null`, so this switches the renderer over to use our custom simplejson which sets ignore_nan=True:

> If ignore_nan is true (default: False), then out of range float values (nan, inf, -inf) will be serialized as null in compliance with the ECMA-262 specification. **If true, this will override allow_nan.**

If you read DRF code they do this: `allow_nan=not self.strict`, but our ignore_nan setting overrides that.

According to https://www.django-rest-framework.org/api-guide/renderers/#custom-renderers you should implement something atop BaseRenderer, but it's easier to simply swap out the encoder with a patch during initialization.

Also, this is relevant information if we ever want to try switching over to orjson (cc @untitaker), I found this nice project https://pypi.org/project/drf-orjson-renderer/.

I can't reproduce this locally though, so I'll go through staging. 