### PR TITLE
feat: Emit breakdowns for all transactions

### DIFF
--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -70,7 +70,7 @@ register(
     epoch_defaults={
         1: {
             "span_ops": {
-                "type": "span_operations",
+                "type": "spanOperations",
                 "matches": ["http", "db", "browser", "resource"],
             }
         },

--- a/src/sentry/relay/config.py
+++ b/src/sentry/relay/config.py
@@ -162,10 +162,9 @@ def get_project_config(project, full_config=True, project_keys=None):
         if dynamic_sampling is not None:
             cfg["config"]["dynamicSampling"] = dynamic_sampling
 
-    if features.has("organizations:performance-ops-breakdown", project.organization):
-        breakdowns_config = project.get_option("sentry:breakdowns")
-        if breakdowns_config is not None:
-            cfg["config"]["breakdowns"] = breakdowns_config
+    breakdowns_config = project.get_option("sentry:breakdowns")
+    if breakdowns_config is not None:
+        cfg["config"]["breakdowns"] = breakdowns_config
 
     if not full_config:
         # This is all we need for external Relay processors

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -16,10 +16,13 @@ _date_regex = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$")
 
 
 def _get_all_keys(config):
-    for key in config:
-        yield key
-        if isinstance(config[key], dict):
-            for key in _get_all_keys(config[key]):
+    for config_key in config:
+        yield config_key
+        if isinstance(config[config_key], dict):
+            for key in _get_all_keys(config[config_key]):
+                # Bypass operations breakdown key
+                if config_key == 'breakdowns' and key == 'span_ops':
+                    continue
                 yield key
 
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs.py
@@ -21,7 +21,7 @@ def _get_all_keys(config):
         if isinstance(config[config_key], dict):
             for key in _get_all_keys(config[config_key]):
                 # Bypass operations breakdown key
-                if config_key == 'breakdowns' and key == 'span_ops':
+                if config_key == "breakdowns" and key == "span_ops":
                     continue
                 yield key
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -16,10 +16,13 @@ _date_regex = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$")
 
 
 def _get_all_keys(config):
-    for key in config:
-        yield key
-        if isinstance(config[key], dict):
-            for key in _get_all_keys(config[key]):
+    for config_key in config:
+        yield config_key
+        if isinstance(config[config_key], dict):
+            for key in _get_all_keys(config[config_key]):
+                # Bypass operations breakdown key
+                if config_key == 'breakdowns' and key == 'span_ops':
+                    continue
                 yield key
 
 

--- a/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
+++ b/tests/sentry/api/endpoints/test_relay_projectconfigs_v2.py
@@ -21,7 +21,7 @@ def _get_all_keys(config):
         if isinstance(config[config_key], dict):
             for key in _get_all_keys(config[config_key]):
                 # Bypass operations breakdown key
-                if config_key == 'breakdowns' and key == 'span_ops':
+                if config_key == "breakdowns" and key == "span_ops":
                     continue
                 yield key
 

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/no_ops_breakdown/full_config.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/no_ops_breakdown/full_config.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-26T06:44:48.641788Z'
+created: '2021-05-13T22:16:37.531016Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -13,7 +13,7 @@ config:
       - db
       - browser
       - resource
-      type: span_operations
+      type: spanOperations
   datascrubbingSettings:
     excludeFields: []
     scrubData: true

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/no_ops_breakdown/slim_config.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/no_ops_breakdown/slim_config.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-04-26T06:44:48.504933Z'
+created: '2021-05-13T22:16:37.389823Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -13,7 +13,7 @@ config:
       - db
       - browser
       - resource
-      type: span_operations
+      type: spanOperations
   datascrubbingSettings:
     excludeFields: []
     scrubData: true

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/full_config.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/full_config.pysnap
@@ -1,11 +1,19 @@
 ---
-created: '2021-04-26T06:44:48.376070Z'
+created: '2021-05-05T19:19:39.085628Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 config:
   allowedDomains:
   - '*'
+  breakdowns:
+    span_ops:
+      matches:
+      - http
+      - db
+      - browser
+      - resource
+      type: span_operations
   datascrubbingSettings:
     excludeFields: []
     scrubData: true

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/full_config.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/full_config.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T19:19:39.085628Z'
+created: '2021-05-13T22:16:37.268371Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -13,7 +13,7 @@ config:
       - db
       - browser
       - resource
-      type: span_operations
+      type: spanOperations
   datascrubbingSettings:
     excludeFields: []
     scrubData: true

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/slim_config.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/slim_config.pysnap
@@ -1,11 +1,19 @@
 ---
-created: '2021-04-26T06:44:48.135605Z'
+created: '2021-05-05T19:19:38.878795Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
 config:
   allowedDomains:
   - '*'
+  breakdowns:
+    span_ops:
+      matches:
+      - http
+      - db
+      - browser
+      - resource
+      type: span_operations
   datascrubbingSettings:
     excludeFields: []
     scrubData: true

--- a/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/slim_config.pysnap
+++ b/tests/sentry/relay/snapshots/test_config/test_get_project_config/ops_breakdown/slim_config.pysnap
@@ -1,5 +1,5 @@
 ---
-created: '2021-05-05T19:19:38.878795Z'
+created: '2021-05-13T22:16:37.059214Z'
 creator: sentry
 source: tests/sentry/relay/test_config.py
 ---
@@ -13,7 +13,7 @@ config:
       - db
       - browser
       - resource
-      type: span_operations
+      type: spanOperations
   datascrubbingSettings:
     excludeFields: []
     scrubData: true


### PR DESCRIPTION
Begin emitting breakdowns for all transactions. The `performance-ops-breakdown` will instead be used to gate the UI product features for displaying these breakdowns.

Related PR: https://github.com/getsentry/relay/pull/993