### PR TITLE
fix(breadcrumb): Fix description not rendering the number 0

### DIFF
--- a/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
+++ b/static/app/components/events/interfaces/breadcrumbs/data/summary.tsx
@@ -39,7 +39,7 @@ class Summary extends React.Component<Props, State> {
 
     return Object.keys(kvData)
       .reverse()
-      .filter(key => defined(kvData[key]) && !!kvData[key])
+      .filter(key => defined(kvData[key]))
       .map(key => {
         const value =
           typeof kvData[key] === 'object'


### PR DESCRIPTION
Currently, the description of a breadcrumb does not render data info equal to `0`. Example:

```
breadcrumbs: {
values: [{
timestamp: 1619190374.923,
type: "default",
level: "info",
message: "hi",
data: {
index: 0
}}]},
```

This PR fixes the issue.