### PR TITLE
fix(ui): Release created/released timestamps

### DIFF
--- a/static/app/views/projectDetail/projectLatestReleases.tsx
+++ b/static/app/views/projectDetail/projectLatestReleases.tsx
@@ -138,11 +138,11 @@ class ProjectLatestReleases extends AsyncComponent<Props, State> {
 
   renderReleaseRow = (release: Release) => {
     const {projectId} = this.props;
-    const {lastDeploy, dateCreated} = release;
+    const {dateCreated, dateReleased} = release;
 
     return (
       <React.Fragment key={release.version}>
-        <DateTime date={lastDeploy?.dateFinished || dateCreated} seconds={false} />
+        <DateTime date={dateReleased || dateCreated} seconds={false} />
         <TextOverflow>
           <StyledVersion
             version={release.version}

--- a/static/app/views/releases/detail/overview/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/projectReleaseDetails.tsx
@@ -19,7 +19,7 @@ type Props = {
 };
 
 const ProjectReleaseDetails = ({release, releaseMeta, orgSlug, projectSlug}: Props) => {
-  const {version, dateCreated, firstEvent, lastEvent} = release;
+  const {version, dateCreated, dateReleased, firstEvent, lastEvent} = release;
 
   return (
     <Wrapper>
@@ -28,6 +28,12 @@ const ProjectReleaseDetails = ({release, releaseMeta, orgSlug, projectSlug}: Pro
         <KeyValueTableRow
           keyName={t('Created')}
           value={<DateTime date={dateCreated} seconds={false} />}
+        />
+        <KeyValueTableRow
+          keyName={t('Released')}
+          value={
+            dateReleased ? <DateTime date={dateReleased} seconds={false} /> : '\u2014'
+          }
         />
         <KeyValueTableRow
           keyName={t('Version')}

--- a/static/app/views/releases/detail/overview/releaseStats.tsx
+++ b/static/app/views/releases/detail/overview/releaseStats.tsx
@@ -54,7 +54,7 @@ function ReleaseStats({
   hasHealthData,
   getHealthData,
 }: Props) {
-  const {lastDeploy, dateCreated, version} = release;
+  const {lastDeploy, dateCreated, dateReleased, version} = release;
 
   const crashCount = getHealthData.getCrashCount(
     version,
@@ -104,10 +104,10 @@ function ReleaseStats({
     <Container>
       <div>
         <SectionHeading>
-          {lastDeploy?.dateFinished ? t('Date Deployed') : t('Date Created')}
+          {dateReleased ? t('Date Released') : t('Date Created')}
         </SectionHeading>
         <SectionContent>
-          <TimeSince date={lastDeploy?.dateFinished ?? dateCreated} />
+          <TimeSince date={dateReleased ?? dateCreated} />
         </SectionContent>
       </div>
 

--- a/static/app/views/releases/list/releaseCard.tsx
+++ b/static/app/views/releases/list/releaseCard.tsx
@@ -59,7 +59,14 @@ const ReleaseCard = ({
   isTopRelease,
   getHealthData,
 }: Props) => {
-  const {version, commitCount, lastDeploy, dateCreated, versionInfo} = release;
+  const {
+    version,
+    commitCount,
+    lastDeploy,
+    dateCreated,
+    dateReleased,
+    versionInfo,
+  } = release;
 
   return (
     <StyledPanel reloading={reloading ? 1 : 0}>
@@ -85,7 +92,7 @@ const ReleaseCard = ({
           {versionInfo?.package && (
             <PackageName ellipsisDirection="left">{versionInfo.package}</PackageName>
           )}
-          <TimeSince date={lastDeploy?.dateFinished || dateCreated} />
+          <TimeSince date={dateReleased || dateCreated} />
           {lastDeploy?.dateFinished && ` \u007C ${lastDeploy.environment}`}
         </ReleaseInfoSubheader>
       </ReleaseInfo>


### PR DESCRIPTION
By default, releases are sorted like: `Coalesce("date_released", "date_added")`.

In UI we used to show timestamp like: `release.lastDeploy?.dateFinished || release.dateCreated`.
(deploy finished is a third timestamp that's not being used as widely)

This caused confusion where in some cases releases seemed sorted in the wrong order:
![image](https://user-images.githubusercontent.com/9060071/117014793-6d8d3a80-acf1-11eb-9c43-df7dc1e7272f.png)

Changing the display logic to be `release.dateReleased || release.dateCreated` instead and communicating in the release sidebar distinction between these two dates.