### PR TITLE
chore: Update eslint rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "enzyme": "3.11.0",
     "enzyme-to-json": "3.6.2",
     "eslint": "5.11.1",
-    "eslint-config-sentry-app": "1.51.0",
+    "eslint-config-sentry-app": "1.52.0",
     "eslint-plugin-simple-import-sort": "^6.0.0",
     "html-webpack-plugin": "^5.3.1",
     "jest": "26.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6661,16 +6661,16 @@ eslint-config-prettier@6.3.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-sentry-app@1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.51.0.tgz#1e48a0cb9e71b99d011c04b0b0cdda93e873f50f"
-  integrity sha512-00Fnnd4pzgwSXB/+KU3c1uqFGH0eDVOkYotIO+EXWQf+DF31Y1QgaNyorCEfw/CdjPNNl+JPdTmLEVy3PwyNXg==
+eslint-config-sentry-app@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-app/-/eslint-config-sentry-app-1.52.0.tgz#40aa82c24f9b7baee8f6736165596a7a4654c6a5"
+  integrity sha512-sBazcZhniWA2XVwUd4jXy4EYTrgSt0TGgHFlceUok+Eha0teAgY5XXdp6gfGZLH7z3dP/YeYvNbmv+/RQE4lqw==
   dependencies:
     "@typescript-eslint/eslint-plugin" "^3.5.0"
     "@typescript-eslint/parser" "^3.5.0"
     eslint-config-prettier "6.3.0"
-    eslint-config-sentry "^1.51.0"
-    eslint-config-sentry-react "^1.51.0"
+    eslint-config-sentry "^1.52.0"
+    eslint-config-sentry-react "^1.52.0"
     eslint-import-resolver-typescript "^2.0.0"
     eslint-import-resolver-webpack "^0.12.2"
     eslint-plugin-emotion "^10.0.27"
@@ -6678,20 +6678,20 @@ eslint-config-sentry-app@1.51.0:
     eslint-plugin-jest "22.17.0"
     eslint-plugin-prettier "3.1.1"
     eslint-plugin-react "7.15.1"
-    eslint-plugin-sentry "^1.51.0"
+    eslint-plugin-sentry "^1.52.0"
     eslint-plugin-simple-import-sort "^6.0.1"
 
-eslint-config-sentry-react@^1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.51.0.tgz#dc46ce486d7653a57fa5f1f84fff14c12103f078"
-  integrity sha512-aREfPxmDwpUYXirtsI0c6mLNoBklRo8Y+pLL4175e0wNo/QJKw9JiMIqckTP5ed+dMN4dOLeG9Y6p5lujlNKUg==
+eslint-config-sentry-react@^1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.52.0.tgz#dc51e239d2f701e223a95a03c0afb152f47c78e6"
+  integrity sha512-pheFPS8NvOlwBjS2DSl3aYMOmm786a62Kd0V8wW68LMQpG9Zekvd1x4jos1WEl0duuVs+zp2YcqkArhiwjlmlw==
   dependencies:
-    eslint-config-sentry "^1.51.0"
+    eslint-config-sentry "^1.52.0"
 
-eslint-config-sentry@^1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.51.0.tgz#c8e37169c2248c86cdce373930a2e3d236bae08c"
-  integrity sha512-k5JN1eropCgOhQ+NBtIiWzG97AziQRQ2MqK3c38ilE0F8Ag1RSwC8ijxqEvaPtPb3CBUCoK+6BzJJQCdUhCkXw==
+eslint-config-sentry@^1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.52.0.tgz#1c9387af9b228b464ce5b2b0879d8b71a0634133"
+  integrity sha512-NwG2/vCsZjOmkfJ810dr2PwbuRXbq6kZywLcqn7KOhYSWENT6QsGym6U2uGbrp4qQzLkxTM/x1Hn+Mj/fSxcWg==
 
 eslint-import-resolver-node@^0.3.3:
   version "0.3.4"
@@ -6789,10 +6789,10 @@ eslint-plugin-react@7.15.1:
     prop-types "^15.7.2"
     resolve "^1.12.0"
 
-eslint-plugin-sentry@^1.51.0:
-  version "1.51.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.51.0.tgz#42232a56be078eec118552d1b17ae01a7d3b32e3"
-  integrity sha512-b+X1s56qHg61f0PKyTXhITBQXvlttKOavAtLvWO3bTIfOXEygn6ZBcBnJ5t6GBue4c+krNd8U/zqw6VfD52Snw==
+eslint-plugin-sentry@^1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.52.0.tgz#54471a0793df1f5356e05acd18b154ceb2beff43"
+  integrity sha512-BeTuwD/3/ciSeviWTs7PctMRMVTW2VKvKS7Lk6frZRfLUhpiVmhbHsMN0e188RbPQbfha14oDS/b4KaCW8oDeQ==
   dependencies:
     requireindex "~1.1.0"
 


### PR DESCRIPTION
Update to allow no react imports, as we now use the new JSX transforms