### PR TITLE
fix(perf): Hide related issues when key_transaction is present

### DIFF
--- a/static/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -30,6 +30,7 @@ type Props = {
 class RelatedIssues extends React.Component<Props> {
   getIssuesEndpoint() {
     const {transaction, organization, start, end, statsPeriod, location} = this.props;
+
     const queryParams = {
       start,
       end,
@@ -53,6 +54,9 @@ class RelatedIssues extends React.Component<Props> {
       }
     });
     currentFilter.addQuery('is:unresolved').setTagValues('transaction', [transaction]);
+
+    // Filter out key_transaction from being passed to issues as it will cause an error.
+    currentFilter.removeTag('key_transaction');
 
     return {
       path: `/organizations/${organization.slug}/issues/`,
@@ -102,11 +106,6 @@ class RelatedIssues extends React.Component<Props> {
       pathname: `/organizations/${organization.slug}/issues/`,
       query: queryParams,
     };
-
-    // Filter out key_transaction from being passed to issues as it will cause an error.
-    const conditions = tokenizeSearch(queryParams.query);
-    conditions.removeTag('key_transaction');
-    queryParams.query = stringifyQueryObject(conditions);
 
     return (
       <React.Fragment>

--- a/static/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -103,6 +103,12 @@ class RelatedIssues extends React.Component<Props> {
       query: queryParams,
     };
 
+    // Don't show related issues if key_transaction tag is present as it's not valid for the issues endpoint
+    const conditions = tokenizeSearch(queryParams.query);
+    if (conditions.hasTag('key_transaction')) {
+      return null;
+    }
+
     return (
       <React.Fragment>
         <ControlsWrapper>

--- a/static/app/views/performance/transactionSummary/relatedIssues.tsx
+++ b/static/app/views/performance/transactionSummary/relatedIssues.tsx
@@ -103,11 +103,10 @@ class RelatedIssues extends React.Component<Props> {
       query: queryParams,
     };
 
-    // Don't show related issues if key_transaction tag is present as it's not valid for the issues endpoint
+    // Filter out key_transaction from being passed to issues as it will cause an error.
     const conditions = tokenizeSearch(queryParams.query);
-    if (conditions.hasTag('key_transaction')) {
-      return null;
-    }
+    conditions.removeTag('key_transaction');
+    queryParams.query = stringifyQueryObject(conditions);
 
     return (
       <React.Fragment>


### PR DESCRIPTION
### Summary
Passing key_transactions to the issues endpoint doesn't work and currently causes an error, so this PR will hide the issues components when that tag is present as a workaround.

Refs VIS-716