### PR TITLE
ref(perf): Fix table data type for vital details

### DIFF
--- a/static/app/utils/performance/vitals/vitalsDetailsTableQuery.tsx
+++ b/static/app/utils/performance/vitals/vitalsDetailsTableQuery.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import {MetaType} from 'app/utils/discover/eventView';
+import GenericDiscoverQuery, {
+  DiscoverQueryProps,
+  GenericChildrenProps,
+} from 'app/utils/discover/genericDiscoverQuery';
+import withApi from 'app/utils/withApi';
+
+type BaseDataRow = {
+  id: string;
+  project: string;
+  transaction: string;
+  count: number;
+  count_unique_user: number;
+  key_transaction: number;
+  [key: string]: React.ReactText;
+};
+
+type LCPDataRow = BaseDataRow & {
+  p50_measurements_lcp: number;
+  p75_measurements_lcp: number;
+  p95_measurements_lcp: number;
+  compare_numeric_aggregate_p75_measurements_lcp_greater_2500: number;
+  compare_numeric_aggregate_p75_measurements_lcp_greater_4000: number;
+};
+type FCPDataRow = BaseDataRow & {
+  p50_measurements_fcp: number;
+  p75_measurements_fcp: number;
+  p95_measurements_fcp: number;
+  compare_numeric_aggregate_p75_measurements_fcp_greater_2500: number;
+  compare_numeric_aggregate_p75_measurements_fcp_greater_4000: number;
+};
+type CLSDataRow = BaseDataRow & {
+  p50_measurements_cls: number;
+  p75_measurements_cls: number;
+  p95_measurements_cls: number;
+  compare_numeric_aggregate_p75_measurements_cls_greater_2500: number;
+  compare_numeric_aggregate_p75_measurements_cls_greater_4000: number;
+};
+type FIDDataRow = BaseDataRow & {
+  p50_measurements_fid: number;
+  p75_measurements_fid: number;
+  p95_measurements_fid: number;
+  compare_numeric_aggregate_p75_measurements_fid_greater_2500: number;
+  compare_numeric_aggregate_p75_measurements_fid_greater_4000: number;
+};
+
+// TODO(perf): Fix if/once we can send column aliases along with a request
+export type TableDataRow = LCPDataRow | FCPDataRow | CLSDataRow | FIDDataRow;
+
+export type TableData = {
+  data: Array<TableDataRow>;
+  meta?: MetaType;
+};
+
+type ChildrenProps = Omit<GenericChildrenProps<TableData>, 'tableData'> & {
+  tableData: TableData | null;
+};
+
+type QueryProps = DiscoverQueryProps & {
+  children: (props: ChildrenProps) => React.ReactNode;
+};
+
+function VitalsCardsDiscoverQuery(props: QueryProps) {
+  return <GenericDiscoverQuery<TableData, QueryProps> route="eventsv2" {...props} />;
+}
+
+export default withApi(VitalsCardsDiscoverQuery);

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -12,7 +12,6 @@ import {IconStar} from 'app/icons';
 import {t} from 'app/locale';
 import {Organization, Project} from 'app/types';
 import {trackAnalyticsEvent} from 'app/utils/analytics';
-import DiscoverQuery, {TableData, TableDataRow} from 'app/utils/discover/discoverQuery';
 import EventView, {EventData, isFieldSortable} from 'app/utils/discover/eventView';
 import {getFieldRenderer} from 'app/utils/discover/fieldRenderers';
 import {
@@ -21,6 +20,10 @@ import {
   Sort,
   WebVital,
 } from 'app/utils/discover/fields';
+import VitalsDetailsTableQuery, {
+  TableData,
+  TableDataRow,
+} from 'app/utils/performance/vitals/vitalsDetailsTableQuery';
 import {stringifyQueryObject, tokenizeSearch} from 'app/utils/tokenizeSearch';
 import CellAction, {Actions, updateQuery} from 'app/views/eventsV2/table/cellAction';
 import {TableColumn} from 'app/views/eventsV2/table/types';
@@ -366,7 +369,7 @@ class Table extends React.Component<Props, State> {
 
     return (
       <div>
-        <DiscoverQuery
+        <VitalsDetailsTableQuery
           eventView={sortedEventView}
           orgSlug={organization.slug}
           location={location}
@@ -401,7 +404,7 @@ class Table extends React.Component<Props, State> {
               <Pagination pageLinks={pageLinks} />
             </React.Fragment>
           )}
-        </DiscoverQuery>
+        </VitalsDetailsTableQuery>
       </div>
     );
   }


### PR DESCRIPTION
### Summary
Previously using the basic DiscoverQuery wrapper the type is 'any' which isn't helpful when trying to find type issues with returned data