### PR TITLE
ref: Refactor transaction post process, pt.2

### DIFF
--- a/src/sentry/receivers/features.py
+++ b/src/sentry/receivers/features.py
@@ -38,6 +38,7 @@ from sentry.signals import (
     save_search_created,
     sso_enabled,
     team_created,
+    transaction_processed,
     user_feedback_received,
 )
 from sentry.utils import metrics
@@ -86,7 +87,6 @@ def record_first_event(project, **kwargs):
     )
 
 
-@event_processed.connect(weak=False)
 def record_event_processed(project, event, **kwargs):
     feature_slugs = []
 
@@ -130,6 +130,10 @@ def record_event_processed(project, event, **kwargs):
         return
 
     FeatureAdoption.objects.bulk_record(project.organization_id, feature_slugs)
+
+
+event_processed.connect(record_event_processed, weak=False)
+transaction_processed.connect(record_event_processed, weak=False)
 
 
 @user_feedback_received.connect(weak=False)

--- a/src/sentry/receivers/transactions.py
+++ b/src/sentry/receivers/transactions.py
@@ -2,12 +2,12 @@ from django.db.models import F
 
 from sentry import analytics
 from sentry.models import Project
-from sentry.signals import event_processed
+from sentry.signals import transaction_processed
 
 
-@event_processed.connect(weak=False)
+@transaction_processed.connect(weak=False)
 def record_first_transaction(project, event, **kwargs):
-    if event.get_event_type() == "transaction" and not project.flags.has_transactions:
+    if not project.flags.has_transactions:
         project.update(flags=F("flags").bitor(Project.flags.has_transactions))
 
         try:

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -53,7 +53,7 @@ buffer_incr_complete = BetterSignal(providing_args=["model", "columns", "extra",
 pending_delete = BetterSignal(providing_args=["instance", "actor"])
 event_processed = BetterSignal(providing_args=["project", "event"])
 
-# This singal should eventually be removed as we should not send
+# This signal should eventually be removed as we should not send
 # transactions through post processing
 transaction_processed = BetterSignal(providing_args=["project", "event"])
 

--- a/src/sentry/signals.py
+++ b/src/sentry/signals.py
@@ -53,6 +53,10 @@ buffer_incr_complete = BetterSignal(providing_args=["model", "columns", "extra",
 pending_delete = BetterSignal(providing_args=["instance", "actor"])
 event_processed = BetterSignal(providing_args=["project", "event"])
 
+# This singal should eventually be removed as we should not send
+# transactions through post processing
+transaction_processed = BetterSignal(providing_args=["project", "event"])
+
 # DEPRECATED
 event_received = BetterSignal(providing_args=["ip", "project"])
 event_accepted = BetterSignal(providing_args=["ip", "data", "project"])

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -3,7 +3,7 @@ import logging
 from sentry import analytics, features
 from sentry.app import locks
 from sentry.exceptions import PluginError
-from sentry.signals import event_processed, issue_unignored
+from sentry.signals import event_processed, issue_unignored, transaction_processed
 from sentry.tasks.base import instrumented_task
 from sentry.utils import metrics
 from sentry.utils.cache import cache
@@ -223,7 +223,7 @@ def post_process_group(
         # This should eventually be completely removed and transactions
         # will not go through any post processing.
         if is_transaction_event:
-            event_processed.send_robust(
+            transaction_processed.send_robust(
                 sender=post_process_group,
                 project=event.project,
                 event=event,

--- a/tests/sentry/receivers/test_transactions.py
+++ b/tests/sentry/receivers/test_transactions.py
@@ -1,7 +1,7 @@
 from exam import fixture
 
 from sentry.models import OrganizationMember, Project
-from sentry.signals import event_processed
+from sentry.signals import event_processed, transaction_processed
 from sentry.testutils import TestCase
 from sentry.testutils.helpers.datetime import before_now, iso_format
 from sentry.utils.compat.mock import patch
@@ -24,7 +24,7 @@ class RecordFirstTransactionTest(TestCase):
             project_id=self.project.id,
         )
 
-        event_processed.send(project=self.project, event=event, sender=type(self.project))
+        transaction_processed.send(project=self.project, event=event, sender=type(self.project))
         project = Project.objects.get(id=self.project.id)
         assert project.flags.has_transactions
 
@@ -43,7 +43,7 @@ class RecordFirstTransactionTest(TestCase):
             project_id=self.project.id,
         )
 
-        event_processed.send(project=self.project, event=event, sender=type(self.project))
+        transaction_processed.send(project=self.project, event=event, sender=type(self.project))
         project = Project.objects.get(id=self.project.id)
         assert project.flags.has_transactions
 
@@ -70,7 +70,7 @@ class RecordFirstTransactionTest(TestCase):
             project_id=self.project.id,
         )
 
-        event_processed.send(project=self.project, event=event, sender=type(self.project))
+        transaction_processed.send(project=self.project, event=event, sender=type(self.project))
         assert self.project.flags.has_transactions
         mock_record.assert_called_with(
             "first_transaction.sent",
@@ -93,5 +93,5 @@ class RecordFirstTransactionTest(TestCase):
             project_id=self.project.id,
         )
 
-        event_processed.send(project=self.project, event=event, sender=type(self.project))
+        transaction_processed.send(project=self.project, event=event, sender=type(self.project))
         assert self.project.flags.has_transactions


### PR DESCRIPTION
One more small step towards the goal of eventually removing
transactions from post processing entirely.

Here we introduce a new (temporary) signal `transaction_processed`
in place of `event_processed` for transactions. Now we no longer call
`record_sourcemaps_received` on transaction events, or `record_first_transaction`
on non-transaction events.