### PR TITLE
feat(footer): Link to marketing site differently

### DIFF
--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -68,7 +68,7 @@ const FooterLink = styled(ExternalLink)`
 `;
 
 const LogoLink = styled(props => (
-  <a href="/" tabIndex={-1} {...props}>
+  <a href="https://sentry.io/welcome/" target="_blank" tabIndex={-1} {...props}>
     <IconSentry size="xl" />
   </a>
 ))`

--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import * as React from 'react';
 import styled from '@emotion/styled';
 
 import Hook from 'app/components/hook';
@@ -19,7 +19,7 @@ function Footer({className}: Props) {
     <footer className={className}>
       <div>
         {config.isOnPremise && (
-          <Fragment>
+          <React.Fragment>
             {'Sentry '}
             {getDynamicText({
               fixed: 'Acceptance Test',
@@ -31,7 +31,7 @@ function Footer({className}: Props) {
                 value: config.version.build.substring(0, 7),
               })}
             </Build>
-          </Fragment>
+          </React.Fragment>
         )}
       </div>
       <LogoLink />
@@ -68,9 +68,9 @@ const FooterLink = styled(ExternalLink)`
 `;
 
 const LogoLink = styled(props => (
-  <a href="https://sentry.io/welcome/" target="_blank" tabIndex={-1} {...props}>
+  <ExternalLink href="https://sentry.io/welcome/" tabIndex={-1} {...props}>
     <IconSentry size="xl" />
-  </a>
+  </ExternalLink>
 ))`
   color: ${p => p.theme.subText};
   display: block;

--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import Hook from 'app/components/hook';
@@ -19,7 +19,7 @@ function Footer({className}: Props) {
     <footer className={className}>
       <div>
         {config.isOnPremise && (
-          <React.Fragment>
+          <Fragment>
             {'Sentry '}
             {getDynamicText({
               fixed: 'Acceptance Test',
@@ -31,7 +31,7 @@ function Footer({className}: Props) {
                 value: config.version.build.substring(0, 7),
               })}
             </Build>
-          </React.Fragment>
+          </Fragment>
         )}
       </div>
       <LogoLink />

--- a/static/app/components/sidebar/sidebarDropdown/index.tsx
+++ b/static/app/components/sidebar/sidebarDropdown/index.tsx
@@ -89,7 +89,7 @@ const SidebarDropdown = ({api, org, orientation, collapsed, config, user}: Props
           </SidebarDropdownActor>
 
           {isOpen && (
-            <OrgUserAndMarketingMenu {...getMenuProps({})}>
+            <OrgAndUserMenu {...getMenuProps({})}>
               {hasOrganization && (
                 <Fragment>
                   <SidebarOrgSummary organization={org} />
@@ -153,13 +153,7 @@ const SidebarDropdown = ({api, org, orientation, collapsed, config, user}: Props
                   </Fragment>
                 )}
               </DemoModeGate>
-
-              <Divider />
-
-              <SidebarMenuItem href="https://sentry.io/welcome/">
-                {t('Homepage')}
-              </SidebarMenuItem>
-            </OrgUserAndMarketingMenu>
+            </OrgAndUserMenu>
           )}
         </SidebarDropdownRoot>
       )}
@@ -237,11 +231,11 @@ const StyledAvatar = styled(Avatar)<{collapsed: boolean}>`
   border-radius: 6px; /* Fixes background bleeding on corners */
 `;
 
-const OrgUserAndMarketingMenu = styled('div')`
+const OrgAndUserMenu = styled('div')`
   ${SidebarDropdownMenu};
   top: 42px;
   min-width: 180px;
-  z-index: ${p => p.theme.zIndex.orgUserAndMarketingMenu};
+  z-index: ${p => p.theme.zIndex.orgAndUserMenu};
 `;
 
 const StyledIconChevron = styled(IconChevron)`

--- a/static/app/utils/theme.tsx
+++ b/static/app/utils/theme.tsx
@@ -448,7 +448,7 @@ const commonTheme = {
     settingsSidebarNav: 1018,
     sidebarPanel: 1019,
     sidebar: 1020,
-    orgUserAndMarketingMenu: 1030,
+    orgAndUserMenu: 1030,
 
     // Sentry user feedback modal
     sentryErrorEmbed: 1090,

--- a/tests/js/spec/components/sidebar/index.spec.jsx
+++ b/tests/js/spec/components/sidebar/index.spec.jsx
@@ -122,7 +122,7 @@ describe('Sidebar', function () {
     it('can open Sidebar org/name dropdown menu', function () {
       wrapper = createWrapper();
       wrapper.find('SidebarDropdownActor').simulate('click');
-      expect(wrapper.find('OrgUserAndMarketingMenu')).toHaveLength(1);
+      expect(wrapper.find('OrgAndUserMenu')).toHaveLength(1);
       expect(wrapper).toSnapshot();
     });
 
@@ -137,7 +137,7 @@ describe('Sidebar', function () {
         organization: org,
       });
       wrapper.find('SidebarDropdownActor').simulate('click');
-      expect(wrapper.find('OrgUserAndMarketingMenu')).toHaveLength(1);
+      expect(wrapper.find('OrgAndUserMenu')).toHaveLength(1);
       expect(
         wrapper.find('SidebarMenuItem[to="/settings/org-slug/members/"]')
       ).toHaveLength(1);


### PR DESCRIPTION
Based on conversation with several folks in private Slack, decision is to link the footer logo to the marketing site vs. adding a new "Homepage" item to the org/user menu. This PR therefore reverts 74d5f1a583378b10e776a8ae48ec0673e4a3d44c ~= #25684 and tweaks the footer logo link. Open in a new tab (yes?) and don't assume we're on https://sentry.io/ (yes! could be self-hosted).