### PR TITLE
feat(alerts): Add fuzzy filtering to team alerts (WOR-743)

### DIFF
--- a/static/app/views/alerts/rules/filter.tsx
+++ b/static/app/views/alerts/rules/filter.tsx
@@ -17,7 +17,8 @@ export type RenderProps = {
 type RenderFunc = (props: RenderProps) => React.ReactElement;
 
 type Props = {
-  header: string;
+  header: React.ReactElement;
+  headerLabel: string;
   onFilterChange: (filterSelection: Set<string>) => void;
   filterList: string[];
   children: RenderFunc;
@@ -50,7 +51,7 @@ class Filter extends React.Component<Props> {
   };
 
   render() {
-    const {children, header, filterList} = this.props;
+    const {children, header, headerLabel, filterList} = this.props;
     const checkedQuantity = this.getNumberOfActiveFilters();
 
     const dropDownButtonProps: Pick<DropdownButtonProps, 'children' | 'priority'> & {
@@ -91,8 +92,9 @@ class Filter extends React.Component<Props> {
         )}
       >
         <MenuContent>
+          {header}
           <Header>
-            <span>{header}</span>
+            <span>{headerLabel}</span>
             <CheckboxFancy
               isChecked={checkedQuantity > 0}
               isIndeterminate={

--- a/static/app/views/alerts/rules/filter.tsx
+++ b/static/app/views/alerts/rules/filter.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import CheckboxFancy from 'app/components/checkboxFancy/checkboxFancy';
 import DropdownButton from 'app/components/dropdownButton';
-import DropdownControl from 'app/components/dropdownControl';
+import DropdownControl, {Content} from 'app/components/dropdownControl';
 import {IconFilter} from 'app/icons';
 import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
@@ -78,6 +78,7 @@ class Filter extends React.Component<Props> {
       <DropdownControl
         menuWidth="240px"
         blendWithActor
+        alwaysRenderMenu={false}
         button={({isOpen, getActorProps}) => (
           <StyledDropdownButton
             {...getActorProps()}
@@ -91,29 +92,41 @@ class Filter extends React.Component<Props> {
           </StyledDropdownButton>
         )}
       >
-        <MenuContent>
-          {header}
-          <Header>
-            <span>{headerLabel}</span>
-            <CheckboxFancy
-              isChecked={checkedQuantity > 0}
-              isIndeterminate={
-                checkedQuantity > 0 && checkedQuantity !== filterList.length
-              }
-              onClick={event => {
-                event.stopPropagation();
-                this.toggleAllFilters();
-              }}
-            />
-          </Header>
-          {children({toggleFilter: this.toggleFilter})}
-        </MenuContent>
+        {({isOpen, getMenuProps}) => (
+          <MenuContent
+            {...getMenuProps()}
+            isOpen={isOpen}
+            blendCorner
+            alignMenu="left"
+            width="240px"
+          >
+            {isOpen && (
+              <React.Fragment>
+                {header}
+                <Header>
+                  <span>{headerLabel}</span>
+                  <CheckboxFancy
+                    isChecked={checkedQuantity > 0}
+                    isIndeterminate={
+                      checkedQuantity > 0 && checkedQuantity !== filterList.length
+                    }
+                    onClick={event => {
+                      event.stopPropagation();
+                      this.toggleAllFilters();
+                    }}
+                  />
+                </Header>
+                {children({toggleFilter: this.toggleFilter})}
+              </React.Fragment>
+            )}
+          </MenuContent>
+        )}
       </DropdownControl>
     );
   }
 }
 
-const MenuContent = styled('div')`
+const MenuContent = styled(Content)`
   max-height: 250px;
   overflow-y: auto;
 `;


### PR DESCRIPTION
![Kapture 2021-05-05 at 13 17 12](https://user-images.githubusercontent.com/9372512/117182525-72f78d00-ada4-11eb-96af-694f570145fd.gif)

Adds a typeahead input to the top of the filter
- Added a `header` prop to the `Filter` component which renders at the top of the menu
- Added an autoFocus input using the `header` prop
- Changed the menu to only render its contents when it is opened. This enables autoFocus to trigger appropriately. `alwaysRenderMenu` on its own didn't seem to do the trick, but maybe I was using it incorrectly.