### PR TITLE
fix(perf): Return standardized tag keys and tag values

### DIFF
--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -76,10 +76,10 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsV2EndpointBa
                     return {"data": []}
 
                 for row in results["data"]:
-                    row["tags_key"] = tagstore.get_standardized_key(row["tags_key"])
                     row["tags_value"] = tagstore.get_tag_value_label(
                         row["tags_key"], row["tags_value"]
                     )
+                    row["tags_key"] = tagstore.get_standardized_key(row["tags_key"])
 
                 return results
 

--- a/src/sentry/api/endpoints/organization_events_facets_performance.py
+++ b/src/sentry/api/endpoints/organization_events_facets_performance.py
@@ -5,7 +5,7 @@ import sentry_sdk
 from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import features, tagstore
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.snuba import discover
@@ -74,6 +74,12 @@ class OrganizationEventsFacetsPerformanceEndpoint(OrganizationEventsV2EndpointBa
 
                 if not results:
                     return {"data": []}
+
+                for row in results["data"]:
+                    row["tags_key"] = tagstore.get_standardized_key(row["tags_key"])
+                    row["tags_value"] = tagstore.get_tag_value_label(
+                        row["tags_key"], row["tags_value"]
+                    )
 
                 return results
 


### PR DESCRIPTION
### Summary
Previously we were returning values directly from snuba (eg. `sentry:release:ab31b23...` instead of just `release:ab31b23...`), which isn't helpful since we usually want to put a tag key and value right back into a query. This re-uses the same functions that event-facets uses to standardize the tag data.