### PR TITLE
fix(quick-trace): Loading state between light and full results

### DIFF
--- a/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
+++ b/static/app/utils/performance/quickTrace/quickTraceQuery.tsx
@@ -85,12 +85,14 @@ export default function QuickTraceQuery({children, event, ...props}: QueryProps)
             }
 
             return children({
-              isLoading: traceFullResults.isLoading || traceLiteResults.isLoading,
-              // once the full results are done loading, we should use not look at the
-              // light results for any errors
-              error: traceFullResults.isLoading
-                ? traceLiteResults.error
-                : traceFullResults.error,
+              // only use the light results loading state if it didn't error
+              // if it did, we should rely on the full results
+              isLoading: traceLiteResults.error
+                ? traceFullResults.isLoading
+                : traceLiteResults.isLoading || traceFullResults.isLoading,
+              // swallow any errors from the light results because we
+              // should rely on the full results in this situations
+              error: traceFullResults.error,
               trace: [],
               // if we reach this point but there were some traces in the full results,
               // that means there were other transactions in the trace, but the current


### PR DESCRIPTION
When the light results error, this should not be emitted. Instead, it should
remain in a loading state and wait for the full results to load.