### PR TITLE
ref(images-loaded): Add Malformed status

### DIFF
--- a/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/status/index.tsx
+++ b/static/app/components/events/interfaces/debugMeta-v2/debugImageDetails/candidate/status/index.tsx
@@ -14,9 +14,11 @@ function Status({status}: Props) {
     case CandidateDownloadStatus.OK: {
       return <Tag type="success">{t('Ok')}</Tag>;
     }
-    case CandidateDownloadStatus.ERROR:
-    case CandidateDownloadStatus.MALFORMED: {
+    case CandidateDownloadStatus.ERROR: {
       return <Tag type="error">{t('Failed')}</Tag>;
+    }
+    case CandidateDownloadStatus.MALFORMED: {
+      return <Tag type="error">{t('Malformed')}</Tag>;
     }
     case CandidateDownloadStatus.NOT_FOUND: {
       return <Tag>{t('Not Found')}</Tag>;


### PR DESCRIPTION
Currently the images loaded details dialog displays the status "failed" when an error occurred during the processing of the debug file or if the debug file is malformed.

This PR updated this logic, now showing "failed" for when an error occurs and "malformed" for when the debug file is malformed. Both status are in red.
