### PR TITLE
fix(auth): Single tenant infinite redirects

### DIFF
--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -185,6 +185,7 @@ class AuthLoginView(BaseView):
                 )
             elif login_form.is_valid():
                 user = login_form.get_user()
+
                 auth.login(request, user, organization_id=organization.id if organization else None)
                 metrics.incr(
                     "login.attempt", instance="success", skip_internal=True, sample_rate=1.0

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -185,7 +185,6 @@ class AuthLoginView(BaseView):
                 )
             elif login_form.is_valid():
                 user = login_form.get_user()
-
                 auth.login(request, user, organization_id=organization.id if organization else None)
                 metrics.incr(
                     "login.attempt", instance="success", skip_internal=True, sample_rate=1.0
@@ -198,14 +197,13 @@ class AuthLoginView(BaseView):
                         om = OrganizationMember.objects.get(
                             organization=organization, email=user.email
                         )
+                        # XXX(jferge): if user is removed / invited but has an acct,
+                        # pop _next so they aren't in infinite redirect on Single Org Mode
                     except OrganizationMember.DoesNotExist:
-                        pass
+                        request.session.pop("_next", None)
                     else:
-                        # XXX(jferge): if user is in 2fa removed state,
-                        # dont redirect to org login page instead redirect to general login where
-                        # they will be prompted to check their email
                         if om.user is None:
-                            return self.redirect(auth.get_login_url())
+                            request.session.pop("_next", None)
 
                 return self.redirect(auth.get_login_redirect(request))
             else:

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -6,6 +6,7 @@ from django.utils.http import urlquote
 from exam import fixture
 
 from sentry import newsletter, options
+from sentry.auth.authenticators import RecoveryCodeInterface, TotpInterface
 from sentry.models import OrganizationMember, User
 from sentry.testutils import TestCase
 from sentry.utils.compat import mock
@@ -56,6 +57,22 @@ class AuthLoginTest(TestCase):
         resp = self.client.post(
             self.path, {"username": self.user.username, "password": "admin", "op": "login"}
         )
+        assert resp.url == "/auth/login/"
+        assert resp.status_code == 302
+
+    def test_login_valid_credentials_2fa_redirect(self):
+        user = self.create_user("bar@example.com")
+        RecoveryCodeInterface().enroll(user)
+        TotpInterface().enroll(user)
+        self.create_member(organization=self.organization, user=user)
+
+        self.client.get(self.path)
+
+        resp = self.client.post(
+            self.path,
+            {"username": user.username, "password": "admin", "op": "login"},
+        )
+        assert resp.url == "/auth/2fa/"
         assert resp.status_code == 302
 
     def test_registration_disabled(self):

--- a/tests/sentry/web/frontend/test_auth_organization_login.py
+++ b/tests/sentry/web/frontend/test_auth_organization_login.py
@@ -2,6 +2,7 @@ from django.test import override_settings
 from django.urls import reverse
 from exam import fixture
 
+from sentry.auth.authenticators import RecoveryCodeInterface, TotpInterface
 from sentry.models import (
     AuthIdentity,
     AuthProvider,
@@ -696,6 +697,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         user = self.create_user("foor@example.com")
         self.create_member(organization=self.organization, user=user)
         member = OrganizationMember.objects.get(organization=self.organization, user=user)
+        member.email = "foor@example.com"
         member.save()
 
         self.session["_next"] = reverse(
@@ -704,7 +706,7 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         self.save_session()
 
         resp = self.client.post(
-            self.path, {"username": self.user, "password": "admin", "op": "login"}, follow=True
+            self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
         )
         assert resp.redirect_chain == [
             (reverse("sentry-organization-settings", args=[self.organization.slug]), 302),
@@ -721,3 +723,103 @@ class OrganizationAuthLoginTest(AuthProviderTestCase):
         assert resp.redirect_chain == [("/auth/login/", 302)]
         assert resp.status_code == 403
         self.assertTemplateUsed(resp, "sentry/no-organization-access.html")
+
+    @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
+    @with_feature({"organizations:create": False})
+    def test_correct_redirect_as_2fa_user_single_org_invited(self):
+        user = self.create_user("foor@example.com")
+
+        RecoveryCodeInterface().enroll(user)
+        TotpInterface().enroll(user)
+
+        self.create_member(organization=self.organization, user=user)
+        member = OrganizationMember.objects.get(organization=self.organization, user=user)
+        member.email = "foor@example.com"
+        member.user = None
+        member.save()
+
+        resp = self.client.post(
+            self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
+        )
+
+        assert resp.redirect_chain == [("/auth/2fa/", 302)]
+
+    def test_correct_redirect_as_2fa_user_invited(self):
+        user = self.create_user("foor@example.com")
+
+        RecoveryCodeInterface().enroll(user)
+        TotpInterface().enroll(user)
+
+        self.create_member(organization=self.organization, user=user)
+        member = OrganizationMember.objects.get(organization=self.organization, user=user)
+        member.email = "foor@example.com"
+        member.user = None
+        member.save()
+
+        resp = self.client.post(
+            self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
+        )
+
+        assert resp.redirect_chain == [("/auth/2fa/", 302)]
+
+    @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
+    @with_feature({"organizations:create": False})
+    def test_correct_redirect_as_2fa_user_single_org_no_membership(self):
+        user = self.create_user("foor@example.com")
+
+        RecoveryCodeInterface().enroll(user)
+        TotpInterface().enroll(user)
+
+        resp = self.client.post(
+            self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
+        )
+
+        assert resp.redirect_chain == [("/auth/2fa/", 302)]
+
+    def test_correct_redirect_as_2fa_user_no_membership(self):
+        user = self.create_user("foor@example.com")
+
+        RecoveryCodeInterface().enroll(user)
+        TotpInterface().enroll(user)
+
+        resp = self.client.post(
+            self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
+        )
+
+        assert resp.redirect_chain == [("/auth/2fa/", 302)]
+
+    @override_settings(SENTRY_SINGLE_ORGANIZATION=True)
+    @with_feature({"organizations:create": False})
+    def test_correct_redirect_as_2fa_user_single_org_member(self):
+        user = self.create_user("foor@example.com")
+
+        RecoveryCodeInterface().enroll(user)
+        TotpInterface().enroll(user)
+
+        self.create_member(organization=self.organization, user=user)
+        member = OrganizationMember.objects.get(organization=self.organization, user=user)
+        member.email = "foor@example.com"
+        member.save()
+
+        resp = self.client.post(
+            self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
+        )
+
+        assert resp.redirect_chain == [("/auth/2fa/", 302)]
+
+    def test_correct_redirect_as_2fa_user_invited_member(self):
+        user = self.create_user("foor@example.com")
+
+        RecoveryCodeInterface().enroll(user)
+        TotpInterface().enroll(user)
+
+        self.create_member(organization=self.organization, user=user)
+        member = OrganizationMember.objects.get(organization=self.organization, user=user)
+        member.email = "foor@example.com"
+        member.save()
+
+        resp = self.client.post(
+            self.path, {"username": user, "password": "admin", "op": "login"}, follow=True
+        )
+
+        assert resp.redirect_chain == [("/auth/2fa/", 302)]


### PR DESCRIPTION
### Summary
In the current flow if a user on a single tenant instance has 2FA enabled and are kicked out of the org (say so they can reset their 2FA manually), or after enabling 2FA,logging out, then trying to rejoin the org, their 2FA login redirect flow breaks.

- Instead of hard redirecting to general login_url, just pop their `_next` session variable.
- Tests also added to cover 2fa login redirects