### PR TITLE
fix(dashboards): Disable pagination on dashboards

### DIFF
--- a/static/app/views/dashboardsV2/widgetQueries.tsx
+++ b/static/app/views/dashboardsV2/widgetQueries.tsx
@@ -194,6 +194,7 @@ class WidgetQueries extends React.Component<Props, State> {
       let url: string = '';
       const params: DiscoverQueryRequestParams = {
         per_page: 5,
+        noPagination: true,
       };
       if (widget.displayType === 'table') {
         url = `/organizations/${organization.slug}/eventsv2/`;


### PR DESCRIPTION
- Dashboards doesn't use pagination so disabling it to give us more
  header room if a users selects too many environments/projects