### PR TITLE
fix(ui): made ignore icon consistent

### DIFF
--- a/static/app/components/actions/ignore.tsx
+++ b/static/app/components/actions/ignore.tsx
@@ -10,7 +10,7 @@ import CustomIgnoreDurationModal from 'app/components/customIgnoreDurationModal'
 import DropdownLink from 'app/components/dropdownLink';
 import Duration from 'app/components/duration';
 import Tooltip from 'app/components/tooltip';
-import {IconChevron, IconMute, IconNot} from 'app/icons';
+import {IconChevron, IconMute} from 'app/icons';
 import {t, tn} from 'app/locale';
 import space from 'app/styles/space';
 import {
@@ -75,7 +75,7 @@ const IgnoreActions = ({
           priority="primary"
           onClick={() => onUpdate({status: ResolutionStatus.UNRESOLVED})}
           label={t('Unignore')}
-          icon={<IconNot size="xs" />}
+          icon={<IconMute size="xs" />}
         />
       </Tooltip>
     );
@@ -123,7 +123,7 @@ const IgnoreActions = ({
           type="button"
           title={t('Ignore')}
           onAction={() => onUpdate({status: ResolutionStatus.IGNORED})}
-          icon={<IconNot size="xs" />}
+          icon={<IconMute size="xs" />}
         >
           {t('Ignore')}
         </ActionLink>


### PR DESCRIPTION
Ignore icon is inconsistent. In some places it's IconNot, other places it's IconMute. So here I’m making it IconMute everywhere for now.


## Before
<img width="370" alt="CleanShot 2021-05-04 at 17 52 27@2x" src="https://user-images.githubusercontent.com/1900676/117086494-84d42400-ad01-11eb-9846-4c9282532b41.png">
<img width="548" alt="CleanShot 2021-05-04 at 17 52 09@2x" src="https://user-images.githubusercontent.com/1900676/117086507-8c93c880-ad01-11eb-88ce-f9475b1ac0f8.png">


## After

<img width="440" alt="CleanShot 2021-05-04 at 17 51 06@2x" src="https://user-images.githubusercontent.com/1900676/117086441-5bb39380-ad01-11eb-839e-d870b4a4ea59.png">
<img width="823" alt="CleanShot 2021-05-04 at 17 49 54@2x" src="https://user-images.githubusercontent.com/1900676/117086449-5eae8400-ad01-11eb-8174-8ec3d2a241c3.png">
<img width="646" alt="CleanShot 2021-05-04 at 17 49 44@2x" src="https://user-images.githubusercontent.com/1900676/117086455-61a97480-ad01-11eb-8ae9-1aea82453fb5.png">




[Jira ticket](https://getsentry.atlassian.net/browse/WOR-872)