### PR TITLE
fix(discover/perf): Update user.display to include user.id

### DIFF
--- a/src/sentry/search/events/fields.py
+++ b/src/sentry/search/events/fields.py
@@ -130,7 +130,7 @@ FIELD_ALIASES = {
         PseudoField(
             USER_DISPLAY_ALIAS,
             USER_DISPLAY_ALIAS,
-            expression=["coalesce", ["user.email", "user.username", "user.ip"]],
+            expression=["coalesce", ["user.email", "user.username", "user.ip", "user.id"]],
         ),
         # the key transaction field is intentially not added to the discover/fields list yet
         # because there needs to be some work on the front end to integrate this into discover

--- a/tests/sentry/search/events/test_fields.py
+++ b/tests/sentry/search/events/test_fields.py
@@ -315,7 +315,7 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["selected_columns"] == [
             "title",
             "issue.id",
-            ["coalesce", ["user.email", "user.username", "user.ip"], "user.display"],
+            ["coalesce", ["user.email", "user.username", "user.ip", "user.id"], "user.display"],
             "message",
             ["toStartOfHour", ["timestamp"], "timestamp.to_hour"],
             ["toStartOfDay", ["timestamp"], "timestamp.to_day"],
@@ -333,7 +333,7 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["groupby"] == [
             "title",
             "issue.id",
-            ["coalesce", ["user.email", "user.username", "user.ip"], "user.display"],
+            ["coalesce", ["user.email", "user.username", "user.ip", "user.id"], "user.display"],
             "message",
             "timestamp.to_hour",
             "timestamp.to_day",
@@ -345,12 +345,12 @@ class ResolveFieldListTest(unittest.TestCase):
         result = resolve_field_list(fields, eventstore.Filter())
         assert result["selected_columns"] == [
             "event.type",
-            ["coalesce", ["user.email", "user.username", "user.ip"], "user.display"],
+            ["coalesce", ["user.email", "user.username", "user.ip", "user.id"], "user.display"],
         ]
         assert result["aggregations"] == [["uniq", "title", "count_unique_title"]]
         assert result["groupby"] == [
             "event.type",
-            ["coalesce", ["user.email", "user.username", "user.ip"], "user.display"],
+            ["coalesce", ["user.email", "user.username", "user.ip", "user.id"], "user.display"],
         ]
 
     def test_aggregate_function_expansion(self):
@@ -372,7 +372,7 @@ class ResolveFieldListTest(unittest.TestCase):
         assert result["aggregations"] == [
             [
                 "uniq",
-                [["coalesce", ["user.email", "user.username", "user.ip"]]],
+                [["coalesce", ["user.email", "user.username", "user.ip", "user.id"]]],
                 "count_unique_user_display",
             ],
         ]
@@ -1190,7 +1190,7 @@ class ResolveFieldListTest(unittest.TestCase):
         fields = ["user.display"]
         result = resolve_field_list(fields, eventstore.Filter(orderby="-user.display"))
         assert result["selected_columns"] == [
-            ["coalesce", ["user.email", "user.username", "user.ip"], "user.display"],
+            ["coalesce", ["user.email", "user.username", "user.ip", "user.id"], "user.display"],
             "id",
             "project.id",
             [

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -945,7 +945,11 @@ class GetSnubaQueryArgsTest(TestCase):
             "user.display:bill@example.com", {"organization_id": self.organization.id}
         )
         assert _filter.conditions == [
-            [["coalesce", ["user.email", "user.username", "user.ip"]], "=", "bill@example.com"]
+            [
+                ["coalesce", ["user.email", "user.username", "user.ip", "user.id"]],
+                "=",
+                "bill@example.com",
+            ]
         ]
         assert _filter.filter_keys == {}
         assert _filter.group_ids == []
@@ -956,7 +960,10 @@ class GetSnubaQueryArgsTest(TestCase):
             [
                 [
                     "match",
-                    [["coalesce", ["user.email", "user.username", "user.ip"]], "'(?i)^jill.*$'"],
+                    [
+                        ["coalesce", ["user.email", "user.username", "user.ip", "user.id"]],
+                        "'(?i)^jill.*$'",
+                    ],
                 ],
                 "=",
                 1,
@@ -968,7 +975,11 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_has_user_display(self):
         _filter = get_filter("has:user.display", {"organization_id": self.organization.id})
         assert _filter.conditions == [
-            [["isNull", [["coalesce", ["user.email", "user.username", "user.ip"]]]], "!=", 1]
+            [
+                ["isNull", [["coalesce", ["user.email", "user.username", "user.ip", "user.id"]]]],
+                "!=",
+                1,
+            ]
         ]
         assert _filter.filter_keys == {}
         assert _filter.group_ids == []
@@ -976,7 +987,11 @@ class GetSnubaQueryArgsTest(TestCase):
     def test_not_has_user_display(self):
         _filter = get_filter("!has:user.display", {"organization_id": self.organization.id})
         assert _filter.conditions == [
-            [["isNull", [["coalesce", ["user.email", "user.username", "user.ip"]]]], "=", 1]
+            [
+                ["isNull", [["coalesce", ["user.email", "user.username", "user.ip", "user.id"]]]],
+                "=",
+                1,
+            ]
         ]
         assert _filter.filter_keys == {}
         assert _filter.group_ids == []

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1676,6 +1676,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
     def test_user_display(self):
         project1 = self.create_project()
         project2 = self.create_project()
+        project3 = self.create_project()
         self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -1696,6 +1697,16 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
             },
             project_id=project2.id,
         )
+        self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "transaction": "/example",
+                "message": "how to make fast",
+                "timestamp": self.two_min_ago,
+                "user": {"id": "cath1234"},
+            },
+            project_id=project3.id,
+        )
 
         features = {"organizations:discover-basic": True, "organizations:global-views": True}
         query = {
@@ -1706,9 +1717,9 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         response = self.do_request(query, features=features)
         assert response.status_code == 200, response.content
         data = response.data["data"]
-        assert len(data) == 2
+        assert len(data) == 3
         result = {r["user.display"] for r in data}
-        assert result == {"catherine", "cathy@example.com"}
+        assert result == {"cath1234", "catherine", "cathy@example.com"}
 
     def test_user_display_with_aggregates(self):
         self.login_as(user=self.user)
@@ -1747,6 +1758,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
     def test_orderby_user_display(self):
         project1 = self.create_project()
         project2 = self.create_project()
+        project3 = self.create_project()
         self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -1766,6 +1778,16 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "user": {"username": "catherine"},
             },
             project_id=project2.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "transaction": "/example",
+                "message": "how to make fast",
+                "timestamp": self.two_min_ago,
+                "user": {"id": "cath1234"},
+            },
+            project_id=project3.id,
         )
 
         features = {"organizations:discover-basic": True, "organizations:global-views": True}
@@ -1778,14 +1800,15 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         response = self.do_request(query, features=features)
         assert response.status_code == 200, response.content
         data = response.data["data"]
-        assert len(data) == 2
+        assert len(data) == 3
         result = [r["user.display"] for r in data]
         # because we're ordering by `-user.display`, we expect the results in reverse sorted order
-        assert result == ["cathy@example.com", "catherine"]
+        assert result == ["cathy@example.com", "catherine", "cath1234"]
 
     def test_orderby_user_display_with_aggregates(self):
         project1 = self.create_project()
         project2 = self.create_project()
+        project3 = self.create_project()
         self.store_event(
             data={
                 "event_id": "a" * 32,
@@ -1805,6 +1828,16 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
                 "user": {"username": "catherine"},
             },
             project_id=project2.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "transaction": "/example",
+                "message": "how to make fast",
+                "timestamp": self.two_min_ago,
+                "user": {"id": "cath1234"},
+            },
+            project_id=project3.id,
         )
 
         features = {"organizations:discover-basic": True, "organizations:global-views": True}
@@ -1820,7 +1853,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(data) == 2
         result = [r["user.display"] for r in data]
         # because we're ordering by `user.display`, we expect the results in sorted order
-        assert result == ["catherine", "cathy@example.com"]
+        assert result == ["catherine", "cathy@example.com", "cath1234"]
 
     @pytest.mark.skip(
         """

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1850,7 +1850,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         response = self.do_request(query, features=features)
         assert response.status_code == 200, response.content
         data = response.data["data"]
-        assert len(data) == 2
+        assert len(data) == 3
         result = [r["user.display"] for r in data]
         # because we're ordering by `user.display`, we expect the results in sorted order
         assert result == ["catherine", "cathy@example.com", "cath1234"]

--- a/tests/snuba/api/endpoints/test_organization_events_v2.py
+++ b/tests/snuba/api/endpoints/test_organization_events_v2.py
@@ -1853,7 +1853,7 @@ class OrganizationEventsV2EndpointTest(APITestCase, SnubaTestCase):
         assert len(data) == 3
         result = [r["user.display"] for r in data]
         # because we're ordering by `user.display`, we expect the results in sorted order
-        assert result == ["catherine", "cathy@example.com", "cath1234"]
+        assert result == ["cath1234", "catherine", "cathy@example.com"]
 
     @pytest.mark.skip(
         """


### PR DESCRIPTION
Previously user.display would show n/a if there was no `user.email`, `user.username` or `user.ip` set. This caused [confusion](https://forum.sentry.io/t/why-is-the-user-column-in-tracing-n-a-when-the-event-has-user-set/13889) in Performance when going from the Transaction Summary to Event Details because the User object was there.