### PR TITLE
fix(trace-view): Send connected_services via amplitude

### DIFF
--- a/src/sentry/api/endpoints/organization_events_trace.py
+++ b/src/sentry/api/endpoints/organization_events_trace.py
@@ -23,7 +23,7 @@ from rest_framework.exceptions import ParseError
 from rest_framework.response import Response
 from sentry_relay.consts import SPAN_STATUS_CODE_TO_NAME
 
-from sentry import analytics, eventstore, features
+from sentry import eventstore, features
 from sentry.api.bases import NoProjects, OrganizationEventsV2EndpointBase
 from sentry.api.serializers.models.event import get_tags_with_meta
 from sentry.eventstore.models import Event
@@ -352,13 +352,6 @@ class OrganizationEventsTraceEndpointBase(OrganizationEventsV2EndpointBase):  # 
                 projects.add(transaction["project.id"])
 
             len_projects = len(projects)
-            if len_projects > 1:
-                analytics.record(
-                    "quick_trace.connected_services",
-                    trace_id=trace_id,
-                    projects=len_projects,
-                    organization_id=org_id,
-                )
             sentry_sdk.set_tag("trace_view.projects", len_projects)
             sentry_sdk.set_tag("trace_view.projects.grouped", group_length(len_projects))
 

--- a/static/app/components/quickTrace/index.tsx
+++ b/static/app/components/quickTrace/index.tsx
@@ -78,7 +78,7 @@ export default function QuickTrace({
 }: QuickTraceProps) {
   let parsedQuickTrace;
   try {
-    parsedQuickTrace = parseQuickTrace(quickTrace, event);
+    parsedQuickTrace = parseQuickTrace(quickTrace, event, organization);
   } catch (error) {
     return <React.Fragment>{'\u2014'}</React.Fragment>;
   }

--- a/static/app/utils/performance/quickTrace/utils.tsx
+++ b/static/app/utils/performance/quickTrace/utils.tsx
@@ -4,7 +4,9 @@ import moment from 'moment-timezone';
 import {Client} from 'app/api';
 import {getTraceDateTimeRange} from 'app/components/events/interfaces/spans/utils';
 import {ALL_ACCESS_PROJECTS} from 'app/constants/globalSelectionHeader';
+import {OrganizationSummary} from 'app/types';
 import {Event, EventTransaction} from 'app/types/event';
+import {trackAnalyticsEvent} from 'app/utils/analytics';
 import EventView from 'app/utils/discover/eventView';
 import {DiscoverQueryProps} from 'app/utils/discover/genericDiscoverQuery';
 import {
@@ -132,7 +134,8 @@ type ParsedQuickTrace = {
 
 export function parseQuickTrace(
   quickTrace: QuickTrace,
-  event: Event
+  event: Event,
+  organization: OrganizationSummary
 ): ParsedQuickTrace | null {
   const {type, trace} = quickTrace;
 
@@ -195,8 +198,10 @@ export function parseQuickTrace(
   const ancestors: TraceLite | null = isFullTrace ? [] : null;
   const children: TraceLite = [];
   const descendants: TraceLite | null = isFullTrace ? [] : null;
+  const projects = new Set();
 
   trace.forEach(e => {
+    projects.add(e.project_id);
     if (isChildren(e)) {
       children.push(e);
     } else if (isFullTrace) {
@@ -207,6 +212,10 @@ export function parseQuickTrace(
       }
     }
   });
+
+  if (isFullTrace && projects.size > 1) {
+    handleProjectMeta(organization, projects.size);
+  }
 
   return {
     root,
@@ -305,4 +314,13 @@ export function isTraceFull(transaction): transaction is TraceFull {
 
 export function isTraceFullDetailed(transaction): transaction is TraceFullDetailed {
   return Boolean((transaction as TraceFullDetailed).event_id);
+}
+
+function handleProjectMeta(organization: OrganizationSummary, projects: number) {
+  trackAnalyticsEvent({
+    eventKey: 'quick_trace.connected_services',
+    eventName: 'Quick Trace: Connected Services',
+    organization_id: parseInt(organization.id, 10),
+    projects,
+  });
 }

--- a/tests/js/spec/utils/performance/quickTrace/utils.spec.tsx
+++ b/tests/js/spec/utils/performance/quickTrace/utils.spec.tsx
@@ -170,11 +170,12 @@ describe('Quick Trace Utils', function () {
   });
 
   describe('parseQuickTrace', function () {
+    const organization = TestStubs.Organization();
     it('parses empty trace', function () {
       const current = generateEventSelector({generation: 0, offset: 0}, 'transaction');
-      expect(() => parseQuickTrace({type: 'empty', trace: []}, current)).toThrow(
-        'Current event not in quick trace'
-      );
+      expect(() =>
+        parseQuickTrace({type: 'empty', trace: []}, current, organization)
+      ).toThrow('Current event not in quick trace');
     });
 
     describe('partial trace', function () {
@@ -182,7 +183,7 @@ describe('Quick Trace Utils', function () {
         const relevantPath = [generateTransactionLite({generation: 0, offset: 0})];
         const current = generateEventSelector({generation: 1, offset: 0}, 'transaction');
         expect(() =>
-          parseQuickTrace({type: 'partial', trace: relevantPath}, current)
+          parseQuickTrace({type: 'partial', trace: relevantPath}, current, organization)
         ).toThrow('Current event not in quick trace');
       });
 
@@ -191,7 +192,8 @@ describe('Quick Trace Utils', function () {
         const current = generateEventSelector({generation: 0, offset: 0}, 'transaction');
         const parsedQuickTrace = parseQuickTrace(
           {type: 'partial', trace: relevantPath},
-          current
+          current,
+          organization
         );
         expect(parsedQuickTrace).toEqual({
           root: null,
@@ -211,7 +213,8 @@ describe('Quick Trace Utils', function () {
         const current = generateEventSelector({generation: 1, offset: 0}, 'transaction');
         const parsedQuickTrace = parseQuickTrace(
           {type: 'partial', trace: relevantPath},
-          current
+          current,
+          organization
         );
         expect(parsedQuickTrace).toEqual({
           root: null,
@@ -231,7 +234,8 @@ describe('Quick Trace Utils', function () {
         const current = generateEventSelector({generation: 2, offset: 0}, 'transaction');
         const parsedQuickTrace = parseQuickTrace(
           {type: 'partial', trace: relevantPath},
-          current
+          current,
+          organization
         );
         expect(parsedQuickTrace).toEqual({
           root: generateTransactionLite({generation: 0, offset: 0}),
@@ -252,7 +256,8 @@ describe('Quick Trace Utils', function () {
         const current = generateEventSelector({generation: 0, offset: 0}, 'transaction');
         const parsedQuickTrace = parseQuickTrace(
           {type: 'partial', trace: relevantPath},
-          current
+          current,
+          organization
         );
         expect(parsedQuickTrace).toEqual({
           root: null,
@@ -276,7 +281,8 @@ describe('Quick Trace Utils', function () {
         const current = generateEventSelector({generation: 1, offset: 1}, 'transaction');
         const parsedQuickTrace = parseQuickTrace(
           {type: 'partial', trace: relevantPath},
-          current
+          current,
+          organization
         );
         expect(parsedQuickTrace).toEqual({
           root: null,
@@ -298,7 +304,8 @@ describe('Quick Trace Utils', function () {
         const current = generateEventSelector({generation: 2, offset: 2}, 'transaction');
         const parsedQuickTrace = parseQuickTrace(
           {type: 'partial', trace: relevantPath},
-          current
+          current,
+          organization
         );
         expect(parsedQuickTrace).toEqual({
           root: generateTransactionLite({generation: 0, offset: 0}),
@@ -321,7 +328,8 @@ describe('Quick Trace Utils', function () {
         const relevantPath = flattenRelevantPaths(current, trace);
         const parsedQuickTrace = parseQuickTrace(
           {type: 'full', trace: relevantPath},
-          current
+          current,
+          organization
         );
         expect(parsedQuickTrace).toMatchObject({
           root: generateTransactionLite({generation: 0, offset: 0}),
@@ -347,7 +355,8 @@ describe('Quick Trace Utils', function () {
         const relevantPath = flattenRelevantPaths(current, trace);
         const parsedQuickTrace = parseQuickTrace(
           {type: 'full', trace: relevantPath},
-          current
+          current,
+          organization
         );
         expect(parsedQuickTrace).toMatchObject({
           root: generateTransactionLite({generation: 0, offset: 0}),
@@ -373,7 +382,8 @@ describe('Quick Trace Utils', function () {
         const relevantPath = flattenRelevantPaths(current, trace);
         const parsedQuickTrace = parseQuickTrace(
           {type: 'full', trace: relevantPath},
-          current
+          current,
+          organization
         );
         expect(parsedQuickTrace).toMatchObject({
           root: generateTransactionLite({generation: 0, offset: 0}),
@@ -394,7 +404,8 @@ describe('Quick Trace Utils', function () {
         const relevantPath = flattenRelevantPaths(current, trace);
         const parsedQuickTrace = parseQuickTrace(
           {type: 'full', trace: relevantPath},
-          current
+          current,
+          organization
         );
         expect(parsedQuickTrace).toMatchObject({
           root: generateTransactionLite({generation: 0, offset: 0}),

--- a/tests/js/spec/utils/performance/quickTrace/utils.spec.tsx
+++ b/tests/js/spec/utils/performance/quickTrace/utils.spec.tsx
@@ -170,6 +170,7 @@ describe('Quick Trace Utils', function () {
   });
 
   describe('parseQuickTrace', function () {
+    // @ts-expect-error
     const organization = TestStubs.Organization();
     it('parses empty trace', function () {
       const current = generateEventSelector({generation: 0, offset: 0}, 'transaction');


### PR DESCRIPTION
- backend analytics only send to big query, but we need these analytics
  in amplitude/reload