### PR TITLE
ref(ui): Pass state type to state property

### DIFF
--- a/static/app/components/acl/featureDisabled.tsx
+++ b/static/app/components/acl/featureDisabled.tsx
@@ -61,7 +61,7 @@ class FeatureDisabled extends React.Component<Props, State> {
     message: t('This feature is not enabled on your Sentry installation.'),
   };
 
-  state = {
+  state: State = {
     showHelp: false,
   };
 

--- a/static/app/components/activity/note/index.tsx
+++ b/static/app/components/activity/note/index.tsx
@@ -63,7 +63,7 @@ type State = {
 };
 
 class Note extends React.Component<Props, State> {
-  state = {
+  state: State = {
     editing: false,
   };
 

--- a/static/app/components/avatar/gravatar.tsx
+++ b/static/app/components/avatar/gravatar.tsx
@@ -20,7 +20,7 @@ type State = {
 };
 
 class Gravatar extends React.Component<Props, State> {
-  state = {
+  state: State = {
     MD5: undefined,
   };
 

--- a/static/app/components/charts/releaseSeries.tsx
+++ b/static/app/components/charts/releaseSeries.tsx
@@ -86,7 +86,7 @@ type State = {
 };
 
 class ReleaseSeries extends React.Component<Props, State> {
-  state = {
+  state: State = {
     releases: null,
     releaseSeries: [],
   };

--- a/static/app/components/charts/transitionChart.tsx
+++ b/static/app/components/charts/transitionChart.tsx
@@ -20,7 +20,7 @@ type State = {
 class TransitionChart extends React.Component<Props, State> {
   static defaultProps = defaultProps;
 
-  state = {
+  state: State = {
     prevReloading: this.props.reloading,
     prevLoading: this.props.loading,
     key: 1,

--- a/static/app/components/customResolutionModal.tsx
+++ b/static/app/components/customResolutionModal.tsx
@@ -39,7 +39,7 @@ function VersionOption({
 }
 
 class CustomResolutionModal extends React.Component<Props, State> {
-  state = {
+  state: State = {
     version: '',
   };
 

--- a/static/app/components/dataExport.tsx
+++ b/static/app/components/dataExport.tsx
@@ -42,7 +42,7 @@ class DataExport extends React.Component<Props, State> {
     if (!isEqual(prevPayload, payload)) this.resetState();
   }
 
-  get initialState() {
+  get initialState(): State {
     return {
       inProgress: false,
     };

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -62,7 +62,7 @@ function addFingerprintInfo(data: VariantData, variant: EventGroupVariant) {
 }
 
 class GroupVariant extends React.Component<Props, State> {
-  state = {
+  state: State = {
     showNonContributing: false,
   };
 

--- a/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
@@ -17,7 +17,7 @@ type State = {
 };
 
 class Summary extends React.Component<Props, State> {
-  state = {
+  state: State = {
     isExpanded: false,
     hasOverflow: false,
   };

--- a/static/app/components/events/interfaces/csp.tsx
+++ b/static/app/components/events/interfaces/csp.tsx
@@ -26,8 +26,12 @@ type Props = {
   data: Record<string, any>;
 };
 
-export default class CspInterface extends React.Component<Props> {
-  state = {view: 'report'};
+type State = {
+  view: string;
+};
+
+export default class CspInterface extends React.Component<Props, State> {
+  state: State = {view: 'report'};
 
   toggleView = value => {
     this.setState({

--- a/static/app/components/events/interfaces/frame/line.tsx
+++ b/static/app/components/events/interfaces/frame/line.tsx
@@ -86,7 +86,7 @@ export class Line extends React.Component<Props, State> {
   // isExpanded can be initialized to true via parent component;
   // data synchronization is not important
   // https://facebook.github.io/react/tips/props-in-getInitialState-as-anti-pattern.html
-  state = {
+  state: State = {
     isExpanded: this.props.isExpanded,
   };
 

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -103,7 +103,7 @@ class GridEditable<
     };
   }
 
-  state = {
+  state: State = {
     numColumn: 0,
   };
 

--- a/static/app/components/gridEditable/index.tsx
+++ b/static/app/components/gridEditable/index.tsx
@@ -103,7 +103,7 @@ class GridEditable<
     };
   }
 
-  state: State = {
+  state: GridEditableState = {
     numColumn: 0,
   };
 

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -91,7 +91,7 @@ class Hovercard extends React.Component<Props, State> {
     this.scheduleUpdate = null;
   }
 
-  state = {
+  state: State = {
     visible: false,
   };
 

--- a/static/app/components/inputInline.tsx
+++ b/static/app/components/inputInline.tsx
@@ -60,7 +60,7 @@ class InputInline extends React.Component<Props, State> {
     return event as React.FormEvent<HTMLInputElement>;
   }
 
-  state = {
+  state: State = {
     isFocused: false,
     isHovering: false,
   };

--- a/static/app/components/modals/redirectToProject.tsx
+++ b/static/app/components/modals/redirectToProject.tsx
@@ -18,7 +18,7 @@ type State = {
 };
 
 class RedirectToProjectModal extends React.Component<Props, State> {
-  state = {
+  state: State = {
     timer: 5,
   };
 

--- a/static/app/components/organizations/timeRangeSelector/timePicker.tsx
+++ b/static/app/components/organizations/timeRangeSelector/timePicker.tsx
@@ -20,7 +20,7 @@ type State = {
 
 const TimePicker = styled(
   class TimePicker extends React.Component<Props, State> {
-    state = {
+    state: State = {
       focused: false,
     };
 

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -37,7 +37,7 @@ class PluginConfig extends React.Component<Props, State> {
     onDisablePlugin: () => {},
   };
 
-  state = {
+  state: State = {
     loading: !plugins.isLoaded(this.props.data),
     testResults: '',
   };

--- a/static/app/components/searchBar.tsx
+++ b/static/app/components/searchBar.tsx
@@ -34,7 +34,7 @@ class SearchBar extends React.PureComponent<Props, State> {
     onSearch: function () {},
   };
 
-  state = {
+  state: State = {
     query: this.props.query || this.props.defaultQuery,
     dropdownVisible: false,
   };

--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -59,7 +59,7 @@ class TimeSince extends React.PureComponent<Props, State> {
     suffix: 'ago',
   };
 
-  state = {
+  state: State = {
     relative: '',
   };
 

--- a/static/app/components/truncate.tsx
+++ b/static/app/components/truncate.tsx
@@ -31,7 +31,7 @@ class Truncate extends React.Component<Props, State> {
     expandDirection: 'right',
   };
 
-  state = {
+  state: State = {
     isExpanded: false,
   };
 

--- a/static/app/themeAndStyleProvider.tsx
+++ b/static/app/themeAndStyleProvider.tsx
@@ -19,7 +19,7 @@ type State = {
 };
 
 class Main extends React.Component<Props, State> {
-  state = {
+  state: State = {
     theme: this.themeName === 'dark' ? darkTheme : lightTheme,
   };
 

--- a/static/app/utils/errorHandler.tsx
+++ b/static/app/utils/errorHandler.tsx
@@ -17,7 +17,7 @@ export default function errorHandler<P>(Component: React.ComponentType<P>) {
       };
     }
 
-    state = {
+    state: State = {
       // we are explicit if an error has been thrown since errors thrown are not guaranteed
       // to be truthy (e.g. throw null).
       hasError: false,

--- a/static/app/utils/projects.tsx
+++ b/static/app/utils/projects.tsx
@@ -127,7 +127,7 @@ class Projects extends React.Component<Props, State> {
     passthroughPlaceholderProject: true,
   };
 
-  state = {
+  state: State = {
     fetchedProjects: [],
     projectsFromStore: [],
     initiallyLoaded: false,

--- a/static/app/utils/withTeamsForUser.tsx
+++ b/static/app/utils/withTeamsForUser.tsx
@@ -29,7 +29,7 @@ const withTeamsForUser = <P extends InjectedTeamsProps>(
   > {
     static displayName = `withUsersTeams(${getDisplayName(WrappedComponent)})`;
 
-    state = {
+    state: InjectedTeamsProps = {
       teams: [],
       loadingTeams: true,
       error: null,

--- a/static/app/views/alerts/rules/details/relatedTransactions.tsx
+++ b/static/app/views/alerts/rules/details/relatedTransactions.tsx
@@ -47,7 +47,7 @@ type TableState = {
   widths: number[];
 };
 class Table extends React.Component<TableProps, TableState> {
-  state = {
+  state: TableState = {
     widths: [],
   };
 

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -56,7 +56,7 @@ class App extends React.Component<Props, State> {
     location: PropTypes.object,
   };
 
-  state = {
+  state: State = {
     loading: false,
     error: false,
     needsUpgrade: ConfigStore.get('user')?.isSuperuser && ConfigStore.get('needsUpgrade'),

--- a/static/app/views/auth/ssoForm.tsx
+++ b/static/app/views/auth/ssoForm.tsx
@@ -17,7 +17,7 @@ type State = {
 };
 
 class SsoForm extends React.Component<Props, State> {
-  state = {
+  state: State = {
     errorMessage: null,
   };
 

--- a/static/app/views/eventsV2/savedQuery/index.tsx
+++ b/static/app/views/eventsV2/savedQuery/index.tsx
@@ -118,7 +118,7 @@ class SavedQueryButtonGroup extends React.PureComponent<Props, State> {
     disabled: false,
   };
 
-  state = {
+  state: State = {
     isNewQuery: true,
     isEditingQuery: false,
 

--- a/static/app/views/eventsV2/table/cellAction.tsx
+++ b/static/app/views/eventsV2/table/cellAction.tsx
@@ -138,7 +138,7 @@ class CellAction extends React.Component<Props, State> {
     this.menuEl = null;
   }
 
-  state = {
+  state: State = {
     isHovering: false,
     isOpen: false,
   };

--- a/static/app/views/eventsV2/table/columnEditModal.tsx
+++ b/static/app/views/eventsV2/table/columnEditModal.tsx
@@ -32,7 +32,7 @@ type State = {
 };
 
 class ColumnEditModal extends React.Component<Props, State> {
-  state = {
+  state: State = {
     columns: this.props.columns,
   };
 

--- a/static/app/views/eventsV2/table/queryField.tsx
+++ b/static/app/views/eventsV2/table/queryField.tsx
@@ -558,7 +558,7 @@ class BufferedInput extends React.Component<InputProps, InputState> {
     this.input = React.createRef();
   }
 
-  state = {
+  state: InputState = {
     value: this.props.value,
   };
 

--- a/static/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
+++ b/static/app/views/integrationPipeline/awsLambdaFunctionSelect.tsx
@@ -40,7 +40,7 @@ export default class AwsLambdaFunctionSelect extends React.Component<Props, Stat
     makeObservable(this);
   }
 
-  state = {
+  state: State = {
     submitting: false,
   };
 

--- a/static/app/views/issueList/noGroupsHandler/index.tsx
+++ b/static/app/views/issueList/noGroupsHandler/index.tsx
@@ -32,7 +32,7 @@ type State = {
  * render one of those states.
  */
 class NoGroupsHandler extends React.Component<Props, State> {
-  state = {
+  state: State = {
     fetchingSentFirstEvent: true,
     sentFirstEvent: false,
     firstEventProjects: null,

--- a/static/app/views/issueList/noGroupsHandler/noUnresolvedIssues.tsx
+++ b/static/app/views/issueList/noGroupsHandler/noUnresolvedIssues.tsx
@@ -26,6 +26,8 @@ const CongratsRobotsVideo = React.lazy(
   () => import(/* webpackChunkName: "CongratsRobotsVideo" */ './congratsRobots')
 );
 
+type State = {hasError: boolean};
+
 /**
  * Error boundary for loading the robots video.
  * This can error because of the file size of the video
@@ -33,17 +35,14 @@ const CongratsRobotsVideo = React.lazy(
  * Silently ignore the error, this isn't really important enough to
  * capture in Sentry
  */
-class ErrorBoundary extends React.Component<
-  {children: React.ReactNode},
-  {hasError: boolean}
-> {
-  static getDerivedStateFromError() {
+class ErrorBoundary extends React.Component<{children: React.ReactNode}, State> {
+  static getDerivedStateFromError(): State {
     return {
       hasError: true,
     };
   }
 
-  state = {
+  state: State = {
     hasError: false,
   };
 

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -51,7 +51,7 @@ async function latestEventAvailable(
 }
 
 class CreateSampleEventButton extends React.Component<Props, State> {
-  state = {
+  state: State = {
     creating: false,
   };
 

--- a/static/app/views/organizationActivity/activityFeedItem.tsx
+++ b/static/app/views/organizationActivity/activityFeedItem.tsx
@@ -37,7 +37,7 @@ type State = {
 class ActivityItem extends React.Component<Props, State> {
   static defaultProps = defaultProps;
 
-  state = {
+  state: State = {
     clipped: this.props.defaultClipped,
   };
 

--- a/static/app/views/organizationIntegrations/integrationIcon.tsx
+++ b/static/app/views/organizationIntegrations/integrationIcon.tsx
@@ -9,6 +9,10 @@ type Props = {
   size?: number;
 };
 
+type State = {
+  imgSrc: Integration['icon'];
+};
+
 type IconProps = Pick<Props, 'size'>;
 
 const StyledIcon = styled('img')<IconProps>`
@@ -18,7 +22,7 @@ const StyledIcon = styled('img')<IconProps>`
   display: block;
 `;
 
-class Icon extends React.Component<Props> {
+class Icon extends React.Component<Props, State> {
   state: State = {
     imgSrc: this.props.integration.icon,
   };

--- a/static/app/views/organizationIntegrations/integrationIcon.tsx
+++ b/static/app/views/organizationIntegrations/integrationIcon.tsx
@@ -19,7 +19,7 @@ const StyledIcon = styled('img')<IconProps>`
 `;
 
 class Icon extends React.Component<Props> {
-  state = {
+  state: State = {
     imgSrc: this.props.integration.icon,
   };
 

--- a/static/app/views/organizationIntegrations/integrationRequest/RequestIntegrationButton.tsx
+++ b/static/app/views/organizationIntegrations/integrationRequest/RequestIntegrationButton.tsx
@@ -21,7 +21,7 @@ type State = {
 };
 
 export default class RequestIntegrationButton extends React.Component<Props, State> {
-  state = {
+  state: State = {
     isOpen: false,
     isSent: false,
   };

--- a/static/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
+++ b/static/app/views/organizationIntegrations/integrationRequest/RequestIntegrationModal.tsx
@@ -27,7 +27,7 @@ type State = {
  * lets the user attach an optional message to be included in the email.
  */
 export default class RequestIntegrationModal extends AsyncComponent<Props, State> {
-  state = {
+  state: State = {
     ...this.getDefaultState(),
     isSending: false,
     message: '',

--- a/static/app/views/organizationIntegrations/integrationServerlessRow.tsx
+++ b/static/app/views/organizationIntegrations/integrationServerlessRow.tsx
@@ -28,7 +28,7 @@ type State = {
 };
 
 class IntegrationServerlessRow extends React.Component<Props, State> {
-  state = {
+  state: State = {
     submitting: false,
   };
   get enabled() {

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -57,7 +57,7 @@ type State = {
   widths: number[];
 };
 class Table extends React.Component<Props, State> {
-  state = {
+  state: State = {
     widths: [],
   };
 

--- a/static/app/views/performance/traceDetails/transactionGroup.tsx
+++ b/static/app/views/performance/traceDetails/transactionGroup.tsx
@@ -31,7 +31,7 @@ type State = {
 };
 
 class TransactionGroup extends React.Component<Props, State> {
-  state = {
+  state: State = {
     isExpanded: true,
   };
 

--- a/static/app/views/performance/transactionSummary/latencyChart.tsx
+++ b/static/app/views/performance/transactionSummary/latencyChart.tsx
@@ -56,7 +56,7 @@ type State = {
  * at each duration bucket, showing the modality of the transaction.
  */
 class LatencyChart extends React.Component<Props, State> {
-  state = {
+  state: State = {
     zoomError: false,
   };
 

--- a/static/app/views/performance/transactionVitals/vitalCard.tsx
+++ b/static/app/views/performance/transactionVitals/vitalCard.tsx
@@ -84,7 +84,7 @@ type State = {
 };
 
 class VitalCard extends React.Component<Props, State> {
-  state = {
+  state: State = {
     refDataRect: null,
     refPixelRect: null,
   };

--- a/static/app/views/performance/vitalDetail/table.tsx
+++ b/static/app/views/performance/vitalDetail/table.tsx
@@ -88,7 +88,7 @@ type State = {
 };
 
 class Table extends React.Component<Props, State> {
-  state = {
+  state: State = {
     widths: [],
   };
 

--- a/static/app/views/releases/detail/overview/chart/healthChartContainer.tsx
+++ b/static/app/views/releases/detail/overview/chart/healthChartContainer.tsx
@@ -33,7 +33,7 @@ type State = {
 };
 
 class ReleaseChartContainer extends React.Component<Props, State> {
-  state = {
+  state: State = {
     shouldRecalculateVisibleSeries: true,
   };
 

--- a/static/app/views/settings/account/apiApplications/row.tsx
+++ b/static/app/views/settings/account/apiApplications/row.tsx
@@ -29,7 +29,7 @@ type State = {
 };
 
 class Row extends React.Component<Props, State> {
-  state = {
+  state: State = {
     loading: false,
   };
 

--- a/static/app/views/settings/components/settingsProjectItem.tsx
+++ b/static/app/views/settings/components/settingsProjectItem.tsx
@@ -17,7 +17,7 @@ type State = {
 };
 
 class ProjectItem extends React.Component<Props, State> {
-  state = {
+  state: State = {
     isBookmarked: this.props.project.isBookmarked,
   };
 

--- a/static/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
+++ b/static/app/views/settings/incidentRules/triggers/chart/thresholdsChart.tsx
@@ -53,7 +53,7 @@ export default class ThresholdsChart extends React.PureComponent<Props, State> {
     data: [],
   };
 
-  state = {
+  state: State = {
     width: -1,
     height: -1,
     yAxisMax: null,

--- a/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/permissionSelection.tsx
@@ -94,7 +94,7 @@ export default class PermissionSelection extends React.Component<Props, State> {
     form: PropTypes.object,
   };
 
-  state = {
+  state: State = {
     permissions: this.props.permissions,
   };
 

--- a/static/app/views/settings/organizationTeams/allTeamsRow.tsx
+++ b/static/app/views/settings/organizationTeams/allTeamsRow.tsx
@@ -27,7 +27,7 @@ type State = {
 };
 
 class AllTeamsRow extends React.Component<Props, State> {
-  state = {
+  state: State = {
     loading: false,
     error: false,
   };

--- a/static/app/views/settings/organizationTeams/teamDetails.tsx
+++ b/static/app/views/settings/organizationTeams/teamDetails.tsx
@@ -37,7 +37,7 @@ type State = {
 class TeamDetails extends React.Component<Props, State> {
   state = this.getInitialState();
 
-  getInitialState() {
+  getInitialState(): State {
     const team = TeamStore.getBySlug(this.props.params.teamId);
 
     return {

--- a/static/app/views/settings/project/projectKeys/details/keySettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/keySettings.tsx
@@ -48,7 +48,7 @@ type State = {
 };
 
 class KeySettings extends React.Component<Props, State> {
-  state = {
+  state: State = {
     loading: false,
     error: false,
   };

--- a/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
+++ b/static/app/views/settings/project/projectKeys/projectKeyCredentials.tsx
@@ -33,7 +33,7 @@ type State = {
 class ProjectKeyCredentials extends React.Component<Props, State> {
   static defaultProps = DEFAULT_PROPS;
 
-  state = {
+  state: State = {
     showDeprecatedDsn: false,
   };
 

--- a/static/app/views/settings/project/projectOwnership/codeowners.tsx
+++ b/static/app/views/settings/project/projectOwnership/codeowners.tsx
@@ -18,11 +18,7 @@ type Props = {
   onDelete: (data: any) => void;
 };
 
-type State = {};
-
-class CodeOwnersPanel extends React.Component<Props, State> {
-  state = {};
-
+class CodeOwnersPanel extends React.Component<Props> {
   handleDelete = async (codeowner: CodeOwners) => {
     const {api, organization, project, onDelete} = this.props;
     const endpoint = `/api/0/projects/${organization.slug}/${project.slug}/codeowners/${codeowner.id}/`;

--- a/static/app/views/settings/project/projectOwnership/selectOwners.tsx
+++ b/static/app/views/settings/project/projectOwnership/selectOwners.tsx
@@ -59,7 +59,7 @@ type State = {
 };
 
 class SelectOwners extends React.Component<Props, State> {
-  state = {
+  state: State = {
     loading: false,
     inputValue: '',
   };

--- a/static/app/views/settings/projectAlerts/ruleRow.tsx
+++ b/static/app/views/settings/projectAlerts/ruleRow.tsx
@@ -34,7 +34,7 @@ type State = {
 };
 
 class RuleRow extends React.Component<Props, State> {
-  state = {loading: false, error: false};
+  state: State = {loading: false, error: false};
 
   renderIssueRule(data: IssueAlertRule) {
     const {params, routes, location, canEdit} = this.props;

--- a/static/app/views/usageStats/index.tsx
+++ b/static/app/views/usageStats/index.tsx
@@ -54,7 +54,7 @@ type State = {
 };
 
 class OrganizationStats extends React.Component<Props, State> {
-  state = {
+  state: State = {
     isCalendarOpen: false,
   };
 


### PR DESCRIPTION
Passing state type to the state property is still required or typescript will attempt to infer the type.

![image](https://user-images.githubusercontent.com/1400464/116945659-1756c380-ac2d-11eb-8d62-fbf1251fd846.png)
