### PR TITLE
ref(integrations): Add spans to externalIssueForm.load

### DIFF
--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -41,7 +41,6 @@ SAMPLED_URL_NAMES = {
     "sentry-extensions-vercel-configure",
     "sentry-extensions-vercel-ui-hook",
     "sentry-api-0-group-integration-details",
-    "integration-details",
     # releases
     "sentry-api-0-organization-releases",
     "sentry-api-0-organization-release-details",

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -41,6 +41,7 @@ SAMPLED_URL_NAMES = {
     "sentry-extensions-vercel-configure",
     "sentry-extensions-vercel-ui-hook",
     "sentry-api-0-group-integration-details",
+    "integration-details",
     # releases
     "sentry-api-0-organization-releases",
     "sentry-api-0-organization-release-details",

--- a/static/app/components/group/externalIssueForm.tsx
+++ b/static/app/components/group/externalIssueForm.tsx
@@ -32,7 +32,7 @@ export default class ExternalIssueForm extends AbstractExternalIssueForm<Props, 
   loadTransaction?: ReturnType<typeof Sentry.startTransaction>;
   submitTransaction?: ReturnType<typeof Sentry.startTransaction>;
 
-  componentDidMount() {
+  componentWillMount() {
     this.loadTransaction = this.startTransaction('load');
   }
 

--- a/static/app/components/group/externalIssueForm.tsx
+++ b/static/app/components/group/externalIssueForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import * as Sentry from '@sentry/react';
 
 import {addSuccessMessage} from 'app/actionCreators/indicator';
@@ -53,6 +52,7 @@ export default class ExternalIssueForm extends AbstractExternalIssueForm<Props, 
     const {group, integration} = this.props;
     const {action} = this.state;
     const transaction = Sentry.startTransaction({name: `externalIssueForm.${type}`});
+    Sentry.getCurrentHub().configureScope(scope => scope.setSpan(transaction));
     transaction.setTag('issueAction', action);
     transaction.setTag('groupID', group.id);
     transaction.setTag('projectID', group.project.id);

--- a/static/app/components/group/externalIssueForm.tsx
+++ b/static/app/components/group/externalIssueForm.tsx
@@ -32,7 +32,8 @@ export default class ExternalIssueForm extends AbstractExternalIssueForm<Props, 
   loadTransaction?: ReturnType<typeof Sentry.startTransaction>;
   submitTransaction?: ReturnType<typeof Sentry.startTransaction>;
 
-  componentWillMount() {
+  constructor(props) {
+    super(props, {});
     this.loadTransaction = this.startTransaction('load');
   }
 


### PR DESCRIPTION
We want to reduce the amount of time spent on external issue form loading, and to do that we need to understand exactly what is taking so long. 

We had instrumented the `externalIssueForm` with `load` and `submit` (seen [here](https://sentry.io/organizations/sentry/discover/results/?field=title&field=transaction.duration&id=6777&name=External+Issue+Form+Load&query=title%3AexternalIssueForm.load&sort=-title&statsPeriod=90d&widths=-1&widths=-1)) but when you click on an individual transaction, you just get one "default" span with no granular information:

<img width="843" alt="Screen Shot 2021-05-05 at 6 45 31 PM" src="https://user-images.githubusercontent.com/29959063/117230500-13b07180-add2-11eb-805b-547ca3015e7c.png">

The transaction wasn't actually _in_ the hub, so this change gives us the waterfall effect we were looking for.
<img width="842" alt="Screen Shot 2021-05-05 at 6 44 41 PM" src="https://user-images.githubusercontent.com/29959063/117230441-f5e30c80-add1-11eb-8edc-cd7e35331fc0.png">
