### PR TITLE
fix(direnv): Do not call pre-commit but check the command's existance

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -24,8 +24,7 @@ log_level="info"
 
 help_message() {
     cat <<EOF
-If you're stuck or have questions, ask in #discuss-dev-tooling.
-For direnv configuration info run: make direnv-help
+For more help run: make direnv-help
 EOF
 }
 

--- a/.envrc
+++ b/.envrc
@@ -188,7 +188,7 @@ fi
 
 debug "Checking pre-commit..."
 
-if [ ! "$(pre-commit 2>/dev/null)" ]; then
+if ! require pre-commit; then
     warn "Looks like you don't have pre-commit installed."
     commands_to_run+=("make setup-git")
 fi

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -217,7 +217,7 @@ reset-db() {
 
 direnv-help() {
     cat >&2 <<EOF
-If you're a Sentry employee, if you're stuck or have questions, ask in #discuss-dev-tooling.
+If you're a Sentry employee and you're stuck or have questions, ask in #discuss-dev-tooling.
 If you're not, please file an issue under https://github.com/getsentry/sentry/issues/new/ and mention @owners-sentry-dev
 
 You can configure the behaviour of direnv by adding the following variables to a .env file:

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -217,6 +217,9 @@ reset-db() {
 
 direnv-help() {
     cat >&2 <<EOF
+If you're a Sentry employee, if you're stuck or have questions, ask in #discuss-dev-tooling.
+If you're not, please file an issue under https://github.com/getsentry/sentry/issues/new/ and mention @owners-sentry-dev
+
 You can configure the behaviour of direnv by adding the following variables to a .env file:
 
 - SENTRY_DIRENV_DEBUG=1: This will allow printing debug messages

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -218,7 +218,7 @@ reset-db() {
 direnv-help() {
     cat >&2 <<EOF
 If you're a Sentry employee and you're stuck or have questions, ask in #discuss-dev-tooling.
-If you're not, please file an issue under https://github.com/getsentry/sentry/issues/new/ and mention @owners-sentry-dev
+If you're not, please file an issue under https://github.com/getsentry/sentry/issues/new/ and mention @getsentry/owners-sentry-dev
 
 You can configure the behaviour of direnv by adding the following variables to a .env file:
 


### PR DESCRIPTION
Calling `pre-commit` is noticeably slower than calling `command -v pre-commit`.

This fixes it and adjusts other output suggestions.