### PR TITLE
feat(api): Add API to track metrics for on-prem installs

### DIFF
--- a/src/sentry/api/endpoints/internal_beacon.py
+++ b/src/sentry/api/endpoints/internal_beacon.py
@@ -20,11 +20,11 @@ class InternalBeaconEndpoint(Endpoint):
 
         if not settings.SENTRY_BEACON:
             logger.info("beacon.skipped", extra={"install_id": install_id, "reason": "disabled"})
-            return
+            return Response(status=204)
 
         if settings.DEBUG:
             logger.info("beacon.skipped", extra={"install_id": install_id, "reason": "debug"})
-            return
+            return Response(status=204)
 
         anonymous = options.get("beacon.anonymous") is not False
 

--- a/src/sentry/api/endpoints/internal_beacon.py
+++ b/src/sentry/api/endpoints/internal_beacon.py
@@ -1,0 +1,55 @@
+import logging
+
+from django.conf import settings
+from rest_framework.response import Response
+
+from sentry import get_version, is_docker, options
+from sentry.api.base import Endpoint
+from sentry.http import safe_urlopen, safe_urlread
+from sentry.tasks.beacon import BEACON_URL, create_broadcasts
+from sentry.utils import json
+
+logger = logging.getLogger("beacon")
+
+
+class InternalBeaconEndpoint(Endpoint):
+    permission_classes = ()
+
+    def post(self, request):
+        install_id = options.get("sentry:install-id")
+
+        if not settings.SENTRY_BEACON:
+            logger.info("beacon.skipped", extra={"install_id": install_id, "reason": "disabled"})
+            return
+
+        if settings.DEBUG:
+            logger.info("beacon.skipped", extra={"install_id": install_id, "reason": "debug"})
+            return
+
+        anonymous = options.get("beacon.anonymous") is not False
+
+        payload = {
+            "type": "metric",
+            "install_id": install_id,
+            "version": get_version(),
+            "docker": is_docker(),
+            "data": request.data.get("data"),
+            "anonymous": anonymous,
+        }
+
+        if not anonymous:
+            payload["admin_email"] = options.get("system.admin-email")
+
+        try:
+            beacon_request = safe_urlopen(BEACON_URL, json=payload, timeout=5)
+            response = safe_urlread(beacon_request)
+        except Exception:
+            logger.warning("beacon.failed", exc_info=True, extra={"install_id": install_id})
+            return Response({"error": "Request failed"}, status=500)
+
+        data = json.loads(response)
+
+        if "notices" in data:
+            create_broadcasts(data["notices"])
+
+        return Response(status=204)

--- a/src/sentry/api/endpoints/internal_beacon.py
+++ b/src/sentry/api/endpoints/internal_beacon.py
@@ -5,9 +5,8 @@ from rest_framework.response import Response
 
 from sentry import get_version, is_docker, options
 from sentry.api.base import Endpoint
-from sentry.http import safe_urlopen, safe_urlread
-from sentry.tasks.beacon import BEACON_URL, create_broadcasts
-from sentry.utils import json
+from sentry.http import safe_urlopen
+from sentry.tasks.beacon import BEACON_URL
 
 logger = logging.getLogger("beacon")
 
@@ -16,6 +15,7 @@ class InternalBeaconEndpoint(Endpoint):
     permission_classes = ()
 
     def post(self, request):
+        error = None
         install_id = options.get("sentry:install-id")
 
         if not settings.SENTRY_BEACON:
@@ -37,23 +37,24 @@ class InternalBeaconEndpoint(Endpoint):
             "install_id": install_id,
             "version": get_version(),
             "docker": is_docker(),
-            "data": request.data.get("data"),
             "anonymous": anonymous,
         }
 
         if not anonymous:
             payload["admin_email"] = options.get("system.admin-email")
 
-        try:
-            beacon_request = safe_urlopen(BEACON_URL, json=payload, timeout=5)
-            response = safe_urlread(beacon_request)
-        except Exception:
-            logger.warning("beacon_metric.failed", exc_info=True, extra={"install_id": install_id})
-            return Response({"error": "Request failed"}, status=500)
+        # Because this is used by the frontend, we want our frontend calls to be batched
+        # in order to reduce the number requests
+        data = request.data.get("data")
+        payload_data = [data] if data is not None else request.data.get("batch_data", [])
 
-        data = json.loads(response)
+        for payload_data_item in payload_data:
+            try:
+                safe_urlopen(BEACON_URL, json={**payload, "data": payload_data_item}, timeout=5)
+            except Exception:
+                logger.warning(
+                    "beacon_metric.failed", exc_info=True, extra={"install_id": install_id}
+                )
+                error = "Request failed"
 
-        if "notices" in data:
-            create_broadcasts(data["notices"])
-
-        return Response(status=204)
+        return Response({"error": "Request failed"}, status=500) if error else Response(status=204)

--- a/src/sentry/api/endpoints/internal_beacon.py
+++ b/src/sentry/api/endpoints/internal_beacon.py
@@ -30,22 +30,15 @@ class InternalBeaconEndpoint(Endpoint):
             )
             return Response(status=204)
 
-        anonymous = options.get("beacon.anonymous") is not False
-
         payload = {
             "type": "metric",
             "install_id": install_id,
             "version": get_version(),
-            "anonymous": anonymous,
         }
 
-        if not anonymous:
-            payload["admin_email"] = options.get("system.admin-email")
-
-        # Because this is used by the frontend, we want our frontend calls to be batched
-        # in order to reduce the number requests
-        data = request.data.get("data")
-        payload_data = [data] if data is not None else request.data.get("batch_data", [])
+        # Because this is used by the frontend, we want our frontend calls to
+        # be batched in order to reduce the number requests
+        payload_data = request.data.get("batch_data", [])
 
         for payload_data_item in payload_data:
             try:

--- a/src/sentry/api/endpoints/internal_beacon.py
+++ b/src/sentry/api/endpoints/internal_beacon.py
@@ -3,7 +3,7 @@ import logging
 from django.conf import settings
 from rest_framework.response import Response
 
-from sentry import get_version, is_docker, options
+from sentry import options
 from sentry.api.base import Endpoint
 from sentry.http import safe_urlopen
 from sentry.tasks.beacon import BEACON_URL
@@ -35,8 +35,6 @@ class InternalBeaconEndpoint(Endpoint):
         payload = {
             "type": "metric",
             "install_id": install_id,
-            "version": get_version(),
-            "docker": is_docker(),
             "anonymous": anonymous,
         }
 

--- a/src/sentry/api/endpoints/internal_beacon.py
+++ b/src/sentry/api/endpoints/internal_beacon.py
@@ -19,11 +19,15 @@ class InternalBeaconEndpoint(Endpoint):
         install_id = options.get("sentry:install-id")
 
         if not settings.SENTRY_BEACON:
-            logger.info("beacon.skipped", extra={"install_id": install_id, "reason": "disabled"})
+            logger.info(
+                "beacon_metric.skipped", extra={"install_id": install_id, "reason": "disabled"}
+            )
             return Response(status=204)
 
         if settings.DEBUG:
-            logger.info("beacon.skipped", extra={"install_id": install_id, "reason": "debug"})
+            logger.info(
+                "beacon_metric.skipped", extra={"install_id": install_id, "reason": "debug"}
+            )
             return Response(status=204)
 
         anonymous = options.get("beacon.anonymous") is not False
@@ -44,7 +48,7 @@ class InternalBeaconEndpoint(Endpoint):
             beacon_request = safe_urlopen(BEACON_URL, json=payload, timeout=5)
             response = safe_urlread(beacon_request)
         except Exception:
-            logger.warning("beacon.failed", exc_info=True, extra={"install_id": install_id})
+            logger.warning("beacon_metric.failed", exc_info=True, extra={"install_id": install_id})
             return Response({"error": "Request failed"}, status=500)
 
         data = json.loads(response)

--- a/src/sentry/api/endpoints/internal_beacon.py
+++ b/src/sentry/api/endpoints/internal_beacon.py
@@ -1,5 +1,6 @@
 import logging
 
+from rest_framework import serializers, status
 from rest_framework.response import Response
 
 from sentry.api.base import Endpoint
@@ -7,11 +8,42 @@ from sentry.tasks.beacon import send_beacon_metric
 
 logger = logging.getLogger("beacon")
 
+# These is an arbitrarily picked limit for both the # of batched metrics supported,
+# as well as the size of the dict for each metric
+MAX_LENGTH = 20
+
+
+class MetricsSerializer(serializers.Serializer):
+    batch_data = serializers.ListField(
+        child=serializers.DictField(
+            # This is intentionally a bit restrictive to limit the size of payloads (and abuse)
+            # These metrics should not be sending complex payloads anyway
+            child=serializers.CharField(max_length=255),
+            allow_empty=False,
+        ),
+        max_length=MAX_LENGTH,
+    )
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+
+        for metric in attrs.get("batch_data"):
+            if len(metric) > MAX_LENGTH:
+                raise serializers.ValidationError(
+                    {"batch_data": f"Dict size must be less than {MAX_LENGTH}"}
+                )
+        return attrs
+
 
 class InternalBeaconEndpoint(Endpoint):
     permission_classes = ()
 
     def post(self, request):
+        serializer = MetricsSerializer(data=request.data)
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
         # Because this is used by the frontend, we want our frontend calls to
         # be batched in order to reduce the number requests.
         send_beacon_metric.delay(metrics=request.data.get("batch_data", []))

--- a/src/sentry/api/endpoints/internal_beacon.py
+++ b/src/sentry/api/endpoints/internal_beacon.py
@@ -3,7 +3,7 @@ import logging
 from django.conf import settings
 from rest_framework.response import Response
 
-from sentry import options
+from sentry import get_version, options
 from sentry.api.base import Endpoint
 from sentry.http import safe_urlopen
 from sentry.tasks.beacon import BEACON_URL
@@ -35,6 +35,7 @@ class InternalBeaconEndpoint(Endpoint):
         payload = {
             "type": "metric",
             "install_id": install_id,
+            "version": get_version(),
             "anonymous": anonymous,
         }
 

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -108,6 +108,7 @@ from .endpoints.group_tombstone_details import GroupTombstoneDetailsEndpoint
 from .endpoints.group_user_reports import GroupUserReportsEndpoint
 from .endpoints.grouping_configs import GroupingConfigsEndpoint
 from .endpoints.index import IndexEndpoint
+from .endpoints.internal_beacon import InternalBeaconEndpoint
 from .endpoints.internal_environment import InternalEnvironmentEndpoint
 from .endpoints.internal_mail import InternalMailEndpoint
 from .endpoints.internal_packages import InternalPackagesEndpoint
@@ -1906,6 +1907,11 @@ urlpatterns = [
                     r"^options/$",
                     SystemOptionsEndpoint.as_view(),
                     name="sentry-api-0-system-options",
+                ),
+                url(
+                    r"^beacon/$",
+                    InternalBeaconEndpoint.as_view(),
+                    name="sentry-api-0-internal-beacon",
                 ),
                 url(r"^quotas/$", InternalQuotasEndpoint.as_view()),
                 url(r"^queue/tasks/$", InternalQueueTasksEndpoint.as_view()),

--- a/src/sentry/tasks/beacon.py
+++ b/src/sentry/tasks/beacon.py
@@ -27,7 +27,7 @@ def send_beacon():
     See the documentation for more details.
     """
     from sentry import options
-    from sentry.models import Broadcast, Organization, Project, Team, User
+    from sentry.models import Organization, Project, Team, User
 
     install_id = options.get("sentry:install-id")
     if not install_id:
@@ -87,23 +87,29 @@ def send_beacon():
         options.set("sentry:latest_version", data["version"]["stable"])
 
     if "notices" in data:
-        upstream_ids = set()
-        for notice in data["notices"]:
-            upstream_ids.add(notice["id"])
-            defaults = {
-                "title": notice["title"],
-                "link": notice.get("link"),
-                "message": notice["message"],
-            }
-            # XXX(dcramer): we're missing a unique constraint on upstream_id
-            # so we're using a lock to work around that. In the future we'd like
-            # to have a data migration to clean up the duplicates and add the constraint
-            lock = locks.get("broadcasts:{}".format(notice["id"]), duration=60)
-            with lock.acquire():
-                affected = Broadcast.objects.filter(upstream_id=notice["id"]).update(**defaults)
-                if not affected:
-                    Broadcast.objects.create(upstream_id=notice["id"], **defaults)
+        create_broadcasts(data["notices"])
 
-        Broadcast.objects.filter(upstream_id__isnull=False).exclude(
-            upstream_id__in=upstream_ids
-        ).update(is_active=False)
+
+def create_broadcasts(notices):
+    from sentry.models import Broadcast
+
+    upstream_ids = set()
+    for notice in notices:
+        upstream_ids.add(notice["id"])
+        defaults = {
+            "title": notice["title"],
+            "link": notice.get("link"),
+            "message": notice["message"],
+        }
+        # XXX(dcramer): we're missing a unique constraint on upstream_id
+        # so we're using a lock to work around that. In the future we'd like
+        # to have a data migration to clean up the duplicates and add the constraint
+        lock = locks.get("broadcasts:{}".format(notice["id"]), duration=60)
+        with lock.acquire():
+            affected = Broadcast.objects.filter(upstream_id=notice["id"]).update(**defaults)
+            if not affected:
+                Broadcast.objects.create(upstream_id=notice["id"], **defaults)
+
+    Broadcast.objects.filter(upstream_id__isnull=False).exclude(
+        upstream_id__in=upstream_ids
+    ).update(is_active=False)

--- a/tests/sentry/api/endpoints/test_internal_beacon.py
+++ b/tests/sentry/api/endpoints/test_internal_beacon.py
@@ -4,22 +4,19 @@ import sentry
 from sentry import options
 from sentry.tasks.beacon import BEACON_URL
 from sentry.testutils import APITestCase
-from sentry.utils import json
 from sentry.utils.compat.mock import patch
 
 
 class InternalBeaconTest(APITestCase):
     @patch("sentry.api.endpoints.internal_beacon.safe_urlopen")
-    @patch("sentry.api.endpoints.internal_beacon.safe_urlread")
     @responses.activate
-    def test_simple(self, safe_urlread, safe_urlopen):
+    def test_simple(self, safe_urlopen):
         self.login_as(self.user, superuser=False)
         url = "/api/0/internal/beacon/"
 
         install_id = options.get("sentry:install-id")
         assert options.set("system.admin-email", "foo@example.com")
         assert options.set("beacon.anonymous", False)
-        safe_urlread.return_value = json.dumps({"notices": []})
 
         response = self.client.post(
             url,
@@ -46,6 +43,66 @@ class InternalBeaconTest(APITestCase):
             },
             timeout=5,
         )
-        safe_urlread.assert_called_once_with(safe_urlopen.return_value)
 
+        assert response.status_code == 204
+
+    @patch("sentry.api.endpoints.internal_beacon.safe_urlopen")
+    @responses.activate
+    def test_batch(self, safe_urlopen):
+        self.login_as(self.user, superuser=False)
+        url = "/api/0/internal/beacon/"
+
+        install_id = options.get("sentry:install-id")
+        assert options.set("system.admin-email", "foo@example.com")
+        assert options.set("beacon.anonymous", False)
+
+        response = self.client.post(
+            url,
+            data={
+                "batch_data": [
+                    {
+                        "description": "SentryApp",
+                        "component": "Foo",
+                    },
+                    {
+                        "description": "SentryApp",
+                        "component": "Bar",
+                    },
+                ]
+            },
+        )
+        safe_urlopen.assert_any_call(
+            BEACON_URL,
+            json={
+                "type": "metric",
+                "install_id": install_id,
+                "version": sentry.get_version(),
+                "docker": sentry.is_docker(),
+                "data": {
+                    "description": "SentryApp",
+                    "component": "Foo",
+                },
+                "anonymous": False,
+                "admin_email": "foo@example.com",
+            },
+            timeout=5,
+        )
+        safe_urlopen.assert_any_call(
+            BEACON_URL,
+            json={
+                "type": "metric",
+                "install_id": install_id,
+                "version": sentry.get_version(),
+                "docker": sentry.is_docker(),
+                "data": {
+                    "description": "SentryApp",
+                    "component": "Bar",
+                },
+                "anonymous": False,
+                "admin_email": "foo@example.com",
+            },
+            timeout=5,
+        )
+
+        assert safe_urlopen.call_count == 2
         assert response.status_code == 204

--- a/tests/sentry/api/endpoints/test_internal_beacon.py
+++ b/tests/sentry/api/endpoints/test_internal_beacon.py
@@ -3,7 +3,7 @@ from sentry.utils.compat.mock import patch
 
 
 class InternalBeaconTest(APITestCase):
-    @patch("sentry.tasks.beacon.send_beacon_metric")
+    @patch("sentry.tasks.beacon.send_beacon_metric.delay")
     def test_simple(self, mock_send_beacon_metric):
         self.login_as(self.user, superuser=False)
         url = "/api/0/internal/beacon/"
@@ -24,7 +24,7 @@ class InternalBeaconTest(APITestCase):
             },
         )
 
-        mock_send_beacon_metric.delay.assert_called_once_with(
+        mock_send_beacon_metric.assert_called_once_with(
             metrics=[
                 {
                     "description": "SentryApp",

--- a/tests/sentry/api/endpoints/test_internal_beacon.py
+++ b/tests/sentry/api/endpoints/test_internal_beacon.py
@@ -1,5 +1,6 @@
 import responses
 
+import sentry
 from sentry import options
 from sentry.tasks.beacon import BEACON_URL
 from sentry.testutils import APITestCase
@@ -31,6 +32,7 @@ class InternalBeaconTest(APITestCase):
             json={
                 "type": "metric",
                 "install_id": install_id,
+                "version": sentry.get_version(),
                 "data": {
                     "description": "SentryApp",
                     "component": "Form",
@@ -73,6 +75,7 @@ class InternalBeaconTest(APITestCase):
             json={
                 "type": "metric",
                 "install_id": install_id,
+                "version": sentry.get_version(),
                 "data": {
                     "description": "SentryApp",
                     "component": "Foo",
@@ -87,6 +90,7 @@ class InternalBeaconTest(APITestCase):
             json={
                 "type": "metric",
                 "install_id": install_id,
+                "version": sentry.get_version(),
                 "data": {
                     "description": "SentryApp",
                     "component": "Bar",

--- a/tests/sentry/api/endpoints/test_internal_beacon.py
+++ b/tests/sentry/api/endpoints/test_internal_beacon.py
@@ -1,0 +1,51 @@
+import responses
+
+import sentry
+from sentry import options
+from sentry.tasks.beacon import BEACON_URL
+from sentry.testutils import APITestCase
+from sentry.utils import json
+from sentry.utils.compat.mock import patch
+
+
+class InternalBeaconTest(APITestCase):
+    @patch("sentry.api.endpoints.internal_beacon.safe_urlopen")
+    @patch("sentry.api.endpoints.internal_beacon.safe_urlread")
+    @responses.activate
+    def test_simple(self, safe_urlread, safe_urlopen):
+        self.login_as(self.user, superuser=False)
+        url = "/api/0/internal/beacon/"
+
+        install_id = options.get("sentry:install-id")
+        assert options.set("system.admin-email", "foo@example.com")
+        assert options.set("beacon.anonymous", False)
+        safe_urlread.return_value = json.dumps({"notices": []})
+
+        response = self.client.post(
+            url,
+            data={
+                "data": {
+                    "description": "SentryApp",
+                    "component": "Form",
+                },
+            },
+        )
+        safe_urlopen.assert_called_once_with(
+            BEACON_URL,
+            json={
+                "type": "metric",
+                "install_id": install_id,
+                "version": sentry.get_version(),
+                "docker": sentry.is_docker(),
+                "data": {
+                    "description": "SentryApp",
+                    "component": "Form",
+                },
+                "anonymous": False,
+                "admin_email": "foo@example.com",
+            },
+            timeout=5,
+        )
+        safe_urlread.assert_called_once_with(safe_urlopen.return_value)
+
+        assert response.status_code == 204

--- a/tests/sentry/api/endpoints/test_internal_beacon.py
+++ b/tests/sentry/api/endpoints/test_internal_beacon.py
@@ -1,22 +1,15 @@
 import responses
 
-import sentry
-from sentry import options
-from sentry.tasks.beacon import BEACON_URL
 from sentry.testutils import APITestCase
 from sentry.utils.compat.mock import patch
 
 
 class InternalBeaconTest(APITestCase):
-    @patch("sentry.api.endpoints.internal_beacon.safe_urlopen")
+    @patch("sentry.tasks.beacon.send_beacon_metric")
     @responses.activate
-    def test_simple(self, safe_urlopen):
+    def test_simple(self, mock_send_beacon_metric):
         self.login_as(self.user, superuser=False)
         url = "/api/0/internal/beacon/"
-
-        install_id = options.get("sentry:install-id")
-        assert options.set("system.admin-email", "foo@example.com")
-        assert options.set("beacon.anonymous", False)
 
         response = self.client.post(
             url,
@@ -33,32 +26,18 @@ class InternalBeaconTest(APITestCase):
                 ]
             },
         )
-        safe_urlopen.assert_any_call(
-            BEACON_URL,
-            json={
-                "type": "metric",
-                "install_id": install_id,
-                "version": sentry.get_version(),
-                "data": {
+
+        mock_send_beacon_metric.delay.assert_called_once_with(
+            metrics=[
+                {
                     "description": "SentryApp",
                     "component": "Foo",
                 },
-            },
-            timeout=5,
-        )
-        safe_urlopen.assert_any_call(
-            BEACON_URL,
-            json={
-                "type": "metric",
-                "install_id": install_id,
-                "version": sentry.get_version(),
-                "data": {
+                {
                     "description": "SentryApp",
                     "component": "Bar",
                 },
-            },
-            timeout=5,
+            ]
         )
 
-        assert safe_urlopen.call_count == 2
         assert response.status_code == 204

--- a/tests/sentry/api/endpoints/test_internal_beacon.py
+++ b/tests/sentry/api/endpoints/test_internal_beacon.py
@@ -21,43 +21,6 @@ class InternalBeaconTest(APITestCase):
         response = self.client.post(
             url,
             data={
-                "data": {
-                    "description": "SentryApp",
-                    "component": "Form",
-                },
-            },
-        )
-        safe_urlopen.assert_called_once_with(
-            BEACON_URL,
-            json={
-                "type": "metric",
-                "install_id": install_id,
-                "version": sentry.get_version(),
-                "data": {
-                    "description": "SentryApp",
-                    "component": "Form",
-                },
-                "anonymous": False,
-                "admin_email": "foo@example.com",
-            },
-            timeout=5,
-        )
-
-        assert response.status_code == 204
-
-    @patch("sentry.api.endpoints.internal_beacon.safe_urlopen")
-    @responses.activate
-    def test_batch(self, safe_urlopen):
-        self.login_as(self.user, superuser=False)
-        url = "/api/0/internal/beacon/"
-
-        install_id = options.get("sentry:install-id")
-        assert options.set("system.admin-email", "foo@example.com")
-        assert options.set("beacon.anonymous", False)
-
-        response = self.client.post(
-            url,
-            data={
                 "batch_data": [
                     {
                         "description": "SentryApp",
@@ -80,8 +43,6 @@ class InternalBeaconTest(APITestCase):
                     "description": "SentryApp",
                     "component": "Foo",
                 },
-                "anonymous": False,
-                "admin_email": "foo@example.com",
             },
             timeout=5,
         )
@@ -95,8 +56,6 @@ class InternalBeaconTest(APITestCase):
                     "description": "SentryApp",
                     "component": "Bar",
                 },
-                "anonymous": False,
-                "admin_email": "foo@example.com",
             },
             timeout=5,
         )

--- a/tests/sentry/api/endpoints/test_internal_beacon.py
+++ b/tests/sentry/api/endpoints/test_internal_beacon.py
@@ -1,12 +1,9 @@
-import responses
-
 from sentry.testutils import APITestCase
 from sentry.utils.compat.mock import patch
 
 
 class InternalBeaconTest(APITestCase):
     @patch("sentry.tasks.beacon.send_beacon_metric")
-    @responses.activate
     def test_simple(self, mock_send_beacon_metric):
         self.login_as(self.user, superuser=False)
         url = "/api/0/internal/beacon/"

--- a/tests/sentry/api/endpoints/test_internal_beacon.py
+++ b/tests/sentry/api/endpoints/test_internal_beacon.py
@@ -1,6 +1,5 @@
 import responses
 
-import sentry
 from sentry import options
 from sentry.tasks.beacon import BEACON_URL
 from sentry.testutils import APITestCase
@@ -32,8 +31,6 @@ class InternalBeaconTest(APITestCase):
             json={
                 "type": "metric",
                 "install_id": install_id,
-                "version": sentry.get_version(),
-                "docker": sentry.is_docker(),
                 "data": {
                     "description": "SentryApp",
                     "component": "Form",
@@ -76,8 +73,6 @@ class InternalBeaconTest(APITestCase):
             json={
                 "type": "metric",
                 "install_id": install_id,
-                "version": sentry.get_version(),
-                "docker": sentry.is_docker(),
                 "data": {
                     "description": "SentryApp",
                     "component": "Foo",
@@ -92,8 +87,6 @@ class InternalBeaconTest(APITestCase):
             json={
                 "type": "metric",
                 "install_id": install_id,
-                "version": sentry.get_version(),
-                "docker": sentry.is_docker(),
                 "data": {
                     "description": "SentryApp",
                     "component": "Bar",


### PR DESCRIPTION
We currently have a "beacon" option that on-premise users can set that allows their Sentry install to ping our SaaS. This piggybacks off the beacon option and adds an API endpoint to allow the frontend to track metrics back to our SaaS beacon endpoint.

We will use this to figure out the number of installs that are using APIs that we would like to deprecate. See https://github.com/getsentry/sentry/pull/25744 for a discussion around this.